### PR TITLE
Fix dead link to confluence

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/development.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/development.md
@@ -9,7 +9,7 @@ import { Icon } from 'dnb-ui-lib/src'
 
 # Development
 
-For more development details you may have a look at the confluence pages about [development details](confluence.tech.dnb.no/display/EDS/).
+For more development details you may have a look at the confluence pages about [development details](https://confluence.tech.dnb.no/display/EDS/).
 
 ## Development environment and defaults
 


### PR DESCRIPTION
Dead link to https://eufemia.dnb.no/uilib/confluence.tech.dnb.no/display/EDS/ should now link to https://confluence.tech.dnb.no/display/EDS/