### PR TITLE
chore: tertiary button requires an icon

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
@@ -278,6 +278,7 @@ const UpdateDemoTools = () => {
       <Button
         text="Reset"
         variant="tertiary"
+        icon="reset"
         disabled={!(errorA || errorB)}
         on_click={() => {
           setErrorA(null)


### PR DESCRIPTION
## Summary

Tertiary button in global-status/Examples.js requires an icon.
Removed the following info message that occurs when visiting the portal for GlobalStatus: 
![image](https://user-images.githubusercontent.com/1359205/114280421-5f713480-9a39-11eb-8162-e7288f01f6d4.png)
