### PR TITLE
fix: border radius transition issue in safari

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -2081,6 +2081,7 @@ legend.dnb-form-label {
     position: relative;
     overflow: hidden;
     width: 100%;
+    will-change: transform;
     height: 0.5rem;
     border-radius: 0.25rem; }
     .dnb-progress-indicator__linear__bar {

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -1497,6 +1497,7 @@ button.dnb-button::-moz-focus-inner {
     position: relative;
     overflow: hidden;
     width: 100%;
+    will-change: transform;
     height: 0.5rem;
     border-radius: 0.25rem; }
     .dnb-progress-indicator__linear__bar {

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
@@ -365,6 +365,7 @@ exports[`ProgressIndicator scss have to match snapshot 1`] = `
     position: relative;
     overflow: hidden;
     width: 100%;
+    will-change: transform;
     height: 0.5rem;
     border-radius: 0.25rem; }
     .dnb-progress-indicator__linear__bar {

--- a/packages/dnb-eufemia/src/components/progress-indicator/style/_progress-indicator.scss
+++ b/packages/dnb-eufemia/src/components/progress-indicator/style/_progress-indicator.scss
@@ -110,6 +110,7 @@
     position: relative;
     overflow: hidden;
     width: 100%;
+    will-change: transform;
 
     // default/basis size
     height: 0.5rem;


### PR DESCRIPTION
Issue:

<img width="1039" alt="Screenshot 2021-05-09 at 22 27 24" src="https://user-images.githubusercontent.com/1359205/117585991-c60b7000-b115-11eb-95a4-c55e9adf1ab9.png">

https://user-images.githubusercontent.com/1359205/117585915-6745f680-b115-11eb-9869-be6df27c8208.mov



After fix:

https://user-images.githubusercontent.com/1359205/117586003-d7ed1300-b115-11eb-89e1-d066c2995b92.mov





