### PR TITLE
fix: ensure that a button still has type button

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -312,7 +312,7 @@ export default class Button extends React.PureComponent {
       onClick: this.onClickHandler,
     }
 
-    if (Element === Anchor && !params.type) {
+    if (Element !== Anchor && !params.type) {
       params.type = 'button'
     }
 

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.js
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.js
@@ -130,6 +130,13 @@ describe('Button component', () => {
     expect(typeof ref.current).toBe('object')
   })
 
+  it('has type of button', () => {
+    const Comp = mount(<Component />)
+    expect(Comp.find('button').instance().getAttribute('type')).toBe(
+      'button'
+    )
+  })
+
   it('should validate with ARIA rules as a button', async () => {
     const Comp = mount(<Component {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -539,6 +539,7 @@ exports[`Dropdown markup have to match snapshot 1`] = `
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
+                  type="button"
                 >
                   <Content
                     aria-controls="dropdown-id-drawer-list"

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
@@ -597,7 +597,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
           target_blank_title={null}
           to={null}
           tooltip={null}
-          type="button"
         >
           <AnchorInstance
             className="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon"
@@ -609,7 +608,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                 "current": <a
                   class="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon dnb-a"
                   href="href"
-                  type="button"
                 >
                   <span
                     class="dnb-button__alignment"
@@ -652,7 +650,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
             target_blank_title={null}
             to={null}
             tooltip={null}
-            type="button"
           >
             <ForwardRef
               class={null}
@@ -665,7 +662,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                   "current": <a
                     class="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon dnb-a"
                     href="href"
-                    type="button"
                   >
                     <span
                       class="dnb-button__alignment"
@@ -710,7 +706,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
               target={null}
               target_blank_title="Åpner et nytt vindu"
               to={null}
-              type="button"
             >
               <ElementInstance
                 class={null}
@@ -723,7 +718,6 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                     "current": <a
                       class="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon dnb-a"
                       href="href"
-                      type="button"
                     >
                       <span
                         class="dnb-button__alignment"
@@ -768,14 +762,12 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                 target={null}
                 target_blank_title="Åpner et nytt vindu"
                 to={null}
-                type="button"
               >
                 <a
                   className="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon dnb-a"
                   disabled={false}
                   href="href"
                   onClick={[Function]}
-                  type="button"
                 >
                   <Content
                     bounding={false}

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.js.snap
@@ -58,6 +58,7 @@ exports[`HelpButton component have to match snapshot 1`] = `
         disabled={false}
         id="help-button"
         onClick={[Function]}
+        type="button"
       >
         <Content
           aria-label="Hjelpetekst"

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -130,6 +130,7 @@ exports[`Modal component have to match snapshot 1`] = `
           class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
           id="modal_id"
           title="modal_title"
+          type="button"
         >
           <span
             class="dnb-button__alignment"
@@ -190,6 +191,7 @@ exports[`Modal component have to match snapshot 1`] = `
             class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
             id="modal_id"
             title="modal_title"
+            type="button"
           >
             <span
               class="dnb-button__alignment"
@@ -245,6 +247,7 @@ exports[`Modal component have to match snapshot 1`] = `
         id="modal_id"
         onClick={[Function]}
         title="modal_title"
+        type="button"
       >
         <Content
           aria-label="modal_title"
@@ -273,6 +276,7 @@ exports[`Modal component have to match snapshot 1`] = `
                 class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
                 id="modal_id"
                 title="modal_title"
+                type="button"
               >
                 <span
                   class="dnb-button__alignment"

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -599,6 +599,7 @@ exports[`Pagination bar component have to match snapshot 1`] = `
                 className="dnb-button dnb-button--secondary dnb-pagination__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--size-small"
                 disabled={true}
                 onClick={[Function]}
+                type="button"
               >
                 <Content
                   bounding={false}
@@ -726,6 +727,7 @@ exports[`Pagination bar component have to match snapshot 1`] = `
                 disabled={false}
                 onClick={[Function]}
                 title="Neste side"
+                type="button"
               >
                 <Content
                   bounding={false}

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.js.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.js.snap
@@ -116,6 +116,7 @@ exports[`Slider component have to match snapshot 1`] = `
             className="dnb-button dnb-button--secondary dnb-slider__button dnb-slider__button--subtract dnb-button--icon-position-right dnb-button--has-icon dnb-button--size-small"
             disabled={false}
             onClick={[Function]}
+            type="button"
           >
             <Content
               aria-label="subtract_title"
@@ -276,6 +277,7 @@ exports[`Slider component have to match snapshot 1`] = `
                 onMouseDown={[Function]}
                 tabIndex="-1"
                 title="thump_title"
+                type="button"
               >
                 <Content
                   aria-hidden={true}
@@ -376,6 +378,7 @@ exports[`Slider component have to match snapshot 1`] = `
             className="dnb-button dnb-button--secondary dnb-slider__button dnb-slider__button--add dnb-button--icon-position-right dnb-button--has-icon dnb-button--size-small"
             disabled={false}
             onClick={[Function]}
+            type="button"
           >
             <Content
               aria-label="add_title"

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -98,6 +98,7 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="-1"
+                  type="button"
                 >
                   <Content
                     aria-hidden={true}
@@ -346,6 +347,7 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="-1"
+                  type="button"
                 >
                   <Content
                     aria-hidden={true}
@@ -623,6 +625,7 @@ exports[`Tabs component have to match snapshot 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 tabIndex="-1"
+                type="button"
               >
                 <Content
                   aria-hidden={true}
@@ -871,6 +874,7 @@ exports[`Tabs component have to match snapshot 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 tabIndex="-1"
+                type="button"
               >
                 <Content
                   aria-hidden={true}

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -149,6 +149,7 @@ exports[`ToggleButton component have to match snapshot 1`] = `
             onKeyDown={[Function]}
             onKeyUp={[Function]}
             title="title"
+            type="button"
           >
             <Content
               aria-describedby="toggle-button-suffix"
@@ -634,6 +635,7 @@ exports[`ToggleButton group component have to match group snapshot 1`] = `
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               onKeyUp={[Function]}
+                              type="button"
                             >
                               <Content
                                 aria-pressed="true"
@@ -926,6 +928,7 @@ exports[`ToggleButton group component have to match group snapshot 1`] = `
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               onKeyUp={[Function]}
+                              type="button"
                             >
                               <Content
                                 aria-pressed="true"


### PR DESCRIPTION
This PR fixes a wrong defined check for adding type

- Added a test to ensure we have type=button
- Because a button will else be able to submit a <form>
- An Anchor does not need that
