### PR TITLE
fix: add role attribute to form-status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/properties.md
@@ -10,6 +10,7 @@ redirect_from:
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `text` or `children`                        | _(optional)_ the `text` appears as the status message. Beside plain text, You can send in a React component as well.                        |
 | `title`                                     | _(optional)_ the `title` attribute in the status.                                                                                           |
+| `role`                                      | _(optional)_ the `role` attribute for accessibility, defaults to `alert`                                                                    |
 | `state`                                     | _(optional)_ defines the visual appearance of the status. These are the statuses `error`, `warn` and `info`. The default status is `error`. |
 | `size`                                      | _(optional)_ defines the appearance size. There are these sizes `default`, `large`. The default status is `default`.                        |
 | `icon`                                      | _(optional)_ the `icon` show before the status text. Defaults to `exclamation`.                                                             |

--- a/packages/dnb-eufemia-sandbox/stories/components/FormStatus.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/FormStatus.js
@@ -3,7 +3,7 @@
  *
  */
 
-import React /* , { useState, useEffect } */ from 'react'
+import React /* , { useState, useEffect } */, { useState } from 'react'
 import { Wrapper, Box } from '../helpers'
 import styled from '@emotion/styled'
 
@@ -47,88 +47,119 @@ const SmallWidth = styled(Input)`
 //   </>
 // )
 
-export const FormStatuseSandbox = () => (
-  <Wrapper>
-    <Box>
-      <Input
-        label="Input with custom status:"
-        status={<CustomStatus />}
-        status_state="info"
-        value="Input value"
-      />
-    </Box>
-    <Box>
-      <SmallWidth
-        label="Small width input:"
-        value="4"
-        status="Adipiscing etiam laoreet et egestas dis massa quis dapibus nam diam est non curae ad hac dictumst"
-      />
-    </Box>
-    <Box>
-      <SmallWidth
-        label="Warning:"
-        value="4"
-        size={3}
-        status="Adipiscing etiam laoreet et egestas dis massa quis dapibus nam diam est non curae ad hac dictumst"
-        status_state="warn"
-      />
-    </Box>
-    <Box>
-      <FormStatus>Status</FormStatus>
-    </Box>
-    <Box>
-      <FormStatus state="info" size="large">
-        Long info text Ipsum habitant enim ullamcorper elit sit elementum
-        platea rutrum eu condimentum erat risus lacinia viverra magnis
-        lobortis nibh mollis suspendisse
-      </FormStatus>
-    </Box>
-    <Box>
-      <FormStatus>
-        <CustomStatus />
-      </FormStatus>
-    </Box>
-    <Box>
-      <Input
-        label="Input label:"
-        // style={{ width: '200px' }}
-        status={<CustomStatus />}
-      >
-        Value
-      </Input>
-    </Box>
-    <Box>
-      <Switch
-        label="Switch label"
-        status="Long text with status vitae tortor metus nulla nunc habitasse adipiscing purus porttitor viverra"
-      />
-    </Box>
-    <Box>
-      <FormSet
-        label_direction="vertical"
-        prevent_submit
-        on_submit={(event) => {
-          console.log('onSubmit', event)
-        }}
-      >
-        <FormRow
-          top="small"
-          label={
-            <Space element="span" className="dnb-h--large">
-              Legend:
-            </Space>
-          }
+export const FormStatuseSandbox = () => {
+  const [showError, setShowError] = useState(false)
+  return (
+    <Wrapper>
+      <Box>
+        <Input
+          label='Input with custom status:'
+          status={<CustomStatus />}
+          status_state='info'
+          value='Input value'
+        />
+      </Box>
+      <Box>
+        <SmallWidth
+          label='Small width input:'
+          value='4'
+          status='Adipiscing etiam laoreet et egestas dis massa quis dapibus nam diam est non curae ad hac dictumst'
+        />
+      </Box>
+      <Box>
+        <SmallWidth
+          label='Warning:'
+          value='4'
+          size={3}
+          status='Adipiscing etiam laoreet et egestas dis massa quis dapibus nam diam est non curae ad hac dictumst'
+          status_state='warn'
+        />
+      </Box>
+      <Box>
+        <FormStatus>Status</FormStatus>
+      </Box>
+      <Box>
+        <FormStatus state='info' size='large'>
+          Long info text Ipsum habitant enim ullamcorper elit sit elementum
+          platea rutrum eu condimentum erat risus lacinia viverra magnis
+          lobortis nibh mollis suspendisse
+        </FormStatus>
+      </Box>
+      <Box>
+        <FormStatus>
+          <CustomStatus />
+        </FormStatus>
+      </Box>
+      <Box>
+        <Input
+          label='Input label:'
+          // style={{ width: '200px' }}
+          status={<CustomStatus />}
         >
-          <DatePicker
-            show_input
-            right="small"
-            bottom="small"
-            status="Long text with status vitae tortor metus nulla nunc habitasse adipiscing purus porttitor viverra"
-          />
-          <Modal right="small">Modal Content</Modal>
-          <Button text="Submit" type="submit" />
-        </FormRow>
-      </FormSet>
-    </Box>
-  </Wrapper>
-)
+          Value
+        </Input>
+      </Box>
+      <Box>
+        <Switch
+          label='Switch label'
+          status='Long text with status vitae tortor metus nulla nunc habitasse adipiscing purus porttitor viverra'
+        />
+      </Box>
+      <Box>
+        <FormSet
+          label_direction='vertical'
+          prevent_submit
+          on_submit={(event) => {
+            console.log('onSubmit', event)
+          }}
+        >
+          <FormRow
+            top='small'
+            label={
+              <Space element='span' className='dnb-h--large'>
+                Legend:
+              </Space>
+            }
+          >
+            <DatePicker
+              show_input
+              right='small'
+              bottom='small'
+              status='Long text with status vitae tortor metus nulla nunc habitasse adipiscing purus porttitor viverra'
+            />
+            <Modal right='small'>Modal Content</Modal>
+            <Button text='Submit' type='submit' />
+          </FormRow>
+        </FormSet>
+      </Box>
+      <Box>
+        <FormSet
+          label_direction='vertical'
+          prevent_submit
+          on_submit={(event) => {
+            setShowError(v => !v)
+            console.log('onSubmit', event)
+          }}
+        >
+          <FormRow
+            top='small'
+            label={
+              <Space element='span' className='dnb-h--large'>
+                Legend:
+              </Space>
+            }
+          >
+            <DatePicker
+              show_input
+              right='small'
+              bottom='small'
+              status={showError && 'Long text with status vitae tortor metus nulla nunc habitasse adipiscing purus porttitor viverra'}
+            />
+            <Modal right='small'>Modal Content</Modal>
+            <Button text='Submit' type='submit' />
+          </FormRow>
+        </FormSet>
+      </Box>
+    </Wrapper>
+  )
+}

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -309,6 +309,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
             icon_size="medium"
             id="autocomplete-id-form-status"
             label="Autocomplete Label:"
+            role="alert"
             size="default"
             skeleton="skeleton"
             state="error"
@@ -325,6 +326,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
               hidden={false}
               id="autocomplete-id-form-status"
               label="Autocomplete Label:"
+              role="alert"
             >
               <span
                 className="dnb-form-status__shell"

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -226,6 +226,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
           icon_size="medium"
           id="date-picker-id-form-status"
           label={null}
+          role="alert"
           size="default"
           skeleton={null}
           state="error"
@@ -241,6 +242,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
             className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
             hidden={false}
             id="date-picker-id-form-status"
+            role="alert"
           >
             <span
               className="dnb-form-status__shell"

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -363,6 +363,7 @@ exports[`Dropdown markup have to match snapshot 1`] = `
             icon_size="medium"
             id="dropdown-id-form-status"
             label="label"
+            role="alert"
             size="default"
             skeleton="skeleton"
             state="error"
@@ -379,6 +380,7 @@ exports[`Dropdown markup have to match snapshot 1`] = `
               hidden={false}
               id="dropdown-id-form-status"
               label="label"
+              role="alert"
             >
               <span
                 className="dnb-form-status__shell"

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.js
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.js
@@ -67,6 +67,7 @@ export default class FormStatus extends React.PureComponent {
     class: PropTypes.string,
     animation: PropTypes.string,
     skeleton: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    role: PropTypes.string,
 
     ...spacingPropTypes,
 
@@ -97,6 +98,7 @@ export default class FormStatus extends React.PureComponent {
     class: null,
     animation: null, // could be 'fade-in'
     skeleton: null,
+    role: 'alert',
 
     className: null,
     children: null,
@@ -303,6 +305,7 @@ export default class FormStatus extends React.PureComponent {
       icon_size, // eslint-disable-line
       skeleton, // eslint-disable-line
       children, // eslint-disable-line
+      role,
 
       ...attributes
     } = props
@@ -341,6 +344,10 @@ export default class FormStatus extends React.PureComponent {
 
       ...attributes,
     }
+    if (role) {
+      params.role = role
+    }
+
     const textParams = {
       className: classnames(
         'dnb-form-status__text',

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.js
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.js
@@ -105,3 +105,24 @@ describe('FormStatus scss', () => {
     expect(scss).toMatchSnapshot()
   })
 })
+
+describe('FormStatus role', () => {
+  it('should have role alert', () => {
+    const Comp = mount(<Component text="status text" />)
+
+    expect(
+      Comp.find('.dnb-form-status').instance().getAttribute('role')
+    ).toBe('alert')
+  })
+
+  it('should be able to override role', () => {
+    const Comp = mount(<Component role='generic' text="status text" />)
+
+    expect(
+      Comp.find('.dnb-form-status').instance().getAttribute('role')
+    ).not.toBe('alert')
+    expect(
+      Comp.find('.dnb-form-status').instance().getAttribute('role')
+    ).toBe('generic')
+  })
+})

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/__snapshots__/FormStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/__snapshots__/FormStatus.test.js.snap
@@ -16,6 +16,7 @@ exports[`FormStatus component have to match snapshot 1`] = `
         "icon_size": "icon_size",
         "id": "id",
         "label": "label",
+        "role": "role",
         "size": "'default'",
         "skeleton": "skeleton",
         "state": true,
@@ -62,6 +63,7 @@ exports[`FormStatus component have to match snapshot 1`] = `
   icon_size="medium"
   id="form-status"
   label={null}
+  role="alert"
   size="default"
   skeleton={null}
   state="error"
@@ -77,6 +79,7 @@ exports[`FormStatus component have to match snapshot 1`] = `
     className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
     hidden={false}
     id="form-status"
+    role="alert"
   >
     <span
       className="dnb-form-status__shell"

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
@@ -1438,6 +1438,7 @@ Array [
                 Label
               </span>
             }
+            role="alert"
             size="default"
             skeleton={null}
             state="error"
@@ -1458,6 +1459,7 @@ Array [
                   Label
                 </span>
               }
+              role="alert"
             >
               <span
                 className="dnb-form-status__shell"


### PR DESCRIPTION
## Summary

Add role attribute to FormStatus component, so when an "error" is shown it's picked up by a screen reader.

The FormStatus component will now add `role="alert"` unless the `disableRole` prop on FormStatus is set to `true`.

## Test plan

I have created two tests, testing that the `role="alert"` is only set if the `disableRole` prop is false.

I also added a new section in the storybook, that toggles the FormStatus when the submit button is clicked. On mac with VoiceOver this triggers the screen reader to read the contents of the status.
