### PR TITLE
[WIP] feat: use ES with ES6 as the default module format

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.md
@@ -60,7 +60,7 @@ The Library is hosted on [NPM](https://www.npmjs.com/package/@dnb/eufemia), so v
 
 ## Production ready
 
-All code examples are shown as ES6 ([ECMAScript 2015](https://en.wikipedia.org/wiki/ECMAScript)). But the production `@dnb/eufemia` is actually compiled down to ES5 (5th Edition). So your product is using production ready code.
+All code examples are shown as ES6 ([ECMAScript 2015](https://en.wikipedia.org/wiki/ECMAScript)). The production `@dnb/eufemia` is compiled down to ES5 (5th Edition) when UMD, ESM or CJS is used. If you need to support Internet Explorer 11, ensure the `browserlist` is set so. Or ensure you compile code down to ES5 and provide all necessary polyfills.
 
 ## Components, Elements and Extensions
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/module-formats.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/module-formats.md
@@ -10,8 +10,8 @@ redirect_from:
 
 To support every modern front end environment, the `@dnb/eufemia` supports different transpiled module formats:
 
-- `ESM` with ES5 (**default**)
-- `ES` with ES6
+- `ES` with ES6 (**default**)
+- `ESM` with ES5
 - `CJS` with ES5
 - `UMD` with ES5
 

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -19,7 +19,7 @@
     "audit:ci:npm": "audit-ci --config ./audit-ci.json --report-type summary",
     "audit:ci:yarn": "audit-ci --config ./audit-ci.json --package-manager=yarn --report-type summary",
     "audit:ci:yarn-outdated": "babel-node ./scripts/prepub/audit/toOpt && audit-ci --config ./audit-ci.json --package-manager=yarn --report-type full && babel-node ./scripts/prepub/audit/toDev",
-    "build": "yarn build:prebuild && yarn build:esm && yarn build:copy",
+    "build": "yarn build:prebuild && yarn build:es && yarn build:copy",
     "prebuild:ci": "yarn build",
     "postbuild:ci": "./scripts/release/postbuild.sh && yarn test:build",
     "build:cjs": "./scripts/release/babel-cjs.sh",

--- a/packages/dnb-eufemia/scripts/release/copyFinaleBuild.js
+++ b/packages/dnb-eufemia/scripts/release/copyFinaleBuild.js
@@ -6,8 +6,8 @@
  * cp does not have the option to ignore existing files.
  * We then overwrite /styles – but then the font/assets path is not correct anymore (-n does not work on mac)
  *
- * "build:copy": "rsync -r --ignore-existing --exclude=dnb-ui-*.min.* ./build/esm/* ./build",
- * "build:copy": "cp -r build/esm/* ./build",
+ * "build:copy": "rsync -r --ignore-existing --exclude=dnb-ui-*.min.* ./build/es/* ./build",
+ * "build:copy": "cp -r build/es/* ./build",
  *
  */
 
@@ -27,7 +27,7 @@ async function copyFinaleBuild() {
     }
     return true
   }
-  await fs.copy('./build/esm/', './build/', {
+  await fs.copy('./build/es/', './build/', {
     filter,
     overwrite: false,
     errorOnExist: false,


### PR DESCRIPTION
This PR will make the Eufemia ES version as the default –  with ES6 as the basis. By now we used ESM, which compiled down to ES5.

In teori, this should be fine, as everyone I'm aware of uses a compiler / bundler.

This also fixes a codesandbox.io issue when importing modules from the package root as named imports.

```jsx
import { Button, DatePicker } from '@dnb/eufemia'
```
