### PR TITLE
feat: customize aria-label and title of progress indicator

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/properties.md
@@ -19,4 +19,5 @@ showTabs: true
 | `show_label`                                | _(optional)_ if set to `true` a default label will be shown.                                                                                                                  |
 | `section_style`                             | _(optional)_ to enable the visual helper `.dnb-section` class. Use a supported modifier from the [Section component](/uilib/components/section/properties). Defaults to null. |
 | `section_spacing`                           | _(optional)_ to modify the `spacing`. Use a supported modifier from the [Section component](/uilib/components/section/properties). Defaults to null.                          |
+| `title`                                     | _(optional)_ used to set title and aria-label. Defaults to the value of progress property, formatted as a percent.                                                            |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                                         |

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -852,6 +852,7 @@ exports[`Pagination bar component have to match snapshot 1`] = `
                         section_style={null}
                         show_label={false}
                         size="default"
+                        title={null}
                         type="circular"
                         visible={true}
                       >
@@ -865,6 +866,7 @@ exports[`Pagination bar component have to match snapshot 1`] = `
                             onComplete={null}
                             progress={null}
                             size="default"
+                            title={null}
                             visible={true}
                           >
                             <div

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.js
@@ -20,6 +20,7 @@ import {
 } from '../space/SpacingHelper'
 import ProgressIndicatorCircular from './ProgressIndicatorCircular'
 import ProgressIndicatorLinear from './ProgressIndicatorLinear'
+import { format } from '../number-format/NumberUtils'
 
 export default class ProgressIndicator extends React.PureComponent {
   static tagName = 'dnb-progress-indicator'
@@ -37,6 +38,7 @@ export default class ProgressIndicator extends React.PureComponent {
     indicator_label: PropTypes.string,
     section_style: PropTypes.string,
     section_spacing: PropTypes.string,
+    title: PropTypes.string,
 
     ...spacingPropTypes,
 
@@ -59,7 +61,7 @@ export default class ProgressIndicator extends React.PureComponent {
     indicator_label: null,
     section_style: null,
     section_spacing: null,
-
+    title: null,
     class: null,
     className: null,
     children: null,
@@ -132,6 +134,7 @@ export default class ProgressIndicator extends React.PureComponent {
       className,
       class: _className,
       children,
+      title,
       progress: _progress, //eslint-disable-line
       visible: _visible, //eslint-disable-line
       complete: _complete, //eslint-disable-line
@@ -144,6 +147,8 @@ export default class ProgressIndicator extends React.PureComponent {
 
     const indicatorLabel =
       label || children || (isTrue(show_label) && indicator_label)
+
+    const progressTitle = title || formatProgress(progress)
 
     validateDOMAttributes(this.props, params)
 
@@ -170,6 +175,7 @@ export default class ProgressIndicator extends React.PureComponent {
             complete={complete}
             onComplete={on_complete}
             callOnCompleteHandler={this.callOnCompleteHandler}
+            title={progressTitle}
           />
         )}
         {type === 'linear' && (
@@ -180,6 +186,7 @@ export default class ProgressIndicator extends React.PureComponent {
             complete={complete}
             onComplete={on_complete}
             callOnCompleteHandler={this.callOnCompleteHandler}
+            title={progressTitle}
           />
         )}
         {indicatorLabel && (
@@ -190,4 +197,14 @@ export default class ProgressIndicator extends React.PureComponent {
       </div>
     )
   }
+}
+
+function formatProgress(progress) {
+  if (parseFloat(progress) > -1) {
+    return format(progress, {
+      decimals: 2,
+      percent: true,
+    })
+  }
+  return null
 }

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.js
@@ -18,6 +18,7 @@ export default class ProgressIndicatorCircular extends React.PureComponent {
     maxOffset: PropTypes.number,
     onComplete: PropTypes.func,
     callOnCompleteHandler: PropTypes.func,
+    title: PropTypes.string,
   }
   static defaultProps = {
     size: null,
@@ -27,6 +28,7 @@ export default class ProgressIndicatorCircular extends React.PureComponent {
     maxOffset: 88,
     onComplete: null,
     callOnCompleteHandler: null,
+    title: null,
   }
   static getDerivedStateFromProps(props, state) {
     state.progress = parseFloat(props.progress)
@@ -143,6 +145,7 @@ export default class ProgressIndicatorCircular extends React.PureComponent {
     const {
       size,
       maxOffset,
+      title,
       progress: _progress, // eslint-disable-line
       visible, // eslint-disable-line
       complete, // eslint-disable-line
@@ -161,8 +164,8 @@ export default class ProgressIndicatorCircular extends React.PureComponent {
 
     if (hasProgressValue) {
       params.role = 'progressbar'
-      params['aria-label'] = `${progress}%`
-      params['title'] = `${progress}%`
+      params['aria-label'] = title
+      params['title'] = title
     } else {
       params.role = 'alert'
       params['aria-busy'] = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.js
@@ -20,6 +20,7 @@ export default class ProgressIndicatorLinear extends React.PureComponent {
     progress: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onComplete: PropTypes.func,
     callOnCompleteHandler: PropTypes.func,
+    title: PropTypes.string,
   }
   static defaultProps = {
     size: null,
@@ -28,6 +29,7 @@ export default class ProgressIndicatorLinear extends React.PureComponent {
     progress: null,
     onComplete: null,
     callOnCompleteHandler: null,
+    title: null,
   }
   static getDerivedStateFromProps(props, state) {
     state.progress = parseFloat(props.progress)
@@ -55,6 +57,7 @@ export default class ProgressIndicatorLinear extends React.PureComponent {
   render() {
     const {
       size,
+      title,
       progress: _progress, // eslint-disable-line
       visible, // eslint-disable-line
       complete, // eslint-disable-line
@@ -74,8 +77,8 @@ export default class ProgressIndicatorLinear extends React.PureComponent {
 
     if (hasProgressValue) {
       params.role = 'progressbar'
-      params['aria-label'] = `${progress}%`
-      params['title'] = `${progress}%`
+      params['aria-label'] = title
+      params['title'] = title
     } else {
       params.role = 'alert'
       params['aria-busy'] = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
@@ -12,6 +12,7 @@ import {
   loadScss,
 } from '../../../core/jest/jestSetup'
 import Component from '../ProgressIndicator'
+import { format } from '../../number-format/NumberUtils'
 
 const props = fakeProps(require.resolve('../ProgressIndicator'), {
   all: true,
@@ -40,10 +41,15 @@ describe('Circular ProgressIndicator component', () => {
       Comp.find('.dnb-progress-indicator__circular')
         .instance()
         .getAttribute('aria-label')
-    ).toBe('50%')
+    ).toBe(
+      format(50, {
+        decimals: 2,
+        percent: true,
+      })
+    )
   })
 
-  it('has role of alert or progressbar depending if progress has a vlaue', () => {
+  it('has role of alert or progressbar depending if progress has a value', () => {
     Comp.setProps({
       progress: undefined,
     })
@@ -71,13 +77,94 @@ describe('Circular ProgressIndicator component', () => {
       Comp.find('.dnb-progress-indicator__circular')
         .instance()
         .getAttribute('aria-label')
-    ).toBe('80%')
+    ).toBe(
+      format(80, {
+        decimals: 2,
+        percent: true,
+      })
+    )
     expect(
       Comp.find(mainLineSelector).instance().getAttribute('style')
     ).toBe('stroke-dashoffset: 17.599999999999994;')
     Comp.setProps({
       progress: 50,
     })
+  })
+
+  it('has aria-label set to the value of progress property when title is default', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={1} />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBe(
+      format(1, {
+        decimals: 2,
+        percent: true,
+      })
+    )
+  })
+
+  it('has title set to the value of progress property when title is default', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={1} />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('title')
+    ).toBe(
+      format(1, {
+        decimals: 2,
+        percent: true,
+      })
+    )
+  })
+
+  it('does not have aria-label when progress, and title is both null', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={null} title={null} />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBeNull()
+  })
+
+  it('does not have title when progress, and title is both null', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={null} title={null} />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('title')
+    ).toBeNull()
+  })
+
+  it('has aria-label set to the value of title property', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={1} title="loading" />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBe('loading')
+  })
+
+  it('has title set to the value of title property', () => {
+    const CircularComp = mount(
+      <Component {...props} type="circular" progress={1} title="loading" />
+    )
+    expect(
+      CircularComp.find('.dnb-progress-indicator__circular')
+        .instance()
+        .getAttribute('title')
+    ).toBe('loading')
   })
 
   it('should validate with ARIA rules as a svg element', async () => {
@@ -104,10 +191,28 @@ describe('Linear ProgressIndicator component', () => {
       Comp.find('.dnb-progress-indicator__linear')
         .instance()
         .getAttribute('aria-label')
-    ).toBe('50%')
+    ).toBe(
+      format(50, {
+        decimals: 2,
+        percent: true,
+      })
+    )
   })
 
-  it('has role of alert or progressbar depending if progress has a vlaue', () => {
+  it('has to have a title with a 50% value', () => {
+    expect(
+      Comp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('title')
+    ).toBe(
+      format(50, {
+        decimals: 2,
+        percent: true,
+      })
+    )
+  })
+
+  it('has role of alert or progressbar depending if progress has a value', () => {
     Comp.setProps({
       progress: undefined,
     })
@@ -135,13 +240,94 @@ describe('Linear ProgressIndicator component', () => {
       Comp.find('.dnb-progress-indicator__linear')
         .instance()
         .getAttribute('aria-label')
-    ).toBe('80%')
+    ).toBe(
+      format(80, {
+        decimals: 2,
+        percent: true,
+      })
+    )
     expect(
       Comp.find(mainLineSelector).instance().getAttribute('style')
     ).toBe('transform: translateX(-20%);')
     Comp.setProps({
       progress: 50,
     })
+  })
+
+  it('has aria-label set to the value of progress property when title is default', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={1} />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBe(
+      format(1, {
+        decimals: 2,
+        percent: true,
+      })
+    )
+  })
+
+  it('has title set to the value of progress property when title is default', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={1} d />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('title')
+    ).toBe(
+      format(1, {
+        decimals: 2,
+        percent: true,
+      })
+    )
+  })
+
+  it('does not have aria-label when progress, and title is both null', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={null} title={null} />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBeNull()
+  })
+
+  it('does not have title when progress, and title is both null', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={null} title={null} />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('title')
+    ).toBeNull()
+  })
+
+  it('has aria-label set to the value of title property', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={1} title="loading" />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('aria-label')
+    ).toBe('loading')
+  })
+
+  it('has title set to the value of title property', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={1} title="loading" />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('title')
+    ).toBe('loading')
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
@@ -19,6 +19,7 @@ exports[`Circular ProgressIndicator component have to match snapshot 1`] = `
         "section_style": "section_style",
         "show_label": "show_label",
         "size": "'default'",
+        "title": "title",
         "type": "'circular'",
         "visible": "visible",
       },
@@ -36,6 +37,7 @@ exports[`Circular ProgressIndicator component have to match snapshot 1`] = `
   section_style={null}
   show_label={false}
   size="default"
+  title={null}
   type="circular"
   visible={true}
 >
@@ -49,13 +51,14 @@ exports[`Circular ProgressIndicator component have to match snapshot 1`] = `
       onComplete={null}
       progress={50}
       size="default"
+      title="50,00 %"
       visible={true}
     >
       <div
-        aria-label="50%"
+        aria-label="50,00 %"
         className="dnb-progress-indicator__circular dnb-progress-indicator__circular--default dnb-progress-indicator__circular--has-progress-value"
         role="progressbar"
-        title="50%"
+        title="50,00 %"
       >
         <ForwardRef
           className="dnb-progress-indicator__circular__line light paused"
@@ -128,6 +131,7 @@ exports[`Linear ProgressIndicator component have to match snapshot 1`] = `
         "section_style": "section_style",
         "show_label": "show_label",
         "size": "'default'",
+        "title": "title",
         "type": "'circular'",
         "visible": "visible",
       },
@@ -145,6 +149,7 @@ exports[`Linear ProgressIndicator component have to match snapshot 1`] = `
   section_style={null}
   show_label={false}
   size="default"
+  title={null}
   type="linear"
   visible={true}
 >
@@ -157,13 +162,14 @@ exports[`Linear ProgressIndicator component have to match snapshot 1`] = `
       onComplete={null}
       progress={50}
       size="default"
+      title="50,00 %"
       visible={true}
     >
       <div
-        aria-label="50%"
+        aria-label="50,00 %"
         className="dnb-progress-indicator__linear dnb-progress-indicator__linear--default"
         role="progressbar"
-        title="50%"
+        title="50,00 %"
       >
         <div
           className="dnb-progress-indicator__linear__bar dnb-progress-indicator__linear__bar-transition"


### PR DESCRIPTION
This PR adds the possibility to customize the aria-label and title of progress indicator.
It also formats the default aria-label and title (progress prop value), using "NumberFormat" percent.

**Before this PR**

Title and aria-label - https://eufemia.dnb.no/uilib/components/progress-indicator/demos:
<img width="1188" alt="Screenshot 2021-06-04 at 10 13 35" src="https://user-images.githubusercontent.com/1359205/120771045-157b6b00-c51f-11eb-86aa-8d993996d924.png">


**Changes in this PR**

Formatting the default aria-label, and title, using "NumberFormat" for percent with 2 decimals:
<img width="1188" alt="Screenshot 2021-06-04 at 10 18 23" src="https://user-images.githubusercontent.com/1359205/120770890-ea911700-c51e-11eb-8bef-5e0c56e9b217.png">


Customizing the aria-label and title of progress indicator, by passing the `title` property:
<img width="1188" alt="Screenshot 2021-06-04 at 10 19 34" src="https://user-images.githubusercontent.com/1359205/120770944-faa8f680-c51e-11eb-96ee-0a5d5b5bd919.png">


