### PR TITLE
fix: add `stretch` property to space

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/properties.md
@@ -19,6 +19,7 @@ These properties are available in many other components and elements.
 | Properties    | Description                                                                                                                                                                                            |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `element`     | _(optional)_ defines the HTML element used. Defaults to `div`.                                                                                                                                         |
+| `stretch`     | _(optional)_ if set to `true`, then the space element will be 100% in `width`.                                                                                                                         |
 | `inline`      | _(optional)_ if set to `true`, then `display: inline-block;` is used, so the HTML elements gets aligned horizontally. Defaults to `false`.                                                             |
 | `no_collapse` | _(optional)_ if set to `true`, then a wrapper with `display: flow-root;` is used. This way You avoid **Margin Collapsing**. Defaults to `false`. _Note:_ You can't use `inline="true"` in combination. |
 

--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.js.snap
@@ -26,6 +26,7 @@ exports[`Skeleton component have to match snapshot 1`] = `
     right={null}
     skeleton={null}
     space={null}
+    stretch={null}
     top={null}
   >
     <Element

--- a/packages/dnb-eufemia/src/components/space/Space.js
+++ b/packages/dnb-eufemia/src/components/space/Space.js
@@ -39,6 +39,7 @@ export default class Space extends React.PureComponent {
 
     ...spacingPropTypes,
 
+    stretch: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     skeleton: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     class: PropTypes.string,
     className: PropTypes.string,
@@ -57,6 +58,7 @@ export default class Space extends React.PureComponent {
 
     ...spacingDefaultProps,
 
+    stretch: null,
     skeleton: null,
     class: null,
 
@@ -93,6 +95,7 @@ export default class Space extends React.PureComponent {
       bottom,
       left,
       space,
+      stretch,
       skeleton,
       id: _id, // eslint-disable-line
       className,
@@ -107,6 +110,7 @@ export default class Space extends React.PureComponent {
     const params = {
       className: classnames(
         'dnb-space',
+        isTrue(stretch) && 'dnb-space--stretch',
         isTrue(inline) && 'dnb-space--inline',
         createSkeletonClass(null, skeleton), // do not send along this.context
         createSpacingClasses({ top, right, bottom, left, space }),

--- a/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.js.snap
+++ b/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.js.snap
@@ -13,6 +13,7 @@ exports[`Space component have to match snapshot 1`] = `
   right={null}
   skeleton="skeleton"
   space={null}
+  stretch="stretch"
   top={null}
 >
   <Element
@@ -380,6 +381,9 @@ exports[`Space scss have to match snapshot 1`] = `
   @media screen and (-ms-high-contrast: none) {
     .dnb-space--no-collapse {
       overflow: auto; } }
+
+.dnb-space--stretch {
+  width: 100%; }
 
 .dnb-space--inline {
   display: inline-block; }

--- a/packages/dnb-eufemia/src/components/space/style/_space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/_space.scss
@@ -157,6 +157,9 @@
       overflow: auto;
     }
   }
+  &--stretch {
+    width: 100%;
+  }
   &--inline {
     display: inline-block;
   }


### PR DESCRIPTION
- This feature is an edge case, and is not needed often
- It is used in the new StepIndicator demos
