### PR TITLE
fix: fix input clear button mouse cursor issue

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -1927,6 +1927,9 @@ legend.dnb-form-label {
       border-radius: var(--button-border-radius); }
       .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
         margin: auto; }
+      html:not([data-whatintent='touch'])
+.dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+        cursor: default; }
   .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
     width: 1rem;
     height: 1rem; }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -2306,6 +2306,9 @@ legend.dnb-form-label {
       border-radius: var(--button-border-radius); }
       .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
         margin: auto; }
+      html:not([data-whatintent='touch'])
+.dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+        cursor: default; }
   .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
     width: 1rem;
     height: 1rem; }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.js.snap
@@ -942,6 +942,9 @@ legend.dnb-form-label {
       border-radius: var(--button-border-radius); }
       .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
         margin: auto; }
+      html:not([data-whatintent='touch'])
+.dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+        cursor: default; }
   .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
     width: 1rem;
     height: 1rem; }

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
@@ -1560,6 +1560,9 @@ legend.dnb-form-label {
       border-radius: var(--button-border-radius); }
       .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
         margin: auto; }
+      html:not([data-whatintent='touch'])
+.dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+        cursor: default; }
   .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
     width: 1rem;
     height: 1rem; }

--- a/packages/dnb-eufemia/src/components/input/style/_input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/_input.scss
@@ -297,6 +297,11 @@
       .dnb-button__icon {
         margin: auto;
       }
+
+      html:not([data-whatintent='touch'])
+        &:not(.dnb-button--has-text):hover[disabled] {
+        cursor: default;
+      }
     }
   }
   &--small &--clear.dnb-input__submit-element {


### PR DESCRIPTION
The clear button on the input field has a not-allowed mouse cursor type – when its not visible.

<img width="399" alt="Screenshot 2021-06-14 at 10 36 40" src="https://user-images.githubusercontent.com/1501870/121863845-90513c80-ccfc-11eb-9736-6a4cef4ce22a.png">


This PR changes the mouse cursor type to be default instead of "not-allowed". 