### PR TITLE
fix(checkbox): fix state styling during state change when status gets enabled

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -199,7 +199,7 @@ exports[`Checkbox scss have to match default theme snapshot 1`] = `
   .dnb-checkbox__input[disabled]:not(:checked):not([data-checked='true']) ~ .dnb-checkbox__button {
     border-color: var(--color-mint-green-50); }
   .dnb-checkbox__input:not([disabled]):checked:active ~ .dnb-checkbox__button,
-  .dnb-checkbox__input:not([disabled])[data-checked='true']:active ~ .dnb-checkbox__button {
+  .dnb-checkbox__input:not([disabled]):not([data-checked='true']):active ~ .dnb-checkbox__button {
     background-color: var(--color-mint-green-50);
     border-color: transparent; }
   .dnb-checkbox__input:not([disabled]):checked:active ~ .dnb-checkbox__gfx,
@@ -220,27 +220,28 @@ exports[`Checkbox scss have to match default theme snapshot 1`] = `
   .dnb-checkbox__input:not([disabled]):focus ~ .dnb-checkbox__button .dnb-checkbox__focus,
   .dnb-checkbox__input:not([disabled]):active ~ .dnb-checkbox__button .dnb-checkbox__focus {
     display: block; }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active) ~ .dnb-checkbox__button {
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active) ~ .dnb-checkbox__button {
     border: none; }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active) ~ .dnb-checkbox__button .dnb-checkbox__focus {
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active) ~ .dnb-checkbox__button .dnb-checkbox__focus {
     display: block;
     --border-color: var(--color-fire-red);
     box-shadow: 0 0 0 0.125rem var(--border-color);
     border-color: transparent; }
     @media screen and (-ms-high-contrast: none) {
-      .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active) ~ .dnb-checkbox__button .dnb-checkbox__focus {
+      .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active) ~ .dnb-checkbox__button .dnb-checkbox__focus {
         box-shadow: 0 0 0 0.125rem var(--color-fire-red); } }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):hover ~ .dnb-checkbox__button {
-    border-color: var(--color-fire-red);
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):hover ~ .dnb-checkbox__button {
     background-color: var(--color-fire-red-8); }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active):not(:hover) ~ .dnb-checkbox__button {
+    .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):hover ~ .dnb-checkbox__button[data-checked='true'] {
+      border-color: var(--color-fire-red); }
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover) ~ .dnb-checkbox__button {
     border-color: var(--color-fire-red-8); }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active):not(:hover):checked ~ .dnb-checkbox__button,
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active):not(:hover)[data-checked='true'] ~ .dnb-checkbox__button {
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover):checked ~ .dnb-checkbox__button,
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover)[data-checked='true'] ~ .dnb-checkbox__button {
     background-color: var(--color-fire-red); }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):hover ~ .dnb-checkbox__gfx {
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):hover ~ .dnb-checkbox__gfx {
     color: var(--color-fire-red); }
-  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:focus):not(:active):not(:hover) ~ .dnb-checkbox__gfx {
+  .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover) ~ .dnb-checkbox__gfx {
     color: var(--color-fire-red-8); }
 "
 `;

--- a/packages/dnb-eufemia/src/components/checkbox/style/themes/dnb-checkbox-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/checkbox/style/themes/dnb-checkbox-theme-ui.scss
@@ -45,7 +45,7 @@
 
   // On active
   &__input:not([disabled]):checked:active ~ &__button,
-  &__input:not([disabled])[data-checked='true']:active ~ &__button {
+  &__input:not([disabled]):not([data-checked='true']):active ~ &__button {
     background-color: var(--color-mint-green-50);
     border-color: transparent;
   }
@@ -88,42 +88,42 @@
 
   // On error state
   /* stylelint-disable */
-  &__status--error
-    &__input:not([disabled]):not(:focus):not(:active)
-    ~ &__button {
+  &__status--error &__input:not([disabled]):not(:active) ~ &__button {
     border: none;
   }
   &__status--error
-    &__input:not([disabled]):not(:focus):not(:active)
+    &__input:not([disabled]):not(:active)
     ~ &__button
     &__focus {
     display: block;
     @include fakeBorder(var(--color-fire-red), $focusRingWidth);
   }
-  &__status--error &__input:not([disabled]):not(:focus):hover ~ &__button {
-    border-color: var(--color-fire-red);
+  &__status--error &__input:not([disabled]):hover ~ &__button {
+    &[data-checked='true'] {
+      border-color: var(--color-fire-red);
+    }
     background-color: var(--color-fire-red-8);
   }
   /* stylelint-enable */
   &__status--error
-    &__input:not([disabled]):not(:focus):not(:active):not(:hover)
+    &__input:not([disabled]):not(:active):not(:hover)
     ~ &__button {
     border-color: var(--color-fire-red-8);
   }
   &__status--error
-    &__input:not([disabled]):not(:focus):not(:active):not(:hover):checked
+    &__input:not([disabled]):not(:active):not(:hover):checked
     ~ &__button,
   &__status--error
-    &__input:not([disabled]):not(:focus):not(:active):not(:hover)[data-checked='true']
+    &__input:not([disabled]):not(:active):not(:hover)[data-checked='true']
     ~ &__button {
     background-color: var(--color-fire-red);
   }
   // check gfx color
-  &__status--error &__input:not([disabled]):not(:focus):hover ~ &__gfx {
+  &__status--error &__input:not([disabled]):hover ~ &__gfx {
     color: var(--color-fire-red);
   }
   &__status--error
-    &__input:not([disabled]):not(:focus):not(:active):not(:hover)
+    &__input:not([disabled]):not(:active):not(:hover)
     ~ &__gfx {
     color: var(--color-fire-red-8);
   }


### PR DESCRIPTION
This PR fixes a request by Marthe.

The change: When using the `status` prop, and the status changes while the users toggles the checkbox, it will potentially confuse a user when the checkbox still is green, but gets red one the element focus disappears. 


This  commit will ensure the visual state changes as expected.

Here is a quick demo of this new version: https://codesandbox.io/s/eufemia-checkbox-state-styles-660bn?file=/src/App.tsx
