### PR TITLE
fix: lower z-index usage in #section component and support up to 5 nested sections

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
@@ -559,7 +559,7 @@ button.dnb-button::-moz-focus-inner {
   .dnb-section::after {
     content: '';
     position: absolute;
-    z-index: -3;
+    z-index: -15;
     left: -100vw;
     top: 0;
     width: 100vw;
@@ -568,9 +568,15 @@ button.dnb-button::-moz-focus-inner {
     background-color: currentColor;
     box-shadow: 99vw 0 0 0 currentColor, 198vw 0 0 0 currentColor, 297vw 0 0 0 currentColor, 396vw 0 0 0 currentColor; }
   .dnb-section > .dnb-section::after {
-    z-index: -2; }
+    z-index: -14; }
   .dnb-section > .dnb-section > .dnb-section::after {
-    z-index: -1; }
+    z-index: -13; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -12; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -11; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -10; }
   .dnb-section--spacing-small {
     padding-top: var(--spacing-small);
     padding-bottom: var(--spacing-small); }

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.js.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.js.snap
@@ -152,7 +152,7 @@ exports[`Section scss have to match snapshot 1`] = `
   .dnb-section::after {
     content: '';
     position: absolute;
-    z-index: -3;
+    z-index: -15;
     left: -100vw;
     top: 0;
     width: 100vw;
@@ -161,9 +161,15 @@ exports[`Section scss have to match snapshot 1`] = `
     background-color: currentColor;
     box-shadow: 99vw 0 0 0 currentColor, 198vw 0 0 0 currentColor, 297vw 0 0 0 currentColor, 396vw 0 0 0 currentColor; }
   .dnb-section > .dnb-section::after {
-    z-index: -2; }
+    z-index: -14; }
   .dnb-section > .dnb-section > .dnb-section::after {
-    z-index: -1; }
+    z-index: -13; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -12; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -11; }
+  .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section > .dnb-section::after {
+    z-index: -10; }
   .dnb-section--spacing-small {
     padding-top: var(--spacing-small);
     padding-bottom: var(--spacing-small); }

--- a/packages/dnb-eufemia/src/components/section/style/_section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/_section.scss
@@ -13,7 +13,7 @@
   &::after {
     content: '';
     position: absolute;
-    z-index: -3;
+    z-index: -15;
     left: -100vw;
     top: 0;
     width: 100vw;
@@ -27,10 +27,19 @@
       297vw 0 0 0 currentColor, 396vw 0 0 0 currentColor;
   }
   & > &::after {
-    z-index: -2;
+    z-index: -14;
   }
   & > & > &::after {
-    z-index: -1;
+    z-index: -13;
+  }
+  & > & > & > &::after {
+    z-index: -12;
+  }
+  & > & > & > & > &::after {
+    z-index: -11;
+  }
+  & > & > & > & > & > &::after {
+    z-index: -10;
   }
 
   &--spacing-small {


### PR DESCRIPTION
Here is a quick CSB that demos the issue: https://codesandbox.io/s/eufemia-textarea-in-nested-sections-0lnvt?file=/src/App.tsx

The border of the textarea dissapers when used in nested sections.