### PR TITLE
fix: currency param should accept string and boolean values

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -50,8 +50,8 @@ export interface formatOptionParams {
   nin?: boolean;
   /** percent type */
   percent?: boolean;
-  /** currency type */
-  currency?: boolean;
+  /** Currency code (ISO 4217) or `true` to use the default, `NOK`. */
+  currency?: string | boolean;
 
   /** Intl.NumberFormat currency option – you can use false or empty string to hide the sign/name */
   currency_display?: string;

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -33,7 +33,7 @@ const NUMBER_CHARS = '\\-0-9,.'
  * @property {boolean} ban - if true, it formats to a Bank Account Number
  * @property {boolean} nin - if true, it formats to a National Identification Number
  * @property {boolean} percent - if true, it formats with a percent
- * @property {boolean} currency - if true, it formats to a currency
+ * @property {string|boolean} currency - currency code (ISO 4217) or `true` to use the default, `NOK`
  * @property {string} currency_display - use false or empty string to hide the sign or "code", "name", "symbol" or "narrowSymbol" – supports the API from number.toLocaleString
  * @property {string} currency_position - can be "before" or "after"
  * @property {string} omit_currency_sign - hides currency sign if true is given


### PR DESCRIPTION
The motivation for making this change is that we migrate our apps to TypeScript, and it seems like the currency param of the number format function only accepts a boolean value(according to the declaration file), but I believe/think the actual implementation accepts a string(Currency code (ISO 4217)) as well.

https://github.com/dnbexperience/eufemia/blob/e412541451c1bc1ab44aea645ae79e954bcde70f/packages/dnb-eufemia/src/components/number-format/NumberUtils.js#L45

https://github.com/dnbexperience/eufemia/blob/e412541451c1bc1ab44aea645ae79e954bcde70f/packages/dnb-eufemia/src/components/number-format/NumberUtils.js#L117

We use the number format function quite a few places in our apps, and especially in our tests 🙏 