### PR TITLE
fix: fix aria-labelledby & remove it on input fields for better a11y

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -16,6 +16,7 @@ import {
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
+  combineLabelledBy,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
@@ -554,13 +555,11 @@ class DropdownInstance extends React.PureComponent {
     }
 
     if (label) {
-      triggerParams['aria-labelledby'] = [
-        triggerParams['aria-labelledby'],
+      triggerParams['aria-labelledby'] = combineLabelledBy(
+        triggerParams,
         id + '-label',
-        id, // used to read the current value
-      ]
-        .filter(Boolean)
-        .join(' ')
+        id // used to read the current value
+      )
     }
 
     // also used for code markup simulation

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -455,9 +455,6 @@ export default class Input extends React.PureComponent {
     if (readOnly) {
       inputParams['aria-readonly'] = inputParams.readOnly = true
     }
-    if (!hasValue && placeholder && focusState !== 'focus') {
-      inputParams['aria-labelledby'] = id + '-placeholder'
-    }
 
     const shellParams = {
       className: classnames(

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.js
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.js
@@ -219,6 +219,49 @@ describe('Input component', () => {
     )
   })
 
+  it('uses aria-placeholder and label for when placeholder is set', async () => {
+    const Comp = mount(
+      <Component
+        id="unique"
+        placeholder="Placeholder-text"
+        label="Label-text"
+      />
+    )
+
+    expect(await axeComponent(Comp)).toHaveNoViolations()
+
+    expect(Comp.find('label').instance().getAttribute('for')).toContain(
+      'unique'
+    )
+    expect(
+      Comp.find('input').instance().getAttribute('aria-placeholder')
+    ).toContain('Placeholder-text')
+
+    Comp.setProps({
+      label: undefined,
+    })
+
+    expect(Comp.exists('label')).toBe(false)
+    expect(
+      Comp.find('input').instance().getAttribute('aria-placeholder')
+    ).toContain('Placeholder-text')
+    expect(
+      Comp.find('input').instance().hasAttribute('aria-labelledby')
+    ).toBe(false)
+
+    Comp.setProps({
+      placeholder: undefined,
+    })
+
+    expect(Comp.exists('label')).toBe(false)
+    expect(
+      Comp.find('input').instance().hasAttribute('aria-placeholder')
+    ).toBe(false)
+    expect(
+      Comp.find('input').instance().hasAttribute('aria-labelledby')
+    ).toBe(false)
+  })
+
   it('has correct medium input size', () => {
     const Comp = mount(<Component size="medium" />)
     expect(Comp.find('.dnb-input--medium').exists()).toBe(true)

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.js
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.js
@@ -13,6 +13,7 @@ import {
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
+  combineLabelledBy,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import {
@@ -226,7 +227,7 @@ export default class RadioGroup extends React.PureComponent {
       )
     }
     if (label) {
-      params['aria-labelledby'] = id + '-label'
+      params['aria-labelledby'] = combineLabelledBy(params, id + '-label')
     }
 
     // also used for code markup simulation

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.js
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.js
@@ -19,6 +19,7 @@ import {
   dispatchCustomElementEvent,
   getPreviousSibling,
   filterProps,
+  combineLabelledBy,
 } from '../../shared/component-helper'
 import {
   spacingPropTypes,
@@ -1123,7 +1124,10 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
       params['aria-label'] = label
     }
     if (selected_key) {
-      params['aria-labelledby'] = `${this._id}-tab-${selected_key}`
+      params['aria-labelledby'] = combineLabelledBy(
+        params,
+        `${this._id}-tab-${selected_key}`
+      )
     }
     return (
       <div

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.js
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.js
@@ -4,6 +4,7 @@ import classnames from 'classnames'
 import {
   validateDOMAttributes,
   isTrue,
+  combineLabelledBy,
 } from '../../shared/component-helper'
 import { createSpacingClasses } from '../space/SpacingHelper'
 import Section from '../section/Section'
@@ -75,7 +76,10 @@ export default class ContentWrapper extends React.PureComponent {
     const params = rest
 
     if (key) {
-      params['aria-labelledby'] = `${id}-tab-${key}`
+      params['aria-labelledby'] = combineLabelledBy(
+        params,
+        `${id}-tab-${key}`
+      )
     }
 
     validateDOMAttributes(this.props, params)

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.js
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.js
@@ -14,6 +14,7 @@ import {
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
+  combineLabelledBy,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import {
@@ -271,7 +272,7 @@ export default class ToggleButtonGroup extends React.PureComponent {
       )
     }
     if (label) {
-      params['aria-labelledby'] = id + '-label'
+      params['aria-labelledby'] = combineLabelledBy(params, id + '-label')
     }
 
     // also used for code markup simulation


### PR DESCRIPTION
- This PR removes the usage of aria-labelledby on input fields
- fixes usage of multi usage (internal + extenal) merge of aria-labelledby on several components, like Slider

My tests has shown that both VoiceOver (latest) and NVDA (latest) works well with only aria-placeholder for placeholder usage. So both the label and the placeholder are getting accounced. 
Also added tests to verify the behaviour.