### PR TITLE
fix: remove main role from modal and enhance usage of aria linking

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/Modal.js
+++ b/packages/dnb-eufemia/src/components/modal/Modal.js
@@ -48,6 +48,7 @@ export default class Modal extends React.PureComponent {
     spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     open_delay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     content_id: PropTypes.string,
+    dialog_title: PropTypes.string,
     close_title: PropTypes.string,
     hide_close_button: PropTypes.oneOfType([
       PropTypes.string,
@@ -150,6 +151,7 @@ export default class Modal extends React.PureComponent {
     spacing: true,
     open_delay: null,
     content_id: null,
+    dialog_title: 'Vindu',
     close_title: 'Lukk', // Close Modal Window
     hide_close_button: false,
     close_button_attributes: null,

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.js
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.js
@@ -26,6 +26,7 @@ import {
 import ScrollView from '../../fragments/scroll-view/ScrollView'
 import ModalContext from './ModalContext'
 import ModalHeader, { ModalHeaderBar } from './ModalHeader'
+import { IS_IOS, IS_SAFARI, IS_MAC } from '../../shared/helpers'
 
 export default class ModalContent extends React.PureComponent {
   static propTypes = {
@@ -41,6 +42,7 @@ export default class ModalContent extends React.PureComponent {
     content_id: PropTypes.string,
     title: PropTypes.node,
     close_title: PropTypes.string,
+    dialog_title: PropTypes.string,
     hide_close_button: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool,
@@ -91,6 +93,7 @@ export default class ModalContent extends React.PureComponent {
     content_id: null,
     title: null,
     close_title: null,
+    dialog_title: null,
     hide_close_button: null,
     close_button_attributes: null,
     spacing: null,
@@ -365,6 +368,7 @@ export default class ModalContent extends React.PureComponent {
       modal_content,
       bar_content,
       close_title, // eslint-disable-line
+      dialog_title, // eslint-disable-line
       hide_close_button, // eslint-disable-line
       close_button_attributes, // eslint-disable-line
       spacing,
@@ -406,19 +410,35 @@ export default class ModalContent extends React.PureComponent {
 
     const contentParams = {
       /**
+       * Do not use role="dialog" on Safari
+       *
        * VoiceOver has troubles with role="dialog" and "Modal in Modal",
        * the result is, only the first Modal gets focus (set by Safari)
-       * so we only use "main" instead of "dialog"
+       *
+       * Tests have shown: Both VoiceOver are working fine with the:
+       * "aria-labelledby" and "aria-describedby" approach
        *
        */
-      role: 'main',
+      role: IS_MAC || IS_SAFARI || IS_IOS ? undefined : 'dialog',
       'aria-modal': 'true',
+
+      /**
+       * ARIA references
+       */
       'aria-labelledby': combineLabelledBy(
         this.props,
         title ? id + '-title' : null,
         labelled_by
       ),
       'aria-describedby': combineDescribedBy(this.props, id + '-content'),
+
+      /**
+       * If no labelled_by and no title is given,
+       * set a fallback "dialog_title"
+       */
+      'aria-label':
+        !title && !labelled_by ? this.props.dialog_title : undefined,
+
       className: classnames(
         'dnb-modal__content',
         mode && `dnb-modal__content--${mode}`,

--- a/packages/dnb-eufemia/src/components/modal/ModalHeader.js
+++ b/packages/dnb-eufemia/src/components/modal/ModalHeader.js
@@ -37,13 +37,19 @@ export default class ModalHeader extends React.PureComponent {
       return cur.type === 'h1' || cur.type === H1
     })
 
+    const usedTitle = title || this.context.title
+    const showTitle = !customHeader && usedTitle
+
     return (
       <Section
         style_type="white"
         className={classnames('dnb-modal__header', className)}
+        id={
+          showTitle ? 'dnb-modal-' + this.context.id + '-title' : undefined
+        }
         {...props}
       >
-        {!customHeader && (title || this.context.title) && (
+        {showTitle && (
           <h1
             className={classnames(
               'dnb-modal__title',
@@ -54,7 +60,7 @@ export default class ModalHeader extends React.PureComponent {
                 : 'dnb-h--large'
             )}
           >
-            {title || this.context.title}
+            {usedTitle}
           </h1>
         )}
         <div className="dnb-modal__header__inner">{children}</div>

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -18,6 +18,7 @@ exports[`Modal component have to match snapshot 1`] = `
         "container_placement": "'left'",
         "content_class": "content_class",
         "content_id": "content_id",
+        "dialog_title": "dialog_title",
         "direct_dom_return": "direct_dom_return",
         "disabled": "disabled",
         "focus_selector": "focus_selector",
@@ -76,10 +77,11 @@ exports[`Modal component have to match snapshot 1`] = `
   className={null}
   close_button_attributes={null}
   close_modal={null}
-  close_title="close_title"
+  close_title="Lukk"
   container_placement={null}
   content_class={null}
   content_id={null}
+  dialog_title="Vindu"
   direct_dom_return={true}
   disabled={null}
   focus_selector={null}
@@ -686,6 +688,7 @@ exports[`Modal component have to match snapshot 1`] = `
           "container_placement": "'left'",
           "content_class": "content_class",
           "content_id": "content_id",
+          "dialog_title": "dialog_title",
           "direct_dom_return": "direct_dom_return",
           "disabled": "disabled",
           "focus_selector": "focus_selector",
@@ -745,10 +748,11 @@ exports[`Modal component have to match snapshot 1`] = `
     closeModal={[Function]}
     close_button_attributes={null}
     close_modal={null}
-    close_title="close_title"
+    close_title="Lukk"
     container_placement={null}
     content_class={null}
     content_id="dnb-modal-modal_id"
+    dialog_title="Separat Vindu"
     direct_dom_return={true}
     focus_selector={null}
     fullscreen="auto"
@@ -793,6 +797,7 @@ exports[`Modal component have to match snapshot 1`] = `
             "container_placement": "'left'",
             "content_class": "content_class",
             "content_id": "content_id",
+            "dialog_title": "dialog_title",
             "direct_dom_return": "direct_dom_return",
             "disabled": "disabled",
             "focus_selector": "focus_selector",
@@ -852,10 +857,11 @@ exports[`Modal component have to match snapshot 1`] = `
       closeModal={[Function]}
       close_button_attributes={null}
       close_modal={null}
-      close_title="close_title"
+      close_title="Lukk"
       container_placement={null}
       content_class={null}
       content_id="dnb-modal-modal_id"
+      dialog_title="Separat Vindu"
       focus_selector={null}
       fullscreen="auto"
       header_content={null}
@@ -889,7 +895,7 @@ exports[`Modal component have to match snapshot 1`] = `
         className="dnb-modal__content dnb-modal__content--auto-fullscreen dnb-modal__content--modal dnb-modal__content--spacing dnb-modal__content--no-animation"
         id="dnb-modal-modal_id"
         onClick={[Function]}
-        role="main"
+        role="dialog"
       >
         <ForwardRef(ScrollViewRef)
           className="dnb-modal__content__inner dnb-core-style"
@@ -949,7 +955,7 @@ exports[`Modal component have to match snapshot 1`] = `
                               <span
                                 class="dnb-button__text dnb-skeleton--show-font"
                               >
-                                close_title
+                                Lukk
                               </span>
                               <span
                                 aria-hidden="true"
@@ -992,7 +998,7 @@ exports[`Modal component have to match snapshot 1`] = `
                       >
                         <CloseButton
                           className={null}
-                          close_title="close_title"
+                          close_title="Lukk"
                           icon_position="left"
                           on_click={[Function]}
                           size="large"
@@ -1023,7 +1029,7 @@ exports[`Modal component have to match snapshot 1`] = `
                             status_props={null}
                             status_state="error"
                             stretch={null}
-                            text="close_title"
+                            text="Lukk"
                             title={null}
                             to={null}
                             tooltip={null}
@@ -1041,7 +1047,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                 bounding={null}
                                 class={null}
                                 className="dnb-modal__close-button"
-                                content="close_title"
+                                content="Lukk"
                                 custom_content={null}
                                 custom_element={null}
                                 custom_method={null}
@@ -1065,7 +1071,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                 status_props={null}
                                 status_state="error"
                                 stretch={null}
-                                text="close_title"
+                                text="Lukk"
                                 title={null}
                                 to={null}
                                 tooltip={null}
@@ -1083,7 +1089,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                   className="dnb-button__text dnb-skeleton--show-font"
                                   key="button-text"
                                 >
-                                  close_title
+                                  Lukk
                                 </span>
                                 <IconPrimary
                                   alt={null}
@@ -1137,7 +1143,7 @@ exports[`Modal component have to match snapshot 1`] = `
                               icon="error"
                               icon_size="medium"
                               id="null-form-status"
-                              label="close_title"
+                              label="Lukk"
                               no_animation={null}
                               role={null}
                               show={null}
@@ -1167,12 +1173,14 @@ exports[`Modal component have to match snapshot 1`] = `
                     class={null}
                     className="dnb-modal__header"
                     element="section"
+                    id="dnb-modal-modal_id-title"
                     inner_ref={null}
                     spacing={null}
                     style_type="white"
                   >
                     <section
                       className="dnb-section dnb-section--white dnb-modal__header"
+                      id="dnb-modal-modal_id-title"
                     >
                       <h1
                         className="dnb-modal__title dnb-space__top--zero dnb-space__bottom--small dnb-h--large"

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.js
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.js
@@ -57,6 +57,7 @@ export default {
       indicator_label: 'Getting data ...',
     },
     Modal: {
+      dialog_title: 'Dialog Window',
       close_title: 'Close',
     },
     NumberFormat: {

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.js
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.js
@@ -57,6 +57,7 @@ export default {
       indicator_label: 'Henter data ...',
     },
     Modal: {
+      dialog_title: 'Separat Vindu',
       close_title: 'Lukk',
     },
     NumberFormat: {


### PR DESCRIPTION
This PR contains changes to the Modal/Drawer component.

The reason: axe-core reports failure about the usage of several role="main"

- Remove `role="main"` on Mac/iOS/Safari
- All other enviroments will use `role="dialog"`
- If no modal title is given, a `aria-label="Dialog"` will be present, defiend in the locale/translation files