### PR TITLE
fix: add type definitions to stylis plugin

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -1,15 +1,15 @@
 {
   "private": true,
   "name": "dnb-design-system-portal",
+  "version": "1.0.0",
   "description": "DNB Design System Portal",
   "license": "SEE LICENSE IN LICENSE FILE",
   "author": "DNB Team & Tobias Høegh",
-  "version": "1.0.0",
   "main": "index.js",
   "scripts": {
     "build": "NODE_NO_WARNINGS=1 gatsby build --no-uglify",
-    "build:version": "node ./scripts/version.js --new-version",
     "build-ci": "yarn build:version && yarn build --prefix-paths && yarn commit-new-pages",
+    "build:version": "node ./scripts/version.js --new-version",
     "clean": "NODE_NO_WARNINGS=1 gatsby clean",
     "precommit": "yarn lint-staged",
     "commit-new-pages": "node ./scripts/commitPages.js",
@@ -21,8 +21,8 @@
     "deploy": "yarn deploy-ci",
     "deploy-ci": "node ./scripts/deploy.js",
     "lint": "eslint --quiet ./src",
-    "lint:ci": "yarn lint:js && yarn lint:styles",
     "lint-staged": "lint-staged",
+    "lint:ci": "yarn lint:js && yarn lint:styles",
     "lint:js": "yarn lint --fix",
     "lint:js:staged": "eslint --quiet --fix",
     "lint:styles": "stylelint './src/**/*.{js,css}'",
@@ -33,7 +33,8 @@
     "test": "jest",
     "test:ci": "jest --ci --passWithNoTests",
     "test:staged": "jest --bail --findRelatedTests ",
-    "test:types": "echo Type checking on the Portal code is not implemented yet",
+    "test:types": "tsc --noEmit",
+    "test:types:watch": "tsc --noEmit --watch",
     "test:update": "jest --updateSnapshot",
     "prettier:components": "prettier --loglevel warn --write './src/uilib/{components,extensions}/**/*.{js,md}' './src/docs/uilib/{components,elements,extensions}/*.{js,md}'",
     "prettier:diff": "prettier --list-different '{scripts,stories,src}/**/*.{js,md}'",
@@ -124,13 +125,14 @@
     "stylelint-config-standard": "22.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0",
-    "svg-react-loader": "0.4.6"
-  },
-  "installConfig": {
-    "hoistingLimits": "dependencies"
+    "svg-react-loader": "0.4.6",
+    "typescript": "4.5.5"
   },
   "buildVersion": "[LOCAL BUILD]",
   "changelogVersion": "April, 5. 2021",
+  "installConfig": {
+    "hoistingLimits": "dependencies"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/dnb-design-system-portal/tsconfig.json
+++ b/packages/dnb-design-system-portal/tsconfig.json
@@ -2,9 +2,18 @@
   "compileOnSave": false,
   "compilerOptions": {
     "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["node", "jest"],
+    "outDir": "./out",
+    "rootDir": ".",
+    "baseUrl": ".",
     "paths": {
       "Pages/*": ["./src/docs/*"]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".cache", "public"]
 }

--- a/packages/dnb-eufemia/src/style/stylis.d.ts
+++ b/packages/dnb-eufemia/src/style/stylis.d.ts
@@ -1,0 +1,38 @@
+export interface StylisElement {
+  type: string;
+  value: string;
+  props: Array<string> | string;
+  root: StylisElement | null;
+  parent: StylisElement | null;
+  children: Array<StylisElement> | string;
+  line: number;
+  column: number;
+  length: number;
+  return: string;
+}
+export type StylisPluginCallback = (
+  element: StylisElement,
+  index: number,
+  children: Array<StylisElement>,
+  callback: StylisPluginCallback
+) => string | void;
+
+export type StylisPlugin = (
+  element: StylisElement,
+  index: number,
+  children: Array<StylisElement>,
+  callback: StylisPluginCallback
+) => string | void;
+
+export interface Options {
+  nonce?: string;
+  stylisPlugins?: Array<StylisPlugin>;
+  key: string;
+  container?: HTMLElement;
+  speedy?: boolean;
+  prepend?: boolean;
+}
+
+export type Properties = Record<string, unknown>;
+
+export function withProperties(properties: Properties): StylisPlugin;

--- a/packages/dnb-eufemia/tsconfig.json
+++ b/packages/dnb-eufemia/tsconfig.json
@@ -6,12 +6,10 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
-    "declaration": true,
     "types": ["node", "jest"],
-    "sourceMap": true,
     "outDir": "./out",
     "rootDir": ".",
     "baseUrl": "."
   },
-  "exclude": ["node_modules", "build"]
+  "exclude": ["./node_modules", "build"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12899,6 +12899,7 @@ __metadata:
     stylelint-config-styled-components: 0.1.1
     stylelint-processor-styled-components: 1.10.0
     svg-react-loader: 0.4.6
+    typescript: 4.5.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Also remove unneeded tsconfig settings, like:

- Creating declaration files
- Creating source maps

Just because we only use tsc with --noEmit