### PR TITLE
fix: typescript types for step-indicator

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.js
@@ -20,7 +20,7 @@ import StepIndicatorModal from './StepIndicatorModal'
 import StepIndicatorList from './StepIndicatorList'
 import { StepIndicatorProvider } from './StepIndicatorContext'
 import {
-  stepIndicatorPropsTypes,
+  stepIndicatorPropTypes,
   stepIndicatorDefaultProps,
 } from './StepIndicatorProps'
 
@@ -32,7 +32,7 @@ export default class StepIndicator extends React.PureComponent {
 
   static propTypes = {
     sidebar_id: PropTypes.string,
-    ...stepIndicatorPropsTypes,
+    ...stepIndicatorPropTypes,
   }
 
   static defaultProps = {

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorProps.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorProps.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { spacingPropTypes } from '../space/SpacingHelper'
 
-export const stepIndicatorPropsTypes = {
+export const stepIndicatorPropTypes = {
   mode: PropTypes.oneOf(['static', 'strict', 'loose']),
   data: PropTypes.oneOfType([
     PropTypes.string,


### PR DESCRIPTION
Seems like it was a ```s``` too much in the variable name of step indicator's TypeScript types.
```stepIndicatorPropsTypes``` vs. ```stepIndicatorPropTypes```.

I think this is what causes the definition file to not include the correct types.

_NB: Make sure you include *PropType in the variable name. This also effects references inside a single file._ - https://eufemia.dnb.no/uilib/development/types#sharing-proptypes-between-components