### PR TITLE
fix: ensure date-picker fires on_change event when clearing a date

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.js
@@ -69,7 +69,11 @@ export default class DatePickerAddon extends React.PureComponent {
   }
 
   callOnChange({ startDate, endDate, event = null } = {}) {
-    this.context.setDate({ startDate, endDate, changeMonthViews: true })
+    this.context.updateState({
+      startDate,
+      endDate,
+      changeMonthViews: true,
+    })
     this.context.callOnChangeHandler({ startDate, endDate, event })
   }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.js
@@ -240,7 +240,7 @@ export default class DatePickerCalendar extends React.PureComponent {
 
       state.changeMonthViews = true
 
-      this.context.setDate(state, () => {
+      this.context.updateState(state, () => {
         // call after state update, so the input get's the latest state as well
         this.callOnSelect({
           event,
@@ -601,7 +601,7 @@ export default class DatePickerCalendar extends React.PureComponent {
                                     resetDate,
                                     event,
                                     onSelect: (state) =>
-                                      this.context.setDate(state, () =>
+                                      this.context.updateState(state, () =>
                                         this.callOnSelect({
                                           event,
                                           nr,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
@@ -52,7 +52,7 @@ export default class DatePickerFooter extends React.PureComponent {
       args.event.persist()
     }
 
-    this.context.setDate(
+    this.context.updateState(
       {
         startDate,
         endDate,
@@ -71,7 +71,7 @@ export default class DatePickerFooter extends React.PureComponent {
       args.event.persist()
     }
 
-    this.context.setDate(
+    this.context.updateState(
       {
         date: undefined,
         startDate: undefined,
@@ -89,11 +89,8 @@ export default class DatePickerFooter extends React.PureComponent {
   render() {
     const { isRange } = this.props
 
-    const {
-      show_reset_button,
-      show_cancel_button,
-      show_submit_button,
-    } = this.context.props
+    const { show_reset_button, show_cancel_button, show_submit_button } =
+      this.context.props
 
     if (
       !isRange &&
@@ -103,11 +100,8 @@ export default class DatePickerFooter extends React.PureComponent {
       return <></>
     }
 
-    const {
-      submit_button_text,
-      cancel_button_text,
-      reset_button_text,
-    } = this.context.translation.DatePicker
+    const { submit_button_text, cancel_button_text, reset_button_text } =
+      this.context.translation.DatePicker
 
     return (
       <div className="dnb-date-picker__footer">

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
@@ -165,16 +165,24 @@ export default class DatePickerInput extends React.PureComponent {
   }
 
   callOnChangeAsInvalid = (state) => {
-    const { startDate, endDate, event } = { ...this.context, ...state }
-    this.context.updateState({ hoverDate: null })
-    if (this.context.hasHadValidDate) {
-      this.context.callOnChangeHandler({ startDate, endDate, event })
-      this.context.updateState({ hasHadValidDate: false })
-    }
+    this.context.updateState(
+      {
+        hoverDate: null,
+      },
+      () => {
+        if (this.context.hasHadValidDate) {
+          const { startDate, endDate, event } = {
+            ...this.context,
+            ...state,
+          }
+          this.context.callOnChangeHandler({ startDate, endDate, event })
+        }
+      }
+    )
   }
 
   callOnChange = ({ startDate, endDate, event }) => {
-    const state = { changeMonthViews: true, hasHadValidDate: false }
+    const state = { changeMonthViews: true }
     if (typeof startDate !== 'undefined' && isValid(startDate)) {
       state.startDate = startDate
     }
@@ -185,7 +193,7 @@ export default class DatePickerInput extends React.PureComponent {
       state.endDate = endDate
     }
 
-    this.context.setDate(state, () => {
+    this.context.updateState(state, () => {
       if (
         (typeof startDate !== 'undefined' && isValid(startDate)) ||
         (typeof endDate !== 'undefined' && isValid(endDate))
@@ -456,7 +464,7 @@ export default class DatePickerInput extends React.PureComponent {
         event,
       })
     } else {
-      this.context.setDate({ [`${mode}Date`]: null })
+      this.context.updateState({ [`${mode}Date`]: null })
       this.context.updateState({ [`__${mode}${type}`]: value })
 
       this.callOnChangeAsInvalid({

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.js
@@ -153,9 +153,8 @@ export default class DatePickerProvider extends React.PureComponent {
 
     if (
       state.lastEventCallCache &&
-      (String(state.lastEventCallCache.startDate) !==
-        String(state.startDate) ||
-        String(state.lastEventCallCache.endDate) !== String(state.endDate))
+      (state.lastEventCallCache.startDate !== state.startDate ||
+        state.lastEventCallCache.endDate !== state.endDate)
     ) {
       state.lastEventCallCache = {}
     }
@@ -164,6 +163,7 @@ export default class DatePickerProvider extends React.PureComponent {
       state.__startDay = pad(format(state.startDate, 'dd'), 2)
       state.__startMonth = pad(format(state.startDate, 'MM'), 2)
       state.__startYear = format(state.startDate, 'yyyy')
+      state.hasHadValidDate = true
     } else if (state.startDate === undefined) {
       state.__startDay = null
       state.__startMonth = null
@@ -174,6 +174,7 @@ export default class DatePickerProvider extends React.PureComponent {
       state.__endDay = pad(format(state.endDate, 'dd'), 2)
       state.__endMonth = pad(format(state.endDate, 'MM'), 2)
       state.__endYear = format(state.endDate, 'yyyy')
+      state.hasHadValidDate = true
     } else if (state.endDate === undefined) {
       state.__endDay = null
       state.__endMonth = null
@@ -241,30 +242,15 @@ export default class DatePickerProvider extends React.PureComponent {
     this.setState({ ...state, _listenForPropChanges: false }, cb)
   }
 
-  setDate = (state, cb = null) => {
-    this.setState({ ...state, _listenForPropChanges: false }, cb)
-
-    const startDateIsValid = Boolean(
-      state.startDate && isValid(state.startDate)
-    )
-    const endDateIsValid = Boolean(state.endDate && isValid(state.endDate))
-
-    this.setState({
-      hasHadValidDate: startDateIsValid || endDateIsValid,
-    })
-  }
-
   callOnChangeHandler = (args) => {
     /**
-     * Prevent on_change to be fired twite if date not has actually changed
+     * Prevent on_change to be fired twice if date not has actually changed
      * We clear the cache inside getDerivedStateFromProps
      */
     if (
       this.state.lastEventCallCache &&
-      String(this.state.lastEventCallCache.startDate) ===
-        String(this.state.startDate) &&
-      String(this.state.lastEventCallCache.endDate) ===
-        String(this.state.endDate)
+      this.state.lastEventCallCache.startDate === this.state.startDate &&
+      this.state.lastEventCallCache.endDate === this.state.endDate
     ) {
       return // stop here
     }
@@ -350,7 +336,6 @@ export default class DatePickerProvider extends React.PureComponent {
         value={{
           translation: this.context.translation,
           setViews: this.setViews,
-          setDate: this.setDate,
           updateState: this.updateState,
           getReturnObject: this.getReturnObject,
           callOnChangeHandler: this.callOnChangeHandler,

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
@@ -509,7 +509,7 @@ describe('DatePicker component', () => {
     expect(on_change.mock.calls[4][0].is_valid).toBe(true)
   })
 
-  it('has valid event calls', () => {
+  it('has valid on_type and on_change event calls', () => {
     const on_type = jest.fn()
     const on_change = jest.fn()
 
@@ -615,7 +615,7 @@ describe('DatePicker component', () => {
     testInteraction({
       type: 'end',
       typeIndex: 4,
-      changeIndex: 2,
+      changeIndex: 3, // because we do not count the first one
       dayElem: endDayElem,
       monthElem: endMonthElem,
       yearElem: endYearElem,


### PR DESCRIPTION
Ensure date-picker fires on_change event when clearing a date – but only if there has been a valid one before
