### PR TITLE
fix: use id when setting data-dnb-modal-active

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.md
@@ -98,6 +98,18 @@ The Modal component is using **3000** as the `z-index`.
 }
 ```
 
+### data-dnb-modal-active
+
+When a Modal / Drawer is open, it will set a HTML attribute on the main HTML Element called `data-dnb-modal-active`. The attribute value will be the ID of the current Modal / Drawer.
+
+This can be used to handle z-index issues from within CSS only:
+
+```css
+html[data-dnb-modal-active='MODAL-ID'] {
+  /* Your css */
+}
+```
+
 ## The Drawer mode
 
 The modal comes with a `drawer` mode. The drawer is made to be used in different content usage than the modal. Typically in context interactions.

--- a/packages/dnb-eufemia/src/components/modal/Modal.js
+++ b/packages/dnb-eufemia/src/components/modal/Modal.js
@@ -394,7 +394,7 @@ export default class Modal extends React.PureComponent {
         }
       }
 
-      this.setActiveState(true)
+      this.setActiveState(this._id)
     } else if (modalActive === false) {
       if (this._triggerRef && this._triggerRef.current) {
         this._triggerRef.current.focus({ preventScroll: true })
@@ -414,8 +414,10 @@ export default class Modal extends React.PureComponent {
         }
       }
 
-      const list = getListOfModalRoots()
-      if (list.length <= 1) {
+      const last = getListOfModalRoots(-1)
+      if (last) {
+        this.setActiveState(last._id)
+      } else if (getListOfModalRoots().length <= 1) {
         this.setActiveState(false)
       }
     }
@@ -453,13 +455,23 @@ export default class Modal extends React.PureComponent {
     }
   }
 
-  setActiveState(modalActive) {
+  setActiveState(modalId) {
     // prevent scrolling on the background
     if (typeof document !== 'undefined') {
       try {
+        if (modalId) {
+          document.documentElement.setAttribute(
+            'data-dnb-modal-active',
+            modalId
+          )
+        } else {
+          document.documentElement.removeAttribute('data-dnb-modal-active')
+        }
+
+        // Deprecated
         document.body.setAttribute(
           'data-dnb-modal-active',
-          modalActive ? 'true' : 'false'
+          modalId ? 'true' : 'false'
         )
       } catch (e) {
         warn(

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.js
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.js
@@ -121,7 +121,7 @@ export default class ModalContent extends React.PureComponent {
   constructor(props) {
     super(props)
     this._contentRef = React.createRef()
-    this._id = makeUniqueId()
+    this._id = props.id
     this._ii = new InteractionInvalidation()
     this._ii.setBypassSelector([
       '.dnb-modal__content',
@@ -239,7 +239,9 @@ export default class ModalContent extends React.PureComponent {
   addToIndex() {
     if (typeof window !== 'undefined') {
       try {
-        window.__modalStack = window.__modalStack || []
+        if (!Array.isArray(window.__modalStack)) {
+          window.__modalStack = []
+        }
         window.__modalStack.push(this)
       } catch (e) {
         warn(e)
@@ -250,7 +252,9 @@ export default class ModalContent extends React.PureComponent {
   removeFromIndex() {
     if (typeof window !== 'undefined') {
       try {
-        window.__modalStack = window.__modalStack || []
+        if (!Array.isArray(window.__modalStack)) {
+          window.__modalStack = []
+        }
         window.__modalStack = window.__modalStack.filter(
           (cur) => cur !== this
         )
@@ -328,7 +332,8 @@ export default class ModalContent extends React.PureComponent {
   onKeyDownHandler = (e) => {
     switch (keycode(e)) {
       case 'esc': {
-        const mostCurrent = [...getListOfModalRoots()].pop()
+        // const mostCurrent = [...getListOfModalRoots()].pop()
+        const mostCurrent = getListOfModalRoots(-1)
 
         if (mostCurrent === this) {
           e.preventDefault()
@@ -395,7 +400,7 @@ export default class ModalContent extends React.PureComponent {
       ...rest
     } = this.props
 
-    const id = content_id || this._id
+    const contentId = content_id || makeUniqueId()
     const style = this.state.color
       ? { '--modal-background-color': `var(--color-${this.state.color})` }
       : null
@@ -430,10 +435,13 @@ export default class ModalContent extends React.PureComponent {
        */
       'aria-labelledby': combineLabelledBy(
         this.props,
-        title ? id + '-title' : null,
+        title ? contentId + '-title' : null,
         labelled_by
       ),
-      'aria-describedby': combineDescribedBy(this.props, id + '-content'),
+      'aria-describedby': combineDescribedBy(
+        this.props,
+        contentId + '-content'
+      ),
 
       /**
        * If no labelled_by and no title is given,
@@ -506,7 +514,10 @@ export default class ModalContent extends React.PureComponent {
     )
 
     const content = (
-      <div id={id + '-content'} className="dnb-modal__content__wrapper">
+      <div
+        id={contentId + '-content'}
+        className="dnb-modal__content__wrapper"
+      >
         {modal_content}
       </div>
     )
@@ -514,13 +525,13 @@ export default class ModalContent extends React.PureComponent {
     return (
       <ModalContext.Provider
         value={{
-          id,
+          id: contentId,
           setBackgroundColor: this.setBackgroundColor,
           ...this.props,
           onCloseClickHandler: this.onCloseClickHandler,
         }}
       >
-        <div id={id} {...contentParams}>
+        <div id={contentId} {...contentParams}>
           <ScrollView {...innerParams}>
             <div
               tabIndex="-1"

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.js
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.js
@@ -345,8 +345,17 @@ describe('Modal component', () => {
     expect(Comp.exists('#content-third')).toBe(false)
 
     Comp.find('button#modal-first').simulate('click')
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('modal-first')
     Comp.find('button#modal-second').simulate('click')
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('modal-second')
     Comp.find('button#modal-third').simulate('click')
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('modal-third')
 
     expect(on_open.first).toHaveBeenCalledTimes(1)
     expect(on_open.second).toHaveBeenCalledTimes(1)
@@ -388,6 +397,9 @@ describe('Modal component', () => {
     expect(on_close.second).toHaveBeenCalledTimes(0)
     expect(on_close.third).toHaveBeenCalledTimes(1)
 
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('modal-second')
     expect(Comp.exists('#content-third')).toBe(false)
     expect(
       Comp.find('#content-second').instance().hasAttribute('aria-hidden')
@@ -412,6 +424,9 @@ describe('Modal component', () => {
     expect(on_close.second).toHaveBeenCalledTimes(1)
     expect(on_close.third).toHaveBeenCalledTimes(1)
 
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('modal-first')
     expect(Comp.exists('#content-second')).toBe(false)
     expect(
       Comp.find('#content-first').instance().hasAttribute('aria-hidden')
@@ -431,6 +446,9 @@ describe('Modal component', () => {
     expect(on_close.third).toHaveBeenCalledTimes(1)
 
     expect(Comp.exists('#content-first')).toBe(false)
+    expect(
+      document.documentElement.hasAttribute('data-dnb-modal-active')
+    ).toBe(false)
   })
 
   it('will prevent closing the modal on prevent_close', () => {
@@ -589,18 +607,18 @@ describe('Modal component', () => {
     expect(document.body.style.boxSizing).toBe('border-box')
     expect(document.body.style.marginRight).toBe('0px')
     expect(document.documentElement.style.height).toBe('100%')
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'true'
-    )
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe(props.id)
 
     // close modal
     elem.simulate('click')
 
     expect(document.body.getAttribute('style')).toBe('')
     expect(document.documentElement.getAttribute('style')).toBe('')
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'false'
-    )
+    expect(
+      document.documentElement.hasAttribute('data-dnb-modal-active')
+    ).toBe(false)
   })
 
   it('runs expected side effects on iOS pre 14', () => {
@@ -635,9 +653,9 @@ describe('Modal component', () => {
       expect.any(Function)
     )
 
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'true'
-    )
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe(props.id)
 
     // close modal
     elem.simulate('click')
@@ -645,9 +663,9 @@ describe('Modal component', () => {
     expect(document.body.getAttribute('style')).toBeFalsy()
     expect(document.documentElement.getAttribute('style')).toBeFalsy()
 
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'false'
-    )
+    expect(
+      document.documentElement.hasAttribute('data-dnb-modal-active')
+    ).toBe(false)
 
     expect(removeEventListener).toBeCalledTimes(2)
     expect(removeEventListener).toHaveBeenCalledWith(
@@ -679,18 +697,18 @@ describe('Modal component', () => {
     expect(document.body.style.right).toBe('0px')
     expect(document.body.style.height).toBe('auto')
     expect(document.documentElement.style.height).toBe('100%')
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'true'
-    )
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe(props.id)
 
     // close modal
     elem.simulate('click')
 
     expect(document.body.getAttribute('style')).toBe('')
     expect(document.documentElement.getAttribute('style')).toBe('')
-    expect(document.body.getAttribute('data-dnb-modal-active')).toBe(
-      'false'
-    )
+    expect(
+      document.documentElement.hasAttribute('data-dnb-modal-active')
+    ).toBe(false)
   })
 
   it('has correct opened state when "open_state" is used', () => {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -1784,7 +1784,7 @@ button.dnb-button::-moz-focus-inner {
   --modal-overlay-transparent: rgba(0, 0, 0, 0);
   --modal-overlay-bg: rgba(0, 0, 0, 0.32); }
 
-[data-dnb-modal-active='true'] {
+[data-dnb-modal-active] {
   user-select: none;
   -webkit-user-select: none; }
 

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -27,7 +27,7 @@
   --modal-overlay-bg: rgba(0, 0, 0, 0.32);
 }
 
-[data-dnb-modal-active='true'] {
+[data-dnb-modal-active] {
   user-select: none;
   -webkit-user-select: none; // Safari / Touch fix
 }


### PR DESCRIPTION
**use id when setting data-dnb-modal-active**

Also, we now set it on the HTML element, instead of the body.

This makes it possible to access this state within the head tag, if needed (e.g. style tag with styles).
