### PR TITLE
fix: set data-dnb-drawer-list-active with id on HTML

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/info.md
@@ -64,3 +64,15 @@ render(
   />
 )
 ```
+
+### data-dnb-drawer-list-active
+
+When a DrawerList is open, it will set a HTML attribute on the main HTML Element called `data-dnb-drawer-list-active`. The attribute value will be the ID of the current DrawerList.
+
+This can be used to handle z-index issues from within CSS only:
+
+```css
+html[data-dnb-drawer-list-active='DrawerList-ID'] {
+  /* Your css */
+}
+```

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -315,10 +315,17 @@ export default class Autocomplete extends React.PureComponent {
     )
   }
 
+  constructor(props) {
+    super(props)
+
+    this._id = props.id || makeUniqueId()
+  }
+
   render() {
     return (
       <DrawerListProvider
         {...this.props}
+        id={this._id}
         data={this.props.data || this.props.children}
         opened={null}
         tagName="dnb-autocomplete"
@@ -326,7 +333,7 @@ export default class Autocomplete extends React.PureComponent {
         prevent_focus
         skip_keysearch
       >
-        <AutocompleteInstance {...this.props} />
+        <AutocompleteInstance id={this._id} {...this.props} />
       </DrawerListProvider>
     )
   }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -53,6 +53,12 @@ export default class DrawerList extends React.PureComponent {
     ...drawerListDefaultProps,
   }
 
+  constructor(props) {
+    super(props)
+
+    this._id = props.id || makeUniqueId()
+  }
+
   static enableWebComponent() {
     registerElement(
       DrawerList.tagName,
@@ -70,10 +76,11 @@ export default class DrawerList extends React.PureComponent {
 
     return (
       <DrawerListProvider
+        id={this._id}
         {...this.props}
         data={this.props.data || this.props.children}
       >
-        <DrawerListInstance {...this.props} />
+        <DrawerListInstance id={this._id} {...this.props} />
       </DrawerListProvider>
     )
   }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
@@ -1049,6 +1049,8 @@ export default class DrawerListProvider extends React.PureComponent {
         if (typeof onStateComplete === 'function') {
           onStateComplete(true)
         }
+
+        this.setActiveState(true)
       }
 
       if (isTrue(this.props.no_animation)) {
@@ -1137,6 +1139,7 @@ export default class DrawerListProvider extends React.PureComponent {
         }
         DrawerListProvider.isOpen = false
 
+        this.setActiveState(false)
         this.removeObservers()
       }
 
@@ -1148,6 +1151,28 @@ export default class DrawerListProvider extends React.PureComponent {
           delayHandler,
           DrawerListProvider.blurDelay
         ) // wait until animation is over
+      }
+    }
+  }
+
+  setActiveState(active) {
+    if (typeof document !== 'undefined') {
+      try {
+        if (active) {
+          document.documentElement.setAttribute(
+            'data-dnb-drawer-list-active',
+            String(this.props.id)
+          )
+        } else {
+          document.documentElement.removeAttribute(
+            'data-dnb-drawer-list-active'
+          )
+        }
+      } catch (e) {
+        warn(
+          'DrawerList: Error on set "data-dnb-drawer-list-active" by using element.setAttribute()',
+          e
+        )
       }
     }
   }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.js
@@ -10,6 +10,7 @@ import {
   axeComponent,
   toJson,
   loadScss,
+  attachToBody,
 } from '../../../core/jest/jestSetup'
 import Component from '../DrawerList'
 
@@ -230,6 +231,31 @@ describe('DrawerList component', () => {
 
     const selectedItem = mockData[props.value + 1]
     expect(on_select.mock.calls[1][0].data).toStrictEqual(selectedItem) // second call!
+  })
+
+  it('will set data-dnb-drawer-list-active with id', () => {
+    const Comp = mount(
+      <Component {...props} opened={false} data={mockData} />,
+      {
+        attachTo: attachToBody(),
+      }
+    )
+
+    Comp.setProps({
+      opened: true,
+    })
+
+    expect(
+      document.documentElement.getAttribute('data-dnb-drawer-list-active')
+    ).toBe(props.id)
+
+    Comp.setProps({
+      opened: false,
+    })
+
+    expect(
+      document.documentElement.hasAttribute('data-dnb-drawer-list-active')
+    ).toBe(false)
   })
 
   it('has valid on_change callback', () => {


### PR DESCRIPTION
This PR make it possible to let CSS styles know if another drawer-list is "open" and what ID it has. 

We may considder to add docs for this as well. 