### PR TITLE
chore: add yarn version to volta project

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "yarn": ">=1.17.0"
   },
   "volta": {
-    "node": "14.17.0"
+    "node": "14.17.0",
+    "yarn": "1.22.10"
   },
   "packageManager": "yarn@3.1.0-rc.8"
 }


### PR DESCRIPTION
Not sure if we "need to" specify the yarn version(not sure if this is the correct version) for volta, but lately, whenever I run any yarn command, I always get the following message error.
```
Volta error: No Yarn version found in this project.
Use `volta pin yarn` to select a version (see `volta help pin` for more info).
```

Could just be that the problem exists between chair and keyboard, if then, feel free to delete this 🙏 