### PR TITLE
chore: make title of tabbar optional

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
@@ -87,9 +87,11 @@ export default function Tabbar({
 
   return (
     <div className="dnb-tabbar">
-      <AutoLinkHeader className="dnb-no-focus" level={1} skip_correction>
-        {title}
-      </AutoLinkHeader>
+      {title && (
+        <AutoLinkHeader className="dnb-no-focus" level={1} skip_correction>
+          {title}
+        </AutoLinkHeader>
+      )}
       <Tabs
         id="tabbar"
         data={preparedTabs}
@@ -144,7 +146,7 @@ Tabbar.propTypes = {
   location: PropTypes.object.isRequired,
   tabs: PropTypes.array,
   defaultTabs: PropTypes.array,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   hideTabs: PropTypes.array,
   usePath: PropTypes.string.isRequired,
   children: PropTypes.node,
@@ -157,6 +159,7 @@ Tabbar.defaultProps = {
     { title: 'Properties', key: '/properties' },
     { title: 'Events', key: '/events' },
   ],
+  title: null,
   hideTabs: null,
   children: null,
 }


### PR DESCRIPTION
Usually when running eufemia locally, `yarn start`, I get the following errors in the console:
![image](https://user-images.githubusercontent.com/1359205/137183993-4abe68ca-ab08-48f7-b5af-9836bfc4b8bb.png)
This PR should fix these errors.