### PR TITLE
chore(Portal): ensure we do unregister the service worker during development

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -102,17 +102,19 @@ const plugins = [
     },
   },
   'gatsby-plugin-emotion',
-  // this (optional) plugin enables Progressive Web App + Offline functionality
-  // To learn more, visit: https://gatsby.app/offline
-  {
-    resolve: 'gatsby-plugin-offline',
-    options: {
-      workboxConfig: {
-        globPatterns: ['*.html'],
-        maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+  process.env.NODE_ENV === 'development'
+    ? 'gatsby-plugin-remove-serviceworker'
+    : {
+        // this (optional) plugin enables Progressive Web App + Offline functionality
+        // To learn more, visit: https://gatsby.app/offline
+        resolve: 'gatsby-plugin-offline',
+        options: {
+          workboxConfig: {
+            globPatterns: ['*.html'],
+            maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+          },
+        },
       },
-    },
-  },
 ].filter(Boolean)
 
 // used for algolia search

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -97,6 +97,7 @@
     "gatsby-plugin-offline": "4.14.0",
     "gatsby-plugin-page-creator": "3.14.0",
     "gatsby-plugin-react-helmet": "4.14.0",
+    "gatsby-plugin-remove-serviceworker": "1.0.0",
     "gatsby-plugin-sass": "4.14.0",
     "gatsby-plugin-sharp": "3.14.0",
     "gatsby-react-router-scroll": "4.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12031,6 +12031,7 @@ __metadata:
     gatsby-plugin-offline: 4.14.0
     gatsby-plugin-page-creator: 3.14.0
     gatsby-plugin-react-helmet: 4.14.0
+    gatsby-plugin-remove-serviceworker: 1.0.0
     gatsby-plugin-sass: 4.14.0
     gatsby-plugin-sharp: 3.14.0
     gatsby-react-router-scroll: 4.14.0
@@ -15262,6 +15263,13 @@ fsevents@^1.2.7:
     gatsby: ^3.0.0-next.0
     react-helmet: ^5.1.3 || ^6.0.0
   checksum: c5c2150d663cbdbedb1bf93ea11b6cb4a08e225bc1f400ad12c41f5b44f7d4a1ed63a4fe10dbdffc46b3fa7def593bfb334c337ea3794d62bfddd8985e77f9ca
+  languageName: node
+  linkType: hard
+
+"gatsby-plugin-remove-serviceworker@npm:1.0.0":
+  version: 1.0.0
+  resolution: "gatsby-plugin-remove-serviceworker@npm:1.0.0"
+  checksum: ecdc0697c7e0b00afc8527a73b4317d95e9cbf77aafae0d82f50a796980d8f411496faa69ab695cc017da262d80f4fcf1a9bc14999eca3e8b81e1563743899f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR ensures we do remove the sw.js during development.

1. when a prod build was visited
2. and we later visit the same port, but during dev, then the service worker did deliver the offline files and did not find "any" new static files, as dev mode is different.