### PR TITLE
Enhance handling of FormStatus / GlobalStatus race condition

### DIFF
--- a/packages/dnb-eufemia-sandbox/stories/components/GlobalStatus.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/GlobalStatus.js
@@ -18,6 +18,7 @@ import {
   FormRow,
   FormSet,
   Autocomplete,
+  DatePicker,
 } from '@dnb/eufemia/src/components'
 import {
   H2,
@@ -62,6 +63,11 @@ export const ComponentAsLabel = () => {
         <Autocomplete
           label={<Component />}
           status={status ? status + '3' : undefined}
+        />
+        <DatePicker
+          label={<Component />}
+          show_input
+          status={status ? status + '4' : undefined}
         />
       </FormSet>
     </>

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1839,7 +1839,7 @@ class AutocompleteInstance extends React.PureComponent {
                     icon_size || (size === 'large' ? 'medium' : 'default')
                   }
                   size={size}
-                  status={!opened && status ? status_state : null}
+                  status={status ? status_state : null}
                   status_state={status_state}
                   type={null}
                   submit_element={submitButton}

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -474,7 +474,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                 size={null}
                 skeleton="skeleton"
                 spellCheck="false"
-                status={null}
+                status="error"
                 status_no_animation={null}
                 status_props={null}
                 status_state="error"
@@ -506,7 +506,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                 value="CC cc"
               >
                 <span
-                  className="dnb-input dnb-input--null dnb-form-component dnb-autocomplete__input dnb-input--icon-position-null dnb-input--has-icon dnb-input--icon-size-icon_size dnb-input--has-submit-element"
+                  className="dnb-input dnb-input--null dnb-form-component dnb-autocomplete__input dnb-input--icon-position-null dnb-input--has-icon dnb-input--icon-size-icon_size dnb-input--has-submit-element dnb-input__status--error"
                   data-has-content="true"
                   data-input-state="virgin"
                 >
@@ -532,13 +532,13 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                       label={null}
                       no_animation={null}
                       role={null}
-                      show={null}
+                      show={false}
                       size="default"
                       skeleton="skeleton"
                       state="error"
                       status="error"
                       stretch={null}
-                      text={null}
+                      text="error"
                       text_id="autocomplete-id-status"
                       title={null}
                       variant={null}

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.js
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.js
@@ -275,7 +275,7 @@ export default class FormStatus extends React.PureComponent {
           status_id,
           {
             state,
-            status_id,
+            // status_id,
             item: {
               status_id: this.state.id,
               text,

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
@@ -768,12 +768,12 @@ exports[`GlobalStatus snapshot have to match component snapshot 1`] = `
     Array [
       Object {
         "id": "id-1",
-        "status_id": "idid-1textitem-1",
+        "item_id": "idid-1textitem-1",
         "text": "item #1",
       },
       Object {
         "id": "id-2",
-        "status_id": "idid-2textitem-2",
+        "item_id": "idid-2textitem-2",
         "text": "item #2",
       },
     ]
@@ -1467,14 +1467,14 @@ Array [
                     >
                       <p
                         className="dnb-p"
-                        id="switch-form-status-0"
+                        id="status-idswitch-form-statustexterror-messagestatus-anchor-labeltypespankeynullrefnullpropschildrenlabel-ownernull-storestatus-anchor-urltrue-0"
                       >
                         error-message
                       </p>
                       <a
-                        aria-describedby="switch-form-status-0"
+                        aria-describedby="status-idswitch-form-statustexterror-messagestatus-anchor-labeltypespankeynullrefnullpropschildrenlabel-ownernull-storestatus-anchor-urltrue-0"
                         className="dnb-anchor"
-                        href="#switch-form-status"
+                        href="#status-idswitch-form-statustexterror-messagestatus-anchor-labeltypespankeynullrefnullpropschildrenlabel-ownernull-storestatus-anchor-urltrue"
                         lang="nb-NO"
                         onClick={[Function]}
                         onKeyDown={[Function]}

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedProps____.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedProps____.js
@@ -1,0 +1,71 @@
+import PropTypes from 'prop-types'
+import Input, { inputPropTypes } from '../input/Input'
+
+export const maskedPropTypes = {
+  mask: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+    PropTypes.func,
+  ]),
+  number_mask: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
+  currency_mask: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
+  mask_options: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  number_format: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  locale: PropTypes.string,
+  as_currency: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  as_number: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  as_percent: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  show_mask: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  show_guide: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  pipe: PropTypes.func,
+  keep_char_positions: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
+  placeholder_char: PropTypes.string,
+  inner_ref: PropTypes.object,
+
+  on_change: PropTypes.func,
+  on_submit: PropTypes.func,
+  on_focus: PropTypes.func,
+  on_blur: PropTypes.func,
+  on_submit_focus: PropTypes.func,
+  on_submit_blur: PropTypes.func,
+
+  ...inputPropTypes,
+}
+
+export const maskedDefaultProps = {
+  ...Input.defaultProps,
+
+  mask: [],
+  number_mask: null,
+  currency_mask: null,
+  mask_options: null,
+  number_format: null,
+  as_currency: null,
+  as_number: null,
+  as_percent: null,
+  locale: null,
+  show_mask: false,
+  show_guide: true,
+  pipe: null,
+  keep_char_positions: false,
+  placeholder_char: '_',
+  inner_ref: null,
+
+  on_change: null,
+  on_submit: null,
+  on_focus: null,
+  on_blur: null,
+  on_submit_focus: null,
+  on_submit_blur: null,
+}

--- a/packages/dnb-eufemia/src/shared/AnimateHeight.js
+++ b/packages/dnb-eufemia/src/shared/AnimateHeight.js
@@ -53,6 +53,8 @@ export default class AnimateHeight {
 
   // Public methods
   setElement(elem, container = null) {
+    this._removeEndEvents() // in case element gets set several times
+
     this.elem =
       elem ||
       (typeof document !== 'undefined' && document.createElement('div'))
@@ -132,6 +134,7 @@ export default class AnimateHeight {
     } catch (e) {
       //
     }
+
     if (animate === false || this.opts?.animate === false) {
       this.elem.style.height = `${toHeight}px`
       this._callOnStart()
@@ -200,12 +203,17 @@ export default class AnimateHeight {
     this.elem.style.height = `${height}px`
     return height
   }
-  adjustTo(fromHeight, toHeight = null, { animate = true } = {}) {
+  adjustTo(fromHeight = null, toHeight = null, { animate = true } = {}) {
     if (!this.elem) {
       return
     }
 
-    toHeight = toHeight !== null ? toHeight : this.getUnknownHeight()
+    if (fromHeight === null) {
+      fromHeight = this.getHeight()
+    }
+    if (toHeight === null) {
+      toHeight = this.getUnknownHeight()
+    }
 
     this.state = 'adjusting'
     this._removeEndEvents() // also, remove events on every open (but not on close!)


### PR DESCRIPTION
This PR fixes an issue where Autocomplete (also DatePicker) includes nested FormStatus, because of inherited components. The inherited, and not visible one did cause the message to disappear in the GlobalStatus – basically at the same time it should have been visible.

Also, it enhances the height animation of a GlobalStatus for when a message is added or removed.  