### PR TITLE
fix: make cache_hash of DrawerList optional

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -455,13 +455,14 @@ DrawerList.Options.displayName = 'DrawerList.Options'
 DrawerList.Options.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
     .isRequired,
-  cache_hash: PropTypes.string.isRequired,
+  cache_hash: PropTypes.string,
   showFocusRing: PropTypes.bool,
   className: PropTypes.string,
   class: PropTypes.string,
   triangleRef: PropTypes.object,
 }
 DrawerList.Options.defaultProps = {
+  cache_hash: null,
   showFocusRing: false,
   className: null,
   class: null,


### PR DESCRIPTION
I was getting a few errors in Chrome's console when running the the following portal page(https://eufemia.dnb.no/uilib/components/fragments/drawer-list/info) locally(http://localhost:8000/uilib/components/fragments/drawer-list/info): 
```
Warning: Failed prop type: The prop `cache_hash` is marked as required in `DrawerList.Options`, but its value is `undefined`...
```

To me, it also seems like it was intended for the cache_hash to be optional, see the documentation for the property cache_hash here https://eufemia.dnb.no/uilib/components/fragments/drawer-list/properties.