### PR TITLE
fix: small spelling mistake in ProgressIndicator test

### DIFF
--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
@@ -272,7 +272,7 @@ describe('Linear ProgressIndicator component', () => {
 
   it('has title set to the value of progress property when title is default', () => {
     const LinearComp = mount(
-      <Component {...props} type="linear" progress={1} d />
+      <Component {...props} type="linear" progress={1} />
     )
     expect(
       LinearComp.find('.dnb-progress-indicator__linear')


### PR DESCRIPTION
I got a small error when running tests for ProgressIndicator:
```
Warning: Received `true` for a non-boolean attribute `d`.
```
Turns out it was a sneaky "d" character in one of the tests.