### PR TITLE
fix: warning message when running tests for DatePicker

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
@@ -168,6 +168,7 @@ describe('DatePicker component', () => {
         {...defaultProps}
         on_days_render={on_days_render}
         range={false}
+        end_date={null}
       />
     )
 


### PR DESCRIPTION
I got a small error when running tests for DatePicker:
```
Eufemia: The DatePicker got a "end_date". You have to set range={true} as well!.
```
To fix/improve this, I set the `end_date` to be null for the given test https://github.com/dnbexperience/eufemia/pull/1056/files