### PR TITLE
chore(Testing): omit / bypass @testing-library act warning

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -142,3 +142,26 @@ if (typeof window !== 'undefined') {
   const { getComputedStyle } = window
   window.getComputedStyle = (...args) => getComputedStyle(...args)
 }
+
+const originalError = console.error
+export function bypassActWarning() {
+  // this is just a little hack to silence a warning that we'll get until we
+  // upgrade to 16.9. See also: https://github.com/facebook/react/pull/14853
+  beforeAll(() => {
+    console.error = (...args) => {
+      if (/Warning.*not wrapped in act/.test(args[0])) {
+        return
+      }
+      originalError.call(console, ...args)
+    }
+  })
+
+  afterAll(() => {
+    console.error = originalError
+  })
+}
+
+// Call it for now regardless
+// TODO: We may call this later only if enzyme is used
+// but we can't call it "inside a test", because we use beforeAll / afterAll
+bypassActWarning()


### PR DESCRIPTION
Right now, even if we don't import anything from @testing-library we get the act warning – even if only a setState is used INSIDE a component, and not the tests.

So I suggest we bypass that warning for now with this PR.