### PR TITLE
fix: fix TS Type import statement duplication issue – happen with the Modal component

### DIFF
--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes.js
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes.js
@@ -85,7 +85,7 @@ export const createTypes = async (
         // file.includes('/Element.js') ||
         // file.includes('/Blockquote.js') ||
         // file.includes('/Button.js')
-        file.includes('/Dropdown')
+        file.includes('/Modal')
       if (isDev && (!isOfInterest || (await existsInGit(destFile)))) {
         return // stop here
       }

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__mocks__/PrimaryComponent.js
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__mocks__/PrimaryComponent.js
@@ -69,6 +69,7 @@ export default class PrimaryComponent extends React.PureComponent {
   }
 
   static Secondary = SecondaryComponent
+  static SecondaryDuplication = SecondaryComponent
 
   render() {
     return [

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginCorrectTypes.test.js.snap
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginCorrectTypes.test.js.snap
@@ -57,6 +57,7 @@ PrimaryComponent.defaultProps = {
   children: null
 };
 PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
 
 const Element = () => {
   return null;

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginExtendTypes.test.js.snap
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginExtendTypes.test.js.snap
@@ -35,6 +35,7 @@ export interface PrimaryComponentProps extends React.HTMLProps<HTMLElement> {
 }
 export default class PrimaryComponent extends React.Component<PrimaryComponentProps, any> {
   static defaultProps: object;
+  static SecondaryDuplication = SecondaryComponent;
   static Secondary = SecondaryComponent;
   render(): JSX.Element;
 }"

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginIncludeDocs.test.js.snap
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginIncludeDocs.test.js.snap
@@ -85,6 +85,7 @@ PrimaryComponent.defaultProps = {
   children: null
 };
 PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
 
 const Element = () => {
   return null;
@@ -233,6 +234,7 @@ PrimaryComponent.defaultProps = {
   children: null
 };
 PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
 
 const Element = () => {
   return null;
@@ -381,6 +383,7 @@ PrimaryComponent.defaultProps = {
   children: null
 };
 PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
 
 const Element = () => {
   return null;

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginPropTypesRelations.test.js.snap
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/__tests__/__snapshots__/babelPluginPropTypesRelations.test.js.snap
@@ -57,6 +57,7 @@ PrimaryComponent.defaultProps = {
   children: null
 };
 PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
 
 const Element = () => {
   return null;

--- a/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/babelPluginExtendTypes.js
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/generateTypes/babelPluginExtendTypes.js
@@ -96,6 +96,21 @@ export function babelPluginExtendTypes(babel, { file } = {}) {
       Program(path) {
         root = path
 
+        const hasImportStatement = (importStatement) => {
+          let exists = false
+
+          root.traverse({
+            ImportDeclaration(path) {
+              if (importStatement === path.toString()) {
+                exists = true
+                path.stop()
+              }
+            },
+          })
+
+          return exists
+        }
+
         const classProperties = getListOfClassProperties({ file })
 
         if (classProperties) {
@@ -109,7 +124,9 @@ export function babelPluginExtendTypes(babel, { file } = {}) {
             }) => {
               root.traverse({
                 ImportDeclaration(path) {
-                  path.insertAfter(babel.template.ast(importStatement))
+                  if (!hasImportStatement(importStatement)) {
+                    path.insertAfter(babel.template.ast(importStatement))
+                  }
                   path.stop()
                 },
               })
@@ -214,7 +231,8 @@ function getListOfClassProperties({ file }) {
                         keyName,
                         valueName,
                         sourceFile,
-                        importStatement: path.parentPath.parentPath.toString(),
+                        importStatement:
+                          path.parentPath.parentPath.toString(),
                       })
 
                       path.stop()

--- a/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.d.ts
@@ -11,6 +11,9 @@ export class AutoSize extends React.Component<AutoSizeProps, any> {
 export interface SkeletonContextProps {
   translation?: {
     Skeleton: {
+      /**
+       * Is used for screen reader text translation, defined in the translation files. You can set a custom text if needed.
+       */
       aria_busy: string;
     };
   };
@@ -23,6 +26,9 @@ export const createSkeletonClass: (
 export interface skeletonDOMAttributesContext {
   translation?: {
     Skeleton: {
+      /**
+       * Is used for screen reader text translation, defined in the translation files. You can set a custom text if needed.
+       */
       aria_busy: string;
     };
   };


### PR DESCRIPTION
During generation of type definition files there was an issue where some import declarations where inserted twice. 

<img width="354" alt="Screenshot 2021-10-26 at 20 29 09" src="https://user-images.githubusercontent.com/1501870/138939219-ffb418a3-fd1e-4ff0-b7a9-5abc65f111e7.png">

https://ci.codesandbox.io/status/dnbexperience/eufemia/pr/1067/builds/1822 from PR #1067