### PR TITLE
fix(Typography): make docs more clear about the values used in typographic elements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.md
@@ -5,6 +5,8 @@ order: 2
 
 # Font Size
 
+For details about what values Typographic elements do use, have a loot at the [Fonts & Typography](/quickguide-designer/fonts#typographic-elements) documentation.
+
 ## Default `font-size` **rem** table
 
 | Pixel | Type       | Rem          | Custom Property        | Info                            |
@@ -12,10 +14,10 @@ order: 2
 | 14px  | `x-small`  | **0.875rem** | `--font-size-x-small`  | Do not use for texts            |
 | 16px  | `small`    | **1rem**     | `--font-size-small`    | [Fallback](#fallback-font-size) |
 | 18px  | `basis`    | **1.125rem** | `--font-size-basis`    | Default size                    |
-| 20px  | `medium`   | **1.25rem**  | `--font-size-medium`   | Lead                            |
-| 26px  | `large`    | **1.625rem** | `--font-size-large`    | Heading                         |
-| 34px  | `x-large`  | **2.125rem** | `--font-size-x-large`  | Heading                         |
-| 48px  | `xx-large` | **3rem**     | `--font-size-xx-large` | Heading                         |
+| 20px  | `medium`   | **1.25rem**  | `--font-size-medium`   |                                 |
+| 26px  | `large`    | **1.625rem** | `--font-size-large`    |                                 |
+| 34px  | `x-large`  | **2.125rem** | `--font-size-x-large`  |                                 |
+| 48px  | `xx-large` | **3rem**     | `--font-size-xx-large` |                                 |
 
 ## Additional `font-size` **em** table
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.md
@@ -9,6 +9,8 @@ import TypographyExamples from 'Pages/uilib/typography/TypographyExamples'
 
 # Font Weights
 
+For details about what values Typographic elements do use, have a loot at the [Fonts & Typography](/quickguide-designer/fonts#typographic-elements) documentation.
+
 ## Eufemia has three (3) font-weights
 
 - <span class="dnb-typo-regular">Regular</span> (normal)
@@ -17,11 +19,11 @@ import TypographyExamples from 'Pages/uilib/typography/TypographyExamples'
 
 ## `font-weight` table
 
-| Type        | Custom Property         | Info      |
-| ----------- | ----------------------- | --------- |
-| **Regular** | `--font-weight-regular` | Body text |
-| **Medium**  | `--font-weight-medium`  | Headings  |
-| **Bold**    | `--font-weight-bold`    |           |
+| Type        | Custom Property         |
+| ----------- | ----------------------- |
+| **Regular** | `--font-weight-regular` |
+| **Medium**  | `--font-weight-medium`  |
+| **Bold**    | `--font-weight-bold`    |
 
 ### How to use the weights (CSS)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/line-height.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/line-height.md
@@ -5,16 +5,18 @@ order: 3
 
 # Line Height
 
+For details about what values Typographic elements do use, have a loot at the [Fonts & Typography](/quickguide-designer/fonts#typographic-elements) documentation.
+
 ## Default `line-height` **rem** table
 
-| Pixel | Type      | Rem          | Custom Property         | Info      |
-| ----- | --------- | ------------ | ----------------------- | --------- |
-| 18px  | `x-small` | **1.125rem** | `--line-height-x-small` |           |
-| 20px  | `small`   | **1.25rem**  | `--line-height-small`   |           |
-| 24px  | `basis`   | **1.5rem**   | `--line-height-basis`   | Body text |
-| 32px  | `medium`  | **2rem**     | `--line-height-medium`  | H2        |
-| 40px  | `large`   | **2.5rem**   | `--line-height-large`   | H1 small  |
-| 56px  | `x-large` | **3.5rem**   | `--line-height-x-large` | H1        |
+| Pixel | Type      | Rem          | Custom Property         |
+| ----- | --------- | ------------ | ----------------------- |
+| 18px  | `x-small` | **1.125rem** | `--line-height-x-small` |
+| 20px  | `small`   | **1.25rem**  | `--line-height-small`   |
+| 24px  | `basis`   | **1.5rem**   | `--line-height-basis`   |
+| 32px  | `medium`  | **2rem**     | `--line-height-medium`  |
+| 40px  | `large`   | **2.5rem**   | `--line-height-large`   |
+| 56px  | `x-large` | **3.5rem**   | `--line-height-x-large` |
 
 <!-- - Used for `<h5>` and `<h6>`, who are not a part of the design system. -->
 


### PR DESCRIPTION
This PR makes it easier to understand (hopefully) on how the css properties in conjunction with what values are used in the typographic elements.
