### PR TITLE
fix: Fix bug where cleanNumber returns void in TS

### DIFF
--- a/packages/dnb-eufemia/jest.config.js
+++ b/packages/dnb-eufemia/jest.config.js
@@ -1,7 +1,7 @@
 const config = {
   testEnvironment: 'jsdom',
   testURL: 'http://localhost',
-  testRegex: '(/__tests__/\\.js|(\\.|/)(test|spec))\\.js?$',
+  testRegex: '(/__tests__/\\.js|(\\.|/)(test|spec))\\.[jt]s?$',
   modulePathIgnorePatterns: [
     'not_in_use',
     '<rootDir>/build/',
@@ -14,7 +14,7 @@ const config = {
   // We  may use this in future when converting to ESM
   // transformIgnorePatterns: ['/node_modules/(?!ora|globby)'],
   transform: {
-    '^.+\\.(js|jsx)$': 'babel-jest',
+    '^.+\\.(js|jsx|ts)$': 'babel-jest',
     '^.+\\.(md|txt|css|scss)$': 'jest-raw-loader',
   },
   moduleNameMapper: {

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -143,6 +143,7 @@
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "13.2.1",
+    "@types/jest": "27.0.2",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.3",
     "audit-ci": "4.1.0",
     "babel-jest": "27.2.4",

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -81,4 +81,4 @@ type cleanNumberOptions = {
 export const cleanNumber: (
   num: number | string,
   options?: cleanNumberOptions
-) => void;
+) => number | string;

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.spec.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.spec.ts
@@ -1,0 +1,8 @@
+import { cleanNumber } from '../NumberUtils'
+
+describe('NumberUtil typescript implementation', () => {
+  it('cleanNumber should return the type supplied to the function', () => {
+    expect(typeof cleanNumber('prefix 815 493 00 suffix')).toBe('string')
+    expect(typeof cleanNumber(81549300)).toBe('number')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,6 +1954,7 @@ __metadata:
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": 13.2.1
+    "@types/jest": 27.0.2
     "@wojtekmaj/enzyme-adapter-react-17": 0.6.3
     audit-ci: 4.1.0
     babel-jest: 27.2.4
@@ -2979,6 +2980,19 @@ __metadata:
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
   checksum: 0d34189874354a63bc80eeb99da75078ea8a65599c6cd0b937cf1909fc9d490f99adf5aa32ca5a67735496f131491f323b750983d471ecbbcd3e3fec618b01df
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^27.2.5":
+  version: 27.2.5
+  resolution: "@jest/types@npm:27.2.5"
+  dependencies:
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^16.0.0
+    chalk: ^4.0.0
+  checksum: 322603c24354a5333b5b7a670464422a46e0244a5a96a35552a7018eb4ac2e84c3b7657336b0ea6aa114963f9b6d0da8b8f6f963cb044fea9e7bc04d464b0ab1
   languageName: node
   linkType: hard
 
@@ -5591,6 +5605,16 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
+  languageName: node
+  linkType: hard
+
+"@types/jest@npm:27.0.2":
+  version: 27.0.2
+  resolution: "@types/jest@npm:27.0.2"
+  dependencies:
+    jest-diff: ^27.0.0
+    pretty-format: ^27.0.0
+  checksum: 814ad5f5d2f277849f47e52906da4b745758e555630fc8cb46a071bde648eefeffb1b35710c530a8cea7fc4ea7c1d813812c120484bf7902ab6c5e473cdd49c9
   languageName: node
   linkType: hard
 
@@ -19040,6 +19064,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^27.0.0":
+  version: 27.3.1
+  resolution: "jest-diff@npm:27.3.1"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^27.0.6
+    jest-get-type: ^27.3.1
+    pretty-format: ^27.3.1
+  checksum: 49231a4ac4bed1cce8f5135db2a26a83673d5cbe5716bca29900a45ae0ddf237099d9091acac436b9c60ab933b0e7ca086ce8cb71f44411b572b69adbe96128d
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^27.0.2, jest-diff@npm:^27.2.4":
   version: 27.2.4
   resolution: "jest-diff@npm:27.2.4"
@@ -19135,6 +19171,13 @@ fsevents@^1.2.7:
   version: 27.0.6
   resolution: "jest-get-type@npm:27.0.6"
   checksum: 2d4c1381bb5ddb212d80ad00497c7cbb3312358e10b62ac19f1fe5a28ae4af709202bfc235b77ec508970b83fd89945937652d636bcaf88614fa00028a6f3138
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^27.3.1":
+  version: 27.3.1
+  resolution: "jest-get-type@npm:27.3.1"
+  checksum: b0b8db1d770c6332b4189bbf4073184489acbb1095410cf53add033daf911577ee6bd1c4f8d747dd2f3d63de42f7eb15c5527fc7288a2855a046f4a8957cd902
   languageName: node
   linkType: hard
 
@@ -26318,6 +26361,18 @@ fsevents@^1.2.7:
     ansi-styles: ^4.0.0
     react-is: ^17.0.1
   checksum: e3b808404d7e1519f0df1aa1f25cee0054ab475775c6b2b8c5568ff23194a92d54bf93274139b6f584ca70fd773be4eaa754b0e03f12bb0a8d1426b07f079976
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.0, pretty-format@npm:^27.3.1":
+  version: 27.3.1
+  resolution: "pretty-format@npm:27.3.1"
+  dependencies:
+    "@jest/types": ^27.2.5
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: 2979eae85a4f7ba1c3946faa8f5c6497cc80dc64ba499ccd5fdada267f82dc664f315a4c1cdd4c0b4b97edbae399a7bf0a957cc1b87feb91cd95f1e436834fed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Fixes a small bug where `cleanNumber()` was specified as void in TypeScript and would not return a value.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Calling `cleanNumber('prefix 815 493 00 suffix')` results in the string `'81549300'`. Likewise, calling `cleanNumber(81549300)` results in the number `81549300`.
