### PR TITLE
chore(Release): fix permission issue to semantic-release-bot

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
This gives the bot access so it has permission to push to a restricted branch

Source: https://github.com/semantic-release/git/issues/196#issuecomment-601310576

## Why

During the release of v9.14 we changed the setup to push back to the release branch in order to persist the change log file. But we got a permission issue where the bot could not push to a protected branch.

Not 100% if this will help.