### PR TITLE
chore: use lower case when skipping CI

### DIFF
--- a/packages/dnb-design-system-portal/scripts/deploy.js
+++ b/packages/dnb-design-system-portal/scripts/deploy.js
@@ -35,7 +35,7 @@ const run = () => {
     {
       message: `Auto-generated deploy commit by ${
         CIName || 'localhost'
-      } ${currentVersion} [CI SKIP]`,
+      } ${currentVersion} [skip ci]`,
       branch: 'gh-pages',
       ...config,
     },

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -288,7 +288,7 @@
           "assets": [
             "CHANGELOG.md"
           ],
-          "message": "chore(release): ${nextRelease.version} [CI SKIP]\n\n${nextRelease.notes}"
+          "message": "chore(release): ${nextRelease.version} [skip ci] \n\n${nextRelease.notes}"
         }
       ]
     ]

--- a/packages/dnb-eufemia/scripts/prepub/commitToBranch.js
+++ b/packages/dnb-eufemia/scripts/prepub/commitToBranch.js
@@ -138,7 +138,7 @@ const commitToBranch = async ({
         `${
           isFeature ? 'feat:' : 'chore:'
         } some ${what} got added/changed during CI | ${files.join(', ')}${
-          skipCI ? ' [CI SKIP]' : ''
+          skipCI ? ' [skip ci]' : ''
         }`
       ).trim()
       log.info(`Commit: ${commitMessage}`)


### PR DESCRIPTION
This PR changes how we skip CI to be GitHub conform. GitHub [blog says](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) they have to be lower case. 

Why do we need the change? 

During release, when the change log gets commited back to release, we don't want this commit to run again. Right now it does run, e.g.:

https://github.com/dnbexperience/eufemia/commit/3d2923a70724b84c6b83362a33851727e1ba101a