### PR TITLE
chore: only run CI on push, and not on PR + push

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,17 +7,6 @@ on:
       - '!**--skip-ci'
       - '!**--visual-reports'
       - 'experiments/**'
-  pull_request:
-    types:
-      - opened
-    branches:
-      - main
-  # workflow_run:
-  #   workflows: ['actions-verify']
-  #   types:
-  #     - completed
-  # schedule:
-  #   - cron: '44 3 * * 5'
 
 jobs:
   action:


### PR DESCRIPTION
In order to "overwrite" existing branches, named `--visual-reports`, we can force push with lease as a solution.