### PR TITLE
chore: fix portal build cache

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,8 @@ on:
       - '**'
       - '!**--skip-ci'
       - '!**--visual-reports'
-      - 'experiments/**'
+      - '!wip/**'
+      - '!experiments/**'
 
 jobs:
   action:
@@ -80,8 +81,7 @@ jobs:
           path: |
             ./packages/dnb-design-system-portal/.cache
             ./packages/dnb-design-system-portal/public
-          key: ${{ runner.os }}-gatsby-${{ steps.date.outputs.timestamp }}
-          restore-keys: ${{ runner.os }}-gatsby-
+          key: ${{ runner.os }}-gatsby-${{ hashFiles('**/yarn.lock') }}-${{ steps.date.outputs.timestamp }}
 
       - name: Build portal
         run: yarn workspace dnb-design-system-portal build-ci

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -227,9 +227,9 @@ async function createRedirects({ graphql, actions }) {
   })
 }
 
-let eufemiaBuildExists = false
+let prebuildExists = false
 try {
-  eufemiaBuildExists = fs.existsSync(require.resolve('@dnb/eufemia/build'))
+  prebuildExists = fs.existsSync(require.resolve('@dnb/eufemia/build'))
 } catch (e) {
   //
 }
@@ -248,7 +248,7 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     },
   })
 
-  if (isCI && eufemiaBuildExists) {
+  if (isCI && prebuildExists) {
     // Get Webpack config
     const config = getConfig()
 

--- a/packages/dnb-eufemia/scripts/prepub/tasks/makeLibStyles.js
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/makeLibStyles.js
@@ -77,18 +77,11 @@ export const runFactory = (
         .pipe(cloneSink.tap())
 
       if (!returnResult && !returnFiles) {
-        stream
-          .pipe(
-            gulp.dest(`./build/cjs/${dest}/`, {
-              cwd: ROOT_DIR,
-            })
-          )
-          .pipe(gulp.dest(`./build/es/${dest}/`, { cwd: ROOT_DIR }))
-          .pipe(
-            gulp.dest(`./build/esm/${dest}/`, {
-              cwd: ROOT_DIR,
-            })
-          )
+        stream.pipe(
+          gulp.dest(`./build/${dest}/`, {
+            cwd: ROOT_DIR,
+          })
+        )
       }
 
       // so tests can test the minified code

--- a/packages/dnb-eufemia/scripts/prepub/tasks/makeMainStyle.js
+++ b/packages/dnb-eufemia/scripts/prepub/tasks/makeMainStyle.js
@@ -93,18 +93,11 @@ export const runFactory = (
         .pipe(cloneSink.tap())
 
       if (!returnResult && !returnFiles) {
-        stream
-          .pipe(
-            gulp.dest('./build/cjs/style', {
-              cwd: ROOT_DIR,
-            })
-          )
-          .pipe(gulp.dest('./build/es/style', { cwd: ROOT_DIR }))
-          .pipe(
-            gulp.dest('./build/esm/style', {
-              cwd: ROOT_DIR,
-            })
-          )
+        stream.pipe(
+          gulp.dest('./build/style', {
+            cwd: ROOT_DIR,
+          })
+        )
       }
 
       // so tests can test the minified code

--- a/packages/dnb-eufemia/scripts/release/babel-cjs.sh
+++ b/packages/dnb-eufemia/scripts/release/babel-cjs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo 'Building cjs ...'
+echo 'Building cjs bundle ...'
 
 cross-env \
 NODE_ENV=production \
@@ -14,11 +14,12 @@ babel ./src \
 --no-copy-ignored \
 --ignore 'src/esm,src/umd,src/core,**/*.test.js,**/__tests__/**/*,**/*.d.ts'
 
-echo 'Building cjs done!'
+echo 'Building cjs bundle done!'
 
 echo 'Copy .d.ts files to cjs ...'
 
 OUT_DIR=./build/cjs babel-node ./scripts/release/copyTypeScriptDefinitionFiles.js
+OUT_DIR=./build/cjs babel-node ./scripts/release/copyStyles.js
 
 echo 'Copy extra cjs package.json ...'
 

--- a/packages/dnb-eufemia/scripts/release/babel-es.sh
+++ b/packages/dnb-eufemia/scripts/release/babel-es.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo 'Building es ...'
+echo 'Building es bundle ...'
 
 cross-env \
 NODE_ENV=production \
@@ -14,8 +14,9 @@ babel ./src \
 --no-copy-ignored \
 --ignore 'src/cjs,src/esm,src/umd,src/core,**/*.test.js,**/__tests__/**/*,**/*.d.ts'
 
-echo 'Building es done!'
+echo 'Building es bundle done!'
 
 echo 'Copy .d.ts files to es ...'
 
 OUT_DIR=./build/es babel-node ./scripts/release/copyTypeScriptDefinitionFiles.js
+OUT_DIR=./build/es babel-node ./scripts/release/copyStyles.js

--- a/packages/dnb-eufemia/scripts/release/babel-esm.sh
+++ b/packages/dnb-eufemia/scripts/release/babel-esm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo 'Building esm ...'
+echo 'Building esm bundle ...'
 
 cross-env \
 NODE_ENV=production \
@@ -14,8 +14,9 @@ babel ./src \
 --no-copy-ignored \
 --ignore 'src/cjs,src/esm,src/umd,src/core,**/*.test.js,**/__tests__/**/*,**/*.d.ts'
 
-echo 'Building esm done!'
+echo 'Building esm bundle done!'
 
 echo 'Copy .d.ts files to esm ...'
 
 OUT_DIR=./build/esm babel-node ./scripts/release/copyTypeScriptDefinitionFiles.js
+OUT_DIR=./build/esm babel-node ./scripts/release/copyStyles.js

--- a/packages/dnb-eufemia/scripts/release/copyStyles.js
+++ b/packages/dnb-eufemia/scripts/release/copyStyles.js
@@ -1,0 +1,32 @@
+/**
+ * Copy .css files recursively
+ *
+ */
+
+import fs from 'fs-extra'
+import path from 'path'
+import globby from 'globby'
+
+if (require.main === module) {
+  copyCSSFiles(process.env.OUT_DIR)
+}
+
+async function copyCSSFiles(dist) {
+  const files = await globby([
+    './build/**/*.css',
+    '!./build/es/',
+    '!./build/esm/',
+    '!./build/cjs/',
+    '!./build/umd/',
+  ])
+
+  for await (const file of files) {
+    const src = path.resolve(file)
+    const dest = path.resolve(dist, file.replace('/build/', '/'))
+
+    await fs.copy(src, dest, {
+      overwrite: false,
+      errorOnExist: false,
+    })
+  }
+}


### PR DESCRIPTION
This PR ensures we invalidate the build cache when there are dependency changes. Also, make it more clear when to consume the prebuild.

And create the the cjs and es styles in their build steps (post build), instead in the pre build step. 