### PR TITLE
chore: refactor Portal data structure and sourcing

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -119,7 +119,6 @@ const plugins = [
 // used for algolia search
 const queries = require('./src/uilib/search/searchQuery')
 if (queries) {
-  require('dotenv').config()
   plugins.push({
     resolve: 'gatsby-plugin-algolia',
     options: {

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -19,108 +19,62 @@ exports.onPreInit = async () => {
   }
 }
 
-exports.onCreateNode = ({ node, ...props }) => {
-  if (node.internal.type === 'Mdx') {
-    createMdxNode({ node, ...props })
-  }
+/**
+ * Extend every mdx type with a siblings array,
+ * based on the slug.
+ *
+ * Every:
+ * mdx.slug = uilib/components/button/demos node
+ * will include:
+ * mother.slug = uilib/components/button
+ * mother.frontmatter.title = Button
+ *
+ */
+exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
+  const typeDefs = `
+    type Mdx implements Node {
+      siblings: [Mdx]
+    }
+  `
+
+  createTypes(typeDefs)
 }
 
-// find the root child which has a frontmatter.title
-// so the Tabbar can use the mother title
-global.nodesCache = {}
-function createMdxNode({
-  node,
-  getNodesByType,
-  getNode, //getNodeAndSavePathDependency could be an option
-  actions,
-}) {
-  const { createNodeField } = actions
+exports.createResolvers = ({ createResolvers }) => {
+  const resolvers = {
+    Mdx: {
+      siblings: {
+        resolve: (source, args, context) => {
+          const slug = source.__gatsby_resolved?.slug
 
-  const parent = getNode(node.parent)
-  const slug = parent.relativePath.replace(parent.ext, '')
+          const hasTitle = Boolean(source.frontmatter?.title)
+          console.log('hasTitle', { hasTitle, slug })
 
-  createNodeField({
-    name: 'slug',
-    node,
-    value: slug,
-  })
+          if (hasTitle || !slug || !slug.includes('uilib')) {
+            return []
+          }
 
-  // to make sure we get nodes which has not been there during the run
-  // we count for the length of all nodes
-
-  // get all nodes
-  const nodes = getNodesByType('Mdx')
-  nodes.forEach(
-    (node) =>
-      (global.nodesCache[node.fileAbsolutePath.replace('.md', '')] = node)
-  )
-
-  const { createParentChildLink } = actions
-
-  // collect the category items - used for search
-  const categoryDir = (node.fileAbsolutePath
-    .replace('.md', '')
-    .match(/.*\/docs\/([^/]*)/) || [])[0]
-
-  const categoryMdx = global.nodesCache[categoryDir]
-
-  if (categoryMdx) {
-    createNodeField({
-      node: categoryMdx,
-      name: 'tag',
-      value: 'category',
-    })
-    createParentChildLink({ parent: node, child: categoryMdx })
+          return slug
+            .split('/')
+            .map((_, i, arr) => {
+              const eq = arr.slice(0, -(i + 1)).join('/')
+              return (
+                eq &&
+                context.nodeModel.findOne({
+                  type: 'Mdx',
+                  query: {
+                    filter: { slug: { eq } },
+                  },
+                })
+              )
+            })
+            .filter(Boolean)
+        },
+      },
+    },
   }
 
-  // from here on we only handle the sub tab linking
-  const motherDir = node.fileAbsolutePath.replace('.md', '')
-
-  // have this check in place only to skip not needed parts
-  if (
-    /uilib\/(components|extensions|elements|helpers|typography)/.test(
-      motherDir
-    )
-  ) {
-    const parts = motherDir.split('/')
-    parts.shift() // do not search on empty parts
-
-    let motherMdx = null
-
-    // traverse down the mother path parts
-    for (let i = 0, l = parts.length; i < l; ++i) {
-      motherMdx = global.nodesCache['/' + parts.join('/')]
-
-      // ohh we got motherMdx, that's fine
-      if (
-        motherMdx &&
-        motherMdx.frontmatter &&
-        motherMdx.frontmatter.title &&
-        motherMdx.frontmatter.title.length > 0 // we don't need to crawler nodes which has a title
-      ) {
-        break
-      }
-
-      // then we continue the next round
-      parts.pop()
-
-      // and stop if the folder is called "src" or "docs"
-      // if we get the parent (node), we can use parent.sourceInstanceName
-      if (parts[parts.length - 1] === 'docs') {
-        break
-      }
-    }
-
-    // Add the mother title to the children
-    if (motherMdx) {
-      createNodeField({
-        node: motherMdx,
-        name: 'tag',
-        value: 'mother',
-      })
-      createParentChildLink({ parent: node, child: motherMdx })
-    }
-  }
+  createResolvers(resolvers)
 }
 
 exports.createPages = async (params) => {
@@ -135,9 +89,7 @@ async function createPages({ graphql, actions }) {
         edges {
           node {
             id
-            fields {
-              slug
-            }
+            slug
           }
         }
       }
@@ -157,8 +109,8 @@ async function createPages({ graphql, actions }) {
     const next = i === edges.length - 1 ? null : edges[i + 1].node
 
     // check if the slug is valid, in case we deleted one during build
-    if (node && node.fields && node.fields.slug) {
-      const slug = node.fields.slug
+    if (node?.slug) {
+      const slug = node.slug
 
       createPage({
         path: slug,
@@ -179,9 +131,7 @@ async function createRedirects({ graphql, actions }) {
       allMdx(filter: { frontmatter: { redirect_from: { ne: null } } }) {
         edges {
           node {
-            fields {
-              slug
-            }
+            slug
             frontmatter {
               redirect_from
             }
@@ -203,10 +153,10 @@ async function createRedirects({ graphql, actions }) {
   // extract all values and push to redirects array
   const redirects = edges.reduce((acc, { node }) => {
     // check if the slug is valid, in case we deleted one during build
-    if (node && node.fields && node.fields.slug) {
+    if (node?.slug) {
       acc.push({
         fromItems: node.frontmatter.redirect_from,
-        toPath: node.fields.slug,
+        toPath: node.slug,
       })
     }
     return acc

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -47,10 +47,7 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: (source, args, context) => {
           const slug = source.__gatsby_resolved?.slug
 
-          const hasTitle = Boolean(source.frontmatter?.title)
-          console.log('hasTitle', { hasTitle, slug })
-
-          if (hasTitle || !slug || !slug.includes('uilib')) {
+          if (!slug) {
             return []
           }
 
@@ -114,7 +111,7 @@ async function createPages({ graphql, actions }) {
 
       createPage({
         path: slug,
-        component: path.resolve('./src/templates/mdx.js'),
+        component: path.resolve(__dirname, './src/templates/mdx.js'),
         context: {
           id: node.id,
           prev,

--- a/packages/dnb-design-system-portal/src/docs/uilib/development/portal.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/development/portal.md
@@ -37,3 +37,19 @@ The build will be exported to the `/public` directory. You can now also run a lo
 # In the `dnb-design-system-portal` directory, run:
 $ yarn serve
 ```
+
+### Run Algolia search queries locally
+
+In order to commit Algolia search queries to the `dev_eufemia_docs` index, you have to:
+
+Create a `.env` file inside `dnb-design-system-portal` with valid:
+
+- `ALGOLIA_INDEX_NAME=dev_eufemia_docs`
+- `ALGOLIA_APP_ID=SLD6KEYMQ9`
+- `ALGOLIA_API_KEY=secret`
+
+In order to make faster local builds, you can:
+
+- Inside `gatsby-config.js` rename all sourcing from `/docs` to `/docs_dummy`
+
+Run `yarn workspace dnb-design-system-portal build`

--- a/packages/dnb-design-system-portal/src/docs_dummy/dummy.md
+++ b/packages/dnb-design-system-portal/src/docs_dummy/dummy.md
@@ -1,0 +1,26 @@
+---
+title: 'Dummy'
+description: 'Dummy'
+menuTitle: 'Dummy'
+status: 'wip'
+order: 1
+icon: 'bell'
+search: 'tag'
+skipSearch: false
+draft: true
+fullscreen: true
+tabs:
+  - title: Dummy
+    key: /dummy$1
+showTabs: true
+hideTabs:
+  - title: Events
+redirect_from:
+  - /other-dummy
+---
+
+# What is this?
+
+This file contains all required GraphQL Frontmatter fields
+
+Have a nice day!

--- a/packages/dnb-design-system-portal/src/docs_dummy/dummy/info.md
+++ b/packages/dnb-design-system-portal/src/docs_dummy/dummy/info.md
@@ -1,0 +1,7 @@
+---
+showTabs: true
+---
+
+## Category h2
+
+Some text

--- a/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
@@ -233,8 +233,13 @@ export default class MainMenu extends React.PureComponent {
   }
 
   render() {
-    const { closeMenu, isOpen, isClosing, isActive, openAsMenu } =
-      this.context
+    const {
+      closeMenu,
+      isOpen,
+      isClosing,
+      isActive,
+      openAsMenu,
+    } = this.context
     const { enableOverlay } = this.props
 
     return (
@@ -249,25 +254,21 @@ export default class MainMenu extends React.PureComponent {
             }
             categories: allMdx(
               filter: {
-                fields: {
-                  slug: {
-                    in: [
-                      "uilib"
-                      "quickguide-designer"
-                      "icons"
-                      "design-system"
-                      "brand"
-                      "principles"
-                    ]
-                  }
+                slug: {
+                  in: [
+                    "uilib"
+                    "quickguide-designer"
+                    "icons"
+                    "design-system"
+                    "brand"
+                    "principles"
+                  ]
                 }
               }
             ) {
               edges {
                 node {
-                  fields {
-                    slug
-                  }
+                  slug
                   frontmatter {
                     title
                     description
@@ -287,10 +288,10 @@ export default class MainMenu extends React.PureComponent {
           categories: { edges },
         }) => {
           const items = edges.reduce(
-            (acc, { node: { fields, frontmatter } }) => {
-              acc[fields.slug] = {
-                url: `/${fields.slug}/`,
-                ...fields,
+            (acc, { node: { slug, frontmatter } }) => {
+              acc[slug] = {
+                url: `/${slug}/`,
+                slug,
                 ...frontmatter,
               }
               return acc

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.js
@@ -9,7 +9,7 @@ import { ClassNames } from '@emotion/react'
 import algoliasearch from 'algoliasearch/lite'
 import { Autocomplete } from '@dnb/eufemia/src/components'
 import { Anchor } from '@dnb/eufemia/src/elements'
-import { navigate } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 import { scrollToAnimation } from '../parts/Layout'
 import { isCI } from 'ci-info'
 
@@ -195,8 +195,9 @@ const makeHitsHumanFriendly = ({ hits, setHidden }) => {
       if (value !== title) {
         content.push(
           <Anchor
+            element={Link}
             key={slug + hash + i}
-            href={`/${slug}#${hash}`}
+            to={`/${slug}#${hash}`}
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
@@ -455,17 +455,13 @@ export default class SidebarLayout extends React.PureComponent {
                 pathPrefix
               }
               allMdx(
-                # limit: 2
-                # sort: { fields: [frontmatter___order], order: ASC }
                 filter: {
                   frontmatter: { title: { ne: null }, draft: { ne: true } }
                 }
               ) {
                 edges {
                   node {
-                    fields {
-                      slug
-                    }
+                    slug
                     frontmatter {
                       title
                       menuTitle
@@ -742,13 +738,7 @@ const prepareNav = ({ location, allMdx, showAll, pathPrefix }) => {
   }
 
   const navItems = allMdx.edges
-    .map(
-      ({
-        node: {
-          fields: { slug },
-        },
-      }) => slug
-    )
+    .map(({ node: { slug } }) => slug)
     .filter((slug) => slug !== '/')
     // preorder
     .sort()
@@ -794,16 +784,10 @@ const prepareNav = ({ location, allMdx, showAll, pathPrefix }) => {
     .map((slugPath) => {
       const {
         node: {
-          fields: { slug },
+          slug,
           frontmatter: { title, order, ...rest },
         },
-      } = allMdx.edges.find(
-        ({
-          node: {
-            fields: { slug },
-          },
-        }) => slug === slugPath
-      )
+      } = allMdx.edges.find(({ node: { slug } }) => slug === slugPath)
 
       const level = slug.split('/').filter((p) => p).length
       level > countLevels ? (countLevels = level) : countLevels

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.js
@@ -35,6 +35,10 @@ const Header = styled.header`
     /* Now, when the drawer tools are opened, we lower it back to appear behind the modal  */
     z-index: 3000;
   }
+  html[data-dnb-drawer-list-active='portal-search'] & {
+    /* Now, when the drawer tools are opened, we lower it back to appear behind the modal  */
+    z-index: 3200;
+  }
 
   top: 0;
   left: 0;

--- a/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
@@ -60,8 +60,7 @@ export default function Tabbar({
       (tabs || defaultTabs)
         // remove the tab if it is hidden in frontmatter
         .filter(
-          ({ title }) =>
-            !(hideTabs && hideTabs.find(({ title: t }) => t === title))
+          ({ title }) => !hideTabs?.find(({ title: t }) => t === title)
         )
         .map(({ key, ...rest }) => {
           const hasPlaceholderChar = key.includes('$1')
@@ -98,19 +97,6 @@ export default function Tabbar({
         tab_element={Link}
         data={preparedTabs}
         selected_key={selectedKey}
-        on_change={({ key }) => navigate(key)}
-        on_mouse_enter={({ key }) => {
-          // preload pages the tab page
-          if (
-            typeof window !== 'undefined' &&
-            typeof window.___loader !== 'undefined'
-          ) {
-            const preloadPath = parsePath(key).pathname
-            if (preloadPath !== path.pathname) {
-              window.___loader.enqueue(preloadPath)
-            }
-          }
-        }}
         render={({ Wrapper, Content, TabsList, Tabs }) => {
           return (
             <Wrapper css={tabsWrapperStyle}>

--- a/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
@@ -6,7 +6,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from '@emotion/react'
-import { parsePath, navigate } from 'gatsby'
+import { Link, parsePath, navigate } from 'gatsby'
 import { Button, Tabs } from '@dnb/eufemia/src/components'
 import { fullscreen as fullscreenIcon } from '@dnb/eufemia/src/icons/secondary_icons'
 import AutoLinkHeader from './AutoLinkHeader'
@@ -15,7 +15,7 @@ export default function Tabbar({
   location,
   title,
   hideTabs,
-  usePath,
+  rootPath,
   tabs,
   defaultTabs,
   children,
@@ -64,17 +64,18 @@ export default function Tabbar({
             !(hideTabs && hideTabs.find(({ title: t }) => t === title))
         )
         .map(({ key, ...rest }) => {
-          if (key.includes('$1')) {
+          const hasPlaceholderChar = key.includes('$1')
+          if (hasPlaceholderChar) {
             key = cleanPath(
               key.replace(/\$1$/, [fullscreenQuery(), path.hash].join(''))
             )
           } else {
             key = cleanPath(
-              [usePath, key, fullscreenQuery(), path.hash].join('')
+              [rootPath, key, fullscreenQuery(), path.hash].join('')
             )
           }
 
-          return { ...rest, key }
+          return { ...rest, key, to: key }
         })
     )
   }, [wasFullscreen]) // eslint-disable-line
@@ -94,6 +95,7 @@ export default function Tabbar({
       )}
       <Tabs
         id="tabbar"
+        tab_element={Link}
         data={preparedTabs}
         selected_key={selectedKey}
         on_change={({ key }) => navigate(key)}
@@ -148,7 +150,7 @@ Tabbar.propTypes = {
   defaultTabs: PropTypes.array,
   title: PropTypes.string,
   hideTabs: PropTypes.array,
-  usePath: PropTypes.string.isRequired,
+  rootPath: PropTypes.string.isRequired,
   children: PropTypes.node,
 }
 Tabbar.defaultProps = {
@@ -192,13 +194,11 @@ const tabsWrapperStyle = css`
   }
 
   @media screen and (max-width: 40em) {
-    ${
-      '' /* .dnb-tabs__tabs {
+    ${'' /* .dnb-tabs__tabs {
       NB: Now this gets handled automatically
       margin: 0 -2rem;
       padding: 0 2rem;
-    } */
-    }
+    } */}
     .dnb-tabs__tabs .dnb-button.fullscreen {
       display: none;
     }

--- a/packages/dnb-design-system-portal/src/templates/mdx.js
+++ b/packages/dnb-design-system-portal/src/templates/mdx.js
@@ -29,7 +29,10 @@ export default class MdxTemplate extends React.PureComponent {
 
     const { body, tableOfContents, siblings } = mdx
 
-    const mother = siblings?.[0] || mdx
+    const makeUseOfCategorySibling = Boolean(
+      !mdx?.frontmatter?.title && mdx?.frontmatter?.showTabs
+    )
+    const mother = makeUseOfCategorySibling ? siblings?.[0] : mdx
     const frontmatter = mother?.frontmatter
 
     const pageDescription = frontmatter?.description || mainDescription

--- a/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
+++ b/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
@@ -13,9 +13,7 @@ const docsQuery = /* GraphQL */ `
       edges {
         node {
           objectID: id
-          fields {
-            slug
-          }
+          slug
           frontmatter {
             title
             description
@@ -26,16 +24,11 @@ const docsQuery = /* GraphQL */ `
             value
             depth
           }
-          # use the first children as the category
-          children {
-            ... on Mdx {
-              fields {
-                slug
-                tag
-              }
-              frontmatter {
-                title
-              }
+          # use the first siblings as the category
+          siblings {
+            slug
+            frontmatter {
+              title
             }
           }
         }
@@ -49,13 +42,13 @@ const flatten = (arr) =>
     .filter(
       ({
         node: {
-          fields: { slug },
+          slug,
           frontmatter: { skipSearch },
         },
       }) => !slug.includes('not_in_use') && skipSearch !== true
     )
     .map(
-      ({ node: { children, fields, frontmatter, headings, ...rest } }) => {
+      ({ node: { siblings, slug, frontmatter, headings, ...rest } }) => {
         if (headings && Array.isArray(headings)) {
           headings = headings.map((item) => ({
             ...item,
@@ -80,10 +73,10 @@ const flatten = (arr) =>
                 ...frontmatter,
                 title: first.value,
               }
-            } else if (Array.isArray(children)) {
-              const category = children
+            } else if (Array.isArray(siblings)) {
+              const category = siblings
                 .reverse()
-                .find(({ fields: { slug } }) => fields.slug.includes(slug))
+                .find(({ slug: _slug }) => slug.includes(_slug))
 
               const {
                 frontmatter: { title, search },
@@ -107,7 +100,7 @@ const flatten = (arr) =>
 
         // bundle our whole request
         const result = {
-          ...fields,
+          slug,
           ...frontmatter,
           ...rest,
           headings,
@@ -118,10 +111,10 @@ const flatten = (arr) =>
         }
 
         // handle category
-        if (children[0]) {
-          const { fields, frontmatter, ...rest } = children[0]
+        if (siblings[0]) {
+          const { slug, frontmatter, ...rest } = siblings[0]
           result.category = {
-            ...fields,
+            slug,
             ...frontmatter,
             ...rest,
           }

--- a/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
+++ b/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
@@ -7,6 +7,8 @@ const { getCurrentBranchName } = require('../utils/git')
 const { makeSlug } = require('../utils/slug')
 const { isCI } = require('ci-info')
 
+require('dotenv').config()
+
 const docsQuery = /* GraphQL */ `
   {
     pages: allMdx {
@@ -78,21 +80,23 @@ const flatten = (arr) =>
                 .reverse()
                 .find(({ slug: _slug }) => slug.includes(_slug))
 
-              const {
-                frontmatter: { title, search },
-              } = category
+              if (category) {
+                const {
+                  frontmatter: { title, search },
+                } = category
 
-              let newTitle = title || search
+                let newTitle = title || search
 
-              if (first && first.depth === 2) {
-                headings.shift()
-                // eslint-disable-next-line no-irregular-whitespace
-                newTitle = `${newTitle} → ${first.value}`
-              }
+                if (first && first.depth === 2) {
+                  headings.shift()
+                  // eslint-disable-next-line no-irregular-whitespace
+                  newTitle = `${newTitle} → ${first.value}`
+                }
 
-              frontmatter = {
-                ...frontmatter,
-                title: newTitle,
+                frontmatter = {
+                  ...frontmatter,
+                  title: newTitle,
+                }
               }
             }
           }
@@ -147,7 +151,7 @@ const runQueriesWhen = (currentBranch) => {
     console.info(
       'If you want to submit searchable data to Algolia, you need to request access keys and put them in a local .env file.'
     )
-    return true
+    return false
   }
 
   if (isCI) {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -1422,7 +1422,14 @@ describe('Autocomplete component', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
   })
 
+  const orig = window.requestAnimationFrame
+  afterEach(() => {
+    window.requestAnimationFrame = orig
+  })
+
   it('will make anchors inside drawer-list item accessible', () => {
+    window.requestAnimationFrame = undefined
+
     const mockData = [
       'first item',
       [

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
@@ -776,6 +776,12 @@ export default class DrawerListProvider extends React.PureComponent {
       case 'enter':
       case 'space':
         {
+          if (e.target.tagName === 'A') {
+            e.target.dispatchEvent(new MouseEvent('click'))
+            this.setHidden()
+            return // stop here, and let the browser + anchor do the rest
+          }
+
           active_item = this.getCurrentActiveItem()
 
           if (
@@ -855,18 +861,28 @@ export default class DrawerListProvider extends React.PureComponent {
                 const after = createTabElem()
                 const before = createTabElem()
 
-                try {
-                  // Now, focus our active element
-                  activeElement.focus()
+                // Now, focus our active element
+                activeElement.focus()
 
-                  // Insert our fake elements
-                  activeElement.appendChild(after)
-                  activeElement.insertBefore(
-                    before,
-                    activeElement.firstChild
-                  )
-                } catch (e) {
-                  //
+                const insertElem = () => {
+                  try {
+                    // Insert our fake elements
+                    activeElement.appendChild(after)
+                    activeElement.insertBefore(
+                      before,
+                      activeElement.firstChild
+                    )
+                  } catch (e) {
+                    //
+                  }
+                }
+
+                // check because of test
+                if (typeof window.requestAnimationFrame === 'function') {
+                  // requestAnimationFrame is need by chromium browsers
+                  window.requestAnimationFrame(insertElem)
+                } else {
+                  insertElem()
                 }
               }
 


### PR DESCRIPTION
This PR changes how the Portal source data. The old method was made before Gatsby had `createSchemaCustomization` and `createResolvers`, which should ensure we do not miss the "title" anymore, as this should be much more stable.

