### PR TITLE
chore: refactor usage of alias'es inside the Portal

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "Pages/*": ["./packages/dnb-design-system-portal/src/docs/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -88,7 +88,7 @@ const plugins = [
       ],
       // Imports in here are globally available in *.md files
       // globalScope: `
-      //   import InlineImg from 'Tags/Img'
+      //   import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
       //   export default { Img }
       // `
       // defaultLayouts: {

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -188,12 +188,7 @@ exports.onCreateWebpackConfig = ({ actions, plugins }) => {
   const config = {
     resolve: {
       alias: {
-        Root: path.resolve(__dirname),
-        Src: path.resolve(__dirname, 'src'),
-        Pages: path.resolve(__dirname, 'src/docs'),
         Docs: path.resolve(__dirname, 'src/docs'),
-        Tags: path.resolve(__dirname, 'src/shared/tags'),
-        Parts: path.resolve(__dirname, 'src/shared/parts'),
       },
     },
     plugins: [

--- a/packages/dnb-design-system-portal/src/docs/contribution.md
+++ b/packages/dnb-design-system-portal/src/docs/contribution.md
@@ -5,7 +5,7 @@ redirect_from:
   - /uilib/development
 ---
 
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 # Contribution

--- a/packages/dnb-design-system-portal/src/docs/design-system/about.md
+++ b/packages/dnb-design-system-portal/src/docs/design-system/about.md
@@ -4,7 +4,7 @@ icon: 'info'
 order: 3
 ---
 
-import WelcomeAdvice from 'Pages/welcome-advice'
+import WelcomeAdvice from 'Docs/welcome-advice'
 
 # About Eufemia
 

--- a/packages/dnb-design-system-portal/src/docs/design-system/about/living-system.md
+++ b/packages/dnb-design-system-portal/src/docs/design-system/about/living-system.md
@@ -3,6 +3,6 @@ title: 'Living System'
 order: 1
 ---
 
-import LivingSystem from 'Pages/uilib/getting-started/living-system'
+import LivingSystem from 'Docs/uilib/getting-started/living-system'
 
 <LivingSystem />

--- a/packages/dnb-design-system-portal/src/docs/design-system/changelog/info-about-releases.md
+++ b/packages/dnb-design-system-portal/src/docs/design-system/changelog/info-about-releases.md
@@ -1,4 +1,4 @@
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 You may also be interested in [details about releases](/uilib/releases) and have a look at the [<Icon icon={GithubLogo} size="default" /> **GitHub Releases**](https://github.com/dnbexperience/eufemia/releases) for versioning of the [@dnb/eufemia](/uilib/).

--- a/packages/dnb-design-system-portal/src/docs/icons.md
+++ b/packages/dnb-design-system-portal/src/docs/icons.md
@@ -4,7 +4,7 @@ description: 'List of all Eufemia icons.'
 order: 1
 ---
 
-import ListAllIcons from "Parts/icons/ListAllIcons";
+import ListAllIcons from "dnb-design-system-portal/src/shared/parts/icons/ListAllIcons";
 
 # Icons
 

--- a/packages/dnb-design-system-portal/src/docs/icons/details.md
+++ b/packages/dnb-design-system-portal/src/docs/icons/details.md
@@ -5,9 +5,9 @@ icon: 'info'
 order: 1
 ---
 
-import InlineImg from 'Tags/Img'
-import IconNearestNeighbour from 'Pages/quickguide-designer/assets/icon-nearest-neighbour.svg'
-import FormStatusIcons from 'Pages/icons/form-status.md'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import IconNearestNeighbour from 'Docs/quickguide-designer/assets/icon-nearest-neighbour.svg'
+import FormStatusIcons from 'Docs/icons/form-status.md'
 
 # Icon Details
 

--- a/packages/dnb-design-system-portal/src/docs/icons/other.md
+++ b/packages/dnb-design-system-portal/src/docs/icons/other.md
@@ -5,7 +5,7 @@ icon: 'helper_classes'
 order: 4
 ---
 
-import FormStatusIcons from 'Pages/icons/form-status.md'
+import FormStatusIcons from 'Docs/icons/form-status.md'
 
 # Other Icons
 

--- a/packages/dnb-design-system-portal/src/docs/icons/primary.md
+++ b/packages/dnb-design-system-portal/src/docs/icons/primary.md
@@ -5,7 +5,7 @@ icon: 'primary'
 order: 2
 ---
 
-import ListAllIcons from "Parts/icons/ListAllIcons";
+import ListAllIcons from "dnb-design-system-portal/src/shared/parts/icons/ListAllIcons";
 
 # Primary Icons
 

--- a/packages/dnb-design-system-portal/src/docs/icons/secondary.md
+++ b/packages/dnb-design-system-portal/src/docs/icons/secondary.md
@@ -5,7 +5,7 @@ icon: 'secondary'
 order: 3
 ---
 
-import ListAllIcons from "Parts/icons/ListAllIcons";
+import ListAllIcons from "dnb-design-system-portal/src/shared/parts/icons/ListAllIcons";
 
 # Secondary Icons
 

--- a/packages/dnb-design-system-portal/src/docs/index.js
+++ b/packages/dnb-design-system-portal/src/docs/index.js
@@ -4,8 +4,8 @@
  */
 
 import React from 'react'
-import MainMenu from 'Src/shared/menu/MainMenu'
-import { MainMenuProvider } from 'Src/shared/menu/MainMenuContext'
+import MainMenu from 'dnb-design-system-portal/src/shared/menu/MainMenu'
+import { MainMenuProvider } from 'dnb-design-system-portal/src/shared/menu/MainMenuContext'
 
 // react component
 export default class App extends React.PureComponent {

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer.md
@@ -3,11 +3,11 @@ title: 'Quick Guide - Designers'
 description: 'Eufemia for designers - design guidelines and resources'
 ---
 
-import InlineImg from 'Tags/Img'
-import FigmaTeam from 'Pages/quickguide-designer/assets/figma-team.svg'
-import FigmaLibraries from 'Pages/quickguide-designer/assets/figma-libraries.svg'
-import FigmaLayoutGrid from 'Pages/quickguide-designer/assets/figma-layout-grid.svg'
-import FigmaLibrary from 'Pages/quickguide-designer/assets/figma-library.svg'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import FigmaTeam from 'Docs/quickguide-designer/assets/figma-team.svg'
+import FigmaLibraries from 'Docs/quickguide-designer/assets/figma-libraries.svg'
+import FigmaLayoutGrid from 'Docs/quickguide-designer/assets/figma-layout-grid.svg'
+import FigmaLibrary from 'Docs/quickguide-designer/assets/figma-library.svg'
 
 # QuickStart - Designers
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors-table.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors-table.md
@@ -1,4 +1,4 @@
-import Table from 'Tags/Table'
+import Table from 'dnb-design-system-portal/src/shared/tags/Table'
 
 <!-- This is the Source of the Colors Table -->
 <Table selectable>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors.md
@@ -3,7 +3,7 @@ title: 'Colors'
 icon: 'colors'
 ---
 
-import ColorsTable from 'Pages/quickguide-designer/colors-table.md'
+import ColorsTable from 'Docs/quickguide-designer/colors-table.md'
 
 # Colors
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/fonts.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/fonts.md
@@ -3,11 +3,11 @@ title: 'Fonts & Typography'
 icon: 'fonts'
 ---
 
-import TypographicRules from 'Pages/quickguide-designer/typography/typographic-rules.md'
-import TypographicElements from 'Pages/quickguide-designer/typography/typographic-elements.md'
-import FontWeights from 'Pages/quickguide-designer/typography/font-weights.md'
-import LineHeight from 'Pages/quickguide-designer/typography/line-height.md'
-import FontFamilies from 'Pages/quickguide-designer/typography/font-families.md'
+import TypographicRules from 'Docs/quickguide-designer/typography/typographic-rules.md'
+import TypographicElements from 'Docs/quickguide-designer/typography/typographic-elements.md'
+import FontWeights from 'Docs/quickguide-designer/typography/font-weights.md'
+import LineHeight from 'Docs/quickguide-designer/typography/line-height.md'
+import FontFamilies from 'Docs/quickguide-designer/typography/font-families.md'
 
 # Fonts & Typography
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/inspiration.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/inspiration.md
@@ -3,9 +3,9 @@ title: 'Inspiration'
 icon: 'inspiration'
 ---
 
-import InlineImg from 'Tags/Img'
-import InspirationSkadeforsikring from 'Pages/quickguide-designer/assets/inspiration-skadeforsikring-guides.svg'
-import InspirationSkadeforsikringNoGuides from 'Pages/quickguide-designer/assets/inspiration-skadeforsikring.svg'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import InspirationSkadeforsikring from 'Docs/quickguide-designer/assets/inspiration-skadeforsikring-guides.svg'
+import InspirationSkadeforsikringNoGuides from 'Docs/quickguide-designer/assets/inspiration-skadeforsikring.svg'
 
 # UI inspiration
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/naming-conventions.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/naming-conventions.md
@@ -3,10 +3,10 @@ title: 'Naming Conventions'
 icon: 'naming'
 ---
 
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 
-import NamingSpace from 'Pages/quickguide-designer/assets/naming-space.svg'
-import TablesSpace from 'Pages/quickguide-designer/assets/tables-space.svg'
+import NamingSpace from 'Docs/quickguide-designer/assets/naming-space.svg'
+import TablesSpace from 'Docs/quickguide-designer/assets/tables-space.svg'
 
 # Naming conventions (Designers)
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.md
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.md
@@ -3,23 +3,23 @@ title: 'Spatial system'
 icon: 'special'
 ---
 
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 
-import TypeAndLayoutSvg from 'Pages/quickguide-designer/assets/type-and-layout.svg'
-import PaddingExampleSvg from 'Pages/quickguide-designer/assets/padding-example.svg'
-import MarginExampleSvg from 'Pages/quickguide-designer/assets/margin-example.svg'
-import BordersAndLinesSvg from 'Pages/quickguide-designer/assets/borders-lines.svg'
-import LineHeightSvg from 'Pages/quickguide-designer/assets/line-height.svg'
-import DesignersIntentionsSvg from 'Pages/quickguide-designer/assets/designers-intentions.svg'
-import MultipleMarginsSvg from 'Pages/quickguide-designer/assets/multiple-margins.svg'
-import PaddingButtonsSvg from 'Pages/quickguide-designer/assets/padding-buttons.svg'
-import ZindexSvg from 'Pages/quickguide-designer/assets/zindex.svg'
-import ExtentsSvg from 'Pages/quickguide-designer/assets/extents.svg'
-import SpaceWithinSvg from 'Pages/quickguide-designer/assets/space-within.svg'
-import TypeOnGridSvg from 'Pages/quickguide-designer/assets/type-on-grid.svg'
-import SpaceBlocksSvg from 'Pages/quickguide-designer/assets/space-blocks.svg'
-import DiscrepanciesSvg from 'Pages/quickguide-designer/assets/discrepancies.svg'
-import StandardSpacingBlocks from 'Pages/quickguide-designer/assets/standard-spacing-blocks.svg'
+import TypeAndLayoutSvg from 'Docs/quickguide-designer/assets/type-and-layout.svg'
+import PaddingExampleSvg from 'Docs/quickguide-designer/assets/padding-example.svg'
+import MarginExampleSvg from 'Docs/quickguide-designer/assets/margin-example.svg'
+import BordersAndLinesSvg from 'Docs/quickguide-designer/assets/borders-lines.svg'
+import LineHeightSvg from 'Docs/quickguide-designer/assets/line-height.svg'
+import DesignersIntentionsSvg from 'Docs/quickguide-designer/assets/designers-intentions.svg'
+import MultipleMarginsSvg from 'Docs/quickguide-designer/assets/multiple-margins.svg'
+import PaddingButtonsSvg from 'Docs/quickguide-designer/assets/padding-buttons.svg'
+import ZindexSvg from 'Docs/quickguide-designer/assets/zindex.svg'
+import ExtentsSvg from 'Docs/quickguide-designer/assets/extents.svg'
+import SpaceWithinSvg from 'Docs/quickguide-designer/assets/space-within.svg'
+import TypeOnGridSvg from 'Docs/quickguide-designer/assets/type-on-grid.svg'
+import SpaceBlocksSvg from 'Docs/quickguide-designer/assets/space-blocks.svg'
+import DiscrepanciesSvg from 'Docs/quickguide-designer/assets/discrepancies.svg'
+import StandardSpacingBlocks from 'Docs/quickguide-designer/assets/standard-spacing-blocks.svg'
 
 # Spatial system
 
@@ -240,8 +240,8 @@ Layout design is not limited to these selected sizing blocks. If you need more s
 
 The [example demo apps](/uilib/getting-started/demos) shows the 8px system in practice.
 
-<!-- import ExampleAarsoppgaveGuidesSvg from 'Pages/quickguide-designer/assets/example-aarsoppgave-guides.svg'
-import ExampleAarsoppgaveSvg from 'Pages/quickguide-designer/assets/example-aarsoppgave.svg'
+<!-- import ExampleAarsoppgaveGuidesSvg from 'Docs/quickguide-designer/assets/example-aarsoppgave-guides.svg'
+import ExampleAarsoppgaveSvg from 'Docs/quickguide-designer/assets/example-aarsoppgave.svg'
 
 <InlineImg src={ExampleAarsoppgaveSvg} caption="A simple example of the 8px system in use" alt="Aarsoppgave example" />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib.md
@@ -3,8 +3,8 @@ title: 'UI Library'
 description: 'Buttons, dropdowns, input fields, components etc.'
 ---
 
-import WelcomeAdvice from 'Pages/welcome-advice.md'
-import WatchingReleases from 'Pages/uilib/info/about-watching-releases.md'
+import WelcomeAdvice from 'Docs/welcome-advice.md'
+import WatchingReleases from 'Docs/uilib/info/about-watching-releases.md'
 
 # UI Library
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.md
@@ -4,8 +4,8 @@ icon: 'about_the_lib'
 order: 1
 ---
 
-import WelcomeAdvice from 'Pages/welcome-advice.md'
-import WatchingReleases from 'Pages/uilib/info/about-watching-releases.md'
+import WelcomeAdvice from 'Docs/welcome-advice.md'
+import WatchingReleases from 'Docs/uilib/info/about-watching-releases.md'
 
 # About the library
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases.md
@@ -5,8 +5,8 @@ redirect_from:
   - /uilib/releases
 ---
 
-import WelcomeAdvice from 'Pages/welcome-advice.md'
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import WelcomeAdvice from 'Docs/welcome-advice.md'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 # Releases and versions

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion.md
@@ -6,8 +6,8 @@ showTabs: true
 status: 'new'
 ---
 
-import AccordionInfo from 'Pages/uilib/components/accordion/info'
-import AccordionDemos from 'Pages/uilib/components/accordion/demos'
+import AccordionInfo from 'Docs/uilib/components/accordion/info'
+import AccordionDemos from 'Docs/uilib/components/accordion/demos'
 
 <AccordionInfo />
 <AccordionDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const AccordionDefaultExample = () => (
   <ComponentBox data-visual-test="accordion-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.md
@@ -8,7 +8,7 @@ AccordionLargeContentExample,
 AccordionCustomisationExample,
 AccordionContainerExample,
 AccordionGroupExample
-} from 'Pages/uilib/components/accordion/Examples'
+} from 'Docs/uilib/components/accordion/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete.md
@@ -5,8 +5,8 @@ order: 1
 showTabs: true
 ---
 
-import AutocompleteInfo from 'Pages/uilib/components/autocomplete/info'
-import AutocompleteDemos from 'Pages/uilib/components/autocomplete/demos'
+import AutocompleteInfo from 'Docs/uilib/components/autocomplete/info'
+import AutocompleteDemos from 'Docs/uilib/components/autocomplete/demos'
 
 <AutocompleteInfo />
 <AutocompleteDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Autocomplete, IconPrimary } from '@dnb/eufemia/src/components'
 import { format } from '@dnb/eufemia/src/components/number-format/NumberUtils'
 import styled from '@emotion/styled'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.md
@@ -13,7 +13,7 @@ AutocompletePredefinedInput,
 AutocompleteDifferentSizes,
 AutocompleteCustomWidth,
 AutocompleteOpened
-} from 'Pages/uilib/components/autocomplete/Examples'
+} from 'Docs/uilib/components/autocomplete/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/events.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/events.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import AutocompleteMethods from 'Pages/uilib/components/autocomplete/methods'
+import AutocompleteMethods from 'Docs/uilib/components/autocomplete/methods'
 
 ## Events
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import AutocompleteMethods from 'Pages/uilib/components/autocomplete/methods'
+import AutocompleteMethods from 'Docs/uilib/components/autocomplete/methods'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/properties.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import DrawerListProperties from 'Pages/uilib/components/fragments/drawer-list/properties'
+import DrawerListProperties from 'Docs/uilib/components/fragments/drawer-list/properties'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
@@ -6,8 +6,8 @@ order: 2
 showTabs: true
 ---
 
-import BreadcrumbInfo from 'Pages/uilib/components/breadcrumb/info'
-import BreadcrumbDemos from 'Pages/uilib/components/breadcrumb/demos'
+import BreadcrumbInfo from 'Docs/uilib/components/breadcrumb/info'
+import BreadcrumbDemos from 'Docs/uilib/components/breadcrumb/demos'
 
 <BreadcrumbInfo />
 <BreadcrumbDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const BreadcrumbSingle = () => (
   <ComponentBox data-visual-test="breadcrumb-single">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/demos.md
@@ -8,7 +8,7 @@ BreadcrumbMultiple,
 BreadcrumbMultipleData,
 BreadcrumbVariants,
 BreadcrumbCollapseOpen
-} from 'Pages/uilib/components/breadcrumb/Examples'
+} from 'Docs/uilib/components/breadcrumb/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button.md
@@ -5,8 +5,8 @@ order: 2
 showTabs: true
 ---
 
-import ButtonInfo from 'Pages/uilib/components/button/info'
-import ButtonDemos from 'Pages/uilib/components/button/demos'
+import ButtonInfo from 'Docs/uilib/components/button/info'
+import ButtonDemos from 'Docs/uilib/components/button/demos'
 
 <ButtonInfo />
 <ButtonDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { bell_medium as Bell, question } from '@dnb/eufemia/src/icons'
 
 export const ButtonPrimary = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.md
@@ -19,7 +19,7 @@ ButtonSignalLarge,
 ButtonIcon,
 ButtonStretch,
 TertiaryWithNoIcon,
-} from 'Pages/uilib/components/button/Examples'
+} from 'Docs/uilib/components/button/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox.md
@@ -5,8 +5,8 @@ order: 2
 showTabs: true
 ---
 
-import CheckboxInfo from 'Pages/uilib/components/checkbox/info'
-import CheckboxDemos from 'Pages/uilib/components/checkbox/demos'
+import CheckboxInfo from 'Docs/uilib/components/checkbox/info'
+import CheckboxDemos from 'Docs/uilib/components/checkbox/demos'
 
 <CheckboxInfo />
 <CheckboxDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const CheckboxUnchecked = () => (
   <ComponentBox data-visual-test="checkbox-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/demos.md
@@ -9,7 +9,7 @@ CheckboxWithError,
 CheckboxSuffix,
 CheckboxDifferentSizes,
 CheckboxDisabled
-} from 'Pages/uilib/components/checkbox/Examples'
+} from 'Docs/uilib/components/checkbox/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker.md
@@ -5,8 +5,8 @@ order: 2
 showTabs: true
 ---
 
-import DatePickerInfo from 'Pages/uilib/components/date-picker/info'
-import DatePickerDemos from 'Pages/uilib/components/date-picker/demos'
+import DatePickerInfo from 'Docs/uilib/components/date-picker/info'
+import DatePickerDemos from 'Docs/uilib/components/date-picker/demos'
 
 <DatePickerInfo />
 <DatePickerDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 import addDays from 'date-fns/addDays'
 import startOfMonth from 'date-fns/startOfMonth'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.md
@@ -15,8 +15,8 @@ DatePickerNoInputStatus,
 DatePickerErrorMessage,
 DatePickerErrorStatus,
 DatePickerCalendar,
-} from 'Pages/uilib/components/date-picker/Examples'
-import ChangeLocale from 'Src/core/ChangeLocale'
+} from 'Docs/uilib/components/date-picker/Examples'
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown.md
@@ -5,8 +5,8 @@ order: 2
 showTabs: true
 ---
 
-import DropdownInfo from 'Pages/uilib/components/dropdown/info'
-import DropdownDemos from 'Pages/uilib/components/dropdown/demos'
+import DropdownInfo from 'Docs/uilib/components/dropdown/info'
+import DropdownDemos from 'Docs/uilib/components/dropdown/demos'
 
 <DropdownInfo />
 <DropdownDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 const Wrapper = styled.div`

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.md
@@ -16,7 +16,7 @@ DropdownSizes,
 DropdownCustomWidth,
 DropdownStatusVertical,
 DropdownListOpened,
-} from 'Pages/uilib/components/dropdown/Examples'
+} from 'Docs/uilib/components/dropdown/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/properties.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import DrawerListProperties from 'Pages/uilib/components/fragments/drawer-list/properties'
+import DrawerListProperties from 'Docs/uilib/components/fragments/drawer-list/properties'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label.md
@@ -7,8 +7,8 @@ hideTabs:
   - title: Events
 ---
 
-import FormLabelInfo from 'Pages/uilib/components/form-label/info'
-import FormLabelDemos from 'Pages/uilib/components/form-label/demos'
+import FormLabelInfo from 'Docs/uilib/components/form-label/info'
+import FormLabelDemos from 'Docs/uilib/components/form-label/demos'
 
 <FormLabelInfo />
 <FormLabelDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row.md
@@ -16,8 +16,8 @@ tabs:
 #   - title: Events
 ---
 
-import FormRowInfo from 'Pages/uilib/components/form-row/info'
-import FormRowDemos from 'Pages/uilib/components/form-row/demos'
+import FormRowInfo from 'Docs/uilib/components/form-row/info'
+import FormRowDemos from 'Docs/uilib/components/form-row/demos'
 
 <FormRowInfo />
 <FormRowDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/demos.md
@@ -16,7 +16,7 @@ FormRowWrap,
 FormRowLegendUsage,
 FormRowInheritContext,
 FormRowDifferentDirections,
-} from 'Pages/uilib/components/form-row/Examples'
+} from 'Docs/uilib/components/form-row/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/info.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set.md
@@ -5,8 +5,8 @@ order: 3
 showTabs: true
 ---
 
-import FormSetInfo from 'Pages/uilib/components/form-set/info'
-import FormSetDemos from 'Pages/uilib/components/form-set/demos'
+import FormSetInfo from 'Docs/uilib/components/form-set/info'
+import FormSetDemos from 'Docs/uilib/components/form-set/demos'
 
 <FormSetInfo />
 <FormSetDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const FormSetDefault = () => (
   <ComponentBox data-visual-test="form-set-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/demos.md
@@ -6,7 +6,7 @@ import {
 FormSetDefault,
 FormSetVertical,
 FormSetSubmit
-} from 'Pages/uilib/components/form-set/Examples'
+} from 'Docs/uilib/components/form-set/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status.md
@@ -10,8 +10,8 @@ redirect_from:
   - /uilib/components/status-message
 ---
 
-import FormStatusInfo from 'Pages/uilib/components/form-status/info'
-import FormStatusDemos from 'Pages/uilib/components/form-status/demos'
+import FormStatusInfo from 'Docs/uilib/components/form-status/info'
+import FormStatusDemos from 'Docs/uilib/components/form-status/demos'
 
 <FormStatusInfo />
 <FormStatusDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import {
   InfoIcon,
   WarnIcon,

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/demos.md
@@ -14,7 +14,7 @@ FormStatusAnimation,
 FormStatusCustom,
 FormStatusLarge,
 FormStatusWithIcons,
-} from 'Pages/uilib/components/form-status/Examples'
+} from 'Docs/uilib/components/form-status/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/info.md
@@ -4,7 +4,7 @@ redirect_from:
   - /uilib/components/status-message/info
 ---
 
-import FormStatusIcons from 'Pages/icons/form-status.md'
+import FormStatusIcons from 'Docs/icons/form-status.md'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list.md
@@ -5,8 +5,8 @@ showTabs: true
 status: null
 ---
 
-import DrawerListInfo from 'Pages/uilib/components/fragments/drawer-list/info'
-import DrawerListDemos from 'Pages/uilib/components/fragments/drawer-list/demos'
+import DrawerListInfo from 'Docs/uilib/components/fragments/drawer-list/info'
+import DrawerListDemos from 'Docs/uilib/components/fragments/drawer-list/demos'
 
 <DrawerListInfo />
 <DrawerListDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 export const DrawerListExampleInteractive = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.md
@@ -8,7 +8,7 @@ DrawerListExampleOnlyToVisualize,
 DrawerListExampleDefault,
 DrawerListExampleSingleItem,
 DrawerListExampleMarkup
-} from 'Pages/uilib/components/fragments/drawer-list/Examples'
+} from 'Docs/uilib/components/fragments/drawer-list/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.md
@@ -8,6 +8,6 @@ hideTabs:
   - title: Properties
 ---
 
-import ScrollViewInfo from 'Pages/uilib/components/fragments/scroll-view/info'
+import ScrollViewInfo from 'Docs/uilib/components/fragments/scroll-view/info'
 
 <ScrollViewInfo />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-error.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-error.md
@@ -7,8 +7,8 @@ hideTabs:
   - title: Events
 ---
 
-import GlobalErrorInfo from 'Pages/uilib/components/global-error/info'
-import GlobalErrorDemos from 'Pages/uilib/components/global-error/demos'
+import GlobalErrorInfo from 'Docs/uilib/components/global-error/info'
+import GlobalErrorDemos from 'Docs/uilib/components/global-error/demos'
 
 <GlobalErrorInfo />
 <GlobalErrorDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status.md
@@ -5,8 +5,8 @@ order: 4
 showTabs: true
 ---
 
-import GlobalStatusComponentInfo from 'Pages/uilib/components/global-status/info'
-import GlobalStatusComponentDemos from 'Pages/uilib/components/global-status/demos'
+import GlobalStatusComponentInfo from 'Docs/uilib/components/global-status/info'
+import GlobalStatusComponentDemos from 'Docs/uilib/components/global-status/demos'
 
 <GlobalStatusComponentInfo />
 <GlobalStatusComponentDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const GlobalStatusError = () => (
   <ComponentBox data-visual-test="global-status">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/demos.md
@@ -9,7 +9,7 @@ GlobalStatusUpdate,
 GlobalStatusCoupling,
 GlobalStatusAddRemoveItems,
 GlobalStatusScrolling,
-} from 'Pages/uilib/components/global-status/Examples'
+} from 'Docs/uilib/components/global-status/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading.md
@@ -8,8 +8,8 @@ hideTabs:
   - title: Events
 ---
 
-import HeadingInfo from 'Pages/uilib/components/heading/info'
-import HeadingDemos from 'Pages/uilib/components/heading/demos'
+import HeadingInfo from 'Docs/uilib/components/heading/info'
+import HeadingDemos from 'Docs/uilib/components/heading/demos'
 
 <HeadingInfo />
 <HeadingDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 const Style = styled.div`

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/demos.md
@@ -7,7 +7,7 @@ HeadingDefault,
 HeadingContext,
 HeadingIsolation,
 HeadingMix
-} from 'Pages/uilib/components/heading/Examples'
+} from 'Docs/uilib/components/heading/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
@@ -6,8 +6,8 @@ order: 4
 showTabs: true
 ---
 
-import HelpButtonInfo from 'Pages/uilib/components/help-button/info'
-import HelpButtonDemos from 'Pages/uilib/components/help-button/demos'
+import HelpButtonInfo from 'Docs/uilib/components/help-button/info'
+import HelpButtonDemos from 'Docs/uilib/components/help-button/demos'
 
 <HelpButtonInfo />
 <HelpButtonDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary.md
@@ -9,8 +9,8 @@ hideTabs:
   - title: Events
 ---
 
-import IconPrimaryInfo from 'Pages/uilib/components/icon-primary/info'
-import IconPrimaryDemos from 'Pages/uilib/components/icon-primary/demos'
+import IconPrimaryInfo from 'Docs/uilib/components/icon-primary/info'
+import IconPrimaryDemos from 'Docs/uilib/components/icon-primary/demos'
 
 <IconPrimaryInfo />
 <IconPrimaryDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon.md
@@ -8,8 +8,8 @@ hideTabs:
   - title: Events
 ---
 
-import IconInfo from 'Pages/uilib/components/icon/info'
-import IconDemos from 'Pages/uilib/components/icon/demos'
+import IconInfo from 'Docs/uilib/components/icon/info'
+import IconDemos from 'Docs/uilib/components/icon/demos'
 
 <IconInfo />
 <IconDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import {
   bell_medium as BellMedium,
   bell as Bell,

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.md
@@ -6,7 +6,7 @@ import IconTests, {
 IconDefault,
 IconBorder,
 IconInheritSized
-} from 'Pages/uilib/components/icon/Examples'
+} from 'Docs/uilib/components/icon/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked.md
@@ -6,8 +6,8 @@ order: 7
 showTabs: true
 ---
 
-import InputMaskedInfo from 'Pages/uilib/components/input-masked/info'
-import InputMaskedDemos from 'Pages/uilib/components/input-masked/demos'
+import InputMaskedInfo from 'Docs/uilib/components/input-masked/info'
+import InputMaskedDemos from 'Docs/uilib/components/input-masked/demos'
 
 <InputMaskedInfo />
 <InputMaskedDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 import { Provider } from '@dnb/eufemia/src/shared'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/demos.md
@@ -10,8 +10,8 @@ InputMaskedExampleCustomNumberMask,
 InputMaskedExampleNumberMask,
 InputMaskedExamplePrefix,
 InputMaskedExamplePhone
-} from 'Pages/uilib/components/input-masked/Examples'
-import ChangeLocale from 'Src/core/ChangeLocale'
+} from 'Docs/uilib/components/input-masked/Examples'
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input.md
@@ -6,8 +6,8 @@ order: 8
 showTabs: true
 ---
 
-import InputInfo from 'Pages/uilib/components/input/info'
-import InputDemos from 'Pages/uilib/components/input/demos'
+import InputInfo from 'Docs/uilib/components/input/info'
+import InputDemos from 'Docs/uilib/components/input/demos'
 
 <InputInfo />
 <InputDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import InputPassword from '@dnb/eufemia/src/components/input/InputPassword'
 import styled from '@emotion/styled'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.md
@@ -17,7 +17,7 @@ InputExampleNumbers,
 InputExamplePassword,
 InputExampleSubmit,
 InputExampleClear
-} from 'Pages/uilib/components/input/Examples'
+} from 'Docs/uilib/components/input/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.md
@@ -2,8 +2,8 @@
 showTabs: true
 ---
 
-import InlineImg from 'Tags/Img'
-import InputMaskedUsage from 'Pages/uilib/components/input/assets/input-masked.svg'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import InputMaskedUsage from 'Docs/uilib/components/input/assets/input-masked.svg'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo.md
@@ -8,8 +8,8 @@ hideTabs:
   - title: Events
 ---
 
-import LogoInfo from 'Pages/uilib/components/logo/info'
-import LogoDemos from 'Pages/uilib/components/logo/demos'
+import LogoInfo from 'Docs/uilib/components/logo/info'
+import LogoDemos from 'Docs/uilib/components/logo/demos'
 
 <LogoInfo />
 <LogoDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal.md
@@ -7,8 +7,8 @@ showTabs: true
 #   - /uilib/components/drawer
 ---
 
-import ModalInfo from 'Pages/uilib/components/modal/info'
-import ModalDemos from 'Pages/uilib/components/modal/demos'
+import ModalInfo from 'Docs/uilib/components/modal/info'
+import ModalDemos from 'Docs/uilib/components/modal/demos'
 
 <ModalInfo />
 <ModalDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 // import styled from '@emotion/styled'
 
 export const ModalExampleDefault = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/demos.md
@@ -14,7 +14,7 @@ ModalExampleStateOnly,
 ModalExampleCloseByCallback,
 ModalExampleCloseByHandler,
 ModalExampleProgressIndicator,
-} from 'Pages/uilib/components/modal/Examples'
+} from 'Docs/uilib/components/modal/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 import ModalExample from './assets/modal-example.svg'
 import ModalExampleButtons from './assets/modal-example-buttons.svg'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.md
@@ -17,8 +17,8 @@ redirect_from:
   - /uilib/components/number
 ---
 
-import NumberInfo from 'Pages/uilib/components/number-format/info'
-import NumberDemos from 'Pages/uilib/components/number-format/demos'
+import NumberInfo from 'Docs/uilib/components/number-format/info'
+import NumberDemos from 'Docs/uilib/components/number-format/demos'
 
 <NumberInfo />
 <NumberDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 const Style = styled.div`

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.md
@@ -14,8 +14,8 @@ NumberNationalIdentification,
 NumberOrganization,
 NumberLocales,
 NumberSpacing,
-} from 'Pages/uilib/components/number-format/Examples'
-import ChangeLocale from 'Src/core/ChangeLocale'
+} from 'Docs/uilib/components/number-format/Examples'
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/provider.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/provider.md
@@ -4,6 +4,6 @@ redirect_from:
   - /uilib/components/number/provider
 ---
 
-import ProviderInfo from 'Pages/uilib/usage/customisation/provider-info.md'
+import ProviderInfo from 'Docs/uilib/usage/customisation/provider-info.md'
 
 <ProviderInfo></ProviderInfo>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination.md
@@ -5,8 +5,8 @@ order: 12
 showTabs: true
 ---
 
-import PaginationInfo from 'Pages/uilib/components/pagination/info'
-import PaginationDemos from 'Pages/uilib/components/pagination/demos'
+import PaginationInfo from 'Docs/uilib/components/pagination/info'
+import PaginationDemos from 'Docs/uilib/components/pagination/demos'
 
 <PaginationInfo />
 <PaginationDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.js
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 import { Section, Space, Button } from '@dnb/eufemia/src/components'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/demos.md
@@ -10,7 +10,7 @@ PaginationExampleInfinityLoadButton,
 PaginationExampleInfinityIndicator,
 PaginationExampleInfinityUnknown,
 PaginationExampleInfinityTable,
-} from 'Pages/uilib/components/pagination/Examples'
+} from 'Docs/uilib/components/pagination/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/properties.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import DrawerListProperties from 'Pages/uilib/components/fragments/drawer-list/properties'
+import DrawerListProperties from 'Docs/uilib/components/fragments/drawer-list/properties'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator.md
@@ -7,8 +7,8 @@ redirect_from:
   - /uilib/components/progress
 ---
 
-import ProgressIndicatorInfo from 'Pages/uilib/components/progress-indicator/info'
-import ProgressIndicatorDemos from 'Pages/uilib/components/progress-indicator/demos'
+import ProgressIndicatorInfo from 'Docs/uilib/components/progress-indicator/info'
+import ProgressIndicatorDemos from 'Docs/uilib/components/progress-indicator/demos'
 
 <ProgressIndicatorInfo />
 <ProgressIndicatorDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.md
@@ -4,7 +4,7 @@ redirect_from:
   - /uilib/components/progress/demos
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio.md
@@ -5,8 +5,8 @@ order: 12
 showTabs: true
 ---
 
-import RadioInfo from 'Pages/uilib/components/radio/info'
-import RadioDemos from 'Pages/uilib/components/radio/demos'
+import RadioInfo from 'Docs/uilib/components/radio/info'
+import RadioDemos from 'Docs/uilib/components/radio/demos'
 
 <RadioInfo />
 <RadioDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const RadioExampleDefault = () => (
   <ComponentBox data-visual-test="radio-group">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/demos.md
@@ -11,7 +11,7 @@ RadioExampleSizes,
 RadioExampleDisabled,
 RadioExampleSuffix,
 RadioVisualTests
-} from 'Pages/uilib/components/radio/Examples'
+} from 'Docs/uilib/components/radio/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section.md
@@ -7,8 +7,8 @@ hideTabs:
   - title: Events
 ---
 
-import SectionInfo from 'Pages/uilib/components/section/info'
-import SectionDemos from 'Pages/uilib/components/section/demos'
+import SectionInfo from 'Docs/uilib/components/section/info'
+import SectionDemos from 'Docs/uilib/components/section/demos'
 
 <SectionInfo />
 <SectionDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const SectionDemo = () => (
   <ComponentBox hideCode data-visual-test="section-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 import {
 SectionDemo,
@@ -18,7 +18,7 @@ SectionDemoSandYellow,
 SectionDemoPistachio,
 SectionDemoFireRed,
 SectionDemoFireRed8,
-} from 'Pages/uilib/components/section/Examples'
+} from 'Docs/uilib/components/section/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton.md
@@ -8,8 +8,8 @@ hideTabs:
   - title: Events
 ---
 
-import SkeletonInfo from 'Pages/uilib/components/skeleton/info'
-import SkeletonDemos from 'Pages/uilib/components/skeleton/demos'
+import SkeletonInfo from 'Docs/uilib/components/skeleton/info'
+import SkeletonDemos from 'Docs/uilib/components/skeleton/demos'
 
 <SkeletonInfo />
 <SkeletonDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/demos.md
@@ -2,9 +2,9 @@
 showTabs: true
 ---
 
-import PortalSkeleton from 'Parts/uilib/PortalSkeleton'
+import PortalSkeleton from 'dnb-design-system-portal/src/shared/parts/uilib/PortalSkeleton'
 import { AllComponents } from 'dnb-design-system-portal/src/docs/uilib/components/form-row/Examples'
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import Provider from '@dnb/eufemia/src/shared/Provider'
 import Context from '@dnb/eufemia/src/shared/Context'
 import { Article } from '@dnb/eufemia/src/components/skeleton/figures'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider.md
@@ -5,8 +5,8 @@ order: 13
 showTabs: true
 ---
 
-import SliderInfo from 'Pages/uilib/components/slider/info'
-import SliderDemos from 'Pages/uilib/components/slider/demos'
+import SliderInfo from 'Docs/uilib/components/slider/info'
+import SliderDemos from 'Docs/uilib/components/slider/demos'
 
 <SliderInfo />
 <SliderDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import '@dnb/eufemia/src/components/slider/style/dnb-range.scss'
 
 ## Demos

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space.md
@@ -7,8 +7,8 @@ hideTabs:
   - title: Events
 ---
 
-import SpaceInfo from 'Pages/uilib/components/space/info'
-import SpaceDemos from 'Pages/uilib/components/space/demos'
+import SpaceInfo from 'Docs/uilib/components/space/info'
+import SpaceDemos from 'Docs/uilib/components/space/demos'
 
 <SpaceInfo />
 <SpaceDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/demos.md
@@ -10,7 +10,7 @@ SpaceExampleMarginCollapse,
 SpaceExampleMargins,
 SpaceVisualTestPatterns,
 SpaceVisualTestElements
-} from 'Pages/uilib/components/space/Examples'
+} from 'Docs/uilib/components/space/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/info.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import SpacingTable from 'Pages/uilib/usage/layout/spacing-table.md'
+import SpacingTable from 'Docs/uilib/usage/layout/spacing-table.md'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator.md
@@ -6,8 +6,8 @@ order: 14
 showTabs: true
 ---
 
-import StepIndicatorInfo from 'Pages/uilib/components/step-indicator/info'
-import StepIndicatorDemos from 'Pages/uilib/components/step-indicator/demos'
+import StepIndicatorInfo from 'Docs/uilib/components/step-indicator/info'
+import StepIndicatorDemos from 'Docs/uilib/components/step-indicator/demos'
 
 <StepIndicatorInfo />
 <StepIndicatorDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { createBrowserHistory } from 'history'
 
 export const StepIndicatorStatic = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos-v1.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos-v1.md
@@ -4,7 +4,7 @@ draft: true
 ---
 
 import { createBrowserHistory } from 'history'
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Demos v1
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.md
@@ -11,7 +11,7 @@ StepIndicatorUrls,
 StepIndicatorSidebar,
 StepIndicatorTextOnly,
 StepIndicatorCustomRenderer
-} from 'Pages/uilib/components/step-indicator/Examples'
+} from 'Docs/uilib/components/step-indicator/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch.md
@@ -4,8 +4,8 @@ order: 15
 showTabs: true
 ---
 
-import SwitchInfo from 'Pages/uilib/components/switch/info'
-import SwitchDemos from 'Pages/uilib/components/switch/demos'
+import SwitchInfo from 'Docs/uilib/components/switch/info'
+import SwitchDemos from 'Docs/uilib/components/switch/demos'
 
 <SwitchInfo />
 <SwitchDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 const onChange = (state) => {
   console.log('onChangeHandler', state)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/demos.md
@@ -9,7 +9,7 @@ SwitchExampleErrorMessage,
 SwitchExampleSuffix,
 SwitchExampleSizes,
 SwitchExampleDisabled
-} from 'Pages/uilib/components/switch/Examples'
+} from 'Docs/uilib/components/switch/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs.md
@@ -6,8 +6,8 @@ order: 16
 showTabs: true
 ---
 
-import TabsInfo from 'Pages/uilib/components/tabs/info'
-import TabsDemos from 'Pages/uilib/components/tabs/demos'
+import TabsInfo from 'Docs/uilib/components/tabs/info'
+import TabsDemos from 'Docs/uilib/components/tabs/demos'
 
 <TabsInfo />
 <TabsDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 import Input from '@dnb/eufemia/src/components/input/Input'
 import styled from '@emotion/styled'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.md
@@ -11,7 +11,7 @@ TabsExampleUsingData,
 TabsExampleRightAligned,
 TabsExampleReachRouterNavigation,
 TabsExampleReactRouterNavigation,
-} from 'Pages/uilib/components/tabs/Examples'
+} from 'Docs/uilib/components/tabs/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea.md
@@ -6,8 +6,8 @@ order: 17
 showTabs: true
 ---
 
-import TextareaInfo from 'Pages/uilib/components/textarea/info'
-import TextareaDemos from 'Pages/uilib/components/textarea/demos'
+import TextareaInfo from 'Docs/uilib/components/textarea/info'
+import TextareaDemos from 'Docs/uilib/components/textarea/demos'
 
 <TextareaInfo />
 <TextareaDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 
 export const TextareaExampleRowsCols = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.md
@@ -13,7 +13,7 @@ TextareaExampleFormStatus,
 TextareaExampleError,
 TextareaExampleDisabled,
 TextareaExampleSuffix
-} from 'Pages/uilib/components/textarea/Examples'
+} from 'Docs/uilib/components/textarea/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button.md
@@ -5,8 +5,8 @@ order: 18
 showTabs: true
 ---
 
-import ToggleButtonInfo from 'Pages/uilib/components/toggle-button/info'
-import ToggleButtonDemos from 'Pages/uilib/components/toggle-button/demos'
+import ToggleButtonInfo from 'Docs/uilib/components/toggle-button/info'
+import ToggleButtonDemos from 'Docs/uilib/components/toggle-button/demos'
 
 <ToggleButtonInfo />
 <ToggleButtonDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const ToggleButtonUnchecked = () => (
   <ComponentBox data-visual-test="toggle-button-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/demos.md
@@ -13,7 +13,7 @@ ToggleButtonStatusMessages,
 ToggleButtonDisabledGroup,
 ToggleButtonSuffix,
 ToggleButtonIconOnly
-} from 'Pages/uilib/components/toggle-button/Examples'
+} from 'Docs/uilib/components/toggle-button/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
@@ -7,8 +7,8 @@ hideTabs:
   - title: Events
 ---
 
-import TooltipInfo from 'Pages/uilib/components/tooltip/info'
-import TooltipDemos from 'Pages/uilib/components/tooltip/demos'
+import TooltipInfo from 'Docs/uilib/components/tooltip/info'
+import TooltipDemos from 'Docs/uilib/components/tooltip/demos'
 
 <TooltipInfo />
 <TooltipDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/Examples.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const TooltipExampleDefault = () => (
   <ComponentBox data-visual-test="tooltip-hover">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.md
@@ -9,7 +9,7 @@ TooltipExampleNumberFormat,
 TooltipExampleNumberFormatWrapped,
 TooltipExampleLinked,
 TooltipExampleActive
-} from 'Pages/uilib/components/tooltip/Examples'
+} from 'Docs/uilib/components/tooltip/Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements.md
@@ -4,18 +4,18 @@ icon: 'elements'
 order: 6
 ---
 
-import CodeBlock from 'Tags/CodeBlock'
-import ComponentBox from 'Tags/ComponentBox'
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Link } from '@dnb/eufemia/src/elements'
-import NotSupportedElements from 'Pages/uilib/elements/not-supported'
-import UnstyledElements from 'Pages/uilib/elements/unstyled'
-import Anchor from 'Pages/uilib/elements/anchor'
-import Blockquote from 'Pages/uilib/elements/blockquote'
-import Tables from 'Pages/uilib/elements/tables'
-import Lists from 'Pages/uilib/elements/lists'
-import Image from 'Pages/uilib/elements/image'
-import Hr from 'Pages/uilib/elements/horizontal-rule'
-import Code from 'Pages/uilib/elements/code'
+import NotSupportedElements from 'Docs/uilib/elements/not-supported'
+import UnstyledElements from 'Docs/uilib/elements/unstyled'
+import Anchor from 'Docs/uilib/elements/anchor'
+import Blockquote from 'Docs/uilib/elements/blockquote'
+import Tables from 'Docs/uilib/elements/tables'
+import Lists from 'Docs/uilib/elements/lists'
+import Image from 'Docs/uilib/elements/image'
+import Hr from 'Docs/uilib/elements/horizontal-rule'
+import Code from 'Docs/uilib/elements/code'
 
 # HTML Elements
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.md
@@ -2,7 +2,7 @@
 title: 'Anchor (Text Link)'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { IconPrimary } from '@dnb/eufemia/src'
 
 ## Anchor (Text Link)

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.md
@@ -2,7 +2,7 @@
 title: 'Blockquote'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Blockquote
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule.md
@@ -4,7 +4,7 @@ redirect_from:
   - /uilib/elements/hr
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Horizontal Rule
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/image.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/image.md
@@ -2,7 +2,7 @@
 title: 'Image'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Image
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
@@ -2,7 +2,7 @@
 title: 'Lists'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Lists
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
@@ -1,4 +1,4 @@
-import CodeBlock from 'Tags/CodeBlock'
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
 
 ## Missing HTML Elements
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/tables.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/tables.md
@@ -2,7 +2,7 @@
 title: 'Tables'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { css, Global } from '@emotion/react'
 
 <Global styles={css`body{ .dnb-app-content { overflow: visible; } }`} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
@@ -1,4 +1,4 @@
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Unstyled HTML Elements
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card.md
@@ -18,8 +18,8 @@ redirect_from:
   - /uilib/patterns/payment-card
 ---
 
-import PaymentCardInfo from 'Pages/uilib/extensions/payment-card/info'
-import PaymentCardDemos from 'Pages/uilib/extensions/payment-card/demos'
+import PaymentCardInfo from 'Docs/uilib/extensions/payment-card/info'
+import PaymentCardDemos from 'Docs/uilib/extensions/payment-card/demos'
 
 <PaymentCardInfo />
 <PaymentCardDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/demos.md
@@ -2,9 +2,9 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import PaymentCard, { getCardData, Designs, ProductType, CardType } from '@dnb/eufemia/src/extensions/payment-card'
-import ChangeLocale from 'Src/core/ChangeLocale'
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/getting-started.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/getting-started.md
@@ -5,7 +5,7 @@ icon: 'getting_started'
 order: 2
 ---
 
-import WelcomeAdvice from 'Pages/welcome-advice.md'
+import WelcomeAdvice from 'Docs/welcome-advice.md'
 import { Button } from '@dnb/eufemia/src'
 
 # Getting Started

--- a/packages/dnb-design-system-portal/src/docs/uilib/getting-started/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/getting-started/demos.md
@@ -5,7 +5,7 @@ order: 5
 ---
 
 import { Button } from '@dnb/eufemia/src'
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 
 # Demo Apps
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers.md
@@ -15,6 +15,6 @@ redirect_from:
   - /uilib/helper-classes
 ---
 
-import HelperClassesInfo from 'Pages/uilib/helpers/info'
+import HelperClassesInfo from 'Docs/uilib/helpers/info'
 
 <HelperClassesInfo />

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import styled from '@emotion/styled'
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 // have a limit because this page is used for screenshot tests
 const Wrapper = styled.div`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.md
@@ -9,8 +9,8 @@ UnstyledListExample,
 ScreenReaderOnlyExample,
 NoScreenReaderExample,
 SelectionExample
-} from 'Pages/uilib/helpers/Examples'
-import SkipLinkExample from 'Pages/uilib/usage/accessibility/examples/skip-link-example.js'
+} from 'Docs/uilib/helpers/Examples'
+import SkipLinkExample from 'Docs/uilib/usage/accessibility/examples/skip-link-example.js'
 
 Reusing classes in the markup instead of using SCSS extends or _mixins_ will prevent duplication in the `@dnb/eufemia`. So also your application will have good benefits from reusing these helper classes.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/info/about-watching-releases.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/info/about-watching-releases.md
@@ -1,5 +1,5 @@
-import EufemiaLogo from 'Pages/contribution/assets/eufemia-logo.js'
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import EufemiaLogo from 'Docs/contribution/assets/eufemia-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 ## The Eufemia Repository

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro.md
@@ -2,6 +2,6 @@
 fullscreen: true
 ---
 
-import IntroPage from 'Pages/uilib/intro/01-about-design-systems.md'
+import IntroPage from 'Docs/uilib/intro/01-about-design-systems.md'
 
 <IntroPage />

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.md
@@ -3,7 +3,7 @@ fullscreen: true
 search: 'Intro - What forms the system?'
 ---
 
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 import WhatIsEufemia from 'Docs/uilib/intro/assets/what-is-a-design-system.svg'
 
 <Intro>

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/06-css-packages.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/06-css-packages.md
@@ -3,7 +3,7 @@ fullscreen: true
 search: 'Intro - CSS Packages'
 ---
 
-import { Next } from 'Tags/Intro'
+import { Next } from 'dnb-design-system-portal/src/shared/tags/Intro'
 import { Link } from '@dnb/eufemia/src/elements'
 
 <Intro>

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.md
@@ -3,7 +3,7 @@ fullscreen: true
 search: 'Intro - Layout'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <Intro>
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/performance-test.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/performance-test.md
@@ -4,7 +4,7 @@ icon: 'performance'
 order: 11
 ---
 
-import PerformanceTest from 'Src/uilib/performance-test/PerformanceTest'
+import PerformanceTest from 'dnb-design-system-portal/src/uilib/performance-test/PerformanceTest'
 
 # Performance Test of Web Components
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography.md
@@ -13,7 +13,7 @@ tabs:
     key: /uilib/typography/paragraph
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Typography in general
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.md
@@ -5,7 +5,7 @@ redirect_from:
   - /uilib/typography/font-weights
 ---
 
-import TypographyExamples from 'Pages/uilib/typography/TypographyExamples'
+import TypographyExamples from 'Docs/uilib/typography/TypographyExamples'
 
 # Font Weights
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/heading.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/heading.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Headings
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/paragraph.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/paragraph.md
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 ## Paragraphs
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage.md
@@ -4,9 +4,9 @@ icon: 'usage'
 order: 3
 ---
 
-<!-- import ReleasesInfo from 'Pages/design-system/changelog/info-about-releases' -->
+<!-- import ReleasesInfo from 'Docs/design-system/changelog/info-about-releases' -->
 
-import WatchingReleases from 'Pages/uilib/info/about-watching-releases.md'
+import WatchingReleases from 'Docs/uilib/info/about-watching-releases.md'
 
 # Usage
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.md
@@ -3,7 +3,7 @@ title: 'Focus'
 description: 'Accessibility helpers to handle focus management and Skip Link usage.'
 ---
 
-import SkipLinkExample from 'Pages/uilib/usage/accessibility/examples/skip-link-example.js'
+import SkipLinkExample from 'Docs/uilib/usage/accessibility/examples/skip-link-example.js'
 
 # Focus Management
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/icons.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/icons.md
@@ -2,8 +2,8 @@
 title: 'Icons'
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
-import Beach from 'Pages/uilib/usage/accessibility/assets/beach'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
+import Beach from 'Docs/uilib/usage/accessibility/assets/beach'
 
 # Accessibility of Icons
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation.md
@@ -5,7 +5,7 @@ status: null
 order: 4
 ---
 
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 # Customization

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/colors.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/colors.md
@@ -3,8 +3,8 @@ title: 'Colors'
 order: 5
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
-import ColorsTable from 'Pages/quickguide-designer/colors-table.md'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
+import ColorsTable from 'Docs/quickguide-designer/colors-table.md'
 
 # Colors
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/component-properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/component-properties.md
@@ -3,7 +3,7 @@ title: 'Component Properties'
 order: 1
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { hamburger as hamburgerIcon } from '@dnb/eufemia/src/icons/secondary_icons'
 
 # Component Properties

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/event-handling.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/event-handling.md
@@ -3,7 +3,7 @@ title: 'Event Handling'
 order: 2
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 # Event Handling
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/provider.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/provider.md
@@ -3,7 +3,7 @@ title: 'Provider / Context'
 order: 9
 ---
 
-import ProviderInfo from 'Pages/uilib/usage/customisation/provider-info.md'
+import ProviderInfo from 'Docs/uilib/usage/customisation/provider-info.md'
 
 # Provider / Context
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.md
@@ -4,9 +4,9 @@ description: 'To ensure flexibility and the possibility of theming, the DNB CSS 
 order: 3
 ---
 
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 import { Icon } from '@dnb/eufemia/src'
-import CSSDiagram from 'Pages/uilib/usage/customisation/assets/css_structure_diagram.js'
+import CSSDiagram from 'Docs/uilib/usage/customisation/assets/css_structure_diagram.js'
 
 # CSS Styles
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/legacy-styling.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/legacy-styling.js
@@ -5,13 +5,15 @@
 
 import React from 'react'
 import styled from '@emotion/styled'
-import InlineImg from 'Tags/Img'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 import { css } from '@emotion/react'
 import { Button, Icon } from '@dnb/eufemia/src/components'
 import { H2, H4, P, Hr, Code } from '@dnb/eufemia/src/elements'
 import { bell } from '@dnb/eufemia/src/icons'
 import LegacyCodeStylingExample from './assets/legacy-code-styling-example.png'
-import PortalStyle, { gridStyle } from 'Src/shared/parts/PortalStyle'
+import PortalStyle, {
+  gridStyle,
+} from 'dnb-design-system-portal/src/shared/parts/PortalStyle'
 
 const LegacyCodeStyling = () => (
   <div

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.md
@@ -3,7 +3,7 @@ title: 'First Steps'
 order: 2
 ---
 
-import GithubLogo from 'Pages/contribution/assets/github-logo.js'
+import GithubLogo from 'Docs/contribution/assets/github-logo.js'
 import { Icon } from '@dnb/eufemia/src'
 
 # First Steps

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/angular.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/angular.md
@@ -1,5 +1,5 @@
-import InlineImg from 'Tags/Img'
-import AngularAppScreenshot from 'Pages/uilib/usage/first-steps/assets/example-angular-1-screenshot.png'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import AngularAppScreenshot from 'Docs/uilib/usage/first-steps/assets/example-angular-1-screenshot.png'
 
 # Angular
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/bundles.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/bundles.md
@@ -3,7 +3,7 @@ title: 'Bundles: UMD and ESM (mjs)'
 order: 10
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 # Bundles
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/react.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/react.md
@@ -3,7 +3,7 @@ title: 'React & TypeScript'
 order: 5
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Button, IconPrimary } from '@dnb/eufemia/src'
 import { hamburger as hamburgerIcon } from '@dnb/eufemia/src/icons/secondary_icons'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/the-basics.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/the-basics.md
@@ -3,7 +3,7 @@ title: 'The Basics'
 order: 2
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <!-- They don't rely on any global style-sheets such as **normalize.css** beside the main DNB Stylesheet. -->
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/web-components.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/web-components.md
@@ -5,7 +5,7 @@ order: 9
 draft: true
 ---
 
-import ComponentBox from 'Tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 # Web Components
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/media-queries.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/media-queries.md
@@ -4,7 +4,7 @@ status: 'new'
 order: 2
 ---
 
-import ComponentBox from 'Src/shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import MediaQuery from '@dnb/eufemia/src/shared/MediaQuery'
 import useMediaQuery from '@dnb/eufemia/src/shared/useMediaQuery'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/spacing.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/spacing.md
@@ -3,7 +3,7 @@ title: 'Spacing'
 order: 1
 ---
 
-import SpacingTable from 'Pages/uilib/usage/layout/spacing-table.md'
+import SpacingTable from 'Docs/uilib/usage/layout/spacing-table.md'
 
 # Spacing
 

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
@@ -3,7 +3,7 @@ import { Modal, Space, Tooltip } from '@dnb/eufemia/src/components'
 import { H2 } from '@dnb/eufemia/src/elements'
 import ToggleGrid from './ToggleGrid'
 import { Context } from '@dnb/eufemia/src/shared'
-import PortalSkeleton from 'Parts/uilib/PortalSkeleton'
+import PortalSkeleton from 'dnb-design-system-portal/src/shared/parts/uilib/PortalSkeleton'
 import ChangeLocale from '../../core/ChangeLocale'
 
 export default function PortalToolsMenu({


### PR DESCRIPTION
This PR simplifies the usage of Webpack aliases inside and between the docs.