### PR TITLE
chore: replace jsconfig with jsconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "Pages/*": ["./packages/dnb-design-system-portal/src/docs/*"]
-    }
-  },
-  "exclude": ["node_modules"]
-}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "husky": "7.0.4",
-    "node-gyp": "8.4.0"
+    "node-gyp": "8.4.0",
+    "typescript": "4.4.4"
   },
   "resolutions": {
     "svg2vectordrawable/svgo": "2.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "jsx": "react",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "jest"],
+    "sourceMap": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "Pages/*": ["./packages/dnb-design-system-portal/src/docs/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13684,6 +13684,7 @@ __metadata:
   dependencies:
     husky: 7.0.4
     node-gyp: 8.4.0
+    typescript: 4.4.4
   languageName: unknown
   linkType: soft
 
@@ -32070,6 +32071,26 @@ __metadata:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  languageName: node
+  linkType: hard
+
+"typescript@npm:4.4.4":
+  version: 4.4.4
+  resolution: "typescript@npm:4.4.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 89ecb8436bb48ef5594d49289f5f89103071716b6e4844278f4fb3362856e31203e187a9c76d205c3f0b674d221a058fd28310dbcbcf5d95e9a57229bb5203f1
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@4.4.4#~builtin<compat/typescript>":
+  version: 4.4.4
+  resolution: "typescript@patch:typescript@npm%3A4.4.4#~builtin<compat/typescript>::version=4.4.4&hash=ddd1e8"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: bd629ad0da4a15d79aaad56baf3ee7d96f6a181760d430ae77f8c5325df7bffd9edee57544a3970e3651e8b796fe03a5838a7eb39c6d46cc3866c0b23d36a0dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
VSCode uses this to let its internal TS to work, but it gets too little config, so we rather sue tscofnig and give it more details there.
