### PR TITLE
fix: fix Breadcrumb Storybook Docgen issue

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,8 +4,6 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
-pnpMode: loose
-
 packageExtensions:
   "@dnb/eufemia@*":
     dependencies:
@@ -40,6 +38,8 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/plugin-ignore-install-options.cjs
-    spec: .yarn/unplugged/yarn-plugin-ignore-install-options-npm-1.0.2-e13e094f36/node_modules/yarn-plugin-ignore-install-options/ignore-install-options-1.0.2.js
+    spec: packages/dnb-design-system-portal/node_modules/yarn-plugin-ignore-install-options/ignore-install-options-1.0.2.js
+
+pnpMode: loose
 
 yarnPath: .yarn/releases/yarn-3.1.0.cjs

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -110,7 +110,7 @@ const plugins = [
 
 if (currentBranch === 'release') {
   plugins.push({
-    // this (optional) plugin enables Progressive Web App + Offline functionality
+    // This (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     resolve: 'gatsby-plugin-offline',
     options: {
@@ -122,7 +122,7 @@ if (currentBranch === 'release') {
   })
 }
 
-// used for algolia search
+// Algolia search
 const queries = require('./src/uilib/search/searchQuery')
 if (queries) {
   plugins.push({
@@ -138,15 +138,6 @@ if (queries) {
 }
 
 module.exports = {
-  flags: {
-    /**
-     * because of the local visual tests,
-     * we disable the SSR features.
-     * The reason? every page takes longer time to render.
-     */
-    DEV_SSR: false,
-    FAST_DEV: false,
-  },
   pathPrefix,
   siteMetadata,
   plugins,

--- a/packages/dnb-eufemia-sandbox/stories/components/Breadcrumb.tsx
+++ b/packages/dnb-eufemia-sandbox/stories/components/Breadcrumb.tsx
@@ -10,12 +10,12 @@ import React, { useState } from 'react'
 import {
   Breadcrumb,
   Skeleton,
-  ToggleButton,
-  Button,
+  // ToggleButton,
+  // Button,
 } from '@dnb/eufemia/src/components'
 import { Provider } from '@dnb/eufemia/src/shared'
 import {
-  BreadcrumbItem,
+  // BreadcrumbItem,
   BreadcrumbItemProps,
 } from '@dnb/eufemia/src/components/breadcrumb/Breadcrumb'
 import { Box, Wrapper } from '../helpers'

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem'
-export * from './Breadcrumb'
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
 import classnames from 'classnames'
@@ -10,6 +9,8 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 import { useMediaQuery, SkeletonTypes } from '../../shared'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import { Button } from '..'
+
+export * from './BreadcrumbItem'
 
 export interface BreadcrumbProps {
   /**
@@ -114,9 +115,7 @@ export const defaultProps = {
   data: null,
 }
 
-export default function Breadcrumb(
-  localProps: BreadcrumbProps & ISpacingProps
-) {
+function Breadcrumb(localProps: BreadcrumbProps & ISpacingProps) {
   // Every component should have a context
   const context = React.useContext(Context)
   // Extract additional props from global context
@@ -240,4 +239,6 @@ export default function Breadcrumb(
 
 Breadcrumb.Item = BreadcrumbItem
 
-export { BreadcrumbItem, BreadcrumbItemProps }
+export { BreadcrumbItem }
+
+export default Breadcrumb

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -65,19 +65,12 @@ export default function BreadcrumbItem(localProps: BreadcrumbItemProps) {
   } = context
 
   // Extract additional props from global context
-  const {
-    text,
-    href,
-    icon,
-    onClick,
-    variant,
-    skeleton,
-    ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
-    defaultProps,
-    context?.BreadcrumbItem
-  )
+  const { text, href, icon, onClick, variant, skeleton, ...props } =
+    extendPropsWithContext(
+      { ...defaultProps, ...localProps },
+      defaultProps,
+      context?.BreadcrumbItem
+    )
 
   const currentIcon =
     icon || (variant === 'home' && homeIcon) || 'chevron_left'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,12 @@
   "compileOnSave": false,
   "compilerOptions": {
     "jsx": "react",
-    "allowJs": false,
+    "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "jest"],
     "sourceMap": true,
+    "outFile": "out.js",
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This PR makes Storybook running again. After we added tsconfig it had some problems due to the underlaing docgen usage and our ts setup.

Also, remove flag in gatsby-config for much faster dev startup time.