### PR TITLE
Fix Autocomplete data value handling

### DIFF
--- a/packages/dnb-eufemia-sandbox/stories/components/Autocomplete.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/Autocomplete.js
@@ -47,6 +47,65 @@ export const SearchNumbers = () => {
   )
 }
 
+const accounts = [
+  { selected_id: 1, content: 'A' },
+  { selected_id: 2, content: 'B' },
+  { selected_id: 3, content: 'C' },
+  { selected_id: 4, content: 'D' },
+]
+export function UpdateEachOther() {
+  const [selectedA, setSelectedA] = React.useState(-1)
+  const [selectedB, setSelectedB] = React.useState(-1)
+  const [selectedAccountsA, setSelectedAccountsA] =
+    React.useState(accounts)
+  const [selectedAccountsB, setSelectedAccountsB] =
+    React.useState(accounts)
+
+  const indexA = selectedAccountsA.findIndex(({ selected_id }) => {
+    return selected_id === selectedA
+  })
+  const indexB = selectedAccountsB.findIndex(({ selected_id }) => {
+    return selected_id === selectedB
+  })
+
+  console.log('selectedA', { selectedAccountsA, selectedA, indexA })
+  console.log('selectedB', { selectedAccountsB, selectedB, indexB })
+
+  return (
+    <>
+      <Autocomplete
+        top
+        right
+        label="selectedA"
+        data={selectedAccountsA}
+        value={indexA}
+        on_change={({ data: account }) => {
+          setSelectedA(account?.selected_id)
+          setSelectedAccountsB(
+            accounts.filter(({ selected_id }) => {
+              return selected_id !== account?.selected_id
+            })
+          )
+        }}
+      />
+      <Autocomplete
+        top
+        label="selectedB"
+        data={selectedAccountsB}
+        value={indexB}
+        on_change={({ data: account }) => {
+          setSelectedB(account?.selected_id)
+          setSelectedAccountsA(
+            accounts.filter(({ selected_id }) => {
+              return selected_id !== account?.selected_id
+            })
+          )
+        }}
+      />
+    </>
+  )
+}
+
 export function onBlur() {
   return (
     <Autocomplete

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -436,12 +436,16 @@ class AutocompleteInstance extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
-      const inputValue = AutocompleteInstance.getCurrentDataTitle(
-        this.context.drawerList.selected_item,
-        this.context.drawerList.original_data
-      )
-      this.setState({
-        inputValue,
+      // Ensure we run getCurrentDataTitle after also data has been update,
+      // in case data has changed
+      this.setState({}, () => {
+        const inputValue = AutocompleteInstance.getCurrentDataTitle(
+          this.context.drawerList.selected_item,
+          this.context.drawerList.original_data
+        )
+        this.setState({
+          inputValue,
+        })
       })
     }
   }

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -390,9 +390,9 @@ class AutocompleteInstance extends React.PureComponent {
         state.inputValue = props.input_value
       }
 
-      if (props.data !== state.init_data) {
+      if (props.data !== state.prevData) {
         state.updateData(props.data)
-        state.init_data = props.data
+        state.prevData = props.data
       }
     }
 
@@ -410,7 +410,7 @@ class AutocompleteInstance extends React.PureComponent {
     this.state = this.state || {}
     this.state._listenForPropChanges = true
     this.state.mode = props.mode
-    this.state.init_data = props.data // only to compare against new data
+    this.state.prevData = props.data // only to compare against new data
     this.state.updateData = this.updateData // only so we can call setData
 
     if (context.drawerList && context.drawerList.current_title) {
@@ -731,20 +731,25 @@ class AutocompleteInstance extends React.PureComponent {
   updateData = (rawData) => {
     // invalidate the local cache now,
     // because we get else the same after we show the new result
-    this.context.drawerList.setState({
-      cache_hash: 'updateData',
-    })
-
-    // If the "selected_key" has changed in comparison to the existing data,
-    // invalidated our selected_item
-    const itemIndex = this.context.drawerList.selected_item
-    if (parseFloat(itemIndex) > -1) {
-      const newItem = rawData[itemIndex]
-      const oldItem = this.context.drawerList.original_data[itemIndex]
-      if (newItem?.selected_key !== oldItem?.selected_key) {
-        this.resetSelectionItem()
+    this.context.drawerList.setState(
+      {
+        cache_hash: 'updateData',
+      },
+      () => {
+        // If the "selected_key" has changed in comparison to the existing data,
+        // invalidated our selected_item
+        // Also, ensure to run if after a state update, because the "selected_item" (value prop) can have changed,
+        // and should match the new data
+        const itemIndex = this.context.drawerList.selected_item
+        if (parseFloat(itemIndex) > -1) {
+          const newItem = rawData[itemIndex]
+          const oldItem = this.context.drawerList.original_data[itemIndex]
+          if (newItem?.selected_key !== oldItem?.selected_key) {
+            this.resetSelectionItem()
+          }
+        }
       }
-    }
+    )
 
     this.context.drawerList.setData(
       () => rawData, // set data as a function, so it gets re-evaluated with normalizeData

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -865,6 +865,24 @@ describe('Autocomplete component', () => {
       />
     )
 
+    // 1. Make first a selected_item change
+    Comp.setProps({ value: 2 })
+
+    // 2. Then update the data
+    Comp.setProps({ data: newMockData })
+
+    // 3. And change the value again
+    Comp.setProps({ value: 1 })
+
+    // It should not trigger the resetSelectionItem method
+    expect(on_change).toHaveBeenCalledTimes(0)
+    expect(Comp.find('input').instance().value).toBe(
+      newMockData[1].content
+    )
+
+    // Reset data and value
+    Comp.setProps({ value: null, data: mockData })
+
     Comp.find('input').simulate('change', { target: { value: 'cc' } })
 
     // Make a selection
@@ -875,9 +893,11 @@ describe('Autocomplete component', () => {
     expect(on_change).toHaveBeenCalledTimes(1)
     expect(on_change.mock.calls[0][0].data).toEqual(mockData[1])
 
+    // Trigger data update
     Comp.find('input').simulate('change', { target: { value: 'c' } })
 
     expect(Comp.find('input').instance().value).toBe('c')
+
     expect(on_change).toHaveBeenCalledTimes(2)
     expect(on_change.mock.calls[1][0].data).toEqual(undefined)
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -711,23 +711,26 @@ describe('Autocomplete component', () => {
     expect(on_focus).toHaveBeenCalledTimes(2)
   })
 
-  it('updates its input value if value prop changes', () => {
+  it('updates its input value if value and data prop changes', () => {
     let value = 0
+    let data = mockData
 
     const Comp = mount(
-      <Component value={value} data={mockData} {...mockProps} />
+      <Component value={value} data={data} {...mockProps} />
     )
 
     Comp.find('input').simulate('focus')
 
     expect(Comp.find('.dnb-input__input').instance().value).toBe(
-      mockData[value]
+      data[value]
     )
 
     value = 1
-    Comp.setProps({ value })
+    data = ['New data', ...mockData]
+
+    Comp.setProps({ value, data })
     expect(Comp.find('.dnb-input__input').instance().value).toBe(
-      mockData[value]
+      data[value]
     )
   })
 


### PR DESCRIPTION
This PR fixes two bugs – similar code wise, but with a different outcome. 
In both cases, we get a new `data` array, but used internally the old one, while using the new `value`.