### PR TITLE
chore: release without dependent checks

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,4 +1,4 @@
-name: Build Check
+name: Build Check # This name is used in the release.yml workflow_run event
 
 on:
   push:
@@ -8,6 +8,10 @@ on:
       - '!**--visual-reports'
       - '!wip/**'
       - '!experiments/**'
+      - '!release'
+      - '!portal'
+      - '!beta'
+      - '!alpha'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Eufemia Release
 
 on:
-  workflow_run:
+  push:
     branches:
       - 'release'
       - 'portal'
       - 'beta'
       - 'alpha'
-    workflows: ['Verify']
-    types:
-      - completed
 
 jobs:
   action:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,6 +8,10 @@ on:
       - '!**--visual-reports'
       - '!wip/**'
       - '!experiments/**'
+      - '!release'
+      - '!portal'
+      - '!beta'
+      - '!alpha'
 
 jobs:
   action:


### PR DESCRIPTION
During 9.16 release I had to force push the changes in this PR in order to get i tout. It looks like the release workflow does not run a a branch, when it is "dependent". It bypass instead the most important steps. 

But because we already run both the Verify and the Build Check on main, we can omit it for now, and just release.