### PR TITLE
chore(Portal): make React import optional

### DIFF
--- a/packages/dnb-design-system-portal/.eslintrc
+++ b/packages/dnb-design-system-portal/.eslintrc
@@ -28,6 +28,7 @@
   ],
   "plugins": ["react", "react-hooks", "jsx-a11y"],
   "rules": {
+    "react/react-in-jsx-scope": "off",
     "no-console": "off",
     "react/prop-types": "warn",
     "react/require-default-props": "warn",

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -141,4 +141,5 @@ module.exports = {
   pathPrefix,
   siteMetadata,
   plugins,
+  jsxRuntime: 'automatic',
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
@@ -3,7 +3,6 @@
  *
  */
 
-import React from 'react'
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const BreadcrumbSingle = () => (

--- a/packages/dnb-eufemia/.eslintrc
+++ b/packages/dnb-eufemia/.eslintrc
@@ -34,6 +34,7 @@
     "security"
   ],
   "rules": {
+    "react/react-in-jsx-scope": "off",
     "import/namespace": "off",
     "no-restricted-imports": [
       "error",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This is a React v17 feature. With this PR we can use it today already. Not sure if I personally will use it that often. But its a feature of Gatsby 4.1, so why not enable it right.