### PR TITLE
fix(InputMasked): fix manual range selection

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -164,6 +164,12 @@ export const correctCaretPosition = (element, maskParams) => {
 
       if (suffix || prefix) {
         const start = element.selectionStart
+        const end = element.selectionEnd
+
+        if (start !== end) {
+          return // stop here
+        }
+
         const suffixStart = element.value.indexOf(suffix)
         const suffixEnd = suffixStart + suffix?.length
         let pos = undefined

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
@@ -361,6 +361,7 @@ describe('InputMasked component', () => {
         target: {
           value,
           selectionStart: value.indexOf('kr'), // set it where the mask starts
+          selectionEnd: value.indexOf('kr'), // set it where the mask starts
           setSelectionRange,
         },
       })


### PR DESCRIPTION
When selecting partial or all input masked content, the selection got lost. This PR fixes this behaviour by checking if the user has selected more than one char.