### PR TITLE
fix(InputMasked): fix misplaced leading zero while typing

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -106,6 +106,17 @@ export const correctNumberValue = ({
     const localNumberValue = localValue.replace(/[^\d,.]/g, '')
     const numberValue = value.replace(/[^\d,.]/g, '')
 
+    const endsWithDecimal = localNumberValue.endsWith(decimalSymbol)
+    const endsWithZeroAndDecimal = localNumberValue.endsWith(
+      `${decimalSymbol}0`
+    )
+
+    if (endsWithDecimal) {
+      value = `${value}${decimalSymbol}`
+    } else if (endsWithZeroAndDecimal) {
+      value = `${value}${decimalSymbol}0`
+    }
+
     /**
      * If the user removes a leading digit and we have left a leading zero.
      *
@@ -123,17 +134,6 @@ export const correctNumberValue = ({
       parseFloat(numberValue) === parseFloat(localNumberValue)
     ) {
       value = localValue
-    }
-
-    const endsWithDecimal = localNumberValue.endsWith(decimalSymbol)
-    const endsWithZeroAndDecimal = localNumberValue.endsWith(
-      `${decimalSymbol}0`
-    )
-
-    if (endsWithDecimal) {
-      value = `${value}${decimalSymbol}`
-    } else if (endsWithZeroAndDecimal) {
-      value = `${value}${decimalSymbol}0`
     }
 
     if (


### PR DESCRIPTION
This PR fixes an issue when `allowLeadingZeroes` was true while typing


Reproduction [CSB](https://codesandbox.io/s/inputmasked-bug-leading-zeroes-l0hf5)