### PR TITLE
fix(InputMasked): handle initial empty string value

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -136,11 +136,7 @@ export const correctNumberValue = ({
       value = localValue
     }
 
-    if (
-      localNumberValue === ''
-      // TODO: Not sure if we need this check
-      // String(value).replace(/[^\d]/g, '') === '0'
-    ) {
+    if (localNumberValue === '' && numberValue === '0') {
       value = ''
     }
   }

--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.js
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.js
@@ -92,7 +92,8 @@ export default class TextMask extends React.PureComponent {
       isPipeChanged
 
     // Сalculate that value was changed
-    const isValueChanged = value !== this.inputRef.current.value
+    const isValueChanged =
+      value !== this.inputRef.current.value || prevProps.value !== value
 
     // Check value and settings to prevent duplicating update() call
     if (isValueChanged || isSettingChanged) {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
@@ -282,6 +282,16 @@ describe('InputMasked component', () => {
     expect(Comp.find('input').instance().value).toBe('NOK 0 012,01 kr')
   })
 
+  it('should update value when initial value was an empty string', () => {
+    const Comp = mount(<Component value="" number_mask />)
+
+    expect(Comp.find('input').instance().value).toBe('')
+
+    Comp.setProps({ value: 1234 })
+
+    expect(Comp.find('input').instance().value).toBe('1 234')
+  })
+
   it('should update value when value has leading zero', () => {
     const Comp = mount(
       <Component


### PR DESCRIPTION
This PR fixes also a reported issue. It occurres when an empty string was given initially. Then the update value prop did not make any changes.  

Reproduction [CSB](https://codesandbox.io/s/inputmasked-bug-empty-string-s4zp2?file=/src/App.jsx)