### PR TITLE
fix(Section): Text color on --fire-red-8

### DIFF
--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.js.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.js.snap
@@ -90,7 +90,7 @@ exports[`Section scss have to match default theme snapshot 1`] = `
     color: var(--color-fire-red); }
 
 .dnb-section--fire-red-8 {
-  color: var(--color-white); }
+  color: var(--color-black-80); }
   .dnb-section--fire-red-8::after {
     color: var(--color-fire-red-8); }
 

--- a/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
@@ -86,7 +86,7 @@
     }
   }
   &--fire-red-8 {
-    color: var(--color-white);
+    color: var(--color-black-80);
     &::after {
       color: var(--color-fire-red-8);
     }


### PR DESCRIPTION
Needed to change this for the new GlobalStatus. Considered it would be best as an independent PR.

Fire-red-8 is a very bright version of fire red, so changed default color to black-80 instead of white (for better contrast).
