### PR TITLE
fix(InputMasked): inputmode usage on Android phones

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -95,7 +95,7 @@
     "classnames": "2.3.1",
     "core-js": "3.19.1",
     "date-fns": "2.25.0",
-    "keycode": "2.2.0",
+    "keycode": "2.2.1",
     "prop-types": "15.7.2",
     "what-input": "5.2.10"
   },

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
@@ -309,10 +309,12 @@ const useCallEvent = ({ setLocalValue }) => {
     value = value || event.target.value
     const keyCode = keycode(event)
     const selStart = event.target.selectionStart
+    const isUnidentified = event.which === 229 || keyCode === undefined // Android issue
 
     // Prevent entering a leading zero
     if (
       name === 'on_key_down' &&
+      !isUnidentified &&
       !maskParams?.allowLeadingZeroes &&
       (keyCode === '0' ||
         (value.replace(/[^\d]/g, '') === '' &&
@@ -330,7 +332,11 @@ const useCallEvent = ({ setLocalValue }) => {
       }
     }
 
-    if (name === 'on_key_down' && maskParams?.decimalSymbol) {
+    if (
+      name === 'on_key_down' &&
+      !isUnidentified &&
+      maskParams?.decimalSymbol
+    ) {
       const hasDecimalSymbol = value.includes(maskParams.decimalSymbol)
       const allowedDecimals =
         maskParams.decimalLimit > 0 || maskParams.allowDecimal !== false

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -9,7 +9,7 @@ import {
   getThousandsSeparator,
 } from '../number-format/NumberUtils'
 import { warn } from '../../shared/component-helper'
-import { IS_IE11 } from '../../shared/helpers'
+import { IS_IE11, IS_ANDROID } from '../../shared/helpers'
 
 const enableLocaleSupportWhen = ['as_number', 'as_percent', 'as_currency']
 const enableNumberMaskWhen = [
@@ -301,7 +301,11 @@ export const handleNumberMask = ({
  */
 export function getInputModeFromMask(mask) {
   const maskParams = mask?.maskParams
-  if (maskParams && mask?.instanceOf === 'createNumberMask') {
+  if (
+    !IS_ANDROID &&
+    maskParams &&
+    mask?.instanceOf === 'createNumberMask'
+  ) {
     return maskParams.allowDecimal && maskParams.decimalLimit !== 0
       ? 'decimal'
       : 'numeric'

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -113,7 +113,15 @@ export const correctNumberValue = ({
 
     if (endsWithDecimal) {
       value = `${value}${decimalSymbol}`
-    } else if (endsWithZeroAndDecimal) {
+    } else if (
+      endsWithZeroAndDecimal &&
+      !numberValue.endsWith(`${decimalSymbol}0`)
+    ) {
+      /**
+       * When the users has 20,02, then hits "backspace",
+       * the returned {numberValue} in the onChange event would then be "20",
+       * but we want it to be 20,0
+       */
       value = `${value}${decimalSymbol}0`
     }
 
@@ -195,7 +203,6 @@ export const correctCaretPosition = (element, maskParams) => {
           pos = suffixStart - 1
         }
 
-        // console.log('pos2', pos)
         if (!isNaN(parseFloat(pos))) {
           element.setSelectionRange(pos, pos)
         }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
@@ -526,6 +526,36 @@ describe('InputMasked component with currency_mask', () => {
     expect(Comp.find('TextMask').props().showMask).toBe(false)
   })
 
+  it('should handle zero after decimal', () => {
+    const Input = () => {
+      const [value, setValue] = React.useState('20.0')
+      return (
+        <Component
+          value={value}
+          currency_mask
+          on_change={({ numberValue }) => {
+            setValue(numberValue)
+          }}
+        />
+      )
+    }
+    const Comp = mount(<Input />)
+
+    expect(Comp.find('input').instance().value).toBe('20,0 kr')
+
+    Comp.find('input').simulate('change', {
+      target: { value: '20,02' },
+    })
+
+    expect(Comp.find('input').instance().value).toBe('20,02 kr')
+
+    Comp.find('input').simulate('change', {
+      target: { value: '20,0' },
+    })
+
+    expect(Comp.find('input').instance().value).toBe('20,0 kr')
+  })
+
   it('can change value to be empty', () => {
     const BasicMask = () => {
       const [floatval, setState] = React.useState(123)

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
@@ -12,6 +12,7 @@ import {
 } from '../../../core/jest/jestSetup'
 import Component from '../InputMasked'
 import Provider from '../../../shared/Provider'
+import * as helpers from '../../../shared/helpers'
 
 const snapshotProps = {
   ...fakeProps(require.resolve('../InputMasked'), {
@@ -287,6 +288,50 @@ describe('InputMasked component', () => {
     expect(onChange.mock.calls[0][0].value).toBe('NOK 0012,01 kr')
     expect(onChange.mock.calls[0][0].numberValue).toBe(12.01)
     expect(Comp.find('input').instance().value).toBe('NOK 0 012,01 kr')
+  })
+
+  it('should change inputmode to text when IS_ANDROID', () => {
+    const onKeyDown = jest.fn()
+    const preventDefault = jest.fn()
+
+    const Comp = mount(
+      <Component
+        {...props}
+        value={1234.5}
+        number_mask
+        on_key_down={onKeyDown}
+      />
+    )
+
+    expect(Comp.find('input').instance().getAttribute('inputmode')).toBe(
+      'numeric'
+    )
+
+    // eslint-disable-next-line
+    helpers.IS_ANDROID = true
+
+    // Re-render
+    Comp.setProps({})
+
+    expect(Comp.find('input').instance().getAttribute('inputmode')).toBe(
+      null
+    )
+
+    // eslint-disable-next-line
+    helpers.IS_ANDROID = false
+
+    Comp.find('input').simulate('keydown', {
+      key: ',',
+      keyCode: 229, // unidentified, while 188 would have worked fine
+      target: {
+        value: '1234.5',
+      },
+      preventDefault,
+    })
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+    expect(preventDefault).toHaveBeenCalledTimes(0)
+    expect(Comp.find('input').instance().value).toBe('1 234')
   })
 
   it('should update value when initial value was an empty string', () => {

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -12,6 +12,7 @@ export { registerElement }
 
 export const PLATFORM_MAC = 'Mac|iPad|iPhone|iPod'
 export const PLATFORM_WIN = 'Win'
+export const PLATFORM_ANDROID = 'Android'
 export const PLATFORM_LINUX = 'Linux'
 export const PLATFORM_IOS = 'iOS|iPhone|iPad|iPod'
 

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -7,6 +7,7 @@ import {
   warn,
   PLATFORM_MAC,
   PLATFORM_WIN,
+  PLATFORM_ANDROID,
   PLATFORM_LINUX,
   PLATFORM_IOS,
 } from './component-helper'
@@ -17,6 +18,7 @@ export let IS_IOS = false
 export let IS_SAFARI = false
 export let IS_WIN = false
 export let IS_MAC = false
+export let IS_ANDROID = false
 export let IS_LINUX = false
 
 export const isMac = () =>
@@ -28,6 +30,11 @@ export const isWin = () =>
   (IS_WIN =
     typeof navigator !== 'undefined' &&
     new RegExp(PLATFORM_WIN, 'i').test(navigator?.platform))
+
+export const isAndroid = () =>
+  (IS_ANDROID =
+    typeof navigator !== 'undefined' &&
+    new RegExp(PLATFORM_ANDROID, 'i').test(navigator?.userAgent))
 
 export const isLinux = () =>
   (IS_LINUX =
@@ -60,6 +67,7 @@ isEdge()
 isiOS()
 isSafari()
 isWin()
+isAndroid()
 isMac()
 isLinux()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,7 +2006,7 @@ __metadata:
     jest-raw-loader: 1.0.1
     jest-screenshot: 0.3.5
     jest-tobetype: 1.2.3
-    keycode: 2.2.0
+    keycode: 2.2.1
     lint-staged: 11.2.6
     lockfile-lint: 4.6.2
     lodash.isequal: 4.5.0
@@ -20263,6 +20263,13 @@ __metadata:
   version: 2.2.0
   resolution: "keycode@npm:2.2.0"
   checksum: cb91c2940a892f1444a41fc08339b8831445a6b095af9103e3061ea7d4bdbfc420135dcb5d9257020e35c374468bb7d4495ea9fcea54e5760196daff3c874fa4
+  languageName: node
+  linkType: hard
+
+"keycode@npm:2.2.1":
+  version: 2.2.1
+  resolution: "keycode@npm:2.2.1"
+  checksum: 7a5c775b2410a3b6d9c07a415ecb70639187a965be239d2c11c71079cb1ca2f9dede94b86426f3ece475dc8ae3debf2367531bbcafc0af8c82f157d9a4f7e6cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Among issues like: a dot appears on the Android soft keyboard, but this lets the user not enter a coma.

Android sends just 229 on most of the keycodes when using the keyDown event.

It always returns 229 because it is a W3C standard to return 229 when an "Input Method Editor" is processing and the event is keydown.  It appeared in a 2010 W3C spec linked below.

A [codepen](https://codepen.io/ashconnolly/pen/WyWgPG?__cf_chl_captcha_tk__=30wzbiTaXd90vfTkcOT6ijFBIqzQToyJk6R65lT3k9U-1637164880-0-gaNycGzNB2U) on that topic.

Because the InputMasked is using the keycode in several ways – we have to do someting.
As of now, we simply avoid using `inputmode`.

Reprod from Marius K. [CSB](https://codesandbox.io/s/optimistic-herschel-uu43h?file=/src/App.jsx)