### PR TITLE
Fix(NumberFormat): types for NumberUtils

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -68,7 +68,7 @@ export interface formatOptionParams {
   /** If an object should be returned, including the "aria" property */
   returnAria?: boolean;
 }
-export type format = (
+export const format: (
   value: formatValue,
   options?: formatOptionParams
 ) => formatReturnType;
@@ -80,7 +80,7 @@ type cleanNumberOptions = {
   suffix?: string; // to help the cleaning process
 };
 
-export type cleanNumber = (
+export const cleanNumber: (
   num: number | string,
   options?: cleanNumberOptions
 ) => number | string;


### PR DESCRIPTION
export format and cleanNumber as functions and not types

## Summary

format and cleanNumber were exported as `type` instead of as a function.
This makes typescript complain about it being used as a type and not a value
