### PR TITLE
StepIndicator SSR enhancement

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.md
@@ -26,7 +26,7 @@ The step indicator has a optionally a Sidebar "sister" component you can place i
 
 ```jsx
 <main>
-	<StepIndicator sidebar_id="unique-id" mode="strict" />
+	<StepIndicator sidebar_id="unique-id" mode="strict" data={[...]} />
 </main>
 
 <aside>
@@ -34,9 +34,31 @@ The step indicator has a optionally a Sidebar "sister" component you can place i
 </aside>
 ```
 
+#### Sidebar and SSR
+
+**NB:** Keep in mind, if you SSR render the Sidebar **before** the main component, it has no access to the `data` and will show a basic skeleton to ensure the sidebar gets its width. This helps to lower the impact of unwanted layout shift.
+
+If you are able to provide the `data` to the Sidebar as well, it will use it during SSR render. You also can provide the data with a wrapper Eufemia Provider (You can nest Eufemia Providers):
+
+```jsx
+<Provider StepIndicator={{ data: [...] }}>
+  <main>
+    <StepIndicator sidebar_id="unique-id" mode="strict" />
+  </main>
+
+  <aside>
+    <StepIndicator.Sidebar sidebar_id="unique-id" />
+  </aside>
+</Provider>
+```
+
 ## Modes
 
 The mode property is mandatory. It tells the component how it should behave.
+
+- [`strict`](/uilib/components/step-indicator#strict-mode)
+- [`loose`](/uilib/components/step-indicator#loose-mode)
+- [`static`](/uilib/components/step-indicator#static-mode)
 
 ### Strict mode
 

--- a/packages/dnb-eufemia-sandbox/stories/components/StepIndicator.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/StepIndicator.js
@@ -9,9 +9,66 @@ import { Wrapper, Box } from '../helpers'
 import { createBrowserHistory } from 'history'
 import { StepIndicator, Button, Space } from '@dnb/eufemia/src/components'
 import { Code } from '@dnb/eufemia/src/elements'
+import { Provider } from '@dnb/eufemia/src/shared'
 
 export default {
   title: 'Eufemia/Components/StepIndicator',
+}
+
+export function RenderDuringSSR() {
+  const [count, increment] = React.useState(0)
+
+  const data = [
+    {
+      title: 'Velg mottaker ' + count,
+    },
+    {
+      title: 'Bestill eller erstatt ' + count,
+      on_click: ({ current_step }) =>
+        console.log('current_step:', current_step),
+      status:
+        'Du må velge bestill nytt kort eller erstatt kort for å kunne fullføre bestillingen din.',
+    },
+    {
+      title: 'Oppsummering ' + count,
+    },
+  ]
+
+  return (
+    <>
+      <Provider StepIndicator={{ data }}>
+        <StepIndicator.Sidebar
+          // showInitialData
+          // top
+          id="sidebar"
+          sidebar_id="unique-id-strict"
+          // data={data}
+          // mode="loose"
+          // current_step={2}
+        />
+        <StepIndicator
+          // skeleton
+          id="main"
+          sidebar_id="unique-id-strict"
+          // mode="strict"
+          mode="loose"
+          data={data}
+          // current_step={0}
+          current_step={1}
+          on_change={({ current_step }) => {
+            console.log('on_change', current_step)
+          }}
+        />
+      </Provider>
+      <Button
+        top
+        on_click={() => {
+          increment((c) => c + 1)
+        }}
+        text="increment"
+      />
+    </>
+  )
 }
 
 const data = [

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.js
@@ -5,15 +5,11 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import Context from '../../shared/Context'
 import {
   makeUniqueId,
   warn,
   registerElement,
-  processChildren,
-  extendPropsWithContext,
 } from '../../shared/component-helper'
-import EventEmitter from '../../shared/EventEmitter'
 import StepIndicatorSidebar from './StepIndicatorSidebar'
 
 import StepIndicatorModal from './StepIndicatorModal'
@@ -26,7 +22,6 @@ import {
 
 export default class StepIndicator extends React.PureComponent {
   static tagName = 'dnb-step-indicator'
-  static contextType = Context
 
   static Sidebar = StepIndicatorSidebar
 
@@ -46,55 +41,6 @@ export default class StepIndicator extends React.PureComponent {
       StepIndicator,
       StepIndicator.defaultProps
     )
-  }
-
-  static getData(props) {
-    let res = []
-    if (props.data) res = props.data
-    else res = processChildren(props)
-    if (typeof res === 'string')
-      return res[0] === '[' ? JSON.parse(res) : []
-    return res || []
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    state.data = StepIndicator.getData(props)
-    state.countSteps = state.data.length
-
-    if (
-      props.current_step !== null &&
-      props.current_step !== state._current_step
-    ) {
-      state.activeStep = parseFloat(props.current_step) || 0
-    }
-
-    /** Deprecated */
-    if (
-      props.active_item !== null &&
-      props.active_item !== state._active_item
-    ) {
-      state.activeStep = parseFloat(props.active_item) || 0
-    }
-
-    /** Deprecated */
-    if (props.active_url && state.data.length > 0) {
-      state.activeStep = state.data.reduce((acc, { url }, i) => {
-        return url &&
-          (url === state.current_step || url === props.active_url)
-          ? i
-          : acc
-      }, parseFloat(state.current_step) || 0)
-    }
-
-    if (!state.listOfReachedSteps.includes(state.activeStep)) {
-      state.listOfReachedSteps.push(state.activeStep)
-    }
-
-    state._current_step = props.current_step
-    state._active_item = props.active_item /** Deprecated */
-    state._active_url = props.active_url /** Deprecated */
-
-    return state
   }
 
   // Deprecated warning
@@ -138,57 +84,15 @@ export default class StepIndicator extends React.PureComponent {
         'StepIndicator: `show_numbers` is deprecated. Use `hide_numbers` instead.'
       )
     }
-
-    this._eventEmitter = EventEmitter.createInstance(this.state.sidebar_id)
-
-    if (!this.state.listOfReachedSteps) {
-      this.state.listOfReachedSteps = []
-    }
-  }
-
-  setActiveStep = (activeStep) => {
-    this.setState({ activeStep })
-  }
-
-  componentWillUnmount() {
-    if (this._eventEmitter) {
-      this._eventEmitter.remove()
-      this._eventEmitter = null
-    }
-  }
-
-  getContextData(context = this.context) {
-    // use only the props from context, who are available here anyway
-    const data = extendPropsWithContext(
-      this.props,
-      StepIndicator.defaultProps,
-      { skeleton: context?.skeleton },
-      context.getTranslation(this.props).StepIndicator,
-      context.FormRow,
-      context.StepIndicator
-    )
-
-    data.stepsLabel = data.step_title
-      ?.replace('%step', this.state.activeStep + 1)
-      .replace('%count', this.state.countSteps)
-    data.stepsLabelExtended = data.step_title_extended
-      ?.replace('%step', this.state.activeStep + 1)
-      .replace('%count', this.state.countSteps)
-
-    return data
   }
 
   render() {
-    const contextData = this.getContextData(this.context)
-
     // deprecated
     if (this.state.isV1) {
       return (
         <StepIndicatorProvider
-          {...this.state}
-          {...contextData}
+          {...this.props}
           sidebar_id={this.state.sidebar_id}
-          setActiveStep={this.setActiveStep}
           listAttributes={this.props}
           isV1={this.state.isV1} // deprecated
         >
@@ -207,10 +111,8 @@ export default class StepIndicator extends React.PureComponent {
 
     return (
       <StepIndicatorProvider
-        {...this.state}
-        {...contextData}
+        {...this.props}
         sidebar_id={this.state.sidebar_id}
-        setActiveStep={this.setActiveStep}
         isV1={this.state.isV1} // deprecated
       >
         <div className="dnb-step-indicator-v2">

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.js
@@ -5,8 +5,13 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import EventEmitter from '../../shared/EventEmitter'
+import Context from '../../shared/Context'
 import { stepIndicatorDefaultProps } from './StepIndicatorProps'
+import {
+  processChildren,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
+import { onMediaQueryChange } from '../../shared/MediaQueryUtils'
 
 // We use this array to filter out unwanted
 const filterAttributes = Object.keys(stepIndicatorDefaultProps)
@@ -15,8 +20,10 @@ const filterAttributes = Object.keys(stepIndicatorDefaultProps)
   })
   .concat([
     'internalId',
+    'isSidebar',
     'hasSidebar',
     'hideSidebar',
+    'sidebarIsVisible',
     'mainTitle',
     'stepsLabel',
     'stepsLabelExtended',
@@ -24,7 +31,12 @@ const filterAttributes = Object.keys(stepIndicatorDefaultProps)
     'setActiveStep',
     'activeStep',
     'countSteps',
+    'openState',
+    'onChangeState',
+    'openHandler',
+    'closeHandler',
     'innerRef',
+    'hasSkeletonData',
     'filterAttributes',
     'listAttributes',
     'onChangeState',
@@ -37,44 +49,185 @@ const StepIndicatorContext = React.createContext(null)
 export default StepIndicatorContext
 
 export class StepIndicatorProvider extends React.PureComponent {
+  static contextType = Context
+
   static propTypes = {
     sidebar_id: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
+    isSidebar: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    isSidebar: false,
+  }
+
+  static getData(props) {
+    let res = []
+    if (props.data) res = props.data
+    else res = processChildren(props)
+    if (typeof res === 'string')
+      return res[0] === '[' ? JSON.parse(res) : []
+    return res || []
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (props.data) {
+      state.data = StepIndicatorProvider.getData(props)
+    }
+    state.countSteps = state.data?.length
+
+    if (
+      parseFloat(props.current_step) > -1 &&
+      props.current_step !== state._current_step
+    ) {
+      state.activeStep = parseFloat(props.current_step) || 0
+    }
+
+    /** Deprecated */
+    if (
+      props.active_item !== null &&
+      props.active_item !== state._active_item
+    ) {
+      state.activeStep = parseFloat(props.active_item) || 0
+    }
+
+    /** Deprecated */
+    if (props.active_url && state.data.length > 0) {
+      state.activeStep = state.data.reduce((acc, { url }, i) => {
+        return url &&
+          (url === state.current_step || url === props.active_url)
+          ? i
+          : acc
+      }, parseFloat(state.current_step) || 0)
+    }
+
+    if (!state.listOfReachedSteps.includes(state.activeStep)) {
+      state.listOfReachedSteps.push(state.activeStep)
+    }
+
+    state.stepsLabel = state.step_title
+      ?.replace('%step', (state.activeStep || 0) + 1)
+      .replace('%count', state.data?.length || 1)
+    state.stepsLabelExtended = state.step_title_extended
+      ?.replace('%step', (state.activeStep || 0) + 1)
+      .replace('%count', state.data?.length || 1)
+
+    state._current_step = props.current_step
+    state._active_item = props.active_item /** Deprecated */
+    state._active_url = props.active_url /** Deprecated */
+
+    return state
   }
 
   constructor(props) {
     super(props)
 
-    this._eventEmitter = EventEmitter.createInstance(props.sidebar_id)
+    this.state = {
+      hasSidebar: true,
+      hideSidebar: false,
+      activeStep: undefined,
+      setActiveStep: this.setActiveStep,
+      onChangeState: this.onChangeState,
+      openHandler: this.openHandler,
+      closeHandler: this.closeHandler,
+    }
 
-    this.state = this._eventEmitter.get()
+    if (!this.state.listOfReachedSteps) {
+      this.state.listOfReachedSteps = []
+    }
   }
 
   componentDidMount() {
-    this._eventEmitter.listen((state) => {
-      this.setState(state)
-    })
+    this._isMounted = true
+
+    // deprecated (remove the check)
+    if (!this.props.isV1) {
+      this._mediaQueryListener = onMediaQueryChange(
+        {
+          min: '0',
+          max: 'medium',
+        },
+        (hideSidebar) => {
+          this.setState({
+            hideSidebar,
+          })
+        },
+        { runOnInit: true }
+      )
+
+      const container = document?.getElementById(
+        'sidebar__' + this.props.sidebar_id
+      )
+      this.setState({
+        hasSidebar: Boolean(container),
+      })
+    }
   }
 
   componentWillUnmount() {
-    if (this._eventEmitter) {
-      this._eventEmitter.remove()
-      this._eventEmitter = null
+    if (this._mediaQueryListener) {
+      this._mediaQueryListener()
     }
   }
 
   componentDidUpdate() {
-    this._eventEmitter.update({
-      ...this.props,
-    })
+    this.setState(this.makeContextValue())
+  }
+
+  setActiveStep = (activeStep) => {
+    this.setState({ activeStep })
+  }
+
+  onChangeState = () => {
+    this.setState({ openState: false })
+  }
+
+  openHandler = () => {
+    this.setState({ openState: true })
+  }
+
+  closeHandler = () => {
+    this.setState({ openState: false })
+  }
+
+  getGlobalContext(context = this.context) {
+    // use only the props from context, who are available here anyway
+    const data = extendPropsWithContext(
+      this.props,
+      stepIndicatorDefaultProps,
+      { skeleton: context?.skeleton },
+      context.getTranslation(context).StepIndicator,
+      context.FormRow,
+      context.StepIndicator
+    )
+
+    return data
+  }
+
+  makeContextValue({
+    state = { ...this.state },
+    props = this.props,
+    context = this.context,
+  } = {}) {
+    const globalContext = this.getGlobalContext(context)
+
+    const value = extendSafe(
+      { filterAttributes },
+      globalContext,
+      {
+        defaultProps: stepIndicatorDefaultProps,
+        props,
+      },
+      state
+    )
+
+    value.sidebarIsVisible = value.hasSidebar && !value.hideSidebar
+
+    return value
   }
 
   render() {
-    const value = {
-      filterAttributes,
-      ...this.props,
-      ...this.state,
-    }
+    const value = this.makeContextValue()
 
     if (typeof window !== 'undefined' && window.IS_TEST) {
       value.no_animation = true
@@ -93,4 +246,35 @@ export class StepIndicatorProvider extends React.PureComponent {
       </StepIndicatorContext.Provider>
     )
   }
+}
+
+/**
+ * Like "Object.assign" – but safe
+ * A new falsy value will not be used, if it exists already
+ * Also,
+ *
+ * @param  {...object} objects
+ * @returns object
+ */
+function extendSafe(...objects) {
+  const obj = {}
+
+  objects.forEach((itm) => {
+    if (itm.defaultProps && itm.props) {
+      itm = Object.entries(itm.props).reduce((acc, [k, v]) => {
+        if (itm.defaultProps[k] !== v) {
+          acc[k] = v
+        }
+        return acc
+      }, {})
+    }
+
+    Object.entries(itm).forEach(([k, v]) => {
+      if (!obj[k] || (obj[k] && v)) {
+        obj[k] = v
+      }
+    })
+  })
+
+  return obj
 }

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.js
@@ -19,7 +19,6 @@ import {
   InfoIcon,
   ErrorIcon,
 } from '../../components/form-status/FormStatus'
-import EventEmitter from '../../shared/EventEmitter'
 import StepIndicatorContext from './StepIndicatorContext'
 
 // Deprecated
@@ -96,7 +95,6 @@ export default class StepIndicatorItem extends React.PureComponent {
   constructor(props, context) {
     super(props)
 
-    this._eventEmitter = EventEmitter.createInstance(context.sidebar_id)
     this._heightAnim = new AnimateHeight({
       animate: !isTrue(context.no_animation),
     })
@@ -110,7 +108,6 @@ export default class StepIndicatorItem extends React.PureComponent {
 
   componentWillUnmount() {
     this._heightAnim.remove()
-    this._eventEmitter.remove()
   }
 
   getSnapshotBeforeUpdate() {
@@ -226,7 +223,9 @@ export default class StepIndicatorItem extends React.PureComponent {
       ?.replace('%step', currentItemNum + 1)
       .replace('%count', countSteps)
 
-    const isCurrent = currentItemNum === activeStep || isTrue(is_current)
+    const isCurrent =
+      currentItemNum === activeStep ||
+      (isTrue(is_current) && isNaN(parseFloat(activeStep)))
     let element = (
       <StepItemWrapper
         number={currentItemNum + 1}

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorModal.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorModal.js
@@ -4,46 +4,60 @@
  */
 
 import React from 'react'
+import ReactDOM from 'react-dom'
 import Modal from '../modal/Modal'
 import StepIndicatorTriggerButton from './StepIndicatorTriggerButton'
 import StepIndicatorList from './StepIndicatorList'
-import StepIndicatorContext, {
-  StepIndicatorProvider,
-} from './StepIndicatorContext'
+import StepIndicatorContext from './StepIndicatorContext'
 
 export default class StepIndicatorModal extends React.PureComponent {
   static contextType = StepIndicatorContext
 
-  state = { open_state: false }
-
   constructor(props) {
     super(props)
+
     this._triggerRef = React.createRef()
+
+    this.state = { container: null }
   }
 
-  onChangeState = () => {
-    this.setState({ open_state: false })
-  }
-
-  openHandler = () => {
-    this.setState({ open_state: true })
-  }
-
-  closeHandler = () => {
-    this.setState({ open_state: false })
+  closeHandler = (...args) => {
     if (this.context.hasSidebar) {
       this._triggerRef.current?.focus()
     }
+    this.context.closeHandler(...args)
+  }
+
+  componentDidMount() {
+    const container = document.getElementById(
+      'sidebar__' + this.context.sidebar_id
+    )
+
+    this.setState({
+      container,
+    })
+  }
+
+  renderPortal() {
+    if (!this.state.container) {
+      return null
+    }
+
+    return ReactDOM.createPortal(
+      <StepIndicatorList />,
+      this.state.container
+    )
   }
 
   render() {
-    if (this.context.hasSidebar && !this.context.hideSidebar) {
-      return null
+    if (this.context.sidebarIsVisible) {
+      return this.renderPortal()
     }
+
     return (
       <>
         <StepIndicatorTriggerButton
-          on_click={this.openHandler}
+          on_click={this.context.openHandler}
           inner_ref={this._triggerRef}
         />
         <Modal
@@ -52,24 +66,18 @@ export default class StepIndicatorModal extends React.PureComponent {
           trigger_hidden
           mode="drawer"
           animation_direction="bottom"
-          open_state={this.state.open_state}
-          on_open={this.openHandler}
+          open_state={this.context.openState}
+          on_open={this.context.openHandler}
           on_close={this.closeHandler}
         >
-          <StepIndicatorProvider
-            {...this.context}
-            sidebar_id={this.context.sidebar_id}
-            onChangeState={this.onChangeState}
-          >
-            <Modal.Content style_type="white">
-              <div className="dnb-step-indicator-v2">
-                <p className="dnb-p dnb-step-indicator__label">
-                  {this.context.stepsLabelExtended}
-                </p>
-                <StepIndicatorList />
-              </div>
-            </Modal.Content>
-          </StepIndicatorProvider>
+          <Modal.Content style_type="white">
+            <div className="dnb-step-indicator-v2">
+              <p className="dnb-p dnb-step-indicator__label">
+                {this.context.stepsLabelExtended}
+              </p>
+              <StepIndicatorList />
+            </div>
+          </Modal.Content>
         </Modal>
       </>
     )

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorProps.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorProps.js
@@ -29,7 +29,7 @@ export const stepIndicatorPropTypes = {
         url_passed: PropTypes.string, // Deprecated
       })
     ),
-  ]).isRequired,
+  ]),
   overview_title: PropTypes.string,
   step_title_extended: PropTypes.string,
   step_title: PropTypes.string,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.js
@@ -137,7 +137,7 @@ export default class StepIndicatorTriggerButton extends React.PureComponent {
           inner_ref={this._buttonRef}
         >
           <StepItemWrapper
-            number={this.context.activeStep + 1}
+            number={(this.context.activeStep || 0) + 1}
             hide_numbers={this.context.hide_numbers}
           >
             {(typeof item === 'string' ? item : item && item.title) || ''}

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator-v1.test.js.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator-v1.test.js.snap
@@ -35,15 +35,10 @@ exports[`StepIndicator component with buttons have to match snapshot 1`] = `
   use_navigation={true}
 >
   <StepIndicatorProvider
-    _active_item={1}
-    _active_url={null}
-    _current_step={null}
-    activeStep={1}
     active_item={1}
     active_url={null}
     class={null}
     className={null}
-    countSteps={3}
     current_step={null}
     data={
       Array [
@@ -60,6 +55,7 @@ exports[`StepIndicator component with buttons have to match snapshot 1`] = `
     }
     hide_numbers={false}
     internalId="unique-buttons"
+    isSidebar={false}
     isV1={true}
     listAttributes={
       Object {
@@ -95,23 +91,16 @@ exports[`StepIndicator component with buttons have to match snapshot 1`] = `
         "use_navigation": true,
       }
     }
-    listOfReachedSteps={
-      Array [
-        1,
-      ]
-    }
     mode={null}
     no_animation={null}
     on_change={null}
     on_click={null}
     on_item_render={null}
-    overview_title="Stegoversikt"
-    setActiveStep={[Function]}
+    overview_title={null}
     sidebar_id="unique-buttons"
-    step_title="Steg %step av %count"
-    step_title_extended="Du er på steg %step av %count"
-    stepsLabel="Steg 2 av 3"
-    stepsLabelExtended="Du er på steg 2 av 3"
+    skeleton={false}
+    step_title={null}
+    step_title_extended={null}
     use_navigation={true}
   >
     <div
@@ -341,15 +330,10 @@ exports[`StepIndicator component with urls have to match snapshot 1`] = `
   use_navigation={null}
 >
   <StepIndicatorProvider
-    _active_item={null}
-    _active_url="?b"
-    _current_step={null}
-    activeStep={1}
     active_item={null}
     active_url="?b"
     class={null}
     className={null}
-    countSteps={3}
     current_step={null}
     data={
       Array [
@@ -370,6 +354,7 @@ exports[`StepIndicator component with urls have to match snapshot 1`] = `
     }
     hide_numbers={false}
     internalId="unique"
+    isSidebar={false}
     isV1={true}
     listAttributes={
       Object {
@@ -409,23 +394,16 @@ exports[`StepIndicator component with urls have to match snapshot 1`] = `
         "use_navigation": null,
       }
     }
-    listOfReachedSteps={
-      Array [
-        1,
-      ]
-    }
     mode={null}
     no_animation={null}
     on_change={null}
     on_click={null}
     on_item_render={null}
-    overview_title="Stegoversikt"
-    setActiveStep={[Function]}
+    overview_title={null}
     sidebar_id="unique"
-    step_title="Steg %step av %count"
-    step_title_extended="Du er på steg %step av %count"
-    stepsLabel="Steg 2 av 3"
-    stepsLabelExtended="Du er på steg 2 av 3"
+    skeleton={false}
+    step_title={null}
+    step_title_extended={null}
     use_navigation={null}
   >
     <div
@@ -900,11 +878,19 @@ exports[`StepIndicator scss have to match snapshot 1`] = `
     background-color: currentColor;
     box-shadow: 100vw 0 0 0 currentColor; }
 
-.dnb-step-indicator__sidebar {
-  max-width: 20rem;
-  margin-right: var(--spacing-x-large); }
-  .dnb-step-indicator__sidebar .dnb-step-indicator__item {
-    min-width: 320px; }
+@media screen and (min-width: 50.1em) {
+  .dnb-step-indicator__sidebar {
+    max-width: 20rem;
+    margin-right: var(--spacing-x-large); }
+    .dnb-step-indicator__sidebar .dnb-step-indicator__item {
+      min-width: 320px; } }
+
+@media screen and (max-width: 50.1em) {
+  .dnb-step-indicator__sidebar--ssr-skeleton {
+    visibility: hidden;
+    overflow: hidden;
+    width: 0;
+    height: 5.5rem; } }
 
 .dnb-step-indicator-v2 .dnb-step-indicator__list {
   display: flex;

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
@@ -3,241 +3,488 @@
 exports[`StepIndicator in loose mode have to match snapshot 1`] = `
 Array [
   <StepIndicatorSidebar
-    internalId={null}
+    current_step={null}
+    data={Array []}
+    mode={null}
     sidebar_id="unique-id-loose-snapshot"
   >
-    <StepIndicatorProvider
-      hasSidebar={true}
-      hideSidebar={false}
-      listAttributes={
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-loose-snapshot"
+    />
+  </StepIndicatorSidebar>,
+  <StepIndicator
+    active_item={null}
+    active_url={null}
+    class={null}
+    className={null}
+    current_step={1}
+    data={
+      Array [
         Object {
-          "internalId": null,
-          "sidebar_id": "unique-id-loose-snapshot",
-        }
+          "title": "Step A",
+        },
+        Object {
+          "title": "Step B",
+        },
+        Object {
+          "title": "Step C",
+        },
+        Object {
+          "title": "Step D",
+        },
+      ]
+    }
+    hide_numbers={false}
+    mode="loose"
+    no_animation={null}
+    on_change={null}
+    on_click={null}
+    on_item_render={null}
+    overview_title={null}
+    sidebar_id="unique-id-loose-snapshot"
+    skeleton={false}
+    step_title={null}
+    step_title_extended={null}
+    use_navigation={null}
+  >
+    <StepIndicatorProvider
+      active_item={null}
+      active_url={null}
+      class={null}
+      className={null}
+      current_step={1}
+      data={
+        Array [
+          Object {
+            "title": "Step A",
+          },
+          Object {
+            "title": "Step B",
+          },
+          Object {
+            "title": "Step C",
+          },
+          Object {
+            "title": "Step D",
+          },
+        ]
       }
+      hide_numbers={false}
+      isSidebar={false}
+      isV1={false}
+      mode="loose"
+      no_animation={null}
+      on_change={null}
+      on_click={null}
+      on_item_render={null}
+      overview_title={null}
       sidebar_id="unique-id-loose-snapshot"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
+      use_navigation={null}
     >
       <div
-        className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+        className="dnb-step-indicator-v2"
       >
-        <StepIndicatorList>
-          <nav
-            className="dnb-step-indicator"
-          >
-            <ol
-              className="dnb-step-indicator__list"
-            >
-              <StepIndicatorItem
-                currentItemNum={0}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="0"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step A"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
+        <StepIndicatorModal>
+          <Portal
+            containerInfo={
+              <div
+                class="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+                id="sidebar__unique-id-loose-snapshot"
               >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--visited"
+                <nav
+                  class="dnb-step-indicator"
                 >
-                  <StepItemButton
-                    aria-describedby="unique-id-loose-snapshot-0"
-                    className={null}
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <button
-                          aria-describedby="unique-id-loose-snapshot-0"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          type="button"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                1
-                                .
-                              </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step A
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </button>,
-                      }
-                    }
-                    onClick={[Function]}
-                    status={null}
-                    status_state="warn"
+                  <ol
+                    class="dnb-step-indicator__list"
                   >
-                    <Button
-                      aria-describedby="unique-id-loose-snapshot-0"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-loose-snapshot-0"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  1
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step A
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
-                        }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--visited"
                     >
                       <button
                         aria-describedby="unique-id-loose-snapshot-0"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                         type="button"
                       >
-                        <Content
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              1
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step A
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-loose-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                    <li
+                      aria-current="step"
+                      class="dnb-step-indicator__item dnb-step-indicator__item--current"
+                    >
+                      <button
+                        aria-describedby="unique-id-loose-snapshot-1"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                        type="button"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              2
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step B
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-loose-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item"
+                    >
+                      <button
+                        aria-describedby="unique-id-loose-snapshot-2"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                        type="button"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              3
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step C
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-loose-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item"
+                    >
+                      <button
+                        aria-describedby="unique-id-loose-snapshot-3"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                        type="button"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              4
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step D
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-loose-snapshot-3"
+                      >
+                        Steg 4 av 4
+                      </span>
+                    </li>
+                  </ol>
+                </nav>
+              </div>
+            }
+          >
+            <StepIndicatorList>
+              <nav
+                className="dnb-step-indicator"
+              >
+                <ol
+                  className="dnb-step-indicator__list"
+                >
+                  <StepIndicatorItem
+                    currentItemNum={0}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="0"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step A"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--visited"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-loose-snapshot-0"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-loose-snapshot-0"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
+                                <span
+                                  class="dnb-step-indicator__item-content"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
+                                  >
+                                    1
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step A
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
+                                <svg
+                                  fill="none"
+                                  height="24"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1.5 15L7.5 21L22.5 3"
+                                    stroke="black"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
+                                  />
+                                </svg>
+                              </span>
+                            </button>,
+                          }
+                        }
+                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                      >
+                        <Button
                           aria-describedby="unique-id-loose-snapshot-0"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step A
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -311,11 +558,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -329,335 +575,336 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-loose-snapshot-0"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
+                            <Content
+                              aria-describedby="unique-id-loose-snapshot-0"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step A
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-loose-snapshot-0"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          1
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step A
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      1
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step A
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  1
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-loose-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={1}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="1"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step B"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      aria-current="step"
+                      className="dnb-step-indicator__item dnb-step-indicator__item--current"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-loose-snapshot-1"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-loose-snapshot-1"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step A
+                                    2
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step B
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-loose-snapshot-0"
-                  >
-                    Steg 1 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={1}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="1"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step B"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  aria-current="step"
-                  className="dnb-step-indicator__item dnb-step-indicator__item--current"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-loose-snapshot-1"
-                    className={null}
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <button
-                          aria-describedby="unique-id-loose-snapshot-1"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          type="button"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                2
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step B
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </button>,
-                      }
-                    }
-                    onClick={[Function]}
-                    status={null}
-                    status_state="warn"
-                  >
-                    <Button
-                      aria-describedby="unique-id-loose-snapshot-1"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-loose-snapshot-1"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  2
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step B
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
+                            </button>,
+                          }
                         }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <button
-                        aria-describedby="unique-id-loose-snapshot-1"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
                         onClick={[Function]}
-                        type="button"
+                        status={null}
+                        status_state="warn"
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-loose-snapshot-1"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step B
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -731,11 +978,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -749,334 +995,335 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-loose-snapshot-1"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
+                            <Content
+                              aria-describedby="unique-id-loose-snapshot-1"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step B
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-loose-snapshot-1"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          2
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step B
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      2
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step B
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  2
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-loose-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={2}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="2"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step C"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-loose-snapshot-2"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-loose-snapshot-2"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step B
+                                    3
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step C
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-loose-snapshot-1"
-                  >
-                    Steg 2 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={2}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="2"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step C"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-loose-snapshot-2"
-                    className={null}
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <button
-                          aria-describedby="unique-id-loose-snapshot-2"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          type="button"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                3
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step C
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </button>,
-                      }
-                    }
-                    onClick={[Function]}
-                    status={null}
-                    status_state="warn"
-                  >
-                    <Button
-                      aria-describedby="unique-id-loose-snapshot-2"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-loose-snapshot-2"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  3
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step C
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
+                            </button>,
+                          }
                         }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <button
-                        aria-describedby="unique-id-loose-snapshot-2"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
                         onClick={[Function]}
-                        type="button"
+                        status={null}
+                        status_state="warn"
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-loose-snapshot-2"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step C
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -1150,11 +1397,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -1168,334 +1414,335 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-loose-snapshot-2"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
+                            <Content
+                              aria-describedby="unique-id-loose-snapshot-2"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step C
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-loose-snapshot-2"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          3
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step C
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      3
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step C
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  3
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-loose-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={3}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="3"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step D"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-loose-snapshot-3"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-loose-snapshot-3"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step C
+                                    4
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step D
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-loose-snapshot-2"
-                  >
-                    Steg 3 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={3}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="3"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step D"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-loose-snapshot-3"
-                    className={null}
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <button
-                          aria-describedby="unique-id-loose-snapshot-3"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          type="button"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                4
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step D
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </button>,
-                      }
-                    }
-                    onClick={[Function]}
-                    status={null}
-                    status_state="warn"
-                  >
-                    <Button
-                      aria-describedby="unique-id-loose-snapshot-3"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-loose-snapshot-3"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  4
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
+                            </button>,
+                          }
                         }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <button
-                        aria-describedby="unique-id-loose-snapshot-3"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
                         onClick={[Function]}
-                        type="button"
+                        status={null}
+                        status_state="warn"
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-loose-snapshot-3"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step D
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -1569,11 +1816,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -1587,128 +1833,259 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-loose-snapshot-3"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
+                            <Content
+                              aria-describedby="unique-id-loose-snapshot-3"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step D
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-loose-snapshot-3"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          4
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step D
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      4
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step D
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  4
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
-                                <span
-                                  className="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    className="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
                             attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
                             title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
-                                <svg
-                                  fill="none"
-                                  height={24}
-                                  viewBox="0 0 24 24"
-                                  width={24}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M1.5 15L7.5 21L22.5 3"
-                                    stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
-                                  />
-                                </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-loose-snapshot-3"
-                  >
-                    Steg 4 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-            </ol>
-          </nav>
-        </StepIndicatorList>
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-loose-snapshot-3"
+                      >
+                        Steg 4 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                </ol>
+              </nav>
+            </StepIndicatorList>
+          </Portal>
+        </StepIndicatorModal>
       </div>
     </StepIndicatorProvider>
+  </StepIndicator>,
+]
+`;
+
+exports[`StepIndicator in loose mode have to match snapshot on small screen 1`] = `
+Array [
+  <StepIndicatorSidebar
+    current_step={null}
+    data={Array []}
+    mode={null}
+    sidebar_id="unique-id-loose-snapshot"
+  >
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-loose-snapshot"
+    />
   </StepIndicatorSidebar>,
   <StepIndicator
     active_item={null}
@@ -1746,15 +2123,10 @@ Array [
     use_navigation={null}
   >
     <StepIndicatorProvider
-      _active_item={null}
-      _active_url={null}
-      _current_step={1}
-      activeStep={1}
       active_item={null}
       active_url={null}
       class={null}
       className={null}
-      countSteps={4}
       current_step={1}
       data={
         Array [
@@ -1773,98 +2145,265 @@ Array [
         ]
       }
       hide_numbers={false}
+      isSidebar={false}
       isV1={false}
-      listOfReachedSteps={
-        Array [
-          1,
-        ]
-      }
       mode="loose"
       no_animation={null}
       on_change={null}
       on_click={null}
       on_item_render={null}
-      overview_title="Stegoversikt"
-      setActiveStep={[Function]}
+      overview_title={null}
       sidebar_id="unique-id-loose-snapshot"
-      step_title="Steg %step av %count"
-      step_title_extended="Du er på steg %step av %count"
-      stepsLabel="Steg 2 av 4"
-      stepsLabelExtended="Du er på steg 2 av 4"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
       use_navigation={null}
     >
       <div
         className="dnb-step-indicator-v2"
       >
-        <StepIndicatorModal />
-      </div>
-    </StepIndicatorProvider>
-  </StepIndicator>,
-]
-`;
-
-exports[`StepIndicator in static mode have to match snapshot 1`] = `
-Array [
-  <StepIndicatorSidebar
-    internalId={null}
-    sidebar_id="unique-id-static-snapshot"
-  >
-    <StepIndicatorProvider
-      hasSidebar={true}
-      hideSidebar={false}
-      listAttributes={
-        Object {
-          "internalId": null,
-          "sidebar_id": "unique-id-static-snapshot",
-        }
-      }
-      sidebar_id="unique-id-static-snapshot"
-    >
-      <div
-        className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
-      >
-        <StepIndicatorList>
-          <div
-            className="dnb-step-indicator"
-          >
-            <ol
-              className="dnb-step-indicator__list"
-            >
-              <StepIndicatorItem
-                currentItemNum={0}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="0"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step A"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--inactive dnb-step-indicator__item--visited"
+        <StepIndicatorModal>
+          <StepIndicatorTriggerButton
+            className={null}
+            inner_ref={
+              Object {
+                "current": <button
+                  aria-describedby="unique-id-loose-snapshot-overview"
+                  class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  id="unique-id-loose-snapshot"
+                  style="height: auto;"
+                  type="button"
                 >
-                  <StepItemButton
-                    aria-describedby="unique-id-static-snapshot-0"
-                    className={null}
-                    element="span"
-                    icon="check"
+                  <span
+                    class="dnb-button__alignment"
+                  >
+                    ‌
+                  </span>
+                  <span
+                    class="dnb-button__text dnb-skeleton--show-font"
+                  >
+                    <span
+                      class="dnb-step-indicator__item-content"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-step-indicator__item-content__number"
+                      >
+                        2
+                        .
+                      </span>
+                      <span
+                        class="dnb-step-indicator__item-content__wrapper"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content__text"
+                        >
+                          Step B
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                    data-test-id="chevron down medium icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19 8.5L12 15.5L5 8.5"
+                        stroke="black"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>,
+              }
+            }
+            on_click={[Function]}
+            sidebar_id={null}
+          >
+            <div
+              aria-live="polite"
+              className="dnb-step-indicator__trigger"
+            >
+              <span
+                className="dnb-sr-only"
+                id="unique-id-loose-snapshot-overview"
+              >
+                Stegoversikt
+              </span>
+              <FormLabel
+                aria-describedby="unique-id-loose-snapshot"
+                class={null}
+                className="dnb-step-indicator__label"
+                disabled={null}
+                element="label"
+                for_id="unique-id-loose-snapshot"
+                id={null}
+                label_direction={null}
+                skeleton={null}
+                sr_only={null}
+                text={null}
+                title={null}
+                vertical={null}
+              >
+                <label
+                  aria-describedby="unique-id-loose-snapshot"
+                  className="dnb-form-label dnb-step-indicator__label"
+                  disabled={false}
+                  htmlFor="unique-id-loose-snapshot"
+                >
+                  Steg 2 av 4
+                </label>
+              </FormLabel>
+              <Button
+                aria-describedby="unique-id-loose-snapshot-overview"
+                bounding={null}
+                class={null}
+                className="dnb-step-indicator__trigger__button"
+                custom_content={null}
+                custom_element={null}
+                custom_method={null}
+                disabled={null}
+                element={null}
+                global_status_id={null}
+                href={null}
+                icon={[Function]}
+                icon_position="right"
+                icon_size="medium"
+                id="unique-id-loose-snapshot"
+                innerRef={null}
+                inner_ref={
+                  Object {
+                    "current": <button
+                      aria-describedby="unique-id-loose-snapshot-overview"
+                      class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      id="unique-id-loose-snapshot"
+                      style="height: auto;"
+                      type="button"
+                    >
+                      <span
+                        class="dnb-button__alignment"
+                      >
+                        ‌
+                      </span>
+                      <span
+                        class="dnb-button__text dnb-skeleton--show-font"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            class="dnb-step-indicator__item-content__wrapper"
+                          >
+                            <span
+                              class="dnb-step-indicator__item-content__text"
+                            >
+                              Step B
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 8.5L12 15.5L5 8.5"
+                            stroke="black"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>,
+                  }
+                }
+                on_click={[Function]}
+                sidebar_id={null}
+                size={null}
+                skeleton={null}
+                status={null}
+                status_no_animation={null}
+                status_props={null}
+                status_state="error"
+                stretch={true}
+                text={null}
+                title={null}
+                to={null}
+                tooltip={null}
+                type={null}
+                variant="secondary"
+                wrap={true}
+              >
+                <button
+                  aria-describedby="unique-id-loose-snapshot-overview"
+                  className="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  disabled={false}
+                  id="unique-id-loose-snapshot"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Content
+                    aria-describedby="unique-id-loose-snapshot-overview"
+                    bounding={null}
+                    class={null}
+                    className="dnb-step-indicator__trigger__button"
+                    content={
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        Step B
+                      </StepItemWrapper>
+                    }
+                    custom_content={null}
+                    custom_element={null}
+                    custom_method={null}
+                    disabled={null}
+                    element={null}
+                    global_status_id={null}
+                    href={null}
+                    icon={[Function]}
+                    icon_position="right"
+                    icon_size="medium"
+                    id="unique-id-loose-snapshot"
+                    innerRef={null}
                     inner_ref={
                       Object {
-                        "current": <span
-                          aria-describedby="unique-id-static-snapshot-0"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                        "current": <button
+                          aria-describedby="unique-id-loose-snapshot-overview"
+                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                          id="unique-id-loose-snapshot"
+                          style="height: auto;"
+                          type="button"
                         >
                           <span
                             class="dnb-button__alignment"
@@ -1881,7 +2420,7 @@ Array [
                                 aria-hidden="true"
                                 class="dnb-step-indicator__item-content__number"
                               >
-                                1
+                                2
                                 .
                               </span>
                               <span
@@ -1890,7 +2429,7 @@ Array [
                                 <span
                                   class="dnb-step-indicator__item-content__text"
                                 >
-                                  Step A
+                                  Step B
                                 </span>
                               </span>
                             </span>
@@ -1898,7 +2437,7 @@ Array [
                           <span
                             aria-hidden="true"
                             class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
+                            data-test-id="chevron down medium icon"
                             role="presentation"
                           >
                             <svg
@@ -1909,7 +2448,7 @@ Array [
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M1.5 15L7.5 21L22.5 3"
+                                d="M19 8.5L12 15.5L5 8.5"
                                 stroke="black"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"
@@ -1917,127 +2456,675 @@ Array [
                               />
                             </svg>
                           </span>
-                        </span>,
+                        </button>,
                       }
                     }
+                    isIconOnly={false}
+                    on_click={[Function]}
+                    sidebar_id={null}
+                    size={null}
+                    skeleton={false}
                     status={null}
-                    status_state="warn"
-                    type=""
+                    status_no_animation={null}
+                    status_props={null}
+                    status_state="error"
+                    stretch={true}
+                    text={null}
+                    title={null}
+                    to={null}
+                    tooltip={null}
+                    type={null}
+                    variant="secondary"
+                    wrap={true}
                   >
-                    <Button
-                      aria-describedby="unique-id-static-snapshot-0"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-static-snapshot-0"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                    <span
+                      className="dnb-button__alignment"
+                      key="button-text-empty"
+                    >
+                      ‌
+                    </span>
+                    <span
+                      className="dnb-button__text dnb-skeleton--show-font"
+                      key="button-text"
+                    >
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        <span
+                          className="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            className="dnb-step-indicator__item-content__wrapper"
                           >
                             <span
-                              class="dnb-button__alignment"
+                              className="dnb-step-indicator__item-content__text"
                             >
-                              ‌
+                              Step B
                             </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  1
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step A
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
-                        }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
+                          </span>
+                        </span>
+                      </StepItemWrapper>
+                    </span>
+                    <IconPrimary
+                      alt={null}
+                      aria-hidden={true}
+                      attributes={null}
+                      border={null}
+                      className="dnb-button__icon"
+                      color={null}
+                      height={null}
+                      icon={[Function]}
+                      inherit_color={true}
+                      key="button-icon"
+                      modifier={null}
+                      size="medium"
+                      skeleton={false}
                       title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
+                      width={null}
+                    >
+                      <span
+                        aria-hidden={true}
+                        className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <chevron_down_medium>
+                          <svg
+                            fill="none"
+                            height={24}
+                            viewBox="0 0 24 24"
+                            width={24}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 8.5L12 15.5L5 8.5"
+                              stroke="black"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                            />
+                          </svg>
+                        </chevron_down_medium>
+                      </span>
+                    </IconPrimary>
+                  </Content>
+                </button>
+                <FormStatus
+                  attributes={null}
+                  class={null}
+                  className={null}
+                  global_status_id={null}
+                  icon="error"
+                  icon_size="medium"
+                  id="unique-id-loose-snapshot-form-status"
+                  label={null}
+                  no_animation={null}
+                  role={null}
+                  show={null}
+                  size="default"
+                  skeleton={null}
+                  state="error"
+                  status="error"
+                  stretch={null}
+                  text={null}
+                  text_id="unique-id-loose-snapshot-status"
+                  title={null}
+                  variant={null}
+                  width_element={null}
+                  width_selector={null}
+                />
+              </Button>
+            </div>
+          </StepIndicatorTriggerButton>
+          <Modal
+            align_content={null}
+            animation_direction="bottom"
+            animation_duration={300}
+            bar_content={null}
+            class={null}
+            className={null}
+            close_button_attributes={null}
+            close_modal={null}
+            close_title="Lukk"
+            container_placement={null}
+            content_class={null}
+            content_id={null}
+            dialog_title="Vindu"
+            direct_dom_return={false}
+            disabled={null}
+            focus_selector={null}
+            fullscreen="auto"
+            header_content={null}
+            hide_close_button={false}
+            id="unique-id-loose-snapshot"
+            labelled_by={null}
+            max_width={null}
+            min_width={null}
+            modal_content={null}
+            mode="drawer"
+            no_animation={false}
+            no_animation_on_mobile={false}
+            on_close={[Function]}
+            on_close_prevent={null}
+            on_open={[Function]}
+            open_delay={null}
+            open_modal={null}
+            open_state={null}
+            overlay_class={null}
+            prevent_close={false}
+            prevent_core_style={false}
+            root_id="root"
+            spacing={true}
+            title="Stegoversikt"
+            trigger={null}
+            trigger_attributes={null}
+            trigger_class={null}
+            trigger_disabled={null}
+            trigger_hidden={true}
+            trigger_icon={null}
+            trigger_icon_position="left"
+            trigger_size={null}
+            trigger_text={null}
+            trigger_title={null}
+            trigger_variant="secondary"
+          />
+        </StepIndicatorModal>
+      </div>
+    </StepIndicatorProvider>
+  </StepIndicator>,
+]
+`;
+
+exports[`StepIndicator in static mode have to match snapshot 1`] = `
+Array [
+  <StepIndicatorSidebar
+    current_step={null}
+    data={Array []}
+    mode={null}
+    sidebar_id="unique-id-static-snapshot"
+  >
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-static-snapshot"
+    />
+  </StepIndicatorSidebar>,
+  <StepIndicator
+    active_item={null}
+    active_url={null}
+    class={null}
+    className={null}
+    current_step={1}
+    data={
+      Array [
+        Object {
+          "title": "Step A",
+        },
+        Object {
+          "title": "Step B",
+        },
+        Object {
+          "title": "Step C",
+        },
+        Object {
+          "title": "Step D",
+        },
+      ]
+    }
+    hide_numbers={false}
+    mode="static"
+    no_animation={null}
+    on_change={null}
+    on_click={null}
+    on_item_render={null}
+    overview_title={null}
+    sidebar_id="unique-id-static-snapshot"
+    skeleton={false}
+    step_title={null}
+    step_title_extended={null}
+    use_navigation={null}
+  >
+    <StepIndicatorProvider
+      active_item={null}
+      active_url={null}
+      class={null}
+      className={null}
+      current_step={1}
+      data={
+        Array [
+          Object {
+            "title": "Step A",
+          },
+          Object {
+            "title": "Step B",
+          },
+          Object {
+            "title": "Step C",
+          },
+          Object {
+            "title": "Step D",
+          },
+        ]
+      }
+      hide_numbers={false}
+      isSidebar={false}
+      isV1={false}
+      mode="static"
+      no_animation={null}
+      on_change={null}
+      on_click={null}
+      on_item_render={null}
+      overview_title={null}
+      sidebar_id="unique-id-static-snapshot"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
+      use_navigation={null}
+    >
+      <div
+        className="dnb-step-indicator-v2"
+      >
+        <StepIndicatorModal>
+          <Portal
+            containerInfo={
+              <div
+                class="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+                id="sidebar__unique-id-static-snapshot"
+              >
+                <div
+                  class="dnb-step-indicator"
+                >
+                  <ol
+                    class="dnb-step-indicator__list"
+                  >
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--inactive dnb-step-indicator__item--visited"
                     >
                       <span
                         aria-describedby="unique-id-static-snapshot-0"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
-                        <Content
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              1
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step A
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-static-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                    <li
+                      aria-current="step"
+                      class="dnb-step-indicator__item dnb-step-indicator__item--current dnb-step-indicator__item--inactive"
+                    >
+                      <span
+                        aria-describedby="unique-id-static-snapshot-1"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              2
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step B
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-static-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <span
+                        aria-describedby="unique-id-static-snapshot-2"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              3
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step C
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-static-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <span
+                        aria-describedby="unique-id-static-snapshot-3"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              4
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step D
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-static-snapshot-3"
+                      >
+                        Steg 4 av 4
+                      </span>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+            }
+          >
+            <StepIndicatorList>
+              <div
+                className="dnb-step-indicator"
+              >
+                <ol
+                  className="dnb-step-indicator__list"
+                >
+                  <StepIndicatorItem
+                    currentItemNum={0}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="0"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step A"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--inactive dnb-step-indicator__item--visited"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-static-snapshot-0"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-static-snapshot-0"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
+                                <span
+                                  class="dnb-step-indicator__item-content"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
+                                  >
+                                    1
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step A
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
+                                <svg
+                                  fill="none"
+                                  height="24"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1.5 15L7.5 21L22.5 3"
+                                    stroke="black"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
+                                  />
+                                </svg>
+                              </span>
+                            </span>,
+                          }
+                        }
+                        status={null}
+                        status_state="warn"
+                        type=""
+                      >
+                        <Button
                           aria-describedby="unique-id-static-snapshot-0"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step A
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -2110,10 +3197,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -2128,331 +3214,332 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-static-snapshot-0"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
+                            <Content
+                              aria-describedby="unique-id-static-snapshot-0"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step A
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-static-snapshot-0"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          1
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step A
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      1
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step A
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  1
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </span>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-static-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={1}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="1"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step B"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      aria-current="step"
+                      className="dnb-step-indicator__item dnb-step-indicator__item--current dnb-step-indicator__item--inactive"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-static-snapshot-1"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-static-snapshot-1"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step A
+                                    2
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step B
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-static-snapshot-0"
-                  >
-                    Steg 1 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={1}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="1"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step B"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  aria-current="step"
-                  className="dnb-step-indicator__item dnb-step-indicator__item--current dnb-step-indicator__item--inactive"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-static-snapshot-1"
-                    className={null}
-                    element="span"
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <span
-                          aria-describedby="unique-id-static-snapshot-1"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                2
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step B
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </span>,
-                      }
-                    }
-                    status={null}
-                    status_state="warn"
-                    type=""
-                  >
-                    <Button
-                      aria-describedby="unique-id-static-snapshot-1"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-static-snapshot-1"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  2
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step B
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
+                            </span>,
+                          }
                         }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <span
-                        aria-describedby="unique-id-static-snapshot-1"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                        type=""
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-static-snapshot-1"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step B
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -2525,10 +3612,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -2543,330 +3629,331 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-static-snapshot-1"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
+                            <Content
+                              aria-describedby="unique-id-static-snapshot-1"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step B
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-static-snapshot-1"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          2
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step B
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      2
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step B
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  2
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </span>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-static-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={2}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="2"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step C"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-static-snapshot-2"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-static-snapshot-2"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step B
+                                    3
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step C
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-static-snapshot-1"
-                  >
-                    Steg 2 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={2}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="2"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step C"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-static-snapshot-2"
-                    className={null}
-                    element="span"
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <span
-                          aria-describedby="unique-id-static-snapshot-2"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                3
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step C
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </span>,
-                      }
-                    }
-                    status={null}
-                    status_state="warn"
-                    type=""
-                  >
-                    <Button
-                      aria-describedby="unique-id-static-snapshot-2"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-static-snapshot-2"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  3
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step C
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
+                            </span>,
+                          }
                         }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <span
-                        aria-describedby="unique-id-static-snapshot-2"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                        type=""
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-static-snapshot-2"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step C
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -2939,10 +4026,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -2957,330 +4043,331 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-static-snapshot-2"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
+                            <Content
+                              aria-describedby="unique-id-static-snapshot-2"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step C
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-static-snapshot-2"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          3
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step C
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      3
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step C
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  3
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </span>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-static-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={3}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="3"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step D"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-static-snapshot-3"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-static-snapshot-3"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step C
+                                    4
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step D
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-static-snapshot-2"
-                  >
-                    Steg 3 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={3}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="3"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step D"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-static-snapshot-3"
-                    className={null}
-                    element="span"
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <span
-                          aria-describedby="unique-id-static-snapshot-3"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                4
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step D
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </span>,
-                      }
-                    }
-                    status={null}
-                    status_state="warn"
-                    type=""
-                  >
-                    <Button
-                      aria-describedby="unique-id-static-snapshot-3"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-static-snapshot-3"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  4
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
+                            </span>,
+                          }
                         }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <span
-                        aria-describedby="unique-id-static-snapshot-3"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                        type=""
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-static-snapshot-3"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step D
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -3353,10 +4440,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -3371,127 +4457,255 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-static-snapshot-3"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
+                            <Content
+                              aria-describedby="unique-id-static-snapshot-3"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step D
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-static-snapshot-3"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          4
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step D
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      4
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step D
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  4
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
-                                <span
-                                  className="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    className="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </StepItemWrapper>
+                              </IconPrimary>
+                            </Content>
                           </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
+                          <FormStatus
                             attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
                             title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
-                                <svg
-                                  fill="none"
-                                  height={24}
-                                  viewBox="0 0 24 24"
-                                  width={24}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M1.5 15L7.5 21L22.5 3"
-                                    stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
-                                  />
-                                </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-static-snapshot-3"
+                      >
+                        Steg 4 av 4
                       </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-static-snapshot-3"
-                  >
-                    Steg 4 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-            </ol>
-          </div>
-        </StepIndicatorList>
+                    </li>
+                  </StepIndicatorItem>
+                </ol>
+              </div>
+            </StepIndicatorList>
+          </Portal>
+        </StepIndicatorModal>
       </div>
     </StepIndicatorProvider>
+  </StepIndicator>,
+]
+`;
+
+exports[`StepIndicator in static mode have to match snapshot on small screen 1`] = `
+Array [
+  <StepIndicatorSidebar
+    current_step={null}
+    data={Array []}
+    mode={null}
+    sidebar_id="unique-id-static-snapshot"
+  >
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-static-snapshot"
+    />
   </StepIndicatorSidebar>,
   <StepIndicator
     active_item={null}
@@ -3529,15 +4743,10 @@ Array [
     use_navigation={null}
   >
     <StepIndicatorProvider
-      _active_item={null}
-      _active_url={null}
-      _current_step={1}
-      activeStep={1}
       active_item={null}
       active_url={null}
       class={null}
       className={null}
-      countSteps={4}
       current_step={1}
       data={
         Array [
@@ -3556,97 +4765,264 @@ Array [
         ]
       }
       hide_numbers={false}
+      isSidebar={false}
       isV1={false}
-      listOfReachedSteps={
-        Array [
-          1,
-        ]
-      }
       mode="static"
       no_animation={null}
       on_change={null}
       on_click={null}
       on_item_render={null}
-      overview_title="Stegoversikt"
-      setActiveStep={[Function]}
+      overview_title={null}
       sidebar_id="unique-id-static-snapshot"
-      step_title="Steg %step av %count"
-      step_title_extended="Du er på steg %step av %count"
-      stepsLabel="Steg 2 av 4"
-      stepsLabelExtended="Du er på steg 2 av 4"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
       use_navigation={null}
     >
       <div
         className="dnb-step-indicator-v2"
       >
-        <StepIndicatorModal />
-      </div>
-    </StepIndicatorProvider>
-  </StepIndicator>,
-]
-`;
-
-exports[`StepIndicator in strict mode have to match snapshot 1`] = `
-Array [
-  <StepIndicatorSidebar
-    internalId={null}
-    sidebar_id="unique-id-strict-snapshot"
-  >
-    <StepIndicatorProvider
-      hasSidebar={true}
-      hideSidebar={false}
-      listAttributes={
-        Object {
-          "internalId": null,
-          "sidebar_id": "unique-id-strict-snapshot",
-        }
-      }
-      sidebar_id="unique-id-strict-snapshot"
-    >
-      <div
-        className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
-      >
-        <StepIndicatorList>
-          <nav
-            className="dnb-step-indicator"
-          >
-            <ol
-              className="dnb-step-indicator__list"
-            >
-              <StepIndicatorItem
-                currentItemNum={0}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="0"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step A"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--visited"
+        <StepIndicatorModal>
+          <StepIndicatorTriggerButton
+            className={null}
+            inner_ref={
+              Object {
+                "current": <button
+                  aria-describedby="unique-id-static-snapshot-overview"
+                  class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  id="unique-id-static-snapshot"
+                  style="height: auto;"
+                  type="button"
                 >
-                  <StepItemButton
-                    aria-describedby="unique-id-strict-snapshot-0"
-                    className={null}
-                    icon="check"
+                  <span
+                    class="dnb-button__alignment"
+                  >
+                    ‌
+                  </span>
+                  <span
+                    class="dnb-button__text dnb-skeleton--show-font"
+                  >
+                    <span
+                      class="dnb-step-indicator__item-content"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-step-indicator__item-content__number"
+                      >
+                        2
+                        .
+                      </span>
+                      <span
+                        class="dnb-step-indicator__item-content__wrapper"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content__text"
+                        >
+                          Step B
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                    data-test-id="chevron down medium icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19 8.5L12 15.5L5 8.5"
+                        stroke="black"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>,
+              }
+            }
+            on_click={[Function]}
+            sidebar_id={null}
+          >
+            <div
+              aria-live="polite"
+              className="dnb-step-indicator__trigger"
+            >
+              <span
+                className="dnb-sr-only"
+                id="unique-id-static-snapshot-overview"
+              >
+                Stegoversikt
+              </span>
+              <FormLabel
+                aria-describedby="unique-id-static-snapshot"
+                class={null}
+                className="dnb-step-indicator__label"
+                disabled={null}
+                element="label"
+                for_id="unique-id-static-snapshot"
+                id={null}
+                label_direction={null}
+                skeleton={null}
+                sr_only={null}
+                text={null}
+                title={null}
+                vertical={null}
+              >
+                <label
+                  aria-describedby="unique-id-static-snapshot"
+                  className="dnb-form-label dnb-step-indicator__label"
+                  disabled={false}
+                  htmlFor="unique-id-static-snapshot"
+                >
+                  Steg 2 av 4
+                </label>
+              </FormLabel>
+              <Button
+                aria-describedby="unique-id-static-snapshot-overview"
+                bounding={null}
+                class={null}
+                className="dnb-step-indicator__trigger__button"
+                custom_content={null}
+                custom_element={null}
+                custom_method={null}
+                disabled={null}
+                element={null}
+                global_status_id={null}
+                href={null}
+                icon={[Function]}
+                icon_position="right"
+                icon_size="medium"
+                id="unique-id-static-snapshot"
+                innerRef={null}
+                inner_ref={
+                  Object {
+                    "current": <button
+                      aria-describedby="unique-id-static-snapshot-overview"
+                      class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      id="unique-id-static-snapshot"
+                      style="height: auto;"
+                      type="button"
+                    >
+                      <span
+                        class="dnb-button__alignment"
+                      >
+                        ‌
+                      </span>
+                      <span
+                        class="dnb-button__text dnb-skeleton--show-font"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            class="dnb-step-indicator__item-content__wrapper"
+                          >
+                            <span
+                              class="dnb-step-indicator__item-content__text"
+                            >
+                              Step B
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 8.5L12 15.5L5 8.5"
+                            stroke="black"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>,
+                  }
+                }
+                on_click={[Function]}
+                sidebar_id={null}
+                size={null}
+                skeleton={null}
+                status={null}
+                status_no_animation={null}
+                status_props={null}
+                status_state="error"
+                stretch={true}
+                text={null}
+                title={null}
+                to={null}
+                tooltip={null}
+                type={null}
+                variant="secondary"
+                wrap={true}
+              >
+                <button
+                  aria-describedby="unique-id-static-snapshot-overview"
+                  className="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  disabled={false}
+                  id="unique-id-static-snapshot"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Content
+                    aria-describedby="unique-id-static-snapshot-overview"
+                    bounding={null}
+                    class={null}
+                    className="dnb-step-indicator__trigger__button"
+                    content={
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        Step B
+                      </StepItemWrapper>
+                    }
+                    custom_content={null}
+                    custom_element={null}
+                    custom_method={null}
+                    disabled={null}
+                    element={null}
+                    global_status_id={null}
+                    href={null}
+                    icon={[Function]}
+                    icon_position="right"
+                    icon_size="medium"
+                    id="unique-id-static-snapshot"
+                    innerRef={null}
                     inner_ref={
                       Object {
                         "current": <button
-                          aria-describedby="unique-id-strict-snapshot-0"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                          aria-describedby="unique-id-static-snapshot-overview"
+                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                          id="unique-id-static-snapshot"
+                          style="height: auto;"
                           type="button"
                         >
                           <span
@@ -3664,7 +5040,7 @@ Array [
                                 aria-hidden="true"
                                 class="dnb-step-indicator__item-content__number"
                               >
-                                1
+                                2
                                 .
                               </span>
                               <span
@@ -3673,7 +5049,7 @@ Array [
                                 <span
                                   class="dnb-step-indicator__item-content__text"
                                 >
-                                  Step A
+                                  Step B
                                 </span>
                               </span>
                             </span>
@@ -3681,7 +5057,7 @@ Array [
                           <span
                             aria-hidden="true"
                             class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
+                            data-test-id="chevron down medium icon"
                             role="presentation"
                           >
                             <svg
@@ -3692,7 +5068,7 @@ Array [
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M1.5 15L7.5 21L22.5 3"
+                                d="M19 8.5L12 15.5L5 8.5"
                                 stroke="black"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"
@@ -3703,127 +5079,674 @@ Array [
                         </button>,
                       }
                     }
-                    onClick={[Function]}
+                    isIconOnly={false}
+                    on_click={[Function]}
+                    sidebar_id={null}
+                    size={null}
+                    skeleton={false}
                     status={null}
-                    status_state="warn"
+                    status_no_animation={null}
+                    status_props={null}
+                    status_state="error"
+                    stretch={true}
+                    text={null}
+                    title={null}
+                    to={null}
+                    tooltip={null}
+                    type={null}
+                    variant="secondary"
+                    wrap={true}
                   >
-                    <Button
-                      aria-describedby="unique-id-strict-snapshot-0"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-strict-snapshot-0"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
+                    <span
+                      className="dnb-button__alignment"
+                      key="button-text-empty"
+                    >
+                      ‌
+                    </span>
+                    <span
+                      className="dnb-button__text dnb-skeleton--show-font"
+                      key="button-text"
+                    >
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        <span
+                          className="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            className="dnb-step-indicator__item-content__wrapper"
                           >
                             <span
-                              class="dnb-button__alignment"
+                              className="dnb-step-indicator__item-content__text"
                             >
-                              ‌
+                              Step B
                             </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  1
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step A
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
-                        }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
+                          </span>
+                        </span>
+                      </StepItemWrapper>
+                    </span>
+                    <IconPrimary
+                      alt={null}
+                      aria-hidden={true}
+                      attributes={null}
+                      border={null}
+                      className="dnb-button__icon"
+                      color={null}
+                      height={null}
+                      icon={[Function]}
+                      inherit_color={true}
+                      key="button-icon"
+                      modifier={null}
+                      size="medium"
+                      skeleton={false}
                       title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
+                      width={null}
+                    >
+                      <span
+                        aria-hidden={true}
+                        className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <chevron_down_medium>
+                          <svg
+                            fill="none"
+                            height={24}
+                            viewBox="0 0 24 24"
+                            width={24}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 8.5L12 15.5L5 8.5"
+                              stroke="black"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                            />
+                          </svg>
+                        </chevron_down_medium>
+                      </span>
+                    </IconPrimary>
+                  </Content>
+                </button>
+                <FormStatus
+                  attributes={null}
+                  class={null}
+                  className={null}
+                  global_status_id={null}
+                  icon="error"
+                  icon_size="medium"
+                  id="unique-id-static-snapshot-form-status"
+                  label={null}
+                  no_animation={null}
+                  role={null}
+                  show={null}
+                  size="default"
+                  skeleton={null}
+                  state="error"
+                  status="error"
+                  stretch={null}
+                  text={null}
+                  text_id="unique-id-static-snapshot-status"
+                  title={null}
+                  variant={null}
+                  width_element={null}
+                  width_selector={null}
+                />
+              </Button>
+            </div>
+          </StepIndicatorTriggerButton>
+          <Modal
+            align_content={null}
+            animation_direction="bottom"
+            animation_duration={300}
+            bar_content={null}
+            class={null}
+            className={null}
+            close_button_attributes={null}
+            close_modal={null}
+            close_title="Lukk"
+            container_placement={null}
+            content_class={null}
+            content_id={null}
+            dialog_title="Vindu"
+            direct_dom_return={false}
+            disabled={null}
+            focus_selector={null}
+            fullscreen="auto"
+            header_content={null}
+            hide_close_button={false}
+            id="unique-id-static-snapshot"
+            labelled_by={null}
+            max_width={null}
+            min_width={null}
+            modal_content={null}
+            mode="drawer"
+            no_animation={false}
+            no_animation_on_mobile={false}
+            on_close={[Function]}
+            on_close_prevent={null}
+            on_open={[Function]}
+            open_delay={null}
+            open_modal={null}
+            open_state={null}
+            overlay_class={null}
+            prevent_close={false}
+            prevent_core_style={false}
+            root_id="root"
+            spacing={true}
+            title="Stegoversikt"
+            trigger={null}
+            trigger_attributes={null}
+            trigger_class={null}
+            trigger_disabled={null}
+            trigger_hidden={true}
+            trigger_icon={null}
+            trigger_icon_position="left"
+            trigger_size={null}
+            trigger_text={null}
+            trigger_title={null}
+            trigger_variant="secondary"
+          />
+        </StepIndicatorModal>
+      </div>
+    </StepIndicatorProvider>
+  </StepIndicator>,
+]
+`;
+
+exports[`StepIndicator in strict mode have to match snapshot 1`] = `
+Array [
+  <StepIndicatorSidebar
+    current_step={null}
+    data={Array []}
+    mode={null}
+    sidebar_id="unique-id-strict-snapshot"
+  >
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-strict-snapshot"
+    />
+  </StepIndicatorSidebar>,
+  <StepIndicator
+    active_item={null}
+    active_url={null}
+    class={null}
+    className={null}
+    current_step={1}
+    data={
+      Array [
+        Object {
+          "title": "Step A",
+        },
+        Object {
+          "title": "Step B",
+        },
+        Object {
+          "title": "Step C",
+        },
+        Object {
+          "title": "Step D",
+        },
+      ]
+    }
+    hide_numbers={false}
+    mode="strict"
+    no_animation={null}
+    on_change={null}
+    on_click={null}
+    on_item_render={null}
+    overview_title={null}
+    sidebar_id="unique-id-strict-snapshot"
+    skeleton={false}
+    step_title={null}
+    step_title_extended={null}
+    use_navigation={null}
+  >
+    <StepIndicatorProvider
+      active_item={null}
+      active_url={null}
+      class={null}
+      className={null}
+      current_step={1}
+      data={
+        Array [
+          Object {
+            "title": "Step A",
+          },
+          Object {
+            "title": "Step B",
+          },
+          Object {
+            "title": "Step C",
+          },
+          Object {
+            "title": "Step D",
+          },
+        ]
+      }
+      hide_numbers={false}
+      isSidebar={false}
+      isV1={false}
+      mode="strict"
+      no_animation={null}
+      on_change={null}
+      on_click={null}
+      on_item_render={null}
+      overview_title={null}
+      sidebar_id="unique-id-strict-snapshot"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
+      use_navigation={null}
+    >
+      <div
+        className="dnb-step-indicator-v2"
+      >
+        <StepIndicatorModal>
+          <Portal
+            containerInfo={
+              <div
+                class="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+                id="sidebar__unique-id-strict-snapshot"
+              >
+                <nav
+                  class="dnb-step-indicator"
+                >
+                  <ol
+                    class="dnb-step-indicator__list"
+                  >
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--visited"
                     >
                       <button
                         aria-describedby="unique-id-strict-snapshot-0"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                         type="button"
                       >
-                        <Content
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              1
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step A
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-strict-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                    <li
+                      aria-current="step"
+                      class="dnb-step-indicator__item dnb-step-indicator__item--current"
+                    >
+                      <button
+                        aria-describedby="unique-id-strict-snapshot-1"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                        type="button"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              2
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step B
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-strict-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <span
+                        aria-describedby="unique-id-strict-snapshot-2"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              3
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step C
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-strict-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                    <li
+                      class="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <span
+                        aria-describedby="unique-id-strict-snapshot-3"
+                        class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      >
+                        <span
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          class="dnb-button__text dnb-skeleton--show-font"
+                        >
+                          <span
+                            class="dnb-step-indicator__item-content"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="dnb-step-indicator__item-content__number"
+                            >
+                              4
+                              .
+                            </span>
+                            <span
+                              class="dnb-step-indicator__item-content__wrapper"
+                            >
+                              <span
+                                class="dnb-step-indicator__item-content__text"
+                              >
+                                Step D
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                          data-test-id="check icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 15L7.5 21L22.5 3"
+                              stroke="black"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-sr-only"
+                        id="unique-id-strict-snapshot-3"
+                      >
+                        Steg 4 av 4
+                      </span>
+                    </li>
+                  </ol>
+                </nav>
+              </div>
+            }
+          >
+            <StepIndicatorList>
+              <nav
+                className="dnb-step-indicator"
+              >
+                <ol
+                  className="dnb-step-indicator__list"
+                >
+                  <StepIndicatorItem
+                    currentItemNum={0}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="0"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step A"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--visited"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-strict-snapshot-0"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-strict-snapshot-0"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
+                                <span
+                                  class="dnb-step-indicator__item-content"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
+                                  >
+                                    1
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step A
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
+                                <svg
+                                  fill="none"
+                                  height="24"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1.5 15L7.5 21L22.5 3"
+                                    stroke="black"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
+                                  />
+                                </svg>
+                              </span>
+                            </button>,
+                          }
+                        }
+                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                      >
+                        <Button
                           aria-describedby="unique-id-strict-snapshot-0"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step A
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -3897,11 +5820,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -3915,335 +5837,336 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-strict-snapshot-0"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={1}
+                            <Content
+                              aria-describedby="unique-id-strict-snapshot-0"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step A
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-strict-snapshot-0"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          1
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step A
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={1}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      1
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step A
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  1
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-strict-snapshot-0"
+                      >
+                        Steg 1 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={1}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="1"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step B"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      aria-current="step"
+                      className="dnb-step-indicator__item dnb-step-indicator__item--current"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-strict-snapshot-1"
+                        className={null}
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <button
+                              aria-describedby="unique-id-strict-snapshot-1"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                              type="button"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step A
+                                    2
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step B
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-strict-snapshot-0"
-                  >
-                    Steg 1 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={1}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="1"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step B"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  aria-current="step"
-                  className="dnb-step-indicator__item dnb-step-indicator__item--current"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-strict-snapshot-1"
-                    className={null}
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <button
-                          aria-describedby="unique-id-strict-snapshot-1"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          type="button"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                2
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step B
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </button>,
-                      }
-                    }
-                    onClick={[Function]}
-                    status={null}
-                    status_state="warn"
-                  >
-                    <Button
-                      aria-describedby="unique-id-strict-snapshot-1"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element={null}
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <button
-                            aria-describedby="unique-id-strict-snapshot-1"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                            type="button"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  2
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step B
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </button>,
+                            </button>,
+                          }
                         }
-                      }
-                      onClick={[Function]}
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type={null}
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <button
-                        aria-describedby="unique-id-strict-snapshot-1"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
                         onClick={[Function]}
-                        type="button"
+                        status={null}
+                        status_state="warn"
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-strict-snapshot-1"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step B
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -4317,11 +6240,10 @@ Array [
                               </button>,
                             }
                           }
-                          isIconOnly={false}
                           onClick={[Function]}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -4335,331 +6257,335 @@ Array [
                           variant="secondary"
                           wrap={true}
                         >
-                          <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                          <button
+                            aria-describedby="unique-id-strict-snapshot-1"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={2}
+                            <Content
+                              aria-describedby="unique-id-strict-snapshot-1"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step B
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element={null}
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <button
+                                    aria-describedby="unique-id-strict-snapshot-1"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          2
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step B
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              isIconOnly={false}
+                              onClick={[Function]}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type={null}
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={2}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      2
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step B
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  2
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </button>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-strict-snapshot-1"
+                      >
+                        Steg 2 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={2}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="2"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step C"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-strict-snapshot-2"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-strict-snapshot-2"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step B
+                                    3
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step C
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </button>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-strict-snapshot-1"
-                  >
-                    Steg 2 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={2}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="2"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step C"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-strict-snapshot-2"
-                    className={null}
-                    element="span"
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <span
-                          aria-describedby="unique-id-strict-snapshot-2"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                3
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step C
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </span>,
-                      }
-                    }
-                    status={null}
-                    status_state="warn"
-                    type=""
-                  >
-                    <Button
-                      aria-describedby="unique-id-strict-snapshot-2"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-strict-snapshot-2"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  3
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step C
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
+                            </span>,
+                          }
                         }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <span
-                        aria-describedby="unique-id-strict-snapshot-2"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                        type=""
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-strict-snapshot-2"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step C
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -4732,10 +6658,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -4750,330 +6675,331 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-strict-snapshot-2"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={3}
+                            <Content
+                              aria-describedby="unique-id-strict-snapshot-2"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step C
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-strict-snapshot-2"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          3
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step C
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={3}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      3
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step C
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  3
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
+                              </IconPrimary>
+                            </Content>
+                          </span>
+                          <FormStatus
+                            attributes={null}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
+                            title={null}
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-strict-snapshot-2"
+                      >
+                        Steg 3 av 4
+                      </span>
+                    </li>
+                  </StepIndicatorItem>
+                  <StepIndicatorItem
+                    currentItemNum={3}
+                    disabled={null}
+                    hide_numbers={false}
+                    inactive={null}
+                    is_active={null}
+                    is_current={null}
+                    key="3"
+                    mode={null}
+                    on_change={null}
+                    on_click={null}
+                    on_item_render={null}
+                    on_render={null}
+                    status={null}
+                    status_state="warn"
+                    step_title="%step"
+                    title="Step D"
+                    url={null}
+                    url_future={null}
+                    url_passed={null}
+                    use_navigation={null}
+                  >
+                    <li
+                      className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
+                    >
+                      <StepItemButton
+                        aria-describedby="unique-id-strict-snapshot-3"
+                        className={null}
+                        element="span"
+                        icon="check"
+                        inner_ref={
+                          Object {
+                            "current": <span
+                              aria-describedby="unique-id-strict-snapshot-3"
+                              class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            >
+                              <span
+                                class="dnb-button__alignment"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                class="dnb-button__text dnb-skeleton--show-font"
+                              >
                                 <span
-                                  className="dnb-step-indicator__item-content__wrapper"
+                                  class="dnb-step-indicator__item-content"
                                 >
                                   <span
-                                    className="dnb-step-indicator__item-content__text"
+                                    aria-hidden="true"
+                                    class="dnb-step-indicator__item-content__number"
                                   >
-                                    Step C
+                                    4
+                                    .
+                                  </span>
+                                  <span
+                                    class="dnb-step-indicator__item-content__wrapper"
+                                  >
+                                    <span
+                                      class="dnb-step-indicator__item-content__text"
+                                    >
+                                      Step D
+                                    </span>
                                   </span>
                                 </span>
                               </span>
-                            </StepItemWrapper>
-                          </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
-                            attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
-                            title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
+                              <span
+                                aria-hidden="true"
+                                class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                data-test-id="check icon"
+                                role="presentation"
+                              >
                                 <svg
                                   fill="none"
-                                  height={24}
+                                  height="24"
                                   viewBox="0 0 24 24"
-                                  width={24}
+                                  width="24"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
                                     d="M1.5 15L7.5 21L22.5 3"
                                     stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="1.5"
                                   />
                                 </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
-                      </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-strict-snapshot-2"
-                  >
-                    Steg 3 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-              <StepIndicatorItem
-                currentItemNum={3}
-                disabled={null}
-                hide_numbers={false}
-                inactive={null}
-                is_active={null}
-                is_current={null}
-                key="3"
-                mode={null}
-                on_change={null}
-                on_click={null}
-                on_item_render={null}
-                on_render={null}
-                status={null}
-                status_state="warn"
-                step_title="%step"
-                title="Step D"
-                url={null}
-                url_future={null}
-                url_passed={null}
-                use_navigation={null}
-              >
-                <li
-                  className="dnb-step-indicator__item dnb-step-indicator__item--inactive"
-                >
-                  <StepItemButton
-                    aria-describedby="unique-id-strict-snapshot-3"
-                    className={null}
-                    element="span"
-                    icon="check"
-                    inner_ref={
-                      Object {
-                        "current": <span
-                          aria-describedby="unique-id-strict-snapshot-3"
-                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        >
-                          <span
-                            class="dnb-button__alignment"
-                          >
-                            ‌
-                          </span>
-                          <span
-                            class="dnb-button__text dnb-skeleton--show-font"
-                          >
-                            <span
-                              class="dnb-step-indicator__item-content"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="dnb-step-indicator__item-content__number"
-                              >
-                                4
-                                .
                               </span>
-                              <span
-                                class="dnb-step-indicator__item-content__wrapper"
-                              >
-                                <span
-                                  class="dnb-step-indicator__item-content__text"
-                                >
-                                  Step D
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="check icon"
-                            role="presentation"
-                          >
-                            <svg
-                              fill="none"
-                              height="24"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1.5 15L7.5 21L22.5 3"
-                                stroke="black"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                              />
-                            </svg>
-                          </span>
-                        </span>,
-                      }
-                    }
-                    status={null}
-                    status_state="warn"
-                    type=""
-                  >
-                    <Button
-                      aria-describedby="unique-id-strict-snapshot-3"
-                      bounding={null}
-                      class={null}
-                      className=""
-                      custom_content={null}
-                      custom_element={null}
-                      custom_method={null}
-                      disabled={null}
-                      element="span"
-                      global_status_id={null}
-                      href={null}
-                      icon="check"
-                      icon_position="right"
-                      icon_size="medium"
-                      id={null}
-                      innerRef={null}
-                      inner_ref={
-                        Object {
-                          "current": <span
-                            aria-describedby="unique-id-strict-snapshot-3"
-                            class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                          >
-                            <span
-                              class="dnb-button__alignment"
-                            >
-                              ‌
-                            </span>
-                            <span
-                              class="dnb-button__text dnb-skeleton--show-font"
-                            >
-                              <span
-                                class="dnb-step-indicator__item-content"
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="dnb-step-indicator__item-content__number"
-                                >
-                                  4
-                                  .
-                                </span>
-                                <span
-                                  class="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    class="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              aria-hidden="true"
-                              class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <svg
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1.5 15L7.5 21L22.5 3"
-                                  stroke="black"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="1.5"
-                                />
-                              </svg>
-                            </span>
-                          </span>,
+                            </span>,
+                          }
                         }
-                      }
-                      on_click={null}
-                      size={null}
-                      skeleton={null}
-                      status={null}
-                      status_no_animation={null}
-                      status_props={null}
-                      status_state="error"
-                      stretch={true}
-                      text={null}
-                      title={null}
-                      to={null}
-                      tooltip={null}
-                      type=""
-                      variant="secondary"
-                      wrap={true}
-                    >
-                      <span
-                        aria-describedby="unique-id-strict-snapshot-3"
-                        className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
-                        disabled={false}
-                        onClick={[Function]}
+                        status={null}
+                        status_state="warn"
+                        type=""
                       >
-                        <Content
+                        <Button
                           aria-describedby="unique-id-strict-snapshot-3"
                           bounding={null}
                           class={null}
                           className=""
-                          content={
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
-                              status={null}
-                              status_state="warn"
-                            >
-                              Step D
-                            </StepItemWrapper>
-                          }
                           custom_content={null}
                           custom_element={null}
                           custom_method={null}
@@ -5146,10 +7072,9 @@ Array [
                               </span>,
                             }
                           }
-                          isIconOnly={false}
                           on_click={null}
                           size={null}
-                          skeleton={false}
+                          skeleton={null}
                           status={null}
                           status_no_animation={null}
                           status_props={null}
@@ -5164,127 +7089,255 @@ Array [
                           wrap={true}
                         >
                           <span
-                            className="dnb-button__alignment"
-                            key="button-text-empty"
+                            aria-describedby="unique-id-strict-snapshot-3"
+                            className="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                            disabled={false}
+                            onClick={[Function]}
                           >
-                            ‌
-                          </span>
-                          <span
-                            className="dnb-button__text dnb-skeleton--show-font"
-                            key="button-text"
-                          >
-                            <StepItemWrapper
-                              hide_numbers={false}
-                              number={4}
+                            <Content
+                              aria-describedby="unique-id-strict-snapshot-3"
+                              bounding={null}
+                              class={null}
+                              className=""
+                              content={
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  Step D
+                                </StepItemWrapper>
+                              }
+                              custom_content={null}
+                              custom_element={null}
+                              custom_method={null}
+                              disabled={null}
+                              element="span"
+                              global_status_id={null}
+                              href={null}
+                              icon="check"
+                              icon_position="right"
+                              icon_size="medium"
+                              id={null}
+                              innerRef={null}
+                              inner_ref={
+                                Object {
+                                  "current": <span
+                                    aria-describedby="unique-id-strict-snapshot-3"
+                                    class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                                  >
+                                    <span
+                                      class="dnb-button__alignment"
+                                    >
+                                      ‌
+                                    </span>
+                                    <span
+                                      class="dnb-button__text dnb-skeleton--show-font"
+                                    >
+                                      <span
+                                        class="dnb-step-indicator__item-content"
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          class="dnb-step-indicator__item-content__number"
+                                        >
+                                          4
+                                          .
+                                        </span>
+                                        <span
+                                          class="dnb-step-indicator__item-content__wrapper"
+                                        >
+                                          <span
+                                            class="dnb-step-indicator__item-content__text"
+                                          >
+                                            Step D
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                      data-test-id="check icon"
+                                      role="presentation"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        width="24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1.5 15L7.5 21L22.5 3"
+                                          stroke="black"
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          stroke-width="1.5"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>,
+                                }
+                              }
+                              isIconOnly={false}
+                              on_click={null}
+                              size={null}
+                              skeleton={false}
                               status={null}
-                              status_state="warn"
+                              status_no_animation={null}
+                              status_props={null}
+                              status_state="error"
+                              stretch={true}
+                              text={null}
+                              title={null}
+                              to={null}
+                              tooltip={null}
+                              type=""
+                              variant="secondary"
+                              wrap={true}
                             >
                               <span
-                                className="dnb-step-indicator__item-content"
+                                className="dnb-button__alignment"
+                                key="button-text-empty"
+                              >
+                                ‌
+                              </span>
+                              <span
+                                className="dnb-button__text dnb-skeleton--show-font"
+                                key="button-text"
+                              >
+                                <StepItemWrapper
+                                  hide_numbers={false}
+                                  number={4}
+                                  status={null}
+                                  status_state="warn"
+                                >
+                                  <span
+                                    className="dnb-step-indicator__item-content"
+                                  >
+                                    <span
+                                      aria-hidden={true}
+                                      className="dnb-step-indicator__item-content__number"
+                                    >
+                                      4
+                                      .
+                                    </span>
+                                    <span
+                                      className="dnb-step-indicator__item-content__wrapper"
+                                    >
+                                      <span
+                                        className="dnb-step-indicator__item-content__text"
+                                      >
+                                        Step D
+                                      </span>
+                                    </span>
+                                  </span>
+                                </StepItemWrapper>
+                              </span>
+                              <IconPrimary
+                                alt={null}
+                                aria-hidden={true}
+                                attributes={null}
+                                border={null}
+                                className="dnb-button__icon"
+                                color={null}
+                                height={null}
+                                icon="check"
+                                inherit_color={true}
+                                key="button-icon"
+                                modifier={null}
+                                size="medium"
+                                skeleton={false}
+                                title={null}
+                                width={null}
                               >
                                 <span
                                   aria-hidden={true}
-                                  className="dnb-step-indicator__item-content__number"
+                                  className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                                  data-test-id="check icon"
+                                  role="presentation"
                                 >
-                                  4
-                                  .
+                                  <check_medium>
+                                    <svg
+                                      fill="none"
+                                      height={24}
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M1.5 15L7.5 21L22.5 3"
+                                        stroke="black"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={1.5}
+                                      />
+                                    </svg>
+                                  </check_medium>
                                 </span>
-                                <span
-                                  className="dnb-step-indicator__item-content__wrapper"
-                                >
-                                  <span
-                                    className="dnb-step-indicator__item-content__text"
-                                  >
-                                    Step D
-                                  </span>
-                                </span>
-                              </span>
-                            </StepItemWrapper>
+                              </IconPrimary>
+                            </Content>
                           </span>
-                          <IconPrimary
-                            alt={null}
-                            aria-hidden={true}
+                          <FormStatus
                             attributes={null}
-                            border={null}
-                            className="dnb-button__icon"
-                            color={null}
-                            height={null}
-                            icon="check"
-                            inherit_color={true}
-                            key="button-icon"
-                            modifier={null}
-                            size="medium"
-                            skeleton={false}
+                            class={null}
+                            className={null}
+                            global_status_id={null}
+                            icon="error"
+                            icon_size="medium"
+                            id="null-form-status"
+                            label={null}
+                            no_animation={null}
+                            role={null}
+                            show={null}
+                            size="default"
+                            skeleton={null}
+                            state="error"
+                            status="error"
+                            stretch={null}
+                            text={null}
+                            text_id="null-status"
                             title={null}
-                            width={null}
-                          >
-                            <span
-                              aria-hidden={true}
-                              className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                              data-test-id="check icon"
-                              role="presentation"
-                            >
-                              <check_medium>
-                                <svg
-                                  fill="none"
-                                  height={24}
-                                  viewBox="0 0 24 24"
-                                  width={24}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M1.5 15L7.5 21L22.5 3"
-                                    stroke="black"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={1.5}
-                                  />
-                                </svg>
-                              </check_medium>
-                            </span>
-                          </IconPrimary>
-                        </Content>
+                            variant={null}
+                            width_element={null}
+                            width_selector={null}
+                          />
+                        </Button>
+                      </StepItemButton>
+                      <span
+                        aria-hidden={true}
+                        className="dnb-sr-only"
+                        id="unique-id-strict-snapshot-3"
+                      >
+                        Steg 4 av 4
                       </span>
-                      <FormStatus
-                        attributes={null}
-                        class={null}
-                        className={null}
-                        global_status_id={null}
-                        icon="error"
-                        icon_size="medium"
-                        id="null-form-status"
-                        label={null}
-                        no_animation={null}
-                        role={null}
-                        show={null}
-                        size="default"
-                        skeleton={null}
-                        state="error"
-                        status="error"
-                        stretch={null}
-                        text={null}
-                        text_id="null-status"
-                        title={null}
-                        variant={null}
-                        width_element={null}
-                        width_selector={null}
-                      />
-                    </Button>
-                  </StepItemButton>
-                  <span
-                    aria-hidden={true}
-                    className="dnb-sr-only"
-                    id="unique-id-strict-snapshot-3"
-                  >
-                    Steg 4 av 4
-                  </span>
-                </li>
-              </StepIndicatorItem>
-            </ol>
-          </nav>
-        </StepIndicatorList>
+                    </li>
+                  </StepIndicatorItem>
+                </ol>
+              </nav>
+            </StepIndicatorList>
+          </Portal>
+        </StepIndicatorModal>
       </div>
     </StepIndicatorProvider>
+  </StepIndicator>,
+]
+`;
+
+exports[`StepIndicator in strict mode have to match snapshot on small screen 1`] = `
+Array [
+  <StepIndicatorSidebar
+    current_step={null}
+    data={Array []}
+    mode={null}
+    sidebar_id="unique-id-strict-snapshot"
+  >
+    <div
+      className="dnb-step-indicator-v2 dnb-step-indicator__sidebar"
+      id="sidebar__unique-id-strict-snapshot"
+    />
   </StepIndicatorSidebar>,
   <StepIndicator
     active_item={null}
@@ -5322,15 +7375,10 @@ Array [
     use_navigation={null}
   >
     <StepIndicatorProvider
-      _active_item={null}
-      _active_url={null}
-      _current_step={1}
-      activeStep={1}
       active_item={null}
       active_url={null}
       class={null}
       className={null}
-      countSteps={4}
       current_step={1}
       data={
         Array [
@@ -5349,30 +7397,499 @@ Array [
         ]
       }
       hide_numbers={false}
+      isSidebar={false}
       isV1={false}
-      listOfReachedSteps={
-        Array [
-          1,
-        ]
-      }
       mode="strict"
       no_animation={null}
       on_change={null}
       on_click={null}
       on_item_render={null}
-      overview_title="Stegoversikt"
-      setActiveStep={[Function]}
+      overview_title={null}
       sidebar_id="unique-id-strict-snapshot"
-      step_title="Steg %step av %count"
-      step_title_extended="Du er på steg %step av %count"
-      stepsLabel="Steg 2 av 4"
-      stepsLabelExtended="Du er på steg 2 av 4"
+      skeleton={false}
+      step_title={null}
+      step_title_extended={null}
       use_navigation={null}
     >
       <div
         className="dnb-step-indicator-v2"
       >
-        <StepIndicatorModal />
+        <StepIndicatorModal>
+          <StepIndicatorTriggerButton
+            className={null}
+            inner_ref={
+              Object {
+                "current": <button
+                  aria-describedby="unique-id-strict-snapshot-overview"
+                  class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  id="unique-id-strict-snapshot"
+                  style="height: auto;"
+                  type="button"
+                >
+                  <span
+                    class="dnb-button__alignment"
+                  >
+                    ‌
+                  </span>
+                  <span
+                    class="dnb-button__text dnb-skeleton--show-font"
+                  >
+                    <span
+                      class="dnb-step-indicator__item-content"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-step-indicator__item-content__number"
+                      >
+                        2
+                        .
+                      </span>
+                      <span
+                        class="dnb-step-indicator__item-content__wrapper"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content__text"
+                        >
+                          Step B
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                    data-test-id="chevron down medium icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19 8.5L12 15.5L5 8.5"
+                        stroke="black"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>,
+              }
+            }
+            on_click={[Function]}
+            sidebar_id={null}
+          >
+            <div
+              aria-live="polite"
+              className="dnb-step-indicator__trigger"
+            >
+              <span
+                className="dnb-sr-only"
+                id="unique-id-strict-snapshot-overview"
+              >
+                Stegoversikt
+              </span>
+              <FormLabel
+                aria-describedby="unique-id-strict-snapshot"
+                class={null}
+                className="dnb-step-indicator__label"
+                disabled={null}
+                element="label"
+                for_id="unique-id-strict-snapshot"
+                id={null}
+                label_direction={null}
+                skeleton={null}
+                sr_only={null}
+                text={null}
+                title={null}
+                vertical={null}
+              >
+                <label
+                  aria-describedby="unique-id-strict-snapshot"
+                  className="dnb-form-label dnb-step-indicator__label"
+                  disabled={false}
+                  htmlFor="unique-id-strict-snapshot"
+                >
+                  Steg 2 av 4
+                </label>
+              </FormLabel>
+              <Button
+                aria-describedby="unique-id-strict-snapshot-overview"
+                bounding={null}
+                class={null}
+                className="dnb-step-indicator__trigger__button"
+                custom_content={null}
+                custom_element={null}
+                custom_method={null}
+                disabled={null}
+                element={null}
+                global_status_id={null}
+                href={null}
+                icon={[Function]}
+                icon_position="right"
+                icon_size="medium"
+                id="unique-id-strict-snapshot"
+                innerRef={null}
+                inner_ref={
+                  Object {
+                    "current": <button
+                      aria-describedby="unique-id-strict-snapshot-overview"
+                      class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                      id="unique-id-strict-snapshot"
+                      style="height: auto;"
+                      type="button"
+                    >
+                      <span
+                        class="dnb-button__alignment"
+                      >
+                        ‌
+                      </span>
+                      <span
+                        class="dnb-button__text dnb-skeleton--show-font"
+                      >
+                        <span
+                          class="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            class="dnb-step-indicator__item-content__wrapper"
+                          >
+                            <span
+                              class="dnb-step-indicator__item-content__text"
+                            >
+                              Step B
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 8.5L12 15.5L5 8.5"
+                            stroke="black"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>,
+                  }
+                }
+                on_click={[Function]}
+                sidebar_id={null}
+                size={null}
+                skeleton={null}
+                status={null}
+                status_no_animation={null}
+                status_props={null}
+                status_state="error"
+                stretch={true}
+                text={null}
+                title={null}
+                to={null}
+                tooltip={null}
+                type={null}
+                variant="secondary"
+                wrap={true}
+              >
+                <button
+                  aria-describedby="unique-id-strict-snapshot-overview"
+                  className="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                  disabled={false}
+                  id="unique-id-strict-snapshot"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Content
+                    aria-describedby="unique-id-strict-snapshot-overview"
+                    bounding={null}
+                    class={null}
+                    className="dnb-step-indicator__trigger__button"
+                    content={
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        Step B
+                      </StepItemWrapper>
+                    }
+                    custom_content={null}
+                    custom_element={null}
+                    custom_method={null}
+                    disabled={null}
+                    element={null}
+                    global_status_id={null}
+                    href={null}
+                    icon={[Function]}
+                    icon_position="right"
+                    icon_size="medium"
+                    id="unique-id-strict-snapshot"
+                    innerRef={null}
+                    inner_ref={
+                      Object {
+                        "current": <button
+                          aria-describedby="unique-id-strict-snapshot-overview"
+                          class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
+                          id="unique-id-strict-snapshot"
+                          style="height: auto;"
+                          type="button"
+                        >
+                          <span
+                            class="dnb-button__alignment"
+                          >
+                            ‌
+                          </span>
+                          <span
+                            class="dnb-button__text dnb-skeleton--show-font"
+                          >
+                            <span
+                              class="dnb-step-indicator__item-content"
+                            >
+                              <span
+                                aria-hidden="true"
+                                class="dnb-step-indicator__item-content__number"
+                              >
+                                2
+                                .
+                              </span>
+                              <span
+                                class="dnb-step-indicator__item-content__wrapper"
+                              >
+                                <span
+                                  class="dnb-step-indicator__item-content__text"
+                                >
+                                  Step B
+                                </span>
+                              </span>
+                            </span>
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                            data-test-id="chevron down medium icon"
+                            role="presentation"
+                          >
+                            <svg
+                              fill="none"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M19 8.5L12 15.5L5 8.5"
+                                stroke="black"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="1.5"
+                              />
+                            </svg>
+                          </span>
+                        </button>,
+                      }
+                    }
+                    isIconOnly={false}
+                    on_click={[Function]}
+                    sidebar_id={null}
+                    size={null}
+                    skeleton={false}
+                    status={null}
+                    status_no_animation={null}
+                    status_props={null}
+                    status_state="error"
+                    stretch={true}
+                    text={null}
+                    title={null}
+                    to={null}
+                    tooltip={null}
+                    type={null}
+                    variant="secondary"
+                    wrap={true}
+                  >
+                    <span
+                      className="dnb-button__alignment"
+                      key="button-text-empty"
+                    >
+                      ‌
+                    </span>
+                    <span
+                      className="dnb-button__text dnb-skeleton--show-font"
+                      key="button-text"
+                    >
+                      <StepItemWrapper
+                        hide_numbers={false}
+                        number={2}
+                        status={null}
+                      >
+                        <span
+                          className="dnb-step-indicator__item-content"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="dnb-step-indicator__item-content__number"
+                          >
+                            2
+                            .
+                          </span>
+                          <span
+                            className="dnb-step-indicator__item-content__wrapper"
+                          >
+                            <span
+                              className="dnb-step-indicator__item-content__text"
+                            >
+                              Step B
+                            </span>
+                          </span>
+                        </span>
+                      </StepItemWrapper>
+                    </span>
+                    <IconPrimary
+                      alt={null}
+                      aria-hidden={true}
+                      attributes={null}
+                      border={null}
+                      className="dnb-button__icon"
+                      color={null}
+                      height={null}
+                      icon={[Function]}
+                      inherit_color={true}
+                      key="button-icon"
+                      modifier={null}
+                      size="medium"
+                      skeleton={false}
+                      title={null}
+                      width={null}
+                    >
+                      <span
+                        aria-hidden={true}
+                        className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
+                        data-test-id="chevron down medium icon"
+                        role="presentation"
+                      >
+                        <chevron_down_medium>
+                          <svg
+                            fill="none"
+                            height={24}
+                            viewBox="0 0 24 24"
+                            width={24}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 8.5L12 15.5L5 8.5"
+                              stroke="black"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                            />
+                          </svg>
+                        </chevron_down_medium>
+                      </span>
+                    </IconPrimary>
+                  </Content>
+                </button>
+                <FormStatus
+                  attributes={null}
+                  class={null}
+                  className={null}
+                  global_status_id={null}
+                  icon="error"
+                  icon_size="medium"
+                  id="unique-id-strict-snapshot-form-status"
+                  label={null}
+                  no_animation={null}
+                  role={null}
+                  show={null}
+                  size="default"
+                  skeleton={null}
+                  state="error"
+                  status="error"
+                  stretch={null}
+                  text={null}
+                  text_id="unique-id-strict-snapshot-status"
+                  title={null}
+                  variant={null}
+                  width_element={null}
+                  width_selector={null}
+                />
+              </Button>
+            </div>
+          </StepIndicatorTriggerButton>
+          <Modal
+            align_content={null}
+            animation_direction="bottom"
+            animation_duration={300}
+            bar_content={null}
+            class={null}
+            className={null}
+            close_button_attributes={null}
+            close_modal={null}
+            close_title="Lukk"
+            container_placement={null}
+            content_class={null}
+            content_id={null}
+            dialog_title="Vindu"
+            direct_dom_return={false}
+            disabled={null}
+            focus_selector={null}
+            fullscreen="auto"
+            header_content={null}
+            hide_close_button={false}
+            id="unique-id-strict-snapshot"
+            labelled_by={null}
+            max_width={null}
+            min_width={null}
+            modal_content={null}
+            mode="drawer"
+            no_animation={false}
+            no_animation_on_mobile={false}
+            on_close={[Function]}
+            on_close_prevent={null}
+            on_open={[Function]}
+            open_delay={null}
+            open_modal={null}
+            open_state={null}
+            overlay_class={null}
+            prevent_close={false}
+            prevent_core_style={false}
+            root_id="root"
+            spacing={true}
+            title="Stegoversikt"
+            trigger={null}
+            trigger_attributes={null}
+            trigger_class={null}
+            trigger_disabled={null}
+            trigger_hidden={true}
+            trigger_icon={null}
+            trigger_icon_position="left"
+            trigger_size={null}
+            trigger_text={null}
+            trigger_title={null}
+            trigger_variant="secondary"
+          />
+        </StepIndicatorModal>
       </div>
     </StepIndicatorProvider>
   </StepIndicator>,
@@ -5668,11 +8185,19 @@ exports[`StepIndicator scss have to match snapshot 1`] = `
     background-color: currentColor;
     box-shadow: 100vw 0 0 0 currentColor; }
 
-.dnb-step-indicator__sidebar {
-  max-width: 20rem;
-  margin-right: var(--spacing-x-large); }
-  .dnb-step-indicator__sidebar .dnb-step-indicator__item {
-    min-width: 320px; }
+@media screen and (min-width: 50.1em) {
+  .dnb-step-indicator__sidebar {
+    max-width: 20rem;
+    margin-right: var(--spacing-x-large); }
+    .dnb-step-indicator__sidebar .dnb-step-indicator__item {
+      min-width: 320px; } }
+
+@media screen and (max-width: 50.1em) {
+  .dnb-step-indicator__sidebar--ssr-skeleton {
+    visibility: hidden;
+    overflow: hidden;
+    width: 0;
+    height: 5.5rem; } }
 
 .dnb-step-indicator-v2 .dnb-step-indicator__list {
   display: flex;

--- a/packages/dnb-eufemia/src/components/step-indicator/style/_step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/_step-indicator.scss
@@ -6,11 +6,24 @@
 @import './_step-indicator-v1.scss';
 
 .dnb-step-indicator__sidebar {
-  max-width: 20rem;
-  margin-right: var(--spacing-x-large);
+  @media screen and (min-width: 50.1em) {
+    max-width: 20rem;
+    margin-right: var(--spacing-x-large);
 
-  .dnb-step-indicator__item {
-    min-width: 320px;
+    .dnb-step-indicator__item {
+      min-width: 320px;
+    }
+  }
+
+  // To avoid layout shift during SSR hydration
+  // we hide the sidebar with skeleton on small screens
+  &--ssr-skeleton {
+    @media screen and (max-width: 50.1em) {
+      visibility: hidden;
+      overflow: hidden;
+      width: 0;
+      height: 5.5rem; // the height of the modal button + label + margin
+    }
   }
 }
 

--- a/packages/dnb-eufemia/src/shared/EventEmitter.js
+++ b/packages/dnb-eufemia/src/shared/EventEmitter.js
@@ -14,6 +14,10 @@
  */
 
 class EventEmitter {
+  static createInstance(id) {
+    return new EventEmitter(id)
+  }
+
   constructor(id) {
     scope.__EEE__ = scope.__EEE__ || {}
     if (!scope.__EEE__[id]) {
@@ -75,8 +79,4 @@ class EventEmitter {
 
 const scope = typeof window !== 'undefined' ? window : EventEmitter
 
-function createInstance(id) {
-  return new EventEmitter(id)
-}
-
-export default { createInstance }
+export default EventEmitter


### PR DESCRIPTION
This PR is a small rewrite where the StepIndicator uses now `React.Portal` to show the Sidebar list (if a Sidebar is given). This change is mainly of internal interrest – its only to ensure we only have ONE context and state, instead of tyring to sync it as before.

Also, this PR will show the Sidebar by default (desktop) – so it gets rendered in desktop mode during SSR – we do this only to lower the layout shift on larger screens, and to avoid large horizontal flickering. 

A skeleton list is rendered during SSR, as long as not the original `data` also is given to the Sidebar.