### PR TITLE
chore(Portal): ensure fullscreen on page reload or first visit with fullscreen url

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
@@ -388,7 +388,10 @@ export default class SidebarLayout extends React.PureComponent {
 
               /* stylelint-disable */
               --aside-width: 30vw; /* IE fix */
-              --aside-width: calc(25vw + 5rem);
+              --aside-width: var(
+                --aside-width-fullscreen,
+                calc(25vw + 5rem)
+              );
               /* stylelint-enable */
 
               /* 2.5rem - but we don't want it to be responsive */

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 import classnames from 'classnames'
 import styled from '@emotion/styled'
-import { Global } from '@emotion/react'
+import { css, Global } from '@emotion/react'
 import MainMenu from '../menu/MainMenu'
 import Sidebar from '../menu/SidebarMenu'
 import StickyMenuBar from '../menu/StickyMenuBar'
@@ -81,7 +81,7 @@ class Layout extends React.PureComponent {
   }
 
   isFullscreen() {
-    const { location, fullscreen } = this.props
+    const { fullscreen, location } = this.props
     return (
       fullscreen ||
       (typeof location !== 'undefined' &&
@@ -96,6 +96,9 @@ class Layout extends React.PureComponent {
 
     return (
       <>
+        <Global styles={portalStyle} />
+        {fs && <Global styles={fullscreenStyles} />}
+
         <a
           className="dnb-skip-link"
           href="#dnb-app-content"
@@ -149,7 +152,7 @@ const Wrapper = styled.div`
   }
 `
 
-const Content = ({ className, fullscreen, children }) => (
+const Content = ({ fullscreen = false, className = null, children }) => (
   <ContentWrapper
     className={classnames(
       'dnb-app-content',
@@ -158,7 +161,6 @@ const Content = ({ className, fullscreen, children }) => (
     )}
   >
     {children}
-    <Global styles={portalStyle} />
   </ContentWrapper>
 )
 Content.propTypes = {
@@ -235,6 +237,13 @@ const StyledMain = styled.main`
   width: 100%;
   min-height: 90vh;
   padding: 0 2rem;
+`
+
+const fullscreenStyles = css`
+  :root {
+    /* ensure the sidebar has not left over margin during fullscreen (SSR issue) */
+    --aside-width-fullscreen: 0;
+  }
 `
 
 const FooterWrapper = styled.footer`


### PR DESCRIPTION
How is was on a page reload or first visit with scrull url:
<img width="496" alt="Screenshot 2021-11-30 at 14 15 52" src="https://user-images.githubusercontent.com/1501870/144054106-9370c320-3f69-44c7-9f4b-5dfe388e97e9.png">

The the left sidebar/white column is now gone with this PR.