### PR TITLE
Enhance Modal / Drawer Performance

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.md
@@ -154,7 +154,7 @@ import { InteractionInvalidation } from '@dnb/eufemia/shared/component-helper'
 const instance = new InteractionInvalidation()
 
 // do not invalidate inside here
-instance.setBypassSelector('.dnb-modal__content')
+instance.setBypassSelector('.dnb-modal__content *')
 
 // Enable the invalidation
 instance.activate()

--- a/packages/dnb-eufemia-sandbox/stories/components/Modal.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/Modal.js
@@ -19,11 +19,12 @@ import {
   FormSet,
   FormRow,
   Tabs,
+  Table,
   FormStatus,
   ProgressIndicator,
   // Space,
   NumberFormat,
-} from '@dnb/eufemia/src/components'
+} from '@dnb/eufemia/src'
 import { ScrollView } from '@dnb/eufemia/src/fragments'
 import { H1, H2, P, Hr } from '@dnb/eufemia/src/elements'
 
@@ -852,3 +853,92 @@ function CloseByCallback() {
     </Modal>
   )
 }
+
+const LargeListOfTrs = () => {
+  const list = []
+
+  for (let i = 0, l = 10000; i < l; ++i) {
+    // for (let i = 0, l = 4; i < l; ++i) {
+    list.push(
+      <tr key={i}>
+        <td>Row {i} Column 1</td>
+        <td>Row {i} Column 2</td>
+        <td>Row {i} Column 3</td>
+        <td align="right">Row {i} Column 4</td>
+      </tr>
+    )
+  }
+
+  return list
+}
+
+export const ModalPerformance = () => (
+  <div>
+    <Modal mode="drawer" trigger_text="Open Drawer" bottom>
+      Content
+    </Modal>
+
+    <Table
+    //  className="dnb-modal--bypass_invalidation_deep"
+    >
+      <caption>A Table Caption</caption>
+      <thead>
+        <tr>
+          <th scope="col" colSpan="2" className="dnb-table--no-wrap">
+            Header
+          </th>
+          <th
+            scope="col"
+            className="dnb-table--sortable dnb-table--reversed"
+          >
+            <Button
+              variant="tertiary"
+              icon="arrow-down"
+              text="Sortable"
+              title="Sort table column"
+              wrap="true"
+            />
+          </th>
+          <th
+            scope="col"
+            align="right"
+            className="dnb-table--sortable dnb-table--active"
+          >
+            <Button
+              variant="tertiary"
+              icon="arrow-down"
+              text="Active"
+              title="Sort table column"
+              wrap="true"
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <p className="dnb-p" aria-hidden="true">
+              Column 1 <b>width p</b> <Button text="Focus me" />
+            </p>
+          </td>
+          <td>
+            <code className="dnb-code">Column 2 with code</code>
+          </td>
+          <td>
+            <span>Column 3 with span</span>
+          </td>
+          <td align="right">Column 4</td>
+        </tr>
+        <tr>
+          <td colSpan="2">Column which spans over two columns</td>
+          <td>Column 3</td>
+          <td align="right">
+            Column 4 <Button text="Focus me" />
+            const template ={' '}
+          </td>
+        </tr>
+        <LargeListOfTrs />
+      </tbody>
+    </Table>
+  </div>
+)

--- a/packages/dnb-eufemia/src/components/modal/Modal.js
+++ b/packages/dnb-eufemia/src/components/modal/Modal.js
@@ -266,7 +266,7 @@ export default class Modal extends React.PureComponent {
 
   constructor(props) {
     super(props)
-    this._id = props.id || makeUniqueId()
+    this._id = props.id || makeUniqueId('modal-')
 
     this._triggerRef = React.createRef()
 

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.js
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.js
@@ -44,7 +44,7 @@ beforeEach(() => {
   document.body.removeAttribute('style')
   document.documentElement.removeAttribute('style')
   document.getElementById('dnb-modal-root')?.remove()
-  window.__modalStack = []
+  window.__modalStack = undefined
 })
 
 describe('Modal component', () => {
@@ -52,6 +52,23 @@ describe('Modal component', () => {
     const Comp = mount(<Component {...props} open_state={true} />)
     expect(toJson(Comp)).toMatchSnapshot()
     Comp.find('button.dnb-modal__close-button').simulate('click')
+  })
+
+  it('should add its instance to the stack', () => {
+    const Comp = mount(
+      <Component {...props}>
+        <button>button</button>
+      </Component>
+    )
+
+    Comp.find('Modal').find('button.dnb-modal__trigger').simulate('click')
+
+    expect(window.__modalStack).toHaveLength(1)
+    expect(typeof window.__modalStack[0]).toBe('object')
+
+    Comp.find('button.dnb-modal__close-button').simulate('click')
+
+    expect(window.__modalStack).toHaveLength(0)
   })
 
   it('should have aria-hidden and tabindex on other elements', () => {
@@ -242,7 +259,6 @@ describe('Modal component', () => {
   })
 
   it('will warn if first heading is not h1', async () => {
-    process.env.NODE_ENV = 'development'
     jest.spyOn(global.console, 'log')
     global.console.log = jest.fn()
 
@@ -291,7 +307,6 @@ describe('Modal component', () => {
     const elements = document.querySelectorAll(
       '.dnb-modal__content__wrapper > .dnb-section'
     )
-    console.log('elements', elements.length)
 
     expect(elements[0].textContent).toContain('bar content')
     expect(elements[1].textContent).toContain('header content')

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -1759,15 +1759,15 @@ button.dnb-button::-moz-focus-inner {
 
 @keyframes show-modal-overlay {
   from {
-    background-color: var(--modal-overlay-transparent); }
+    opacity: 0; }
   to {
-    background-color: var(--modal-overlay-bg); } }
+    opacity: var(--modal-overlay-opacity); } }
 
 @keyframes hide-modal-overlay {
   from {
-    background-color: var(--modal-overlay-bg); }
+    opacity: var(--modal-overlay-opacity); }
   to {
-    background-color: var(--modal-overlay-transparent); } }
+    opacity: 0; } }
 
 :root {
   --modal-z-index: 3000;
@@ -1781,8 +1781,8 @@ button.dnb-button::-moz-focus-inner {
   --modal-drawer-min-width: 25rem;
   --modal-drawer-max-width: 40rem;
   --modal-drawer-header-min-height: 6rem;
-  --modal-overlay-transparent: rgba(0, 0, 0, 0);
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32); }
+  --modal-overlay-bg: black;
+  --modal-overlay-opacity: 0.32; }
 
 html[data-dnb-modal-active] {
   user-select: none;
@@ -2032,22 +2032,13 @@ html[data-dnb-modal-active] {
     top: 0;
     width: 100%;
     height: 100%;
-    will-change: background-color;
-    background-color: var(--modal-overlay-transparent);
-    box-shadow: 0 100vh 0 0 var(--modal-overlay-bg); }
-    .dnb-modal__overlay--modal {
-      animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards 0ms; }
-    .dnb-modal__overlay--drawer {
-      animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards 100ms; }
-    .dnb-modal__overlay--hide {
-      animation: hide-modal-overlay var(--modal-animation-duration) ease-in-out forwards; }
+    background-color: var(--modal-overlay-bg); }
   .dnb-modal-root__inner .dnb-modal__overlay {
-    opacity: 0;
-    transition: opacity 300ms ease-in-out; }
+    animation: hide-modal-overlay var(--modal-animation-duration) ease-in-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {
-    opacity: 1; }
-  html[data-visual-test] .dnb-modal-root__inner .dnb-modal__overlay {
-    transition: none; }
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards 0ms; }
+    .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
+      animation: hide-modal-overlay var(--modal-animation-duration) ease-in-out forwards; }
   html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
     animation-delay: 0ms !important;
     animation-duration: 0ms !important; }

--- a/packages/dnb-eufemia/src/components/modal/style/_modal-mixins.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal-mixins.scss
@@ -85,17 +85,17 @@
 
 @keyframes show-modal-overlay {
   from {
-    background-color: var(--modal-overlay-transparent);
+    opacity: 0;
   }
   to {
-    background-color: var(--modal-overlay-bg);
+    opacity: var(--modal-overlay-opacity);
   }
 }
 @keyframes hide-modal-overlay {
   from {
-    background-color: var(--modal-overlay-bg);
+    opacity: var(--modal-overlay-opacity);
   }
   to {
-    background-color: var(--modal-overlay-transparent);
+    opacity: 0;
   }
 }

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -23,8 +23,8 @@
   --modal-drawer-header-min-height: 6rem;
 
   // Overlay
-  --modal-overlay-transparent: rgba(0, 0, 0, 0);
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32);
+  --modal-overlay-bg: black;
+  --modal-overlay-opacity: 0.32;
 }
 
 html[data-dnb-modal-active] {
@@ -390,39 +390,22 @@ html[data-dnb-modal-active] {
     width: 100%;
     height: 100%;
 
-    will-change: background-color;
-    background-color: var(--modal-overlay-transparent);
-    box-shadow: 0 100vh 0 0 var(--modal-overlay-bg);
+    background-color: var(--modal-overlay-bg);
+  }
 
-    // Modal & Drawer mode
-    &--modal {
-      animation: show-modal-overlay var(--modal-animation-duration)
-        ease-out forwards 0ms;
-    }
-    &--drawer {
-      animation: show-modal-overlay var(--modal-animation-duration)
-        ease-out forwards 100ms;
-    }
+  &-root__inner &__overlay {
+    animation: hide-modal-overlay var(--modal-animation-duration)
+      ease-in-out forwards;
+  }
+
+  &-root__inner:last-of-type &__overlay {
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out
+      forwards 0ms;
+
     &--hide {
       animation: hide-modal-overlay var(--modal-animation-duration)
         ease-in-out forwards;
     }
-  }
-
-  &-root__inner &__overlay {
-    opacity: 0;
-    transition: opacity 300ms ease-in-out;
-  }
-  // We may possibly use something like this to avoid the transition
-  // when there are several stacked modals
-  // &-root__inner:nth-of-type(n + 2) &__overlay {
-  //   animation-duration: 0ms !important;
-  // }
-  &-root__inner:last-of-type &__overlay {
-    opacity: 1;
-  }
-  html[data-visual-test] &-root__inner &__overlay {
-    transition: none;
   }
 
   /* stylelint-disable-next-line */

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -831,22 +831,9 @@ export class InteractionInvalidation {
           ) {
             node._orig_ariahidden = node.getAttribute('aria-hidden')
           }
-          // Skip the outline for now - or does it give a value?
-          // if (
-          //   node &&
-          //   typeof node._orig_outline === 'undefined' &&
-          //   node.style.outline
-          // ) {
-          //   node._orig_outline = node.style.outline
-          // }
 
           node.setAttribute('tabindex', '-1')
           node.setAttribute('aria-hidden', 'true')
-
-          // tabindex=-1 does not prevent the mouse from focusing the node (which
-          // would show a focus outline around the element). prevent this by disabling
-          // outline styles while the modal is open
-          // node.style.outline = 'none'
         } catch (e) {
           //
         }
@@ -876,14 +863,6 @@ export class InteractionInvalidation {
         } else {
           node.removeAttribute('aria-hidden')
         }
-
-        // Skip the outline for now - or does it give a value?
-        // if (node && typeof node._orig_outline !== 'undefined') {
-        //   node.style.outline = node._orig_outline
-        //   delete node._orig_outline
-        // } else if(node.style) {
-        //   node.style.outline = null
-        // }
       } catch (e) {
         //
       }

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -7,15 +7,15 @@ import React from 'react'
 import keycode from 'keycode'
 import whatInput from 'what-input'
 import { registerElement } from './custom-element'
-import { IS_IE11 } from './helpers'
+import {
+  warn,
+  IS_IE11,
+  PLATFORM_MAC,
+  PLATFORM_WIN,
+  PLATFORM_LINUX,
+} from './helpers'
 
-export { registerElement }
-
-export const PLATFORM_MAC = 'Mac|iPad|iPhone|iPod'
-export const PLATFORM_WIN = 'Win'
-export const PLATFORM_ANDROID = 'Android'
-export const PLATFORM_LINUX = 'Linux'
-export const PLATFORM_IOS = 'iOS|iPhone|iPad|iPod'
+export { registerElement, warn }
 
 if (
   typeof process !== 'undefined' &&
@@ -724,17 +724,6 @@ export const isInsideScrollView = (
     return elem == window ? null : elem
   }
   return elem == window ? false : Boolean(elem)
-}
-
-export const warn = (...e) => {
-  if (
-    typeof process !== 'undefined' &&
-    process.env.NODE_ENV !== 'production' &&
-    typeof console !== 'undefined' &&
-    typeof console.log === 'function'
-  ) {
-    console.log('Eufemia:', ...e)
-  }
 }
 
 export const convertJsxToString = (elements, separator = undefined) => {

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -7,6 +7,7 @@ import React from 'react'
 import keycode from 'keycode'
 import whatInput from 'what-input'
 import { registerElement } from './custom-element'
+import { IS_IE11 } from './helpers'
 
 export { registerElement }
 
@@ -793,115 +794,133 @@ export class InteractionInvalidation {
   }
 
   activate(targetElement = null) {
-    if (!this.nodesToInvalidate) {
+    if (!this._nodesToInvalidate) {
       this._runInvalidaiton(targetElement)
     }
   }
 
   revert() {
     this._revertInvalidation()
-    this.nodesToInvalidate = null
+    this._nodesToInvalidate = null
   }
 
   _runInvalidaiton(targetElement) {
-    if (
-      typeof document === 'undefined'
-      // || isTouchDevice() // as for now, we do the same on touch devices
-    ) {
+    if (typeof document === 'undefined') {
       return // stop here
     }
 
-    this.nodesToInvalidate = this.getNodesToInvalidate(targetElement)
+    this._nodesToInvalidate = this.getNodesToInvalidate(targetElement)
 
-    if (Array.isArray(this.nodesToInvalidate)) {
-      this.nodesToInvalidate.forEach((node) => {
-        try {
-          // save the previous tabindex state so we can restore it on close
-          if (
-            node &&
-            typeof node._orig_tabindex === 'undefined' &&
-            node.hasAttribute('tabindex')
-          ) {
-            node._orig_tabindex = node.getAttribute('tabindex')
-          }
-          if (
-            node &&
-            typeof node._orig_ariahidden === 'undefined' &&
-            node.hasAttribute('aria-hidden')
-          ) {
-            node._orig_ariahidden = node.getAttribute('aria-hidden')
-          }
+    // 1. Save the previous tabindex and aria-hidden state so we can restore it on close
+    // 2. And invalidate the node
+    for (const node of this._nodesToInvalidate) {
+      if (!node) {
+        continue
+      }
 
-          node.setAttribute('tabindex', '-1')
-          node.setAttribute('aria-hidden', 'true')
-        } catch (e) {
-          //
-        }
-      })
+      const tabindex = node.getAttribute('tabindex')
+      const ariahidden = node.getAttribute('aria-hidden')
+
+      const dataset = node.dataset
+
+      if (tabindex !== null && typeof dataset._tabindex === 'undefined') {
+        node.dataset._tabindex = tabindex
+      }
+      if (
+        ariahidden !== null &&
+        typeof dataset._ariahidden === 'undefined'
+      ) {
+        node.dataset._ariahidden = ariahidden
+      }
+
+      node.setAttribute('tabindex', '-1')
+      node.setAttribute('aria-hidden', 'true')
     }
   }
 
   _revertInvalidation() {
-    if (!this.nodesToInvalidate) {
+    if (!Array.isArray(this._nodesToInvalidate)) {
       return // stop here
     }
 
     // restore or remove tabindex and aria-hidden from nodes
-    this.nodesToInvalidate.forEach((node) => {
-      try {
-        if (node && typeof node._orig_tabindex !== 'undefined') {
-          node.setAttribute('tabindex', node._orig_tabindex)
-          node._orig_tabindex = null
-          delete node._orig_tabindex
-        } else {
-          node.removeAttribute('tabindex')
-        }
-        if (node && typeof node._orig_ariahidden !== 'undefined') {
-          node.setAttribute('aria-hidden', node._orig_ariahidden)
-          node._orig_ariahidden = null
-          delete node._orig_ariahidden
-        } else {
-          node.removeAttribute('aria-hidden')
-        }
-      } catch (e) {
-        //
+    for (const node of this._nodesToInvalidate) {
+      if (!node) {
+        continue
       }
-    })
+
+      if (typeof node.dataset._tabindex !== 'undefined') {
+        node.setAttribute('tabindex', node.dataset._tabindex)
+        node.dataset._tabindex = null
+      } else {
+        node.removeAttribute('tabindex')
+      }
+      if (typeof node.dataset._ariahidden !== 'undefined') {
+        node.setAttribute('aria-hidden', node.dataset._ariahidden)
+        node.dataset._ariahidden = null
+      } else {
+        node.removeAttribute('aria-hidden')
+      }
+    }
   }
 
   getNodesToInvalidate(targetElement = null) {
     if (typeof document === 'undefined') {
-      return // stop here
+      return [] // stop here
     }
 
     if (typeof targetElement === 'string') {
       targetElement = document.querySelector(targetElement)
     }
 
-    const skipTheseNodes =
-      this.bypassSelectors && this.bypassSelectors.length > 0
-        ? Array.from(
-            (this.bypassElement || document).querySelectorAll(
-              this.bypassSelectors
-                ? this.bypassSelectors.map((s) => `${s} *`).join(', ')
-                : '*'
-            )
-          )
-        : []
-
     // by only finding elements that do not have tabindex="-1" we ensure we don't
     // corrupt the previous state of the element if a modal was already open
     const rootSelector = targetElement ? '*' : 'html *'
+
     const elementSelector = this.bypassSelectors
       .map((s) => `:not(${s})`)
       .join('')
-    const selector = `${rootSelector} ${elementSelector}:not(script):not(style):not(path)`
+
+    const selector = `${rootSelector} ${elementSelector}:not(script):not(style):not(path):not(head *)`
+
+    // JSDOM and IE11 has issues with the selector :not(x *), so we used it only in the browser,
+    // so we remove the asterisk from the selector, but add it to the exclude selectors list and make another querySelectorAll call
+    // - so we query all bypass selectors with "asterisk" manually
+    if (IS_IE11 || process.env.NODE_ENV === 'test') {
+      const excludeSelectors = []
+
+      const testSelector = selector
+        .split(':')
+        .map((localSel) => {
+          if (localSel.endsWith(' *)')) {
+            excludeSelectors.push(
+              ...Array.from(
+                (
+                  targetElement || document.documentElement
+                ).querySelectorAll(localSel.match(/\(([^)]*)\)/)[1])
+              )
+            )
+            localSel = localSel.replace(' *', '')
+          }
+
+          return localSel
+        })
+        .join(':')
+
+      return Array.from(
+        (targetElement || document.documentElement).querySelectorAll(
+          testSelector
+        )
+      ).filter((node) => !excludeSelectors.includes(node))
+    }
+
+    // console.log('selector', selector)
 
     return Array.from(
       (targetElement || document.documentElement).querySelectorAll(
         selector
       )
-    ).filter((node) => !skipTheseNodes.includes(node))
+    )
   }
 }
 

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -3,14 +3,11 @@
  *
  */
 
-import {
-  warn,
-  PLATFORM_MAC,
-  PLATFORM_WIN,
-  PLATFORM_ANDROID,
-  PLATFORM_LINUX,
-  PLATFORM_IOS,
-} from './component-helper'
+export const PLATFORM_MAC = 'Mac|iPad|iPhone|iPod'
+export const PLATFORM_WIN = 'Win'
+export const PLATFORM_ANDROID = 'Android'
+export const PLATFORM_LINUX = 'Linux'
+export const PLATFORM_IOS = 'iOS|iPhone|iPad|iPod'
 
 export let IS_IE11 = false
 export let IS_EDGE = false
@@ -420,4 +417,18 @@ export async function copyToClipboard(string) {
   }
 
   return success
+}
+
+export const warn = (...e) => {
+  if (
+    typeof process !== 'undefined' &&
+    process.env.NODE_ENV !== 'production' &&
+    typeof console !== 'undefined' &&
+    typeof console.log === 'function'
+  ) {
+    // Use log instead of warn,
+    // because of the stack track some browser do add
+    // which takes a lot of visual space in the console
+    console.log('Eufemia:', ...e)
+  }
 }


### PR DESCRIPTION
This PR aims to enhacne performance issues when opening the Modal / Drawer while a large amount of table rows are already in the DOM.

The first approach was to lower the amount of DOM maniulations during the invalidatione phase. But;

- Tests confirm that we can't remove `tabindex=-1` 
- And the same tests do also confirm, that making the attribute changes do take actualy the lowest amount of all CPU usage. On a table with 10 000 rows, it takes under 0.5s

So what takes the most CPU? Its the browser re-paint phase. Why does the browser need to make a repoiant when the Modal opens and closes? Because it changes every visible pixle:

- we need to change some styles on the body and html element to lock scrolling
- we show an overlay with opacity

Now, this PR still includes a couple of enhancements:

- We delay the `tabindex=-1` until the modal is opened (sadly, with 10 000 table rows, we still have almost the same delay)
- Use opacity for the overlay (its hardware accelerated) – instead of background-color with a alpha channel (opacity is hardware accelerated by defualt, and do not need the will-change property)

🍀 Now, what can project do to enhance their amount of DOM content? There are a couple of options. One is to use a virtualized scroller for that particular table – which only puts the visible parts in to the DOM.


