### PR TITLE
chore(Autocomplete): add test to confirm the submit button has type="button"

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -608,6 +608,16 @@ describe('Autocomplete component', () => {
     expect(elem.hasClass('dnb-autocomplete--opened')).toBe(true)
   })
 
+  it('has type="button" on submit button', () => {
+    const Comp = mount(<Component {...props} data={mockData} />)
+
+    expect(
+      Comp.find('button.dnb-input__submit-button__button')
+        .instance()
+        .getAttribute('type')
+    ).toBe('button')
+  })
+
   it('has correct length of li elements', () => {
     const Comp = mount(<Component {...props} data={mockData} />)
 


### PR DESCRIPTION
Adding a test to confim it. Heres a codesandbox that [confirms](https://codesandbox.io/s/eufemia-autocomplete-form-submit-weyzq?file=/src/App.tsx) it got fixed in v9.14
