### PR TITLE
chore(Portal): include publish version in portal footer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,7 +64,6 @@ steps:
       branch:
         include:
           - release
-          - release-*
           - portal
           - beta
           - alpha
@@ -99,7 +98,6 @@ steps:
       branch:
         include:
           - release
-          - release-*
           - portal
           - beta
           - alpha
@@ -166,7 +164,6 @@ steps:
         include:
           - main
           - release
-          - release-*
           - beta
           - alpha
 
@@ -187,7 +184,6 @@ steps:
       branch:
         include:
           - release
-          - release-*
           - portal
 
   - name: publish release
@@ -209,7 +205,6 @@ steps:
       branch:
         include:
           - release
-          - release-*
           - beta
           - alpha
 

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -7,15 +7,11 @@ const fs = require('fs-extra')
 const path = require('path')
 const { isCI } = require('repo-utils')
 const getCurrentBranchName = require('current-git-branch')
-const {
-  createNewVersion,
-  createNewChangelogVersion,
-} = require('./scripts/version.js')
+const { init } = require('./scripts/version.js')
 
 exports.onPreInit = async () => {
   if (process.env.NODE_ENV === 'production') {
-    await createNewVersion()
-    await createNewChangelogVersion()
+    await init()
   }
 }
 
@@ -40,7 +36,7 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
   createTypes(typeDefs)
 }
 
-exports.createResolvers = ({ stage, createResolvers }) => {
+exports.createResolvers = ({ createResolvers }) => {
   const resolvers = {
     Mdx: {
       siblings: {

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -129,7 +129,8 @@
     "typescript": "4.5.5"
   },
   "buildVersion": "[LOCAL BUILD]",
-  "changelogVersion": "April, 5. 2021",
+  "releaseVersion": "[LOCAL BUILD]",
+  "changelogVersion": "[LOCAL BUILD]",
   "installConfig": {
     "hoistingLimits": "dependencies"
   },

--- a/packages/dnb-design-system-portal/scripts/deploy.js
+++ b/packages/dnb-design-system-portal/scripts/deploy.js
@@ -8,7 +8,9 @@ const dotenv = require('dotenv')
 const ghpages = require('gh-pages')
 const { CIName } = require('repo-utils')
 const ora = require('ora')
-const { currentVersion } = require('./version.js')
+const packageJson = require('../package.json')
+
+const { currentVersion } = packageJson.buildVersion
 
 // import .env variables
 dotenv.config()

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -5,53 +5,72 @@
 
 const fs = require('fs-extra')
 const path = require('path')
-const { isCI } = require('repo-utils')
-const packageJson = require('../package.json')
+const { isCI } = require('ci-info')
+const {
+  getNextReleaseVersion,
+} = require('@dnb/eufemia/scripts/release/getNextReleaseVersion')
 
-exports.currentVersion = packageJson.buildVersion
+const init = async () => {
+  if (!isCI) {
+    console.log(
+      'You may only set a new deploy version on a CI environment!'
+    )
+    return false
+  }
+
+  await createBuildNewVersion()
+  await createNewChangelogVersion()
+  await createReleaseNewVersion()
+}
+
+exports.init = init
 
 // run only if the script was executed from command line
 if (
   require.main === module &&
   process.argv.indexOf('--new-version') !== -1
 ) {
-  createNewVersion()
-  createNewChangelogVersion()
+  init()
 }
 
-async function createNewVersion() {
-  if (!isCI) {
-    console.log(
-      'You may only set a new deploy version on a CI environment!'
-    )
-    return false
-  }
+async function createBuildNewVersion() {
   try {
+    const file = path.resolve(__dirname, '../package.json')
+    const packageJson = await fs.readJson(file)
     const date = new Date().toLocaleString('nb-NO', {
       timeZone: 'Europe/Oslo',
     })
     packageJson.buildVersion = date
 
     // Update the extracted version of package.json with the build version
-    await fs.writeFile(
-      path.resolve(__dirname, '../package.json'),
-      JSON.stringify(packageJson, null, 2)
-    )
+    await fs.writeFile(file, JSON.stringify(packageJson, null, 2))
 
-    console.log(`New version is ${date}!`)
+    console.log(`New build version is ${date}`)
   } catch (e) {
-    console.log(`Failed to create new version! \n${e.message}`)
+    console.warn(`Failed to create new build version! \n${e.message}`)
+  }
+}
+
+async function createReleaseNewVersion() {
+  try {
+    const file = path.resolve(__dirname, '../package.json')
+    const packageJson = await fs.readJson(file)
+    const version = (await getNextReleaseVersion()) || 'Not released'
+    packageJson.releaseVersion = version
+
+    // Update the extracted version of package.json with the build version
+    await fs.writeFile(file, JSON.stringify(packageJson, null, 2))
+
+    console.log(`New release version is ${version}`)
+  } catch (e) {
+    console.warn(`Failed to create new release version! \n${e.message}`)
   }
 }
 
 async function createNewChangelogVersion() {
-  if (!isCI) {
-    console.log(
-      'You may only set a new deploy version on a CI environment!'
-    )
-    return false
-  }
   try {
+    const file = path.resolve(__dirname, '../package.json')
+    const packageJson = await fs.readJson(file)
     const changelogFilePath = path.resolve(
       __dirname,
       '../../../',
@@ -66,14 +85,10 @@ async function createNewChangelogVersion() {
     packageJson.changelogVersion = changelogVersion
 
     // Update the extracted version of package.json with the change log version
-    await fs.writeFile(
-      path.resolve(__dirname, '../package.json'),
-      JSON.stringify(packageJson, null, 2)
-    )
+    await fs.writeFile(file, JSON.stringify(packageJson, null, 2))
   } catch (e) {
-    console.log(`Failed to create new static version file! \n${e.message}`)
+    console.warn(
+      `Failed to create new static version file! \n${e.message}`
+    )
   }
 }
-
-exports.createNewVersion = createNewVersion
-exports.createNewChangelogVersion = createNewChangelogVersion

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.js
@@ -21,9 +21,8 @@ import {
   setPageFocusElement,
   scrollToLocationHashId,
 } from '@dnb/eufemia/src/shared/helpers'
-import { Context } from '@dnb/eufemia/src/shared'
 import { Logo, GlobalStatus } from '@dnb/eufemia/src/components'
-import { createSkeletonClass } from '@dnb/eufemia/src/components/skeleton/SkeletonHelper'
+import { P } from '@dnb/eufemia/src/elements'
 
 export function scrollToAnimation() {
   // if url hash is defined, scroll to the id
@@ -234,7 +233,7 @@ const MainContent = React.forwardRef((props, ref) => (
 
 const StyledMain = styled.main`
   width: 100%;
-  min-height: 85vh;
+  min-height: 90vh;
   padding: 0 2rem;
 `
 
@@ -245,35 +244,32 @@ const FooterWrapper = styled.footer`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 2rem;
 
   padding: 1rem;
 
   border-top: 1px solid var(--color-black-border);
   background-color: var(--color-emerald-green);
   color: var(--color-white);
-
-  a {
-    margin-left: 0.5rem;
-  }
-  small {
-    padding: 0 2rem;
-  }
 `
 const Footer = () => {
-  const { skeleton } = React.useContext(Context)
   return (
     <FooterWrapper>
+      <P>
+        <small>
+          Package release: {packageJson.releaseVersion} <br />
+          Portal update: {packageJson.buildVersion}
+        </small>
+      </P>
+
       <Logo height="40" color="white" />
-      <small className={createSkeletonClass('font', skeleton)}>
-        Last Portal update: {packageJson.buildVersion}
-        <Link
-          to="/license"
-          className="dnb-anchor dnb-anchor--contrast dnb-anchor--no-underline"
-        >
-          Copyright (c) 2018-present DNB.no
-        </Link>
-      </small>
-      <span />
+
+      <Link
+        to="/license"
+        className="dnb-anchor dnb-anchor--contrast dnb-anchor--no-underline"
+      >
+        Copyright (c) 2018-present DNB.no
+      </Link>
     </FooterWrapper>
   )
 }

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -250,7 +250,6 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "release",
-      "release-*",
       {
         "name": "beta",
         "prerelease": true

--- a/packages/dnb-eufemia/scripts/release/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/release/getNextReleaseVersion.js
@@ -1,0 +1,69 @@
+/**
+ * Get next package version number before release
+ *
+ */
+
+// When on a "release" branch:
+// run: yarn nodemon --exec 'babel-node ./scripts/release/getNextReleaseVersion.js' --ext js --watch './scripts/**/*'
+// run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/release/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
+
+const { exec } = require('child_process')
+const getBranchName = require('current-git-branch')
+const dotenv = require('dotenv')
+
+dotenv.config()
+
+const command = 'yarn workspace @dnb/eufemia semantic-release --dry-run'
+const releaseBranches = ['release', 'beta', 'alpha']
+
+// run this script if it is called from bash / command line
+if (require.main === module) {
+  getNextReleaseVersion()
+}
+
+async function getNextReleaseVersion() {
+  const branchName = getBranchName()
+
+  if (releaseBranches.includes(branchName)) {
+    try {
+      const log = await runCommand(command)
+      const nextVersion = log.match(
+        /The next release version is ([^\n]*)/
+      )?.[1]
+
+      if (nextVersion) {
+        return nextVersion
+      }
+    } catch (e) {
+      console.error(e)
+    }
+  } else {
+    console.warn(
+      `The current git branch ${branchName} is not one of the release branches ${releaseBranches.join(
+        ','
+      )}`
+    )
+  }
+
+  return null
+}
+
+function runCommand(command) {
+  return new Promise((resolve, reject) => {
+    try {
+      exec(command, (error, stdout, stderr) => {
+        if (error) {
+          return reject(error)
+        }
+        if (stderr) {
+          return reject(stderr)
+        }
+        return resolve(stdout)
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+exports.getNextReleaseVersion = getNextReleaseVersion


### PR DESCRIPTION
closes #1060

This PR will include the release version in the footer of the portal. It will only display a version if the current branch is one of the release branches.
Else it will display `Not released` (I'm glad for better ideas there 😀)

It will look like this:

<img width="823" alt="Screenshot 2022-02-02 at 08 52 32" src="https://user-images.githubusercontent.com/1501870/152114320-6c8b82b3-d7aa-4890-8fe3-fe559738e3f9.png">

