### PR TITLE
fix(InputMasked): inherit of provider/context props

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.js
@@ -6,7 +6,10 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { registerElement } from '../../shared/component-helper'
+import {
+  registerElement,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import InputMaskedContext from './InputMaskedContext'
 import InputMaskedElement from './InputMaskedElement'
 import Input, { inputPropTypes } from '../input/Input'
@@ -14,12 +17,22 @@ import Context from '../../shared/Context'
 
 const InputMasked = React.forwardRef((props, ref) => {
   const context = React.useContext(Context)
+
+  const contextAndProps = React.useCallback(
+    extendPropsWithContext(
+      props,
+      InputMasked.defaultProps,
+      context?.InputMasked
+    ),
+    [props, InputMasked.defaultProps, context?.InputMasked]
+  )
+
   return (
     <InputMaskedContext.Provider
       value={{
         inner_ref: ref,
-        props,
-        ...context,
+        props: contextAndProps,
+        context,
       }}
     >
       <InputMaskedElement />

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -61,7 +61,6 @@ export const isRequestingNumberMask = (props) => {
 export const correctNumberValue = ({
   localValue = null,
   props,
-  context,
   locale,
   maskParams,
 }) => {
@@ -85,13 +84,11 @@ export const correctNumberValue = ({
   /**
    * This only runs IF "number_format" is set – we do not use it else
    */
-  const numberFormatFromContext = context?.InputMasked?.number_format
-  if (props.number_format || numberFormatFromContext) {
+  if (props.number_format) {
     const options = {
       locale,
       decimals: 0,
-      ...fromJSON(props.number_format),
-      ...numberFormatFromContext,
+      ...props.number_format,
     }
     if (shouldHaveDecimals) {
       options.decimals = maskParams.decimalLimit
@@ -245,19 +242,13 @@ export const handlePercentMask = ({ props, locale, maskParams }) => {
  * @property {object} currency_mask Component property for change the currency parameters
  * @returns object maskParams
  */
-export const handleCurrencyMask = ({
-  context,
-  mask_options,
-  currency_mask,
-}) => {
+export const handleCurrencyMask = ({ mask_options, currency_mask }) => {
   const maskParams = {
     showMask: true,
     placeholderChar: null,
     allowDecimal: true,
     decimalLimit: 2,
     decimalSymbol: ',',
-    ...context?.InputMasked?.mask_options,
-    ...context?.InputMasked?.currency_mask,
     ...mask_options,
     ...currency_mask,
   }
@@ -283,15 +274,9 @@ export const handleCurrencyMask = ({
  * @property {object} number_mask Component property for change the number parameters
  * @returns object maskParams
  */
-export const handleNumberMask = ({
-  context,
-  mask_options,
-  number_mask,
-}) => {
+export const handleNumberMask = ({ mask_options, number_mask }) => {
   const maskParams = {
     decimalSymbol: ',',
-    ...context?.InputMasked?.mask_options,
-    ...context?.InputMasked?.number_mask,
     ...mask_options,
     ...number_mask,
   }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.js
@@ -194,6 +194,7 @@ describe('InputMasked component', () => {
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalledTimes(0)
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
     expect(onKeyDown.mock.calls[0][0].value).toBe('NOK 1 234,56 kr')
     expect(onKeyDown.mock.calls[0][0].numberValue).toBe(1234.56)
 
@@ -207,7 +208,7 @@ describe('InputMasked component', () => {
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalledTimes(1)
-    expect(onKeyDown).toHaveBeenCalledTimes(1)
+    expect(onKeyDown).toHaveBeenCalledTimes(2)
 
     Comp.setProps({
       number_mask: {
@@ -244,8 +245,8 @@ describe('InputMasked component', () => {
       },
       preventDefault,
     })
-    expect(preventDefault).toHaveBeenCalledTimes(2)
-    expect(onKeyDown).toHaveBeenCalledTimes(2)
+    expect(preventDefault).toHaveBeenCalledTimes(3)
+    expect(onKeyDown).toHaveBeenCalledTimes(4)
   })
 
   it('should allow leading zero when removing first letter', () => {
@@ -445,7 +446,7 @@ describe('InputMasked component', () => {
       preventDefault,
     })
     expect(preventDefault).toHaveBeenCalledTimes(1)
-    expect(onKeyDown).toHaveBeenCalledTimes(0)
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
 
     Comp.setProps({
       number_mask: {
@@ -461,12 +462,13 @@ describe('InputMasked component', () => {
       },
       preventDefault,
     })
-    expect(onKeyDown.mock.calls[0][0].value).toBe('0 kr')
-    expect(onKeyDown).toHaveBeenCalledTimes(1)
+
+    expect(onKeyDown).toHaveBeenCalledTimes(2)
+    expect(onKeyDown.mock.calls[1][0].value).toBe('0 kr')
     expect(preventDefault).toHaveBeenCalledTimes(1)
   })
 
-  it('should accept mask only (ssn)', () => {
+  it('should accept custom mask only', () => {
     const onKeyDown = jest.fn()
     const preventDefault = jest.fn()
     const newValue = '010203 12345'
@@ -507,6 +509,51 @@ describe('InputMasked component', () => {
     expect(preventDefault).toHaveBeenCalledTimes(0)
     expect(onKeyDown).toHaveBeenCalledTimes(1)
     expect(onKeyDown.mock.calls[0][0].value).toBe('010203 12345')
+
+    Comp.setProps({
+      mask_options: {
+        allowLeadingZeroes: false,
+      },
+    })
+
+    Comp.find('input').simulate('keydown', {
+      key: '0',
+      keyCode: 48, // zero
+      target: {
+        value: newValue,
+        selectionStart: 0, // set it to be a leading zero
+      },
+      preventDefault,
+    })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(onKeyDown).toHaveBeenCalledTimes(2)
+  })
+
+  it('should accept provider props with custom mask', () => {
+    const Comp = mount(
+      <Provider value={{ InputMasked: { value: '00020300000' } }}>
+        <Component
+          value="11020312345"
+          mask={() => [
+            /[0-9]/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            ' ',
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+          ]}
+        />
+      </Provider>
+    )
+
+    expect(Comp.find('input').instance().value).toBe('110203 12345')
   })
 
   it('should show placeholder chars when show_mask is true', () => {


### PR DESCRIPTION
The InputMasked did not properly handle provider/context props as well as accepting local props when a custom mask only is used. This PR fixes both.