### PR TITLE
chore: remove import of cite from @dnb/eufemia/src

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.md
@@ -4,7 +4,7 @@ order: 2
 icon: 'naming'
 ---
 
-import { Button, Blockquote, cite } from '@dnb/eufemia/src'
+import { Button, Blockquote } from '@dnb/eufemia/src'
 
 # New contributor
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements.md
@@ -8,14 +8,14 @@ import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Link } from '@dnb/eufemia/src/elements'
 import NotSupportedElements from 'Docs/uilib/elements/not-supported'
-import UnstyledElements from 'Docs/uilib/elements/unstyled'
-import Anchor from 'Docs/uilib/elements/anchor'
-import Blockquote from 'Docs/uilib/elements/blockquote'
-import Tables from 'Docs/uilib/elements/tables'
-import Lists from 'Docs/uilib/elements/lists'
-import Image from 'Docs/uilib/elements/image'
-import Hr from 'Docs/uilib/elements/horizontal-rule'
-import Code from 'Docs/uilib/elements/code'
+import UnstyledElementsDemos from 'Docs/uilib/elements/unstyled'
+import AnchorDemos from 'Docs/uilib/elements/anchor'
+import BlockquoteDemos from 'Docs/uilib/elements/blockquote'
+import TablesDemos from 'Docs/uilib/elements/tables'
+import ListsDemos from 'Docs/uilib/elements/lists'
+import ImageDemos from 'Docs/uilib/elements/image'
+import HrDemos from 'Docs/uilib/elements/horizontal-rule'
+import CodeDemos from 'Docs/uilib/elements/code'
 
 # HTML Elements
 
@@ -78,14 +78,14 @@ render(<StyledLink href="/" target="_blank">Styled Link</StyledLink>)
 `}
 </ComponentBox>
 
-<Anchor />
-<Lists />
-<Tables />
-<Blockquote />
-<Image />
-<Hr />
-<UnstyledElements />
-<Code />
+<AnchorDemos />
+<ListsDemos />
+<TablesDemos />
+<BlockquoteDemos />
+<ImageDemos />
+<HrDemos />
+<UnstyledElementsDemos />
+<CodeDemos />
 
 ---
 


### PR DESCRIPTION
Removes the following warning from the terminal: 
_Attempted import error: 'cite' is not exported from '@dnb/eufemia/src' (imported as 'cite')_

And from the dev console:
_export 'cite' (imported as 'cite') was not found in '@dnb/eufemia/src' (possible exports: Accordion, Anchor, Autocomplete, Blockquote, Breadcrumb, Button, Checkbox, Code, DatePicker, Dd, Div, Dl, Dropdown, Dt, FormLabel, FormRow, FormSet, FormStatus, GlobalError, GlobalStatus, H, H1, H2, H3, H4, H5, H6, Heading, HelpButton, Hr, Icon, IconPrimary, Img, Ingress, Input, InputMasked, Lead, Li, Link, Logo, Modal, NumberFormat, Ol, P, Pagination, Paragraph, ProgressIndicator, Radio, Section, Skeleton, Slider, Space, Span, StepIndicator, Switch, Table, Tabs, Tag, Td, Textarea, Th, ToggleButton, Tooltip, Tr, Ul, default)_
