### PR TITLE
fix(Breadcrumb): forward props in BreadcrumbItem to span as well

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -103,7 +103,7 @@ export default function BreadcrumbItem(localProps: BreadcrumbItemProps) {
           {...props}
         />
       ) : (
-        <span className="dnb-breadcrumb__item__span">
+        <span className="dnb-breadcrumb__item__span" {...props}>
           <IconPrimary
             icon={currentIcon}
             className="dnb-breadcrumb__item__span__icon"


### PR DESCRIPTION
Fixing a reported issue when sending down props to `<Breadcrumb.Item data-testid="breadcrumb-item-card" onClick={null}/>` without interaction. Check out the [slack thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1640792268004600).

Successfully ran tests and screenshot tests, as well as manual testing 👍 