### PR TITLE
fix(Breadcrumb): improve accessibility

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -88,7 +88,7 @@ export default function BreadcrumbItem(localProps: BreadcrumbItemProps) {
     <li
       className="dnb-breadcrumb__item"
       data-testid="breadcrumb-item"
-      aria-current={variant === 'current' ? true : undefined}
+      aria-current={variant === 'current' ? 'page' : undefined}
     >
       {isInteractive ? (
         <Button

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -94,7 +94,7 @@ describe('Breadcrumb', () => {
     ).toBe('Page 2')
   })
 
-  it('current will have aria-current="true', () => {
+  it('current item will have aria-current="page', () => {
     render(
       <Breadcrumb
         data={[
@@ -106,7 +106,7 @@ describe('Breadcrumb', () => {
     )
 
     const lastElem = screen.getAllByTestId('breadcrumb-item').slice(-1)[0]
-    expect(lastElem.getAttribute('aria-current')).toBe('true')
+    expect(lastElem.getAttribute('aria-current')).toBe('page')
   })
 
   it('variant collapse opens the collapsed content on click', () => {


### PR DESCRIPTION
Improved accessibility of the current breadcrumb-item by using [aria-current="page"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) instead of aria-current="true".

From MDN: _"...In a breadcrumb list, when a link within a set of pagination links is styled to indicate the user is currently on that page, aria-current="page" should be set on that link"_ 