### PR TITLE
fix: fix rendering of DatePickerFooter when show_reset_button is prov…

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
@@ -98,7 +98,8 @@ export default class DatePickerFooter extends React.PureComponent {
     if (
       !isRange &&
       !isTrue(show_submit_button) &&
-      !isTrue(show_cancel_button)
+      !isTrue(show_cancel_button) &&
+      !isTrue(show_reset_button)
     ) {
       return <></>
     }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
@@ -361,7 +361,6 @@ describe('DatePicker component', () => {
 
     const Comp = mount(
       <Component
-        range
         opened
         no_animation
         show_reset_button
@@ -372,6 +371,54 @@ describe('DatePicker component', () => {
     const resetElem = Comp.find('button[data-visual-test="reset"]')
     expect(resetElem.exists()).toBe(true)
     expect(resetElem.text()).toMatch(reset_button_text)
+  })
+
+  it('footer is rendered when show_reset_button is provided', () => {
+    const Comp = mount(<Component opened no_animation show_reset_button />)
+
+    const datePickerFooter = Comp.find('.dnb-date-picker__footer')
+    expect(datePickerFooter.exists()).toBe(true)
+  })
+
+  it('footer is rendered when show_cancel_button is provided', () => {
+    const Comp = mount(
+      <Component opened no_animation show_cancel_button />
+    )
+
+    const datePickerFooter = Comp.find('.dnb-date-picker__footer')
+    expect(datePickerFooter.exists()).toBe(true)
+  })
+
+  it('footer is rendered when show_submit_button is provided', () => {
+    const Comp = mount(
+      <Component opened no_animation show_submit_button />
+    )
+
+    const datePickerFooter = Comp.find('.dnb-date-picker__footer')
+    expect(datePickerFooter.exists()).toBe(true)
+  })
+
+  it('footer is rendered when range is provided', () => {
+    const Comp = mount(<Component opened no_animation range />)
+
+    const datePickerFooter = Comp.find('.dnb-date-picker__footer')
+    expect(datePickerFooter.exists()).toBe(true)
+  })
+
+  it('footer is not rendered', () => {
+    const Comp = mount(
+      <Component
+        opened
+        no_animation
+        show_reset_button={false}
+        show_cancel_button={false}
+        show_submit_button={false}
+        range={false}
+      />
+    )
+
+    const datePickerFooter = Comp.find('.dnb-date-picker__footer')
+    expect(datePickerFooter.exists()).toBe(false)
   })
 
   it('has a working month correction', () => {


### PR DESCRIPTION
DatePickerFooter wasn't rendered when providing `show_reset_button={true}`.
This PR renders DatePickerFooter when `show_reset_button={true}` is provided to DatePicker.