### PR TITLE
fix: added export of Bar in Pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test:update": "yarn workspace @dnb/eufemia test:update",
     "test:screenshots": "yarn workspace @dnb/eufemia test:screenshots",
     "test:screenshots:update": "yarn workspace @dnb/eufemia test:screenshots:update",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint": "yarn workspace @dnb/eufemia lint && yarn workspace dnb-design-system-portal lint",
+    "lint:ci": "yarn workspace @dnb/eufemia lint:ci && yarn workspace dnb-design-system-portal lint:ci"
   },
   "devDependencies": {
     "husky": "7.0.4",

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.md
@@ -38,10 +38,15 @@ import 'intersection-observer'
 
 ### Default pagination and content handling
 
-You can either only use the pagination component with the buttons (bar) and have your content outside, but linked together with your own states.
+You can put your content inside the pagination wrapper. This has the advantage that it gives screen-reader users an easier way to interact and understand the content. It will also "keep" the old page height until the next page is inserted while showing an indicator.
 
-- or you put your content inside the pagination wrapper. This has the advantage that it gives screen-reader users an easier way to interact and understand the content.
-- and it will "keep" the old page height until the next page is inserted while showing an indicator.
+The pagination component can be used outside of the content. Then you have to export the `Bar` component directly from Pagination and link it together with your own states.
+
+```jsx
+import { Bar } from '@dnb/eufemia/components/Pagination'
+```
+
+We recommend contacting one of the developers at Eufemia ([Slack channel #eufemia-web](https://dnb-it.slack.com/archives/CMXABCHEY)) to help you set up `Bar`, so that the pagination becomes screen-reader compliant.
 
 #### Pagination method #1
 

--- a/packages/dnb-eufemia-sandbox/stories/components/Pagination.js
+++ b/packages/dnb-eufemia-sandbox/stories/components/Pagination.js
@@ -11,6 +11,7 @@ import { P } from '@dnb/eufemia/src/elements'
 import { Button, Section } from '@dnb/eufemia/src/components'
 import Pagination, {
   createPagination,
+  Bar,
 } from '@dnb/eufemia/src/components/pagination/Pagination'
 
 export default {
@@ -40,7 +41,7 @@ for (let i = 1; i <= 300; i++) {
   tableItems.push({ ssn: i, text: String(i), expanded: false })
 }
 
-export const Infinity = () => {
+export const InfinitySandbox = () => {
   const props = {
     current_page: 3,
     // page_count: 30,
@@ -66,10 +67,42 @@ export const Infinity = () => {
   )
 }
 
+export const PaginationNoChildren = () => (
+  <Wrapper>
+    <Box>
+      <Bar
+        page_count={10}
+        currentPage={2}
+        on_change={(page) => {
+          console.log(page)
+        }}
+      />
+    </Box>
+    <Box>
+      <Bar
+        page_count={10}
+        currentPage={2}
+        on_change={(page) => {
+          console.log(page)
+        }}
+      />
+    </Box>
+  </Wrapper>
+)
+
 export const PaginationSandbox = () => (
   <Wrapper>
     <Box>
       <PaginationRender />
+    </Box>
+    <Box>
+      <Pagination
+        page_count={10}
+        currentPage={2}
+        on_change={(page) => {
+          console.log(page)
+        }}
+      />
     </Box>
     <Box>
       <Pagination page_count={2}>

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.js
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.js
@@ -320,6 +320,10 @@ Pagination.Content = PaginationContent
 const PaginationWrapper = Pagination
 const InfinityMarkerWrapper = InfinityMarker
 
+export const Bar = (props) => (
+  <Pagination fallback_element={() => null} {...props} />
+)
+
 export const createPagination = (initProps = {}) => {
   const store = React.createRef({})
   const rerender = React.createRef(null)

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.js
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.js
@@ -12,7 +12,7 @@ import {
   toJson,
   loadScss,
 } from '../../../core/jest/jestSetup'
-import Component, { createPagination } from '../Pagination'
+import Component, { createPagination, Bar } from '../Pagination'
 
 const snapshotProps = {
   ...fakeProps(require.resolve('../Pagination'), {
@@ -575,6 +575,13 @@ describe('Infinity scroller', () => {
     expect(on_change).toHaveBeenCalledTimes(2)
     expect(on_load).toHaveBeenCalledTimes(4)
     expect(on_end).toHaveBeenCalledTimes(1)
+  })
+
+  it('should show pagination bar using Bar component', () => {
+    const Comp = mount(<Bar {...props} on_change={jest.fn()} />)
+
+    expect(Comp.exists('.dnb-pagination__bar')).toBe(true)
+    expect(Comp.exists('.dnb-pagination__indicator')).toBe(false)
   })
 
   // compare the snapshot

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -361,6 +361,12 @@ exports[`Pagination bar have to match snapshot 1`] = `
       },
     }
   }
+  4={
+    Object {
+      "displayName": "Bar",
+      "props": Object {},
+    }
+  }
   align="left"
   button_title={null}
   class={null}
@@ -527,6 +533,12 @@ exports[`Pagination bar have to match snapshot 1`] = `
         "props": Object {
           "children": "children",
         },
+      }
+    }
+    4={
+      Object {
+        "displayName": "Bar",
+        "props": Object {},
       }
     }
     align="left"
@@ -702,6 +714,12 @@ exports[`Pagination bar have to match snapshot 1`] = `
           "props": Object {
             "children": "children",
           },
+        }
+      }
+      4={
+        Object {
+          "displayName": "Bar",
+          "props": Object {},
         }
       }
       align="left"


### PR DESCRIPTION
Pagination (mode pagination) rendered loading spinner as content when no children was given. 

Added a test for the reported issue as well 
