### PR TITLE
Fix dialog being omitted in accessability tree

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -124,6 +124,7 @@ export default class ModalContent extends React.PureComponent<
         [
           // Bypass modal content
           '.dnb-modal__content *',
+          `#dnb-modal-${this.props.root_id || 'root'}`,
           `#dnb-modal-${this.props.root_id || 'root'} *`,
 
           // TODO: Eventually in future, make it possible to bypass invalidation from outside

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -698,6 +698,37 @@ describe('Modal component', () => {
     Comp.find('button.dnb-modal__close-button').simulate('click')
   })
 
+  it('should not add aria-hidden to the modal root', () => {
+    const modalContent = 'Modal Content'
+
+    const Comp = mount(
+      <div>
+        <Component
+          {...props}
+          title={null}
+          modal_content={null}
+          direct_dom_return={false}
+        >
+          {modalContent}
+        </Component>
+
+        <button id="my-button">I should become hidden after open</button>
+      </div>,
+      { attachTo: attachToBody() }
+    )
+
+    Comp.find('button.dnb-modal__trigger').simulate('click')
+
+    const id = `#dnb-modal-${props.id}`
+    const modalRoot = document.querySelector(id)
+    const outsideButton = document.querySelector('#my-button')
+
+    expect(modalRoot.getAttribute('aria-hidden')).toBeFalsy()
+    expect(outsideButton.getAttribute('aria-hidden')).toEqual('true')
+
+    Comp.find('button.dnb-modal__close-button').simulate('click')
+  })
+
   it('runs expected side effects on desktop', () => {
     const Comp = mount(<Component {...props} />)
     const elem = Comp.find('button')


### PR DESCRIPTION
This omits the modal root from getting
aria-hidden="true" added to it, which
removes the modal from the accessibility tree

## Summary

The modal root component got `aria-hidden="true"` added to it when opening the dialog, rendering the content inside not accessible in the accessibility tree.

This adds additional ignore of the modal root component in the `aria-hidden` handler logic.

## Test plan

I added a new test, for checking that a button outside still gets `aria-hidden="true"`, and the modal root no longer get it. However I could not get the test to work, I tried both using `document.querySelector` and `Comp.find` as seen in the tried test. As well as with and without the `{attachTo: attachToBody()}` option.

I have verified the described effect/change in Storybook, as well as when using it as a component in our application.
