### PR TITLE
chore: remove unused style for payment card

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.js.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.js.snap
@@ -437,7 +437,6 @@ exports[`PaymentCard scss have to match snapshot 1`] = `
  *
  */
 :root {
-  --dnb-payment-shadow-figma: 0 8px 16px rgba(51, 51, 51, 0.08);
   --dnb-payment-bg-default: linear-gradient(
     184.55deg,
     var(--color-sea-green) 6.31%,

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/_payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/_payment-card.scss
@@ -4,7 +4,6 @@
  */
 
 :root {
-  --dnb-payment-shadow-figma: 0 8px 16px rgba(51, 51, 51, 0.08);
   --dnb-payment-bg-default: linear-gradient(
     184.55deg,
     var(--color-sea-green) 6.31%,


### PR DESCRIPTION
Doesn't seem like the following variable is used, ```--dnb-payment-shadow-figma```