### PR TITLE
docs: remove double spacing below tabs

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/Tabbar.js
@@ -147,7 +147,7 @@ Tabbar.defaultProps = {
   children: null,
 }
 Tabbar.ContentWrapper = (props) => (
-  <Tabs.ContentWrapper id="tabbar" {...props} />
+  <Tabs.ContentWrapper id="tabbar" content_spacing={false} {...props} />
 )
 
 const tabsWrapperStyle = css`
@@ -175,11 +175,13 @@ const tabsWrapperStyle = css`
   }
 
   @media screen and (max-width: 40em) {
-    ${'' /* .dnb-tabs__tabs {
+    ${
+      '' /* .dnb-tabs__tabs {
       NB: Now this gets handled automatically
       margin: 0 -2rem;
       padding: 0 2rem;
-    } */}
+    } */
+    }
     .dnb-tabs__tabs .dnb-button.fullscreen {
       display: none;
     }


### PR DESCRIPTION
With approval from UX, this PR removes the space below tabs. This is okay since every tab content has a title with enough spacing.
