### PR TITLE
docs: update "new" status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion.md
@@ -1,9 +1,8 @@
 ---
 title: 'Accordion'
-description: 'The Accordion component, also know as a ComboBox, completes / suggests values during typing.'
+description: 'The Accordion component, also known as a ComboBox, completes / suggests values during typing.'
 order: 1
 showTabs: true
-status: 'new'
 ---
 
 import AccordionInfo from 'Docs/uilib/components/accordion/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading.md
@@ -1,7 +1,6 @@
 ---
 title: 'Heading'
 description: 'The Heading component is a helper to create automated semantic headings within a boundary of some rules.'
-status: 'new'
 order: 4
 showTabs: true
 hideTabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
@@ -1,7 +1,6 @@
 ---
 title: 'HelpButton'
 description: 'A help button with custom semantics, helping screen readers determine the meaning of that button'
-status: 'new'
 order: 4
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton.md
@@ -2,7 +2,6 @@
 title: 'Skeleton'
 description: 'The Skeleton component is a visual building block helper.'
 order: 12
-status: 'new'
 showTabs: true
 hideTabs:
   - title: Events

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
@@ -1,6 +1,5 @@
 ---
 title: 'Tooltip'
-status: 'new'
 order: 21
 showTabs: true
 hideTabs:


### PR DESCRIPTION
Removed "new" status from docs for components that are older than 1-2 years.