### PR TITLE
fix(DrawerList): ensure DrawerList is unsetting its global attributes on unmount

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.js
@@ -39,7 +39,7 @@ export const SearchBarInput = () => {
     debounce(
       ({ value }) => {
         searchIndex.current
-          .search(value)
+          ?.search(value)
           .then(({ hits }) => {
             updateData(
               makeHitsHumanFriendly({ hits, setHidden, emptyData })

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
@@ -127,6 +127,7 @@ export default class DrawerListProvider extends React.PureComponent {
     clearTimeout(this._scrollTimeout)
     clearTimeout(this._ddTimeout)
 
+    this.setActiveState(false)
     this.removeObservers()
   }
 

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.js
@@ -258,6 +258,29 @@ describe('DrawerList component', () => {
     ).toBe(false)
   })
 
+  it('will unset data-dnb-drawer-list-active on unmount', () => {
+    const Comp = mount(
+      <Component {...props} opened={false} data={mockData} />,
+      {
+        attachTo: attachToBody(),
+      }
+    )
+
+    Comp.setProps({
+      opened: true,
+    })
+
+    expect(
+      document.documentElement.getAttribute('data-dnb-drawer-list-active')
+    ).toBe(props.id)
+
+    Comp.unmount()
+
+    expect(
+      document.documentElement.hasAttribute('data-dnb-drawer-list-active')
+    ).toBe(false)
+  })
+
   it('has valid on_change callback', () => {
     const on_change = jest.fn()
     const on_select = jest.fn()


### PR DESCRIPTION
This PR ensures the DrawerList will "reset" global attributes is has set during its open event.