### PR TITLE
fix syntax highlighting

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.md
@@ -10,25 +10,27 @@ title: 'Code'
 
 - `@dnb/eufemia/style/themes/theme-ui/prism/dnb-prism-theme.js`
 
+You find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/theme-ui/prism/dnb-prism-theme.js).
+
 ### Code and Pre Tag usage
 
 Styling for both the `<code>` and the `<pre>` tags are build in the `@dnb/eufemia`.
-So simply use them in your syntax:
+
+So simply use them for your code syntax:
 
 ```html
 <p class="dnb-p">
-  My <code class="dnb-code">Formatted example</code> in a Paragraph
+  My <code class="dnb-code">formatted text</code> inside a paragraph
 </p>
 
 <pre class="dnb-pre">
-  One line
-  New lines
+  Code Syntax
 </pre>
 ```
 
-### Code and Typography
+#### Code and Typography
 
-`<code>` snippets look best when rendered in a _Monotype_ font. Developers will normally have installed some of these fonts on their devices. Here is an example of CSS `font-family` usage:
+When you use `<code>` or `<pre>` – the DNB _DNBMono_ font is used, like so:
 
 ```css
 font-family: var(--font-family-monospace);

--- a/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
+++ b/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
@@ -1256,6 +1256,7 @@ thead > tr > th.dnb-table--active .dnb-button:hover:focus .dnb-button__text::aft
   margin: -0.25em 0;
   padding: 0.25em 0.25em;
   /* 2px 4px */
+  overflow: auto;
   font-size: inherit;
   text-decoration: inherit;
   line-height: var(--line-height-xx-small--em);

--- a/packages/dnb-eufemia/src/style/elements/code.scss
+++ b/packages/dnb-eufemia/src/style/elements/code.scss
@@ -8,6 +8,8 @@
   margin: -0.25em 0;
   padding: 0.25em 0.25em; /* 2px 4px */
 
+  overflow: auto;
+
   font-size: inherit;
   text-decoration: inherit;
   line-height: var(--line-height-xx-small--em); // 1.5rem - 0.25em - 0.25em


### PR DESCRIPTION
This PR fixes both some outdated docs about the font usage and ensures there will be a scroll-bar when not enough space is left to show the content inside the `<code>` element.