### PR TITLE
fix: use discriminated union for props alt and src

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -22,16 +22,17 @@ import AvatarGroup, { AvatarGroupContext } from './AvatarGroup'
 
 export * from './AvatarGroup'
 
+type AltSrcProps =
+  | {
+      alt?: string
+      src?: string
+    }
+  | { alt: string; src: string }
+
 export type AvatarSizes = 'small' | 'medium' | 'large' | 'x-large'
 export type AvatarVariants = 'primary' | 'secondary' | 'tertiary'
 
 export interface AvatarProps {
-  /**
-   * Used in combination with `src` to provide an alt attribute for the `img` element.
-   * Default: null
-   */
-  alt?: string
-
   /**
    * Custom className on the component root
    * Default: null
@@ -57,12 +58,6 @@ export interface AvatarProps {
   size?: AvatarSizes
 
   /**
-   * Specifies the path to the image
-   * Default: null
-   */
-  src?: string
-
-  /**
    * Props applied to the `img` element if the component is used to display an image.
    * Default: null
    */
@@ -76,17 +71,15 @@ export interface AvatarProps {
 }
 
 export const defaultProps = {
-  alt: null,
   className: null,
   size: 'medium',
-  src: null,
   imgProps: null,
   variant: 'primary',
   skeleton: false,
   children: null,
 }
 
-function Avatar(localProps: AvatarProps & ISpacingProps) {
+function Avatar(localProps: AvatarProps & AltSrcProps & ISpacingProps) {
   // Every component should have a context
   const context = React.useContext(Context)
   const avatarGroupContext = React.useContext(AvatarGroupContext)

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -19,12 +19,14 @@ import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
 import { extendPropsWithContext } from '../../shared/component-helper'
 
+type AltSrcProps =
+  | {
+      alt?: string
+      src?: string
+    }
+  | { alt: string; src: string }
+
 export interface InfoCardProps {
-  /**
-   * Used in combination with `src` to provide an alt attribute for the `img` element.
-   * Default: null
-   */
-  alt?: string
   /**
    * Aligns the content to center, rather than left
    * Default: false
@@ -50,11 +52,6 @@ export interface InfoCardProps {
    * Default: null
    */
   skeleton?: SkeletonTypes
-  /**
-   * Specifies the path to the image
-   * Default: null
-   */
-  src?: string
   /**
    * Image src, will replace the 'icon' with the image
    * Default: null
@@ -98,13 +95,11 @@ export interface InfoCardProps {
 }
 
 export const defaultProps = {
-  alt: null,
   centered: false,
   className: null,
   skeleton: false,
   icon: LightbulbIcon,
   imgProps: null,
-  src: null,
   title: null,
   onAccept: null,
   onClose: null,
@@ -114,7 +109,9 @@ export const defaultProps = {
   acceptButtonAttributes: null,
 }
 
-function InfoCard(localProps: InfoCardProps & ISpacingProps) {
+function InfoCard(
+  localProps: InfoCardProps & AltSrcProps & ISpacingProps
+) {
   // Every component should have a context
   const context = React.useContext(Context)
   // Extract additional props from global context

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -49,12 +49,12 @@ describe('InfoCard', () => {
 
   it('renders the image', () => {
     const img_src = '/android-chrome-192x192.png'
+    const img_alt = 'alt text'
 
-    render(
-      <InfoCard text="text" imgProps={{ alt: 'alt-text', src: img_src }} />
-    )
+    render(<InfoCard text="text" src={img_src} alt={img_alt} />)
 
     expect(screen.queryByRole('img').getAttribute('src')).toBe(img_src)
+    expect(screen.queryByRole('img').getAttribute('alt')).toBe(img_alt)
   })
 
   it('renders imgProps', () => {

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -16,19 +16,14 @@ import Context from '../../shared/Context'
 import { SkeletonTypes } from '../../shared/interfaces'
 import { extendPropsWithContext } from '../../shared/component-helper'
 
+type IconAltProps =
+  | {
+      icon?: IconPrimaryIcon
+      iconAlt?: string
+    }
+  | { icon: IconPrimaryIcon; iconAlt: string }
+
 export interface TimelineItemProps {
-  /**
-   * Icon displaying on the left side.
-   * Default: `check` for state `completed`, `pin` for state `current`, and `calendar` for state `upcoming` .
-   */
-  icon?: IconPrimaryIcon
-
-  /**
-   * Text displaying the title of the item's corresponding page.
-   * Default: translations based on the icon.
-   */
-  iconAlt?: string
-
   /**
    * Text displaying the name of the timeline item.
    */
@@ -58,8 +53,6 @@ export interface TimelineItemProps {
 }
 
 const defaultProps = {
-  icon: null,
-  iconAlt: null,
   name: null,
   date: null,
   infoMessage: null,
@@ -67,7 +60,9 @@ const defaultProps = {
   skeleton: false,
 }
 
-export default function TimelineItem(localProps: TimelineItemProps) {
+export default function TimelineItem(
+  localProps: TimelineItemProps & IconAltProps
+) {
   // Every component should have a context
   const context = React.useContext(Context)
   const {


### PR DESCRIPTION
Not sure if we want this or not.
This is just a suggestion to make a property required when an other property is available.
In these examples, either both `alt` and `src` is required, otherwise both are optional.
So if only providing `alt` or `src`, typescript will tell us that the missing property is required.