### PR TITLE
fix(StepIndicator): fix height animation issue when CSS is loaded too slow

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.js
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.js
@@ -51,6 +51,7 @@ export default class StepIndicatorTriggerButton extends React.PureComponent {
 
   componentDidMount() {
     this._heightAnim.setElement(this._buttonRef.current)
+    this._prevStep = this.context.activeStep
   }
 
   componentWillUnmount() {
@@ -61,14 +62,9 @@ export default class StepIndicatorTriggerButton extends React.PureComponent {
     if (this._prevStep !== this.context.activeStep) {
       const toHeight = this._heightAnim.getUnknownHeight()
 
-      // make animation smooth
-      // because we set the height before requestAnimationFrame
-      // also, to ensure smoothness, the parent li wrapper (&__trigger) needs flex column
-      this._heightAnim.adjustFrom(height)
-
       this._heightAnim.adjustTo(height, toHeight)
+      this._prevStep = this.context.activeStep
     }
-    this._prevStep = this.context.activeStep
   }
 
   render() {

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
@@ -2171,7 +2171,6 @@ Array [
                   aria-describedby="unique-id-loose-snapshot-overview"
                   class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                   id="unique-id-loose-snapshot"
-                  style="height: auto;"
                   type="button"
                 >
                   <span
@@ -2288,7 +2287,6 @@ Array [
                       aria-describedby="unique-id-loose-snapshot-overview"
                       class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       id="unique-id-loose-snapshot"
-                      style="height: auto;"
                       type="button"
                     >
                       <span
@@ -2402,7 +2400,6 @@ Array [
                           aria-describedby="unique-id-loose-snapshot-overview"
                           class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                           id="unique-id-loose-snapshot"
-                          style="height: auto;"
                           type="button"
                         >
                           <span
@@ -4787,7 +4784,6 @@ Array [
                   aria-describedby="unique-id-static-snapshot-overview"
                   class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                   id="unique-id-static-snapshot"
-                  style="height: auto;"
                   type="button"
                 >
                   <span
@@ -4904,7 +4900,6 @@ Array [
                       aria-describedby="unique-id-static-snapshot-overview"
                       class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       id="unique-id-static-snapshot"
-                      style="height: auto;"
                       type="button"
                     >
                       <span
@@ -5018,7 +5013,6 @@ Array [
                           aria-describedby="unique-id-static-snapshot-overview"
                           class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                           id="unique-id-static-snapshot"
-                          style="height: auto;"
                           type="button"
                         >
                           <span
@@ -7417,7 +7411,6 @@ Array [
                   aria-describedby="unique-id-strict-snapshot-overview"
                   class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                   id="unique-id-strict-snapshot"
-                  style="height: auto;"
                   type="button"
                 >
                   <span
@@ -7534,7 +7527,6 @@ Array [
                       aria-describedby="unique-id-strict-snapshot-overview"
                       class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       id="unique-id-strict-snapshot"
-                      style="height: auto;"
                       type="button"
                     >
                       <span
@@ -7648,7 +7640,6 @@ Array [
                           aria-describedby="unique-id-strict-snapshot-overview"
                           class="dnb-button dnb-button--secondary dnb-button--has-text dnb-step-indicator__trigger__button dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                           id="unique-id-strict-snapshot"
-                          style="height: auto;"
                           type="button"
                         >
                           <span

--- a/packages/dnb-eufemia/src/shared/AnimateHeight.js
+++ b/packages/dnb-eufemia/src/shared/AnimateHeight.js
@@ -50,6 +50,14 @@ export default class AnimateHeight {
       this.onCloseEnd = null
     }
   }
+  _emitTransitionEnd() {
+    try {
+      const event = new CustomEvent('transitionend')
+      this.elem.dispatchEvent(event)
+    } catch (e) {
+      warn(e)
+    }
+  }
 
   // Public methods
   setElement(elem, container = null) {
@@ -127,24 +135,20 @@ export default class AnimateHeight {
     this.onEndStack.push(fn)
   }
   start(fromHeight, toHeight, { animate = true } = {}) {
-    try {
-      if (window.location.href.includes('data-visual-test')) {
-        animate = false
-      }
-    } catch (e) {
-      //
+    if (window?.location?.href?.includes('data-visual-test')) {
+      animate = false
     }
 
-    if (animate === false || this.opts?.animate === false) {
+    if (
+      fromHeight === toHeight ||
+      animate === false ||
+      this.opts?.animate === false
+    ) {
       this.elem.style.height = `${toHeight}px`
+
       this._callOnStart()
 
-      try {
-        const event = new CustomEvent('transitionend')
-        this.elem.dispatchEvent(event)
-      } catch (e) {
-        warn(e)
-      }
+      this._emitTransitionEnd()
 
       return // stop here
     }

--- a/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.js
@@ -136,237 +136,297 @@ describe('AnimateHeight', () => {
     expect(changedHeight).toBe(200)
   })
 
-  it('start without animation should work properly', () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element)
+  describe('start', () => {
+    it('start without animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
 
-    const onStart = jest.fn()
-    inst.onStart(onStart)
-    const onEnd = jest.fn()
-    inst.onEnd(onEnd)
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    const onTransitionEnd = jest.fn()
-    element.addEventListener('transitionend', onTransitionEnd)
-    expect(onTransitionEnd).toHaveBeenCalledTimes(0)
+      const onTransitionEnd = jest.fn()
+      element.addEventListener('transitionend', onTransitionEnd)
+      expect(onTransitionEnd).toHaveBeenCalledTimes(0)
 
-    const fromHeight = 100
-    const toHeight = 200
-    inst.start(fromHeight, toHeight, { animate: false })
+      const fromHeight = 100
+      const toHeight = 200
+      inst.start(fromHeight, toHeight, { animate: false })
 
-    expect(onTransitionEnd).toHaveBeenCalledTimes(1)
-    expect(element.getAttribute('style')).toBe('height: 200px;')
+      await wait(1)
 
-    expect(onStart).toHaveBeenCalledTimes(1)
-    expect(onEnd).toHaveBeenCalledTimes(0)
+      expect(onTransitionEnd).toHaveBeenCalledTimes(1)
+      expect(element.getAttribute('style')).toBe('height: 200px;')
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(0)
+    })
+
+    it('start with animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element, container)
+
+      emulateSetContainerHeight()
+
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
+
+      const onTransitionEnd = jest.fn()
+      element.addEventListener('transitionend', onTransitionEnd)
+      expect(onTransitionEnd).toHaveBeenCalledTimes(0)
+
+      const fromHeight = 100
+      const toHeight = 200
+      inst.start(fromHeight, toHeight)
+
+      expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(2)
+      expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
+        1,
+        undefined
+      )
+      expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
+        2,
+        undefined
+      )
+
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+
+      await wait(1)
+
+      expect(element.getAttribute('style')).toBe('height: 100px;')
+      expect(container.getAttribute('style')).toBe('min-height: 100px;')
+
+      await wait(1)
+
+      expect(element.getAttribute('style')).toBe('height: 200px;')
+      expect(container.getAttribute('style')).toBe('min-height: 300px;')
+
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
+
+      expect(element.getAttribute('style')).toBe('height: 200px;')
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(0)
+    })
   })
 
-  it('start with animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element, container)
+  describe('adjustTo', () => {
+    it('adjustTo with animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element, container)
 
-    emulateSetContainerHeight()
+      emulateSetContainerHeight()
 
-    const onStart = jest.fn()
-    inst.onStart(onStart)
-    const onEnd = jest.fn()
-    inst.onEnd(onEnd)
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    const onTransitionEnd = jest.fn()
-    element.addEventListener('transitionend', onTransitionEnd)
-    expect(onTransitionEnd).toHaveBeenCalledTimes(0)
+      const onTransitionEnd = jest.fn()
+      element.addEventListener('transitionend', onTransitionEnd)
 
-    const fromHeight = 100
-    const toHeight = 200
-    inst.start(fromHeight, toHeight)
+      const fromHeight = 100
+      const toHeight = 200
+      inst.adjustTo(fromHeight, toHeight)
 
-    expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(2)
-    expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
-      1,
-      undefined
-    )
-    expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
-      2,
-      undefined
-    )
+      expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(2)
+      expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
+        1,
+        undefined
+      )
+      expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
+        2,
+        undefined
+      )
 
-    expect(onStart).toHaveBeenCalledTimes(1)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+      await wait(1)
 
-    await wait(0)
+      expect(element.getAttribute('style')).toBe('height: 100px;')
+      expect(container.getAttribute('style')).toBe('min-height: 100px;')
 
-    expect(element.getAttribute('style')).toBe('height: 100px;')
-    expect(container.getAttribute('style')).toBe('min-height: 100px;')
+      await wait(1)
 
-    await wait(0)
+      expect(element.getAttribute('style')).toBe('height: 200px;')
+      expect(container.getAttribute('style')).toBe('min-height: 300px;')
 
-    expect(element.getAttribute('style')).toBe('height: 200px;')
-    expect(container.getAttribute('style')).toBe('min-height: 300px;')
+      simulateAnimationEnd()
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
+      expect(element.getAttribute('style')).toBe('height: auto;')
 
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
 
-    expect(element.getAttribute('style')).toBe('height: 200px;')
+      expect(onTransitionEnd).toHaveBeenCalledTimes(1)
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
+
+    it('adjustTo with animation and same height should call events', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
+
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
+
+      const onTransitionEnd = jest.fn()
+      element.addEventListener('transitionend', onTransitionEnd)
+
+      // await wait(1)
+      const fromHeight = 100
+      const toHeight = 100
+      inst.adjustTo(fromHeight, toHeight)
+
+      expect(element.getAttribute('style')).toBe('height: auto;')
+
+      expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(0)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(0)
+
+      expect(onTransitionEnd).toHaveBeenCalledTimes(1)
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('adjustTo with animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element, container)
+  describe('open', () => {
+    it('open without animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
 
-    emulateSetContainerHeight()
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    const onStart = jest.fn()
-    inst.onStart(onStart)
-    const onEnd = jest.fn()
-    inst.onEnd(onEnd)
+      jest
+        .spyOn(element, 'clientHeight', 'get')
+        .mockImplementation(() => 100)
 
-    const onTransitionEnd = jest.fn()
-    element.addEventListener('transitionend', onTransitionEnd)
-    expect(onTransitionEnd).toHaveBeenCalledTimes(0)
+      inst.open({ animate: false })
 
-    const fromHeight = 100
-    const toHeight = 200
-    inst.adjustTo(fromHeight, toHeight)
+      await wait(1)
 
-    expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(2)
-    expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
-      1,
-      undefined
-    )
-    expect(window.cancelAnimationFrame).toHaveBeenNthCalledWith(
-      2,
-      undefined
-    )
+      expect(element.getAttribute('style')).toBe('height: auto;')
 
-    expect(onStart).toHaveBeenCalledTimes(1)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(0)
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
 
-    await wait(0)
+    it('open with animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
 
-    expect(element.getAttribute('style')).toBe('height: 100px;')
-    expect(container.getAttribute('style')).toBe('min-height: 100px;')
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    await wait(0)
+      jest
+        .spyOn(element, 'clientHeight', 'get')
+        .mockImplementation(() => 100)
 
-    expect(element.getAttribute('style')).toBe('height: 200px;')
-    expect(container.getAttribute('style')).toBe('min-height: 300px;')
+      inst.open()
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
 
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
+      await wait(1)
 
-    expect(onEnd).toHaveBeenCalledTimes(1)
+      expect(element.getAttribute('style')).toBe('height: 0px;')
 
-    expect(element.getAttribute('style')).toBe('height: auto;')
+      await wait(1)
+
+      expect(element.getAttribute('style')).toBe('height: 100px;')
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
+
+      simulateAnimationEnd()
+
+      expect(element.getAttribute('style')).toBe('height: auto;')
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('open without animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element)
+  describe('close', () => {
+    it('close without animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
 
-    jest
-      .spyOn(element, 'clientHeight', 'get')
-      .mockImplementation(() => 100)
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    inst.open({ animate: false })
+      jest
+        .spyOn(element, 'clientHeight', 'get')
+        .mockImplementation(() => 100)
 
-    await wait(1)
+      inst.close({ animate: false })
 
-    expect(element.getAttribute('style')).toBe('height: auto;')
+      await wait(1)
 
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
+      expect(element.getAttribute('style')).toBe(
+        'height: 0px; visibility: hidden;'
+      )
 
-    expect(element.getAttribute('style')).toBe('height: auto;')
+      expect(element.getAttribute('style')).toBe(
+        'height: 0px; visibility: hidden;'
+      )
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(0)
-  })
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(0)
 
-  it('close without animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element)
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
 
-    jest
-      .spyOn(element, 'clientHeight', 'get')
-      .mockImplementation(() => 100)
+    it('close with animation should work properly', async () => {
+      const inst = new AnimateHeight()
+      inst.setElement(element)
 
-    inst.close({ animate: false })
+      const onStart = jest.fn()
+      inst.onStart(onStart)
+      const onEnd = jest.fn()
+      inst.onEnd(onEnd)
 
-    await wait(1)
+      jest
+        .spyOn(element, 'clientHeight', 'get')
+        .mockImplementation(() => 100)
 
-    expect(element.getAttribute('style')).toBe(
-      'height: 0px; visibility: hidden;'
-    )
+      inst.close()
 
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
 
-    expect(element.getAttribute('style')).toBe(
-      'height: 0px; visibility: hidden;'
-    )
+      await wait(1)
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(0)
-  })
+      expect(element.getAttribute('style')).toBe('height: 100px;')
 
-  it('open with animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element)
+      await wait(1)
 
-    jest
-      .spyOn(element, 'clientHeight', 'get')
-      .mockImplementation(() => 100)
+      expect(element.getAttribute('style')).toBe('height: 0px;')
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
 
-    inst.open()
+      simulateAnimationEnd()
 
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+      expect(element.getAttribute('style')).toBe(
+        'height: 0px; visibility: hidden;'
+      )
 
-    await wait(0)
-
-    expect(element.getAttribute('style')).toBe('height: 0px;')
-
-    await wait(0)
-
-    expect(element.getAttribute('style')).toBe('height: 100px;')
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
-
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
-
-    expect(element.getAttribute('style')).toBe('height: auto;')
-  })
-
-  it('close with animation should work properly', async () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element)
-
-    jest
-      .spyOn(element, 'clientHeight', 'get')
-      .mockImplementation(() => 100)
-
-    inst.close()
-
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
-
-    await wait(0)
-
-    expect(element.getAttribute('style')).toBe('height: 100px;')
-
-    await wait(0)
-
-    expect(element.getAttribute('style')).toBe('height: 0px;')
-    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
-
-    const event = new CustomEvent('transitionend')
-    element.dispatchEvent(event)
-
-    expect(element.getAttribute('style')).toBe(
-      'height: 0px; visibility: hidden;'
-    )
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+    })
   })
 })
 
 const wait = (t) => new Promise((r) => setTimeout(r, t))
+
+function simulateAnimationEnd() {
+  const event = new CustomEvent('transitionend')
+  element.dispatchEvent(event)
+}


### PR DESCRIPTION
This PR fixes an issue as described like so:

> The findings where that Chromium loads and runs the the JS earlier than the styles. So the button has initially 33px (no styling) and changes almost frame by frame down to 27px during the rendering phase, before the styles pops in place – but that was too late, much later than the didMount event, so the component did use and set the lower height.

The fix is basically, that we ensure, the element gets an of `height: auto` when the from/to are the same values. This way, we let chrome do its thing, but only care about animation, when the values are not equal.