### PR TITLE
chore(repo-utils): add repo-utils to check CI instead of external dependency

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,6 +55,9 @@ jobs:
         if: steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
+      - name: Verify isCI
+        run: yarn workspace repo-utils test-is-ci
+
       - name: Audit dependencies
         run: yarn workspace @dnb/eufemia audit:ci
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "version": "1.0.0",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "tools/*"
   ],
   "main": "./packages/eufemia/index.js",
   "scripts": {

--- a/packages/dnb-design-system-portal/cypress/plugins/index.js
+++ b/packages/dnb-design-system-portal/cypress/plugins/index.js
@@ -4,7 +4,7 @@
  */
 
 // require('dotenv').config()
-const { isCI } = require('ci-info')
+const { isCI } = require('repo-utils')
 
 /**
  * @type {Cypress.PluginConfig}

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs-extra')
 const path = require('path')
-const { isCI } = require('ci-info')
+const { isCI } = require('repo-utils')
 const getCurrentBranchName = require('current-git-branch')
 const {
   createNewVersion,

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -67,7 +67,6 @@
     "@netlify/plugin-gatsby": "1.0.3",
     "babel-preset-gatsby": "2.1.0",
     "camelcase": "6.2.0",
-    "ci-info": "3.2.0",
     "cross-env": "7.0.3",
     "current-git-branch": "1.1.0",
     "date-fns": "2.25.0",

--- a/packages/dnb-design-system-portal/scripts/deploy.js
+++ b/packages/dnb-design-system-portal/scripts/deploy.js
@@ -6,7 +6,7 @@
 
 const dotenv = require('dotenv')
 const ghpages = require('gh-pages')
-const { name: CIName } = require('ci-info')
+const { CIName } = require('repo-utils')
 const ora = require('ora')
 const { currentVersion } = require('./version.js')
 

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs-extra')
 const path = require('path')
-const { isCI } = require('ci-info')
+const { isCI } = require('repo-utils')
 const packageJson = require('../package.json')
 
 exports.currentVersion = packageJson.buildVersion

--- a/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
+++ b/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
@@ -13,7 +13,7 @@ import { Provider, Context } from '@dnb/eufemia/src/shared'
 import enUS from '@dnb/eufemia/src/shared/locales/en-US'
 import stylisPlugin from '@dnb/eufemia/src/style/stylis'
 import { isTrue } from '@dnb/eufemia/src/shared/component-helper'
-import { isCI } from 'ci-info'
+import { isCI } from 'repo-utils'
 
 /**
  * Import Eufemia Styles

--- a/packages/dnb-design-system-portal/src/uilib/search/searchHelpers.js
+++ b/packages/dnb-design-system-portal/src/uilib/search/searchHelpers.js
@@ -1,4 +1,4 @@
-const { isCI } = require('ci-info')
+const { isCI } = require('repo-utils')
 
 // Finds current index name for the Algolia search
 const getIndexName = (currentBranch) => {

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -151,7 +151,6 @@
     "browserslist": "4.18.0",
     "camelcase": "6.2.0",
     "chalk": "4.1.2",
-    "ci-info": "3.2.0",
     "color": "4.0.1",
     "cross-env": "7.0.3",
     "cssnano": "5.0.10",

--- a/packages/dnb-eufemia/scripts/prepub/commitToBranch.js
+++ b/packages/dnb-eufemia/scripts/prepub/commitToBranch.js
@@ -4,7 +4,7 @@
  */
 
 const dotenv = require('dotenv')
-const { isCI } = require('ci-info')
+const { isCI } = require('repo-utils')
 const ora = require('ora')
 const path = require('path')
 const simpleGit = require('simple-git/promise') // More info: https://github.com/steveukx/git-js#readme

--- a/tools/repo-utils/node-utils.js
+++ b/tools/repo-utils/node-utils.js
@@ -1,0 +1,5 @@
+const isCI =
+  String(process.env.CI || process.env.GITHUB_ACTIONS) === 'true'
+
+exports.isCI = isCI
+exports.CIName = isCI ? 'GitHub Actions' : null

--- a/tools/repo-utils/node-utils.test.js
+++ b/tools/repo-utils/node-utils.test.js
@@ -1,0 +1,4 @@
+const assert = require('assert')
+const { isCI } = require('./node-utils')
+
+assert(isCI === true, 'isCI should be ture')

--- a/tools/repo-utils/package.json
+++ b/tools/repo-utils/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "repo-utils",
+  "description": "DNB Design System Portal Repo Utils",
+  "license": "SEE LICENSE IN LICENSE FILE",
+  "author": "DNB Team & Tobias Høegh",
+  "version": "1.0.0",
+  "main": "node-utils.js",
+  "scripts": {
+    "test-is-ci": "node node-utils.test.js"
+  },
+  "volta": {
+    "extends": "./package.json"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,7 +2098,6 @@ __metadata:
     browserslist: 4.18.0
     camelcase: 6.2.0
     chalk: 4.1.2
-    ci-info: 3.2.0
     classnames: 2.3.1
     color: 4.0.1
     core-js: 3.19.1
@@ -9862,7 +9861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:3.2.0, ci-info@npm:^3.2.0":
+"ci-info@npm:^3.2.0":
   version: 3.2.0
   resolution: "ci-info@npm:3.2.0"
   checksum: c68995a94e95ce3f233ff845e62dfc56f2e8ff1e3f5c1361bcdd520cbbc9726d8a54cbc1a685cb9ee19c3c5e71a1dade6dda23eb364b59b8e6c32508a9b761bc
@@ -12337,7 +12336,6 @@ __metadata:
     algoliasearch: 4.12.0
     babel-preset-gatsby: 2.1.0
     camelcase: 6.2.0
-    ci-info: 3.2.0
     classnames: 2.3.1
     cross-env: 7.0.3
     css-vars-ponyfill: 2.4.7
@@ -28716,6 +28714,12 @@ __metadata:
   checksum: a330e7c4fda2ba7978472dcaf9ee9129755ca0d704f903b4fc5f0384170f74fdaf1b3f10977ec3fc910cb992f90896c17c8e44d0de327cb9f01ee9bb7eed8d24
   languageName: node
   linkType: hard
+
+"repo-utils@workspace:tools/repo-utils":
+  version: 0.0.0-use.local
+  resolution: "repo-utils@workspace:tools/repo-utils"
+  languageName: unknown
+  linkType: soft
 
 "request@npm:^2.87.0, request@npm:^2.88.0, request@npm:^2.88.2":
   version: 2.88.2


### PR DESCRIPTION
This PR fixes a GitHub Actions change, where they lately changes the CI env variable from being a boolean to a string. This is not based on research, but from own tests.

We change with this PR to our own check.