### PR TITLE
feat: add usePropsWithContext hook for hook based components

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
@@ -103,7 +103,7 @@ And use it as so:
 
 ```tsx
 import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 const defaultProps = {
   myString: null, // can be null, as we get our default from the translation file
@@ -112,11 +112,8 @@ const defaultProps = {
 function MyComponent(props: Types) {
   const context = React.useContext(Context)
 
-  const { myString } = extendPropsWithContext(
-    {
-      ...props,
-      ...defaultProps,
-    },
+  const { myString } = usePropsWithContext(
+    props,
     defaultProps,
     context.getTranslation(props).MyComponent // details below 👇
     // ...
@@ -132,7 +129,7 @@ The function `getTranslation` will along with the properties support both `local
 
 ```tsx
 import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 const defaultProps = {
   myParam: null,
@@ -141,11 +138,8 @@ const defaultProps = {
 function MyComponent(props: Types) {
   const context = React.useContext(Context)
 
-  const { myParam, ...rest } = extendPropsWithContext(
-    {
-      ...props,
-      ...defaultProps,
-    },
+  const { myParam, ...rest } = usePropsWithContext(
+    props,
     defaultProps,
     context.MyComponent
     // ...
@@ -164,7 +158,7 @@ import { Context } from '../../shared'
 import classnames from 'classnames'
 import {
   validateDOMAttributes,
-  extendPropsWithContext,
+  usePropsWithContext,
 } from '../../shared/component-helper'
 import {
   spacingPropTypes, // In case you need them as PropTypes
@@ -186,11 +180,8 @@ const defaultProps = {
 function MyComponent(props: MyComponentProps) {
   const context = React.useContext(Context)
 
-  const { myParam, className, ...rest } = extendPropsWithContext(
-    {
-      ...props,
-      ...defaultProps,
-    },
+  const { myParam, className, ...rest } = usePropsWithContext(
+    props,
     defaultProps
     // ...
   )
@@ -215,7 +206,7 @@ It depends from case to case on how you would make skeleton support available. T
 
 ```tsx
 import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -228,11 +219,8 @@ const defaultProps = {
 function MyComponent(props: Types) {
   const context = React.useContext(Context)
 
-  const { skeleton, className, ...rest } = extendPropsWithContext(
-    {
-      ...props,
-      ...defaultProps,
-    },
+  const { skeleton, className, ...rest } = usePropsWithContext(
+    props,
     defaultProps,
     { skeleton: context?.skeleton }
     // ...

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -11,10 +11,8 @@ import Img, { ImgProps } from '../../elements/Img'
 // Shared
 import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
-import {
-  extendPropsWithContext,
-  warn,
-} from '../../shared/component-helper'
+import { warn } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import AvatarGroup, { AvatarGroupContext } from './AvatarGroup'
@@ -99,8 +97,8 @@ function Avatar(localProps: AvatarProps & ISpacingProps) {
     src,
     imgProps,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
+  } = usePropsWithContext(
+    localProps,
     defaultProps,
     context?.Avatar,
     avatarGroupContext

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -8,7 +8,7 @@ import { AvatarSizes, AvatarVariants } from './Avatar'
 // Shared
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 export interface AvatarGroupProps {
   /**
@@ -71,11 +71,7 @@ function AvatarGroup(localProps: AvatarGroupProps & ISpacingProps) {
     maxElements: maxElementsProp,
     variant,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
-    defaultProps,
-    context?.AvatarGroup
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.AvatarGroup)
 
   const maxElements =
     maxElementsProp && maxElementsProp > 0 ? maxElementsProp : 4

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -11,7 +11,7 @@ import Button from '../button/Button'
 import { useMediaQuery } from '../../shared'
 import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem'
@@ -149,8 +149,8 @@ function Breadcrumb(localProps: BreadcrumbProps & ISpacingProps) {
     data,
     href,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
+  } = usePropsWithContext(
+    localProps,
     defaultProps,
     context?.translation?.Breadcrumb,
     context?.Breadcrumb

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -13,7 +13,7 @@ import homeIcon from '../../icons/home'
 // Shared
 import Context from '../../shared/Context'
 import { SkeletonTypes } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 export interface BreadcrumbItemProps {
   /**
@@ -73,11 +73,7 @@ export default function BreadcrumbItem(localProps: BreadcrumbItemProps) {
 
   // Extract additional props from global context
   const { text, href, icon, onClick, variant, skeleton, ...props } =
-    extendPropsWithContext(
-      { ...defaultProps, ...localProps },
-      defaultProps,
-      context?.BreadcrumbItem
-    )
+    usePropsWithContext(localProps, defaultProps, context?.BreadcrumbItem)
 
   const currentIcon =
     icon || (variant === 'home' && homeIcon) || 'chevron_left'

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -4,7 +4,8 @@ export type ButtonVariant =
   | 'primary'
   | 'secondary'
   | 'tertiary'
-  | 'signal';
+  | 'signal'
+  | 'unstyled';
 export type ButtonSize = 'default' | 'small' | 'medium' | 'large';
 export type ButtonIcon =
   | string

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -17,7 +17,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 export interface InfoCardProps {
   /**
@@ -135,7 +135,7 @@ function InfoCard(localProps: InfoCardProps & ISpacingProps) {
     closeButtonAttributes,
     acceptButtonAttributes,
     ...props
-  } = extendPropsWithContext({
+  } = usePropsWithContext({
     ...defaultProps,
     ...localProps,
   })

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -3,15 +3,13 @@ import classnames from 'classnames'
 
 // Components
 import IconPrimary, { IconPrimaryIcon } from '../icon-primary/IconPrimary'
-import Button from '../button/Button'
+import Button, { ButtonProps } from '../button/Button'
 
 // Shared
 import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
-import {
-  warn,
-  extendPropsWithContext,
-} from '../../shared/component-helper'
+import { warn } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import TagGroup from './TagGroup'
@@ -93,8 +91,8 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
     onDelete,
     omitOnKeyUpDeleteEvent,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
+  } = usePropsWithContext(
+    localProps,
     defaultProps,
     context?.translation?.Tag,
     context?.Tag,
@@ -125,13 +123,16 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
     }
   }
 
+  const buttonAttr: typeof props & Pick<ButtonProps, 'element' | 'type'> =
+    props
+
   if (!isInteractive) {
-    props.element = 'span'
-    props.type = ''
+    buttonAttr.element = 'span'
+    buttonAttr.type = ''
   }
 
   if (isRemovable) {
-    props.icon = getDeleteIcon()
+    buttonAttr.icon = getDeleteIcon()
   }
 
   if (!tagGroupContext) {
@@ -155,7 +156,7 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
           ? (e) => handleKeyUp(e)
           : undefined
       }
-      {...props}
+      {...buttonAttr}
     />
   )
 

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -7,7 +7,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 // Shared
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 import { TagGroupContext } from './TagContext'
 
 export interface TagGroupProps {
@@ -45,11 +45,7 @@ function TagGroup(localProps: TagGroupProps & ISpacingProps) {
     className,
     children: childrenProp,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
-    defaultProps,
-    context?.TagGroup
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.TagGroup)
 
   let children = childrenProp
 

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -7,7 +7,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 // Shared
 import Context from '../../shared/Context'
 import { ISpacingProps, SkeletonTypes } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import TimelineItem, { TimelineItemProps } from './TimelineItem'
@@ -57,11 +57,7 @@ function Timeline(localProps: TimelineProps & ISpacingProps) {
     data,
     children: childrenItems,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
-    defaultProps,
-    context?.Timeline
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.Timeline)
 
   const spacingClasses = createSpacingClasses(props)
 

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -14,7 +14,7 @@ import pinIcon from '../../icons/pin'
 // Shared
 import Context from '../../shared/Context'
 import { SkeletonTypes } from '../../shared/interfaces'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import { usePropsWithContext } from '../../shared/hooks'
 
 export interface TimelineItemProps {
   /**
@@ -90,11 +90,7 @@ export default function TimelineItem(localProps: TimelineItemProps) {
     state,
     skeleton,
     ...props
-  } = extendPropsWithContext(
-    { ...defaultProps, ...localProps },
-    defaultProps,
-    context?.TimelineItem
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.TimelineItem)
 
   const stateIsCompleted = state === 'completed'
   const stateIsCurrent = state === 'current'

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -193,7 +193,7 @@ describe('"validateDOMAttributes" should', () => {
     const props = {}
     const params = {}
     const res = validateDOMAttributes(props, params)
-    expect(params).toMatchObject(res)
+    expect(params).toEqual(res)
   })
 
   it('has equal object after sending a json object as an prop.attributes', () => {
@@ -201,7 +201,7 @@ describe('"validateDOMAttributes" should', () => {
     const props = { attributes: JSON.stringify(attr) }
     const params = {}
     const res = validateDOMAttributes(props, params)
-    expect(res).toMatchObject(attr)
+    expect(res).toEqual(attr)
   })
 
   it('"disabled" property should be removed once its value is false', () => {
@@ -297,7 +297,7 @@ describe('"processChildren" should', () => {
       },
     }
     const res = processChildren(props)
-    expect(res.props).toMatchObject({ children: 'foo new content' })
+    expect(res.props).toEqual({ children: 'foo new content' })
   })
 })
 
@@ -310,22 +310,22 @@ describe('"extend" should', () => {
     expect(extend(false, object2, object1)).not.toBe(object2)
   })
   it('extend an object and have correct object shape', () => {
-    expect(extend({ key: null }, { key: 'value' })).toMatchObject({
+    expect(extend({ key: null }, { key: 'value' })).toEqual({
       key: 'value',
     })
-    expect(extend({ key: 'value' }, { key: null })).toMatchObject({
+    expect(extend({ key: 'value' }, { key: null })).toEqual({
       key: 'value',
     })
   })
   it('extend an object recursively and have correct object shape', () => {
     expect(
       extend({ key1: { key2: null } }, { key1: { key2: 'value' } })
-    ).toMatchObject({
+    ).toEqual({
       key1: { key2: 'value' },
     })
     expect(
       extend({ key1: { key2: 'value' } }, { key1: { key2: null } })
-    ).toMatchObject({
+    ).toEqual({
       key1: { key2: 'value' },
     })
     expect(
@@ -333,7 +333,7 @@ describe('"extend" should', () => {
         { key1: { key2: 'value' } },
         { key1: { key2: null, foo: 'bar' } }
       )
-    ).toMatchObject({
+    ).toEqual({
       key1: { key2: 'value', foo: 'bar' },
     })
   })
@@ -347,7 +347,7 @@ describe('"extendPropsWithContext" should', () => {
         { key: { x: 'y' }, foo: null }, // default props
         { key: 'I can’t replace You', foo: 'bar' }
       )
-    ).toMatchObject({
+    ).toEqual({
       key: { x: 'y' },
       foo: 'bar', // because the prop was null, we get bar
     })
@@ -455,12 +455,12 @@ describe('"dispatchCustomElementEvent" should', () => {
     }
     dispatchCustomElementEvent(instance, 'my_event', { event, attributes })
     expect(my_event.mock.calls.length).toBe(1)
-    expect(
-      my_event.mock.calls[0][0].event.currentTarget.dataset
-    ).toMatchObject({
-      attr: 'value',
-      prop: 'value',
-    })
+    expect(my_event.mock.calls[0][0].event.currentTarget.dataset).toEqual(
+      expect.objectContaining({
+        attr: 'value',
+        prop: 'value',
+      })
+    )
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/hooks/__tests__/usePropsWithContext.test.ts
+++ b/packages/dnb-eufemia/src/shared/hooks/__tests__/usePropsWithContext.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { usePropsWithContext } from '../usePropsWithContext'
+
+describe('usePropsWithContext', () => {
+  it('should extend prop from other context object', () => {
+    const props = { key: { x: 'y' }, foo: null }
+    const defaultProps = { key: { x: 'y' }, foo: null }
+    const context1 = { key: 'I can’t replace You', foo: 'bar' }
+
+    const result = usePropsWithContext(props, defaultProps, context1)
+
+    expect(result).toEqual({
+      key: { x: 'y' },
+      foo: 'bar', // because the prop was null, we get bar
+    })
+  })
+
+  it('should extend multible contexts', () => {
+    const props = { prop1: 'prop1', prop2: 'prop2' }
+    const defaultProps = {
+      default1: 'default1',
+      a: null,
+      b: null,
+    }
+    const context1 = { a: 'a' }
+    const context2 = { b: 'b' }
+    const context3 = { c: 'c' }
+
+    const result = usePropsWithContext(
+      props,
+      defaultProps,
+      context1,
+      context2,
+      context3
+    )
+
+    expect(result).toEqual({
+      default1: 'default1',
+      prop1: 'prop1',
+      prop2: 'prop2',
+      a: 'a',
+      b: 'b',
+      // c: 'c', // but not c
+    })
+  })
+
+  it('should extend defaults', () => {
+    const props = { foo: 'bar' }
+    const defaultProps = { key: 'is-default' }
+
+    const result = usePropsWithContext(props, defaultProps)
+
+    expect(result).toEqual({
+      key: 'is-default',
+      foo: 'bar',
+    })
+  })
+
+  it('should render as a React Hook', () => {
+    const props = { key: { x: 'y' }, foo: null }
+    const defaultProps = { key: { x: 'y' }, foo: null }
+    const context1 = { key: 'I can’t replace You', foo: 'bar' }
+
+    const { result } = renderHook(() =>
+      usePropsWithContext(props, defaultProps, context1)
+    )
+
+    expect(result.current).toEqual({
+      key: { x: 'y' },
+      foo: 'bar', // because the prop was null, we get bar
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/shared/hooks/index.ts
+++ b/packages/dnb-eufemia/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePropsWithContext } from './usePropsWithContext'

--- a/packages/dnb-eufemia/src/shared/hooks/usePropsWithContext.ts
+++ b/packages/dnb-eufemia/src/shared/hooks/usePropsWithContext.ts
@@ -1,0 +1,45 @@
+export type DefaultsProps = Record<string, unknown>
+export type Contexts = Array<Record<string, unknown>>
+
+/**
+ * Extends props from a given context
+ * but give the context second priority only
+ *
+ * @param props object of component properties
+ * @param defaults object of potential default values
+ * @param contexts the rest of all context to merge
+ * @returns merged properties
+ */
+function usePropsWithContext<Props>(
+  props: Props,
+  defaults: DefaultsProps = {},
+  ...contexts: Contexts
+) {
+  const context = contexts.reduce((acc, cur) => {
+    if (cur) {
+      acc = { ...acc, ...cur }
+    }
+    return acc
+  }, {})
+
+  props = { ...defaults, ...props }
+
+  return {
+    ...props,
+    ...Object.entries(context).reduce((acc, [key, value]) => {
+      if (
+        // check if a prop of the same name exists
+        typeof props[key] !== 'undefined' &&
+        // and if it was NOT defined as a component prop, because its still the same as the defaults
+        props[key] === defaults[key]
+      ) {
+        // then we use the context value
+        acc[key] = value
+      }
+      return acc
+    }, {}),
+  }
+}
+
+export { usePropsWithContext }
+export default usePropsWithContext


### PR DESCRIPTION
This PR is all about better TS support.

The new hook `usePropsWithContext` replaces `extendPropsWithContext` and returns the type given as the first property. This ensures the new object returned functions with the wanted type. 

As an example, the `Tag.tsx ` did use a not typed variant of unstyled – it was valid because we got back `any`.

EDIT: This PR relies on PR #1235