### PR TITLE
chore: remove yarn-plugin-ignore-install-options

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,8 +37,6 @@ packageExtensions:
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
-  - path: .yarn/plugins/plugin-ignore-install-options.cjs
-    spec: packages/dnb-design-system-portal/node_modules/yarn-plugin-ignore-install-options/ignore-install-options-1.0.2.js
 
 pnpMode: loose
 

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -123,8 +123,7 @@
     "stylelint-config-standard": "22.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0",
-    "svg-react-loader": "0.4.6",
-    "yarn-plugin-ignore-install-options": "1.0.2"
+    "svg-react-loader": "0.4.6"
   },
   "installConfig": {
     "hoistingLimits": "dependencies"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12401,7 +12401,6 @@ __metadata:
     stylelint-config-styled-components: 0.1.1
     stylelint-processor-styled-components: 1.10.0
     svg-react-loader: 0.4.6
-    yarn-plugin-ignore-install-options: 1.0.2
   languageName: unknown
   linkType: soft
 
@@ -34743,13 +34742,6 @@ __metadata:
     y18n: ^3.2.1
     yargs-parser: ^5.0.1
   checksum: 0c330ce1338cd9f293157bf8955af6833ae59032ab1bc936510ce7a216de9bb65b05b39a82ff0e7359bfb643342cc05de5049ce50ee9404b0818f65911fb59a5
-  languageName: node
-  linkType: hard
-
-"yarn-plugin-ignore-install-options@npm:1.0.2":
-  version: 1.0.2
-  resolution: "yarn-plugin-ignore-install-options@npm:1.0.2"
-  checksum: 4a8bb6a99c8d69a99290619d55cf54019074ec308506a3a94b6b44460be29daf2e546267fac4745b1e9839539dd41766b44081358166e38d6cfe0e50803162f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Gatsby Cloud now supports Yarn v2 (and with that, it should support v3 as well)

Based on this feedback: https://gatsby.canny.io/gatsby-cloud/p/support-yarn-2-and-pnp-api

Background:

Because Gatsby Cloud did run its own install command, with with flags, which got removed in yarn v2 and v3 - so the install command could not get executed.

To overcome this, I created a plugin, that removed all install flags. But with this PR we remove this plugin.
