### PR TITLE
docs: remove signal-orange from Section

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/properties.md
@@ -25,7 +25,6 @@ You can easily [customize the color](/uilib/components/section#customize-color).
 | `pistachio`     | uses `--color-pistachio`.                                                                           |
 | `black-3`       | uses `--color-black-3`.                                                                             |
 | `emerald-green` | uses `--color-emerald-green`.                                                                       |
-| `signal-orange` | uses `--color-signal-orange`.                                                                       |
 | `fire-red`      | uses `--color-fire-red`. Is used by [GlobalStatus](/uilib/components/global-status)                 |
 | `divider`       | uses `--color-white` as background with a border-line on top and bottom.                            |
 | `transparent`   | CSS transparent. Used in situations where a Section is of interest, but without a color as a basis. |


### PR DESCRIPTION
Looks like `signal-orange` is a deprecated `style_type` for `Section`.
