### PR TITLE
fix: label of avatar group to be react node

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -15,7 +15,7 @@ export interface AvatarGroupProps {
    * Label to describe the avatar group
    * Default: null
    */
-  label: string
+  label: React.ReactNode
 
   /**
    * Custom className on the component root

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -128,7 +128,7 @@ describe('Avatar', () => {
   })
 
   describe('AvatarGroup', () => {
-    it('renders the label', () => {
+    it('renders the label as string', () => {
       const label = 'avatar'
       render(
         <Avatar.Group label={label} maxElements={2}>
@@ -141,6 +141,23 @@ describe('Avatar', () => {
       expect(screen.queryByTestId('avatar-group-label').textContent).toBe(
         label
       )
+    })
+
+    it('renders the label as react node', () => {
+      const label = <span data-testid="react-node">ReactNode</span>
+      render(
+        <Avatar.Group label={label} maxElements={2}>
+          <Avatar>A</Avatar>
+          <Avatar>B</Avatar>
+          <Avatar>C</Avatar>
+        </Avatar.Group>
+      )
+      expect(screen.queryByTestId('avatar-group-label')).not.toBeNull()
+      expect(
+        within(screen.queryByTestId('avatar-group-label')).queryByTestId(
+          'react-node'
+        )
+      ).not.toBeNull()
     })
 
     it('renders the "elements left"-avatar when having more avatars than maxElements', () => {


### PR DESCRIPTION
Reason for wanting to change from string to React.ReactNode is because we often pass in translations in pm-netbank, like `<FormattedMessage>`, etc.