### PR TITLE
fix: label of tag group to be react node

### DIFF
--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -15,7 +15,7 @@ export interface TagGroupProps {
    * Aria label to describe the tag group
    * Default: null
    */
-  label: string
+  label: React.ReactNode
 
   /**
    * Custom className on the component root

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import Tag from '../Tag'
 import {
   axeComponent,
@@ -16,11 +16,24 @@ describe('Tag Group', () => {
     expect(screen.queryByTestId('tag')).toBeNull()
   })
 
-  it('renders the label', () => {
+  it('renders the label as string', () => {
     const label = 'tags'
     render(<Tag.Group label={label} />)
     expect(screen.queryByTestId('tag-group-label')).not.toBeNull()
     expect(screen.queryByTestId('tag-group-label').textContent).toBe(label)
+  })
+
+  it('renders the label as react node', () => {
+    const label = <span data-testid="react-node">ReactNode</span>
+    render(<Tag.Group label={label} />)
+
+    expect(screen.queryByTestId('tag-group-label')).not.toBeNull()
+
+    expect(
+      within(screen.queryByTestId('tag-group-label')).queryByTestId(
+        'react-node'
+      )
+    ).not.toBeNull()
   })
 
   it('renders a tag group with multiple tag elements by children', () => {


### PR DESCRIPTION
Reason for wanting to change from string to React.ReactNode is because we often pass in translations in pm-netbank, like `<FormattedMessage>`, etc.