### PR TITLE
fix(InfoCard): change text props to React.ReactNode

### DIFF
--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -25,7 +25,7 @@ export interface InfoCardProps {
    * Used in combination with `src` to provide an alt attribute for the `img` element.
    * Default: null
    */
-  alt?: string
+  alt?: React.ReactNode
   /**
    * Aligns the content to center, rather than left
    * Default: false
@@ -60,12 +60,12 @@ export interface InfoCardProps {
    * Image src, will replace the 'icon' with the image
    * Default: null
    */
-  text: string
+  text: React.ReactNode
   /**
    * Component title
    * Default: null
    */
-  title?: string
+  title?: React.ReactNode
   /**
    * Is called when the close button is clicked
    * Default: null
@@ -75,7 +75,7 @@ export interface InfoCardProps {
    * The text of the close button.
    * Default: null
    */
-  closeButtonText?: string
+  closeButtonText?: React.ReactNode
   /**
    * Is called when the accept button is clicked
    * Default: null
@@ -85,7 +85,7 @@ export interface InfoCardProps {
    * The text of the accept button.
    * Default: null
    */
-  acceptButtonText?: string
+  acceptButtonText?: React.ReactNode
   /**
    * Additional attributes for the close button.
    * Default: null
@@ -200,7 +200,7 @@ const InfoCard = (localProps: InfoCardProps & ISpacingProps) => {
         {!acceptButtonIsHidden && (
           <Button
             type="button"
-            data-testid="into-card-accept-button"
+            data-testid="info-card-accept-button"
             variant="secondary"
             right={!centered && 'small'}
             on_click={onAccept}
@@ -211,7 +211,7 @@ const InfoCard = (localProps: InfoCardProps & ISpacingProps) => {
         {!closeButtonIsHidden && (
           <Button
             type="button"
-            data-testid="into-card-close-button"
+            data-testid="info-card-close-button"
             variant="tertiary"
             top={centered && 'small'}
             on_click={onClose}

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -12,7 +12,7 @@ describe('InfoCard', () => {
     expect(screen.queryByTestId('info-card')).not.toBeNull()
   })
 
-  it('renders the title', () => {
+  it('renders the title as string', () => {
     const title = 'my title'
 
     render(<InfoCard text="text" title={title} />)
@@ -23,7 +23,20 @@ describe('InfoCard', () => {
     )
   })
 
-  it('renders the text', () => {
+  it('renders the title as react node', () => {
+    const title = <span data-testid="react-node">ReactNode</span>
+
+    render(<InfoCard text="text" title={title} />)
+
+    expect(screen.queryByTestId('info-card-title')).not.toBeNull()
+    expect(
+      within(screen.queryByTestId('info-card-title')).queryByTestId(
+        'react-node'
+      )
+    ).not.toBeNull()
+  })
+
+  it('renders the text as string', () => {
     const text = 'my-text'
 
     render(<InfoCard text={text} />)
@@ -32,6 +45,19 @@ describe('InfoCard', () => {
     expect(screen.queryByTestId('info-card-text').textContent).toMatch(
       text
     )
+  })
+
+  it('renders the text as react node', () => {
+    const text = <span data-testid="react-node">ReactNode</span>
+
+    render(<InfoCard text={text} />)
+
+    expect(screen.queryByTestId('info-card-text')).not.toBeNull()
+    expect(
+      within(screen.queryByTestId('info-card-text')).queryByTestId(
+        'react-node'
+      )
+    ).not.toBeNull()
   })
 
   it('renders the icon', () => {
@@ -83,15 +109,15 @@ describe('InfoCard', () => {
   it('does not render the buttons', () => {
     render(<InfoCard text="text" />)
 
-    expect(screen.queryByTestId('into-card-accept-button')).toBeNull()
-    expect(screen.queryByTestId('into-card-close-button')).toBeNull()
+    expect(screen.queryByTestId('info-card-accept-button')).toBeNull()
+    expect(screen.queryByTestId('info-card-close-button')).toBeNull()
   })
 
   it('renders the accept button when on_accept is provided', () => {
     const onAccept = jest.fn()
     render(<InfoCard text="text" onAccept={onAccept} />)
 
-    const buttonElement = screen.queryByTestId('into-card-accept-button')
+    const buttonElement = screen.queryByTestId('info-card-accept-button')
 
     expect(buttonElement).not.toBeNull()
 
@@ -100,21 +126,36 @@ describe('InfoCard', () => {
     expect(onAccept).toHaveBeenCalled()
   })
 
-  it('renders the accept button text', () => {
+  it('renders the accept button text as string', () => {
     const acceptButtonText = 'some text'
     render(<InfoCard text="text" acceptButtonText={acceptButtonText} />)
 
-    const buttonElement = screen.queryByTestId('into-card-accept-button')
+    const buttonElement = screen.queryByTestId('info-card-accept-button')
 
     expect(buttonElement).not.toBeNull()
     expect(buttonElement.textContent).toMatch(acceptButtonText)
+  })
+
+  it('renders the accept button text as react node', () => {
+    const acceptButtonText = (
+      <span data-testid="react-node">ReactNode</span>
+    )
+
+    render(<InfoCard text="text" acceptButtonText={acceptButtonText} />)
+
+    expect(screen.queryByTestId('info-card-accept-button')).not.toBeNull()
+    expect(
+      within(
+        screen.queryByTestId('info-card-accept-button')
+      ).queryByTestId('react-node')
+    ).not.toBeNull()
   })
 
   it('renders the close button when on_close is provided', () => {
     const onClose = jest.fn()
     render(<InfoCard text="text" onClose={onClose} />)
 
-    const buttonElement = screen.queryByTestId('into-card-close-button')
+    const buttonElement = screen.queryByTestId('info-card-close-button')
 
     expect(buttonElement).not.toBeNull()
 
@@ -123,14 +164,27 @@ describe('InfoCard', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('renders the close button text', () => {
+  it('renders the close button text as string', () => {
     const closeButtonText = 'some text'
     render(<InfoCard text="text" closeButtonText={closeButtonText} />)
 
-    const buttonElement = screen.queryByTestId('into-card-close-button')
+    const buttonElement = screen.queryByTestId('info-card-close-button')
 
     expect(buttonElement).not.toBeNull()
     expect(buttonElement.textContent).toMatch(closeButtonText)
+  })
+
+  it('renders the close button text as react node', () => {
+    const closeButtonText = <span data-testid="react-node">ReactNode</span>
+
+    render(<InfoCard text="text" closeButtonText={closeButtonText} />)
+
+    expect(screen.queryByTestId('info-card-close-button')).not.toBeNull()
+    expect(
+      within(screen.queryByTestId('info-card-close-button')).queryByTestId(
+        'react-node'
+      )
+    ).not.toBeNull()
   })
 
   it('renders the accept button with additional props', () => {
@@ -144,7 +198,7 @@ describe('InfoCard', () => {
       />
     )
 
-    const buttonElement = screen.queryByTestId('into-card-accept-button')
+    const buttonElement = screen.queryByTestId('info-card-accept-button')
 
     expect(buttonElement.getAttribute('href')).toMatch(href)
   })
@@ -159,7 +213,7 @@ describe('InfoCard', () => {
       />
     )
 
-    const buttonElement = screen.queryByTestId('into-card-close-button')
+    const buttonElement = screen.queryByTestId('info-card-close-button')
 
     expect(buttonElement.getAttribute('href')).toMatch(href)
   })


### PR DESCRIPTION
Reason for wanting to change from string to React.ReactNode is because we often pass in translations in pm-netbank, like `<FormattedMessage>`, etc.