### PR TITLE
chore: revert #1237

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,6 +37,8 @@ packageExtensions:
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
+  - path: .yarn/plugins/plugin-ignore-install-options.cjs
+    spec: packages/dnb-design-system-portal/node_modules/yarn-plugin-ignore-install-options/ignore-install-options-1.0.2.js
 
 pnpMode: loose
 

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -125,7 +125,8 @@
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0",
     "svg-react-loader": "0.4.6",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "yarn-plugin-ignore-install-options": "1.0.2"
   },
   "buildVersion": "[LOCAL BUILD]",
   "releaseVersion": "[LOCAL BUILD]",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12733,6 +12733,7 @@ __metadata:
     stylelint-processor-styled-components: 1.10.0
     svg-react-loader: 0.4.6
     typescript: 4.5.5
+    yarn-plugin-ignore-install-options: 1.0.2
   languageName: unknown
   linkType: soft
 
@@ -35229,6 +35230,13 @@ __metadata:
     y18n: ^3.2.1
     yargs-parser: ^5.0.1
   checksum: 0c330ce1338cd9f293157bf8955af6833ae59032ab1bc936510ce7a216de9bb65b05b39a82ff0e7359bfb643342cc05de5049ce50ee9404b0818f65911fb59a5
+  languageName: node
+  linkType: hard
+
+"yarn-plugin-ignore-install-options@npm:1.0.2":
+  version: 1.0.2
+  resolution: "yarn-plugin-ignore-install-options@npm:1.0.2"
+  checksum: 4a8bb6a99c8d69a99290619d55cf54019074ec308506a3a94b6b44460be29daf2e546267fac4745b1e9839539dd41766b44081358166e38d6cfe0e50803162f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From the logs of this PR #1262 it looks like Gatsby has just reverted the support of yarn v3 (probably temporarily)

