### PR TITLE
fix(NumberUtils): "replace" did not exists on IE11 

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -54,7 +54,7 @@ export interface formatOptionParams {
   currency?: string | boolean;
 
   /** Intl.NumberFormat currency option – you can use false or empty string to hide the sign/name */
-  currency_display?: string;
+  currency_display?: string | boolean;
   /** currency option */
   currency_position?: formatCurrencyPosition;
   /** hides the currency sign */
@@ -84,3 +84,29 @@ export const cleanNumber: (
   num: number | string,
   options?: cleanNumberOptions
 ) => number | string;
+
+export const copyWithEffect: (
+  value: number | string,
+  label?: string,
+  positionElement?: HTMLElement
+) => boolean;
+
+export const getFallbackCurrencyDisplay: (
+  locale?: string,
+  currency_display?: string
+) => string;
+
+export const getDecimalSeparator: (locale?: string) => string;
+
+export const getThousandsSeparator: (locale?: string) => string;
+
+export const getCurrencySymbol: (
+  locale?: string,
+  currency?: string,
+  currencyDisplay?: string
+) => string;
+
+export const countDecimals: (
+  value: number | string,
+  currency_display?: string
+) => number;

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -231,8 +231,8 @@ export const format = (
 
     // IE has a bug, where negative numbers has a parenthesis around the number
     if (IS_IE11) {
-      display = display.replace(/^\((.*)\)$/, '-$1')
-      aria = aria.replace(/^\((.*)\)$/, '-$1')
+      display = String(display).replace(/^\((.*)\)$/, '-$1')
+      aria = String(aria).replace(/^\((.*)\)$/, '-$1')
       display = prepareMinus(display, locale)
       aria = prepareMinus(aria, locale)
     }

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -16,6 +16,7 @@ import {
   getCurrencySymbol,
   countDecimals,
 } from '../NumberUtils'
+import type { formatReturnValue } from '../NumberUtils'
 
 const locale = LOCALE
 const value = 12345678.9876
@@ -188,6 +189,39 @@ describe('Decimals format', () => {
         omit_currency_sign: true,
       })
     ).toBe('-12,345.68')
+  })
+
+  it('should handle wired IE11 issue', () => {
+    Object.defineProperty(helpers, 'IS_IE11', {
+      value: true,
+      writable: true,
+    })
+
+    // Mock the IE parenthesis issue
+    jest
+      .spyOn(Number.prototype, 'toLocaleString')
+      .mockImplementationOnce(() => {
+        return `(12345,67 norske kroner)`
+      })
+
+    const resultNegative = format(-12345.67, {
+      currency: true,
+      returnAria: true,
+      locale: 'nb-NO',
+    }) as formatReturnValue
+    const resultPositive = format(12345.67, {
+      currency: true,
+      returnAria: true,
+      locale: 'nb-NO',
+    }) as formatReturnValue
+
+    Object.defineProperty(helpers, 'IS_IE11', {
+      value: false,
+      writable: true,
+    })
+
+    expect(resultNegative.aria).toBe('-12345,67 norske kroner')
+    expect(resultPositive.aria).toBe('12345,67 norske kroner')
   })
 })
 

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -5,7 +5,7 @@
 
 import { mockGetSelection } from '../../../core/jest/jestSetup'
 import { LOCALE } from '../../../shared/defaults'
-import { isMac } from '../../../shared/helpers'
+import * as helpers from '../../../shared/helpers'
 import {
   format,
   cleanNumber,
@@ -32,7 +32,7 @@ beforeAll(() => {
   platformGetter.mockReturnValue('Mac')
   languageGetter.mockReturnValue(locale)
 
-  isMac() // just to update the exported const: IS_MAC
+  helpers.isMac() // just to update the exported const: IS_MAC
 
   mockGetSelection()
 })
@@ -97,7 +97,7 @@ describe('Decimals format', () => {
     expect(format(num, { currency: true, decimals: 4 })).toBe(
       '-12 345,6789 kr'
     )
-    expect(format(String(num), { currency: true, decimals: '4' })).toBe(
+    expect(format(String(num), { currency: true, decimals: 4 })).toBe(
       '-12 345,6789 kr'
     )
     expect(
@@ -452,7 +452,7 @@ describe('NumberFormat percentage', () => {
       '−4,17 %'
     )
     expect(
-      format(-4.165, { percent: true, decimals: '2', omit_rounding: true })
+      format(-4.165, { percent: true, decimals: 2, omit_rounding: true })
     ).toBe('−4,16 %')
   })
 


### PR DESCRIPTION
More details about the issue [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1643204645078400)