### PR TITLE
chore: enhance false-positive visual test reports

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
@@ -37,7 +37,7 @@ module.exports = async function () {
   }
 
   // commit a tar of the reports if we are on a CI
-  if (isCI) {
+  if (isCI && global.__EVENT_FAILURE_CACHE__.length > 0) {
     console.log(
       chalk.yellow('Will commit "jest-screenshot-report" to git.')
     )


### PR DESCRIPTION
The retry feature we lately added seems to work as expected.

But when there are re-try attempts, our jest-screenshot dependency creates a report. This report gets not removed and during the global teardown event, we then commit the reports to a new branch.

With this commit, we check put the name of a test in a cache, and remove it on success. At the end we then have hopefully an empty list, and will not commit the reports.
