### PR TITLE
chore: move process polyfill to Webpack config as it is recommended

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-browser.js
+++ b/packages/dnb-design-system-portal/gatsby-browser.js
@@ -10,12 +10,8 @@ import {
   pageElement,
 } from './src/core/PortalStylesAndProviders'
 import smoothscroll from 'smoothscroll-polyfill'
-import process from 'process/browser'
 
 smoothscroll.polyfill()
-
-// was added during webpack 4 to 5 migration
-global.process = process
 
 if (typeof window !== 'undefined') {
   setIsTest(window.location)

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -192,6 +192,9 @@ exports.onCreateWebpackConfig = ({ actions, plugins }) => {
         'process.env.CURRENT_BRANCH': JSON.stringify(currentBranch),
         'process.env.PREBUILD_EXISTS': JSON.stringify(prebuildExists),
       }),
+
+      // Webpack 4 to 5 migration
+      plugins.provide({ process: 'process/browser' }),
     ],
   }
 


### PR DESCRIPTION
Use the recommended [migration method](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#process-is-not-defined) for this Webpack 5 polyfill.