### PR TITLE
fix: css change to fix aliasing artifacts for ProgressIndicator

### DIFF
--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
@@ -223,6 +223,21 @@ exports[`ProgressIndicator scss have to match default theme snapshot 1`] = `
 .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
   stroke: var(--color-emerald-green); }
 
+.dnb-progress-indicator__circular--small .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+  stroke-width: 3.1; }
+
+.dnb-progress-indicator__circular--medium .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+  stroke-width: 3.3; }
+
+.dnb-progress-indicator__circular--default .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+  stroke-width: 3.5; }
+
+.dnb-progress-indicator__circular--large .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+  stroke-width: 3.7; }
+
+.dnb-progress-indicator__circular--huge .dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+  stroke-width: 3.9; }
+
 .dnb-progress-indicator__linear {
   background-color: var(--color-black-8); }
   .dnb-progress-indicator__linear--small {

--- a/packages/dnb-eufemia/src/components/progress-indicator/style/themes/dnb-progress-indicator-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/progress-indicator/style/themes/dnb-progress-indicator-theme-ui.scss
@@ -43,6 +43,23 @@
     &__line.dark &__circle {
       stroke: var(--color-emerald-green);
     }
+
+    // compensate for 'aliasing artifacts' seen when rendering same sized, lighter on dark elements
+    &--small &__line.dark &__circle {
+      stroke-width: 3.1;
+    }
+    &--medium &__line.dark &__circle {
+      stroke-width: 3.3;
+    }
+    &--default &__line.dark &__circle {
+      stroke-width: 3.5;
+    }
+    &--large &__line.dark &__circle {
+      stroke-width: 3.7;
+    }
+    &--huge &__line.dark &__circle {
+      stroke-width: 3.9;
+    }
   }
 
   // linear variant


### PR DESCRIPTION
## Summary

There is an aliasing artifact (checked on both FF and chrome) when 2 same sized svg shapes are drawn on top of one another, it's not really visible when drawing 'dark on light', but it's more so when 'light on dark'. This is somewhat of a quickfix (slightly hacky?). So there's probably a more "proper" solution by not overlapping shapes/paths of similar size, animating both the increasing light shape but also the decreasing dark shape?

I think loading indicators are some of the first things users will notice on any element / page that requires loading, and they are usually the "only thing on the page" surrounded by whitespace, and if it looks "cheap" like bucket fill in ms-paint with 'edge aliasing artifacts', then that probably leaves a negative impression :)

image below should show the 'artifacts'.

![image](https://user-images.githubusercontent.com/819074/153103304-3bc3ed22-b8ff-48d4-8bab-d33f2f5b2306.png)


## Test plan

I tested it by looking at the component before and after in the storybook, running it by going into the sandbox directory and running `yarn run start`. I tried to follow what I could find at the contribution guidelines, but hopefully this is a decent starting point :) 
