### PR TITLE
feat(ProgressIndicator): Add aria-valuenow value

### DIFF
--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.js
@@ -166,6 +166,7 @@ export default class ProgressIndicatorCircular extends React.PureComponent {
       params.role = 'progressbar'
       params['aria-label'] = title
       params['title'] = title
+      params['aria-valuenow'] = progress
     } else {
       params.role = 'alert'
       params['aria-busy'] = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.js
@@ -79,6 +79,7 @@ export default class ProgressIndicatorLinear extends React.PureComponent {
       params.role = 'progressbar'
       params['aria-label'] = title
       params['title'] = title
+      params['aria-valuenow'] = progress
     } else {
       params.role = 'alert'
       params['aria-busy'] = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.js
@@ -330,6 +330,30 @@ describe('Linear ProgressIndicator component', () => {
     ).toBe('loading')
   })
 
+  it('has aria-valuenow set to the value of progress property', () => {
+    const progress = 30;
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={progress} title="loading" />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('aria-valuenow')
+    ).toBe(`${progress}`)
+  })
+
+  it('does not have aria-valuenow when progress is null', () => {
+    const LinearComp = mount(
+      <Component {...props} type="linear" progress={null} />
+    )
+    expect(
+      LinearComp.find('.dnb-progress-indicator__linear')
+        .instance()
+        .getAttribute('aria-valuenow')
+    ).toBeNull()
+  })
+
+
   it('should validate with ARIA rules', async () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.js.snap
@@ -56,6 +56,7 @@ exports[`Circular ProgressIndicator component have to match snapshot 1`] = `
     >
       <div
         aria-label="50,00 %"
+        aria-valuenow={50}
         className="dnb-progress-indicator__circular dnb-progress-indicator__circular--default dnb-progress-indicator__circular--has-progress-value"
         role="progressbar"
         title="50,00 %"
@@ -167,6 +168,7 @@ exports[`Linear ProgressIndicator component have to match snapshot 1`] = `
     >
       <div
         aria-label="50,00 %"
+        aria-valuenow={50}
         className="dnb-progress-indicator__linear dnb-progress-indicator__linear--default"
         role="progressbar"
         title="50,00 %"


### PR DESCRIPTION
Add `aria-valuenow`values to `ProgressIndicator` when progress property is defined for accessibility reasons.

From MDN Docs: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow
 - The aria-valuenow enables defining a current numeric value between the minimum and maximum values. The minimum and maximum values are defined with [aria-valuemin](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) and [aria-valuemax](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax). 
 - If there is no known value, like when a progress bar is in an indeterminate state, don't set an aria-valuenow attribute.
