### PR TITLE
fix(Internal): ensure usePropsWithContext will use context regardless

### DIFF
--- a/packages/dnb-eufemia/src/shared/hooks/__tests__/usePropsWithContext.test.ts
+++ b/packages/dnb-eufemia/src/shared/hooks/__tests__/usePropsWithContext.test.ts
@@ -40,7 +40,7 @@ describe('usePropsWithContext', () => {
       prop2: 'prop2',
       a: 'a',
       b: 'b',
-      // c: 'c', // but not c
+      c: 'c',
     })
   })
 

--- a/packages/dnb-eufemia/src/shared/hooks/usePropsWithContext.ts
+++ b/packages/dnb-eufemia/src/shared/hooks/usePropsWithContext.ts
@@ -27,12 +27,8 @@ function usePropsWithContext<Props>(
   return {
     ...props,
     ...Object.entries(context).reduce((acc, [key, value]) => {
-      if (
-        // check if a prop of the same name exists
-        typeof props[key] !== 'undefined' &&
-        // and if it was NOT defined as a component prop, because its still the same as the defaults
-        props[key] === defaults[key]
-      ) {
+      // if it was NOT defined as a component prop, because its still the same as the defaults
+      if (props[key] === defaults[key]) {
         // then we use the context value
         acc[key] = value
       }


### PR DESCRIPTION
While default props are listed, with functional components and TS we do not need to list all anymore just to ensure that we use the context. So with this PR we use the context as long as the prop is not set.
