### PR TITLE
chore: remove unused defaults props with null as value

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
@@ -141,7 +141,7 @@ import { Context } from '../../shared'
 import { usePropsWithContext } from '../../shared/hooks'
 
 const defaultProps = {
-  myString: null, // can be null, as we get our default from the translation file
+  myParam: 'value',
 }
 
 function MyComponent(props: Types) {
@@ -167,7 +167,7 @@ import { Context } from '../../shared'
 import { usePropsWithContext } from '../../shared/hooks'
 
 const defaultProps = {
-  myParam: null,
+  myParam: 'value',
 }
 
 function MyComponent(props: Types) {
@@ -205,11 +205,11 @@ import {
 } from '../space/Space'
 
 interface MyComponentProps extends SpaceProps {
-  myParam: string
+  myParam?: string
 }
 
 const defaultProps = {
-  myParam: null,
+  myParam: 'value',
 }
 
 function MyComponent(props: MyComponentProps) {

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -72,14 +72,9 @@ export interface AvatarProps {
 }
 
 export const defaultProps = {
-  alt: null,
-  className: null,
   size: 'medium',
-  src: null,
-  imgProps: null,
   variant: 'primary',
   skeleton: false,
-  children: null,
 }
 
 const Avatar = (localProps: AvatarProps & ISpacingProps) => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -111,12 +111,7 @@ export interface BreadcrumbProps {
 }
 
 export const defaultProps = {
-  className: null,
   skeleton: false,
-  children: null,
-  variant: null,
-  onClick: null,
-  href: null,
   navText: 'Back',
   goBackText: 'Back',
   homeText: 'Home',
@@ -124,7 +119,6 @@ export const defaultProps = {
   isCollapsed: true,
   styleType: 'transparent',
   collapsedStyleType: 'pistachio',
-  data: null,
   spacing: false,
 }
 
@@ -165,7 +159,7 @@ const Breadcrumb = (localProps: BreadcrumbProps & ISpacingProps) => {
   })
 
   let currentVariant = variant
-  if (variant === null) {
+  if (!variant) {
     if (childrenItems || data) {
       currentVariant = isSmallScreen ? 'collapse' : 'multiple'
     } else {

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -99,18 +99,9 @@ export interface InfoCardProps {
 }
 
 export const defaultProps = {
-  alt: null,
   centered: false,
-  className: null,
   skeleton: false,
   icon: LightbulbIcon,
-  imgProps: null,
-  src: null,
-  title: null,
-  onAccept: null,
-  onClose: null,
-  closeButtonText: null,
-  acceptButtonText: null,
   closeButtonAttributes: null,
   acceptButtonAttributes: null,
 }

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -67,13 +67,7 @@ export interface TagProps {
 }
 
 export const defaultProps = {
-  className: null,
   skeleton: false,
-  text: null,
-  children: null,
-  icon: null,
-  onClick: null,
-  onDelete: null,
   omitOnKeyUpDeleteEvent: false,
 }
 


### PR DESCRIPTION
Not sure if this is something that makes things better, but at least, we do not need them anymore.