### PR TITLE
feat(Avatar): add hasLabel to omit non-existing avatar group warning

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/properties.md
@@ -14,7 +14,8 @@ showTabs: true
 | `src`                                       | _(optional)_ Specifies the path to the image                                                                                      |
 | `skeleton`                                  | _(optional)_ Applies loading skeleton.                                                                                            |
 | `imgProps`                                  | _(optional)_ [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image. |
-| `variant`                                   | _(optional)_ Override the variant of the component. Options: `primary` \| `secondary` \| `tertiary`. Defaults to `primary`.       |
+| `variant`                                   | _(optional)_ Override the variant of the component. Options: `primary` \| `secondary` \|
+| `hasLabel`                                   | _(optional)_ If aria-hidden is set to "true" or if a label is given, typical inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar. Use `true` to omit the `Avatar group required:` warning.| `tertiary`. Defaults to `primary`.       |
 | `className`                                 | _(optional)_ Custom className for the component root.                                                                             |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                             |
 

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -69,6 +69,13 @@ export interface AvatarProps {
    * Default: primary.
    */
   variant?: AvatarVariants
+
+  /**
+   * If an avatar is hidden from the screen reader (by setting aria-hidden="true") or if label is given, typical inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar.
+   * Use `true` to omit the `Avatar group required:` warning.
+   * Default: null
+   */
+  hasLabel?: boolean
 }
 
 export const defaultProps = {
@@ -92,6 +99,7 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
     variant,
     src,
     imgProps,
+    hasLabel,
     ...props
   } = usePropsWithContext(
     localProps,
@@ -121,7 +129,7 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
     children = childrenProp
   }
 
-  if (!avatarGroupContext) {
+  if (!avatarGroupContext && !hasLabel) {
     warn(
       `Avatar group required: An Avatar requires an Avatar.Group with label description as a parent component. This is to ensure correct semantic and accessibility.`
     )

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -127,6 +127,13 @@ describe('Avatar', () => {
     expect(global.console.log).toBeCalled()
   })
 
+  it('will not warn when hasLabel is true', () => {
+    process.env.NODE_ENV = 'development'
+    global.console.log = jest.fn()
+    mount(<Avatar hasLabel />)
+    expect(global.console.log).not.toBeCalled()
+  })
+
   describe('AvatarGroup', () => {
     it('renders the label as string', () => {
       const label = 'avatar'

--- a/packages/dnb-eufemia/src/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/stories/Avatar.stories.tsx
@@ -1,0 +1,28 @@
+/**
+ * @dnb/eufemia Component Story
+ *
+ */
+
+import React from 'react'
+
+import Avatar from '../Avatar'
+import { Provider } from '../../../shared'
+
+export default {
+  title: 'Eufemia/Components/Avatar',
+}
+
+export const AvatarWithoutGroup = () => {
+  return (
+    <Provider>
+      <Avatar>Without Group</Avatar>
+    </Provider>
+  )
+}
+export const AvatarWithoutLabel = () => {
+  return (
+    <Provider>
+      <Avatar hasLabel>Avatar.WithoutLabel</Avatar>
+    </Provider>
+  )
+}


### PR DESCRIPTION
Did the same for Avatar as we did in [Tag](https://github.com/dnbexperience/eufemia/pull/1314).