### PR TITLE
fix(Modal): containerPlacement bug for top

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2296,7 +2296,7 @@ html[data-dnb-modal-active] {
       justify-content: flex-start; }
     .dnb-modal__content--fullscreen .dnb-modal__content__content {
       height: auto; }
-    .dnb-modal__content--left {
+    .dnb-modal__content--left, .dnb-modal__content--top {
       align-items: flex-start;
       justify-content: flex-start; }
     .dnb-modal__content--right {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2293,7 +2293,7 @@ html[data-dnb-modal-active] {
       justify-content: flex-start; }
     .dnb-modal__content--fullscreen .dnb-modal__content__content {
       height: auto; }
-    .dnb-modal__content--left {
+    .dnb-modal__content--left, .dnb-modal__content--top {
       align-items: flex-start;
       justify-content: flex-start; }
     .dnb-modal__content--right {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2308,7 +2308,7 @@ html[data-dnb-modal-active] {
       justify-content: flex-start; }
     .dnb-modal__content--fullscreen .dnb-modal__content__content {
       height: auto; }
-    .dnb-modal__content--left {
+    .dnb-modal__content--left, .dnb-modal__content--top {
       align-items: flex-start;
       justify-content: flex-start; }
     .dnb-modal__content--right {

--- a/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
+++ b/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
@@ -436,6 +436,14 @@ export const DrawerSandbox = () => (
         </Modal.Content>
       </Modal>
     </Box>
+    <Box>
+      <Modal
+        mode="drawer"
+        title="Top drawer"
+        container_placement="top"
+        modal_content="something"
+      />
+    </Box>
   </Wrapper>
 )
 

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -56,7 +56,8 @@ html[data-dnb-modal-active] {
       height: auto;
     }
 
-    &--left {
+    &--left,
+    &--top {
       align-items: flex-start;
       justify-content: flex-start;
     }


### PR DESCRIPTION
This had the same cause as the previous reported issue with containerplacement left, where the default alignment was different for mode drawer in the original version. Hope and think this will fix the reported issue with the background too
