### PR TITLE
feat(Portal): Suffix page titles with "| Eufemia"

### DIFF
--- a/packages/dnb-design-system-portal/src/templates/mdx.js
+++ b/packages/dnb-design-system-portal/src/templates/mdx.js
@@ -51,7 +51,7 @@ export default class MdxTemplate extends React.PureComponent {
     return (
       <>
         <Head>
-          <title>{pageTitle}</title>
+          <title>{pageTitle} | Eufemia</title>
           <meta name="description" content={pageDescription} />
         </Head>
 


### PR DESCRIPTION
Suffixed page titles with "| Eufemia" in the portal.

This is just a suggested change of common practice on how page titles should be.
It makes it easier to find and search through logs etc.

Used pipe instead of dash since [DNB.no](https://www.dnb.no/forside-ung) uses this pattern as well.

Feel free to ignore this PR if this is not what we want.