### PR TITLE
chore(CI): add CACHE_VERSION to invalidate GitHub Actions cache

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -52,8 +52,8 @@ jobs:
         id: modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-modules-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
 
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -40,8 +40,8 @@ jobs:
         id: modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-modules-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
 
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'
@@ -64,8 +64,8 @@ jobs:
           path: |
             ./packages/dnb-design-system-portal/.cache
             ./packages/dnb-design-system-portal/public
-          key: ${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
-          restore-keys: ${{ runner.os }}-gatsby-dev-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
 
       - name: Build portal
         run: yarn workspace dnb-design-system-portal build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
         id: modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-modules-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
 
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -52,8 +52,8 @@ jobs:
         id: modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-modules-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
 
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -49,8 +49,8 @@ jobs:
         id: yarn-cache
         with:
           path: ./.yarn/cache
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-deps-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -66,8 +66,8 @@ jobs:
           path: |
             ./packages/dnb-design-system-portal/.cache
             ./packages/dnb-design-system-portal/public
-          key: ${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
-          restore-keys: ${{ runner.os }}-gatsby-dev-
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
 
       - name: Build portal
         run: yarn workspace dnb-design-system-portal build


### PR DESCRIPTION
With this fix, we can quickly invalidate all caches by changing the ENV in GitHub env settings. This is because, there is no way to invalidate the GitHub Actions cache. So this is a recommended solution.

Its only meant to use for special cases. Until now, we never did really need that. But when we need it, we need to do it quickly (most probably).
