### PR TITLE
fix(Avatar): Allow Avatar.Group to set skeleton prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/properties.md
@@ -6,18 +6,18 @@ showTabs: true
 
 ### `Avatar` properties
 
-| Properties                                  | Description                                                                                                                       |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `size`                                      | _(optional)_ Size of the Avatar. Options: `small` \| `medium` \| `large` \| `x-large`. Defaults to `medium`.                      |
-| `children`                                  | _(optional)_ Content of the component.                                                                                            |
-| `alt`                                       | _(optional)_ Used in combination with `src` to provide an alt attribute for the `img` element.                                    |
-| `src`                                       | _(optional)_ Specifies the path to the image                                                                                      |
-| `skeleton`                                  | _(optional)_ Applies loading skeleton.                                                                                            |
-| `imgProps`                                  | _(optional)_ [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image. |
-| `variant`                                   | _(optional)_ Override the variant of the component. Options: `primary` \| `secondary` \|
-| `hasLabel`                                   | _(optional)_ If aria-hidden is set to "true" or if a label is given, typical inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar. Use `true` to omit the `Avatar group required:` warning.| `tertiary`. Defaults to `primary`.       |
-| `className`                                 | _(optional)_ Custom className for the component root.                                                                             |
-| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                             |
+| Properties                                  | Description                                                                                                                                                                                                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `size`                                      | _(optional)_ Size of the Avatar. Options: `small` \| `medium` \| `large` \| `x-large`. Defaults to `medium`.                                                                                                                              |
+| `children`                                  | _(optional)_ Content of the component.                                                                                                                                                                                                    |
+| `alt`                                       | _(optional)_ Used in combination with `src` to provide an alt attribute for the `img` element.                                                                                                                                            |
+| `src`                                       | _(optional)_ Specifies the path to the image                                                                                                                                                                                              |
+| `skeleton`                                  | _(optional)_ Applies loading skeleton.                                                                                                                                                                                                    |
+| `imgProps`                                  | _(optional)_ [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image.                                                                                                         |
+| `variant`                                   | _(optional)_ Override the variant of the component. Options: `primary` \| `secondary` \|                                                                                                                                                  |
+| `hasLabel`                                  | _(optional)_ If aria-hidden is set to "true" or if a label is given, typical inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar. Use `true` to omit the `Avatar group required:` warning. | `tertiary`. Defaults to `primary`. |
+| `className`                                 | _(optional)_ Custom className for the component root.                                                                                                                                                                                     |
+| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                                                                                                     |
 
 ### `Avatar.Group` properties
 
@@ -30,3 +30,4 @@ showTabs: true
 | `children`                                  | _(optional)_ The Avatars to group.                                                                                                             |
 | `className`                                 | _(optional)_ Custom className for the component root.                                                                                          |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                          |
+| `skeleton`                                  | _(optional)_ Applies loading skeleton.                                                                                                         |

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -105,8 +105,8 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
     localProps,
     defaultProps,
     context?.Avatar,
-    avatarGroupContext,
-    { skeleton: context?.skeleton }
+    { skeleton: context?.skeleton },
+    avatarGroupContext
   )
 
   let children = null

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -9,6 +9,7 @@ import { AvatarSizes, AvatarVariants } from './Avatar'
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
 import { usePropsWithContext } from '../../shared/hooks'
+import { SkeletonShow } from '../skeleton/Skeleton'
 
 export interface AvatarGroupProps {
   /**
@@ -46,6 +47,12 @@ export interface AvatarGroupProps {
    * Default: primary.
    */
   variant?: AvatarVariants
+
+  /**
+   * Skeleton should be applied when loading content
+   * Default: null
+   */
+  skeleton?: SkeletonShow
 }
 
 export const defaultProps = {
@@ -55,6 +62,7 @@ export const defaultProps = {
   size: 'medium',
   children: null,
   variant: 'primary',
+  skeleton: null,
 }
 
 export const AvatarGroupContext = React.createContext(null)

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -6,6 +6,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 import { AvatarSizes, AvatarVariants } from './Avatar'
 
 // Shared
+import { validateDOMAttributes } from '../../shared/component-helper'
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
 import { usePropsWithContext } from '../../shared/hooks'
@@ -50,7 +51,7 @@ export interface AvatarGroupProps {
 
   /**
    * Skeleton should be applied when loading content
-   * Default: null
+   * Default: false
    */
   skeleton?: SkeletonShow
 }
@@ -62,7 +63,7 @@ export const defaultProps = {
   size: 'medium',
   children: null,
   variant: 'primary',
-  skeleton: null,
+  skeleton: false,
 }
 
 export const AvatarGroupContext = React.createContext(null)
@@ -79,12 +80,9 @@ const AvatarGroup = (localProps: AvatarGroupProps & ISpacingProps) => {
     maxElements: maxElementsProp,
     variant,
     ...props
-  } = usePropsWithContext(
-    localProps, 
-    defaultProps, 
-    context?.AvatarGroup,
-    { skeleton: context?.skeleton }
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.AvatarGroup, {
+    skeleton: context?.skeleton,
+  })
 
   const maxElements =
     maxElementsProp && maxElementsProp > 0 ? maxElementsProp : 4
@@ -116,6 +114,10 @@ const AvatarGroup = (localProps: AvatarGroupProps & ISpacingProps) => {
   }
 
   const spacingClasses = createSpacingClasses(props)
+  const {
+    skeleton, // eslint-disable-line
+    ...attributes
+  } = validateDOMAttributes({}, props)
 
   return (
     <AvatarGroupContext.Provider value={props}>
@@ -126,7 +128,7 @@ const AvatarGroup = (localProps: AvatarGroupProps & ISpacingProps) => {
           className
         )}
         data-testid="avatar-group"
-        {...props}
+        {...attributes}
       >
         <span data-testid="avatar-group-label" className="dnb-sr-only">
           {label}

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -79,7 +79,12 @@ const AvatarGroup = (localProps: AvatarGroupProps & ISpacingProps) => {
     maxElements: maxElementsProp,
     variant,
     ...props
-  } = usePropsWithContext(localProps, defaultProps, context?.AvatarGroup)
+  } = usePropsWithContext(
+    localProps, 
+    defaultProps, 
+    context?.AvatarGroup,
+    { skeleton: context?.skeleton }
+  )
 
   const maxElements =
     maxElementsProp && maxElementsProp > 0 ? maxElementsProp : 4

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -309,6 +309,20 @@ describe('Avatar', () => {
       expect(screen.queryByTestId('elements-left')).not.toBeNull()
       expect(avatarsDisplayed.length).toBe(3)
     })
+
+    it('renders skeleton if skeleton is true', () => {
+      const skeletonClassName = 'dnb-skeleton'
+
+      render(
+        <Avatar.Group skeleton label="label">
+          <Avatar>A</Avatar>
+        </Avatar.Group>
+      )
+
+      expect(screen.queryByTestId('avatar').className).toMatch(
+        skeletonClassName
+      )
+    })
   })
 })
 


### PR DESCRIPTION
This PR just adds the property and type for skeleton to the Avatar.Group, so that it will be easier/possible to use the component with the skeleton prop. The functionality is/was already in place, take a look at https://eufemia.dnb.no/uilib/components/avatar and add the skeleton property to one of the demos/examples.

```
<Avatar.Group skeleton label="label">
   <Avatar>A</Avatar>
</Avatar.Group>
 ```