### PR TITLE
fix(Tag): Allow Tag.Group to set skeleton prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag/properties.md
@@ -24,3 +24,4 @@ showTabs: true
 | `children`                                  | _(optional)_ Content of the component. Can be used instead of the `data`-property, by adding Tag elements as children `<Tag {...props} />`. |
 | `className`                                 | _(optional)_ Custom className for the component root.                                                                                       |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                       |
+| `skeleton`                                  | _(optional)_ Applies loading skeleton.                                                                                                      |

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -54,7 +54,12 @@ const TagGroup = (localProps: TagGroupProps & ISpacingProps) => {
     className,
     children: childrenProp,
     ...props
-  } = usePropsWithContext(localProps, defaultProps, context?.TagGroup)
+  } = usePropsWithContext(
+    localProps, 
+    defaultProps, 
+    context?.TagGroup,
+    { skeleton: context?.skeleton }
+  )
 
   let children = childrenProp
 

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -33,7 +33,7 @@ export interface TagGroupProps {
 
   /**
    * Skeleton should be applied when loading content
-   * Default: null
+   * Default: false
    */
   skeleton?: SkeletonShow
 }
@@ -42,7 +42,7 @@ export const defaultProps = {
   label: null,
   className: null,
   children: null,
-  skeleton: null,
+  skeleton: false,
 }
 
 const TagGroup = (localProps: TagGroupProps & ISpacingProps) => {
@@ -54,12 +54,9 @@ const TagGroup = (localProps: TagGroupProps & ISpacingProps) => {
     className,
     children: childrenProp,
     ...props
-  } = usePropsWithContext(
-    localProps, 
-    defaultProps, 
-    context?.TagGroup,
-    { skeleton: context?.skeleton }
-  )
+  } = usePropsWithContext(localProps, defaultProps, context?.TagGroup, {
+    skeleton: context?.skeleton,
+  })
 
   let children = childrenProp
 
@@ -70,13 +67,17 @@ const TagGroup = (localProps: TagGroupProps & ISpacingProps) => {
   }
 
   const spacingClasses = createSpacingClasses(props)
+  const {
+    skeleton, // eslint-disable-line
+    ...attributes
+  } = validateDOMAttributes({}, props)
 
   return (
     <TagGroupContext.Provider value={props}>
       <span
         className={classnames('dnb-tag__group', spacingClasses, className)}
         data-testid="tag-group"
-        {...validateDOMAttributes({}, props)}
+        {...attributes}
       >
         <span data-testid="tag-group-label" className="dnb-sr-only">
           {label}

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -10,6 +10,7 @@ import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
 import { usePropsWithContext } from '../../shared/hooks'
 import { TagGroupContext } from './TagContext'
+import { SkeletonShow } from '../skeleton/Skeleton'
 
 export interface TagGroupProps {
   /**
@@ -29,12 +30,19 @@ export interface TagGroupProps {
    * Default: null
    */
   children?: React.ReactNode
+
+  /**
+   * Skeleton should be applied when loading content
+   * Default: null
+   */
+  skeleton?: SkeletonShow
 }
 
 export const defaultProps = {
   label: null,
   className: null,
   children: null,
+  skeleton: null,
 }
 
 const TagGroup = (localProps: TagGroupProps & ISpacingProps) => {

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -61,6 +61,20 @@ describe('Tag Group', () => {
       customClassName
     )
   })
+
+  it('renders a tag with skeleton if skeleton is true', () => {
+    const skeletonClassName = 'dnb-skeleton'
+
+    render(
+      <Tag.Group skeleton label="tags">
+        <Tag>skeleton</Tag>
+      </Tag.Group>
+    )
+
+    expect(screen.queryByTestId('tag').className).toMatch(
+      skeletonClassName
+    )
+  })
 })
 
 describe('Tag', () => {


### PR DESCRIPTION
This PR just adds the property and type for skeleton to the Tag.Group, so that it will be easier/possible to use the component with the skeleton prop. The functionality is/was already in place, take a look at https://eufemia.dnb.no/uilib/components/tag and add the skeleton property to one of the demos/examples.

```
<Tag.Group skeleton label="tags">
   <Tag />
</Tag.Group>
 ```