### PR TITLE
fix(Theming): simplify the theming logic

### DIFF
--- a/packages/dnb-eufemia/src/style/core/properties.scss
+++ b/packages/dnb-eufemia/src/style/core/properties.scss
@@ -105,17 +105,12 @@
   --shadow-default-y: 8px;
   --shadow-default-blur-radius: 16px;
   --shadow-default-color: rgba(51, 51, 51, 0.08);
-}
 
-@mixin setProperties() {
-  :root {
-    @content;
+  @if mixin-exists('propertiesCustomisation') {
+    @include propertiesCustomisation();
   }
 }
 
-$hasCustomProperties: false !default;
-@if $hasCustomProperties == false {
-  :root {
-    @include getDefaultProperties();
-  }
+:root {
+  @include getDefaultProperties();
 }

--- a/packages/dnb-eufemia/src/style/elements/typography.scss
+++ b/packages/dnb-eufemia/src/style/elements/typography.scss
@@ -27,6 +27,10 @@
     padding-top: 0;
     padding-bottom: 0.03125rem;
   }
+
+  @if mixin-exists('headingDefaultsCustomisation') {
+    @include headingDefaultsCustomisation();
+  }
 }
 @mixin headingStyle_xx-large() {
   font-size: var(--font-size-xx-large);
@@ -37,6 +41,10 @@
     display: block;
     font-size: var(--font-size-x-large);
     line-height: var(--line-height-large);
+  }
+
+  @if mixin-exists('headingStyle_xx-largeCustomisation') {
+    @include headingStyle_xx-largeCustomisation();
   }
 }
 @mixin headingStyle_x-large() {
@@ -49,6 +57,10 @@
     font-size: var(--font-size-x-large);
     line-height: var(--line-height-large);
   }
+
+  @if mixin-exists('headingStyle_x-largeCustomisation') {
+    @include headingStyle_x-largeCustomisation();
+  }
 }
 @mixin headingStyle_large() {
   font-size: var(--font-size-large);
@@ -58,6 +70,10 @@
   & > small {
     font-size: var(--font-size-medium);
     line-height: calc(var(--line-height-medium) - 0.125rem);
+  }
+
+  @if mixin-exists('headingStyle_largeCustomisation') {
+    @include headingStyle_largeCustomisation();
   }
 }
 // Like Lead / --lead
@@ -69,6 +85,10 @@
   & > small {
     font-size: var(--font-size-basis);
     line-height: var(--line-height-basis);
+  }
+
+  @if mixin-exists('headingStyle_mediumCustomisation') {
+    @include headingStyle_mediumCustomisation();
   }
 }
 @mixin headingStyle_basis() {
@@ -92,12 +112,9 @@
 @mixin headingStyle_x-small() {
   font-size: var(--font-size-x-small);
   line-height: var(--line-height-x-small);
-
-  // font-weight: var(--font-weight-regular);
 }
 @mixin paragraphStyle() {
   font-size: var(--font-size-basis);
-  // color: var(--color-black-80);
   color: var(--theme-color-black-80, currentColor);
 
   // if we not reset margin, the browser is using: margin-block-end: 1rem;

--- a/packages/dnb-eufemia/src/style/themes/theme-eiendom/dnb-theme-eiendom.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-eiendom/dnb-theme-eiendom.scss
@@ -5,8 +5,7 @@
  */
 
 // change some properties
-@import '../../core/properties.scss';
-@include setProperties() {
+@mixin propertiesCustomisation() {
   // eiendom colors
   --color-eiendom-green: #a5e1d2;
   --color-eiendom-emerald: #00343e;
@@ -15,9 +14,22 @@
   --color-sea-green: fuchsia;
 }
 
-// before we again import "properties.scss" by "dnb-theme-ui.scss"
-// we set this var to true
-$hasCustomProperties: true;
+// import additional font
+$fonts-path: '../../../../assets/fonts' !default;
+@font-face {
+  font-family: DNBMono;
+  src: url('#{$fonts-path}/DNBMono-Medium.woff2') format('woff2'),
+    url('#{$fonts-path}/DNBMono-Medium.woff') format('woff'),
+    url('#{$fonts-path}/DNBMono-Medium.ttf') format('truetype');
+  font-weight: 500; // have to be the same as: --font-weight-medium
+  font-style: normal;
+  font-display: fallback;
+}
+
+// change headings
+@mixin headingDefaultsCustomisation() {
+  font-family: var(--font-family-monospace);
+}
 
 // import the default theme, and go from there
 // will also have all the component themes included


### PR DESCRIPTION
By checking if an existing `@mixin` exists, we can insert custom styles and properties by defining this customization `@mixin` with custom css styles.

With this PR, all headings to use DNBMono in medium weight. Just as a POC.

<img width="764" alt="Screenshot 2022-03-10 at 21 40 42" src="https://user-images.githubusercontent.com/1501870/157750769-370d6578-254e-4f98-899a-b1d515d6b6c9.png">

