### PR TITLE
docs(Tag): Change heading levels by only one factor

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag/demos.md
@@ -13,7 +13,7 @@ TagSkeleton,
 
 ## Demos
 
-#### Tag
+### Tag
 
 To ensure the correct use of the Tags, we require using a `Tag.Group` with `Tag`-components as children. <br/>
 The required `label`-property in `Tag.Group` will ensure the correct use of accessibility for screen readers. <br/>
@@ -21,27 +21,27 @@ See more examples below.
 
 <TagDefault />
 
-#### Tag with icon
+### Tag with icon
 
 <TagWithIcon />
 
-#### Removable tag
+### Removable tag
 
 Use the `onDelete`-prop to make a tag removable. A removable tag supports adds a `onClick`-event to the underlying `Button`-component. <br/>
 Removable tags will not support the `icon`-prop and will also be ignored if a `onClick`-prop is defined.
 
 <TagRemovable />
 
-#### Multiple removable tags
+### Multiple removable tags
 
 Removable tags can for example be used in filter lists. This example simple example on how to implement a filter list using removable `Tags`.<br/> When a `Tag` is focused (e.g. when tabbing) releasing `Backspace` or `Delete` (`keyup` event) will call the `onDelete`-handler. This behavior can be omitted by setting the `omitOnKeyUpDeleteEvent`-prop to `true`.
 
 <TagMultipleRemovable />
 
-#### Tag used inside text
+### Tag used inside text
 
 <TagInline />
 
-#### Tag used as skeleton
+### Tag used as skeleton
 
 <TagSkeleton />


### PR DESCRIPTION
Fixes the following warning from the browsers console:

```
Eufemia Heading levels can only be changed by factor one! Got: 3 and had before 1 - The new level is 2 
NB: This warning was triggered by:  #
```