### PR TITLE
feat(Theme): create theme handler Gatsby Plugin

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -106,6 +106,19 @@ const plugins = [
   },
   'gatsby-plugin-sass',
   'gatsby-plugin-emotion',
+  {
+    resolve: 'gatsby-plugin-eufemia-theme-handler',
+    options: {
+      themes: {
+        ui: { name: 'DNB light' }, // universal identity
+        eiendom: { name: 'DNB Eiendom (WIP)' },
+      },
+      defaultTheme:
+        process.env.GATSBY_CLOUD && currentBranch.includes('eiendom')
+          ? 'eiendom'
+          : process.env.GATSBY_THEME_STYLE_DEV || 'ui',
+    },
+  },
 ].filter(Boolean)
 
 if (currentBranch === 'release') {
@@ -138,6 +151,11 @@ if (queries) {
 }
 
 module.exports = {
+  flags: {
+    FAST_DEV: true,
+    PRESERVE_FILE_DOWNLOAD_CACHE: true,
+    PARALLEL_SOURCING: true,
+  },
   pathPrefix,
   siteMetadata,
   plugins,

--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -8,8 +8,21 @@ const path = require('path')
 const { isCI } = require('repo-utils')
 const getCurrentBranchName = require('current-git-branch')
 const { init } = require('./scripts/version.js')
+const {
+  defineSrcAddition,
+} = require('gatsby-plugin-eufemia-theme-handler/collectThemes')
+
+let prebuildExists = false
+const currentBranch = getCurrentBranchName()
 
 exports.onPreInit = async () => {
+  try {
+    prebuildExists = fs.existsSync(require.resolve('@dnb/eufemia/build'))
+  } catch (e) {
+    //
+  }
+  defineSrcAddition(isCI && prebuildExists ? 'build/' : 'src/')
+
   if (process.env.NODE_ENV === 'production') {
     await init()
   }
@@ -171,15 +184,6 @@ async function createRedirects({ graphql, actions }) {
   })
 }
 
-let prebuildExists = false
-try {
-  prebuildExists = fs.existsSync(require.resolve('@dnb/eufemia/build'))
-} catch (e) {
-  //
-}
-
-const currentBranch = getCurrentBranchName()
-
 exports.onCreateWebpackConfig = ({ actions, plugins }) => {
   const config = {
     resolve: {
@@ -225,8 +229,8 @@ exports.onCreateDevServer = () => {
 
 function getStyleTheme() {
   let themeName = 'ui'
-  if (typeof process.env.GATSBY_STYLE_THEME !== 'undefined') {
-    themeName = process.env.GATSBY_STYLE_THEME
+  if (typeof process.env.GATSBY_THEME_STYLE_DEV !== 'undefined') {
+    themeName = process.env.GATSBY_THEME_STYLE_DEV
   }
 
   /**

--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.js
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Dropdown } from '@dnb/eufemia/src'
+
+import {
+  getThemes,
+  getTheme,
+  setTheme,
+} from 'gatsby-plugin-eufemia-theme-handler'
+
+export default function ChangeStyleTheme(props) {
+  const themes = getThemes()
+  const themeName = getTheme()
+
+  const date = Object.entries(themes).reduce((acc, [key, { name }]) => {
+    acc[key] = capitalizeFirstLetter(name)
+    return acc
+  }, {})
+
+  return (
+    <Dropdown
+      value={themeName}
+      data={date}
+      on_change={({ data: { value } }) => {
+        setTheme(value)
+      }}
+      {...props}
+    />
+  )
+}
+
+function capitalizeFirstLetter(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}

--- a/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
+++ b/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
@@ -23,12 +23,12 @@ if (isCI && process.env.PREBUILD_EXISTS) {
   require('@dnb/eufemia/build/style/dnb-ui-extensions.min.css')
   require('@dnb/eufemia/build/style/dnb-ui-core.min.css')
   require('@dnb/eufemia/build/style/dnb-ui-components.min.css')
-  require(`@dnb/eufemia/build/style/themes/theme-${process.env.STYLE_THEME}/dnb-theme-${process.env.STYLE_THEME}.min.css`)
+  // Themes are imported by "gatsby-plugin-eufemia-theme-handler"
 } else {
   require('@dnb/eufemia/src/style/extensions')
   require('@dnb/eufemia/src/style/core')
   require('@dnb/eufemia/src/style/components')
-  require(`@dnb/eufemia/src/style/themes/${process.env.STYLE_THEME}`)
+  // Themes are imported by "gatsby-plugin-eufemia-theme-handler"
 }
 
 import cssVars from 'css-vars-ponyfill'

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.md
@@ -9,94 +9,25 @@ Read the [Styling examples](/uilib/usage/customisation/styling) on how to includ
 This section is about how theming works and how to actually create a custom theme.
 
 - [Theming](#theming)
+  - [Integrated theming](#integrated-theming)
+    - [Brand theming](#brand-theming)
+  - [Run your application with a different theme](#run-your-application-with-a-different-theme)
+    - [Run the portal with a different theme](#run-the-portal-with-a-different-theme)
+    - [Technical aspects](#technical-aspects)
+    - [Local Theming setup](#local-theming-setup)
+      - [_Method:_ yarn link and SASS](#method-yarn-link-and-sass)
   - [WIP: Ready to use themes](#wip-ready-to-use-themes)
     - [Chrome Extension: Eufemia Theme Manager](#chrome-extension-eufemia-theme-manager)
   - [Component theming](#component-theming)
     - [Theming inside your application](#theming-inside-your-application)
     - [Using `postcss-replace`](#using-postcss-replace)
     - [Using CSS (vars) Custom Properties](#using-css-vars-custom-properties)
-  - [Integrated theming](#integrated-theming)
-    - [Brand theming](#brand-theming)
-    - [Run the portal with a different theme](#run-the-portal-with-a-different-theme)
-    - [Technical aspects](#technical-aspects)
-    - [Local Theming setup](#local-theming-setup)
-      - [_Method:_ yarn link and SASS](#method-yarn-link-and-sass)
-
-## WIP: Ready to use themes
-
-Right now, theres work going on to create Eufemia Themes that utilize both color and spacing and the [Spatial system](/quickguide-designer/spatial-system).
-
-The plan is to extend the documentation here later on on how to select and use a theme inside an application.
-
-### Chrome Extension: Eufemia Theme Manager
-
-Use the [Chrome Browser Extension](https://chrome.google.com/webstore/detail/eufemia-theme-manager/pijolaebmeacaekbhoefjmhogckdcclb) to:
-
-- test themes on web applications
-- create new possible themes
-- look how the outcome would be if a theme would be used
-- and create areas where a different or a modified theme would make more sense
-
-You can also download the [Chrome Browser Extension (ZIP)](https://github.com/dnbexperience/eufemia-theme-manager/raw/main/eufemia-theme-manager-extension/web-ext-artifacts/eufemia_theme_manager-latest.zip), and install it manually in your browser. To do so, go to `chrome://extensions` and drag & drop the downloaded ZIP file in the opened extensions tab.
-
-Contributions are welcome. Heres the [source code](https://github.com/dnbexperience/eufemia-theme-manager).
-
-## Component theming
-
-By default, all the HTML Elements (components) are built by separating the "visual styling" parts from the "functional layout" parts. This way we can create new custom visual styles:
-
-```js
-/button/style/_button.scss // layout styles
-/button/style/themes/dnb-button-theme-ui.scss // main theme styles
-/button/style/themes/dnb-button-theme-eiendom.scss// additional theme styles
-```
-
-- The main theme (`ui`) does contain mainly colorization and sizes.
-- While all the raw positioning and layout related properties are in the main `.scss` file, starting with an underscore: `_button.scss`
-
-It's still possible to overwrite the _layout_ properties to customize our theme even further, if that is needed.
-
-### Theming inside your application
-
-You can skip to import the default theme `dnb-theme-ui` and create your own visual styles for every component you use in your App:
-
-```diff
-import '@dnb/eufemia/style/core' // or /basis, when dnb-core-style is used
-import '@dnb/eufemia/style/components'
-- import '@dnb/eufemia/style/themes/ui'
-```
-
-This approach is fragile, because further Eufemia changes and updates will possibly misalign with your customization.
-
-Therefore, its probably a good idea to rather create theme styling files inside of the Eufemia repo itself. More on that topic in [integrated theming](#integrated-theming).
-
-### Using `postcss-replace`
-
-If your applications only need new colors or other CSS properties, you could simply replace all the properties with [postcss-replace](https://www.npmjs.com/package/postcss-replace) using this config scheme:
-
-```js
-{
-  resolve: 'gatsby-plugin-postcss',
-  options: {
-    postCssPlugins: [
-      require('postcss-replace')({
-        pattern: /#([A-Fa-f0-9]+)/,
-        data: {
-          '007272': '#YOUR_COLOR' // sea-green
-        }
-      })
-    ]
-  }
-}
-```
-
-### Using CSS (vars) Custom Properties
-
-This is for sure a very nice and powerful solution, but lacks Internet Explorer support.
 
 ## Integrated theming
 
 Eufemia supports theming right inside where all the style-sources lives. Having the ability to control different styles as close to the source as possible, will make it possible to carefully handle continues improvements over time.
+
+Themes are independent style packages, which should not be imported in parallel. But rather either – or.
 
 ### Brand theming
 
@@ -106,14 +37,29 @@ Eufemia is a system that is build on top of brand-assets. So means, it should be
 
 Therefore, instead of overwriting Eufemia (DNB main brand) styles inside projects, it is beneficial to create additional brand themes – directly where the source of the original brand lives.
 
-The default DNB brand theme is called: `ui` which stands for _user interface_.
+The default DNB brand theme is called: `ui` which stands for _universal identity_.
+
+## Run your application with a different theme
+
+You can easily switch the static import of styles to a different theme:
+
+```diff
+import '@dnb/eufemia/style/core' // or /basis, when "dnb-core-style" is used
+import '@dnb/eufemia/style/components'
+- import '@dnb/eufemia/style/themes/ui'
++ import '@dnb/eufemia/style/themes/eiendom'
+```
+
+How ever, giving the user the ability to switch a theme during runtime, is a very much different challenge.
+
+The Eufemia Portal (documentation) uses [`gatsby-plugin-eufemia-theme-handler`](https://github.com/dnbexperience/eufemia/tree/main/packages/gatsby-plugin-eufemia-theme-handler) to handle it both in development and production mode. You may install it to use it in your application as well.
 
 ### Run the portal with a different theme
 
-- Create a new `/packages/dnb-design-system-portal/.env` file that includes e.g. `GATSBY_STYLE_THEME=eiendom` and start the portal with `$ yarn start`.
-- What theme gets imported is defined in this file: `PortalStylesAndProviders`.
-- WIP: We may add an easy way to switch themes directly in the portal itself.
-- WIP: We may also find a solution to make visual tests to verify some theme changed properties.
+- Create a new `/packages/dnb-design-system-portal/.env` file that includes e.g. `GATSBY_THEME_STYLE_DEV=eiendom` and start the portal with `$ yarn start`.
+- What theme gets imported is handled in the Gatsby Plugin `gatsby-plugin-eufemia-theme-handler`.
+- In the Portal Tools you can switch to a different theme.
+- You can also define a different them in the url itself `path/?dnb-theme=ui`.
 
 ### Technical aspects
 
@@ -178,3 +124,75 @@ import 'dnb-eufemia/src/style/themes/dnb-theme-[MY THEME].scss'
     ...
   }
 ```
+
+## WIP: Ready to use themes
+
+Right now, theres work going on to create Eufemia Themes that utilize both color and spacing and the [Spatial system](/quickguide-designer/spatial-system).
+
+The plan is to extend the documentation here later on on how to select and use a theme inside an application.
+
+### Chrome Extension: Eufemia Theme Manager
+
+Use the [Chrome Browser Extension](https://chrome.google.com/webstore/detail/eufemia-theme-manager/pijolaebmeacaekbhoefjmhogckdcclb) to:
+
+- test themes on web applications
+- create new possible themes
+- look how the outcome would be if a theme would be used
+- and create areas where a different or a modified theme would make more sense
+
+You can also download the [Chrome Browser Extension (ZIP)](https://github.com/dnbexperience/eufemia-theme-manager/raw/main/eufemia-theme-manager-extension/web-ext-artifacts/eufemia_theme_manager-latest.zip), and install it manually in your browser. To do so, go to `chrome://extensions` and drag & drop the downloaded ZIP file in the opened extensions tab.
+
+Contributions are welcome. Heres the [source code](https://github.com/dnbexperience/eufemia-theme-manager).
+
+## Component theming
+
+By default, all the HTML Elements (components) are built by separating the "visual styling" parts from the "functional layout" parts. This way we can create new custom visual styles:
+
+```js
+/button/style/_button.scss // layout styles
+/button/style/themes/dnb-button-theme-ui.scss // main theme styles
+/button/style/themes/dnb-button-theme-eiendom.scss// additional theme styles
+```
+
+- The main theme (`ui`) does contain mainly colorization and sizes.
+- While all the raw positioning and layout related properties are in the main `.scss` file, starting with an underscore: `_button.scss`
+
+It's still possible to overwrite the _layout_ properties to customize our theme even further, if that is needed.
+
+### Theming inside your application
+
+You can skip to import the default theme `dnb-theme-ui` and create your own visual styles for every component you use in your App:
+
+```diff
+import '@dnb/eufemia/style/core' // or /basis, when "dnb-core-style" is used
+import '@dnb/eufemia/style/components'
+- import '@dnb/eufemia/style/themes/ui'
+```
+
+This approach is fragile, because further Eufemia changes and updates will possibly misalign with your customization.
+
+Therefore, its probably a good idea to rather create theme styling files inside of the Eufemia repo itself. More on that topic in [integrated theming](#integrated-theming).
+
+### Using `postcss-replace`
+
+If your applications only need new colors or other CSS properties, you could simply replace all the properties with [postcss-replace](https://www.npmjs.com/package/postcss-replace) using this config scheme:
+
+```js
+{
+  resolve: 'gatsby-plugin-postcss',
+  options: {
+    postCssPlugins: [
+      require('postcss-replace')({
+        pattern: /#([A-Fa-f0-9]+)/,
+        data: {
+          '007272': '#YOUR_COLOR' // sea-green
+        }
+      })
+    ]
+  }
+}
+```
+
+### Using CSS (vars) Custom Properties
+
+This is for sure a very nice and powerful solution, but lacks Internet Explorer support.

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
@@ -5,6 +5,7 @@ import ToggleGrid from './ToggleGrid'
 import { Context } from '@dnb/eufemia/src/shared'
 import PortalSkeleton from 'dnb-design-system-portal/src/shared/parts/uilib/PortalSkeleton'
 import ChangeLocale from '../../core/ChangeLocale'
+import ChangeStyleTheme from '../../core/ChangeStyleTheme'
 
 export default function PortalToolsMenu({
   className,
@@ -52,6 +53,13 @@ export default function PortalToolsMenu({
           <H2 size="small">Change portal language</H2>
           <Space top>
             <ChangeLocale />
+          </Space>
+        </Space>
+
+        <Space top="large">
+          <H2 size="small">Change style theme</H2>
+          <Space top>
+            <ChangeStyleTheme />
           </Space>
         </Space>
 

--- a/packages/dnb-eufemia/.gitignore
+++ b/packages/dnb-eufemia/.gitignore
@@ -31,6 +31,7 @@
 /docs
 /vue.js
 /index.*
+!index.js
 /lib.js
 /web-components.*
 /web-components

--- a/packages/dnb-eufemia/index.js
+++ b/packages/dnb-eufemia/index.js
@@ -1,0 +1,1 @@
+// Will get replaced during build

--- a/packages/gatsby-plugin-eufemia-theme-handler/.gitignore
+++ b/packages/gatsby-plugin-eufemia-theme-handler/.gitignore
@@ -1,0 +1,1 @@
+load-eufemia-themes.js

--- a/packages/gatsby-plugin-eufemia-theme-handler/LICENSE
+++ b/packages/gatsby-plugin-eufemia-theme-handler/LICENSE
@@ -1,0 +1,37 @@
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License,
+as defined below, subject to the following condition.
+
+Without limiting other conditions in the License,
+the grant of rights under the License will not include,
+and the License does not grant to you,
+the right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any
+or all of the rights granted to you under the License
+to provide to third parties,
+for a fee or other consideration
+(including without limitation fees for hosting
+or consulting/ support services related to the Software),
+a product or service whose value derives,
+entirely or substantially, from the functionality of the Software.
+Any license notice or attribution required by
+the License must also include this
+Commons Cause License Condition notice.
+
+https://commonsclause.com/
+
+Software: DNB Design System (Eufemia)
+License: Apache 2.0 with Commons Clause
+Licensor: DNB Bank ASA, Org nr. 984 851 006
+
+Copyright (c) 2018-present DNB.no, https://www.dnb.no/
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/gatsby-plugin-eufemia-theme-handler/README.md
+++ b/packages/gatsby-plugin-eufemia-theme-handler/README.md
@@ -1,0 +1,72 @@
+# Gatsby Plugin to load Eufemia Themes
+
+This plugin is a easy to use drop-in solution to load different DNB Eufemia Themes. It also support changing a theme in production runtime.
+
+## Features
+
+- The current theme used is stored in the Browsers localStorage under the key `dnb-theme`
+- You can define a theme in the URL (not IE11 supported): `https://eufemia.dnb.no/?dnb-theme=ui`
+- Automatically splits theme styles into separate Webpack chunks, not matter if you have imported them already in your app or not
+- Supports both build an dev mode with fast refresh and hot module replacement
+- Loads only one theme package at a time. When the user switches to another theme, a new CSS theme file will be downloaded.
+
+## How to use
+
+Install `yarn add gatsby-plugin-eufemia-theme-handler` and add it to your `gatsby-config.js` file:
+
+```js
+// gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-eufemia-theme-handler',
+      options: {
+        themes: {
+          ui: { name: 'DNB Eufemia' },
+          eiendom: { name: 'DNB Eiendom' },
+        },
+        defaultTheme: 'ui',
+      },
+    },
+  ]
+}
+```
+
+You can also use the interceptor methods from inside your components:
+
+```js
+// Your React Component
+import {
+  getThemes,
+  getTheme,
+  setTheme,
+} from 'gatsby-plugin-eufemia-theme-handler'
+```
+
+## How it works
+
+Gatsby bundles all styles into one single Webpack chunk (commons.css) and inlines it into every HTML page as inline styles with the attribute `data-identity="gatsby-global-css"`.
+
+What this plugin does is:
+
+- Collect all `dnb-theme` files (`{scss,css}`) – also check if they are located in `/src` or needs to be collected from `/build`. Both are used by the Eufemia repo/portal.
+- After we have collected all available theme files, we create or update a static import `load-eufemia-themes.js`, which is git-ignored.
+- Split theme styles into separate CSS files (Webpack chunks) inside `gatsby-node.js`
+- Inserts some JavaScript in the HTML head in order to handle what theme file should be shown (`inlineScriptProd` and `inlineScriptDev`)
+- Load these inline scripts via Webpack inline module loaders: `!raw-loader!terser-loader!`
+- By using localStorage, we block the HTML rendering, this way we do avoid flickering of a default theme
+
+### In prod
+
+- Leave the default theme style as a separate inline style, but move it after `commons.css` – this is how the styles should be imported in the first place (theme files after all other css packages) – if not, visual tests will fail, as we get wrong CSS specificity
+- Remove all other themes styles to be inlined, but keep track on the CSS files, defined in `data-href`
+- Only set the link href if the current theme is not the default one
+
+### In dev
+
+During dev, we do not get any inline styles from Gatsby – they are handled by Webpack only via the hot module replacement.
+
+- Now, that we have split out the themes styles in separate CSS files `/${key}.css`, we simply need to load them as plain css files via a link with href inside the head element.
+- During runtime, we need to ensure that our link with the id `eufemia-style-theme` is placed after `commons.css`. We do that with `headElement.appendChild(styleElement)`
+- Use `uniqueId` to reload css files as there is not unique build hash, unlike we get during production
+- Use `MutationObserver` to reload the current theme file, because Webpack uses hot module replacement, so we need to reload as well

--- a/packages/gatsby-plugin-eufemia-theme-handler/collectThemes.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/collectThemes.js
@@ -1,0 +1,48 @@
+const path = require('path')
+const fs = require('fs')
+const globby = require('globby')
+
+function createThemesImport(pluginOptions) {
+  const limitThemes = Object.keys(pluginOptions.themes || [])
+  const packageRoot = path.dirname(require.resolve('@dnb/eufemia'))
+  const selector = 'style/themes/**/dnb-theme-*.{scss,css}'
+  const themesFiles = globby
+    .sync([
+      path.join(packageRoot, selector),
+      path.join(packageRoot, '**/' + selector),
+    ])
+    .filter((file) => {
+      return !file.includes('/build/style/')
+    })
+  const themes = themesFiles
+    .map((file) => {
+      const themeName = (file.match(/\/dnb-theme-([^.]*)\./) || [])?.[1]
+      return themeName
+    })
+    .filter((themeName) => {
+      return limitThemes.length === 0 || limitThemes.includes(themeName)
+    })
+  const srcAddition = globalThis.eufemiaThemeImportAddition
+    ? globalThis.eufemiaThemeImportAddition
+    : themesFiles.some((file) => file.includes('/src/'))
+    ? 'src/'
+    : ''
+
+  const imports = themes.map((themeName) => {
+    return `import '@dnb/eufemia/${srcAddition}style/themes/${themeName}'`
+  })
+
+  fs.writeFileSync(
+    path.resolve(__dirname, 'load-eufemia-themes.js'),
+    imports.join('\n')
+  )
+
+  return themes
+}
+
+function defineSrcAddition(srcAddition) {
+  globalThis.eufemiaThemeImportAddition = srcAddition
+}
+
+exports.defineSrcAddition = defineSrcAddition
+exports.createThemesImport = createThemesImport

--- a/packages/gatsby-plugin-eufemia-theme-handler/gatsby-browser.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/gatsby-browser.js
@@ -1,0 +1,1 @@
+import './load-eufemia-themes'

--- a/packages/gatsby-plugin-eufemia-theme-handler/gatsby-node.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/gatsby-node.js
@@ -1,0 +1,54 @@
+/**
+ * Gatsby Node setup
+ *
+ */
+
+const { createThemesImport } = require('./collectThemes')
+
+exports.pluginOptionsSchema = ({ Joi }) => {
+  return Joi.object({
+    themes: Joi.object().required(),
+    defaultTheme: Joi.string().required(),
+  })
+}
+
+exports.onPreBootstrap = (_, pluginOptions) => {
+  // ensure to run this after the main app has run onPreInit
+  createThemesImport(pluginOptions)
+}
+
+exports.onCreateWebpackConfig = (
+  { stage, actions, plugins, getConfig },
+  pluginOptions
+) => {
+  const config = getConfig()
+
+  config.plugins.push(
+    plugins.define({
+      'process.env.EUFEMIA_THEME_defaultTheme': JSON.stringify(
+        pluginOptions.defaultTheme
+      ),
+      'process.env.EUFEMIA_THEME_themes': JSON.stringify(
+        pluginOptions.themes
+      ),
+    })
+  )
+
+  if (stage === 'develop' || stage === 'build-javascript') {
+    config.optimization.splitChunks.cacheGroups.styles = {
+      ...config.optimization.splitChunks.cacheGroups.styles,
+      name(module) {
+        if (module.context.includes('/style/themes/')) {
+          const match = module.context.match(/\/([^/]*)$/)
+          const moduleName = match[1].replace('theme-', '')
+
+          return moduleName
+        }
+
+        return 'commons'
+      },
+    }
+  }
+
+  actions.replaceWebpackConfig(config)
+}

--- a/packages/gatsby-plugin-eufemia-theme-handler/gatsby-ssr.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/gatsby-ssr.js
@@ -1,0 +1,3 @@
+import './load-eufemia-themes'
+
+export { onPreRenderHTML } from './themeHandler'

--- a/packages/gatsby-plugin-eufemia-theme-handler/index.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/index.js
@@ -1,0 +1,1 @@
+export * from './themeHandler'

--- a/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptDev.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptDev.js
@@ -1,0 +1,50 @@
+if (typeof window !== 'undefined') {
+  let uniqueId = ''
+
+  window.__updateEufemiaThemeFileDev = ({
+    styleElement,
+    headElement,
+    theme,
+    reload,
+  }) => {
+    try {
+      if (reload) {
+        uniqueId = '?' + Date.now()
+      }
+      styleElement.setAttribute('href', theme.file + uniqueId)
+
+      const moveAfterCommons = () => {
+        headElement.appendChild(styleElement)
+      }
+      if (document.readyState === 'complete') {
+        moveAfterCommons()
+      } else {
+        window.addEventListener('load', moveAfterCommons)
+      }
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  try {
+    const headElement = document.querySelector('html head')
+    const logMutations = (mutations) => {
+      for (const mutation of mutations) {
+        const element = mutation.nextSibling
+        if (
+          element &&
+          (element.src || element.href || '').includes('/commons.')
+        ) {
+          const themeName = window.__getEufemiaTheme()
+          window.__updateEufemiaThemeFile(themeName, true)
+          break
+        }
+      }
+    }
+
+    const observer = new MutationObserver(logMutations)
+    observer.observe(headElement, { childList: true })
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptProd.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptProd.js
@@ -1,0 +1,62 @@
+if (typeof window !== 'undefined') {
+  window.__updateEufemiaThemeFile = (themeName, reload) => {
+    try {
+      const styleElement = document.getElementById('eufemia-style-theme')
+      const headElement = document.querySelector('html head')
+      const themes = __AVAILABLE_THEMES__
+      const theme = themes[themeName]
+
+      if (
+        (themeName !== __DEFAULT_THEME__ || reload) &&
+        theme &&
+        !theme.isDev
+      ) {
+        styleElement.setAttribute('href', theme.file)
+
+        // Remove existing inline styles
+        const inlineStyleElement = document.querySelector(
+          '[data-href^="' + theme.file + '"]'
+        )
+        if (inlineStyleElement) {
+          headElement.removeChild(inlineStyleElement)
+        }
+        const defaultStyleElement = document.querySelector(
+          '[data-href^="' + themes[__DEFAULT_THEME__].file + '"]'
+        )
+        if (defaultStyleElement) {
+          headElement.removeChild(defaultStyleElement)
+        }
+      }
+
+      if (typeof window.__updateEufemiaThemeFileDev === 'function') {
+        window.__updateEufemiaThemeFileDev({
+          styleElement,
+          headElement,
+          theme,
+          reload,
+        })
+      }
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  window.__getEufemiaTheme = () => {
+    try {
+      const urlParams = new URLSearchParams(window.location.search)
+      const themeName = urlParams.get('dnb-theme')
+      if (themeName) {
+        return themeName
+      }
+    } catch (e) {
+      console.error(e)
+    }
+    try {
+      return window.localStorage.getItem('dnb-theme') || __DEFAULT_THEME__
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  window.__updateEufemiaThemeFile(window.__getEufemiaTheme())
+}

--- a/packages/gatsby-plugin-eufemia-theme-handler/package.json
+++ b/packages/gatsby-plugin-eufemia-theme-handler/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "gatsby-plugin-eufemia-theme-handler",
+  "description": "Gatsby Plugin to handle visual themes for @dnb/eufemia",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "visual theme",
+    "eufemia",
+    "design system",
+    "dnb"
+  ],
+  "license": "SEE LICENSE IN LICENSE FILE",
+  "author": "DNB Team & Tobias Høegh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dnbexperience/eufemia.git"
+  },
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "globby": "11.0.4",
+    "terser-loader": "2.0.2"
+  },
+  "peedDependencies": {
+    "@dnb/eufemia": ">=9",
+    "react": ">=17",
+    "gatsby": ">=3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
@@ -1,0 +1,154 @@
+import React from 'react'
+
+import inlineScriptProd from '!raw-loader!terser-loader!./inlineScriptProd.js'
+import inlineScriptDev from '!raw-loader!terser-loader!./inlineScriptDev.js'
+
+const defaultTheme = process.env.EUFEMIA_THEME_defaultTheme || 'ui'
+const availableThemes = process.env.EUFEMIA_THEME_themes || {}
+const availableThemesArray = Object.keys(availableThemes)
+
+export function getThemes() {
+  return availableThemes
+}
+
+export function isValidTheme(themeName) {
+  return availableThemesArray.includes(themeName)
+}
+
+export function getTheme() {
+  try {
+    const themeName =
+      window.localStorage.getItem('dnb-theme') || defaultTheme
+
+    if (!isValidTheme(themeName)) {
+      console.error('Not valid themeName:', themeName)
+      return defaultTheme // stop here
+    }
+
+    return themeName
+  } catch (e) {
+    console.error(e)
+    return defaultTheme
+  }
+}
+
+export function setTheme(themeName) {
+  if (!isValidTheme(themeName)) {
+    console.error('Not valid themeName:', themeName)
+    return // stop here
+  }
+
+  try {
+    window.__updateEufemiaThemeFile(themeName, true)
+    window.localStorage.setItem('dnb-theme', themeName)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+let cachedHeadComponents = null
+export const onPreRenderHTML = ({
+  getHeadComponents,
+  replaceHeadComponents,
+}) => {
+  let headComponents = getHeadComponents()
+
+  const isDev = process.env.NODE_ENV !== 'production'
+
+  // Make themes to not be embedded, but rather load as css files
+  if (!isDev) {
+    let defaultElement
+    for (const element of headComponents) {
+      if (element.type === 'style' && element.props['data-href']) {
+        if (
+          availableThemesArray.some((name) => {
+            return element.props['data-href'].includes(`/${name}.`)
+          })
+        ) {
+          const themeName = (element.props['data-href'].match(
+            /\/([^.]*)\./
+          ) || [])?.[1]
+
+          // Collect all theme CSS file paths
+          if (availableThemes[themeName]) {
+            availableThemes[themeName].file = element.props['data-href']
+
+            // Store the default inline styles,
+            // and place it below data-href="/commons.*.css"
+            if (themeName === defaultTheme) {
+              defaultElement = element
+              headComponents[element] = null
+            } else {
+              // Remove the inline style
+              // but not when its the default theme
+              delete element.props['data-href']
+              delete element.props['data-identity']
+              delete element.props.dangerouslySetInnerHTML
+            }
+          }
+        }
+      }
+    }
+
+    headComponents.push(defaultElement)
+  } else {
+    for (const key in availableThemes) {
+      availableThemes[key].isDev = true
+      availableThemes[key].file = `/${key}.css` // during dev, we get this file from the Webpack cache (not in /public)
+    }
+  }
+
+  /**
+   * We cache the result of the first page,
+   * and re-use on all other pages.
+   */
+  if (cachedHeadComponents) {
+    headComponents.push(...cachedHeadComponents)
+    replaceHeadComponents(headComponents)
+    return // stop here
+  }
+
+  cachedHeadComponents = []
+
+  cachedHeadComponents.push(
+    <link
+      id="eufemia-style-theme"
+      key="theme-style"
+      rel="stylesheet"
+      type="text/css"
+      as="style"
+    />
+  )
+
+  const replaceGlobalVars = (s) => {
+    return s
+      .replace(/__DEFAULT_THEME__/g, JSON.stringify(defaultTheme))
+      .replace(/__AVAILABLE_THEMES__/g, JSON.stringify(availableThemes))
+  }
+
+  /**
+   * NB: The dev script needs to be placed before the prod!
+   */
+  if (isDev) {
+    cachedHeadComponents.push(
+      <script
+        key="eufemia-style-theme-script-dev"
+        dangerouslySetInnerHTML={{
+          __html: replaceGlobalVars(inlineScriptDev),
+        }}
+      />
+    )
+  }
+
+  cachedHeadComponents.push(
+    <script
+      key="eufemia-style-theme-script-prod"
+      dangerouslySetInnerHTML={{
+        __html: replaceGlobalVars(inlineScriptProd),
+      }}
+    />
+  )
+
+  headComponents.push(...cachedHeadComponents)
+  replaceHeadComponents(headComponents)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15612,6 +15612,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gatsby-plugin-eufemia-theme-handler@workspace:packages/gatsby-plugin-eufemia-theme-handler":
+  version: 0.0.0-use.local
+  resolution: "gatsby-plugin-eufemia-theme-handler@workspace:packages/gatsby-plugin-eufemia-theme-handler"
+  dependencies:
+    globby: 11.0.4
+    terser-loader: 2.0.2
+  languageName: unknown
+  linkType: soft
+
 "gatsby-plugin-gatsby-cloud@npm:4.8.0":
   version: 4.8.0
   resolution: "gatsby-plugin-gatsby-cloud@npm:4.8.0"
@@ -21203,6 +21212,17 @@ __metadata:
     emojis-list: ^3.0.0
     json5: ^1.0.1
   checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  languageName: node
+  linkType: hard
+
+"loader-utils@npm:^2":
+  version: 2.0.2
+  resolution: "loader-utils@npm:2.0.2"
+  dependencies:
+    big.js: ^5.2.2
+    emojis-list: ^3.0.0
+    json5: ^2.1.2
+  checksum: 9078d1ed47cadc57f4c6ddbdb2add324ee7da544cea41de3b7f1128e8108fcd41cd3443a85b7ee8d7d8ac439148aa221922774efe4cf87506d4fb054d5889303
   languageName: node
   linkType: hard
 
@@ -29123,7 +29143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.0, schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+"schema-utils@npm:^3, schema-utils@npm:^3.0, schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
   version: 3.1.1
   resolution: "schema-utils@npm:3.1.1"
   dependencies:
@@ -31323,6 +31343,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"terser-loader@npm:2.0.2":
+  version: 2.0.2
+  resolution: "terser-loader@npm:2.0.2"
+  dependencies:
+    loader-utils: ^2
+    schema-utils: ^3
+    terser: ^5
+  peerDependencies:
+    webpack: ^4 || ^5
+  checksum: 71bec4fe610dcd7f9496ce832cd31002cec682acae744f4e12f6353d95e9052be9952b119dde04306583dc8b0b9a0fa5a3ae886f7ac6a1c65595299f855a19d2
+  languageName: node
+  linkType: hard
+
 "terser-webpack-plugin@npm:^4.2.3":
   version: 4.2.3
   resolution: "terser-webpack-plugin@npm:4.2.3"
@@ -31397,6 +31430,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: f980789097d4f856c1ef4b9a7ada37beb0bb022fb8aa3057968862b5864ad7c244253b3e269c9eb0ab7d0caf97b9521273f2d1cf1e0e942ff0016e0583859c71
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5":
+  version: 5.12.1
+  resolution: "terser@npm:5.12.1"
+  dependencies:
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map: ~0.7.2
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: dd33af5d87a1159bcc38f354707505f1449a33d1491c512e9536f11fea7c3474cdc40e2e5fdf75f58658cfaab8ef47cb7454acd6406b2ce487675cb1978c6275
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes how the portal imports theme styles. Everything is handled via Webpack, where we split out theme CSS files into separate packages and load them as soon as the user selects a different theme. But all logic is separated in a Gatsby Plugin.

Using a different theme is possible today already. This PR is all about letting the user or the app change a theme. 

This solution does not lower the LH score 👍

Future tasks

- This Gatsby plugin can easily be used by applications as well. We may a release of that NPM package.
- Create visual tests for other brand themes. It should be pretty straight forward, as we now can load a certain theme CSS via `https://eufemia.dnb.no/?dnb-theme=ui`

Only Eufemia Portal related; What should we call the default Eufemia DNB theme? In code its called `ui`. Right now its called DNB light. Any better ideas?

<img width="604" alt="Screenshot 2022-03-15 at 11 51 03" src="https://user-images.githubusercontent.com/1501870/158362069-52a9a243-7407-479b-a1af-81b864e8f45b.png">
 