### PR TITLE
docs: improve headers in list summary from pages

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
@@ -54,7 +54,11 @@ const ListSummaryFromDocs = ({ slug, useAsIndex = false }) => {
                     <br />
                   </Li>
                 ) : (
-                  <AutoLinkHeader useSlug={'/' + slug} title={title}>
+                  <AutoLinkHeader
+                    level="2"
+                    useSlug={'/' + slug}
+                    title={title}
+                  >
                     <Anchor href={'/' + slug}>{title}</Anchor>
                   </AutoLinkHeader>
                 )}


### PR DESCRIPTION
Fixes the following warning from the browsers console when running locally:

```
Eufemia Can not decrease to heading level 1! Had before 2 - The new level is 2 
NB: This warning was triggered by:  #
```