### PR TITLE
docs: fix <div> cannot appear as a descendant of <p>

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
@@ -50,7 +50,7 @@ render(<Ul>
 
 ## Ordered Lists (nested)
 
-<ComponentBox hideCode useRender data-visual-test="lists-ol" caption="Nested ol list by using `.dnb-ol--nested`">
+<ComponentBox hideCode useRender data-visual-test="lists-ol" caption="Nested ol list by using '.dnb-ol--nested'">
 {`
 // import { Ol, Li } from '@dnb/eufemia/elements'
 // Instead of using className="dnb-ol", we use Ol (and Li)
@@ -83,7 +83,7 @@ render(<Ol nested>
 
 The list marker will be inside of wrapped text / text with newlines.
 
-<ComponentBox hideCode useRender data-visual-test="lists-ol-style-position" caption="Nested ol with inside modifier `.dnb-ol--inside`">
+<ComponentBox hideCode useRender data-visual-test="lists-ol-style-position" caption="Nested ol with inside modifier '.dnb-ol--inside'">
 {`
 // import { Ol, Li } from '@dnb/eufemia/elements'
 const WidthLimit = styled.div\`


### PR DESCRIPTION
This is an alternative fix for the following warning from the browsers console when running the list docs locally:

```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

Screenshot as well:
![image](https://user-images.githubusercontent.com/1359205/159486253-98a57396-0f59-40f9-9262-4db0f1f22846.png)


I think this fix is "okay", but I don't like that the only way I found of solving this was to include prettier-ignore, as prettier would "format away" the fix if not including prettier-ignore.