### PR TITLE
docs(HTML Elements): Improve heading levels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.md
@@ -5,7 +5,7 @@ title: 'Anchor (Text Link)'
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { IconPrimary } from '@dnb/eufemia/src'
 
-## Anchor (Text Link)
+# Anchor (Text Link)
 
 The Anchor, also knows as `Link` is used to navigate from one page to the next HTML page.
 
@@ -27,7 +27,7 @@ render(<Anchor href="/uilib/elements/anchor">Accessible text</Anchor>)
 </a>
 ```
 
-### Anchor states
+## Anchor states
 
 <ComponentBox>
 {`
@@ -61,7 +61,7 @@ render(<Anchor href="/uilib/elements/anchor">Accessible text</Anchor>)
 `}
 </ComponentBox>
 
-### Additional Anchor helper classes
+## Additional Anchor helper classes
 
 To force a specific state of style, use the following classes to do so:
 
@@ -112,14 +112,14 @@ To force a specific state of style, use the following classes to do so:
 `}
 </ComponentBox>
 
-### Anchor modifiers
+## Anchor modifiers
 
 - `.dnb-anchor--no-animation` <a href="/uilib/elements/anchor" class="dnb-anchor dnb-anchor--no-animation">No Animation</a>
 - `.dnb-anchor--no-style` <a href="/uilib/elements/anchor" class="dnb-anchor dnb-anchor--no-style">No Style</a>
 - `.dnb-anchor--no-hover` <a href="/uilib/elements/anchor" class="dnb-anchor dnb-anchor--no-hover">No Hover</a>
 - `.dnb-anchor--no-underline` <a href="/uilib/elements/anchor" class="dnb-anchor dnb-anchor--no-underline">No Underline</a>
 
-### Anchor with icons
+## Anchor with icons
 
 <ComponentBox hideCode>
 {`
@@ -133,7 +133,7 @@ To force a specific state of style, use the following classes to do so:
 `}
 </ComponentBox>
 
-### Anchor in headings
+## Anchor in headings
 
 <ComponentBox hideCode>
 {`
@@ -150,7 +150,7 @@ To force a specific state of style, use the following classes to do so:
 `}
 </ComponentBox>
 
-### Customize blank target graphic
+## Customize blank target graphic
 
 You may use a [tool like this url-encoder](https://yoksel.github.io/url-encoder/) to **url-encode** your SVG.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.md
@@ -4,9 +4,9 @@ title: 'Blockquote'
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-## Blockquote
+# Blockquote
 
-### Default Blockquote
+## Default Blockquote
 
 <ComponentBox hideCode>
 {`
@@ -17,7 +17,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 `}
 </ComponentBox>
 
-### Blockquote with graphics on top
+## Blockquote with graphics on top
 
 <ComponentBox hideCode>
 {`
@@ -30,7 +30,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 `}
 </ComponentBox>
 
-### Blockquote with transparent background (`no-background`)
+## Blockquote with transparent background (`no-background`)
 
 <ComponentBox hideCode>
 {`
@@ -46,7 +46,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 `}
 </ComponentBox>
 
-### Blockquote with transparent background and graphics on top
+## Blockquote with transparent background and graphics on top
 
 <ComponentBox hideCode>
 {`

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.md
@@ -2,9 +2,9 @@
 title: 'Code'
 ---
 
-## Code
+# Code
 
-### Code and Syntax highlighting
+## Code and Syntax highlighting
 
 [Prism](https://prismjs.com) is a popular Syntax Highlighting tool. DNB has its own **theme** You can use:
 
@@ -12,7 +12,7 @@ title: 'Code'
 
 You find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/theme-ui/prism/dnb-prism-theme.js).
 
-### Code and Pre Tag usage
+## Code and Pre Tag usage
 
 Styling for both the `<code>` and the `<pre>` tags are build in the `@dnb/eufemia`.
 
@@ -28,7 +28,7 @@ So simply use them for your code syntax:
 </pre>
 ```
 
-#### Code and Typography
+### Code and Typography
 
 When you use `<code>` or `<pre>` – the DNB _DNBMono_ font is used, like so:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule.md
@@ -6,7 +6,7 @@ redirect_from:
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-## Horizontal Rule
+# Horizontal Rule
 
 The `<hr />` tag in HTML stands for horizontal rule and is used to insert a horizontal rule or a thematic break in an HTML page to divide or separate document sections. The `<hr />` tag is an empty tag and it does not require an end tag.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/image.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/image.md
@@ -4,7 +4,7 @@ title: 'Image'
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-## Image
+# Image
 
 The image element associated with the class `dnb-img` does not have much opinionated styling. It exists more to have a future possibility to optimize and add features.
 
@@ -16,7 +16,7 @@ import { Img } from '@dnb/eufemia/elements'
 render(<InlineImg alt="..." src="..." width="100" height="100" />)
 ```
 
-### Basic image element
+## Basic image element
 
 <ComponentBox data-visual-test="image-plain" useRender hideCode>
 {`
@@ -37,7 +37,7 @@ render(<CustomImage />)
 `}
 </ComponentBox>
 
-### Image with invalid source
+## Image with invalid source
 
 <ComponentBox data-visual-test="image-no-source" useRender hideCode>
 {`
@@ -53,7 +53,7 @@ render(
 `}
 </ComponentBox>
 
-### Image with caption
+## Image with caption
 
 <ComponentBox data-visual-test="image-caption" useRender hideCode>
 {`
@@ -75,7 +75,7 @@ render(<CustomImage />)
 `}
 </ComponentBox>
 
-### Image element with skeleton
+## Image element with skeleton
 
 <ComponentBox data-visual-test="image-skeleton" useRender>
 {`

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.md
@@ -4,9 +4,9 @@ title: 'Lists'
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-## Lists
+# Lists
 
-### List modifiers
+## List modifiers
 
 - `.dnb-ul--nested` / `.dnb-ol--nested` will ensure a nested structure of several lists
 - `.dnb-ol--outside` (default) defines the position of the marker
@@ -24,7 +24,7 @@ render(
 )
 ```
 
-### Unordered Lists
+## Unordered Lists
 
 <ComponentBox hideCode useRender data-visual-test="lists-ul">
 {`
@@ -48,7 +48,7 @@ render(<Ul>
 `}
 </ComponentBox>
 
-### Ordered Lists (nested)
+## Ordered Lists (nested)
 
 <ComponentBox hideCode useRender data-visual-test="lists-ol" caption="Nested ol list by using `.dnb-ol--nested`">
 {`
@@ -79,7 +79,7 @@ render(<Ol nested>
 `}
 </ComponentBox>
 
-#### Ordered list style position (outside vs inside)
+### Ordered list style position (outside vs inside)
 
 The list marker will be inside of wrapped text / text with newlines.
 
@@ -117,7 +117,7 @@ render(<WidthLimit>
 `}
 </ComponentBox>
 
-#### Ordered list with other types
+### Ordered list with other types
 
 Ordered lists do support natively other types, like _letters_ and _roman numerals_. You can define that by using the `type` HTML attribute.
 
@@ -142,7 +142,7 @@ Ordered lists do support natively other types, like _letters_ and _roman numeral
 `}
 </ComponentBox>
 
-### Definition Lists
+## Definition Lists
 
 Use Definition Lists when ever you have to tie together any items that have a direct relationship with each other (name/value sets).
 
@@ -170,7 +170,7 @@ render(<Dl>
 `}
 </ComponentBox>
 
-### Remove list styles
+## Remove list styles
 
 <ComponentBox hideCode data-visual-test="lists-reset">
 {`

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
@@ -1,6 +1,6 @@
 import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
 
-## Missing HTML Elements
+# Missing HTML Elements
 
 Not every commonly used HTML Elements are included yet in the `@dnb/eufemia`. This decision is made by the DNB UX Team and relies on a principle to make UX design as good as possible, consistent and more thoughtful towards a broader customer target.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/tables.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/tables.md
@@ -7,17 +7,17 @@ import { css, Global } from '@emotion/react'
 
 <Global styles={css`body{ .dnb-app-content { overflow: visible; } }`} />
 
-## Tables
+# Tables
 
 The following table has a default style. But in future, there will be several extensions and styles to choose from.
 
 You may consider using `table-layout: fixed;`. You can use the modifier class in doing so: `.dnb-table--fixed`
 
-### Working Demo
+## Working Demo
 
 Check out a [working example on CodeSandbox](https://codesandbox.io/embed/eufemia-react-table-x4cwc), using `react-table`.
 
-### Classes
+## Classes
 
 **NB:** Tables get their default table style by only having correct markup and the **`.dnb-table`** class assigned.
 
@@ -80,7 +80,7 @@ To enhance or manipulate the the table style, you can make use of a couple helpe
 `}
 </ComponentBox>
 
-### Default Table style
+## Default Table style
 
 <ComponentBox hideCode data-visual-test="table-default">
 {`
@@ -142,7 +142,7 @@ To enhance or manipulate the the table style, you can make use of a couple helpe
 `}
 </ComponentBox>
 
-### Table with sticky header
+## Table with sticky header
 
 **NB:** Keep in mind, you have to avoid using `overflow: hidden;` on any child elements to get `position: sticky;` to work. This is a know issue happening on every modern browser. There are various tricks, including [this deallocation / sync solution](https://uxdesign.cc/position-stuck-96c9f55d9526).
 
@@ -213,7 +213,7 @@ To enhance or manipulate the the table style, you can make use of a couple helpe
 `}
 </ComponentBox>
 
-### Table with long header text (wrapping)
+## Table with long header text (wrapping)
 
 Also, the table header is set to **small** font-size.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
@@ -1,6 +1,6 @@
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-## Unstyled HTML Elements
+# Unstyled HTML Elements
 
 In order to use the inherited [Skeleton](/uilib/components/skeleton), there are a number of un-styled HTML elements, that do inherit and react to the Skeleton Provider.
 
@@ -11,7 +11,7 @@ import { Span, Div } from '@dnb/eufemia/elements'
 - `Span`
 - `Div`
 
-### Example usage of span
+## Example usage of span
 
 <ComponentBox data-visual-test="span-skeleton" useRender>
 {`


### PR DESCRIPTION
Fixes the following warning from the browsers console when running locally:

```
Eufemia Can not decrease to heading level 1! Had before 2 - The new level is 2 
NB: This warning was triggered by:  #
```