### PR TITLE
fix(VisuallyHidden): use span as default element so it can be used inside paragraphs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/properties.md
@@ -6,9 +6,9 @@ showTabs: true
 
 ### `VisuallyHidden` properties
 
-| Properties                                  | Description                                                                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `children`                                  | _(optional)_ The content you want to be visually hidden.It can be a `string` or a `React Element`.                                                                                |
-| `className`                                 | _(optional)_ Custom className for the component root.                                                                                                  |
-| `element`                                   | _(optional)_ Custom root HTML element for the component. Defaults to `<div>`                                                                                                  |
-| `focusable`                                 | _(optional)_ Set to `true` to hide an element by default, but to display it when it’s focused (e.g. by a keyboard-only user) root. Defaults to false                                                                                                 |
+| Properties  | Description                                                                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`  | _(optional)_ The content you want to be visually hidden.It can be a `string` or a `React Element`.                                                   |
+| `className` | _(optional)_ Custom className for the component root.                                                                                                |
+| `element`   | _(optional)_ Custom root HTML element for the component. Defaults to `<span>`                                                                        |
+| `focusable` | _(optional)_ Set to `true` to hide an element by default, but to display it when it’s focused (e.g. by a keyboard-only user) root. Defaults to false |

--- a/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
@@ -26,7 +26,7 @@ export interface VisuallyHiddenProps {
 
   /**
    * Root element of the component
-   * Default: div
+   * Default: span
    */
   element?: string | React.ReactNode
 }
@@ -35,7 +35,7 @@ export const defaultProps = {
   className: null,
   children: null,
   focusable: false,
-  element: 'div',
+  element: 'span',
 }
 
 const VisuallyHidden = (localProps: VisuallyHiddenProps) => {

--- a/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
@@ -48,11 +48,16 @@ describe('VisuallyHidden', () => {
     )
   })
 
-  it('renders with custom HTML element', () => {
-    render(<VisuallyHidden element="span">Span</VisuallyHidden>)
+  it('renders with span as the default element', () => {
+    render(<VisuallyHidden>I'm a span</VisuallyHidden>)
     expect(document.querySelector('span') instanceof HTMLElement).toBe(
       true
     )
+  })
+
+  it('renders with custom HTML element', () => {
+    render(<VisuallyHidden element="div">I'm a div</VisuallyHidden>)
+    expect(document.querySelector('div') instanceof HTMLElement).toBe(true)
   })
 
   it('renders with provider', () => {

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
@@ -201,7 +201,9 @@ describe('"warn" should', () => {
     jest.resetAllMocks()
   })
 
-  it('run console.log with several messages', () => {
+  it('run console.log in development', () => {
+    const env = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
     warn('message-1', 'message-2')
 
     expect(global.console.log).toHaveBeenCalledTimes(1)
@@ -211,6 +213,24 @@ describe('"warn" should', () => {
       'message-1',
       'message-2'
     )
+
+    process.env.NODE_ENV = env
+  })
+
+  it('run console.log in test', () => {
+    const env = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
+
+    warn('message-1', 'message-2')
+
+    expect(global.console.log).toHaveBeenCalledTimes(1)
+    expect(global.console.log).toHaveBeenCalledWith(
+      '\u001b[0m\u001b[1m\u001b[38;5;23m\u001b[48;5;152mEufemia\u001b[49m\u001b[39m\u001b[22m\u001b[0m',
+      'message-1',
+      'message-2'
+    )
+
+    process.env.NODE_ENV = env
   })
 
   it('run not log if NODE_ENV is production', () => {

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -434,7 +434,8 @@ export const warn = (...params) => {
     typeof console !== 'undefined' &&
     typeof console.log === 'function'
   ) {
-    const isBrowser = typeof window !== 'undefined'
+    const isBrowser =
+      typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
 
     if (isBrowser) {
       const styles = [
@@ -445,7 +446,11 @@ export const warn = (...params) => {
       ].join(';')
       console.log('%cEufemia', styles, ...params)
     } else {
-      console.log('Eufemia:', ...params)
+      console.log(
+        // How to generate it: JSON.stringify(chalk.reset.bold.hex('#00343E').bgHex('#A5E1D2')('Eufemia'))
+        '\u001b[0m\u001b[1m\u001b[38;5;23m\u001b[48;5;152mEufemia\u001b[49m\u001b[39m\u001b[22m\u001b[0m',
+        ...params
+      )
     }
   }
 }


### PR DESCRIPTION
I think, because `VisuallyHidden` will mostly be used for text messages primarily, we should use span as the default element. Typically when used inside a paragraph, we have to use a span, and not a div. Now, it also can be used inside a heading too.