### PR TITLE
fix: remove alignment helper from a11y tree

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1802,6 +1802,7 @@ class AutocompleteInstance extends React.PureComponent {
       onSubmit: this.toggleVisible,
       'aria-haspopup': 'listbox',
       'aria-expanded': isExpanded,
+      'aria-label': !hidden ? submit_button_title : undefined,
       tooltip: hidden ? submit_button_title : null,
       className: opened ? 'dnb-button--active' : null,
     }

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -490,6 +490,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                   <ForwardRef
                     aria-expanded={true}
                     aria-haspopup="listbox"
+                    aria-label="submit_button_title"
                     className="dnb-button--active"
                     disabled="disabled"
                     icon="submit_button_icon"
@@ -606,6 +607,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                         <ForwardRef
                           aria-expanded={true}
                           aria-haspopup="listbox"
+                          aria-label="submit_button_title"
                           className="dnb-button--active"
                           disabled="disabled"
                           icon="submit_button_icon"
@@ -622,6 +624,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                           <InputSubmitButton
                             aria-expanded={true}
                             aria-haspopup="listbox"
+                            aria-label="submit_button_title"
                             className="dnb-button--active"
                             disabled="disabled"
                             icon="submit_button_icon"
@@ -651,6 +654,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                               <Button
                                 aria-expanded={true}
                                 aria-haspopup="listbox"
+                                aria-label="submit_button_title"
                                 bounding={null}
                                 class={null}
                                 className="dnb-input__submit-button__button dnb-button--input-button dnb-button--active"
@@ -691,6 +695,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                                 <button
                                   aria-expanded={true}
                                   aria-haspopup="listbox"
+                                  aria-label="submit_button_title"
                                   className="dnb-button dnb-button--secondary dnb-input__submit-button__button dnb-button--input-button dnb-button--active dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-icon_size dnb-button--size-medium"
                                   disabled={false}
                                   id="autocomplete-id-submit-button"
@@ -704,6 +709,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                                   <Content
                                     aria-expanded={true}
                                     aria-haspopup="listbox"
+                                    aria-label="submit_button_title"
                                     bounding={null}
                                     class={null}
                                     className="dnb-input__submit-button__button dnb-button--input-button dnb-button--active"
@@ -744,8 +750,9 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                                     wrap={null}
                                   >
                                     <span
+                                      aria-hidden={true}
                                       className="dnb-button__alignment"
-                                      key="button-text-empty"
+                                      key="button-alignment"
                                     >
                                       ‌
                                     </span>

--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -405,7 +405,11 @@ function Content({
 
       {content && (
         <>
-          <span key="button-text-empty" className="dnb-button__alignment">
+          <span
+            key="button-alignment"
+            className="dnb-button__alignment"
+            aria-hidden
+          >
             &zwnj;
           </span>
           <span
@@ -422,7 +426,11 @@ function Content({
         // so the icon button gets vertical aligned
         // we need the dnb-button__text for alignment
         !content && icon && (
-          <span key="button-text-empty" className="dnb-button__alignment">
+          <span
+            key="button-alignment"
+            className="dnb-button__alignment"
+            aria-hidden
+          >
             &zwnj;
           </span>
         )

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.js
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.js
@@ -144,6 +144,25 @@ describe('Button component', () => {
     )
   })
 
+  it('has alignment helper with aria-hidden', () => {
+    const Comp = mount(<Component text="Button" />)
+    expect(
+      Comp.find('.dnb-button__alignment')
+        .instance()
+        .getAttribute('aria-hidden')
+    ).toBe('true')
+    expect(Comp.find('.dnb-button__text').text()).toBe('Button')
+
+    Comp.setProps({ text: undefined, icon: 'bell' })
+
+    expect(
+      Comp.find('.dnb-button__alignment')
+        .instance()
+        .getAttribute('aria-hidden')
+    ).toBe('true')
+    expect(Comp.exists('.dnb-button__text')).toBe(false)
+  })
+
   it('should validate with ARIA rules as a button', async () => {
     const Comp = mount(<Component {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
@@ -25,6 +25,7 @@ exports[`Button component have to match default button snapshot 1`] = `
         type="type"
       >
         <span
+          aria-hidden="true"
           class="dnb-button__alignment"
         >
           ‌
@@ -68,6 +69,7 @@ exports[`Button component have to match default button snapshot 1`] = `
         type="type"
       >
         <span
+          aria-hidden="true"
           class="dnb-button__alignment"
         >
           ‌
@@ -151,6 +153,7 @@ exports[`Button component have to match default button snapshot 1`] = `
             type="type"
           >
             <span
+              aria-hidden="true"
               class="dnb-button__alignment"
             >
               ‌
@@ -194,6 +197,7 @@ exports[`Button component have to match default button snapshot 1`] = `
             type="type"
           >
             <span
+              aria-hidden="true"
               class="dnb-button__alignment"
             >
               ‌
@@ -246,8 +250,9 @@ exports[`Button component have to match default button snapshot 1`] = `
       wrap="wrap"
     >
       <span
+        aria-hidden={true}
         className="dnb-button__alignment"
-        key="button-text-empty"
+        key="button-alignment"
       >
         ‌
       </span>
@@ -354,6 +359,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
         type="type"
       >
         <span
+          aria-hidden="true"
           class="dnb-button__alignment"
         >
           ‌
@@ -398,6 +404,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
         type="type"
       >
         <span
+          aria-hidden="true"
           class="dnb-button__alignment"
         >
           ‌
@@ -479,6 +486,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
             type="type"
           >
             <span
+              aria-hidden="true"
               class="dnb-button__alignment"
             >
               ‌
@@ -539,6 +547,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
               type="type"
             >
               <span
+                aria-hidden="true"
                 class="dnb-button__alignment"
               >
                 ‌
@@ -601,6 +610,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                 type="type"
               >
                 <span
+                  aria-hidden="true"
                   class="dnb-button__alignment"
                 >
                   ‌
@@ -681,6 +691,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                     type="type"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -725,6 +736,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                     type="type"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -777,8 +789,9 @@ exports[`Button component have to match href="..." snapshot 1`] = `
               wrap="wrap"
             >
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -385,6 +385,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -1398,6 +1399,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -1468,6 +1470,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                         type="button"
                                       >
                                         <span
+                                          aria-hidden="true"
                                           class="dnb-button__alignment"
                                         >
                                           ‌
@@ -1553,6 +1556,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                             type="button"
                                           >
                                             <span
+                                              aria-hidden="true"
                                               class="dnb-button__alignment"
                                             >
                                               ‌
@@ -1601,8 +1605,9 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                       wrap={null}
                                     >
                                       <span
+                                        aria-hidden={true}
                                         className="dnb-button__alignment"
-                                        key="button-text-empty"
+                                        key="button-alignment"
                                       >
                                         ‌
                                       </span>

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -148,6 +148,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               type="button"
             >
               <span
+                aria-hidden="true"
                 class="dnb-button__alignment"
               >
                 ‌
@@ -212,6 +213,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 type="button"
               >
                 <span
+                  aria-hidden="true"
                   class="dnb-button__alignment"
                 >
                   ‌
@@ -299,6 +301,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -348,8 +351,9 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               wrap={null}
             >
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>
@@ -447,6 +451,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -511,6 +516,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -551,6 +557,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -616,6 +623,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -655,6 +663,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -885,6 +894,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                                       type="button"
                                     >
                                       <span
+                                        aria-hidden="true"
                                         class="dnb-button__alignment"
                                       >
                                         ‌
@@ -1015,8 +1025,9 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                                         wrap={null}
                                       >
                                         <span
+                                          aria-hidden={true}
                                           className="dnb-button__alignment"
-                                          key="button-text-empty"
+                                          key="button-alignment"
                                         >
                                           ‌
                                         </span>

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -146,6 +146,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               type="button"
             >
               <span
+                aria-hidden="true"
                 class="dnb-button__alignment"
               >
                 ‌
@@ -210,6 +211,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 type="button"
               >
                 <span
+                  aria-hidden="true"
                   class="dnb-button__alignment"
                 >
                   ‌
@@ -297,6 +299,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -346,8 +349,9 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               wrap={null}
             >
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>
@@ -445,6 +449,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -509,6 +514,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -549,6 +555,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -614,6 +621,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -653,6 +661,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -882,6 +891,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                                       type="button"
                                     >
                                       <span
+                                        aria-hidden="true"
                                         class="dnb-button__alignment"
                                       >
                                         ‌
@@ -1012,8 +1022,9 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                                         wrap={null}
                                       >
                                         <span
+                                          aria-hidden={true}
                                           className="dnb-button__alignment"
-                                          key="button-text-empty"
+                                          key="button-alignment"
                                         >
                                           ‌
                                         </span>

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
@@ -767,6 +767,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                   href="href"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -821,6 +822,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                     href="href"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -877,6 +879,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                       href="href"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -962,8 +965,9 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                     wrap={null}
                   >
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
@@ -1074,8 +1074,9 @@ exports[`GlobalStatus snapshot have to match component snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1443,8 +1444,9 @@ Array [
                         wrap={null}
                       >
                         <span
+                          aria-hidden={true}
                           className="dnb-button__alignment"
-                          key="button-text-empty"
+                          key="button-alignment"
                         >
                           ‌
                         </span>

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.js.snap
@@ -98,8 +98,9 @@ exports[`HelpButton component have to match snapshot 1`] = `
           wrap={null}
         >
           <span
+            aria-hidden={true}
             className="dnb-button__alignment"
-            key="button-text-empty"
+            key="button-alignment"
           >
             ‌
           </span>

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
@@ -419,8 +419,9 @@ exports[`Input component have to match type="search" snapshot 1`] = `
                     wrap={null}
                   >
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/InputPassword.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/InputPassword.test.js.snap
@@ -349,8 +349,9 @@ exports[`InputPassword component have to match snapshot 1`] = `
                         wrap={null}
                       >
                         <span
+                          aria-hidden={true}
                           className="dnb-button__alignment"
-                          key="button-text-empty"
+                          key="button-alignment"
                         >
                           ‌
                         </span>

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`Modal component have to match snapshot 1`] = `
             type="button"
           >
             <span
+              aria-hidden="true"
               class="dnb-button__alignment"
             >
               ‌
@@ -201,6 +202,7 @@ exports[`Modal component have to match snapshot 1`] = `
               type="button"
             >
               <span
+                aria-hidden="true"
                 class="dnb-button__alignment"
               >
                 ‌
@@ -288,6 +290,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -337,8 +340,9 @@ exports[`Modal component have to match snapshot 1`] = `
             wrap={null}
           >
             <span
+              aria-hidden={true}
               className="dnb-button__alignment"
-              key="button-text-empty"
+              key="button-alignment"
             >
               ‌
             </span>
@@ -436,6 +440,7 @@ exports[`Modal component have to match snapshot 1`] = `
                 type="button"
               >
                 <span
+                  aria-hidden="true"
                   class="dnb-button__alignment"
                 >
                   ‌
@@ -500,6 +505,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -540,6 +546,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -605,6 +612,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -644,6 +652,7 @@ exports[`Modal component have to match snapshot 1`] = `
                     type="button"
                   >
                     <span
+                      aria-hidden="true"
                       class="dnb-button__alignment"
                     >
                       ‌
@@ -901,6 +910,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -1031,8 +1041,9 @@ exports[`Modal component have to match snapshot 1`] = `
                                       wrap={null}
                                     >
                                       <span
+                                        aria-hidden={true}
                                         className="dnb-button__alignment"
-                                        key="button-text-empty"
+                                        key="button-alignment"
                                       >
                                         ‌
                                       </span>

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -848,8 +848,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1005,8 +1006,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1170,8 +1172,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1290,8 +1293,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1409,8 +1413,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>
@@ -1528,8 +1533,9 @@ exports[`Pagination bar have to match snapshot 1`] = `
                       wrap={null}
                     >
                       <span
+                        aria-hidden={true}
                         className="dnb-button__alignment"
-                        key="button-text-empty"
+                        key="button-alignment"
                       >
                         ‌
                       </span>

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Article.js
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Article.js
@@ -64,6 +64,7 @@ export default class SkeletonArticle extends React.PureComponent {
             'dnb-skeleton--shape',
             'dnb-space__bottom--large'
           )}
+          aria-hidden
           style={{
             width: '50%',
           }}

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Circle.js
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Circle.js
@@ -64,6 +64,7 @@ export default class SkeletonCircle extends React.PureComponent {
             'dnb-skeleton--shape',
             'dnb-space__bottom--large'
           )}
+          aria-hidden
           style={{
             width: '50%',
           }}

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Product.js
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Product.js
@@ -64,6 +64,7 @@ export default class SkeletonProduct extends React.PureComponent {
             'dnb-skeleton--shape',
             'dnb-space__bottom--large'
           )}
+          aria-hidden
           style={{
             width: '50%',
           }}

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Table.js
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Table.js
@@ -64,6 +64,7 @@ export default class SkeletonTable extends React.PureComponent {
             'dnb-skeleton--shape',
             'dnb-space__bottom--large'
           )}
+          aria-hidden
           style={{
             width: '50%',
           }}

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.js.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.js.snap
@@ -181,8 +181,9 @@ exports[`Slider component have to match snapshot 1`] = `
               wrap={null}
             >
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>
@@ -494,8 +495,9 @@ exports[`Slider component have to match snapshot 1`] = `
               wrap={null}
             >
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
@@ -110,6 +110,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -179,6 +180,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -247,6 +249,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -315,6 +318,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -423,6 +427,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -505,6 +510,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -617,6 +623,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -689,8 +696,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -843,6 +851,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -925,6 +934,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -1037,6 +1047,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -1109,8 +1120,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -1262,6 +1274,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -1344,6 +1357,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -1456,6 +1470,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -1528,8 +1543,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -1681,6 +1697,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -1763,6 +1780,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -1875,6 +1893,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -1947,8 +1966,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -2174,6 +2194,7 @@ Array [
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -2290,6 +2311,7 @@ Array [
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -2403,6 +2425,7 @@ Array [
                           type="button"
                         >
                           <span
+                            aria-hidden="true"
                             class="dnb-button__alignment"
                           >
                             ‌
@@ -2475,8 +2498,9 @@ Array [
                     wrap={true}
                   >
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>
@@ -2807,6 +2831,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -2875,6 +2900,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -2942,6 +2968,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -3009,6 +3036,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -3117,6 +3145,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -3198,6 +3227,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -3306,6 +3336,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -3377,8 +3408,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -3531,6 +3563,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -3612,6 +3645,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -3720,6 +3754,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -3791,8 +3826,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -3944,6 +3980,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -4025,6 +4062,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -4133,6 +4171,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -4204,8 +4243,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -4357,6 +4397,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -4438,6 +4479,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -4546,6 +4588,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -4617,8 +4660,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -4844,6 +4888,7 @@ Array [
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -4960,6 +5005,7 @@ Array [
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -5073,6 +5119,7 @@ Array [
                           type="button"
                         >
                           <span
+                            aria-hidden="true"
                             class="dnb-button__alignment"
                           >
                             ‌
@@ -5145,8 +5192,9 @@ Array [
                     wrap={true}
                   >
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>
@@ -5478,6 +5526,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -5547,6 +5596,7 @@ Array [
                         type="button"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -5614,6 +5664,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -5681,6 +5732,7 @@ Array [
                         class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                       >
                         <span
+                          aria-hidden="true"
                           class="dnb-button__alignment"
                         >
                           ‌
@@ -5789,6 +5841,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -5871,6 +5924,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -5983,6 +6037,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -6055,8 +6110,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -6209,6 +6265,7 @@ Array [
                               type="button"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -6291,6 +6348,7 @@ Array [
                                 type="button"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -6403,6 +6461,7 @@ Array [
                                     type="button"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -6475,8 +6534,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -6628,6 +6688,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -6709,6 +6770,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -6817,6 +6879,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -6888,8 +6951,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -7041,6 +7105,7 @@ Array [
                               class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                             >
                               <span
+                                aria-hidden="true"
                                 class="dnb-button__alignment"
                               >
                                 ‌
@@ -7122,6 +7187,7 @@ Array [
                                 class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                               >
                                 <span
+                                  aria-hidden="true"
                                   class="dnb-button__alignment"
                                 >
                                   ‌
@@ -7230,6 +7296,7 @@ Array [
                                     class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-medium dnb-button--stretch dnb-button--wrap"
                                   >
                                     <span
+                                      aria-hidden="true"
                                       class="dnb-button__alignment"
                                     >
                                       ‌
@@ -7301,8 +7368,9 @@ Array [
                               wrap={true}
                             >
                               <span
+                                aria-hidden={true}
                                 className="dnb-button__alignment"
-                                key="button-text-empty"
+                                key="button-alignment"
                               >
                                 ‌
                               </span>
@@ -7528,6 +7596,7 @@ Array [
                   type="button"
                 >
                   <span
+                    aria-hidden="true"
                     class="dnb-button__alignment"
                   >
                     ‌
@@ -7644,6 +7713,7 @@ Array [
                       type="button"
                     >
                       <span
+                        aria-hidden="true"
                         class="dnb-button__alignment"
                       >
                         ‌
@@ -7757,6 +7827,7 @@ Array [
                           type="button"
                         >
                           <span
+                            aria-hidden="true"
                             class="dnb-button__alignment"
                           >
                             ‌
@@ -7829,8 +7900,9 @@ Array [
                     wrap={true}
                   >
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -146,8 +146,9 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                       key="button-bounding"
                     />
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>
@@ -423,8 +424,9 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                       key="button-bounding"
                     />
                     <span
+                      aria-hidden={true}
                       className="dnb-button__alignment"
-                      key="button-text-empty"
+                      key="button-alignment"
                     >
                       ‌
                     </span>
@@ -732,8 +734,9 @@ exports[`Tabs component have to match snapshot 1`] = `
                     key="button-bounding"
                   />
                   <span
+                    aria-hidden={true}
                     className="dnb-button__alignment"
-                    key="button-text-empty"
+                    key="button-alignment"
                   >
                     ‌
                   </span>
@@ -1009,8 +1012,9 @@ exports[`Tabs component have to match snapshot 1`] = `
                     key="button-bounding"
                   />
                   <span
+                    aria-hidden={true}
                     className="dnb-button__alignment"
-                    key="button-text-empty"
+                    key="button-alignment"
                   >
                     ‌
                   </span>

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -125,7 +125,9 @@ const TimelineItem = (localProps: TimelineItemProps) => {
         className="dnb-timeline__item__label__icon"
         data-testid="timeline-item-label-icon"
       >
-        <span key="icon-alignment">&zwnj;</span>
+        <span key="icon-alignment" aria-hidden>
+          &zwnj;
+        </span>
         {!skeleton && currentIcon && (
           <Icon
             icon={currentIcon}

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -378,8 +378,9 @@ exports[`ToggleButton component have to match snapshot 1`] = `
                 </Checkbox>
               </span>
               <span
+                aria-hidden={true}
                 className="dnb-button__alignment"
-                key="button-text-empty"
+                key="button-alignment"
               >
                 ‌
               </span>
@@ -967,8 +968,9 @@ exports[`ToggleButton group component have to match group snapshot 1`] = `
                                   </Radio>
                                 </span>
                                 <span
+                                  aria-hidden={true}
                                   className="dnb-button__alignment"
-                                  key="button-text-empty"
+                                  key="button-alignment"
                                 >
                                   ‌
                                 </span>
@@ -1349,8 +1351,9 @@ exports[`ToggleButton group component have to match group snapshot 1`] = `
                                   </Radio>
                                 </span>
                                 <span
+                                  aria-hidden={true}
                                   className="dnb-button__alignment"
-                                  key="button-text-empty"
+                                  key="button-alignment"
                                 >
                                   ‌
                                 </span>

--- a/packages/dnb-eufemia/src/shared/AlignmentHelper.js
+++ b/packages/dnb-eufemia/src/shared/AlignmentHelper.js
@@ -1,5 +1,7 @@
 /**
- * Spacing helper
+ * Alignment helper
+ *
+ * This helper element provides needed help when it comes to HTML inline alignment (vertically)
  *
  */
 
@@ -7,7 +9,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-// We use the w tag so NVDA not our after with content: '\00A0' as blank
 export default function AlignmentHelper({
   className,
   children,


### PR DESCRIPTION
As this alignment helper only is of visual interest, we want it to hide from the accessibility tree. NVDA & Firefox did report it. None of the other screen reader & browsers did. But we should anyway remove it. 