### PR TITLE
docs(HTML Elements): Removes docs for elements in HTML elements overview docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements.md
@@ -9,20 +9,13 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Link } from '@dnb/eufemia/src/elements'
 import NotSupportedElements from 'Docs/uilib/elements/not-supported'
 import UnstyledElementsDemos from 'Docs/uilib/elements/unstyled'
-import AnchorDemos from 'Docs/uilib/elements/anchor'
-import BlockquoteDemos from 'Docs/uilib/elements/blockquote'
-import TablesDemos from 'Docs/uilib/elements/tables'
-import ListsDemos from 'Docs/uilib/elements/lists'
-import ImageDemos from 'Docs/uilib/elements/image'
-import HrDemos from 'Docs/uilib/elements/horizontal-rule'
-import CodeDemos from 'Docs/uilib/elements/code'
 import ListSummaryFromPages from 'dnb-design-system-portal/src/shared/parts/ListSummaryFromPages'
 
 # HTML Elements
 
 The `@dnb/eufemia` contains styling for the most commonly used [HTML Elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) defined by the UX team at DNB. You may also have a look at [Typography](/uilib/typography) for headings and paragraph usage.
 
-## Overview
+## Elements
 
 <ListSummaryFromPages useAsIndex slug="uilib/elements/" />
 
@@ -69,14 +62,7 @@ render(<StyledLink href="/" target="_blank">Styled Link</StyledLink>)
 `}
 </ComponentBox>
 
-<AnchorDemos />
-<ListsDemos />
-<TablesDemos />
-<BlockquoteDemos />
-<ImageDemos />
-<HrDemos />
 <UnstyledElementsDemos />
-<CodeDemos />
 
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/not-supported.md
@@ -1,6 +1,6 @@
 import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
 
-# Missing HTML Elements
+## Missing HTML Elements
 
 Not every commonly used HTML Elements are included yet in the `@dnb/eufemia`. This decision is made by the DNB UX Team and relies on a principle to make UX design as good as possible, consistent and more thoughtful towards a broader customer target.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/unstyled.md
@@ -1,6 +1,6 @@
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-# Unstyled HTML Elements
+## Unstyled HTML Elements
 
 In order to use the inherited [Skeleton](/uilib/components/skeleton), there are a number of un-styled HTML elements, that do inherit and react to the Skeleton Provider.
 
@@ -11,7 +11,7 @@ import { Span, Div } from '@dnb/eufemia/elements'
 - `Span`
 - `Div`
 
-## Example usage of span
+### Example usage of span
 
 <ComponentBox data-visual-test="span-skeleton" useRender>
 {`


### PR DESCRIPTION
This PR removes docs for the specific html elements from the html elements overview doc, as the elements are already linked to in the docs, and have their own doc/page.

In my opinion, this will make the html elements overview doc a bit cleaner, as it has quite a lot of text [today](https://eufemia.dnb.no/uilib/elements), scroll scroll 📜