### PR TITLE
docs: hide visual <li> bullet appearing in card

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/Card.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.js
@@ -15,6 +15,7 @@ import classnames from 'classnames'
 import { P } from '@dnb/eufemia/src/elements'
 
 const CardWrapper = styled.li`
+  list-style-type: none;
   width: calc(33.333333% - 1rem);
 
   margin: 0.5rem;


### PR DESCRIPTION
Removes the list bullet visual appearing in Card in the portal.

See the bug here: 

<img width="629" alt="Skjermbilde 2022-03-31 kl  15 11 44" src="https://user-images.githubusercontent.com/35217511/161062599-d9de4c52-62bd-4b04-a42d-486dd127b43a.png">

