### PR TITLE
fix(Skeleton): Missing properties in PropTypes

### DIFF
--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
@@ -65,6 +65,16 @@ export interface SkeletonProps extends React.HTMLProps<HTMLElement> {
   figure?: SkeletonFigure;
 
   /**
+   * Is used for screen reader text translation, defined in the translation files. You can set a custom text if needed.
+   */
+  aria_busy?: string;
+
+  /**
+   * Is used for screen reader text translation, defined in the translation files. You can set a custom text if needed.
+   */
+  aria_ready?: string;
+
+  /**
    * Set any HTML element type you have to use. A couple of aria attributes will be set on this element while active. Defaults to `div`
    */
   element?: React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.js
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.js
@@ -35,6 +35,8 @@ export default class Skeleton extends React.PureComponent {
       PropTypes.func,
       PropTypes.node,
     ]),
+    aria_busy: PropTypes.string,
+    aria_ready: PropTypes.string,
     element: PropTypes.node,
 
     ...spacingPropTypes,


### PR DESCRIPTION
Fixes the following warning when running `yarn build:types`:

```
✖ The property "aria_busy" is not defined in PropTypes!
Component: Skeleton
File: ./src/components/skeleton/Skeleton.js


✖ The property "aria_ready" is not defined in PropTypes!
Component: Skeleton
File: ./src/components/skeleton/Skeleton.js
```