### PR TITLE
fix(Autocomplete): Missing properties in PropTypes

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -208,6 +208,13 @@ export default class Autocomplete extends React.PureComponent {
     skeleton: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     portal_class: PropTypes.string,
     drawer_class: PropTypes.string,
+    page_offset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    observer_element: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node,
+    ]),
+    min_height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    enable_body_lock: PropTypes.bool,
 
     class: PropTypes.string,
     className: PropTypes.string,
@@ -293,6 +300,10 @@ export default class Autocomplete extends React.PureComponent {
     skeleton: null,
     portal_class: null,
     drawer_class: null,
+    page_offset: null,
+    observer_element: null,
+    min_height: null,
+    enable_body_lock: false,
 
     class: null,
     className: null,

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -27,6 +27,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
   disable_reorder="disable_reorder"
   disabled="disabled"
   drawer_class="drawer_class"
+  enable_body_lock={true}
   focusable="focusable"
   global_status_id="main"
   icon="icon"
@@ -45,10 +46,12 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
   label_direction="horizontal"
   label_sr_only="label_sr_only"
   max_height={1}
+  min_height="min_height"
   mode="sync"
   no_animation={true}
   no_options="no_options"
   no_scroll_animation="no_scroll_animation"
+  observer_element="observer_element"
   on_blur={[Function]}
   on_change={[Function]}
   on_focus={[Function]}
@@ -60,6 +63,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
   open_on_focus="open_on_focus"
   opened={true}
   options_render={Object {}}
+  page_offset="page_offset"
   placeholder="placeholder"
   portal_class="portal_class"
   prevent_close="prevent_close"
@@ -116,6 +120,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
     disable_reorder="disable_reorder"
     disabled="disabled"
     drawer_class="drawer_class"
+    enable_body_lock={true}
     fixed_position={false}
     focusable="focusable"
     global_status_id="main"
@@ -140,12 +145,12 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
     label_sr_only="label_sr_only"
     list_class={null}
     max_height={1}
-    min_height={10}
+    min_height="min_height"
     mode="sync"
     no_animation={true}
     no_options="no_options"
     no_scroll_animation="no_scroll_animation"
-    observer_element={null}
+    observer_element="observer_element"
     on_blur={[Function]}
     on_change={[Function]}
     on_focus={[Function]}
@@ -159,7 +164,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
     open_on_focus="open_on_focus"
     opened={null}
     options_render={Object {}}
-    page_offset={null}
+    page_offset="page_offset"
     placeholder="placeholder"
     portal_class="portal_class"
     prepared_data={null}
@@ -221,6 +226,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
       disable_reorder="disable_reorder"
       disabled="disabled"
       drawer_class="drawer_class"
+      enable_body_lock={true}
       focusable="focusable"
       global_status_id="main"
       icon="icon"
@@ -239,10 +245,12 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
       label_direction="horizontal"
       label_sr_only="label_sr_only"
       max_height={1}
+      min_height="min_height"
       mode="sync"
       no_animation={true}
       no_options="no_options"
       no_scroll_animation="no_scroll_animation"
+      observer_element="observer_element"
       on_blur={[Function]}
       on_change={[Function]}
       on_focus={[Function]}
@@ -254,6 +262,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
       open_on_focus="open_on_focus"
       opened={true}
       options_render={Object {}}
+      page_offset="page_offset"
       placeholder="placeholder"
       portal_class="portal_class"
       prevent_close="prevent_close"
@@ -1131,6 +1140,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                   "disable_reorder": "disable_reorder",
                   "disabled": "disabled",
                   "drawer_class": "drawer_class",
+                  "enable_body_lock": true,
                   "focusable": "focusable",
                   "global_status_id": "main",
                   "icon": "icon",
@@ -1149,10 +1159,12 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                   "label_direction": "horizontal",
                   "label_sr_only": "label_sr_only",
                   "max_height": 1,
+                  "min_height": "min_height",
                   "mode": "sync",
                   "no_animation": true,
                   "no_options": "no_options",
                   "no_scroll_animation": "no_scroll_animation",
+                  "observer_element": "observer_element",
                   "on_blur": [Function],
                   "on_change": [Function],
                   "on_focus": [Function],
@@ -1164,6 +1176,7 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                   "open_on_focus": "open_on_focus",
                   "opened": true,
                   "options_render": Object {},
+                  "page_offset": "page_offset",
                   "placeholder": "placeholder",
                   "portal_class": "portal_class",
                   "prevent_close": "prevent_close",

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -166,6 +166,7 @@ exports[`Dropdown markup have to match snapshot 1`] = `
     default_value="default_value"
     direction="bottom"
     disabled="disabled"
+    enable_body_lock={false}
     fixed_position={false}
     focusable="focusable"
     global_status_id="main"

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js
@@ -46,6 +46,7 @@ export default class DrawerListProvider extends React.PureComponent {
   static propTypes = {
     ...drawerListPropTypes,
 
+    enable_body_lock: PropTypes.bool,
     use_drawer_on_mobile: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool,
@@ -61,6 +62,7 @@ export default class DrawerListProvider extends React.PureComponent {
   static defaultProps = {
     ...drawerListDefaultProps,
 
+    enable_body_lock: false,
     use_drawer_on_mobile: null,
     page_offset: null,
     observer_element: null,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.js.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.js.snap
@@ -154,6 +154,7 @@ exports[`DrawerList markup have to match snapshot 1`] = `
     }
     default_value={null}
     direction="bottom"
+    enable_body_lock={false}
     fixed_position={false}
     focusable={false}
     handle_dismiss_focus={null}


### PR DESCRIPTION
Fixes the following warning when running `yarn build:types`:

```
✖ The property "enable_body_lock" is not defined in PropTypes!
Component: Autocomplete
File: ./src/components/autocomplete/Autocomplete.js


✖ The property "min_height" is not defined in PropTypes!
Component: Autocomplete
File: ./src/components/autocomplete/Autocomplete.js


✖ The property "page_offset" is not defined in PropTypes!
Component: Autocomplete
File: ./src/components/autocomplete/Autocomplete.js


✖ The property "observer_element" is not defined in PropTypes!
Component: Autocomplete
File: ./src/components/autocomplete/Autocomplete.js

```