### PR TITLE
chore: remove /promise from simple-git import

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
+++ b/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
@@ -7,7 +7,7 @@ const dotenv = require('dotenv')
 const { isCI } = require('repo-utils')
 const ora = require('ora')
 const path = require('path')
-const simpleGit = require('simple-git/promise') // More info: https://github.com/steveukx/git-js#readme
+const simpleGit = require('simple-git') // More info: https://github.com/steveukx/git-js#readme
 
 // import .env variables
 dotenv.config()


### PR DESCRIPTION
After the security update of simple-git to its latest version, we get this warning during  visual test runs:

```bash
simple-git has supported promises / async await since version 2.6.0.
 Importing from 'simple-git/promise' has been deprecated and will be
 removed by July 2022.
```

This PR makes this requested change.
