### PR TITLE
fix: declare v17 as Eufemias peer dependency

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -105,8 +105,8 @@
     "what-input": "5.2.10"
   },
   "peerDependencies": {
-    "react": ">=16.12",
-    "react-dom": ">=16.12"
+    "react": "^17",
+    "react-dom": "^17"
   },
   "devDependencies": {
     "@babel/cli": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,8 +2398,8 @@ __metadata:
     wait-on: 6.0.0
     what-input: 5.2.10
   peerDependencies:
-    react: ">=16.12"
-    react-dom: ">=16.12"
+    react: ^17
+    react-dom: ^17
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Until we actually support v18 of React – we need to declare its peer dependency to v17 as of now.
