### PR TITLE
chore: unexposes enzyme's shallow

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -5,7 +5,7 @@
 
 import { axe, toHaveNoViolations } from 'jest-axe'
 import fakeProps from 'react-fake-props'
-import { shallow, mount, render } from './enzyme'
+import { mount, render } from './enzyme'
 import ReactDOMServer from 'react-dom/server'
 import fs from 'fs-extra'
 import onceImporter from 'node-sass-once-importer'
@@ -16,7 +16,6 @@ import toJson from 'enzyme-to-json'
 
 export {
   fakeProps, // we have also our own replacement function called "fakeAllProps"
-  shallow,
   mount,
   render,
   toJson,


### PR DESCRIPTION
Just a suggestion, as we are not supposed to "shallow test".

_Do not shallow test, but test components like a user would interact (use mount or render to also test their children)._ - https://eufemia.dnb.no/uilib/usage/best-practices/for-testing#integration-tests