### PR TITLE
fix(HelpButton): ensure Drawer/Dialog/Modal trigger button gets a label

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
@@ -18,15 +18,18 @@ export default function PortalToolsMenu({
       id="portal-tools"
       mode="drawer"
       title="Portal Tools"
-      trigger_size="default"
-      trigger_icon="more"
-      trigger_class={className}
-      trigger_attributes={{
+      triggerAttributes={{
+        size: 'default',
+        icon: 'more',
+        icon_size: 'medium',
+        class: className,
+        title: 'Portal Tools',
         skeleton: false,
-        // Use 4001 to be over header of 4000
+        left: 'x-small',
         tooltip: (
           <Tooltip
             position={tooltipPosition}
+            // Use 4001 to be over header of 4000
             style={{ zIndex: 4001 }}
             fixed_position
           >
@@ -34,9 +37,7 @@ export default function PortalToolsMenu({
           </Tooltip>
         ),
       }}
-      trigger_icon_size="default"
-      close_button_attributes={{ skeleton: false }}
-      left="x-small"
+      closeButtonAttributes={{ skeleton: false }}
       {...props}
     >
       <Modal.Content spacing>

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.js
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.js
@@ -90,15 +90,15 @@ export default class HelpButtonInstance extends React.PureComponent {
           this.props
         ).HelpButton.aria_role
       }
+    }
 
-      if (!params.text && !params['aria-label']) {
-        let ariaLabel = convertJsxToString(props.title || props.children)
-        if (!ariaLabel) {
-          ariaLabel = this.context.getTranslation(this.props).HelpButton
-            .title
-        }
-        params['aria-label'] = ariaLabel
+    if (!params.text && !params['aria-label']) {
+      let ariaLabel = convertJsxToString(props.title || props.children)
+      if (!ariaLabel) {
+        ariaLabel = this.context.getTranslation(this.props).HelpButton
+          .title
       }
+      params['aria-label'] = ariaLabel
     }
 
     if (icon === 'information' && !size) {

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.js
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.js
@@ -7,10 +7,15 @@ import React from 'react'
 import {
   mount,
   fakeProps,
+  axeComponent,
   toJson,
   loadScss,
 } from '../../../core/jest/jestSetup'
 import Component from '../HelpButton'
+import {
+  question as QuestionIcon,
+  information_medium as InformationIcon,
+} from '../../../icons'
 
 const snapshotProps = fakeProps(require.resolve('../HelpButton'), {})
 snapshotProps.id = 'help-button'
@@ -28,11 +33,31 @@ describe('HelpButton component', () => {
     expect(toJson(Comp)).toMatchSnapshot()
   })
 
-  it('should have correct default icon', () => {
+  it('should have question icon by default', () => {
     const Comp = mount(<Component {...props} />)
     expect(
       Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
     ).toBe('question icon')
+    expect(Comp.find('svg').html()).toBe(mount(<QuestionIcon />).html())
+    expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
+  })
+
+  it('should use "information" icon when set', () => {
+    const Comp = mount(<Component {...props} icon="information" />)
+    expect(
+      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+    ).toBe('information icon')
+    expect(Comp.find('svg').html()).toBe(mount(<InformationIcon />).html())
+    expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
+  })
+
+  it('should use given icon', () => {
+    const Comp = mount(<Component {...props} icon={InformationIcon} />)
+    expect(
+      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+    ).toBe('information medium icon')
+    expect(Comp.find('svg').html()).toBe(mount(<InformationIcon />).html())
+    expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
   })
 
   it('should have correct role description', () => {
@@ -44,19 +69,53 @@ describe('HelpButton component', () => {
     ).toBe('Hjelp-knapp')
   })
 
-  it('should have correct aria label', () => {
-    const Comp = mount(<Component {...props} />)
-    expect(
-      Comp.find('.dnb-button').instance().getAttribute('aria-label')
-    ).toBe('Hjelpetekst')
-  })
+  describe('with bell icon', () => {
+    it('should have correct aria-label', () => {
+      const Comp = mount(<Component {...props} icon="bell" />)
+      expect(
+        Comp.find('.dnb-button').instance().getAttribute('aria-label')
+      ).toBe('Hjelpetekst')
+    })
 
-  it('should have not aria-label if text is given', () => {
-    const Comp = mount(<Component {...props} text="button text" />)
-    expect(
-      Comp.find('.dnb-button').instance().hasAttribute('aria-label')
-    ).toBe(false)
-    expect(Comp.find('.dnb-button').text().trim()).toBe('‌button text')
+    it('should have not aria-label if text is given', () => {
+      const Comp = mount(
+        <Component {...props} icon="bell" text="button text" />
+      )
+      expect(
+        Comp.find('.dnb-button').instance().hasAttribute('aria-label')
+      ).toBe(false)
+      expect(Comp.find('.dnb-button').text().trim()).toBe('‌button text')
+    })
+
+    it('should have aria-label if title is given, but no text', () => {
+      const Comp = mount(
+        <Component {...props} icon="bell" title="button title" />
+      )
+      expect(
+        Comp.find('.dnb-button').instance().getAttribute('aria-label')
+      ).toBe('button title')
+      expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
+    })
+
+    it('should use given aria-label if title is given, but no text', () => {
+      const Comp = mount(
+        <Component
+          {...props}
+          icon="bell"
+          title="button title"
+          aria-label="custom aria-label"
+        />
+      )
+      expect(
+        Comp.find('.dnb-button').instance().getAttribute('aria-label')
+      ).toBe('custom aria-label')
+      expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
+    })
+
+    it('should validate with ARIA rules', async () => {
+      const Comp = mount(<Component {...props} icon="bell" />)
+      expect(await axeComponent(Comp)).toHaveNoViolations()
+    })
   })
 
   it('should open a modal if children are given', () => {
@@ -73,6 +132,11 @@ describe('HelpButton component', () => {
     )
 
     expect(textContent).toContain(modalContent)
+  })
+
+  it('should validate with ARIA rules', async () => {
+    const Comp = mount(<Component {...props} />)
+    expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 })
 


### PR DESCRIPTION
This PR fixes an issue where the internally used `HelpButton`, via a Modal/Drawer/Dialog did not get a aria-label - when used with icon only.

<img width="480" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/1501870/165475849-c0468564-846d-436a-a99b-cc2a99ec3364.png">

We also update the usage of the same in the Portal.