### PR TITLE
docs: navigate to /contribute instead of /uilib/development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ![Contributors](https://img.shields.io/github/contributors/dnbexperience/eufemia?style=for-the-badge) ![Issues](https://img.shields.io/github/issues/dnbexperience/eufemia?style=for-the-badge) ![Pull Requests](https://img.shields.io/github/issues-pr/dnbexperience/eufemia?style=for-the-badge)
 
-Find more information about how to contribute in [the development](https://eufemia.dnb.no/uilib/development) section. But in short, follow along and read the rest of this short readme text.
+Find more information about how to contribute in [the development](https://eufemia.dnb.no/contribute) section. But in short, follow along and read the rest of this short readme text.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add @dnb/eufemia
 
 ## Contribution
 
-Find more information about how to contribute in [Eufemia Portal - Development](https://eufemia.dnb.no/uilib/development).
+Find more information about how to contribute in [Eufemia Portal - Contribute](https://eufemia.dnb.no/contribute).
 
 ### Our contributors
 

--- a/packages/dnb-design-system-portal/src/docs/contribute.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute.md
@@ -1,8 +1,6 @@
 ---
 title: 'Contribution Guide'
 description: 'Project overview, development guides, conventions etc.'
-redirect_from:
-  - /uilib/development
 ---
 
 import { Button } from '@dnb/eufemia/src'


### PR DESCRIPTION
Instead of navigating to https://eufemia.dnb.no/uilib/development which redirects to https://eufemia.dnb.no/contribute, this PR just navigates directly to https://eufemia.dnb.no/contribute