### PR TITLE
fix(Dialog): fix Safari issue not able to scroll

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
@@ -60,7 +60,7 @@ export default function DialogContent({
     alignContent = variant === 'information' ? 'left' : 'centered'
   }
 
-  const innerParams = {
+  const scrollViewParams = {
     className: classnames(
       !isTrue(preventCoreStyle) && 'dnb-core-style',
 
@@ -108,7 +108,7 @@ export default function DialogContent({
   }
 
   return (
-    <ScrollView {...innerParams}>
+    <ScrollView {...scrollViewParams}>
       <div
         tabIndex={-1}
         className="dnb-dialog__inner dnb-no-focus"

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2120,21 +2120,25 @@ button.dnb-button::-moz-focus-inner {
   --dialog-spacing-minus: -2rem; }
 
 .dnb-dialog {
-  position: relative;
-  max-height: 100vh;
-  border-radius: 0.5rem;
   box-shadow: var(--shadow-default);
   user-select: text;
   -webkit-user-select: text;
   border: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  position: relative;
+  border-radius: 0.5rem;
+  max-height: 100vh; }
+  @supports (-webkit-touch-callout: none) {
+    @media (max-height: 40em) and (orientation: portrait) {
+      .dnb-dialog {
+        max-height: 88vh;
+        border-radius: 0; } } }
   .dnb-dialog--information {
     min-width: var(--dialog-min-width);
     width: var(--dialog-avg-width);
     max-width: var(--dialog-max-width); }
   .dnb-dialog--confirmation {
-    max-width: var(--dialog-confirm-max-width);
-    margin: 0 1rem; }
+    max-width: var(--dialog-confirm-max-width); }
   @media screen and (max-width: 40em) {
     .dnb-dialog--auto-fullscreen {
       width: 100%;
@@ -2172,9 +2176,6 @@ button.dnb-button::-moz-focus-inner {
         margin-top: calc(var(--dialog-spacing) / 2); } }
   .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
     padding: calc(var(--dialog-spacing)); }
-    @supports (-webkit-touch-callout: none) {
-      .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
-        padding-bottom: calc(var(--dialog-spacing) * 8); } }
   .dnb-dialog__inner {
     position: relative;
     display: flex;
@@ -2275,10 +2276,6 @@ button.dnb-button::-moz-focus-inner {
     margin-top: 3.5rem; }
   .dnb-dialog__icon ~ .dnb-dialog__header {
     margin-top: 1.5rem; }
-  @supports (-webkit-touch-callout: none) {
-    @media (max-height: 40em) and (orientation: landscape) {
-      .dnb-dialog:not(.dnb-dialog--fullscreen) {
-        max-height: 80vh; } } }
 
 [data-visual-test].hide-page-content #___gatsby {
   opacity: 0; }

--- a/packages/dnb-eufemia/src/components/dialog/style/_dialog.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/_dialog.scss
@@ -16,15 +16,24 @@
 }
 
 .dnb-dialog {
-  position: relative;
-  max-height: 100vh;
-  border-radius: 0.5rem;
   @include defaultDropShadow();
 
   user-select: text;
   -webkit-user-select: text; // Safari / Touch fix
   border: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+  position: relative;
+  border-radius: 0.5rem;
+  max-height: 100vh;
+
+  @include IS_SAFARI_MOBILE() {
+    // iOS on iPhone fix
+    @media (max-height: 40em) and (orientation: portrait) {
+      max-height: 88vh;
+      border-radius: 0;
+    }
+  }
 
   &--information {
     min-width: var(--dialog-min-width);
@@ -34,7 +43,11 @@
 
   &--confirmation {
     max-width: var(--dialog-confirm-max-width);
-    margin: 0 1rem;
+    // margin: 0 1rem; // Do not use margin in here – it makes Safari not scrollable
+
+    // @at-root .dnb-modal__content {
+    //   padding: 2rem;
+    // }
   }
 
   &--auto-fullscreen {
@@ -79,10 +92,6 @@
 
   &--spacing#{&}--confirmation &__inner {
     padding: calc(var(--dialog-spacing)); // 2rem (32px)
-
-    @include IS_SAFARI_MOBILE {
-      padding-bottom: calc(var(--dialog-spacing) * 8);
-    }
   }
 
   &__inner {
@@ -249,16 +258,6 @@
 
   &__icon ~ &__header {
     margin-top: 1.5rem;
-  }
-
-  @include IS_SAFARI_MOBILE() {
-    // iOS on iPhone fix
-    // Because Safari includes the navigation bar on the height
-    @media (max-height: 40em) and (orientation: landscape) {
-      &:not(#{&}--fullscreen) {
-        max-height: 80vh;
-      }
-    }
   }
 }
 

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2116,21 +2116,25 @@ button.dnb-button::-moz-focus-inner {
   --dialog-spacing-minus: -2rem; }
 
 .dnb-dialog {
-  position: relative;
-  max-height: 100vh;
-  border-radius: 0.5rem;
   box-shadow: var(--shadow-default);
   user-select: text;
   -webkit-user-select: text;
   border: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  position: relative;
+  border-radius: 0.5rem;
+  max-height: 100vh; }
+  @supports (-webkit-touch-callout: none) {
+    @media (max-height: 40em) and (orientation: portrait) {
+      .dnb-dialog {
+        max-height: 88vh;
+        border-radius: 0; } } }
   .dnb-dialog--information {
     min-width: var(--dialog-min-width);
     width: var(--dialog-avg-width);
     max-width: var(--dialog-max-width); }
   .dnb-dialog--confirmation {
-    max-width: var(--dialog-confirm-max-width);
-    margin: 0 1rem; }
+    max-width: var(--dialog-confirm-max-width); }
   @media screen and (max-width: 40em) {
     .dnb-dialog--auto-fullscreen {
       width: 100%;
@@ -2168,9 +2172,6 @@ button.dnb-button::-moz-focus-inner {
         margin-top: calc(var(--dialog-spacing) / 2); } }
   .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
     padding: calc(var(--dialog-spacing)); }
-    @supports (-webkit-touch-callout: none) {
-      .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
-        padding-bottom: calc(var(--dialog-spacing) * 8); } }
   .dnb-dialog__inner {
     position: relative;
     display: flex;
@@ -2271,10 +2272,6 @@ button.dnb-button::-moz-focus-inner {
     margin-top: 3.5rem; }
   .dnb-dialog__icon ~ .dnb-dialog__header {
     margin-top: 1.5rem; }
-  @supports (-webkit-touch-callout: none) {
-    @media (max-height: 40em) and (orientation: landscape) {
-      .dnb-dialog:not(.dnb-dialog--fullscreen) {
-        max-height: 80vh; } } }
 
 [data-visual-test].hide-page-content #___gatsby {
   opacity: 0; }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2134,21 +2134,25 @@ button.dnb-button::-moz-focus-inner {
   --dialog-spacing-minus: -2rem; }
 
 .dnb-dialog {
-  position: relative;
-  max-height: 100vh;
-  border-radius: 0.5rem;
   box-shadow: var(--shadow-default);
   user-select: text;
   -webkit-user-select: text;
   border: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  position: relative;
+  border-radius: 0.5rem;
+  max-height: 100vh; }
+  @supports (-webkit-touch-callout: none) {
+    @media (max-height: 40em) and (orientation: portrait) {
+      .dnb-dialog {
+        max-height: 88vh;
+        border-radius: 0; } } }
   .dnb-dialog--information {
     min-width: var(--dialog-min-width);
     width: var(--dialog-avg-width);
     max-width: var(--dialog-max-width); }
   .dnb-dialog--confirmation {
-    max-width: var(--dialog-confirm-max-width);
-    margin: 0 1rem; }
+    max-width: var(--dialog-confirm-max-width); }
   @media screen and (max-width: 40em) {
     .dnb-dialog--auto-fullscreen {
       width: 100%;
@@ -2186,9 +2190,6 @@ button.dnb-button::-moz-focus-inner {
         margin-top: calc(var(--dialog-spacing) / 2); } }
   .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
     padding: calc(var(--dialog-spacing)); }
-    @supports (-webkit-touch-callout: none) {
-      .dnb-dialog--spacing.dnb-dialog--confirmation .dnb-dialog__inner {
-        padding-bottom: calc(var(--dialog-spacing) * 8); } }
   .dnb-dialog__inner {
     position: relative;
     display: flex;
@@ -2289,10 +2290,6 @@ button.dnb-button::-moz-focus-inner {
     margin-top: 3.5rem; }
   .dnb-dialog__icon ~ .dnb-dialog__header {
     margin-top: 1.5rem; }
-  @supports (-webkit-touch-callout: none) {
-    @media (max-height: 40em) and (orientation: landscape) {
-      .dnb-dialog:not(.dnb-dialog--fullscreen) {
-        max-height: 80vh; } } }
 
 [data-visual-test].hide-page-content #___gatsby {
   opacity: 0; }


### PR DESCRIPTION
When the Dialog component is used with a large content, it was not scrollable on the Safari iOS browser. 
This PR fixes the issue by removing the visual margin. Why does the margin have that of a huge impact? I do not know at the moment. Even a padding outside the `.dnb-dialog` makes the scrollview not scrollable anymore.

This PR is still in WIP.