### PR TITLE
Remove invalid spacing attributes

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -12,7 +12,7 @@ import Img, { ImgProps } from '../../elements/Img'
 import Context from '../../shared/Context'
 import { ISpacingProps } from '../../shared/interfaces'
 import { SkeletonShow } from '../skeleton/Skeleton'
-import { warn } from '../../shared/component-helper'
+import { validateDOMAttributes, warn } from '../../shared/component-helper'
 import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
@@ -90,6 +90,14 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
   const avatarGroupContext = React.useContext(AvatarGroupContext)
 
   // Extract additional props from global context
+  const allProps = usePropsWithContext(
+    localProps,
+    defaultProps,
+    context?.Avatar,
+    { skeleton: context?.skeleton },
+    avatarGroupContext
+  )
+
   const {
     alt,
     className,
@@ -101,13 +109,7 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
     imgProps,
     hasLabel,
     ...props
-  } = usePropsWithContext(
-    localProps,
-    defaultProps,
-    context?.Avatar,
-    { skeleton: context?.skeleton },
-    avatarGroupContext
-  )
+  } = allProps
 
   let children = null
 
@@ -135,6 +137,8 @@ const Avatar = (localProps: AvatarProps & ISpacingProps) => {
       `Avatar group required: An Avatar requires an Avatar.Group with label description as a parent component. This is to ensure correct semantic and accessibility.`
     )
   }
+
+  validateDOMAttributes(allProps, props)
 
   return (
     <span

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -165,6 +165,33 @@ describe('Avatar', () => {
     )
   })
 
+  it('should support spacing props', () => {
+    const img_alt = 'custom_alt_label'
+
+    render(
+      <Avatar.Group label="label" top>
+        <Avatar
+          top="2rem"
+          alt={img_alt}
+          src="/android-chrome-192x192.png"
+        />
+      </Avatar.Group>
+    )
+
+    const element = screen.getByTestId('avatar')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-avatar',
+      'dnb-avatar--primary',
+      'dnb-avatar--size-medium',
+      'dnb-space__top--large',
+    ])
+  })
+
   describe('AvatarGroup', () => {
     it('renders the label as string', () => {
       const label = 'avatar'

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -16,7 +16,10 @@ import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem'
-import { convertJsxToString } from '../../shared/component-helper'
+import {
+  convertJsxToString,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 
 export interface BreadcrumbProps {
   /**
@@ -126,6 +129,13 @@ const Breadcrumb = (localProps: BreadcrumbProps & ISpacingProps) => {
   // Every component should have a context
   const context = React.useContext(Context)
   // Extract additional props from global context
+  const allProps = usePropsWithContext(
+    localProps,
+    defaultProps,
+    context?.translation?.Breadcrumb,
+    context?.Breadcrumb,
+    { skeleton: context?.skeleton }
+  )
   const {
     className,
     skeleton,
@@ -143,13 +153,7 @@ const Breadcrumb = (localProps: BreadcrumbProps & ISpacingProps) => {
     data,
     href,
     ...props
-  } = usePropsWithContext(
-    localProps,
-    defaultProps,
-    context?.translation?.Breadcrumb,
-    context?.Breadcrumb,
-    { skeleton: context?.skeleton }
-  )
+  } = allProps
   const skeletonClasses = createSkeletonClass('font', skeleton, context)
   const spacingClasses = createSpacingClasses(props)
 
@@ -189,6 +193,8 @@ const Breadcrumb = (localProps: BreadcrumbProps & ISpacingProps) => {
       {childrenItems}
     </ol>
   )
+
+  validateDOMAttributes(allProps, props)
 
   return (
     <nav

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -139,6 +139,30 @@ describe('Breadcrumb', () => {
     expect(screen.getByRole('button').className).toMatch(skeletonClassName)
   })
 
+  it('should support spacing props', () => {
+    render(
+      <Breadcrumb
+        data={[
+          { href: '/' },
+          { href: '/page1', text: 'Page 1' },
+          { href: '/page1/page2', text: 'Page 2' },
+        ]}
+        top="2rem"
+      />
+    )
+
+    const element = screen.getByTestId('breadcrumb-nav')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['aria-label', 'class', 'data-testid'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-breadcrumb',
+      'dnb-space__top--large',
+    ])
+  })
+
   describe('BreadcrumbItem', () => {
     it('renders breadcrumbitem as a link', () => {
       render(<BreadcrumbItem href="/url" text="Page" />)

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -244,6 +244,22 @@ describe('InfoCard', () => {
     )
   })
 
+  it('should support spacing props', () => {
+    render(<InfoCard text="text" top="2rem" />)
+
+    const element = screen.getByTestId('info-card')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['data-testid', 'class'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-info-card',
+      'dnb-space__top--large',
+      'dnb-div',
+    ])
+  })
+
   describe('InfoCard aria', () => {
     it('should validate', async () => {
       const Component = render(<InfoCard text="text" />)

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -15,6 +15,7 @@ import { usePropsWithContext } from '../../shared/hooks'
 // Internal
 import TagGroup from './TagGroup'
 import { TagGroupContext } from './TagContext'
+import { createSpacingClasses } from '../space/SpacingHelper'
 
 export interface TagProps {
   /**
@@ -83,6 +84,14 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
   const tagGroupContext = React.useContext(TagGroupContext)
 
   // Extract additional props from global context
+  const allProps = usePropsWithContext(
+    localProps,
+    defaultProps,
+    context?.translation?.Tag,
+    context?.Tag,
+    tagGroupContext
+  )
+
   const {
     className,
     skeleton,
@@ -93,25 +102,22 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
     onDelete,
     omitOnKeyUpDeleteEvent,
     ...props
-  } = usePropsWithContext(
-    localProps,
-    defaultProps,
-    context?.translation?.Tag,
-    context?.Tag,
-    tagGroupContext
-  )
+  } = allProps
 
   const content = text || children
   const isClickable = !!onClick
   const isRemovable = !!onDelete && !isClickable
   const isInteractive = isClickable || isRemovable
-
+  const spacingClasses = createSpacingClasses(props)
   const tagClassNames = classnames(
     'dnb-tag',
     className,
+    spacingClasses,
     isInteractive && 'dnb-tag--interactive',
     isRemovable && 'dnb-tag--removable'
   )
+  const buttonAttr: typeof props & Pick<ButtonProps, 'element' | 'type'> =
+    props
 
   const isDeleteKeyboardEvent = (keyboardEvent) => {
     return (
@@ -124,9 +130,6 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
       onDelete(event)
     }
   }
-
-  const buttonAttr: typeof props & Pick<ButtonProps, 'element' | 'type'> =
-    props
 
   if (!isInteractive) {
     buttonAttr.element = 'span'

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -75,6 +75,25 @@ describe('Tag Group', () => {
       skeletonClassName
     )
   })
+
+  it('should support spacing props', () => {
+    render(
+      <Tag.Group label="tags" top="2rem">
+        <Tag>Tag</Tag>
+      </Tag.Group>
+    )
+
+    const element = screen.getByTestId('tag-group')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-tag__group',
+      'dnb-space__top--large',
+    ])
+  })
 })
 
 describe('Tag', () => {
@@ -193,6 +212,29 @@ describe('Tag', () => {
     expect(
       screen.queryByTestId('tag').querySelector('.dnb-icon')
     ).toBeTruthy()
+  })
+
+  it('should support spacing props', () => {
+    render(
+      <Tag.Group label="tags">
+        <Tag left="2rem">Tag</Tag>
+      </Tag.Group>
+    )
+
+    const element = screen.getByTestId('tag')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-button',
+      'dnb-button--unstyled',
+      'dnb-button--has-text',
+      'dnb-space__left--large',
+      'dnb-tag',
+      'dnb-button--size-small',
+    ])
   })
 
   describe('with onClick', () => {

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -12,6 +12,7 @@ import { usePropsWithContext } from '../../shared/hooks'
 
 // Internal
 import TimelineItem, { TimelineItemProps } from './TimelineItem'
+import { validateDOMAttributes } from '../../shared/component-helper'
 
 export interface TimelineProps {
   /**
@@ -51,16 +52,23 @@ export const defaultProps = {
 const Timeline = (localProps: TimelineProps & ISpacingProps) => {
   // Every component should have a context
   const context = React.useContext(Context)
+
   // Extract additional props from global context
+  const allProps = usePropsWithContext(
+    localProps,
+    defaultProps,
+    context?.Timeline,
+    {
+      skeleton: context?.skeleton,
+    }
+  )
   const {
     className,
     skeleton,
     data,
     children: childrenProp,
     ...props
-  } = usePropsWithContext(localProps, defaultProps, context?.Timeline, {
-    skeleton: context?.skeleton,
-  })
+  } = allProps
 
   const spacingClasses = createSpacingClasses(props)
 
@@ -74,6 +82,8 @@ const Timeline = (localProps: TimelineProps & ISpacingProps) => {
       })
     })
   }
+
+  validateDOMAttributes(allProps, props)
 
   return (
     <div

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -82,6 +82,31 @@ describe('Timeline', () => {
     )
   })
 
+  it('should support spacing props', () => {
+    render(
+      <Timeline
+        data={[
+          {
+            name: 'Upcoming',
+            state: 'upcoming',
+          },
+        ]}
+        top="2rem"
+      />
+    )
+
+    const element = screen.getByTestId('timeline')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-timeline',
+      'dnb-space__top--large',
+    ])
+  })
+
   describe('TimelineItem', () => {
     it('renders name', () => {
       const name = 'Completed'


### PR DESCRIPTION
Some components did not "remove" the spacing props when set. They just got added as HTML attributes. But when e.g. `space={{ }}` or `top={true}` was used, React throws an error warning. 

With that PR we add some tests to verify the feature.