### PR TITLE
fix(HeightAnimation): ensure quick state changes to react without animating from start to finish

### DIFF
--- a/packages/dnb-eufemia/src/shared/AnimateHeight.js
+++ b/packages/dnb-eufemia/src/shared/AnimateHeight.js
@@ -19,6 +19,11 @@ export default class AnimateHeight {
   }
   _callOnEnd() {
     this.isAnimating = false
+
+    if (this.state !== 'opened') {
+      delete this.__currentHeight
+    }
+
     this._removeEndEvents()
 
     this.onEndStack.forEach((fn) => {
@@ -37,6 +42,10 @@ export default class AnimateHeight {
     this.elem.style.width = ''
   }
   _removeEndEvents() {
+    if (!this.elem) {
+      return // stop here
+    }
+
     if (this.onOpenEnd) {
       this.elem.removeEventListener('transitionend', this.onOpenEnd)
       this.onOpenEnd = null
@@ -67,7 +76,7 @@ export default class AnimateHeight {
       elem ||
       (typeof document !== 'undefined' && document.createElement('div'))
 
-    // get tr element
+    // TODO: remove when responsive tables are supported
     if (String(this.elem?.nodeName).toLowerCase() === 'td') {
       this.elem = this.elem.parentElement
     }
@@ -112,6 +121,10 @@ export default class AnimateHeight {
       return null
     }
 
+    if (this.isAnimating && this.__currentHeight) {
+      return this.__currentHeight
+    }
+
     this.elem.style.width = this.getWidth()
 
     if (this.elem.parentElement) {
@@ -121,11 +134,11 @@ export default class AnimateHeight {
     this.elem.style.visibility = 'hidden'
     this.elem.style.height = 'auto'
 
-    const height = this.getHeight()
+    this.__currentHeight = this.getHeight()
 
     this._restore()
 
-    return height
+    return this.__currentHeight
   }
 
   onStart(fn) {
@@ -166,6 +179,10 @@ export default class AnimateHeight {
 
       // make the animation
       this.reqId1 = window.requestAnimationFrame(() => {
+        if (!this.elem) {
+          return // stop here
+        }
+
         this.elem.style.height = `${fromHeight}px`
 
         if (this.container) {

--- a/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.js
@@ -119,6 +119,50 @@ describe('AnimateHeight', () => {
     expect(inst.getUnknownHeight()).toBe(100)
   })
 
+  it('open should call getUnknownHeight', () => {
+    const inst = new AnimateHeight()
+
+    jest.spyOn(inst, 'getUnknownHeight').mockImplementation(jest.fn())
+
+    inst.setElement(element)
+    inst.open()
+
+    expect(inst.getUnknownHeight).toHaveBeenCalledTimes(1)
+  })
+
+  it('getUnknownHeight should use cached height during animation', () => {
+    const inst = new AnimateHeight()
+
+    jest
+      .spyOn(element, 'clientHeight', 'get')
+      .mockImplementation(() => 100)
+
+    expect(inst.__currentHeight).toBe(undefined)
+    expect(inst.isAnimating).toBe(undefined)
+
+    inst.setElement(element)
+    inst.open()
+
+    expect(inst.isAnimating).toBe(true)
+    expect(inst.__currentHeight).toBe(100)
+
+    jest
+      .spyOn(element, 'clientHeight', 'get')
+      .mockImplementation(() => 200)
+
+    inst.getUnknownHeight()
+
+    expect(inst.__currentHeight).toBe(100)
+
+    delete inst.elem
+
+    expect(inst.getUnknownHeight()).toBe(null)
+
+    inst._callOnEnd()
+
+    expect(inst.__currentHeight).toBe(undefined)
+  })
+
   it('adjustFrom should set and return height', () => {
     const inst = new AnimateHeight()
     inst.setElement(element)


### PR DESCRIPTION
This PR fixes an issue when animating from `auto` (open) to `0px` (closed) – but the user triggers the animation one more time (while the animation is running), we started again from `0px`, which lead to a "flicker".

Effects:
- Accordion
- GlobalStatus
- FormStatus
- StepIndicator
- Soon Table (responsive)

**Fix**
https://user-images.githubusercontent.com/1501870/172583539-2d6b27cf-8f81-480f-a355-e0e32decb22a.mov


**Current**
https://user-images.githubusercontent.com/1501870/172583627-8c0a8bd5-b09e-4e8a-8009-3a655da21e55.mov



