### PR TITLE
chore(Portal): get SSR consistent code syntax (highlighting) wrapping behaviour

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.js
@@ -253,7 +253,6 @@ class LiveCode extends React.PureComponent {
           {!global.IS_TEST && !hideCode && (
             <div
               className={classnames(
-                'dnb-pre',
                 'dnb-live-editor',
                 createSkeletonClass('code', this.context.skeleton)
               )}
@@ -264,7 +263,7 @@ class LiveCode extends React.PureComponent {
               </label>
               <LiveEditor
                 id={this._id}
-                className="dnb-live-editor__editable"
+                className="dnb-live-editor__editable dnb-pre"
                 onChange={(code) => {
                   this.setState({ code })
                 }}
@@ -370,6 +369,7 @@ const LiveCodeEditor = styled.div`
 
   .prism-code {
     padding: 0 !important; /* use important because of inline styles */
+    white-space: pre-wrap !important; /* use important because of inline styles */
   }
 `
 


### PR DESCRIPTION
This PR will fix the diff we have between SSR and browser rendered code syntax wrapping behavior.

We use `react-live` and they use `pre-wrap` so code syntax gets wrapped to a newline, when space is missing.

but during SSR, their styles get not applied in v3 (we should maybe also fix that and make a PR – when we have time).

But more important, we "could change how we like to have it. Because its very normal to just show a scrollbar instead.

I personally like better the wrapping for our use case (dirty code snippets/examples).
But the reason why I like that better, is because when we have "long text" in the examples, they add a really long scrollbar.

But the question is still; **Should we change the behavior and use a scrollbar?** (in contrast what `react-live` sets as their default).

Wrapped (like we have today):
<img width="760" alt="Screenshot 2022-06-10 at 10 26 02" src="https://user-images.githubusercontent.com/1501870/173026697-b2e3466d-cf53-490d-849c-5ad273b05aef.png">

With scrollbar:
<img width="763" alt="Screenshot 2022-06-10 at 10 25 37" src="https://user-images.githubusercontent.com/1501870/173026774-99446374-8f5f-4c27-b3d0-80ed54d37d44.png">


The SSR issue, during a **page refresh**:

https://user-images.githubusercontent.com/1501870/173026462-94abdbc4-ce40-4c4c-91f0-5ee2c9e5dc6d.mov


