### PR TITLE
chore(CI): run visual tests on main branch

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -9,7 +9,6 @@ on:
       - '!wip/**'
       - '!experiments/**'
       - '!release'
-      - '!main'
       - '!portal'
       - '!beta'
       - '!alpha'


### PR DESCRIPTION
We can "possible" break visual tests because do not force branches to be rebased from main (up to date) before merge. 

We may try – for a while – to have run them on the `main` branch. And if they fail, we may press the button to re-run. Even, they should work ok, as they to "re-run" each test up to a couple of times, if they fail. 
