### PR TITLE
chore(CI): speed up build time when making build for visual tests

### DIFF
--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -68,7 +68,7 @@ jobs:
           restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
 
       - name: Build portal
-        run: yarn workspace dnb-design-system-portal build
+        run: yarn workspace dnb-design-system-portal build-visual-test
 
       - name: Icons postbuild
         run: yarn workspace @dnb/eufemia postbuild:figma:ci

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -70,7 +70,7 @@ jobs:
           restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
 
       - name: Build portal
-        run: yarn workspace dnb-design-system-portal build
+        run: yarn workspace dnb-design-system-portal build-visual-test
 
       - name: Run visual tests
         run: yarn workspace @dnb/eufemia test:screenshots:ci

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -48,8 +48,8 @@ const plugins = [
   'gatsby-plugin-meta-redirect',
   'gatsby-plugin-catch-links',
   'gatsby-plugin-react-helmet',
-  'gatsby-plugin-sharp', // is used by gatsby-remark-images
-  'gatsby-remark-images',
+  process.env.SKIP_IMAGE_PROCESSING !== '1' && 'gatsby-plugin-sharp', // is used by gatsby-remark-images
+  process.env.SKIP_IMAGE_PROCESSING !== '1' && 'gatsby-remark-images',
   {
     resolve: 'gatsby-plugin-page-creator',
     options: {
@@ -83,7 +83,7 @@ const plugins = [
       // rehypePlugins: [], // hastPlugins
       // remarkPlugins: [], // mdPlugins
       gatsbyRemarkPlugins: [
-        {
+        process.env.SKIP_IMAGE_PROCESSING !== '1' && {
           resolve: 'gatsby-remark-images',
           options: {
             maxWidth: 1024,
@@ -93,7 +93,7 @@ const plugins = [
             // wrapperStyle: {}
           },
         },
-      ],
+      ].filter(Boolean),
       // Imports in here are globally available in *.md files
       // globalScope: `
       //   import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -7,8 +7,9 @@
   "author": "DNB Team & Tobias Høegh",
   "main": "src/docs/index.js",
   "scripts": {
-    "build": "NODE_NO_WARNINGS=1 gatsby build --no-uglify",
+    "build": "NODE_NO_WARNINGS=1 gatsby build",
     "build-ci": "yarn build:version && yarn build --prefix-paths",
+    "build-visual-test": "SKIP_IMAGE_PROCESSING=1 gatsby build --no-uglify",
     "build:version": "node ./scripts/version.js --new-version",
     "clean": "NODE_NO_WARNINGS=1 gatsby clean",
     "precommit": "yarn lint-staged",

--- a/packages/dnb-design-system-portal/src/docs/contribute/faq.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/faq.md
@@ -91,7 +91,7 @@ This is only meant for "setup testing" purposes! In order to make faster local b
 
 - Inside `gatsby-config.js` rename all sourcing from `/docs` to `/docs_dummy`
 
-Run `yarn workspace dnb-design-system-portal build`
+Run `yarn workspace dnb-design-system-portal build-visual-test`
 
 ## I get Gatsby 404 Not Found on the pages I work on
 

--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerSetup.js
@@ -41,7 +41,7 @@ const startStaticServer = async () => {
         })
       } else {
         throw new Error(
-          'No /public folder found. Make sure you run "yarn workspace dnb-design-system-portal build" first!'
+          'No /public folder found. Make sure you run "yarn workspace dnb-design-system-portal build-visual-test" first!'
         )
       }
     }


### PR DESCRIPTION
Omit image processing when creating a build for visual tests.

This step takes several minutes: `Running gatsby-plugin-sharp.IMAGE_PROCESSING jobs - 345.638s` but we do not test images (I think).
