### PR TITLE
chore(repo): update Node.js version to latest v14

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.0
+          node-version: 14.19.3
 
       - name: Use node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.0
+          node-version: 14.19.3
 
       - name: Use node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.0
+          node-version: 14.19.3
 
       - name: Use node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.0
+          node-version: 14.19.3
 
       - name: Use node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.0
+          node-version: 14.19.3
 
       - name: Use yarn cache
         uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yarn": ">=1.17.0"
   },
   "volta": {
-    "node": "14.17.0",
+    "node": "14.19.3",
     "yarn": "1.22.10"
   },
   "packageManager": "yarn@3.2.0"


### PR DESCRIPTION
This version includes a fix so we can/would run jest with Yarn PnP: https://github.com/nodejs/node/pull/41221
