### PR TITLE
chore(CI): refactor visual test run

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -13,24 +13,75 @@ on:
       - '!beta'
       - '!alpha'
 
+env:
+  GH_EMAIL: ${{ secrets.GH_EMAIL }}
+  GH_NAME: ${{ secrets.GH_NAME }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
+  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+  ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+  ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
+  ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+  CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+
 jobs:
-  action:
+  portal-build:
+    name: Build Portal
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.17.0
+
+      - name: Use node_modules cache
+        uses: actions/cache@v2
+        id: modules-cache
+        with:
+          path: '**/node_modules'
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
+
+      - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=timestamp::$(date +'%Y-%W')"
+
+      - name: Use Gatsby cache
+        uses: actions/cache@v2
+        id: gatsby-cache
+        with:
+          path: |
+            ./packages/dnb-design-system-portal/.cache
+            ./packages/dnb-design-system-portal/public
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
+
+      - name: Build portal
+        run: yarn workspace dnb-design-system-portal build-visual-test
+
+      - name: Store portal artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: portal-build-artifact
+          path: ./packages/dnb-design-system-portal/public
+
+  visual-test:
     name: Visual Test Action
 
     runs-on: macos-latest
-
-    env:
-      GH_EMAIL: ${{ secrets.GH_EMAIL }}
-      GH_NAME: ${{ secrets.GH_NAME }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-      FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
-      ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
-      ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-      ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-      ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
     steps:
       - name: Git checkout
@@ -54,25 +105,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=timestamp::$(date +'%Y-%W')"
-
-      - name: Use Gatsby cache
-        uses: actions/cache@v2
-        id: gatsby-cache
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
         with:
-          path: |
-            ./packages/dnb-design-system-portal/.cache
-            ./packages/dnb-design-system-portal/public
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-${{ steps.date.outputs.timestamp }}
-          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-dev-
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Build Portal
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          intervalSeconds: 3
+          timeoutSeconds: 900
 
-      - name: Build portal
-        run: yarn workspace dnb-design-system-portal build-visual-test
+      - name: Re-store portal artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: portal-build-artifact
+          path: ./packages/dnb-design-system-portal/public
 
       - name: Run visual tests
-        run: yarn workspace @dnb/eufemia test:screenshots:ci
+        run: yarn workspace dnb-design-system-portal test:screenshots:ci
 
       - name: Slack
         uses: 8398a7/action-slack@v3

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -31,6 +31,8 @@
     "test": "jest",
     "test:ci": "jest --ci --passWithNoTests",
     "test:staged": "jest --bail --findRelatedTests ",
+    "test:screenshots": "yarn workspace @dnb/eufemia test:screenshots",
+    "test:screenshots:ci": "start-server-and-test serve http://localhost:8000 'yarn workspace @dnb/eufemia test:screenshots'",
     "test:types": "tsc --noEmit",
     "test:types:watch": "tsc --noEmit --watch",
     "test:update": "jest --updateSnapshot",


### PR DESCRIPTION
I have hopes that this can at least shape off some minutes.

With this PR we build the portal on Linux and test with macOS. 

What is the reason behind this? macOS is very much slower in Github Actions, so we now use it for the only one reason – testing visually.