### PR TITLE
fix(Dialog): fix Modal backdrop / overlay false-positive click issue while e.g. selecting

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -818,6 +818,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
             className="dnb-modal__content dnb-modal__content--auto-fullscreen dnb-dialog__root dnb-modal__content--custom"
             id="dnb-modal-dialog_id"
             onClick={[Function]}
+            onMouseDown={[Function]}
             role="dialog"
             style={null}
           >

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -814,6 +814,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
             className="dnb-modal__content dnb-modal__content--auto-fullscreen dnb-modal__content--right dnb-drawer__root dnb-modal__content--custom"
             id="dnb-modal-drawer_id"
             onClick={[Function]}
+            onMouseDown={[Function]}
             role="dialog"
             style={null}
           >

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -641,6 +641,7 @@ describe('Modal component', () => {
     expect(on_close_prevent).toHaveBeenCalledTimes(1)
 
     // trigger the close on the overlay
+    Comp.find('div.dnb-modal__content').simulate('mousedown')
     Comp.find('div.dnb-modal__content').simulate('click')
 
     expect(on_close_prevent).toHaveBeenCalledTimes(2)
@@ -666,6 +667,7 @@ describe('Modal component', () => {
     preventClose = false
 
     // trigger the close on the overlay
+    Comp.find('div.dnb-modal__content').simulate('mousedown')
     Comp.find('div.dnb-modal__content').simulate('click')
 
     expect(Comp.exists('div.dnb-modal__content')).toBe(true)
@@ -691,10 +693,55 @@ describe('Modal component', () => {
     expect(testTriggeredBy).toBe(null)
 
     // trigger the close on the overlay
+    Comp.find('div.dnb-modal__content').simulate('mousedown')
     Comp.find('div.dnb-modal__content').simulate('click')
 
     expect(on_close).toHaveBeenCalledTimes(1)
     expect(testTriggeredBy).toBe('overlay')
+    expect(Comp.exists('div.dnb-modal__content')).toBe(false)
+  })
+
+  it('will omit close when no mousedown was fired', () => {
+    const on_close = jest.fn()
+    const Comp = mount(<Component {...props} on_close={on_close} />)
+    Comp.find('button').simulate('click')
+
+    // trigger the close on the overlay
+    Comp.find('div.dnb-modal__content').simulate('click')
+
+    expect(on_close).toHaveBeenCalledTimes(0)
+    expect(Comp.exists('div.dnb-modal__content')).toBe(true)
+  })
+
+  it('will only close when mousedown and click DOM targets are the same', () => {
+    const on_close = jest.fn()
+    const Comp = mount(<Component {...props} on_close={on_close} />)
+
+    Comp.find('button').simulate('click')
+
+    const contentElement = Comp.find('div.dnb-modal__content')
+    const target = contentElement.instance()
+    const currentTarget = contentElement.instance()
+    const differentTarget = document.createElement('DIV')
+
+    // trigger the close on the overlay
+    contentElement.simulate('mousedown', {
+      target,
+      currentTarget,
+    })
+    contentElement.simulate('click', { target: differentTarget }) // simulate with different target
+
+    expect(on_close).toHaveBeenCalledTimes(0)
+    expect(Comp.exists('div.dnb-modal__content')).toBe(true)
+
+    // trigger the close on the overlay
+    contentElement.simulate('mousedown', {
+      target,
+      currentTarget,
+    })
+    contentElement.simulate('click', { target })
+
+    expect(on_close).toHaveBeenCalledTimes(1)
     expect(Comp.exists('div.dnb-modal__content')).toBe(false)
   })
 

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -789,6 +789,7 @@ exports[`Modal component have to match snapshot 1`] = `
           className="dnb-modal__content dnb-modal__content--auto-fullscreen dnb-modal__content--modal"
           id="dnb-modal-modal_id"
           onClick={[Function]}
+          onMouseDown={[Function]}
           role="dialog"
           style={null}
         >


### PR DESCRIPTION
Reported by @sivran via Slack:

> Could we ignore the onMouseUp event when releasing the mouse outside the modal?
It’s an issue when e.g. selecting text inside an input field and releasing the mouse outside the modal by accident.

https://user-images.githubusercontent.com/1501870/173918168-63f2125a-d0f6-475a-9c42-b63093bfc901.mov


