### PR TITLE
fix(DatePicker): make keyboard usage in input not throw

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
@@ -259,47 +259,54 @@ export default class DatePickerInput extends React.PureComponent {
   }
 
   prepareCounting = async ({ keyCode, target, event }) => {
-    const isDate = target
-      .getAttribute('class')
-      .match(/__input--([day|month|year]+)($|\s)/)[1]
-    const isInRange = target
-      .getAttribute('id')
-      .match(/[0-9]-([start|end]+)-/)[1]
+    try {
+      const isDate = target
+        .getAttribute('class')
+        .match(/__input--([day|month|year]+)($|\s)/)[1]
 
-    let date =
-      isInRange === 'start' ? this.context.startDate : this.context.endDate
+      const isInRange = target
+        .getAttribute('id')
+        .match(/-([start|end]+)-/)[1]
 
-    // do nothing if date is not set yet
-    if (!date) {
-      return
-    }
+      let date =
+        isInRange === 'start'
+          ? this.context.startDate
+          : this.context.endDate
 
-    const count = keyCode === 'up' ? 1 : -1
-
-    if (keyCode === 'up' || keyCode === 'down') {
-      switch (isDate) {
-        case 'day':
-          date = addDays(date, count)
-          break
-        case 'month':
-          date = addMonths(date, count)
-          break
-        case 'year':
-          date = addYears(date, count)
-          break
+      // do nothing if date is not set yet
+      if (!date) {
+        return
       }
+
+      const count = keyCode === 'up' ? 1 : -1
+
+      if (keyCode === 'up' || keyCode === 'down') {
+        switch (isDate) {
+          case 'day':
+            date = addDays(date, count)
+            break
+          case 'month':
+            date = addMonths(date, count)
+            break
+          case 'year':
+            date = addYears(date, count)
+            break
+        }
+      }
+
+      this.callOnChange({
+        [isInRange === 'start' ? 'startDate' : 'endDate']: date,
+        event,
+      })
+
+      await wait(1) // to get the correct position afterwards
+
+      const endPos = target.value.length
+      target.focus()
+      target.setSelectionRange(0, endPos)
+    } catch (e) {
+      warn(e)
     }
-
-    this.callOnChange({
-      [isInRange === 'start' ? 'startDate' : 'endDate']: date,
-      event,
-    })
-
-    await wait(1) // to get the correct position afterwards
-
-    const endPos = target.value.length
-    target.focus()
-    target.setSelectionRange(0, endPos)
   }
 
   onFocusHandler = (event) => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.js
@@ -1029,6 +1029,7 @@ describe('DatePicker component', () => {
         range
         start_date={defaultProps.start_date}
         end_date={defaultProps.end_date}
+        id="unique-id"
       />,
       { attachTo: attachToBody() }
     )


### PR DESCRIPTION
Adding an id prop to the DatePicker component breaks incrementing / decrementing the date inputs using the arrow keys.

Thanks @sivran for reporting 🙏

[Re-prod](https://codesandbox.io/s/smoosh-water-o94piq?file=/src/App.tsx)

The fix:

```diff
- .match(/[0-9]-([start|end]+)-/)[1]
+ .match(/-([start|end]+)-/)[1]
```

We also wrap this whole code block in a try catch because it contains DOM interaction.