### PR TITLE
fix(Autocomplete): touch device issue on first focus

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1989,7 +1989,6 @@ class AutocompleteInstance extends React.PureComponent {
                 on_pre_change={this.onPreChangeHandler}
                 on_key_down={this.onReserveActivityHandler}
                 onMouseDown={this.onReserveActivityHandler}
-                onTouchStart={this.onReserveActivityHandler}
               />
             </span>
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -785,7 +785,6 @@ describe('Autocomplete component', () => {
       attributes: {
         ...params,
         onMouseDown: expect.any(Function),
-        onTouchStart: expect.any(Function),
       },
       data: null,
       ulElement: null,
@@ -916,12 +915,6 @@ describe('Autocomplete component', () => {
 
     // Try to call on_blur by mousedown
     Comp.find('.dnb-drawer-list').simulate('mousedown')
-    Comp.find('input').simulate('blur')
-    expect(on_blur).toHaveBeenCalledTimes(0)
-    expect(onBlur).toHaveBeenCalledTimes(0)
-
-    // Try to call on_blur by touch
-    Comp.find('.dnb-drawer-list').simulate('touchstart')
     Comp.find('input').simulate('blur')
     expect(on_blur).toHaveBeenCalledTimes(0)
     expect(onBlur).toHaveBeenCalledTimes(0)

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -849,7 +849,6 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                 no_animation={true}
                 no_scroll_animation="no_scroll_animation"
                 onMouseDown={[Function]}
-                onTouchStart={[Function]}
                 on_change={[Function]}
                 on_hide={[Function]}
                 on_key_down={[Function]}
@@ -901,7 +900,6 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                   no_animation={true}
                   no_scroll_animation="no_scroll_animation"
                   onMouseDown={[Function]}
-                  onTouchStart={[Function]}
                   on_change={[Function]}
                   on_hide={[Function]}
                   on_key_down={[Function]}
@@ -936,7 +934,6 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
                       disabled="disabled"
                       id="autocomplete-id-drawer-list"
                       onMouseDown={[Function]}
-                      onTouchStart={[Function]}
                     >
                       <span
                         className="dnb-drawer-list__list dnb-autocomplete__list dnb-drawer-list__list--no-animation"

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -556,7 +556,7 @@ DrawerList.Item.defaultProps = {
   value: null,
 }
 
-export function ItemContent({ hash, children }) {
+export function ItemContent({ hash = '', children }) {
   let content = null
 
   if (Array.isArray(children.content || children)) {


### PR DESCRIPTION
Report:
> We are having issues with Autocomplete on mobile devices where the dropdown is sometimes immediately closed after opening it. The same behavior can be observed on the Eufemia documentation page by:
Opening dev tools
Clicking on "device emulation"
Scaling the width down to a "mobile device"
I have not been able to reproduce it by doing some specific actions unfortunately, it looks like it sometimes selects whatever item in the dropdown is being hovered, and closes immediately as a result of being selected.

Thanks for reporting Christian 🙏

We fix this issue by removing the extra touch event (`onTouchStart`) handler and just use `onMouseDown` as touch devices do anyway fire it. 
The issue was that our event handler function got fired twice.