### PR TITLE
docs: Remove 'new' status for components older than 6 months

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar.md
@@ -1,7 +1,7 @@
 ---
 title: 'Avatar'
 description: 'The avatar component are identifiers that makes people and companies more scannable.'
-status: 'new'
+status: null
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
@@ -1,7 +1,7 @@
 ---
 title: 'Breadcrumb'
 description: 'The Breadcrumb component is a bar for navigation showing current web path'
-status: 'new'
+status: null
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card.md
@@ -1,7 +1,7 @@
 ---
 title: 'InfoCard'
 description: 'The infocard is used to give the user more information than we can give in a messagebox. It can also be used as to give useful tips.'
-status: 'new'
+status: null
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tag'
 description: 'The Tag component'
-status: 'new'
+status: null
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/timeline.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/timeline.md
@@ -1,7 +1,7 @@
 ---
 title: 'Timeline'
 description: 'The Timeline component shows events in chronological order and gives a great overview of the overall process'
-status: 'new'
+status: null
 showTabs: true
 ---
 


### PR DESCRIPTION
Removed '`new`' status for components older than 6 months, including 
`InfoCard`, `Avatar`, `Breadcrumb`, `Timeline`, `Tag`. 