### PR TITLE
feat(Timeline): add fullwidth to info message

### DIFF
--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -218,6 +218,7 @@ const TimelineItem = (localProps: TimelineItemProps) => {
             state="info"
             className="dnb-timeline__item__content__info"
             data-testid="timeline-item-content-info"
+            stretch
           />
         )}
       </div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Added stretch to `FormStatus` used as `infoMessage`  in `TimelineItem` to match the design.

From [Figma](https://www.figma.com/file/cdtwQD8IJ7pTeE45U148r1/Eufemia---Web?node-id=19553%3A7463):
<img width="589" alt="Skjermbilde 2022-07-21 kl  08 17 17" src="https://user-images.githubusercontent.com/21338570/180217794-6c67f7a6-c8b2-4a92-a952-ca008ec661b7.png">


