### PR TITLE
docs: fix example usage of color docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/colors.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/colors.md
@@ -20,10 +20,10 @@ Read more about why and how to [use a polyfill](/uilib/usage/customisation/styli
 
 <ComponentBox hideCode useRender>
 {`
-const Paragraph = styled(P)\`
+const ParagraphStyled = styled(P)\`
   color: var(--color-sky-blue);
 \`
-render(<Paragraph>I'm Sky blue.</Paragraph>)
+render(<ParagraphStyled>I'm Sky blue.</ParagraphStyled>)
 `}
 </ComponentBox>
 


### PR DESCRIPTION
This PR fixes the following "example usage" in colors docs.
https://eufemia.dnb.no/uilib/usage/customisation/colors/#example-usage