### PR TITLE
chore(Docs): simplify Examples syntax to only use a string instead of a function

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.js
@@ -12,7 +12,8 @@ import {
 
 export const AccordionDefaultExample = () => (
   <ComponentBox data-visual-test="accordion-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Accordion
   expanded
 	remember_state
@@ -34,24 +35,28 @@ export const AccordionDefaultExample = () => (
 		Accordion content
 	</Accordion>
 </Accordion.Provider>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AccordionLargeContentExample = () => (
   <ComponentBox data-visual-test="accordion-large" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Accordion expanded bottom="large" title="Large content with long titleScelerisque eget cubilia tempus ipsum aenean dolor suscipit egestas potenti at eleifend platea interdum magnis amet molestie sem faucibus netus "
 >
   <P>Hendrerit dictum elit facilisis aliquet eleifend potenti leo nec praesent sollicitudin elementum scelerisque ridiculus neque nisi risus et habitant torquent nam pellentesque dictumst porttitor accumsan a nibh fringilla facilisi lacus sagittis mauris libero tellus justo ultricies tempor viverra sodales vestibulum proin tempus lorem cubilia at velit sociis sit malesuada class consectetur turpis metus vulputate tortor cum nisl ornare ligula platea quam gravida sapien penatibus ad curae varius hac ultrices ipsum felis vehicula fermentum rutrum parturient congue sed vel magnis laoreet donec id consequat augue mi semper volutpat urna in condimentum luctus cursus fames dignissim magna suspendisse bibendum mus natoque diam</P>
 </Accordion>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AccordionCustomisationExample = () => (
   <ComponentBox data-visual-test="accordion-custom">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Accordion
   group="unique-id"
   left_component={<IconPrimary icon="bell" />}
@@ -74,13 +79,15 @@ export const AccordionCustomisationExample = () => (
     </P>
   </Accordion.Content>
 </Accordion>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AccordionContainerExample = () => (
   <ComponentBox useRender hideCode data-visual-test="accordion-container">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 function AccordionWithContainer() {
   const ref1 = React.useRef()
   const ref2 = React.useRef()
@@ -188,13 +195,15 @@ function ChangingContent({ changeHeight, children }) {
   )
 }
 render(<AccordionWithContainer />)
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AccordionGroupExample = () => (
   <ComponentBox data-visual-test="accordion-group">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Accordion.Group expanded allow_close_all>
 	<Accordion expanded={false}>
     <Accordion.Header>Accordion title</Accordion.Header>
@@ -216,7 +225,8 @@ export const AccordionGroupExample = () => (
     </Accordion.Content>
 	</Accordion>
 </Accordion.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -226,7 +236,8 @@ export const AccordionPlainVariant = () => {
       data-visual-test="accordion-variant-plain"
       scope={{ AddIcon, SubtractIcon }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Accordion
   variant="plain"
   title="Accordion with plain variant"
@@ -250,7 +261,8 @@ export const AccordionPlainVariant = () => {
 >
   content
 </Accordion>
-`}
+`
+      }
     </ComponentBox>
   ) : null
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.js
@@ -25,12 +25,14 @@ const Wrapper = styled.div`
 export const AutocompleteDefaultExample = () => (
   <Wrapper>
     <ComponentBox scope={{ topMovies }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Autocomplete
   data={topMovies}
   label="Label:"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -38,7 +40,8 @@ export const AutocompleteDefaultExample = () => (
 export const AutocompleteNumbersExample = () => (
   <Wrapper>
     <ComponentBox useRender scope={{ format }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const numbers = [
   format(20001234567, { ban: true }),
   format(22233344425, { ban: true }),
@@ -54,7 +57,8 @@ render(
     search_numbers={true}
   />
 )
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -65,7 +69,8 @@ export const AutocompleteWithCustomTitle = () => (
       data-visual-test="autocomplete-closed"
       scope={{ topMovies }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Autocomplete
   data={topMovies}
   keep_value={true}
@@ -76,7 +81,8 @@ export const AutocompleteWithCustomTitle = () => (
     console.log('on_change', data)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -84,7 +90,8 @@ export const AutocompleteWithCustomTitle = () => (
 export const AutocompleteDynamicallyUpdatedData = () => (
   <Wrapper>
     <ComponentBox scope={{ topMovies }} useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const onTypeHandler = ({
   value,
   showIndicator,
@@ -122,7 +129,8 @@ render(<Autocomplete
   no_scroll_animation="true"
   placeholder="Search ..."
 />)
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -130,7 +138,8 @@ render(<Autocomplete
 export const AutocompleteFirstFocusUpdate = () => (
   <Wrapper>
     <ComponentBox scope={{ topMovies }} useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const onFocusHandler = ({ updateData, dataList, showIndicatorItem }) => {
   if(!dataList.length){
     showIndicatorItem()
@@ -148,7 +157,8 @@ render(<Autocomplete
   }}
   on_focus={onFocusHandler}
 />)
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -159,7 +169,8 @@ export const AutocompleteToggleExample = () => (
       data-visual-test="autocomplete-drawer-button"
       scope={{ topMovies }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Autocomplete
   label="Label:"
   show_submit_button="true"
@@ -169,7 +180,8 @@ export const AutocompleteToggleExample = () => (
 >
   {() => (topMovies)}
 </Autocomplete>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -180,7 +192,8 @@ export const AutocompletePredefinedInput = () => (
       data-visual-test="autocomplete-drawer-search"
       scope={{ topMovies }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Autocomplete
   label="Label:"
   input_value="the pa ther"
@@ -191,7 +204,8 @@ export const AutocompletePredefinedInput = () => (
 >
   {() => (topMovies)}
 </Autocomplete>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -202,7 +216,8 @@ export const AutocompleteDifferentSizes = () => (
       data-visual-test="autocomplete-sizes"
       scope={{ topMovies }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow direction="vertical">
   <Autocomplete
     label="Label:"
@@ -223,7 +238,8 @@ export const AutocompleteDifferentSizes = () => (
     data={() => (topMovies)}
   />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -234,7 +250,8 @@ export const AutocompleteCustomWidth = () => (
     scope={{ topMovies }}
     useRender
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const CustomWidthOne = styled(Autocomplete)\`
   .dnb-autocomplete__shell {
     width: 10rem;
@@ -283,7 +300,8 @@ render(<FormRow direction="vertical">
     data={topMovies}
   />
 </FormRow>)
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -319,7 +337,8 @@ export const AutocompleteSuffix = () => {
       scope={{ numbers }}
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const CustomWidth = styled(Autocomplete)\`
   .dnb-drawer-list__root,
   .dnb-autocomplete__shell {
@@ -339,7 +358,8 @@ render(
     label_direction="vertical"
   />
 )
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -355,7 +375,8 @@ export const AutocompleteOpened = () => {
         scope={{ topMovies }}
         hideCode
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <Autocomplete
   label="Label:"
   input_value="lord"
@@ -377,7 +398,8 @@ export const AutocompleteOpened = () => {
   data={topMovies}
   className="focus-trigger"
 />
-`}
+`
+        }
       </ComponentBox>
     </Wrapper>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.js
@@ -12,91 +12,109 @@ import {
 
 export const AvatarSizeDefault = () => (
   <ComponentBox hideCode data-visual-test="avatar-size-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Persons:">
   <Avatar>Ola Nordmann</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarSizeSmall = () => (
   <ComponentBox hideCode data-visual-test="avatar-size-small">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 Text <Avatar.Group label="Animals:">
   <Avatar size="small">Duck</Avatar>
 </Avatar.Group> Text
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarSizeMedium = () => (
   <ComponentBox hideCode data-visual-test="avatar-size-medium">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Stocks:">
   <Avatar size="medium">NFLX</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarSizeLarge = () => (
   <ComponentBox hideCode data-visual-test="avatar-size-large">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Companies:">
   <Avatar size="large">Amazon</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarSizeXLarge = () => (
   <ComponentBox hideCode data-visual-test="avatar-size-x-large">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="TV Shows:">
   <Avatar size="x-large">Friends</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarVariantDefault = () => (
   <ComponentBox hideCode data-visual-test="avatar-variant-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Dogs:">
   <Avatar>Kleiner münsterländer</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarVariantPrimary = () => (
   <ComponentBox hideCode data-visual-test="avatar-variant-primary">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Cities:">
   <Avatar variant="primary">Oslo</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarVariantSecondary = () => (
   <ComponentBox hideCode data-visual-test="avatar-variant-secondary">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Countries:">
   <Avatar variant="secondary">Spain</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarVariantTertiary = () => (
   <ComponentBox hideCode data-visual-test="avatar-variant-tertiary">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Cars:">
   <Avatar variant="tertiary">Tesla</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -106,13 +124,15 @@ export const AvatarConfettiIcon = () => (
     scope={{ Confetti }}
     data-visual-test="avatar-children-icon-primary"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Icons:">
   <Avatar variant="primary">
     <Icon icon={Confetti} />
   </Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -122,13 +142,15 @@ export const AvatarCardIcon = () => (
     scope={{ Card }}
     data-visual-test="avatar-children-icon-secondary"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Icons:">
   <Avatar variant="secondary">
     <Icon icon={Card} />
   </Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -138,31 +160,36 @@ export const AvatarAccountCardIcon = () => (
     scope={{ AccountCard }}
     data-visual-test="avatar-children-icon-tertiary"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Icons:">
   <Avatar variant="tertiary">
     <Icon icon={AccountCard} />
   </Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarDNBLogo = () => (
   <ComponentBox hideCode data-visual-test="avatar-children-logo">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Logos:">
   <Avatar>
     <Logo size="auto" />
   </Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarImageDNB = () => (
   <ComponentBox hideCode data-visual-test="avatar-image-local-png">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Banks:">
   <Avatar 
     src="/android-chrome-192x192.png" 
@@ -170,13 +197,15 @@ export const AvatarImageDNB = () => (
     size="x-large"
   />
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarImagePinnedTab = () => (
   <ComponentBox hideCode data-visual-test="avatar-image-local-svg">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Icons:">
   <Avatar 
     variant="tertiary"
@@ -184,13 +213,15 @@ export const AvatarImagePinnedTab = () => (
     alt="DNB Logo" 
   />
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const AvatarImageTobias = () => (
   <ComponentBox hideCode data-visual-test="avatar-image-external">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Profiles:">
   <Avatar 
     src="/images/avatars/1501870.jpg" 
@@ -198,7 +229,8 @@ export const AvatarImageTobias = () => (
     size="large"
   />
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -208,7 +240,8 @@ export const AvatarImageProps = () => (
     noFragments={false}
     data-visual-test="avatar-image-props"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const imgProps = {
     width: "48", 
@@ -227,13 +260,15 @@ export const AvatarImageProps = () => (
     </Avatar.Group>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GroupedAvatarsSmall = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-small">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 Text <Avatar.Group label="Friends:" size="small" variant="primary" maxElements={6}>
   <Avatar>Anders</Avatar>
   <Avatar>Bjørnar</Avatar>
@@ -243,13 +278,15 @@ Text <Avatar.Group label="Friends:" size="small" variant="primary" maxElements={
   <Avatar>Frida</Avatar>
   <Avatar>Gøril</Avatar>
 </Avatar.Group> Text
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GroupedAvatarsMedium = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-medium">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Employees:" size="medium" maxElements={5}>
   <Avatar>Anders</Avatar>
   <Avatar>Bjørnar</Avatar>
@@ -259,13 +296,15 @@ export const GroupedAvatarsMedium = () => (
   <Avatar>Frida</Avatar>
   <Avatar>Gøril</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GroupedAvatarsLarge = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-large">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Borrowers:" size="large" variant="tertiary" maxElements={4}>
   <Avatar>Anders</Avatar>
   <Avatar>Bjørnar</Avatar>
@@ -275,13 +314,15 @@ export const GroupedAvatarsLarge = () => (
   <Avatar>Frida</Avatar>
   <Avatar>Gøril</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GroupedAvatarsXLarge = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-x-large">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Enemies:" size="x-large" variant="secondary" maxElements={3}>
   <Avatar>Anders</Avatar>
   <Avatar>Bjørnar</Avatar>
@@ -291,13 +332,15 @@ export const GroupedAvatarsXLarge = () => (
   <Avatar>Frida</Avatar>
   <Avatar>Gøril</Avatar>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GroupedAvatarsImg = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-image">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Avatar.Group label="Eufemia contributors:" size="large" maxElements={5}>
   <Avatar src="/images/avatars/1501870.jpg" alt="Profile picture"/>
   <Avatar src="/images/avatars/35217511.jpg" alt="Profile picture"/>
@@ -307,6 +350,7 @@ export const GroupedAvatarsImg = () => (
   <Avatar src="/images/avatars/1501870.jpg" alt="Profile picture"/>
   <Avatar src="/images/avatars/1501870.jpg" alt="Profile picture"/>
 </Avatar.Group>
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge/Examples.js
@@ -11,9 +11,11 @@ import {
 
 export const BadgeNotification = () => (
   <ComponentBox hideCode data-visual-test="badge-variant-notification">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={1} label="Notifications:" variant="notification"/>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -22,9 +24,11 @@ export const BadgeNotificationInline = () => (
     hideCode
     data-visual-test="badge-variant-notification-inline"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 Text <Badge content={1} label="Notifications:" variant="notification"/> Text
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -33,21 +37,25 @@ export const BadgeNotificationAvatar = () => (
     hideCode
     data-visual-test="badge-variant-notification-avatar"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={1} label="Notifications:" variant="notification">
   <Avatar.Group label="Persons:">
     <Avatar size="large">A</Avatar>
   </Avatar.Group>
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
 export const BadgeDefault = () => (
   <ComponentBox hideCode data-visual-test="badge-variant-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content="New"/>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -56,9 +64,11 @@ export const BadgeInformationInline = () => (
     hideCode
     data-visual-test="badge-variant-information-inline"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 Text <Badge content="Info" variant="information"/> Text
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -67,61 +77,71 @@ export const BadgeInformationAvatar = () => (
     hideCode
     data-visual-test="badge-variant-information-avatar"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content="Ny" variant="information">
   <Avatar.Group label="Persons:">
     <Avatar size="large" variant="secondary">A</Avatar>
   </Avatar.Group>
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
 export const BadgeTopLeft = () => (
   <ComponentBox hideCode data-visual-test="badge-top-left">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={66} label="Notifications:" vertical="top" horizontal="left" variant="notification">
   <Avatar.Group label="Persons:">
     <Avatar size="large">A</Avatar>
   </Avatar.Group>
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
 export const BadgeTopRight = () => (
   <ComponentBox hideCode data-visual-test="badge-top-right">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={1} label="Notifications:" vertical="top" horizontal="right" variant="notification">
   <Avatar.Group label="Persons:">
     <Avatar size="large">A</Avatar>
   </Avatar.Group>
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
 export const BadgeBottomLeft = () => (
   <ComponentBox hideCode data-visual-test="badge-bottom-left">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={13} label="Notifications:" vertical="bottom" horizontal="left" variant="notification">
   <Avatar.Group label="Persons:">
     <Avatar size="large">A</Avatar>
   </Avatar.Group>
 </Badge>
-      `}
+      `
+    }
   </ComponentBox>
 )
 
 export const BadgeBottomRight = () => (
   <ComponentBox hideCode data-visual-test="badge-bottom-right">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={58} label="Notifications:" vertical="bottom" horizontal="right" variant="notification">
   <Avatar.Group label="Persons:">
     <Avatar size="large">A</Avatar>
   </Avatar.Group>
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -133,11 +153,13 @@ export const BadgeMailIcon = () => (
     scope={{ Email }}
     data-visual-test="badge-alternative-icon"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={99} label="Notifications:" variant="notification" vertical="top" horizontal="right">
   <Icon icon={Email} size="x-large" />
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
@@ -147,7 +169,8 @@ export const BadgeImgWithIcon = () => (
     scope={{ Confetti }}
     data-visual-test="badge-alternative-img"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Badge content={<Icon icon={Confetti} />}>
   <Img 
   src="https://avatars.githubusercontent.com/u/1501870?v=4" 
@@ -156,6 +179,7 @@ export const BadgeImgWithIcon = () => (
   width="64"
 />
 </Badge>
-  `}
+  `
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/Examples.js
@@ -7,19 +7,22 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const BreadcrumbSingle = () => (
   <ComponentBox data-visual-test="breadcrumb-single">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Breadcrumb
   onClick={() => {
       console.log('Going back!')
     }}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const BreadcrumbMultipleData = () => (
   <ComponentBox noFragments={false} data-visual-test="breadcrumb-multiple">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   // You can also import pages from a store and only do a remapping
   const pages = [
@@ -45,25 +48,29 @@ export const BreadcrumbMultipleData = () => (
     <Breadcrumb data={pages} spacing/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const BreadcrumbMultiple = () => (
   <ComponentBox data-visual-test="breadcrumb-multiple-children">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Breadcrumb spacing>
   <Breadcrumb.Item onClick={() => {console.log("go home!")}} variant="home" />
   <Breadcrumb.Item text="Page item" onClick={() => {console.log("go to page 1")}} />
   <Breadcrumb.Item text="Page item" onClick={() => {console.log("go to page 2")}} variant="current" />
 </Breadcrumb>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const BreadcrumbVariants = () => (
   <ComponentBox noFragments={false} data-visual-test="breadcrumb-collapse">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const pages = [
     {
@@ -85,7 +92,8 @@ export const BreadcrumbVariants = () => (
     <Breadcrumb variant="collapse" data={pages} spacing/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -94,7 +102,8 @@ export const BreadcrumbCollapseOpen = () => (
     noFragments={false}
     data-visual-test="breadcrumb-collapse-open"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const pages = [
     {
@@ -115,6 +124,7 @@ export const BreadcrumbCollapseOpen = () => (
     <Breadcrumb variant="collapse" data={pages} isCollapsed={false} spacing />
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.js
@@ -9,7 +9,8 @@ import { bell_medium as Bell, question } from '@dnb/eufemia/src/icons'
 
 export const ButtonPrimary = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   text="Primary button with text only"
   on_click={() => {
@@ -17,13 +18,15 @@ export const ButtonPrimary = () => (
   }}
   data-visual-test="button-primary"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonSecondary = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   variant="secondary"
   onClick={() => {
@@ -33,13 +36,15 @@ export const ButtonSecondary = () => (
 >
   Secondary button with text only
 </Button>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonDisabled = () => (
   <ComponentBox data-visual-test="button-disabled">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   text="Disabled primary button"
   disabled
@@ -63,37 +68,43 @@ export const ButtonDisabled = () => (
   disabled
   right
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonPrimaryWithIcon = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   text="Primary button with icon"
   icon="chevron_right"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonPrimaryWithIconLeft = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   icon_position="left"
   icon="chevron_left"
 >
   Primary button with icon on left
 </Button>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonTertiary = () => (
   <ComponentBox data-visual-test="button-tertiary-all">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   variant="tertiary"
   text="Tertiary button with icon on left"
@@ -108,39 +119,45 @@ export const ButtonTertiary = () => (
   icon="chevron_left"
   right="1rem"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonTertiaryTop = () => (
   <ComponentBox data-visual-test="button-tertiary-top">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   variant="tertiary"
   icon_position="top"
   icon="close"
   text="Button text"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonCustomContent = () => (
   <ComponentBox data-visual-test="button-custom-content">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   icon="close"
   icon_position="right"
   text="Button with custom content"
   custom_content={<IconPrimary icon="check" right="small" />}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonTertiaryWrap = () => (
   <ComponentBox data-visual-test="button-tertiary-wrap">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   wrap
   variant="tertiary"
@@ -148,13 +165,15 @@ export const ButtonTertiaryWrap = () => (
   icon="chevron_left"
   icon_position="left"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonAnchor = () => (
   <ComponentBox data-visual-test="button-anchor">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   text="Primary with href"
   href="/uilib/components/button/demos"
@@ -179,26 +198,30 @@ export const ButtonAnchor = () => (
   size="default"
   right
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonSignal = () => (
   <ComponentBox scope={{ Bell }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   variant="signal"
   text="Signal Button"
   icon={Bell}
   data-visual-test="button-signal"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonSignalLarge = () => (
   <ComponentBox scope={{ Bell }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   variant="signal"
   text="Large Signal Button"
@@ -206,13 +229,15 @@ export const ButtonSignalLarge = () => (
   size="large"
   icon_size="medium"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ButtonIcon = () => (
   <ComponentBox scope={{ question }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   title="Disabled Icon only Button"
   icon="calendar"
@@ -239,7 +264,8 @@ export const ButtonIcon = () => (
   icon={question}
   status="error"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -252,9 +278,11 @@ export const TertiaryWithNoIcon = () => {
       title="Tertiary button with no icon"
       data-visual-test="button-tertiary-no-icon"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button text="Tertiary button with no icon" variant="tertiary" />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -268,9 +296,11 @@ export const UnstyledVariant = () => {
       title="Unstyled button with icon"
       data-visual-test="button-unstyled"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button text="Unstyled button with icon" icon="bell" variant="unstyled" />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -281,14 +311,16 @@ export const ButtonStretch = () => {
   }
   return (
     <ComponentBox title="Button with stretch property" scope={{ Bell }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   text="A stretched button"
   icon={<Bell />}
   size="large"
   data-visual-test="button-stretch"
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -296,7 +328,8 @@ export const ButtonStretch = () => {
 export const PrimaryButtonSizes = () => {
   return (
     <ComponentBox scope={{ Bell }} hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   text="Default button"
   on_click={() => {
@@ -329,7 +362,8 @@ export const PrimaryButtonSizes = () => {
   icon="chevron_right"
   left
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -337,7 +371,8 @@ export const PrimaryButtonSizes = () => {
 export const SecondaryButtonSizes = () => {
   return (
     <ComponentBox scope={{ Bell }} hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   text="Default button"
   on_click={() => {
@@ -374,7 +409,8 @@ export const SecondaryButtonSizes = () => {
   variant="secondary"
   left
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -382,7 +418,8 @@ export const SecondaryButtonSizes = () => {
 export const TertiaryButtonSizes = () => {
   return (
     <ComponentBox scope={{ Bell }} hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   text="Default button"
   on_click={() => {
@@ -401,7 +438,8 @@ export const TertiaryButtonSizes = () => {
   variant="tertiary"
   left
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -409,7 +447,8 @@ export const TertiaryButtonSizes = () => {
 export const SignalButtonSizes = () => {
   return (
     <ComponentBox scope={{ Bell }} hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   text="Default button"
   on_click={() => {
@@ -446,7 +485,8 @@ export const SignalButtonSizes = () => {
   variant="signal"
   left
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -454,7 +494,8 @@ export const SignalButtonSizes = () => {
 export const IconButtonSizes = () => {
   return (
     <ComponentBox hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Button
   title="Small sized button with add icon"
   icon="add"
@@ -478,7 +519,8 @@ export const IconButtonSizes = () => {
   size="large"
   left
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.js
@@ -8,68 +8,80 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const CheckboxUnchecked = () => (
   <ComponentBox data-visual-test="checkbox-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox
   label="Checkbox"
   on_change={(e) => console.log(e)}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const CheckboxChecked = () => (
   <ComponentBox data-visual-test="checkbox-checked">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox
   label="Label:"
   label_position="left"
   checked
   on_change={({ checked }) => console.log(checked)}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const CheckboxWithError = () => (
   <ComponentBox data-visual-test="checkbox-error">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox
   label="Checkbox"
   checked
   status="Error message"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const CheckboxSuffix = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox
   label="Checkbox"
   checked
   suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const CheckboxDifferentSizes = () => (
   <ComponentBox data-visual-test="checkbox-sizes">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox size="medium" label="Medium" right="large" checked />
 <Checkbox size="large" label="Large" checked />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const CheckboxDisabled = () => (
   <ComponentBox data-visual-test="checkbox-disabled">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Checkbox
   checked
   disabled
 />
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.js
@@ -24,7 +24,8 @@ const Wrapper = styled.div`
 export const DatePickerRange = () =>
   global.IS_TEST ? null : (
     <ComponentBox scope={{ addDays, startOfMonth, lastDayOfMonth }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   start_date="2019-04-01"
@@ -59,14 +60,16 @@ export const DatePickerRange = () =>
     }
   ]}
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerWithInput = () =>
   global.IS_TEST ? null : (
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date={new Date()}
@@ -80,14 +83,16 @@ export const DatePickerWithInput = () =>
     console.log('on_cancel', date)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerTrigger = () => (
   <Wrapper>
     <ComponentBox data-visual-test="date-picker-trigger-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date="2019-05-05"
@@ -99,7 +104,8 @@ export const DatePickerTrigger = () => (
     console.log('on_show', date)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -107,7 +113,8 @@ export const DatePickerTrigger = () => (
 export const DatePickerHiddenNav = () =>
   global.IS_TEST ? null : (
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date="2022/05/05"
@@ -124,28 +131,32 @@ export const DatePickerHiddenNav = () =>
     console.log('on_hide', date)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerMonthOnly = () =>
   global.IS_TEST ? null : (
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date="05/02/2019"
   date_format="MM/dd/yyyy"
   only_month={true}
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerDisabled = () =>
   global.IS_TEST ? null : (
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date={new Date()}
@@ -153,35 +164,40 @@ export const DatePickerDisabled = () =>
   status="Please select a valid date"
   status_state="info"
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerSuffix = () =>
   global.IS_TEST ? null : (
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date={new Date()}
   show_input
   suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
 />
-`}
+`
+      }
     </ComponentBox>
   )
 
 export const DatePickerLinked = () => (
   <Wrapper>
     <ComponentBox data-visual-test="date-picker-input">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   range
   link
   show_input
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -189,14 +205,16 @@ export const DatePickerLinked = () => (
 export const DatePickerNoInputStatus = () => (
   <Wrapper>
     <ComponentBox data-visual-test="date-picker-trigger-error">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date="2019-05-05"
   hide_navigation={true}
   status="Please select a valid date"
 />
- `}
+ `
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -204,7 +222,8 @@ export const DatePickerNoInputStatus = () => (
 export const DatePickerErrorMessage = () => (
   <Wrapper>
     <ComponentBox data-visual-test="date-picker-input-error">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date="2019-05-05"
@@ -213,28 +232,32 @@ export const DatePickerErrorMessage = () => (
   stretch={true}
   status={<span>Status message with <b>HTML</b> inside</span>}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
 
 export const DatePickerErrorStatus = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <DatePicker
   label="DatePicker:"
   date={new Date()}
   hide_navigation={true}
   status="error"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const DatePickerCalendar = () => (
   <Wrapper>
     <ComponentBox data-visual-test="date-picker-calendar">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DatePicker
   opened="true"
   prevent_close="true"
@@ -243,7 +266,8 @@ export const DatePickerCalendar = () => (
   start_date="2019-05-05"
   end_date="2019-06-05"
 />
- `}
+ `
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -255,7 +279,8 @@ export const DatePickerScreenshotTests = () => {
   return (
     <Wrapper>
       <ComponentBox data-visual-test="date-picker-sizes">
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <FormRow vertical>
   <DatePicker
     label="DatePicker:"
@@ -281,7 +306,8 @@ export const DatePickerScreenshotTests = () => {
     show_input={true}
   />
 </FormRow>
- `}
+ `
+        }
       </ComponentBox>
     </Wrapper>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/Examples.js
@@ -15,18 +15,21 @@ import {
 
 export const DialogExampleDefault = () => (
   <ComponentBox data-visual-test="dialog-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog title="What is a Dialog?">
   <P>The Dialog component is a Modal variation that appears at the center of the screen. The Dialog has similar functionality to a traditional popup window and is mostly used for informational purposes (for example explaining a word on the page). Similar to Modal, it has to be triggered by the user to appear. Typical usage would be to read an explanation, then closing it.</P>
   <Button variant="secondary" size="large" top="large">Read more</Button>
 </Dialog>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const DialogExampleHelpButton = () => (
   <ComponentBox data-visual-test="dialog-help-button">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Input
   label="Input"
   placeholder="Placeholder ..."
@@ -36,13 +39,15 @@ export const DialogExampleHelpButton = () => (
     </Dialog>
   }
 />
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const DialogExampleFullscreen = () => (
   <ComponentBox data-visual-test="dialog-fullscreen">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   title={<span className="dnb-sr-only">"Hidden" Dialog title</span>}
   fullscreen
@@ -53,13 +58,15 @@ export const DialogExampleFullscreen = () => (
   }}
   modalContent="The Dialog component is a Modal variation that appears at the center of the screen. The Dialog has similar functionality to a traditional popup window and is mostly used for informational purposes."
 />
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const DialogExampleDelayClose = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   title=".5s close delay"
   triggerAttributes={{
@@ -80,13 +87,15 @@ export const DialogExampleDelayClose = () => (
   <P>Click outside me, and I will be closed within 1 second.</P>
   <Input label="Focus:" top>Focus me with Tab key</Input>
 </Dialog>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const DialogExampleCustomTrigger = () => (
   <ComponentBox data-visual-test="dialog-custom-trigger">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   title="Modal Title"
   trigger={(props) => (
@@ -95,7 +104,8 @@ export const DialogExampleCustomTrigger = () => (
 >
     <P>This Modal was opened by a custom trigger component.</P>
 </Dialog>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
@@ -104,7 +114,8 @@ export const FullDialogExample = () => (
     data-visual-test="full-dialog"
     scope={{ handleBack: () => {} }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   title="Custom title"
   >
@@ -122,13 +133,15 @@ export const FullDialogExample = () => (
   </Button>
   <FormStatus state="info">This is a formstatus in a Dialog</FormStatus>
 </Dialog>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const DialogExampleProgressIndicator = () => (
   <ComponentBox data-visual-test="dialog-progress-indicator">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   spacing={false}
   fullscreen={false}
@@ -147,7 +160,8 @@ export const DialogExampleProgressIndicator = () => (
     bottom="large"
   />
 </Dialog>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
@@ -156,7 +170,8 @@ export const DialogConfirmDefault = () => (
     data-visual-test="dialog-confirm-default"
     scope={{ bell_medium }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   variant="confirmation"
   title="Dialog confirmation title"
@@ -166,7 +181,8 @@ export const DialogConfirmDefault = () => (
   triggerAttributes={{
     text: 'Trigger button',
   }}
-/>`}
+/>`
+    }
   </ComponentBox>
 )
 
@@ -175,7 +191,8 @@ export const DialogConfirmDelete = () => (
     data-visual-test="dialog-confirm-delete"
     scope={{ trash_medium }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   variant="confirmation"
   confirmType="warning"
@@ -189,7 +206,8 @@ export const DialogConfirmDelete = () => (
     text: 'Delete record',
     icon: trash_medium,
   }}
-/>`}
+/>`
+    }
   </ComponentBox>
 )
 
@@ -201,7 +219,8 @@ export const DialogConfirmLoggedOut = () => (
     scope={{ log_out_medium, loginHandler }}
     useRender
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const Component = () => {
   const [open, setOpen] = React.useState(false)
   return (
@@ -232,7 +251,8 @@ const Component = () => {
   )
 }
 render(<Component />)	
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -241,7 +261,8 @@ export const DialogConfirmCookies = () => (
     data-visual-test="dialog-confirm-cookie"
     scope={{ cookie_medium, edit }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Dialog
   triggerAttributes={{
     text: 'Show cookie dialog',
@@ -274,7 +295,8 @@ export const DialogConfirmCookies = () => (
     />
   </Dialog.Action>
 </Dialog>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -290,7 +312,8 @@ export const DialogConfirmScrollableContent = () => {
       data-visual-test="dialog-scroll-content"
       scope={{ scrollRef }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dialog
   triggerAttributes={{
     text: 'Show cookie dialog',
@@ -351,7 +374,8 @@ export const DialogConfirmScrollableContent = () => {
     />
   </Dialog.Action>
 </Dialog>
-`}
+`
+      }
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/Examples.js
@@ -7,7 +7,8 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const SimpleDrawerExample = () => (
   <ComponentBox data-visual-test="simple-drawer">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Drawer 
   title="Drawer title"
   triggerAttributes={{text: "Open drawer"}}
@@ -28,7 +29,8 @@ export const SimpleDrawerExample = () => (
     phasellus praesent justo mollis montes velit taciti gravida
   </P>
 </Drawer>    
-    `}
+    `
+    }
   </ComponentBox>
 )
 export const FullDrawerExample = () => (
@@ -36,7 +38,8 @@ export const FullDrawerExample = () => (
     data-visual-test="full-drawer"
     scope={{ handleBack: () => {} }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Drawer
   title="Custom title"
   >
@@ -106,13 +109,15 @@ export const FullDrawerExample = () => (
     </Tabs.Content>
   </Drawer.Body>
 </Drawer>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const DrawerCustomTriggerExample = () => (
   <ComponentBox data-visual-test="drawer-custom-trigger">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Drawer 
   title="Drawer with custom trigger"
   triggerAttributes={{
@@ -129,13 +134,15 @@ export const DrawerCustomTriggerExample = () => (
   </P>
   </Drawer.Body>
 </Drawer>    
-    `}
+    `
+    }
   </ComponentBox>
 )
 
 export const DrawerCallbackExample = () => (
   <ComponentBox data-visual-test="callback-drawer">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Drawer 
   title="Drawer title"
   triggerAttributes={{text: "Open drawer"}}
@@ -147,13 +154,15 @@ export const DrawerCallbackExample = () => (
     </>
   )}
 </Drawer>    
-    `}
+    `
+    }
   </ComponentBox>
 )
 
 export const DrawerNoAnimationNoSpacing = () => (
   <ComponentBox data-visual-test="drawer-no-animation">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Drawer 
   title="No spacing or animation"
   noAnimation
@@ -171,6 +180,7 @@ export const DrawerNoAnimationNoSpacing = () => (
     <FormStatus state="info">This is a lorem ipsum dolor</FormStatus>
 </Drawer.Body>
 </Drawer>    
-    `}
+    `
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.js
@@ -65,7 +65,8 @@ const data = [
 export const DropdownFind = () => (
   <Wrapper>
     <ComponentBox useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const scrollableData = [
   {
     content: 'A'
@@ -103,7 +104,8 @@ render(
     label="Label:"
   />
 )
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -111,7 +113,8 @@ render(
 export const DropdownNoValue = () => (
   <Wrapper>
     <ComponentBox data-visual-test="dropdown-closed" useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const data = [
   // Every data item can, beside "content" - contain what ever
   {
@@ -156,7 +159,8 @@ render(
     }}
   />
 )
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -165,7 +169,8 @@ export const DropdownEllipsisOverflow = () =>
   typeof window !== 'undefined' && window.IS_TEST ? (
     <Wrapper>
       <ComponentBox data-visual-test="dropdown-ellipsis" useRender>
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 render(
   <Dropdown
     data={['Long text that will overflow with CSS ellipsis']}
@@ -173,7 +178,8 @@ render(
     label="Label:"
   />
 )
-`}
+`
+        }
       </ComponentBox>
     </Wrapper>
   ) : null
@@ -195,7 +201,8 @@ export const DropdownDirections = () => {
         scope={{ visualTestProps }}
         data-visual-test="dropdown-item-directions"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <Dropdown
   label="Label:"
   data={[
@@ -213,7 +220,8 @@ export const DropdownDirections = () => {
   ]}
   {...visualTestProps(typeof window !== 'undefined' && window.IS_TEST && window.location.search.includes('item-directions'))}
 />
-  `}
+  `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -222,7 +230,8 @@ export const DropdownDirections = () => {
 export const DropdownIconLeft = () => (
   <Wrapper>
     <ComponentBox scope={{ data }} data-visual-test="dropdown-left-icon">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dropdown
   label="Label:"
   icon_position="left"
@@ -236,7 +245,8 @@ export const DropdownIconLeft = () => (
     console.log('on_show')
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -244,7 +254,8 @@ export const DropdownIconLeft = () => (
 export const DropdownActionMenu = () => (
   <Wrapper>
     <ComponentBox scope={{ data }} data-visual-test="dropdown-action_menu">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dropdown
   title="ActionMenu"
   action_menu={true}
@@ -260,7 +271,8 @@ export const DropdownActionMenu = () => (
     </>
   ]}
 />
- `}
+ `
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -268,7 +280,8 @@ export const DropdownActionMenu = () => (
 export const DropdownTertiary = () => (
   <Wrapper>
     <ComponentBox scope={{ data }} data-visual-test="dropdown-tertiary">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dropdown
   variant="tertiary"
   independent_width={true}
@@ -276,7 +289,8 @@ export const DropdownTertiary = () => (
   align_dropdown="left"
   data={data}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -299,7 +313,8 @@ export const DropdownMoreMenu = () => {
         scope={{ visualTestProps }}
         data-visual-test="dropdown-more_menu"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <Dropdown
   more_menu="true"
   size="small"
@@ -337,7 +352,8 @@ export const DropdownMoreMenu = () => {
     console.log('on_select', active_item)
   }}
 />
-  `}
+  `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -346,12 +362,14 @@ export const DropdownMoreMenu = () => {
 export const DropdownDisabled = () => (
   <Wrapper>
     <ComponentBox scope={{ data }} data-visual-test="dropdown-disabled">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dropdown 
   disabled 
   data={['Disabled Dropdown']} 
   label="Label:" />
-      `}
+      `
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -359,13 +377,15 @@ export const DropdownDisabled = () => (
 export const DropdownDisabledTertiary = () => (
   <Wrapper>
     <ComponentBox data-visual-test="dropdown-disabled-tertiary">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
   <Dropdown 
     disabled 
     variant="tertiary" 
     data={['Disabled Dropdown']} 
     label="Disabled tertiary dropdown" />
-    `}
+    `
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -390,7 +410,8 @@ export const DropdownCustomEvent = () => {
         useRender
         data-visual-test="dropdown-action_menu-custom"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 const CustomComponent = () => (
   <CustomComponentInner
     onTouchStart={preventDefault}
@@ -430,7 +451,8 @@ render(
     {...visualTestProps(typeof window !== 'undefined' && window.IS_TEST && window.location.search.includes('action_menu-custom'))}
   />
 )
-  `}
+  `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -439,7 +461,8 @@ render(
 export const DropdownSizes = () => (
   <Wrapper>
     <ComponentBox data-visual-test="dropdown-sizes" scope={{ data }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow direction="vertical">
   <Dropdown
     label="Label:"
@@ -460,7 +483,8 @@ export const DropdownSizes = () => (
     data={() => (data)}
   />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -472,7 +496,8 @@ export const DropdownCustomWidth = () => (
       scope={{ data }}
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const CustomWidthOne = styled(Dropdown)\`
   .dnb-dropdown__shell {
     width: 10rem;
@@ -533,7 +558,8 @@ render(<FormRow direction="vertical">
     data={data}
   />
 </FormRow>)
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -544,14 +570,16 @@ export const DropdownStatusVertical = () => (
       data-visual-test="dropdown-status-error"
       scope={{ data }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Dropdown
   data={data}
   label="Label:"
   label_direction="vertical"
   status="Message to the user"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -563,7 +591,8 @@ export const DropdownListOpened = () => (
       scope={{ data }}
       hideCode
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <span className="dnb-drawer-list__list">
   <ul className="dnb-drawer-list__options">
     <li className="dnb-drawer-list__option first-of-type">
@@ -590,7 +619,8 @@ export const DropdownListOpened = () => (
     <li className="dnb-drawer-list__triangle" />
   </ul>
 </span>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.md
@@ -9,7 +9,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Default form-label
 
 <ComponentBox data-visual-test="form-label-default">
-	{() => /* jsx */ `
+	{/* jsx */ `
 <FormLabel for_id="alone-1">
   Default horizontal FormLabel:
 </FormLabel>
@@ -20,7 +20,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Vertical form-label
 
 <ComponentBox data-visual-test="form-label-vertical">
-	{() => /* jsx */ `
+	{/* jsx */ `
 <FormLabel for_id="alone-2" label_direction="vertical">
   Vertical FormLabel:
 </FormLabel>
@@ -31,7 +31,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Vertical form-label without a `for_id`
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <FormLabel vertical={true}>
   Without for_id (select me):
 </FormLabel>
@@ -42,7 +42,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Linked label (pattern)
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <form className="dnb-form">
   <div className="dnb-form__item">
     <div className="dnb-form__cell">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.js
@@ -70,7 +70,8 @@ const Box = styled(Space)`
 export const FormRowVerticalAlignedLabels = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-vertical-label">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow
     label={
       <Ingress top="0" bottom="small">
@@ -82,7 +83,8 @@ export const FormRowVerticalAlignedLabels = () => (
   <Input label="Label A:" value="Input A" right="small" />
   <Input label="Label B:" value="Input B" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -90,11 +92,13 @@ export const FormRowVerticalAlignedLabels = () => (
 export const FormRowLegendIndentUsage = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow indent="default" label="A long horizontal legend (FormLabel) with a lot of informative text and a default indent:">
   <Checkbox id="alone-1" label="Checkbox" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -102,7 +106,8 @@ export const FormRowLegendIndentUsage = () => (
 export const FormRowSectionStyle = () => (
   <TestStyles>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow
   section_style="mint-green"
   section_spacing="default"
@@ -111,7 +116,8 @@ export const FormRowSectionStyle = () => (
 >
   <Checkbox label="Checkbox" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -119,7 +125,8 @@ export const FormRowSectionStyle = () => (
 export const FormRowCombineVerticalAndHorizontal = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-combined" useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 // 1. In the nested FormRow we reset the layout to not be vertical
 // 2. So we can use a different direction ("label_direction")
 render(
@@ -144,7 +151,8 @@ render(
     <Input label="Vertical input C" top="medium" />
   </FormRow>
 )
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -152,7 +160,8 @@ render(
 export const FormRowCustomIndentLayout = () => (
   <TestStyles>
     <ComponentBox useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const CustomRow = styled(FormRow)\`
   align-items: flex-end;
   > .dnb-form-label {
@@ -166,7 +175,8 @@ render(
     <Checkbox label="Checkbox" />
   </CustomRow>
 )
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -174,11 +184,13 @@ render(
 export const FormRowDefault = () => (
   <TestStyles>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow>
   <Input label="Default horizontal FormRow:" placeholder="Input ..." />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -186,12 +198,14 @@ export const FormRowDefault = () => (
 export const FormRowVertical = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-vertical">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow direction="vertical" label="Label legend for the inputs:">
   <Input label="Vertical direction:" placeholder="Input A ..." />
   <Input label="Vertical direction:" placeholder="Input B ..." top="small" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -202,7 +216,8 @@ export const FormRowVerticalDirection = () => (
       data-visual-test="form-row-vertical-label-button"
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const CustomRow = styled(FormRow)\`
   .dnb-form-row__content .dnb-button {
     align-self: flex-end;
@@ -218,7 +233,8 @@ render(
   <Button text="Button" />
 </CustomRow>
 )
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -226,7 +242,8 @@ render(
 export const FormRowNoWrap = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-horizontal-no_wrap">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow
   label="A long horizontal legend (FormLabel) with a lot of informative text:"
   indent="true"
@@ -236,7 +253,8 @@ export const FormRowNoWrap = () => (
   <Input label="Input label A:" right="small"  />
   <Input label="Input label B:"  />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -244,7 +262,8 @@ export const FormRowNoWrap = () => (
 export const FormRowWrap = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-horizontal-wrap">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow
   label="Long label labwl Adipiscing mauris dis proin nec Condimentum egestas class blandit netus non a suscipit id urna:"
   indent
@@ -256,7 +275,8 @@ export const FormRowWrap = () => (
   <Input label="Input B:" top="small" right="small" />
   <Input label="Input C:" top="small" right="small" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -264,7 +284,8 @@ export const FormRowWrap = () => (
 export const FormRowLegendUsage = () => (
   <TestStyles>
     <ComponentBox data-visual-test="form-row-legend">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormSet label_direction="vertical">
   <FormRow label="Label legend for the inputs:" >
     <Input label="Vertical label direction:" placeholder="Input A ..." right="small" />
@@ -274,7 +295,8 @@ export const FormRowLegendUsage = () => (
     <Checkbox label="Checkbox" />
   </FormRow>
 </FormSet>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -282,12 +304,14 @@ export const FormRowLegendUsage = () => (
 export const FormRowInheritContext = () => (
   <TestStyles>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow vertical={true} disabled={true}>
   <Input label="Vertical input A:" placeholder="Input A ..." />
   <Input label="Vertical input B:" placeholder="Input B ..." top="medium" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -295,7 +319,8 @@ export const FormRowInheritContext = () => (
 export const FormRowDifferentDirections = () => (
   <TestStyles>
     <ComponentBox useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const PhoneRow = styled(FormRow)\`
 .dnb-dropdown__shell,
 .dnb-dropdown__list {
@@ -329,7 +354,8 @@ render(
   </PhoneRow>
 </FormRow>
 )
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -356,7 +382,8 @@ export default class FormRowVisualTests extends React.PureComponent {
           scope={{ AllComponents }}
           data-visual-test="form-row-all-horizontal-direction"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <FormRow
   // label="Horizontal:"
   // indent="true"
@@ -365,75 +392,88 @@ export default class FormRowVisualTests extends React.PureComponent {
 >
   <AllComponents horizontal />
 </FormRow>
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="Vertical direction"
           scope={{ AllComponents, WidthLimit }}
           data-visual-test="form-row-all-vertical-direction"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <WidthLimit>
   <FormRow label="Vertical direction:" direction="vertical">
     <AllComponents />
   </FormRow>
 </WidthLimit>
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="Vertical everything"
           scope={{ AllComponents, WidthLimit }}
           data-visual-test="form-row-all-vertical-everything"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <WidthLimit>
   <FormRow label="Vertical everything:" vertical="true">
    <AllComponents />
   </FormRow>
 </WidthLimit>
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="Vertical label direction"
           scope={{ AllComponents }}
           data-visual-test="form-row-all-vertical-label-direction"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <FormRow label="Vertical label direction:" label_direction="vertical">
   <AllComponents horizontal />
 </FormRow>
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="Vertical label direction, no labels"
           scope={{ AllComponents }}
           data-visual-test="form-row-all-vertical-label-direction-no-label"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <FormRow label="Vertical label direction, no labels:" label_direction="vertical">
   <AllComponents horizontal hideLabel />
 </FormRow>
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="All form components which has the stretch property"
           scope={{ AllStretchComponents }}
           data-visual-test="form-row-all-stretch-components"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <AllStretchComponents />
-`}
+`
+          }
         </ComponentBox>
         <ComponentBox
           title="Horizontal centered"
           data-visual-test="form-row-centered"
         >
-          {() => /* jsx */ `
+          {
+            /* jsx */ `
 <FormRow centered>
   <div className="box1" />
   <div className="box2" />
 </FormRow>
-`}
+`
+          }
         </ComponentBox>
       </TestStyles>
     )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/Examples.js
@@ -8,7 +8,8 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const FormSetDefault = () => (
   <ComponentBox data-visual-test="form-set-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormSet indent="true">
   <FormRow no_label>
     <H2>A semantic h2 in a FormRow without a label</H2>
@@ -23,26 +24,30 @@ export const FormSetDefault = () => (
     </Radio.Group>
   </FormRow>
 </FormSet>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormSetVertical = () => (
   <ComponentBox data-visual-test="form-set-vertical">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormSet direction="vertical">
   <FormRow label={<Space element="span" className="dnb-h--large">Custom Legend:</Space>}>
     <Input label="Label:" bottom />
     <Input label="Label:" />
   </FormRow>
 </FormSet>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormSetSubmit = () => (
   <ComponentBox data-visual-test="form-set-submit">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormSet
     direction="horizontal"
     on_submit={({ event }) => console.log('on_submit', event)}
@@ -53,6 +58,7 @@ export const FormSetSubmit = () => (
     <Button type="submit" text="Trigger submit" />
   </FormRow>
 </FormSet>
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.js
@@ -14,73 +14,86 @@ import {
 
 export const FormStatusDefault = () => (
   <ComponentBox data-visual-test="form-status">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormStatus
   text="Failure text"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusWithInfo = () => (
   <ComponentBox data-visual-test="form-status-info">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormStatus
   title="Hover title"
   text="Long info nisl tempus hendrerit tortor dapibus nascetur taciti porta risus cursus fusce platea enim curabitur proin nibh ut luctus magnis metus"
   state="info"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusWithStretch = () => (
   <ComponentBox data-visual-test="form-status-stretch">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormStatus
   stretch={true}
   text="Long info nisl tempus hendrerit tortor dapibus nascetur taciti porta risus cursus fusce platea enim curabitur proin nibh ut luctus magnis metus"
   state="warn"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusWithWarn = () => (
   <ComponentBox data-visual-test="form-status-warn">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormStatus state="warn" variant="outlined">
   Warningmessage. Take notice!
 </FormStatus>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusWithMarketing = () => (
   <ComponentBox data-visual-test="form-status-marketing">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormStatus state="marketing" variant="outlined">
 Marketingmessage. What a deal!
 </FormStatus>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusInput = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Input
   label="Input with status:"
   status="You have to fill in this field"
   value="Input value"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusAnimation = () => (
   <ComponentBox useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const ToggleAnimation = () => {
   const [status, setStatus] = React.useState(null)
   const toggleStatus = () => {
@@ -101,13 +114,15 @@ const ToggleAnimation = () => {
   )
 }
 render(<ToggleAnimation />)
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusCustom = () => (
   <ComponentBox data-visual-test="form-status-custom" useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const CustomStatus = () => (
   <>My info <Link href="/">with a link</Link> and more text</>
 )
@@ -119,13 +134,15 @@ render(
     value="Input value"
   />
 )
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const FormStatusLarge = () => (
   <ComponentBox useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const myHTML = \`
   My HTML
   <a class="dnb-anchor" href="/" target="_blank">with a link</a>
@@ -137,7 +154,8 @@ render(
     <CustomStatus />
   </FormStatus>
 )
-`}
+`
+    }
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.js
@@ -10,7 +10,8 @@ import styled from '@emotion/styled'
 export const DrawerListExampleInteractive = () => (
   <Wrapper>
     <ComponentBox useRender scope={{ data }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const DrawerListWithState = props => {
   const [opened, setOpened] = React.useState(false)
   const Relative = styled.span\`
@@ -36,7 +37,8 @@ const DrawerListWithState = props => {
   )
 }
 render(<DrawerListWithState />)
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -44,7 +46,8 @@ render(<DrawerListWithState />)
 export const DrawerListExampleOnlyToVisualize = () => (
   <Wrapper>
     <ComponentBox data-visual-test="drawer-list" scope={{ data }} hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <span className="dnb-drawer-list__list">
   <ul className="dnb-drawer-list__options">
     <li className="dnb-drawer-list__option first-of-type">
@@ -71,7 +74,8 @@ export const DrawerListExampleOnlyToVisualize = () => (
     <li className="dnb-drawer-list__triangle" />
   </ul>
 </span>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -79,7 +83,8 @@ export const DrawerListExampleOnlyToVisualize = () => (
 export const DrawerListExampleDefault = () => (
   <Wrapper>
     <ComponentBox scope={{ data }} data-visual-test="drawer-list-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <DrawerList
   skip_portal
   opened
@@ -94,7 +99,8 @@ export const DrawerListExampleDefault = () => (
     console.log('on_show')
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -106,7 +112,8 @@ export const DrawerListExampleSingleItem = () => (
       useRender
       data-visual-test="drawer-list-events"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const CustomComponent = () => (
   <CustomComponentInner
     onTouchStart={preventDefault}
@@ -152,7 +159,8 @@ render(
     suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
   />
 )
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -160,7 +168,8 @@ render(
 export const DrawerListExampleMarkup = () => (
   <Wrapper>
     <ComponentBox data-visual-test="drawer-items" useRender>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const list = [
   { value: 'A' },
   { value: 'B' },
@@ -198,7 +207,8 @@ const DrawerListWithState = props => {
   )
 }
 render(<DrawerListWithState />)
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.md
@@ -9,7 +9,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### To showcase the 404 status component
 
 <ComponentBox data-visual-test="global-error-404">
-{() => /* jsx */ `
+{/* jsx */ `
 <GlobalError status="404" />
 `}
 </ComponentBox>
@@ -17,7 +17,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### To showcase the 500 status component
 
 <ComponentBox data-visual-test="global-error-500">
-{() => /* jsx */ `
+{/* jsx */ `
 <GlobalError status="500" />
 `}
 </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.js
@@ -8,7 +8,8 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const GlobalStatusError = () => (
   <ComponentBox data-visual-test="global-status">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <GlobalStatus
   title="Custom Title"
   text="Failure text"
@@ -25,13 +26,15 @@ export const GlobalStatusError = () => (
   omit_set_focus="true"
   id="demo-1"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GlobalStatusInfo = () => (
   <ComponentBox data-visual-test="global-status-info">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <GlobalStatus
   state="info"
   title="Custom info title ..."
@@ -43,13 +46,15 @@ export const GlobalStatusInfo = () => (
   omit_set_focus="true"
   id="demo-4"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GlobalStatusCoupling = () => (
   <ComponentBox useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const InputWithError = () => {
   const [errorMessage, setErrorMessage] = React.useState(null)
   return (
@@ -68,13 +73,15 @@ const InputWithError = () => {
 render(
   <InputWithError />
 )
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GlobalStatusAddRemoveItems = () => (
   <ComponentBox noFragments={false} hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const [count, toggleUpdateStatus] = React.useState(0)
   return (
@@ -127,13 +134,15 @@ export const GlobalStatusAddRemoveItems = () => (
     </>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GlobalStatusScrolling = () => (
   <ComponentBox hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Button
   text="Scroll to main GlobalStatus"
   on_click={() => {
@@ -144,13 +153,15 @@ export const GlobalStatusScrolling = () => (
     })
   }}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const GlobalStatusUpdate = () => (
   <ComponentBox useRender hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const Context = React.createContext()
 
 const UpdateDemo = () => {
@@ -286,6 +297,7 @@ const UpdateDemoTools = () => {
 }
 
 render(<UpdateDemo />)
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/Examples.js
@@ -17,7 +17,8 @@ const Style = styled.div`
 export const HeadingDefault = () => (
   <Style>
     <ComponentBox data-visual-test="heading-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Heading.Level debug reset={1}>
   <Heading>h1</Heading>
   <Heading>h2</Heading>
@@ -27,7 +28,8 @@ export const HeadingDefault = () => (
   <Heading level="2" size="x-large">h2</Heading>
   <Heading skip_correction level={4}>h4</Heading>
 </Heading.Level>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -35,7 +37,8 @@ export const HeadingDefault = () => (
 export const HeadingContext = () => (
   <Style>
     <ComponentBox data-visual-test="heading-context">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Heading.Level debug reset={1}>
   <Heading>h1</Heading>
   <Heading>h2</Heading>
@@ -54,7 +57,8 @@ export const HeadingContext = () => (
     <Heading>h3</Heading>
   </Heading.Decrease>
 </Heading.Level>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -65,7 +69,8 @@ export const HeadingIsolation = () => (
       useRender
       // data-visual-test="heading-level-isolation"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const App = () => {
   const [showHeading, setShowHeading] = React.useState(false)
 
@@ -97,7 +102,8 @@ const App = () => {
   )
 }
 render(<App />)
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -105,7 +111,8 @@ render(<App />)
 export const HeadingMix = () => (
   <Style>
     <ComponentBox data-visual-test="heading-mixin">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Heading.Level debug reset={1}>
   <Heading>h1</Heading>
   <Heading>h2</Heading>
@@ -113,7 +120,8 @@ export const HeadingMix = () => (
   <H3 level="use">Increase to h3</H3>
   <Heading>h3</Heading>
 </Heading.Level>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.md
@@ -10,7 +10,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="help-button-default">
     {
-    () => /* jsx */ `
+    /* jsx */ `
 <HelpButton>
     Text
 </HelpButton>
@@ -21,7 +21,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="help-button-suffix">
     {
-    () => /* jsx */ `
+    /* jsx */ `
 <Input
     size={10}
     placeholder="Input ..."
@@ -34,7 +34,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="help-button-sizes">
     {
-    () => /* jsx */ `
+    /* jsx */ `
 <HelpButton title="Custom title">Text</HelpButton>
 <HelpButton
     size="small"
@@ -49,7 +49,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Help button with an information icon
 
 <ComponentBox>
-    {() => /* jsx */ `
+    {/* jsx */ `
 <HelpButton icon="information" tooltip="More info">
     <Dl>
         <Dt>Term</Dt>
@@ -66,7 +66,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="help-button-inline">
     {
-    () => /* jsx */ `
+    /* jsx */ `
 Text <HelpButton>
     Text
 </HelpButton> Text

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.md
@@ -9,7 +9,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Default and Medium-sized icons (responsive)
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <IconPrimary icon="question" title="Give icons a title" />
 <IconPrimary
   icon="question_medium"
@@ -22,7 +22,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Default Icon with custom, but fixed size (64)
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <IconPrimary
   icon="question"
   size="64"

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.js
@@ -18,11 +18,13 @@ export const IconDefault = () => (
     data-visual-test="icon-default"
     scope={{ Bell, BellMedium }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Icon icon={Bell} title="Give Icons a Title, or ..." />
 <Icon icon={BellMedium} aria-hidden />
 <Bell title="I'm not responsive!" />{/* <- Not responsive! */}
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -31,7 +33,8 @@ export const IconBorder = () => (
     data-visual-test="icon-border"
     scope={{ Bell, BellMedium }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <P>
   <Icon border="true" icon={Bell} right />
   <Icon border="true" icon={BellMedium} size="medium" right />
@@ -42,7 +45,8 @@ export const IconBorder = () => (
     text="Button"
   />
 </P>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -51,13 +55,15 @@ export const IconInheritSized = () => (
     data-visual-test="icon-inherit-sized"
     scope={{ Bell, BellMedium }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <h1 className="dnb-h--xx-large">
   h1 with auto sized{' '}
   <Icon icon={BellMedium} size="auto" aria-hidden />{' '}
   icon
 </h1>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -72,7 +78,8 @@ export const IconMedium = () => {
       scope={{ Bell, BellMedium }}
       title="Explicit defined size: medium"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Icon icon={BellMedium} size="16" title="force default size" />
 <Icon icon={BellMedium} title="is medium anyway" />
 <Icon icon={Bell} size="medium" title="force medium size" />
@@ -83,7 +90,8 @@ export const IconMedium = () => {
   height="24"
   title="not responsive"
 />
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -100,7 +108,8 @@ export const IconPrimary = () => {
       title="All **primary** icons listed as medium sized icons"
       noFragments={false}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 () => {
   const Icons = () => getListOfIcons(PrimaryIconsMedium).map(
     ({iconName, Svg}) => {
@@ -119,7 +128,8 @@ export const IconPrimary = () => {
   )
   return <Icons />
 }
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -136,7 +146,8 @@ export const IconSecondary = () => {
       title="All **secondary** icons listed as medium sized icons"
       noFragments={false}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 () => {
   const uniqueList = {}
   const Icons = () => getListOfIcons(SecondaryIconsMedium).map(
@@ -161,7 +172,8 @@ export const IconSecondary = () => {
   )
   return <Icons />
 }
-`}
+`
+      }
     </ComponentBox>
   )
 }
@@ -178,15 +190,14 @@ export default function IconTests() {
 
 export const IconColors = () => {
   return (
-    <ComponentBox
-      data-visual-test="icon-colors"
-      scope={{ BellMedium }}
-    >
-      {() => /* jsx */ `
+    <ComponentBox data-visual-test="icon-colors" scope={{ BellMedium }}>
+      {
+        /* jsx */ `
 <Icon icon={BellMedium} color="var(--color-fire-red)" title="CSS variable" />
 <Icon icon={BellMedium} color="#DC2A2A" title="Hex" />
 <Icon icon={BellMedium} color="rgb(220,42,42)" title="RGB" />
-`}
+`
+      }
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/Examples.js
@@ -9,28 +9,33 @@ import { card_medium as Card } from '@dnb/eufemia/src/icons'
 
 export const InfoCardBasic = () => (
   <ComponentBox data-visual-test="info-card-basic">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const InfoCardTitle = () => (
   <ComponentBox noFragments={false} data-visual-test="info-card-title">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
   title="Title of your info/tip" 
 />
-    `}
+    `
+    }
   </ComponentBox>
 )
 
 export const InfoCardButtons = () => (
   <ComponentBox noFragments={false} data-visual-test="info-card-buttons">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
   title="Title of your info/tip" 
@@ -39,7 +44,8 @@ export const InfoCardButtons = () => (
   acceptButtonText="Accept"
   onAccept={() => {console.log("onAccept")}}
 />
-      `}
+      `
+    }
   </ComponentBox>
 )
 
@@ -48,7 +54,8 @@ export const InfoCardButtonsCentered = () => (
     noFragments={false}
     data-visual-test="info-card-buttons-centered"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   centered
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
@@ -58,7 +65,8 @@ export const InfoCardButtonsCentered = () => (
   acceptButtonText="Accept"
   onAccept={() => {console.log("onAccept")}}
 />
-      `}
+      `
+    }
   </ComponentBox>
 )
 
@@ -67,14 +75,16 @@ export const InfoCardAcceptButton = () => (
     noFragments={false}
     data-visual-test="info-card-accept-button"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
   title="Title of your info/tip" 
   acceptButtonText="Accept"
   onAccept={() => {console.log("onAccept")}}
 />
-    `}
+    `
+    }
   </ComponentBox>
 )
 
@@ -83,57 +93,66 @@ export const InfoCardCloseButton = () => (
     noFragments={false}
     data-visual-test="info-card-close-button"
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
   title="Title of your info/tip" 
   closeButtonText="Close"
   onClose={() => {console.log("onClose")}}
 />
-    `}
+    `
+    }
   </ComponentBox>
 )
 
 export const InfoCardCustomIcon = () => (
   <ComponentBox scope={{ Card }} data-visual-test="info-card-custom-icon">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard 
   text="This is a description of some information or a tip that will inform the user of something that will help them." 
   title="Title of your info/tip" 
   icon={Card} 
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const InfoCardCentered = () => (
   <ComponentBox data-visual-test="info-card-centered">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard
   text="This is a description of some information or a tip that will inform the user of something that will help them."  
   title="Title of your info/tip" 
   centered={true}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const InfoCardCustomImage = () => (
   <ComponentBox data-visual-test="info-card-custom-image">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard
   text="This is a description of some information or a tip that will inform the user of something that will help them."  
   title="This is the InfoCard with a custom image" 
   src="/images/avatars/1501870.jpg"
   alt="Profile picture"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const InfoCardCustomImageCentered = () => (
   <ComponentBox data-visual-test="info-card-custom-image-centered">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <InfoCard
   text="This is a description of some information or a tip that will inform the user of something that will help them."  
   title="This is the InfoCard with a custom image" 
@@ -141,6 +160,7 @@ export const InfoCardCustomImageCentered = () => (
   src="/images/avatars/1501870.jpg"
   alt="Profile picture"
 />
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/Examples.js
@@ -15,7 +15,8 @@ import { Provider } from '@dnb/eufemia/src/shared'
 export const InputMaskedExampleNumberLocale = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-masked-number">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow vertical>
   <InputMasked
     label="Number:"
@@ -51,7 +52,8 @@ export const InputMaskedExampleNumberLocale = () => (
     }}
   />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -62,7 +64,8 @@ export const InputMaskedExampleCurrencyLocale = () => (
       data-visual-test="input-masked-currency"
       scope={{ Provider }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow vertical>
   <InputMasked
     label="Currency:"
@@ -94,7 +97,8 @@ export const InputMaskedExampleCurrencyLocale = () => (
     />
   </Provider>
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -102,7 +106,8 @@ export const InputMaskedExampleCurrencyLocale = () => (
 export const InputMaskedExampleCurrencyMask = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-masked-currency_mask">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow vertical>
   <InputMasked
     label="Left aligned (default):"
@@ -124,7 +129,8 @@ export const InputMaskedExampleCurrencyMask = () => (
     }}
   />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -132,7 +138,8 @@ export const InputMaskedExampleCurrencyMask = () => (
 export const InputMaskedExampleCustomNumberMask = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <InputMasked
   label="Masked amount:"
   show_mask
@@ -145,7 +152,8 @@ export const InputMaskedExampleCustomNumberMask = () => (
     console.log(numberValue)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -153,7 +161,8 @@ export const InputMaskedExampleCustomNumberMask = () => (
 export const InputMaskedExampleNumberMask = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-masked-number_mask">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <InputMasked
   label="Masked input:"
   value="1000000"
@@ -166,7 +175,8 @@ export const InputMaskedExampleNumberMask = () => (
     console.log(parseInt(numberValue || 0, 10))
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -174,7 +184,8 @@ export const InputMaskedExampleNumberMask = () => (
 export const InputMaskedExamplePrefix = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <InputMasked
   label="Masked input:"
   number_mask={{
@@ -186,7 +197,8 @@ export const InputMaskedExamplePrefix = () => (
     console.log(numberValue)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -194,7 +206,8 @@ export const InputMaskedExamplePrefix = () => (
 export const InputMaskedExamplePhone = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-masked-phone">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <InputMasked
   label="Masked input:"
   mask={[
@@ -222,7 +235,8 @@ export const InputMaskedExamplePhone = () => (
     console.log(numberValue)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
@@ -23,12 +23,14 @@ const Wrapper = styled.div`
 export const InputExampleDefault = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-placeholder">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="Label:"
   placeholder="Placeholder text"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -36,7 +38,8 @@ export const InputExampleDefault = () => (
 export const InputExampleSearch = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-search">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="Search:"
   type="search"
@@ -48,7 +51,8 @@ export const InputExampleSearch = () => (
     console.log('Submit:', value)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -56,7 +60,8 @@ export const InputExampleSearch = () => (
 export const InputExampleMedium = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-medium">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   size="medium"
   type="search"
@@ -66,7 +71,8 @@ export const InputExampleMedium = () => (
     console.log('on_change', value)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -74,7 +80,8 @@ export const InputExampleMedium = () => (
 export const InputExampleWithIcon = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-icon">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="Input with icon:"
   placeholder="Input"
@@ -90,7 +97,8 @@ export const InputExampleWithIcon = () => (
   icon="check"
   align="right"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -98,13 +106,15 @@ export const InputExampleWithIcon = () => (
 export const InputExampleDisabled = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-disabled">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   disabled
   label="Disabled input:"
   placeholder="Disabled Input with a placeholder"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -112,13 +122,15 @@ export const InputExampleDisabled = () => (
 export const InputExampleFailureStatus = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="Show status:"
   status="error"
   value="Shows status with border only"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -126,13 +138,15 @@ export const InputExampleFailureStatus = () => (
 export const InputExampleFormStatus = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-error">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="With FormStatus:"
   status="You have to fill in this field"
   value="Input value with error"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -140,7 +154,8 @@ export const InputExampleFormStatus = () => (
 export const InputExampleSuffix = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label={<Space element="span" className="dnb-h--large">Fødselsnummer</Space>}
   label_direction="vertical"
@@ -151,7 +166,8 @@ export const InputExampleSuffix = () => (
     console.log('on_change', value)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -159,7 +175,8 @@ export const InputExampleSuffix = () => (
 export const InputExampleStretched = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-stretch">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow
   label="Long label labwl Adipiscing mauris dis proin nec:"
   indent="true"
@@ -168,7 +185,8 @@ export const InputExampleStretched = () => (
 >
   <Input value="I stretch ..." stretch status="Status message" status_state="warn" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -176,7 +194,8 @@ export const InputExampleStretched = () => (
 export const InputExampleNumbers = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Input
   label="Label:"
   autocomplete="on"
@@ -189,7 +208,8 @@ export const InputExampleNumbers = () => (
     return String(value).toUpperCase()
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -197,7 +217,8 @@ export const InputExampleNumbers = () => (
 export const InputExampleSubmit = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormSet
   prevent_submit={true}
   on_submit={(event) => {
@@ -225,7 +246,8 @@ export const InputExampleSubmit = () => (
     <Button text="Submit" type="submit" />
   </FormRow>
 </FormSet>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -236,7 +258,8 @@ export const InputExamplePassword = () => (
       scope={{ InputPassword }}
       data-visual-test="input-password"
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <InputPassword
   label="Label:"
   placeholder="A placeholder text"
@@ -250,7 +273,8 @@ export const InputExamplePassword = () => (
     console.log('on_hide_password')
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -258,7 +282,8 @@ export const InputExamplePassword = () => (
 export const InputExampleClear = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-clear">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow direction="vertical">
   <Input
     clear={true}
@@ -279,7 +304,8 @@ export const InputExampleClear = () => (
     top
   />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -291,7 +317,8 @@ export const InputScreenshotTests = () => {
   return (
     <Wrapper>
       <ComponentBox data-visual-test="input-align">
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <FormRow label="Left aligned" vertical>
   <Input value="Plain" />
   <Input value="Search" type="search" />
@@ -372,7 +399,8 @@ export const InputScreenshotTests = () => {
     align="right"
   />
 </FormRow>
-`}
+`
+        }
       </ComponentBox>
     </Wrapper>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.md
@@ -10,7 +10,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
  <ComponentBox data-visual-test="logo-auto-size">
 	{
-	() => /* jsx */ `
+	/* jsx */ `
 <span style={{fontSize: '12rem'}}>
   <Logo size="auto" />
 </span>
@@ -22,7 +22,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="logo-inherit-size">
 	{
-	() => /* jsx */ `
+	/* jsx */ `
 <span style={{height: '12rem'}}>
   <Logo size="inherit" />
 </span>
@@ -34,7 +34,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="logo-default">
 	{
-	() => /* jsx */ `
+	/* jsx */ `
 <Logo height="192" />
 `
 	}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/Examples.js
@@ -16,7 +16,8 @@ export const ExampleCard = ({ children }) => (
 )
 export const ModalExampleModeCustom = () => (
   <ComponentBox data-visual-test="modal-custom" scope={{ ExampleCard }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal mode="custom">
   <ExampleCard>
     <P>
@@ -24,13 +25,15 @@ export const ModalExampleModeCustom = () => (
     </P>
   </ExampleCard>
 </Modal>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const ModalExampleStateOnly = () => (
   <ComponentBox useRender scope={{ ExampleCard }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const Component = () => {
   const [modalIsActive, setModalState] = React.useState(false)
   return (
@@ -56,13 +59,15 @@ const Component = () => {
   )
 }
 render(<Component />)
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const ModalExampleCloseByHandler = () => (
   <ComponentBox scope={{ ExampleCard }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   title="Auto close"
   trigger_text="Click me"
@@ -78,6 +83,7 @@ export const ModalExampleCloseByHandler = () => (
     <P>This Modal will close in 3 seconds.</P>
   </ExampleCard>
 </Modal>
-	`}
+	`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/visual-tests/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/visual-tests/Examples.js
@@ -8,7 +8,8 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const ModalExampleDrawerHeader = () => (
   <ComponentBox data-visual-test="modal-drawer-header">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   mode="drawer"
   trigger_text="Open Drawer"
@@ -81,13 +82,15 @@ export const ModalExampleDrawerHeader = () => (
     </P>
   </Modal.Content>
 </Modal>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const ModalExampleDrawerBasic = () => (
   <ComponentBox data-visual-test="modal-drawer-basic">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   mode="drawer"
   title="Drawer Title"
@@ -97,12 +100,14 @@ export const ModalExampleDrawerBasic = () => (
     <P top>This is a left aligned Drawer content.</P>
   </Modal.Content>
 </Modal>
-	`}
+	`
+    }
   </ComponentBox>
 )
 export const DrawerWithoutSpacing = () => (
   <ComponentBox data-visual-test="drawer-no-spacing">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   mode="drawer"
   title="Drawer without spacing"
@@ -113,25 +118,29 @@ export const DrawerWithoutSpacing = () => (
     <P top>This is a left aligned Drawer content.</P>
   </Modal.Content>
 </Modal>
-  `}
+  `
+    }
   </ComponentBox>
 )
 
 export const ModalExampleDefault = () => (
   <ComponentBox data-visual-test="modal-trigger-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal title="Modal Title">
   <Modal.Content spacing style_type="mint-green">
     <P>This is the modal text.</P>
   </Modal.Content>
 </Modal>
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const ModalExampleHelpButton = () => (
   <ComponentBox data-visual-test="modal-help-button">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Input
   label="Input"
   placeholder="Placeholder ..."
@@ -143,13 +152,15 @@ export const ModalExampleHelpButton = () => (
     </Modal>
   }
 />
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const ModalExampleFullscreen = () => (
   <ComponentBox data-visual-test="modal-fullscreen">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   title={<span className="dnb-sr-only">"Hidden" Modal title</span>}
   fullscreen="true"
@@ -158,19 +169,22 @@ export const ModalExampleFullscreen = () => (
   trigger_icon="bell"
   modal_content="This is the modal text. Triggered by a tertiary button."
 />
-	`}
+	`
+    }
   </ComponentBox>
 )
 
 export const DrawerExamplePlacementLeft = () => (
   <ComponentBox data-visual-test="modal-drawer-leftsided">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Modal
   mode="drawer"
   title="Modal title"
   container_placement="left"
   modal_content="This is the modal text. Triggered by a tertiary button."
 />
-	`}
+	`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.js
@@ -20,7 +20,8 @@ const Style = styled.div`
 export const NumberDefault = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat value="12345" srLabel="Total:" />
   <NumberFormat>-12345678.9</NumberFormat>
@@ -28,7 +29,8 @@ export const NumberDefault = () => (
   <NumberFormat decimals={1}>-1234.54321</NumberFormat>
   <NumberFormat decimals={2}>-1234</NumberFormat>
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -36,13 +38,15 @@ export const NumberDefault = () => (
 export const NumberPercent = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-percent">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat percent value="12.34" />
   <NumberFormat percent>-12.34</NumberFormat>
   <NumberFormat percent decimals={1}>-12.34</NumberFormat>
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -50,7 +54,8 @@ export const NumberPercent = () => (
 export const NumberCurrency = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-currency">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat currency>12345</NumberFormat>
   <NumberFormat currency currency_position="before" value={-12345678.9} />
@@ -61,7 +66,8 @@ export const NumberCurrency = () => (
     currency_display="code"
   />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -69,7 +75,8 @@ export const NumberCurrency = () => (
 export const NumberCompact = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-compact">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat compact decimals={1}>1234</NumberFormat>
   <NumberFormat
@@ -100,7 +107,8 @@ export const NumberCompact = () => (
     decimals={3}
   />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -108,7 +116,8 @@ export const NumberCompact = () => (
 export const NumberPhone = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-phone">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat value="99999999" phone />
   <NumberFormat value="4799999999" phone />
@@ -117,7 +126,8 @@ export const NumberPhone = () => (
   <NumberFormat value="+47116000" phone selectall="false" />
   <NumberFormat value="+4702000" phone />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -125,11 +135,13 @@ export const NumberPhone = () => (
 export const NumberBankAccount = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-ban">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat value="20001234567" ban />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -137,11 +149,13 @@ export const NumberBankAccount = () => (
 export const NumberNationalIdentification = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-nin">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat value="18089212345" nin />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -149,11 +163,13 @@ export const NumberNationalIdentification = () => (
 export const NumberOrganization = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-org">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <P>
   <NumberFormat value="123456789" org suffix="MVA" />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -161,7 +177,8 @@ export const NumberOrganization = () => (
 export const NumberLocales = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-locales">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <H3>Numbers</H3>
 <P>
   <NumberFormat locale="nb-NO" value="-12345678.9" />
@@ -179,7 +196,8 @@ export const NumberLocales = () => (
   <NumberFormat locale="de-CH" value="-12345.6" currency />
   <NumberFormat locale="fr-CH" value="-12345.6" currency />
 </P>
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )
@@ -187,10 +205,12 @@ export const NumberLocales = () => (
 export const NumberSpacing = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-spacing">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 text <NumberFormat value="1234" currency left right />
 text <NumberFormat value="5678" currency left right /> text 
-`}
+`
+      }
     </ComponentBox>
   </Style>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.js
@@ -32,7 +32,8 @@ const LargePage = styled.div`
 
 export const PaginationExampleDefault = () => (
   <ComponentBox data-visual-test="pagination-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Pagination
   page_count={888}
   current_page={4}
@@ -42,13 +43,15 @@ export const PaginationExampleDefault = () => (
 >
   <P>Current Page Content</P>
 </Pagination>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const PaginationExampleWithCallback = () => (
   <ComponentBox hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Pagination
   page_count={5}
   startup_page={3}
@@ -58,13 +61,15 @@ export const PaginationExampleWithCallback = () => (
 >
   {({ pageNumber }) => <P>Page {pageNumber}</P>}
 </Pagination>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const PaginationExampleCentered = () => (
   <ComponentBox scope={{ LargePage }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Pagination
   align="center"
   page_count={30}
@@ -78,7 +83,8 @@ export const PaginationExampleCentered = () => (
     return () => clearTimeout(timeout)
   }}
 </Pagination>
-`}
+`
+    }
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.js
@@ -38,7 +38,8 @@ const LargePage = styled.div`
 
 export const PaginationExampleInfinityLoadButton = () => (
   <ComponentBox scope={{ HeightLimit, LargePage }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <HeightLimit>
   <Pagination
     mode="infinity"
@@ -59,13 +60,15 @@ export const PaginationExampleInfinityLoadButton = () => (
     }}
   />
 </HeightLimit>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const PaginationExampleInfinityIndicator = () => (
   <ComponentBox scope={{ HeightLimit, LargePage }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <HeightLimit>
   <Pagination
     mode="infinity"
@@ -92,13 +95,15 @@ export const PaginationExampleInfinityIndicator = () => (
     }}
   />
 </HeightLimit>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const PaginationExampleInfinityUnknown = () => (
   <ComponentBox scope={{ HeightLimit, LargePage }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <HeightLimit>
   <Pagination
     mode="infinity"
@@ -130,17 +135,20 @@ export const PaginationExampleInfinityUnknown = () => (
     }}
   />
 </HeightLimit>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const PaginationExampleInfinityTable = () => (
   <ComponentBox scope={{ HeightLimit, PaginationTableExample }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <HeightLimit height="60rem">
   <PaginationTableExample />
 </HeightLimit>
-`}
+`
+    }
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.md
@@ -11,7 +11,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Default ProgressIndicator is Circular
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator />
 `}
 </ComponentBox>
@@ -19,7 +19,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Default Circular ProgressIndicator
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator
   type="circular"
 />
@@ -29,7 +29,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Circular ProgressIndicator with a label in a horizontal direction
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator
   // label="Custom label ..."
   type="circular"
@@ -42,7 +42,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Circular ProgressIndicator with a label in a vertical direction
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator
   // label="Custom label ..."
   type="circular"
@@ -55,7 +55,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Shows a large Circular ProgressIndicator with a static 50% in progress
 
 <ComponentBox data-visual-test="progress-indicator-circular--primary">
-	{() => /* jsx */ `
+	{/* jsx */ `
   <ProgressIndicator
     type="circular"
     progress="50"
@@ -68,7 +68,7 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 ### Circular ProgressIndicator with random value
 
 <ComponentBox useRender>
-	{() => /* jsx */ `
+	{/* jsx */ `
 const ChangeValue = () => {
 	const [value, setValue] = React.useState(50)
 	return (
@@ -97,7 +97,7 @@ render(<ChangeValue />)
 ### Circular ProgressIndicator with random progress value to show the transition
 
 <ComponentBox noFragments={false}>
-	{() => /* jsx */ `
+	{/* jsx */ `
 () => {
   const random = (min, max) => (Math.floor( Math.random () * (max - min + 1)) + min)
   const [progress, setProgressIndicator] = React.useState(random(1, 100))
@@ -119,7 +119,7 @@ render(<ChangeValue />)
 ### Circular ProgressIndicator with random `on_complete` callback
 
 <ComponentBox noFragments={false}>
-	{() => /* jsx */ `
+	{/* jsx */ `
 () => {
   const random = (min, max) => (Math.floor( Math.random () * (max - min + 1)) + min)
   const [visible, setVisible] = React.useState(true)
@@ -144,7 +144,7 @@ render(<ChangeValue />)
 ### Circular ProgressIndicator inside a Modal
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <Modal
   spacing={false}
   max_width="12rem"
@@ -169,7 +169,7 @@ render(<ChangeValue />)
 ### Default Linear ProgressIndicator
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
   <ProgressIndicator 
     type="linear" 
   />
@@ -179,7 +179,7 @@ render(<ChangeValue />)
 ### Small Linear ProgressIndicator
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
   <ProgressIndicator 
     type="linear"
     size="small"
@@ -190,7 +190,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator with a label in a horizontal direction
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator
   type="linear"
   // label="Custom label ..."
@@ -203,7 +203,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator with a label in a vertical direction
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <ProgressIndicator
   type="linear"
   // label="Custom label ..."
@@ -216,7 +216,7 @@ render(<ChangeValue />)
 ### Shows a large Linear ProgressIndicator with a static 50% in progress
 
 <ComponentBox data-visual-test="progress-indicator-linear--primary">
-	{() => /* jsx */ `
+	{/* jsx */ `
   <ProgressIndicator 
     type="linear" 
     progress="50"
@@ -229,7 +229,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator with random value
 
 <ComponentBox useRender>
-	{() => /* jsx */ `
+	{/* jsx */ `
 const ChangeValue = () => {
 	const [value, setValue] = React.useState(50)
 	return (
@@ -257,7 +257,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator with random progress value to show the transition
 
 <ComponentBox noFragments={false}>
-	{() => /* jsx */ `
+	{/* jsx */ `
 () => {
   const random = (min, max) => (Math.floor( Math.random () * (max - min + 1)) + min)
   const [progress, setProgressIndicator] = React.useState(random(1, 100))
@@ -278,7 +278,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator with random `on_complete` callback
 
 <ComponentBox noFragments={false}>
-	{() => /* jsx */ `
+	{/* jsx */ `
 () => {
   const random = (min, max) => (Math.floor( Math.random () * (max - min + 1)) + min)
   const [visible, setVisible] = React.useState(true)
@@ -303,7 +303,7 @@ render(<ChangeValue />)
 ### Linear ProgressIndicator inside a Modal
 
 <ComponentBox>
-	{() => /* jsx */ `
+	{/* jsx */ `
 <Modal
   spacing={false}
   max_width="12rem"

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/visual-tests.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/visual-tests.md
@@ -5,7 +5,7 @@ draft: true
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 <ComponentBox data-visual-test="progress-indicator-sizes">
-  {() => /* jsx */ `
+  {/* jsx */ `
 <div style={{ display: 'flex' }}>
 	<ProgressIndicator progress="50" size="small" />
 	<ProgressIndicator progress="50" size="medium" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.js
@@ -8,7 +8,8 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const RadioExampleDefault = () => (
   <ComponentBox data-visual-test="radio-group">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio.Group
   label="Radio Group:"
   on_change={({ value }) => { console.log('on_change', value) }}
@@ -21,13 +22,15 @@ export const RadioExampleDefault = () => (
     value="third"
   />
 </Radio.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleVerticalGroup = () => (
   <ComponentBox data-visual-test="radio-group-vertical">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio.Group
   label="Vertical Group:"
   layout_direction="column"
@@ -41,13 +44,15 @@ export const RadioExampleVerticalGroup = () => (
     checked
   />
 </Radio.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleGroupStatus = () => (
   <ComponentBox data-visual-test="radio-group-status">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio.Group
   label="Radio Group with status:"
   layout_direction="column"
@@ -71,13 +76,15 @@ export const RadioExampleGroupStatus = () => (
     status_state="info"
   />
 </Radio.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleWithoutGroup = () => (
   <ComponentBox data-visual-test="radio-group-plain">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <FormRow label="Plain Radio group:">
   <Radio
     value="first"
@@ -105,22 +112,26 @@ export const RadioExampleWithoutGroup = () => (
     right
   />
 </FormRow>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleSizes = () => (
   <ComponentBox data-visual-test="radio-sizes">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio size="medium" label="Medium" right="large" checked />
 <Radio size="large" label="Large" checked />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleDisabled = () => (
   <ComponentBox data-visual-test="radio-group-disabled">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio.Group
   label="Disabled Group:"
   disabled
@@ -135,13 +146,15 @@ export const RadioExampleDisabled = () => (
     checked
   />
 </Radio.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const RadioExampleSuffix = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Radio.Group
   label="With suffixes:"
   label_position="left"
@@ -160,7 +173,8 @@ export const RadioExampleSuffix = () => (
     checked
   />
 </Radio.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -171,23 +185,27 @@ export function RadioVisualTests() {
         title="Unchecked Radio (Single Radio buttons should not be used)"
         data-visual-test="radio-default"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <Radio
   label="Single Radio"
 />
-`}
+`
+        }
       </ComponentBox>
       <ComponentBox
         title="Checked Radio (Single Radio buttons should not be used)"
         data-visual-test="radio-checked"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <Radio
   label="Checked Radio"
   checked
   on_change={({ checked }) => console.log(checked)}
 />
-`}
+`
+        }
       </ComponentBox>
     </>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.js
@@ -8,138 +8,165 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const SectionDemo = () => (
   <ComponentBox hideCode data-visual-test="section-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section>
 	<P>Visual DNB Section: <Anchor href="#">default</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoSpacing = () => (
   <ComponentBox hideCode data-visual-test="section-spacing">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="large">
   <P space={0}>Visual DNB Section: <Anchor href="#">default with spacing</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoWhite = () => (
   <ComponentBox hideCode data-visual-test="section-white">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="white">
   <P space={0}>Visual DNB Section: <Anchor href="#">white</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoDivider = () => (
   <ComponentBox hideCode data-visual-test="section-divider">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="divider">
   <P space={0}>Visual DNB Section: <Anchor href="#">divider</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoMintGreen = () => (
   <ComponentBox hideCode data-visual-test="section-mint-green">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="mint-green">
   <P space={0}>Visual DNB Section: <Anchor href="#">mint-green</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoSeaGreen = () => (
   <ComponentBox hideCode data-visual-test="section-sea-green">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="sea-green">
   <P space={0}>Visual DNB Section: <Anchor href="#">sea-green</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoEmeraldGreen = () => (
   <ComponentBox hideCode data-visual-test="section-emerald-green">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="emerald-green">
   <P space={0}>Visual DNB Section: <Anchor href="#">emerald-green</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoLavender = () => (
   <ComponentBox data-visual-test="section-lavender">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="lavender">
   <P space={0}>Visual DNB Section: <Anchor href="#">lavender</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoBlack3 = () => (
   <ComponentBox data-visual-test="section-black-3">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="black-3">
   <P space={0}>Visual DNB Section: <Anchor href="#">black-3</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoSandYellow = () => (
   <ComponentBox data-visual-test="section-sand-yellow">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="sand-yellow">
   <P space={0}>Visual DNB Section: <Anchor href="#">sand-yellow</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoPistachio = () => (
   <ComponentBox data-visual-test="section-pistachio">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="pistachio">
   <P space={0}>Visual DNB Section: <Anchor href="#">pistachio</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoFireRed = () => (
   <ComponentBox data-visual-test="section-fire-red">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="fire-red">
   <P space={0}>Visual DNB Section: <Anchor href="#">fire-red</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionDemoFireRed8 = () => (
   <ComponentBox data-visual-test="section-fire-red-8">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Section spacing="true" style_type="fire-red-8">
   <P space={0}>Visual DNB Section: <Anchor href="#">fire-red-8</Anchor></P>
 </Section>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SectionZIndex = () =>
   !globalThis.IS_TEST ? null : (
     <ComponentBox data-visual-test="section-z-index">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Section spacing style_type="mint-green-12">
     mint-green-12
     <div>
@@ -186,6 +213,7 @@ export const SectionZIndex = () =>
       </Section>
     </div>
   </Section>
-`}
+`
+      }
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.md
@@ -10,7 +10,7 @@ import '@dnb/eufemia/src/components/slider/style/dnb-range.scss'
 ### Default Slider
 
 <ComponentBox data-visual-test="slider-default">
-  {() => /* jsx */ `
+  {/* jsx */ `
 <Slider
   min={0}
   max={100}
@@ -24,7 +24,7 @@ import '@dnb/eufemia/src/components/slider/style/dnb-range.scss'
 ### Vertical slider with steps of 10
 
 <ComponentBox data-visual-test="slider-vertical" useRender>
-  {() => /* jsx */ `
+  {/* jsx */ `
 const VerticalWrapper = styled.div\`
   display: inline-flex;
   flex-direction: column;
@@ -48,7 +48,7 @@ render(<VerticalWrapper>
 ### Horizontal and vertical slider in sync with input field
 
 <ComponentBox useRender>
-  {() => /* jsx */ `
+  {/* jsx */ `
 const Component = () => {
   const [value, setValue] = React.useState(70)
   return (<>
@@ -98,7 +98,7 @@ render(<Component />)
 ### Slider with a suffix
 
 <ComponentBox>
-  {() => /* jsx */ `
+  {/* jsx */ `
 <Slider
   min={0}
   max={100}
@@ -114,7 +114,7 @@ render(<Component />)
 In order to get the styles, import also: `@dnb/eufemia/components/slider/style/dnb-range.min.css`
 
 <ComponentBox>
-  {() => /* jsx */ `
+  {/* jsx */ `
 <FormRow>
   <FormLabel for_id="range-slider">
     Native Range Slider

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/Examples.js
@@ -16,13 +16,15 @@ export const SpaceExamplesMethod1 = () => (
       data-visual-test="spacing-method-space"
       scope={{ RedBox }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <RedBox>
   <Space top="large x-small">
     <Input label="Input:" />
   </Space>
 </RedBox>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -30,14 +32,16 @@ export const SpaceExamplesMethod1 = () => (
 export const SpaceExamplesMethod2 = () => (
   <TestStyles>
     <ComponentBox data-visual-test="spacing-method-form-row">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow>
   <Input label="Input A:" />
 </FormRow>
 <FormRow top="medium">
   <Input label="Input B:" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -45,12 +49,14 @@ export const SpaceExamplesMethod2 = () => (
 export const SpaceExamplesMethod3 = () => (
   <TestStyles>
     <ComponentBox data-visual-test="spacing-method-component">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <FormRow>
   <Input label="Input A:" right="small" />
   <Input label="Input B:" />
 </FormRow>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -58,7 +64,8 @@ export const SpaceExamplesMethod3 = () => (
 export const SpaceExampleMarginCollapse = () => (
   <TestStyles>
     <ComponentBox hideCode scope={{ RedBox, Vertical }}>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Vertical>
   <RedBox>
     <Space bottom="small">
@@ -71,7 +78,8 @@ export const SpaceExampleMarginCollapse = () => (
     </Space>
   </RedBox>
 </Vertical>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -79,7 +87,8 @@ export const SpaceExampleMarginCollapse = () => (
 export const SpaceExampleMargins = () => (
   <TestStyles>
     <ComponentBox data-visual-test="spacing-margins" hideCode>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Space top="large x-small" right="2.5" bottom="2.5rem" left="40px" >
   <details>
     <summary>
@@ -88,7 +97,8 @@ export const SpaceExampleMargins = () => (
     And this are my CSS classes: <code className="dnb-code">dnb-space dnb-space__top--large dnb-space__top--x-small dnb-space__right--large dnb-space__right--x-small dnb-space__bottom--large dnb-space__bottom--x-small dnb-space__left--large dnb-space__left--x-small</code>
   </details>
 </Space>
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -101,7 +111,8 @@ export const SpaceVisualTestPatterns = () => (
       hideCode
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const TestCase = (props) => {
   return <CustomStyle {...props}>{listOfBoxes.map((v) => (
     <Space key={v} top={v}>
@@ -123,7 +134,8 @@ render(
     <TestCase />
   </div>
 )
-`}
+`
+      }
     </ComponentBox>
   </TestStyles>
 )
@@ -140,7 +152,8 @@ export const SpaceVisualTestElements = () =>
         hideCode
         useRender
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 const listOfBoxes = []
 for (let i = 0, c = 0, l = 10; i <= l; i++) {
   listOfBoxes.push(String(c))
@@ -168,7 +181,8 @@ render(
     <TestCase />
   </div>
 )
-`}
+`
+        }
       </ComponentBox>
     </TestStyles>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
@@ -9,7 +9,8 @@ import { createBrowserHistory } from 'history'
 
 export const StepIndicatorStatic = () => (
   <ComponentBox data-visual-test="step-indicator-static">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <StepIndicator
   sidebar_id="unique-id-static"
   mode="static"
@@ -31,13 +32,15 @@ export const StepIndicatorStatic = () => (
     }
   ]}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorStrict = () => (
   <ComponentBox data-visual-test="step-indicator-strict">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <StepIndicator.Sidebar sidebar_id="unique-id-strict" />
 <StepIndicator
   sidebar_id="unique-id-strict"
@@ -61,13 +64,15 @@ export const StepIndicatorStrict = () => (
     }
   ]}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorLoose = () => (
   <ComponentBox data-visual-test="step-indicator-loose" useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const InteractiveDemo = () => {
   const [step, setStep] = React.useState(1)
 
@@ -109,13 +114,15 @@ const InteractiveDemo = () => {
   )
 }
 render(<InteractiveDemo />)
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorCustomized = () => (
   <ComponentBox useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 function CustomStepIndicator({ children, ...props }) {
   const [step, setStep] = React.useState(0)
   return (
@@ -160,13 +167,15 @@ render(<CustomStepIndicator
 		}
 	}}
 </CustomStepIndicator>)
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorSidebar = () => (
   <ComponentBox data-visual-test="step-indicator-sidebar">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <StepIndicator
   style={{ display: 'none' }}
   sidebar_id="unique-id-sidebar"
@@ -185,13 +194,15 @@ export const StepIndicatorSidebar = () => (
   ]}
 />
 <StepIndicator.Sidebar sidebar_id="unique-id-sidebar" top="large" />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorTextOnly = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <StepIndicator
   sidebar_id="unique-id-text"
   mode="static"
@@ -202,13 +213,15 @@ export const StepIndicatorTextOnly = () => (
     'Oppsummering'
   ]}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const StepIndicatorCustomRenderer = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <StepIndicator
   sidebar_id="unique-id-renderer"
   mode="strict"
@@ -247,7 +260,8 @@ export const StepIndicatorCustomRenderer = () => (
     }
   ]}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -260,7 +274,8 @@ export const StepIndicatorUrls = () => (
     hideCode
     useRender
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const history = createBrowserHistory()
 const StepIndicatorWithUrl = () => {
 	const [activeUrl, setActiveUrl] = React.useState(history.location.search)
@@ -301,6 +316,7 @@ render(<>
 	<StepIndicatorWithUrl />
 	<Section spacing style_type="lavender"><Anchor href="?b">Navigate to B</Anchor></Section>
 </>)
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.js
@@ -12,70 +12,82 @@ const onChange = (state) => {
 
 export const SwitchExampleDefault = () => (
   <ComponentBox data-visual-test="switch-default" scope={{ onChange }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch
   label="Switch"
   on_change={onChange}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SwitchExampleChecked = () => (
   <ComponentBox data-visual-test="switch-checked" scope={{ onChange }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch
   label="Label:"
   label_position="left"
   checked
   on_change={({ checked }) => console.log(checked)}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SwitchExampleErrorMessage = () => (
   <ComponentBox data-visual-test="switch-error" scope={{ onChange }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch
   label="Switch"
   checked
   status="Error message"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SwitchExampleSuffix = () => (
   <ComponentBox scope={{ onChange }}>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch
   label="Switch"
   checked
   suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SwitchExampleSizes = () => (
   <ComponentBox data-visual-test="switch-sizes">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch size="medium" label="Medium" right="large" checked />
 <Switch size="large" label="Large" right="large" checked />
 <Switch size="large" label="Large" />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const SwitchExampleDisabled = () => (
   <ComponentBox data-visual-test="switch-disabled">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Switch
   checked
   disabled
   label="Disabled"
 />
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.js
@@ -14,7 +14,8 @@ import { BrowserRouter, Route, withRouter } from 'react-router-dom'
 export const TabsExampleContentOutside = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Tabs
   id="unique-linked-id"
   data={[
@@ -34,7 +35,8 @@ export const TabsExampleContentOutside = () => (
     return <H2>{ key }</H2>
   }}
 </Tabs.Content>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -46,7 +48,8 @@ export const TabsExampleContentObject = () => (
       data-visual-test="tabs-tablist"
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const data = [
   { title: 'First', key: 'first' },
   { title: 'Second', key: 'second' },
@@ -58,7 +61,8 @@ render(
     { exampleContent /* See Example Content below */ }
   </Tabs>
 )
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -69,7 +73,8 @@ export const TabsExampleUsingData = () => (
       data-visual-test="tabs-clickhandler"
       scope={{ exampleContent }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Tabs
   data={{
     first: {
@@ -92,7 +97,8 @@ export const TabsExampleUsingData = () => (
     console.log('on_change', selected_key)
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -103,11 +109,13 @@ export const TabsExampleScrollable = () => (
       data-visual-test="tabs-tablist-scrollable"
       scope={{ manyTabs, manyTabsContent }}
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Tabs data={manyTabs}>
   { manyTabsContent }
 </Tabs>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -115,7 +123,8 @@ export const TabsExampleScrollable = () => (
 export const TabsExampleLeftAligned = () => (
   <Wrapper>
     <ComponentBox data-visual-test="tabs-section-styles">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Tabs tabs_style="mint-green" content_style="black-3">
   <Tabs.Content title="First">
     <H2 top={0} bottom>First</H2>
@@ -124,7 +133,8 @@ export const TabsExampleLeftAligned = () => (
     <H2 top={0} bottom>Second</H2>
   </Tabs.Content>
 </Tabs>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -135,7 +145,8 @@ export const TabsExampleHorizontalAligned = () => (
     scope={{ manyTabs }}
     useRender
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 
 const FlexWrapper = styled.div\`
   display: flex;
@@ -184,7 +195,8 @@ function TabsHorizontalAligned() {
 }
 
 render(<TabsHorizontalAligned />)
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -194,7 +206,8 @@ export const TabsExampleMaxWidth = () => (
     scope={{ manyTabs }}
     useRender
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 
 const MaxWidthWrapper = styled.div\`
   max-width: 30rem;
@@ -216,7 +229,8 @@ function TabsMaxWidth() {
 }
 
 render(<TabsMaxWidth />)
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -228,7 +242,8 @@ export const TabsExampleReactRouterNavigation = () =>
         scope={{ BrowserRouter, Route, withRouter }}
         useRender
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 // import { Router, Route, withRouter } from 'react-router-dom'
 const tabsData = [
   { title: 'Home', key: 'home' },
@@ -259,7 +274,8 @@ const TabsNav = withRouter(({ history, location }) => (
   </Tabs>
 ))
 render(<BrowserRouter><TabsNav /></BrowserRouter>)
-`}
+`
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -268,7 +284,8 @@ export const TabsExampleReachRouterNavigation = () =>
   typeof window === 'undefined' ? null : (
     <Wrapper>
       <ComponentBox scope={{ Location, Router, navigate }} useRender>
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 // import { Location, Router, navigate } from '@reach/router'
 const Home = () => <H2>Home</H2>
 const About = () => <H2>About</H2>
@@ -299,7 +316,8 @@ render(
     }}
   </Location>
 )
-`}
+`
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -342,7 +360,8 @@ const Wrapper = styled.div`
 export const TabsNoBorder = () => (
   <Wrapper>
     <ComponentBox data-visual-test="tabs-no-border">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Tabs no_border={true}>
   <Tabs.Content title="First">
     <H2 top={0} bottom>First</H2>
@@ -351,7 +370,8 @@ export const TabsNoBorder = () => (
     <H2 top={0} bottom>Second</H2>
   </Tabs.Content>
 </Tabs>
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag/Examples.js
@@ -12,12 +12,14 @@ import {
 
 export const TagDefault = () => (
   <ComponentBox data-visual-test="tag-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Tag.Group label="Payment types:">
   <Tag>Digipost</Tag>
   <Tag>AvtaleGiro</Tag>
 </Tag.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -26,41 +28,48 @@ export const TagWithIcon = () => (
     data-visual-test="tag-icon"
     scope={{ EInvoice, AInvoice, DigiPost }}
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Tag.Group label="Betalingstyper:">
   <Tag icon={AInvoice} text="AvtaleGiro" />
   <Tag icon={EInvoice} text="eFaktura" />
   <Tag icon={DigiPost} text="DigiPost" />
 </Tag.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TagRemovable = () => (
   <ComponentBox data-visual-test="tag-removable">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Tag.Group label="Files:">
   <Tag text='Eufemia.tsx' onDelete={() => { console.log("I was deleted!")}}/>
 </Tag.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TagInline = () => (
   <ComponentBox data-visual-test="tag-inline">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 Text <Tag.Group label="Inline:">
   <Tag text="First" /> between 
   <Tag text="Second" />
   <Tag text="Third" />
 </Tag.Group> Text
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TagMultipleRemovable = () => (
   <ComponentBox data-visual-test="tag-removable-list" useRender>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 const Genres = () => {
   const [tagData, setTagData] = React.useState([
     { key: 0, text: 'Action' },
@@ -91,18 +100,21 @@ const Genres = () => {
   )
 }
 render(<Genres />)
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TagSkeleton = () => (
   <ComponentBox data-visual-test="tag-skeleton">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Tag.Group label="Skeletons:">
   <Tag skeleton text="Skeleton" /> 
   <Tag skeleton text="Skeleton" />
   <Tag skeleton text="Skeleton" />
 </Tag.Group>
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
@@ -10,7 +10,8 @@ import styled from '@emotion/styled'
 export const TextareaExampleRowsCols = () => (
   <Wrapper>
     <ComponentBox data-visual-test="textarea-default">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Default:"
   rows="2"
@@ -20,7 +21,8 @@ export const TextareaExampleRowsCols = () => (
   on_focus={() => { console.log('on_focus') }}
   on_blur={() => { console.log('on_blur') }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -28,12 +30,14 @@ export const TextareaExampleRowsCols = () => (
 export const TextareaExamplePlaceholder = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Placeholder:"
   placeholder="Placeholder text"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -41,7 +45,8 @@ export const TextareaExamplePlaceholder = () => (
 export const TextareaExampleVertical = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Vertical:"
   label_direction="vertical"
@@ -49,7 +54,8 @@ export const TextareaExampleVertical = () => (
   cols="33"
   value="Textarea value with more than 3 lines\nNewline\nNewline\nNewline\nNewline"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -57,14 +63,16 @@ export const TextareaExampleVertical = () => (
 export const TextareaExampleStretched = () => (
   <Wrapper>
     <ComponentBox data-visual-test="textarea-stretch">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Horizontal:"
   stretch="true"
   rows="3"
   value="Nec litora inceptos vestibulum id interdum donec gravida."
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -72,7 +80,8 @@ export const TextareaExampleStretched = () => (
 export const TextareaExampleAutoresize = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Autogrow:"
   rows={1}
@@ -85,7 +94,8 @@ export const TextareaExampleAutoresize = () => (
     }
   }}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -93,7 +103,8 @@ export const TextareaExampleAutoresize = () => (
 export const TextareaExampleMaxLength = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Length limit:"
   rows="3"
@@ -102,7 +113,8 @@ export const TextareaExampleMaxLength = () => (
   required
   value="Nec litora inceptos vestibulum id interdum donec gravida."
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -110,14 +122,16 @@ export const TextareaExampleMaxLength = () => (
 export const TextareaExampleFormStatus = () => (
   <Wrapper>
     <ComponentBox data-visual-test="textarea-error">
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Error Message:"
   cols="33"
   value="Nec litora inceptos vestibulum id interdum donec gravida."
   status="Message to the user"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -125,13 +139,15 @@ export const TextareaExampleFormStatus = () => (
 export const TextareaExampleError = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Show status:"
   status="error"
   value="Shows status with border only"
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -139,13 +155,15 @@ export const TextareaExampleError = () => (
 export const TextareaExampleDisabled = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Disabled:"
   disabled
   value="Nec litora inceptos vestibulum id interdum donec gravida."
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )
@@ -153,13 +171,15 @@ export const TextareaExampleDisabled = () => (
 export const TextareaExampleSuffix = () => (
   <Wrapper>
     <ComponentBox>
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 <Textarea
   label="Textarea with suffix:"
   value="Nec litora inceptos vestibulum id interdum donec gravida."
   suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
 />
-`}
+`
+      }
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/Examples.js
@@ -12,7 +12,8 @@ import {
 
 export const TimelineSingleCompleted = () => (
   <ComponentBox data-visual-test="timeline-single-completed" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
   <Timeline 
     data={[
       {
@@ -21,13 +22,15 @@ export const TimelineSingleCompleted = () => (
       }
     ]}
   />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineSingleCurrent = () => (
   <ComponentBox data-visual-test="timeline-single-current" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
   <Timeline 
     data={[
       {
@@ -36,13 +39,15 @@ export const TimelineSingleCurrent = () => (
       }
     ]}
   />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineSingleUpcoming = () => (
   <ComponentBox data-visual-test="timeline-single-upcoming" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
   <Timeline 
     data={[
       {
@@ -51,7 +56,8 @@ export const TimelineSingleUpcoming = () => (
       }
     ]}
   />
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -61,7 +67,8 @@ export const TimelineMultipleData = () => (
     data-visual-test="timeline-multiple"
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -84,7 +91,8 @@ export const TimelineMultipleData = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -94,7 +102,8 @@ export const TimelineMultipleCompletedData = () => (
     data-visual-test="timeline-multiple-completed"
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -119,7 +128,8 @@ export const TimelineMultipleCompletedData = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -129,7 +139,8 @@ export const TimelineMultipleUpcomingData = () => (
     data-visual-test="timeline-multiple-upcoming"
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -154,7 +165,8 @@ export const TimelineMultipleUpcomingData = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -164,7 +176,8 @@ export const TimelineMultipleCurrentData = () => (
     data-visual-test="timeline-multiple-current"
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -189,13 +202,15 @@ export const TimelineMultipleCurrentData = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineMultiple = () => (
   <ComponentBox data-visual-test="timeline-multiple-children" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Timeline>
   <Timeline.Item 
     title="Completed event" 
@@ -212,7 +227,8 @@ export const TimelineMultiple = () => (
     state="upcoming"
   />
 </Timeline>
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -222,7 +238,8 @@ export const TimelineStates = () => (
     data-visual-test="timeline-states"
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -249,7 +266,8 @@ export const TimelineStates = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
@@ -260,7 +278,8 @@ export const TimelineIcons = () => (
     scope={{ Confetti, Card, AccountCard }}
     hideCode
   >
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 () => {
   const events = [
     {
@@ -287,13 +306,15 @@ export const TimelineIcons = () => (
     <Timeline data={events}/>
   )
 }
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineSkeleton = () => (
   <ComponentBox data-visual-test="timeline-skeleton" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
   <Timeline
     skeleton
     data={[
@@ -314,13 +335,15 @@ export const TimelineSkeleton = () => (
       },      
     ]}
   />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineAsChildrenSkeleton = () => (
   <ComponentBox data-visual-test="timeline-children-skeleton" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Timeline skeleton>
   <Timeline.Item 
     title="Upcoming" 
@@ -338,13 +361,15 @@ export const TimelineAsChildrenSkeleton = () => (
     state="completed"
   />
 </Timeline>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const TimelineItemSkeleton = () => (
   <ComponentBox data-visual-test="timeline-item-skeleton" hideCode>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
   <Timeline
     data={[
       {
@@ -361,6 +386,7 @@ export const TimelineItemSkeleton = () => (
       }
     ]}
   />
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.js
@@ -8,31 +8,36 @@ import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
 export const ToggleButtonUnchecked = () => (
   <ComponentBox data-visual-test="toggle-button-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton
   label="Label:"
   text="Toggle Me"
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonChecked = () => (
   <ComponentBox data-visual-test="toggle-button-checked">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton
   label="Label:"
   text="Checked ToggleButton"
   checked
   on_change={({ checked }) => { console.log('on_change', checked) }}
 />
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonDefault = () => (
   <ComponentBox data-visual-test="toggle-button-group-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="ToggleButton Group:"
   value="first"
@@ -45,13 +50,15 @@ export const ToggleButtonDefault = () => (
     value="third"
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonMultiselect = () => (
   <ComponentBox data-visual-test="toggle-button-group-multiselect">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="Multi-select:"
   multiselect="true"
@@ -65,13 +72,15 @@ export const ToggleButtonMultiselect = () => (
     value="third"
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonVertical = () => (
   <ComponentBox data-visual-test="toggle-button-group-vertical">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="Vertical Group:"
   layout_direction="column"
@@ -87,13 +96,15 @@ export const ToggleButtonVertical = () => (
     checked
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonStatus = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="ToggleButton Group with status:"
   status="Error message"
@@ -116,13 +127,15 @@ export const ToggleButtonStatus = () => (
     checked="true"
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonStatusMessages = () => (
   <ComponentBox data-visual-test="toggle-button-group-status">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="ToggleButtons with status:"
   variant="radio"
@@ -146,13 +159,15 @@ export const ToggleButtonStatusMessages = () => (
     status_state="info"
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonDisabledGroup = () => (
   <ComponentBox data-visual-test="toggle-button-group-disabled">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="Disabled Group:"
   disabled
@@ -166,13 +181,15 @@ export const ToggleButtonDisabledGroup = () => (
     checked
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonSuffix = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group
   label="With suffixes:"
   suffix={<HelpButton title="Group suffix">Group suffix</HelpButton>}
@@ -190,18 +207,21 @@ export const ToggleButtonSuffix = () => (
     checked
   />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const ToggleButtonIconOnly = () => (
   <ComponentBox>
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <ToggleButton.Group label="Icons only:">
   <ToggleButton icon="bell" value="first" checked />
   <ToggleButton icon="loupe" value="second" />
   <ToggleButton icon="calendar" value="third" />
 </ToggleButton.Group>
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/Examples.js
@@ -5,37 +5,44 @@
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 
-
 export const VisuallyHiddenDefault = () => (
   <ComponentBox data-visual-test="visually-hidden-default">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <VisuallyHidden>Hidden content</VisuallyHidden>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const VisuallyHiddenFocusable = () => (
   <ComponentBox data-visual-test="visually-hidden-focusable">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <VisuallyHidden focusable>
   <Anchor href="/">Hidden, but focusable content</Anchor>
 </VisuallyHidden>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const VisuallyHiddenUseCase = () => (
   <ComponentBox data-visual-test="visually-hidden-use-case">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <Anchor href="/">Read more <VisuallyHidden element="span">about Eufemia</VisuallyHidden></Anchor>
-`}
+`
+    }
   </ComponentBox>
 )
 
 export const VisuallyHiddenSpan = () => (
   <ComponentBox data-visual-test="visually-hidden-span">
-    {() => /* jsx */ `
+    {
+      /* jsx */ `
 <VisuallyHidden element="span">Hidden, with custom HTML element</VisuallyHidden>
-`}
+`
+    }
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/Examples.js
@@ -24,7 +24,8 @@ export function PaymentCardAllCards() {
       data-visual-test="all-cards"
       useRender
     >
-      {() => /* jsx */ `
+      {
+        /* jsx */ `
 const demoCards = [
   'VE1',
   'VL2',
@@ -49,7 +50,8 @@ const Cards = ()=>demoCards.map((product_code) => {
 	)
 })
 render(<Cards />)
-	`}
+	`
+      }
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/demos.md
@@ -18,7 +18,7 @@ PaymentCardAllCards
 Basic card using productCode.
 
 <ComponentBox scope={{PaymentCard}} data-visual-test="payment-card-basic">
-	{() => /* jsx */ `
+	{/* jsx */ `
 <PaymentCard
   product_code="NK1"
   card_number="************1337"
@@ -40,7 +40,7 @@ import PaymentCard, {
 ```
 
 <ComponentBox scope={{PaymentCard,Designs,ProductType,CardType}} useRender>
-  {() => /* jsx */ `
+  {/* jsx */ `
 const customData = {
   productCode: 'UNDEFINED',
   productName: 'DNB Custom Card',
@@ -64,7 +64,7 @@ render(
 Basic card using product code and status.
 
 <ComponentBox scope={{PaymentCard}} data-visual-test="payment-card-status">
-	{() => /* jsx */ `
+	{/* jsx */ `
 <PaymentCard
   product_code="VG2"
   card_status="blocked"
@@ -78,7 +78,7 @@ Basic card using product code and status.
 **NB:** The compact variant have to be aligned to a not yet defined SSOT style.
 
 <ComponentBox scope={{PaymentCard}} data-visual-test="payment-card-compact">
-	{() => /* jsx */ `
+	{/* jsx */ `
 <PaymentCard
   variant="compact"
   product_code="VG1"

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
@@ -20,7 +20,8 @@ export function CoreStyleExample() {
         hideCode
         data-visual-test="helper-core-style"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <div className="dnb-core-style">
   <h3 className="dnb-h--medium">Wrapper with the DNB Body Style (CSS reset)</h3>
   <p className="dnb-p">
@@ -28,7 +29,8 @@ export function CoreStyleExample() {
     and <a href="/uilib/usage/customisation/styling#core-style" className="dnb-anchor">Use Eufemia Styles elsewhere</a>
   </p>
 </div>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -38,7 +40,8 @@ export function TabFocusExample() {
   return (
     <Wrapper className="dnb-spacing">
       <ComponentBox reactLive hideCode data-visual-test="helper-tap-focus">
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <details>
   <summary className="dnb-tab-focus">
     Try to focus me with the Tab key
@@ -46,7 +49,8 @@ export function TabFocusExample() {
   My main focus state has been removed and replaced by the
   helping class <code className="dnb-code">.dnb-tab-focus</code>
 </details>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -60,7 +64,8 @@ export function UnstyledListExample() {
         hideCode
         data-visual-test="helper-unstyled-list"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <ul className="dnb-unstyled-list">
   <li>I'm an unstyled list item</li>
   <li>Me too!</li>
@@ -69,7 +74,8 @@ export function UnstyledListExample() {
 <ul className="dnb-ul">
   <li>But I'm not.</li>
 </ul>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -79,7 +85,8 @@ export function ScreenReaderOnlyExample() {
   return (
     <Wrapper className="dnb-spacing">
       <ComponentBox reactLive hideCode data-visual-test="helper-sr-only">
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <p className="dnb-p">
   Hidden text
   <span className="dnb-sr-only--inline">
@@ -87,7 +94,8 @@ export function ScreenReaderOnlyExample() {
     me. Unless you're using a screen reader.
   </span>!
 </p>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -101,12 +109,14 @@ export function NoScreenReaderExample() {
         hideCode
         data-visual-test="helper-not-sr-only"
       >
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <p className="dnb-p dnb-sr-only dnb-not-sr-only">
   I'm the opposite of .dnb-sr-only, so you should be able to see
   me.
 </p>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )
@@ -116,11 +126,13 @@ export function SelectionExample() {
   return (
     <Wrapper className="dnb-spacing">
       <ComponentBox reactLive hideCode data-visual-test="helper-selection">
-        {() => /* jsx */ `
+        {
+          /* jsx */ `
 <p className="dnb-selection dnb-p__size--basis">
   If you select a part of this text, you will see the selection highlight is green.
 </p>
-        `}
+        `
+        }
       </ComponentBox>
     </Wrapper>
   )


### PR DESCRIPTION
We have used a function, only to make the VSCode [extension](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel) Babel Template Literal to work properly. But VSCode with [this extension](https://marketplace.visualstudio.com/items?itemName=Razio.es6-string-jsx) just works fine.

We have it already as a [recommendation](https://github.com/dnbexperience/eufemia/blob/8ee83266742208b74a364f7ead1f9004f9699864/.vscode/extensions.json#L9).

The code change is simply done with a search (`() => /* jsx */`) and replace (`/* jsx */ ``).