### PR TITLE
chore(Slider): add back support for FormRow

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started.md
@@ -184,6 +184,33 @@ function MyComponent(props: Types) {
 }
 ```
 
+#### FormRow support with `includeValidProps`
+
+Form elements, like input, checkbox, slider etc. do support some [FormRow](/uilib/components/form-row) properties. In order to support them, you can use `includeValidProps`, so only valid properties will effected the component.
+
+```tsx
+import { Context } from '../../shared'
+import { usePropsWithContext } from '../../shared/hooks'
+import { includeValidProps } from '../../components/form-row/FormRowHelpers'
+
+const defaultProps = {
+  myParam: 'value',
+}
+
+function MyComponent(props: Types) {
+  const context = React.useContext(Context)
+
+  const { myParam, skeleton, ...rest } = usePropsWithContext(
+    props,
+    defaultProps,
+    includeValidProps(context?.FormRow)
+    context.MyComponent,
+  )
+
+  // Use myParam and spread the ...rest
+}
+```
+
 #### Spacing support
 
 It depends from case to case on how you would make [spacing](/uilib/components/space) support available. But you may always give the developer to send in the spacing properties to the very root element of your component.

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.js
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.js
@@ -15,6 +15,7 @@ import {
   validateDOMAttributes,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
+
 import Context from '../../shared/Context'
 import FormLabel from '../form-label/FormLabel'
 import {
@@ -151,8 +152,7 @@ export default class FormRow extends React.PureComponent {
       this.context.FormRow
     )
 
-    let {
-      label,
+    const {
       label_direction,
       label_sr_only,
       label_id,
@@ -172,13 +172,17 @@ export default class FormRow extends React.PureComponent {
       disabled,
       skeleton,
       wrap,
-      id: _id, // eslint-disable-line
       className,
       class: _className,
       skipContentWrapperIfNested,
 
+      id: _id, // eslint-disable-line
+      label: _label, // eslint-disable-line
+
       ...attributes
     } = props
+
+    let { label } = props
 
     const isNested =
       this.context.FormRow && this.context.FormRow.itsMeAgain
@@ -294,7 +298,6 @@ export default class FormRow extends React.PureComponent {
                     `dnb-form-row__content--${indent_offset || 'default'}`,
                   responsive && 'dnb-responsive-component'
                 )}
-                ref={this._contentRef}
               >
                 {children}
               </div>
@@ -306,7 +309,12 @@ export default class FormRow extends React.PureComponent {
   }
 }
 
-const Fieldset = ({ useFieldset, className, children, ...props }) => {
+const Fieldset = ({
+  useFieldset,
+  children,
+  className = null,
+  ...props
+}) => {
   if (useFieldset) {
     return (
       <fieldset

--- a/packages/dnb-eufemia/src/components/form-row/FormRowHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/form-row/FormRowHelpers.tsx
@@ -1,4 +1,5 @@
 import { isTrue } from '../../shared/component-helper'
+import { filterValidProps } from '../../shared/helpers/filterValidProps'
 
 type FormRowProps = {
   label_direction?: 'vertical' | 'horizontal'
@@ -12,4 +13,18 @@ export const prepareFormRowContext = (props: FormRowProps) => {
       : props.label_direction
   }
   return props
+}
+
+const validFormRowProps = {
+  skeleton: null,
+  disabled: null,
+  vertical: null,
+  label_direction: null,
+}
+
+export const includeValidProps = (
+  props: FormRowProps,
+  excludeProps: Record<string, unknown>
+) => {
+  return filterValidProps(props, validFormRowProps, excludeProps)
 }

--- a/packages/dnb-eufemia/src/components/slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/Slider.tsx
@@ -16,6 +16,7 @@ import {
   combineDescribedBy,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
+import { includeValidProps } from '../../components/form-row/FormRowHelpers'
 import { usePropsWithContext } from '../../shared/hooks'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { withCamelCaseProps } from '../../shared/helpers/withCamelCaseProps'
@@ -106,9 +107,19 @@ function Slider(localProps: IncludeCamelCase<SliderProps>) {
   const allProps = usePropsWithContext(
     localProps,
     defaultProps,
-    context?.translation?.Slider,
-    context?.Slider,
-    { skeleton: context?.skeleton }
+    { skeleton: context?.skeleton },
+    context?.getTranslation(localProps).Slider,
+    includeValidProps(
+      context?.FormRow,
+
+      /**
+       * Exclude some props
+       */
+      {
+        vertical: null,
+      }
+    ),
+    context?.Slider
   )
 
   const [_id] = React.useState(makeUniqueId)
@@ -445,7 +456,7 @@ function Slider(localProps: IncludeCamelCase<SliderProps>) {
       variant="secondary"
       icon="subtract"
       size="small"
-      aria-label={subtract_title.replace('%s', humanNumber)}
+      aria-label={subtract_title?.replace('%s', humanNumber)}
       on_click={onSubtractClickHandler}
       disabled={disabled}
       skeleton={skeleton}
@@ -459,7 +470,7 @@ function Slider(localProps: IncludeCamelCase<SliderProps>) {
       variant="secondary"
       icon="add"
       size="small"
-      aria-label={add_title.replace('%s', humanNumber)}
+      aria-label={add_title?.replace('%s', humanNumber)}
       on_click={onAddClickHandler}
       disabled={disabled}
       skeleton={skeleton}

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -114,7 +114,7 @@ export type ContextProps = {
 export type GetTranslationProps = {
   lang?: Locale
   locale?: Locale
-}
+} & Record<string, unknown>
 
 export type Locale = string | 'nb-NO' | 'en-GB' | 'en-US'
 export type ComponentTranslationsName = string

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
@@ -1,0 +1,32 @@
+import { filterValidProps } from '../filterValidProps'
+
+describe('filterValidProps', () => {
+  it('should return only declared props', () => {
+    type Props = {
+      key: string
+      foo: string
+    }
+    const props: Props = { key: 'only-me', foo: 'bar' }
+    const validKeys = { key: null }
+
+    const result = filterValidProps(props, validKeys)
+    expect(result).toEqual({
+      key: 'only-me',
+    })
+  })
+
+  it('should exclude unwanted props', () => {
+    type Props = {
+      key: string
+      foo: string
+    }
+    const props: Props = { key: 'only-me', foo: 'bar' }
+    const validKeys = { key: null, foo: null }
+    const excludeKeys = { foo: null }
+
+    const result = filterValidProps(props, validKeys, excludeKeys)
+    expect(result).toEqual({
+      key: 'only-me',
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
@@ -1,0 +1,30 @@
+/**
+ * Filters out props from a given object/context
+ * It returns a new object, with keys defined in validKeys
+ *
+ * @param props object of component properties
+ * @param validKeys object with keys that should get returned
+ * @param excludeKeys object with keys that should be excluded
+ * @returns filtered properties
+ */
+function filterValidProps<Props>(
+  props: Props,
+  validKeys: Record<string, unknown>,
+  excludeKeys?: Record<string, unknown>
+) {
+  const res = {} as Props,
+    o = Object.prototype.hasOwnProperty
+
+  for (const key in props) {
+    if (
+      o.call(validKeys, key) &&
+      (!excludeKeys || (excludeKeys && !o.call(excludeKeys, key)))
+    ) {
+      res[key] = props[key]
+    }
+  }
+
+  return res
+}
+
+export { filterValidProps }


### PR DESCRIPTION
- Fix failing screenshot/visual test
- Make Slider support FormRow again
- Write docs about how
- Add filterValidProps helper function (for "internal" usage as of now)
- Add includeValidProps to FormRow
