### PR TITLE
fix(Drawer): fix Safari text selection + drag/scroll issue

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2035,14 +2035,6 @@ button.dnb-button::-moz-focus-inner {
     width: 100%;
     height: 100%;
     overflow-x: hidden; }
-    .dnb-drawer__inner::after {
-      content: '';
-      position: absolute;
-      z-index: -4;
-      left: 0;
-      top: 0;
-      width: 100vw;
-      height: 100%; }
   .dnb-drawer--spacing .dnb-drawer__inner {
     padding: 0 var(--drawer-spacing) 0; }
     @media screen and (min-width: 72em) {

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2031,6 +2031,7 @@ button.dnb-button::-moz-focus-inner {
     display: flex;
     flex-direction: column;
     z-index: 10;
+    /** Sets the color on scroll overflow (at the bottom) */
     background-color: var(--modal-background-color, transparent);
     width: 100%;
     height: 100%;
@@ -2338,8 +2339,7 @@ button.dnb-button::-moz-focus-inner {
  */
 :root {
   --modal-z-index: 3000;
-  --modal-animation-duration: 300ms;
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32); }
+  --modal-animation-duration: 300ms; }
 
 html[data-dnb-modal-active] {
   user-select: none;
@@ -2388,8 +2388,7 @@ html[data-dnb-modal-active] {
     left: 0;
     top: 0;
     width: 100%;
-    height: 100%;
-    background-color: var(--modal-overlay-bg); }
+    height: 100%; }
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {

--- a/packages/dnb-eufemia/src/components/dialog/style/themes/dnb-dialog-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/themes/dnb-dialog-theme-ui.scss
@@ -7,11 +7,4 @@
 
 .dnb-dialog {
   background: var(--color-white);
-
-  &__root {
-    // Used by "setBackgroundColor"
-    &::after {
-      background-color: var(--modal-background-color);
-    }
-  }
 }

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2045,6 +2045,7 @@ button.dnb-button::-moz-focus-inner {
     display: flex;
     flex-direction: column;
     z-index: 10;
+    /** Sets the color on scroll overflow (at the bottom) */
     background-color: var(--modal-background-color, transparent);
     width: 100%;
     height: 100%;
@@ -2352,8 +2353,7 @@ button.dnb-button::-moz-focus-inner {
  */
 :root {
   --modal-z-index: 3000;
-  --modal-animation-duration: 300ms;
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32); }
+  --modal-animation-duration: 300ms; }
 
 html[data-dnb-modal-active] {
   user-select: none;
@@ -2402,8 +2402,7 @@ html[data-dnb-modal-active] {
     left: 0;
     top: 0;
     width: 100%;
-    height: 100%;
-    background-color: var(--modal-overlay-bg); }
+    height: 100%; }
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2049,14 +2049,6 @@ button.dnb-button::-moz-focus-inner {
     width: 100%;
     height: 100%;
     overflow-x: hidden; }
-    .dnb-drawer__inner::after {
-      content: '';
-      position: absolute;
-      z-index: -4;
-      left: 0;
-      top: 0;
-      width: 100vw;
-      height: 100%; }
   .dnb-drawer--spacing .dnb-drawer__inner {
     padding: 0 var(--drawer-spacing) 0; }
     @media screen and (min-width: 72em) {

--- a/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
@@ -38,8 +38,8 @@ export const DrawerSandbox = () => (
     <Box>
       {/* <Button variant="tertiary" text="Button" /> */}
       <Drawer
-        // no_animation
-        // open_state="opened"
+        noAnimation
+        openState="opened"
         // fullscreen
         containerPlacement="right"
         //align_content="right"

--- a/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
@@ -50,16 +50,6 @@
     width: 100%;
     height: 100%;
     overflow-x: hidden;
-
-    &::after {
-      content: '';
-      position: absolute;
-      z-index: -4;
-      left: 0;
-      top: 0;
-      width: 100vw;
-      height: 100%;
-    }
   }
 
   &--spacing &__inner {

--- a/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
@@ -45,6 +45,8 @@
     display: flex;
     flex-direction: column;
     z-index: 10;
+
+    /** Sets the color on scroll overflow (at the bottom) */
     background-color: var(--modal-background-color, transparent);
 
     width: 100%;

--- a/packages/dnb-eufemia/src/components/drawer/style/themes/dnb-drawer-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/themes/dnb-drawer-theme-ui.scss
@@ -7,11 +7,4 @@
 
 .dnb-drawer {
   background: var(--color-white);
-
-  &__root {
-    // Used by "setBackgroundColor"
-    &::after {
-      background-color: var(--modal-background-color);
-    }
-  }
 }

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -347,13 +347,7 @@ export default class ModalContent extends React.PureComponent<
   }
 
   setBackgroundColor = (color: string) => {
-    document.documentElement.style.setProperty(
-      '--modal-background-color',
-      color
-    )
-    this.setState({
-      color,
-    })
+    this.setState({ color })
   }
 
   render() {
@@ -488,6 +482,7 @@ export default class ModalContent extends React.PureComponent<
       >
         <div
           id={contentId}
+          /** Sets the color on scroll overflow (at the bottom) */
           style={
             (color
               ? { '--modal-background-color': `var(--color-${color})` }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2019,6 +2019,7 @@ button.dnb-button::-moz-focus-inner {
     display: flex;
     flex-direction: column;
     z-index: 10;
+    /** Sets the color on scroll overflow (at the bottom) */
     background-color: var(--modal-background-color, transparent);
     width: 100%;
     height: 100%;
@@ -2326,8 +2327,7 @@ button.dnb-button::-moz-focus-inner {
  */
 :root {
   --modal-z-index: 3000;
-  --modal-animation-duration: 300ms;
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32); }
+  --modal-animation-duration: 300ms; }
 
 html[data-dnb-modal-active] {
   user-select: none;
@@ -2376,8 +2376,7 @@ html[data-dnb-modal-active] {
     left: 0;
     top: 0;
     width: 100%;
-    height: 100%;
-    background-color: var(--modal-overlay-bg); }
+    height: 100%; }
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2023,14 +2023,6 @@ button.dnb-button::-moz-focus-inner {
     width: 100%;
     height: 100%;
     overflow-x: hidden; }
-    .dnb-drawer__inner::after {
-      content: '';
-      position: absolute;
-      z-index: -4;
-      left: 0;
-      top: 0;
-      width: 100vw;
-      height: 100%; }
   .dnb-drawer--spacing .dnb-drawer__inner {
     padding: 0 var(--drawer-spacing) 0; }
     @media screen and (min-width: 72em) {

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -8,7 +8,6 @@
 :root {
   --modal-z-index: 3000;
   --modal-animation-duration: 300ms;
-  --modal-overlay-bg: rgba(0, 0, 0, 0.32);
 }
 
 html[data-dnb-modal-active] {
@@ -78,8 +77,6 @@ html[data-dnb-modal-active] {
 
     width: 100%;
     height: 100%;
-
-    background-color: var(--modal-overlay-bg);
   }
 
   &-root__inner &__overlay {

--- a/packages/dnb-eufemia/src/components/modal/style/themes/dnb-modal-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/themes/dnb-modal-theme-ui.scss
@@ -5,11 +5,12 @@
 
 @import '../../../../style/themes/imports.scss';
 
+:root {
+  --modal-overlay-bg: rgba(0, 0, 0, 0.32);
+}
+
 .dnb-modal {
-  &__content {
-    // Used by "setBackgroundColor"
-    &::after {
-      background-color: var(--modal-background-color);
-    }
+  &__overlay {
+    background-color: var(--modal-overlay-bg);
   }
 }


### PR DESCRIPTION
Reported in this [thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1660052015576469).

There was a pseudo-element that cause in Safari Desktop a wired scroll effect when selecting text and dragging the mouse to the right side. That pseudo-element seems to not be used, as there where not other visible styles attached to it (whooot? yes 🫣) so we remove it for now. It may be some helper for scrolling or something. But it should then be declared as so.