### PR TITLE
fix(Drawer): fix possible Safari selection causing selection scroll (horizontal) issue

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2142,15 +2142,16 @@ button.dnb-button::-moz-focus-inner {
     position: sticky;
     top: 0;
     z-index: 99;
-    margin: var(--drawer-spacing) 0; }
+    margin: var(--drawer-spacing) calc(var(--drawer-spacing) * -1);
+    padding: 0 var(--drawer-spacing); }
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section.dnb-drawer__navigation--sticky {
     z-index: 2999; }
   .dnb-drawer .dnb-drawer__navigation--sticky::before {
     content: '';
     position: absolute;
     z-index: -1;
-    left: -50%;
-    right: -50%;
+    left: 0;
+    right: 0;
     bottom: 0;
     height: 300%;
     box-shadow: var(--shadow-default); }
@@ -2412,8 +2413,7 @@ html[data-dnb-modal-active] {
   .dnb-modal__header__bar.dnb-section {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
-    width: 100%; }
+    justify-content: space-between; }
     @media screen and (-ms-high-contrast: none) {
       .dnb-modal__header__bar.dnb-section {
         align-items: center; } }

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2156,15 +2156,16 @@ button.dnb-button::-moz-focus-inner {
     position: sticky;
     top: 0;
     z-index: 99;
-    margin: var(--drawer-spacing) 0; }
+    margin: var(--drawer-spacing) calc(var(--drawer-spacing) * -1);
+    padding: 0 var(--drawer-spacing); }
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section.dnb-drawer__navigation--sticky {
     z-index: 2999; }
   .dnb-drawer .dnb-drawer__navigation--sticky::before {
     content: '';
     position: absolute;
     z-index: -1;
-    left: -50%;
-    right: -50%;
+    left: 0;
+    right: 0;
     bottom: 0;
     height: 300%;
     box-shadow: var(--shadow-default); }
@@ -2426,8 +2427,7 @@ html[data-dnb-modal-active] {
   .dnb-modal__header__bar.dnb-section {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
-    width: 100%; }
+    justify-content: space-between; }
     @media screen and (-ms-high-contrast: none) {
       .dnb-modal__header__bar.dnb-section {
         align-items: center; } }

--- a/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
@@ -218,7 +218,8 @@
     z-index: 99; // below #dropdown and #date-picker
 
     // on large screens
-    margin: var(--drawer-spacing) 0;
+    margin: var(--drawer-spacing) calc(var(--drawer-spacing) * -1);
+    padding: 0 var(--drawer-spacing);
   }
   &--spacing &__navigation.dnb-section#{&}__navigation--sticky {
     z-index: 2999; // above #dropdown and #date-picker and below #modal
@@ -230,8 +231,8 @@
       content: '';
       position: absolute;
       z-index: -1;
-      left: -50%;
-      right: -50%;
+      left: 0;
+      right: 0;
       bottom: 0;
       height: 300%; // hide the top shadow
 

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2130,15 +2130,16 @@ button.dnb-button::-moz-focus-inner {
     position: sticky;
     top: 0;
     z-index: 99;
-    margin: var(--drawer-spacing) 0; }
+    margin: var(--drawer-spacing) calc(var(--drawer-spacing) * -1);
+    padding: 0 var(--drawer-spacing); }
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section.dnb-drawer__navigation--sticky {
     z-index: 2999; }
   .dnb-drawer .dnb-drawer__navigation--sticky::before {
     content: '';
     position: absolute;
     z-index: -1;
-    left: -50%;
-    right: -50%;
+    left: 0;
+    right: 0;
     bottom: 0;
     height: 300%;
     box-shadow: var(--shadow-default); }
@@ -2400,8 +2401,7 @@ html[data-dnb-modal-active] {
   .dnb-modal__header__bar.dnb-section {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
-    width: 100%; }
+    justify-content: space-between; }
     @media screen and (-ms-high-contrast: none) {
       .dnb-modal__header__bar.dnb-section {
         align-items: center; } }

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -123,7 +123,6 @@ html[data-dnb-modal-active] {
       display: flex;
       flex-direction: row;
       justify-content: space-between;
-      width: 100%;
 
       @include IS_IE() {
         align-items: center; // IE11 uses top as default


### PR DESCRIPTION
Reported [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1661162150422519?thread_ts=1660052015.576469&cid=CMXABCHEY) 🐛

Here is a [demo build](https://eufemia-fixdrawerstickyheader.gtsb.io/uilib/components/drawer/demos/#drawer-with-custom-content).

It only happens in Safari Desktop (v15). And its a Safari bug. But this PR provides a fix for it.

## How to reproduce?

When scrolling down, and selecting text from left to right, the content of the drawer, moves to the left.

## The reason?

The shadow of the header bar, which is again in a pseudo-element, makes the content moving to the left. If we remove the `overflow: hidden` also a Safari scroll-bar (horizontal) will show up.

## The fix

We can avoid that the pseudo-element is placed "outside of the view" to the right, and use rather a negative margin with a padding to get the correct spacing and placement in place.

