### PR TITLE
docs(Tooltip): add docs for animate_position prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.md
@@ -12,6 +12,7 @@ showTabs: true
 | `position`                                  | _(optional)_ defines the offset position to the target element the arrow appears. Can be `top`, `right`, `left` and `bottom`. Defaults to `top`. |
 | `align`                                     | _(optional)_ defines the offset alignment to the target element the arrow appears. Can be `center`, `right` and `left`.Defaults to `center`.     |
 | `arrow`                                     | _(optional)_ defines the direction where the arrow appears. Can be `center`, `top`, `right`, `bottom` and `left`. Defaults to `center`.          |
+| `animate_position`                          | _(optional)_ set to `true` to animate a single Tooltip from one element to another element. You also need to set a unique `group` name.          |
 | `fixed_position`                            | _(optional)_ If set to `true`, the Tooltip will be fixed in its scroll position by using CSS `position: fixed;`. Defaults to `false`.            |
 | `skip_portal`                               | _(optional)_ set to `true` to disable the React Portal behavior. Defaults to `false`.                                                            |
 | `no_animation`                              | _(optional)_ set to `true` if no fade-in animation should be used.                                                                               |


### PR DESCRIPTION
Saw we had an example using the prop, `animate_position`, in https://eufemia.dnb.no/uilib/components/tooltip/#tooltip-with-position-animation
Thought it could be nice to add the property to the list of properties, and a small explanation of what it is.