### PR TITLE
chore(useEventEmitter): move import from "helpers" to "component-helper"

### DIFF
--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -19,6 +19,7 @@ export { usePropsWithContext } from './hooks/usePropsWithContext'
 export { InteractionInvalidation } from './helpers/InteractionInvalidation'
 export { extendPropsWithContext } from './helpers/extendPropsWithContext'
 export { registerElement } from './custom-element'
+export { useEventEmitter } from './helpers/useEventEmitter'
 
 export { getPreviousSibling, warn }
 

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -1,6 +1,8 @@
 /**
  * Global helpers
  *
+ * NB: Do not import other deps in this file.
+ * Just to have things clean and one directional.
  */
 
 export const PLATFORM_MAC = 'Mac|iPad|iPhone|iPod'
@@ -17,8 +19,6 @@ export let IS_WIN = false
 export let IS_MAC = false
 export let IS_ANDROID = false
 export let IS_LINUX = false
-
-export * from './helpers/useEventEmitter'
 
 export const isMac = () =>
   (IS_MAC =

--- a/packages/dnb-eufemia/src/shared/stories/EventEmitter.stories.tsx
+++ b/packages/dnb-eufemia/src/shared/stories/EventEmitter.stories.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import { useEventEmitter } from '../helpers'
+import { useEventEmitter } from '../component-helper'
 import ToggleButton from '../../components/toggle-button/ToggleButton'
 
 export default {


### PR DESCRIPTION
Just to have things clean and one directional.

This is in relation to PR #1568