### PR TITLE
fix(Avatar): don't overwrite SVG color

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.js
@@ -178,7 +178,7 @@ export const AvatarDNBLogo = () => (
       /* jsx */ `
 <Avatar.Group label="Logos:">
   <Avatar>
-    <Logo size="auto" />
+    <Logo size="auto" inherit_color />
   </Avatar>
 </Avatar.Group>
 `

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -15,9 +15,6 @@ exports[`Avatar scss have to match default theme snapshot 1`] = `
  */
 .dnb-avatar {
   color: var(--color-pistachio); }
-  .dnb-avatar svg {
-    color: var(--color-pistachio);
-    fill: var(--color-pistachio); }
   .dnb-avatar--primary {
     background-color: var(--color-emerald-green); }
   .dnb-avatar--secondary {
@@ -25,9 +22,6 @@ exports[`Avatar scss have to match default theme snapshot 1`] = `
   .dnb-avatar--tertiary {
     background-color: var(--color-mint-green);
     color: var(--color-emerald-green); }
-    .dnb-avatar--tertiary svg {
-      color: var(--color-emerald-green);
-      fill: var(--color-emerald-green); }
 "
 `;
 

--- a/packages/dnb-eufemia/src/components/avatar/style/themes/dnb-avatar-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/avatar/style/themes/dnb-avatar-theme-ui.scss
@@ -8,10 +8,6 @@
 .dnb-avatar {
   color: var(--color-pistachio);
 
-  svg {
-    color: var(--color-pistachio);
-    fill: var(--color-pistachio);
-  }
   &--primary {
     background-color: var(--color-emerald-green);
   }
@@ -21,9 +17,5 @@
   &--tertiary {
     background-color: var(--color-mint-green);
     color: var(--color-emerald-green);
-    svg {
-      color: var(--color-emerald-green);
-      fill: var(--color-emerald-green);
-    }
   }
 }


### PR DESCRIPTION


Due to SVG path changes, the [card icon](https://github.com/dnbexperience/eufemia/pull/1575/files#diff-eac78f1448dd7a3bd40fe11a60945a1412cc91bc75027e8ad08aebefeec994f8) can not get colored with `fill` color anymore:

<img width="42" alt="Screenshot 2022-09-22 at 12 58 41" src="https://user-images.githubusercontent.com/1501870/191729510-f5e6079d-caea-4773-991d-21f96687ee4f.png">

By default, the Icon component does inherit colors, so we may rather relay on that. The only thing left (with a negative result) is the Logo component. This PR #1578 will fix our tests.