### PR TITLE
fix(Modal): Safari Desktop fullscreen video issue

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2272,7 +2272,7 @@ button.dnb-button::-moz-focus-inner {
     .dnb-dialog__icon__primary.dnb-dialog__icon--info ::after {
       background-color: var(--color-pistachio); }
   html:not([data-visual-test]) .dnb-dialog {
-    animation: show-modal var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal var(--modal-animation-duration) ease-out; }
   html:not([data-visual-test]) .dnb-dialog--hide {
     animation: hide-modal 220ms ease-in-out forwards; }
   .dnb-dialog--no-animation {
@@ -2367,7 +2367,7 @@ html[data-dnb-modal-active] {
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {
-    animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out; }
     .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
       animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {

--- a/packages/dnb-eufemia/src/components/dialog/style/_dialog.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/_dialog.scss
@@ -190,7 +190,7 @@
 
   // Animation in
   html:not([data-visual-test]) & {
-    animation: show-modal var(--modal-animation-duration) ease-out forwards;
+    animation: show-modal var(--modal-animation-duration) ease-out;
   }
   // Animation out
   html:not([data-visual-test]) &--hide {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2287,7 +2287,7 @@ button.dnb-button::-moz-focus-inner {
     .dnb-dialog__icon__primary.dnb-dialog__icon--info ::after {
       background-color: var(--color-pistachio); }
   html:not([data-visual-test]) .dnb-dialog {
-    animation: show-modal var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal var(--modal-animation-duration) ease-out; }
   html:not([data-visual-test]) .dnb-dialog--hide {
     animation: hide-modal 220ms ease-in-out forwards; }
   .dnb-dialog--no-animation {
@@ -2382,7 +2382,7 @@ html[data-dnb-modal-active] {
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {
-    animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out; }
     .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
       animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2259,7 +2259,7 @@ button.dnb-button::-moz-focus-inner {
     .dnb-dialog__icon__primary.dnb-dialog__icon--info ::after {
       background-color: var(--color-pistachio); }
   html:not([data-visual-test]) .dnb-dialog {
-    animation: show-modal var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal var(--modal-animation-duration) ease-out; }
   html:not([data-visual-test]) .dnb-dialog--hide {
     animation: hide-modal 220ms ease-in-out forwards; }
   .dnb-dialog--no-animation {
@@ -2354,7 +2354,7 @@ html[data-dnb-modal-active] {
   .dnb-modal-root__inner .dnb-modal__overlay {
     animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   .dnb-modal-root__inner:last-of-type .dnb-modal__overlay {
-    animation: show-modal-overlay var(--modal-animation-duration) ease-out forwards; }
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out; }
     .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
       animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards; }
   html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {

--- a/packages/dnb-eufemia/src/components/modal/style/_modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/_modal.scss
@@ -85,8 +85,7 @@ html[data-dnb-modal-active] {
   }
 
   &-root__inner:last-of-type &__overlay {
-    animation: show-modal-overlay var(--modal-animation-duration) ease-out
-      forwards;
+    animation: show-modal-overlay var(--modal-animation-duration) ease-out;
 
     &--hide {
       animation: hide-modal-overlay var(--modal-animation-duration)


### PR DESCRIPTION
Here is a reprod [CSB](https://codesandbox.io/s/eufemia-modal-fullscreen-safari-bug-3sv139?file=/src/App.tsx). 


# The bug 

Run [this here](https://3sv139.csb.app) in Safari Desktop, click on the full-screen button, even without playing the video:

<img width="370" alt="Screenshot 2022-09-26 at 18 26 34" src="https://user-images.githubusercontent.com/1501870/192331717-eea2e52d-b7c5-49f1-8a7f-64b846d600a4.png">

You see this here, instead of the full-screen video:

<img width="1238" alt="Screenshot 2022-09-26 at 18 30 12" src="https://user-images.githubusercontent.com/1501870/192331796-1c692744-b44d-4835-85a1-12d44ea53aa3.png">

# Reason and solution

This is because of the CSS animation and the `forwards` usage. But happily, we do not need in on the "show" animation, because, that's anyway our "default". So we can remove it. Full-screen video works now fine without it.