### PR TITLE
chore(Icon): replace data-test-id with data-testid

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.js.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.js.snap
@@ -92,7 +92,7 @@ exports[`Accordion component have to match snapshot 1`] = `
               <span
                 aria-hidden={true}
                 className="dnb-icon dnb-icon--medium dnb-icon--inherit-color"
-                data-test-id="chevron-down icon"
+                data-testid="chevron-down icon"
                 role="presentation"
               >
                 <chevron_down_medium>

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.js
@@ -1820,7 +1820,7 @@ describe('Autocomplete component', () => {
         .not('.dnb-input__clear-button')
         .find('.dnb-icon')
         .instance()
-        .getAttribute('data-test-id')
+        .getAttribute('data-testid')
     ).toContain('chevron down')
   })
 
@@ -1971,7 +1971,7 @@ describe('Autocomplete component', () => {
         .not('.dnb-input__clear-button')
         .find('.dnb-icon')
         .instance()
-        .getAttribute('data-test-id')
+        .getAttribute('data-testid')
     ).toContain('bell')
   })
 

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -59,13 +59,13 @@ describe('Avatar', () => {
     render(
       <Avatar.Group label="label">
         <Avatar>
-          <Icon icon={Confetti} data-testid="confetti-icon" />
+          <Icon icon={Confetti} />
         </Avatar>
       </Avatar.Group>
     )
 
     const avatar = screen.queryByTestId('avatar')
-    expect(within(avatar).queryByTestId('confetti-icon')).not.toBeNull()
+    expect(within(avatar).queryByTestId('confetti icon')).not.toBeNull()
     expect(screen.queryByTestId('avatar-label')).toBeNull()
   })
 

--- a/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
+++ b/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
@@ -69,9 +69,7 @@ describe('Badge', () => {
 
   it('renders children as content', () => {
     render(
-      <Badge
-        content={<Icon icon={Confetti} data-testid="confetti-icon" />}
-      >
+      <Badge content={<Icon icon={Confetti} />}>
         <Avatar.Group label="children:">
           <Avatar>A</Avatar>
         </Avatar.Group>
@@ -79,7 +77,7 @@ describe('Badge', () => {
     )
 
     const badgeRoot = screen.queryByTestId('badge-root')
-    expect(within(badgeRoot).queryByTestId('confetti-icon')).not.toBeNull()
+    expect(within(badgeRoot).queryByTestId('confetti icon')).not.toBeNull()
   })
 
   it('warns when notification badge content is a string', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -196,17 +196,11 @@ describe('Breadcrumb', () => {
     })
 
     it('will render custom icon', () => {
-      const CustomIcon = (
-        <IconPrimary
-          data-testid="breadcrumb-item-custom-icon"
-          icon="bell"
-        />
-      )
+      const CustomIcon = <IconPrimary icon="bell" />
       render(<BreadcrumbItem text="Just text" icon={CustomIcon} />)
 
-      const element = screen.queryByTestId('breadcrumb-item-custom-icon')
+      const element = screen.queryByTestId('bell icon')
       expect(element).not.toBeNull()
-      expect(element.getAttribute('data-test-id')).toBe('bell icon')
     })
 
     it('renders a skeleton if skeleton is true', () => {

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
@@ -38,7 +38,7 @@ exports[`Button component have to match default button snapshot 1`] = `
         <span
           aria-hidden="true"
           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-          data-test-id="question icon"
+          data-testid="question icon"
           role="presentation"
         >
           <svg
@@ -82,7 +82,7 @@ exports[`Button component have to match default button snapshot 1`] = `
         <span
           aria-hidden="true"
           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-          data-test-id="question icon"
+          data-testid="question icon"
           role="presentation"
         >
           <svg
@@ -166,7 +166,7 @@ exports[`Button component have to match default button snapshot 1`] = `
             <span
               aria-hidden="true"
               class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-              data-test-id="question icon"
+              data-testid="question icon"
               role="presentation"
             >
               <svg
@@ -210,7 +210,7 @@ exports[`Button component have to match default button snapshot 1`] = `
             <span
               aria-hidden="true"
               class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-              data-test-id="question icon"
+              data-testid="question icon"
               role="presentation"
             >
               <svg
@@ -282,7 +282,7 @@ exports[`Button component have to match default button snapshot 1`] = `
         <span
           aria-hidden={true}
           className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-          data-test-id="question icon"
+          data-testid="question icon"
           role="presentation"
         >
           <question>
@@ -371,7 +371,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
         <span
           aria-hidden="true"
           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-          data-test-id="question icon"
+          data-testid="question icon"
           role="presentation"
         >
           <svg
@@ -415,7 +415,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
         <span
           aria-hidden="true"
           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-          data-test-id="question icon"
+          data-testid="question icon"
           role="presentation"
         >
           <svg
@@ -490,7 +490,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
             <span
               aria-hidden="true"
               class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-              data-test-id="question icon"
+              data-testid="question icon"
               role="presentation"
             >
               <svg
@@ -543,7 +543,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
               <span
                 aria-hidden="true"
                 class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                data-test-id="question icon"
+                data-testid="question icon"
                 role="presentation"
               >
                 <svg
@@ -597,7 +597,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                 <span
                   aria-hidden="true"
                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <svg
@@ -671,7 +671,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -715,7 +715,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -787,7 +787,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
                 <span
                   aria-hidden={true}
                   className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <question>

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -396,7 +396,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="calendar icon"
+                        data-testid="calendar icon"
                         role="presentation"
                       >
                         <svg
@@ -1413,7 +1413,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="calendar icon"
+                                      data-testid="calendar icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -1485,7 +1485,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                         <span
                                           aria-hidden="true"
                                           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                          data-test-id="calendar icon"
+                                          data-testid="calendar icon"
                                           role="presentation"
                                         >
                                           <svg
@@ -1571,7 +1571,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                             <span
                                               aria-hidden="true"
                                               class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                              data-test-id="calendar icon"
+                                              data-testid="calendar icon"
                                               role="presentation"
                                             >
                                               <svg
@@ -1638,7 +1638,7 @@ exports[`DatePicker component have to match snapshot 1`] = `
                                         <span
                                           aria-hidden={true}
                                           className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                          data-test-id="calendar icon"
+                                          data-testid="calendar icon"
                                           role="presentation"
                                         >
                                           <calendar>

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               <span
                 aria-hidden="true"
                 class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                data-test-id="question icon"
+                data-testid="question icon"
                 role="presentation"
               >
                 <svg
@@ -220,7 +220,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 <span
                   aria-hidden="true"
                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <svg
@@ -308,7 +308,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -376,7 +376,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 <span
                   aria-hidden={true}
                   className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <question>
@@ -445,7 +445,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -509,7 +509,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -550,7 +550,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -616,7 +616,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -656,7 +656,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="question icon"
+                        data-testid="question icon"
                         role="presentation"
                       >
                         <svg
@@ -862,7 +862,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                                   <span
                                     aria-hidden="true"
                                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                    data-test-id="close icon"
+                                    data-testid="close icon"
                                     role="presentation"
                                   >
                                     <svg
@@ -948,7 +948,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                                         <span
                                           aria-hidden="true"
                                           class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                          data-test-id="close icon"
+                                          data-testid="close icon"
                                           role="presentation"
                                         >
                                           <svg
@@ -1097,7 +1097,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                                             <span
                                               aria-hidden={true}
                                               className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                              data-test-id="close icon"
+                                              data-testid="close icon"
                                               role="presentation"
                                             >
                                               <close>

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               <span
                 aria-hidden="true"
                 class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                data-test-id="question icon"
+                data-testid="question icon"
                 role="presentation"
               >
                 <svg
@@ -218,7 +218,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 <span
                   aria-hidden="true"
                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <svg
@@ -306,7 +306,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -374,7 +374,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 <span
                   aria-hidden={true}
                   className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <question>
@@ -443,7 +443,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -507,7 +507,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -548,7 +548,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -614,7 +614,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -654,7 +654,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="question icon"
+                        data-testid="question icon"
                         role="presentation"
                       >
                         <svg
@@ -871,7 +871,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="close icon"
+                                  data-testid="close icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -965,7 +965,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                                       <span
                                         aria-hidden="true"
                                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                        data-test-id="close icon"
+                                        data-testid="close icon"
                                         role="presentation"
                                       >
                                         <svg
@@ -1114,7 +1114,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                                           <span
                                             aria-hidden={true}
                                             className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                            data-test-id="close icon"
+                                            data-testid="close icon"
                                             role="presentation"
                                           >
                                             <close>

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.js
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.js
@@ -354,7 +354,7 @@ describe('Dropdown component', () => {
     })
 
     expect(
-      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+      Comp.find('.dnb-icon').instance().getAttribute('data-testid')
     ).toBe('chevron down icon')
 
     const event = on_change.mock.calls[0][0]
@@ -490,7 +490,7 @@ describe('Dropdown component', () => {
     expect(Comp.exists('.dnb-drawer-list__option--selected')).toBe(false)
 
     expect(
-      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+      Comp.find('.dnb-icon').instance().getAttribute('data-testid')
     ).toBe('more icon')
 
     expect(Comp.exists('.dnb-dropdown__text')).toBe(false)

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
@@ -774,7 +774,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="chevron left icon"
+                    data-testid="chevron left icon"
                     role="presentation"
                   >
                     <svg
@@ -823,7 +823,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="chevron left icon"
+                      data-testid="chevron left icon"
                       role="presentation"
                     >
                       <svg
@@ -873,7 +873,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron left icon"
+                        data-testid="chevron left icon"
                         role="presentation"
                       >
                         <svg
@@ -973,7 +973,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron left icon"
+                        data-testid="chevron left icon"
                         role="presentation"
                       >
                         <chevron_left>

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.js.snap
@@ -1095,7 +1095,7 @@ exports[`GlobalStatus snapshot have to match component snapshot 1`] = `
                         <span
                           aria-hidden={true}
                           className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="close icon"
+                          data-testid="close icon"
                           role="presentation"
                         >
                           <close>
@@ -1448,7 +1448,7 @@ Array [
                           <span
                             aria-hidden={true}
                             className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="close icon"
+                            data-testid="close icon"
                             role="presentation"
                           >
                             <close>

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -31,7 +31,7 @@ describe('HelpButton component', () => {
   it('should have question icon by default', () => {
     const Comp = mount(<Component {...props} />)
     expect(
-      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+      Comp.find('.dnb-icon').instance().getAttribute('data-testid')
     ).toBe('question icon')
     expect(Comp.find('svg').html()).toBe(mount(<QuestionIcon />).html())
     expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
@@ -40,7 +40,7 @@ describe('HelpButton component', () => {
   it('should use "information" icon when set', () => {
     const Comp = mount(<Component {...props} icon="information" />)
     expect(
-      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+      Comp.find('.dnb-icon').instance().getAttribute('data-testid')
     ).toBe('information icon')
     expect(Comp.find('svg').html()).toBe(mount(<InformationIcon />).html())
     expect(Comp.find('.dnb-button').text().trim()).toBe('‌')
@@ -49,7 +49,7 @@ describe('HelpButton component', () => {
   it('should use given icon', () => {
     const Comp = mount(<Component {...props} icon={InformationIcon} />)
     expect(
-      Comp.find('.dnb-icon').instance().getAttribute('data-test-id')
+      Comp.find('.dnb-icon').instance().getAttribute('data-testid')
     ).toBe('information medium icon')
     expect(Comp.find('svg').html()).toBe(mount(<InformationIcon />).html())
     expect(Comp.find('.dnb-button').text().trim()).toBe('‌')

--- a/packages/dnb-eufemia/src/components/icon-primary/__tests__/__snapshots__/IconPrimary.test.js.snap
+++ b/packages/dnb-eufemia/src/components/icon-primary/__tests__/__snapshots__/IconPrimary.test.js.snap
@@ -19,7 +19,7 @@ exports[`IconPrimary component have to match snapshot 1`] = `
   <span
     aria-hidden={true}
     className="dnb-icon dnb-icon--default dnb-icon--inherit-color"
-    data-test-id="question icon"
+    data-testid="question icon"
     role="presentation"
   >
     <question>

--- a/packages/dnb-eufemia/src/components/icon/Icon.js
+++ b/packages/dnb-eufemia/src/components/icon/Icon.js
@@ -361,7 +361,7 @@ export const prepareIcon = (props, context) => {
       typeof process !== 'undefined' &&
       process.env.NODE_ENV === 'test'
     ) {
-      wrapperParams['data-test-id'] = wrapperParams['aria-label']
+      wrapperParams['data-testid'] = wrapperParams['aria-label']
     }
     delete wrapperParams['aria-label']
   }

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -66,12 +66,7 @@ describe('InfoCard', () => {
 
     render(<InfoCard text="text" icon={icon} />)
 
-    const iconContainer = screen.queryByTestId('info-card-icon')
-
-    expect(iconContainer).not.toBeNull()
-    expect(
-      within(iconContainer).queryByTestId('custom-icon')
-    ).not.toBeNull()
+    expect(screen.queryByTestId('custom-icon')).not.toBeNull()
   })
 
   it('renders the image', () => {

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
@@ -448,7 +448,7 @@ exports[`Input component have to match type="search" snapshot 1`] = `
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="loupe icon"
+                        data-testid="loupe icon"
                         role="presentation"
                       >
                         <loupe>

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/InputPassword.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/InputPassword.test.js.snap
@@ -377,7 +377,7 @@ exports[`InputPassword component have to match snapshot 1`] = `
                           <span
                             aria-hidden={true}
                             className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="view icon"
+                            data-testid="view icon"
                             role="presentation"
                           >
                             <view>

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`Modal component have to match snapshot 1`] = `
             <span
               aria-hidden="true"
               class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-              data-test-id="question icon"
+              data-testid="question icon"
               role="presentation"
             >
               <svg
@@ -209,7 +209,7 @@ exports[`Modal component have to match snapshot 1`] = `
               <span
                 aria-hidden="true"
                 class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                data-test-id="question icon"
+                data-testid="question icon"
                 role="presentation"
               >
                 <svg
@@ -297,7 +297,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -365,7 +365,7 @@ exports[`Modal component have to match snapshot 1`] = `
               <span
                 aria-hidden={true}
                 className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                data-test-id="question icon"
+                data-testid="question icon"
                 role="presentation"
               >
                 <question>
@@ -434,7 +434,7 @@ exports[`Modal component have to match snapshot 1`] = `
                 <span
                   aria-hidden="true"
                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                  data-test-id="question icon"
+                  data-testid="question icon"
                   role="presentation"
                 >
                   <svg
@@ -498,7 +498,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -539,7 +539,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -605,7 +605,7 @@ exports[`Modal component have to match snapshot 1`] = `
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="question icon"
+                    data-testid="question icon"
                     role="presentation"
                   >
                     <svg
@@ -645,7 +645,7 @@ exports[`Modal component have to match snapshot 1`] = `
                     <span
                       aria-hidden="true"
                       class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="question icon"
+                      data-testid="question icon"
                       role="presentation"
                     >
                       <svg
@@ -854,7 +854,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="close icon"
+                                  data-testid="close icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -940,7 +940,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                       <span
                                         aria-hidden="true"
                                         class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                        data-test-id="close icon"
+                                        data-testid="close icon"
                                         role="presentation"
                                       >
                                         <svg
@@ -1089,7 +1089,7 @@ exports[`Modal component have to match snapshot 1`] = `
                                           <span
                                             aria-hidden={true}
                                             className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                                            data-test-id="close icon"
+                                            data-testid="close icon"
                                             role="presentation"
                                           >
                                             <close>

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.js
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.js
@@ -75,7 +75,7 @@ describe('Pagination bar', () => {
       prevNavButton
         .find('span.dnb-icon')
         .instance()
-        .getAttribute('data-test-id')
+        .getAttribute('data-testid')
     ).toBe('chevron left icon')
   })
 

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.js.snap
@@ -865,7 +865,7 @@ exports[`Pagination bar have to match snapshot 1`] = `
                         <span
                           aria-hidden={true}
                           className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="chevron left icon"
+                          data-testid="chevron left icon"
                           role="presentation"
                         >
                           <chevron_left>
@@ -1023,7 +1023,7 @@ exports[`Pagination bar have to match snapshot 1`] = `
                         <span
                           aria-hidden={true}
                           className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="chevron right icon"
+                          data-testid="chevron right icon"
                           role="presentation"
                         >
                           <chevron_right>

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.js.snap
@@ -142,7 +142,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -212,7 +212,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -281,7 +281,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -350,7 +350,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -459,7 +459,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -542,7 +542,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -655,7 +655,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -754,7 +754,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -883,7 +883,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -966,7 +966,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -1079,7 +1079,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -1178,7 +1178,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -1306,7 +1306,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -1389,7 +1389,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -1502,7 +1502,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -1601,7 +1601,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -1729,7 +1729,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -1812,7 +1812,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -1925,7 +1925,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -2024,7 +2024,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -2226,7 +2226,7 @@ Array [
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="chevron right medium icon"
+                    data-testid="chevron right medium icon"
                     role="presentation"
                   >
                     <svg
@@ -2343,7 +2343,7 @@ Array [
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <svg
@@ -2457,7 +2457,7 @@ Array [
                           <span
                             aria-hidden="true"
                             class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="chevron right medium icon"
+                            data-testid="chevron right medium icon"
                             role="presentation"
                           >
                             <svg
@@ -2555,7 +2555,7 @@ Array [
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <chevron_right_medium>
@@ -2862,7 +2862,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -2931,7 +2931,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -2999,7 +2999,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -3067,7 +3067,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -3176,7 +3176,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -3258,7 +3258,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -3367,7 +3367,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -3465,7 +3465,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -3594,7 +3594,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -3676,7 +3676,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -3785,7 +3785,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -3883,7 +3883,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -4011,7 +4011,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -4093,7 +4093,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -4202,7 +4202,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -4300,7 +4300,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -4428,7 +4428,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -4510,7 +4510,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -4619,7 +4619,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -4717,7 +4717,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -4919,7 +4919,7 @@ Array [
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="chevron right medium icon"
+                    data-testid="chevron right medium icon"
                     role="presentation"
                   >
                     <svg
@@ -5036,7 +5036,7 @@ Array [
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <svg
@@ -5150,7 +5150,7 @@ Array [
                           <span
                             aria-hidden="true"
                             class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="chevron right medium icon"
+                            data-testid="chevron right medium icon"
                             role="presentation"
                           >
                             <svg
@@ -5248,7 +5248,7 @@ Array [
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <chevron_right_medium>
@@ -5556,7 +5556,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -5626,7 +5626,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -5694,7 +5694,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -5762,7 +5762,7 @@ Array [
                         <span
                           aria-hidden="true"
                           class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                          data-test-id="check icon"
+                          data-testid="check icon"
                           role="presentation"
                         >
                           <svg
@@ -5871,7 +5871,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -5954,7 +5954,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -6067,7 +6067,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -6166,7 +6166,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -6295,7 +6295,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -6378,7 +6378,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -6491,7 +6491,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -6590,7 +6590,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -6718,7 +6718,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -6800,7 +6800,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -6909,7 +6909,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -7007,7 +7007,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -7135,7 +7135,7 @@ Array [
                               <span
                                 aria-hidden="true"
                                 class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                data-test-id="check icon"
+                                data-testid="check icon"
                                 role="presentation"
                               >
                                 <svg
@@ -7217,7 +7217,7 @@ Array [
                                 <span
                                   aria-hidden="true"
                                   class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <svg
@@ -7326,7 +7326,7 @@ Array [
                                     <span
                                       aria-hidden="true"
                                       class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                      data-test-id="check icon"
+                                      data-testid="check icon"
                                       role="presentation"
                                     >
                                       <svg
@@ -7424,7 +7424,7 @@ Array [
                                 <span
                                   aria-hidden={true}
                                   className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                                  data-test-id="check icon"
+                                  data-testid="check icon"
                                   role="presentation"
                                 >
                                   <check_medium>
@@ -7626,7 +7626,7 @@ Array [
                   <span
                     aria-hidden="true"
                     class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                    data-test-id="chevron right medium icon"
+                    data-testid="chevron right medium icon"
                     role="presentation"
                   >
                     <svg
@@ -7743,7 +7743,7 @@ Array [
                       <span
                         aria-hidden="true"
                         class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <svg
@@ -7857,7 +7857,7 @@ Array [
                           <span
                             aria-hidden="true"
                             class="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                            data-test-id="chevron right medium icon"
+                            data-testid="chevron right medium icon"
                             role="presentation"
                           >
                             <svg
@@ -7955,7 +7955,7 @@ Array [
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--medium dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right medium icon"
+                        data-testid="chevron right medium icon"
                         role="presentation"
                       >
                         <chevron_right_medium>

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -172,7 +172,7 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron left icon"
+                        data-testid="chevron left icon"
                         role="presentation"
                       >
                         <chevron_left>
@@ -450,7 +450,7 @@ exports[`A single Tab component has to work with "Tabs.Content" from outside 1`]
                       <span
                         aria-hidden={true}
                         className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-test-id="chevron right icon"
+                        data-testid="chevron right icon"
                         role="presentation"
                       >
                         <chevron_right>
@@ -760,7 +760,7 @@ exports[`Tabs component have to match snapshot 1`] = `
                     <span
                       aria-hidden={true}
                       className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="chevron left icon"
+                      data-testid="chevron left icon"
                       role="presentation"
                     >
                       <chevron_left>
@@ -1038,7 +1038,7 @@ exports[`Tabs component have to match snapshot 1`] = `
                     <span
                       aria-hidden={true}
                       className="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-test-id="chevron right icon"
+                      data-testid="chevron right icon"
                       role="presentation"
                     >
                       <chevron_right>

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -73,6 +73,12 @@ export interface TagProps {
    * Default: null
    */
   omitOnKeyUpDeleteEvent?: boolean
+
+  /**
+   * Internal property
+   * Has translation in context
+   */
+  removeIconTitle?: string
 }
 
 export const defaultProps = {
@@ -103,6 +109,7 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
     onClick,
     onDelete,
     omitOnKeyUpDeleteEvent,
+    removeIconTitle, // has a translation in context
     ...props
   } = allProps
 
@@ -170,7 +177,7 @@ const Tag = (localProps: TagProps & ISpacingProps) => {
   function getDeleteIcon() {
     return (
       <IconPrimary
-        data-testid="tag-delete-icon"
+        title={removeIconTitle}
         inherit_color={false}
         icon={
           <svg

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import Tag from '../Tag'
+import nbNO from '../../../shared/locales/nb-NO'
 import {
   axeComponent,
   loadScss,
   mount,
 } from '../../../core/jest/jestSetup'
 import { Provider } from '../../../shared'
+
+const nb = nbNO['nb-NO'].Tag
 
 describe('Tag Group', () => {
   it('renders without children', () => {
@@ -376,7 +379,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(screen.queryByTestId('tag-delete-icon')).not.toBeNull()
+      expect(screen.getByTitle(nb.removeIconTitle)).not.toBeNull()
     })
 
     it('fires onClick event if both onClick and onDelete are defined', () => {

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -169,9 +169,7 @@ describe('Timeline', () => {
     })
 
     it('renders custom icon', () => {
-      const CustomIcon = (
-        <IconPrimary data-testid="timeline-item-custom-icon" icon="bell" />
-      )
+      const CustomIcon = <IconPrimary icon="bell" />
       render(
         <TimelineItem
           icon={CustomIcon}
@@ -180,9 +178,8 @@ describe('Timeline', () => {
         />
       )
 
-      const element = screen.queryByTestId('timeline-item-custom-icon')
+      const element = screen.queryByTestId('bell icon')
       expect(element).not.toBeNull()
-      expect(element.getAttribute('data-test-id')).toBe('bell icon')
     })
 
     it('renders custom alt label', () => {

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.js
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.js
@@ -119,5 +119,8 @@ export default {
     Logo: {
       alt: 'DNB Logo',
     },
+    Tag: {
+      removeIconTitle: 'Remove',
+    },
   },
 }

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.js
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.js
@@ -119,5 +119,8 @@ export default {
     Logo: {
       alt: 'DNB Logo',
     },
+    Tag: {
+      removeIconTitle: 'Fjern',
+    },
   },
 }


### PR DESCRIPTION
This PR renames the property `data-test-id` to  `data-testid`, so that we can use the `ByTestId` query from [Testing Library](https://testing-library.com/docs/queries/bytestid/).

The suggested improvement has come as a result of this discussion.
https://github.com/dnbexperience/eufemia/pull/1581#discussion_r980069352