### PR TITLE
docs(Icon): replace data-test-id with data-testid

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
@@ -50,6 +50,11 @@ v10 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 1. Find the `show_delay` property and replace it with `showDelay`.
 1. Find the `hide_delay` property and replace it with `hideDelay`.
 
+### [Icon](/uilib/components/icon)
+
+1. Find the `data-test-id` property and replace it with `data-testid`.
+   The usage of `data-test-id` will most likely be found in your tests.
+
 ### Deprecations
 
 - `use_scrollwheel` and `on_init` properties, as well as the `raw_value` event value from [Slider](/uilib/components/slider) was removed in order to support multiple buttons.


### PR DESCRIPTION
I found out that the changes as part of #1583 is to some extent "breaking" for a few applications in the monorepo, as I see a few tests that rely on the `data-test-id`, that will need to be changed to `data-testid`.