### PR TITLE
chore(CI): remove retry snapshots

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
@@ -36,7 +36,7 @@ module.exports = async function () {
     )
   }
 
-  const countFailures = global.__EVENT_FAILURE_CACHE__.length
+  const countFailures = Object.keys(global.__EVENT_FAILURE_CACHE__).length
   console.log(
     chalk.green(`Jest screenshot tests had ${countFailures} failures`)
   )


### PR DESCRIPTION
I have seen it a lot. When a visual test first fails, it creates a bunch of additional failed "retry" snapshots. Even when they succeed after some retries. But when one fails, we get these snapshots in the report as well.

This PR removes the "retry" snapshots.

Tested locally:

<img width="669" alt="Screenshot 2022-09-28 at 21 15 20" src="https://user-images.githubusercontent.com/1501870/192871423-3ff65a74-05d1-43bf-acb9-bc9c999932ad.png">
