### PR TITLE
fix(Tooltip): fix React Portal handling

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -481,7 +481,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               }
               className={null}
               fixedPosition={false}
-              group="dialog_id-tooltip"
+              group={null}
               hideDelay={500}
               id="dialog_id-tooltip"
               internalId="dialog_id-tooltip"
@@ -588,10 +588,11 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 }
                 className={null}
                 fixedPosition={false}
-                group="dialog_id-tooltip"
+                group={null}
                 hideDelay={500}
                 id="dialog_id-tooltip"
                 internalId="dialog_id-tooltip"
+                keepInDOM={true}
                 key="tooltip"
                 noAnimation={false}
                 position="top"
@@ -680,7 +681,155 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 }
                 targetSelector={null}
                 tooltip="dialog_title"
-              />
+              >
+                <Portal
+                  containerInfo={
+                    <div
+                      class="dnb-tooltip__portal dnb-core-style"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-tooltip"
+                        role="tooltip"
+                      >
+                        <span
+                          class="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                        />
+                        <span
+                          class="dnb-tooltip__content"
+                          id="dialog_id-tooltip"
+                        >
+                          dialog_title
+                        </span>
+                      </span>
+                    </div>
+                  }
+                >
+                  <TooltipContainer
+                    active={false}
+                    align={null}
+                    animatePosition={false}
+                    arrow="center"
+                    attributes={
+                      Object {
+                        "children": "dialog_title",
+                        "className": "dnb-tooltip",
+                      }
+                    }
+                    className={null}
+                    fixedPosition={false}
+                    group={null}
+                    hideDelay={500}
+                    id="dialog_id-tooltip"
+                    internalId="dialog_id-tooltip"
+                    keepInDOM={true}
+                    noAnimation={false}
+                    position="top"
+                    showDelay={300}
+                    size="basis"
+                    skipPortal={null}
+                    target={
+                      <button
+                        aria-describedby="dialog_id-tooltip"
+                        aria-label="dialog_title"
+                        aria-roledescription="Hjelp-knapp"
+                        class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                        id="dialog_id"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                          data-testid="question icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                              stroke="#000"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    }
+                    targetElement={
+                      <button
+                        aria-describedby="dialog_id-tooltip"
+                        aria-label="dialog_title"
+                        aria-roledescription="Hjelp-knapp"
+                        class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                        id="dialog_id"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                          data-testid="question icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                              stroke="#000"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    }
+                    targetSelector={null}
+                    tooltip="dialog_title"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="dnb-tooltip"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="tooltip"
+                      style={Object {}}
+                    >
+                      <span
+                        className="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                      />
+                      <span
+                        className="dnb-tooltip__content"
+                        id="dialog_id-tooltip"
+                      >
+                        dialog_title
+                      </span>
+                    </span>
+                  </TooltipContainer>
+                </Portal>
+              </TooltipPortal>
             </TooltipWithEvents>
           </Tooltip>
         </Button>

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -479,7 +479,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               }
               className={null}
               fixedPosition={false}
-              group="drawer_id-tooltip"
+              group={null}
               hideDelay={500}
               id="drawer_id-tooltip"
               internalId="drawer_id-tooltip"
@@ -586,10 +586,11 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 }
                 className={null}
                 fixedPosition={false}
-                group="drawer_id-tooltip"
+                group={null}
                 hideDelay={500}
                 id="drawer_id-tooltip"
                 internalId="drawer_id-tooltip"
+                keepInDOM={true}
                 key="tooltip"
                 noAnimation={false}
                 position="top"
@@ -678,7 +679,155 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 }
                 targetSelector={null}
                 tooltip="drawer_title"
-              />
+              >
+                <Portal
+                  containerInfo={
+                    <div
+                      class="dnb-tooltip__portal dnb-core-style"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-tooltip"
+                        role="tooltip"
+                      >
+                        <span
+                          class="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                        />
+                        <span
+                          class="dnb-tooltip__content"
+                          id="drawer_id-tooltip"
+                        >
+                          drawer_title
+                        </span>
+                      </span>
+                    </div>
+                  }
+                >
+                  <TooltipContainer
+                    active={false}
+                    align={null}
+                    animatePosition={false}
+                    arrow="center"
+                    attributes={
+                      Object {
+                        "children": "drawer_title",
+                        "className": "dnb-tooltip",
+                      }
+                    }
+                    className={null}
+                    fixedPosition={false}
+                    group={null}
+                    hideDelay={500}
+                    id="drawer_id-tooltip"
+                    internalId="drawer_id-tooltip"
+                    keepInDOM={true}
+                    noAnimation={false}
+                    position="top"
+                    showDelay={300}
+                    size="basis"
+                    skipPortal={null}
+                    target={
+                      <button
+                        aria-describedby="drawer_id-tooltip"
+                        aria-label="drawer_title"
+                        aria-roledescription="Hjelp-knapp"
+                        class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                        id="drawer_id"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                          data-testid="question icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                              stroke="#000"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    }
+                    targetElement={
+                      <button
+                        aria-describedby="drawer_id-tooltip"
+                        aria-label="drawer_title"
+                        aria-roledescription="Hjelp-knapp"
+                        class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                        id="drawer_id"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="dnb-button__alignment"
+                        >
+                          ‌
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                          data-testid="question icon"
+                          role="presentation"
+                        >
+                          <svg
+                            fill="none"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                              stroke="#000"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="1.5"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    }
+                    targetSelector={null}
+                    tooltip="drawer_title"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="dnb-tooltip"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="tooltip"
+                      style={Object {}}
+                    >
+                      <span
+                        className="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                      />
+                      <span
+                        className="dnb-tooltip__content"
+                        id="drawer_id-tooltip"
+                      >
+                        drawer_title
+                      </span>
+                    </span>
+                  </TooltipContainer>
+                </Portal>
+              </TooltipPortal>
             </TooltipWithEvents>
           </Tooltip>
         </Button>

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -470,7 +470,7 @@ exports[`Modal component have to match snapshot 1`] = `
             }
             className={null}
             fixedPosition={false}
-            group="modal_id-tooltip"
+            group={null}
             hideDelay={500}
             id="modal_id-tooltip"
             internalId="modal_id-tooltip"
@@ -577,10 +577,11 @@ exports[`Modal component have to match snapshot 1`] = `
               }
               className={null}
               fixedPosition={false}
-              group="modal_id-tooltip"
+              group={null}
               hideDelay={500}
               id="modal_id-tooltip"
               internalId="modal_id-tooltip"
+              keepInDOM={true}
               key="tooltip"
               noAnimation={false}
               position="top"
@@ -669,7 +670,155 @@ exports[`Modal component have to match snapshot 1`] = `
               }
               targetSelector={null}
               tooltip="modal_title"
-            />
+            >
+              <Portal
+                containerInfo={
+                  <div
+                    class="dnb-tooltip__portal dnb-core-style"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="dnb-tooltip"
+                      role="tooltip"
+                    >
+                      <span
+                        class="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                      />
+                      <span
+                        class="dnb-tooltip__content"
+                        id="modal_id-tooltip"
+                      >
+                        modal_title
+                      </span>
+                    </span>
+                  </div>
+                }
+              >
+                <TooltipContainer
+                  active={false}
+                  align={null}
+                  animatePosition={false}
+                  arrow="center"
+                  attributes={
+                    Object {
+                      "children": "modal_title",
+                      "className": "dnb-tooltip",
+                    }
+                  }
+                  className={null}
+                  fixedPosition={false}
+                  group={null}
+                  hideDelay={500}
+                  id="modal_id-tooltip"
+                  internalId="modal_id-tooltip"
+                  keepInDOM={true}
+                  noAnimation={false}
+                  position="top"
+                  showDelay={300}
+                  size="basis"
+                  skipPortal={null}
+                  target={
+                    <button
+                      aria-describedby="modal_id-tooltip"
+                      aria-label="modal_title"
+                      aria-roledescription="Hjelp-knapp"
+                      class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                      id="modal_id"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-button__alignment"
+                      >
+                        ‌
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                        data-testid="question icon"
+                        role="presentation"
+                      >
+                        <svg
+                          fill="none"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                            stroke="#000"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  }
+                  targetElement={
+                    <button
+                      aria-describedby="modal_id-tooltip"
+                      aria-label="modal_title"
+                      aria-roledescription="Hjelp-knapp"
+                      class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                      id="modal_id"
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="dnb-button__alignment"
+                      >
+                        ‌
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                        data-testid="question icon"
+                        role="presentation"
+                      >
+                        <svg
+                          fill="none"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                            stroke="#000"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  }
+                  targetSelector={null}
+                  tooltip="modal_title"
+                >
+                  <span
+                    aria-hidden={true}
+                    className="dnb-tooltip"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="tooltip"
+                    style={Object {}}
+                  >
+                    <span
+                      className="dnb-tooltip__arrow dnb-tooltip__arrow__arrow--center dnb-tooltip__arrow__position--top"
+                    />
+                    <span
+                      className="dnb-tooltip__content"
+                      id="modal_id-tooltip"
+                    >
+                      modal_title
+                    </span>
+                  </span>
+                </TooltipContainer>
+              </Portal>
+            </TooltipPortal>
           </TooltipWithEvents>
         </Tooltip>
       </Button>

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -151,7 +151,6 @@ function Thumb({ value, currentIndex }: ThumbProps) {
         {tooltip && (
           <Tooltip
             key={`group-${currentIndex}`}
-            group={allProps.id + currentIndex}
             targetElement={elemRef}
             animatePosition={shouldAnimate}
             active={showTooltip || alwaysShowTooltip}

--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -156,8 +156,19 @@ describe('Slider component', () => {
   })
 
   describe('Tooltip', () => {
+    beforeEach(() => {
+      document.body.innerHTML = ''
+    })
+
     it('shows always a Tooltip when alwaysShowTooltip is true', () => {
-      render(<Slider {...props} tooltip alwaysShowTooltip />)
+      render(
+        <Slider
+          {...props}
+          id="unique-tooltip-01"
+          tooltip
+          alwaysShowTooltip
+        />
+      )
 
       const tooltipElem = document.querySelector('.dnb-tooltip')
 
@@ -169,17 +180,22 @@ describe('Slider component', () => {
 
     it('shows Tooltip on hover with numberFormat', async () => {
       render(
-        <Slider {...props} numberFormat={{ currency: 'EUR' }} tooltip />
+        <Slider
+          {...props}
+          id="unique-tooltip-02"
+          numberFormat={{ currency: 'EUR' }}
+          tooltip
+        />
       )
 
       const mainElem = document.querySelector('.dnb-slider')
       const thumbElem = mainElem.querySelector(
         '.dnb-slider__thumb .dnb-button'
       )
-      const tooltipElem = document.querySelector('.dnb-tooltip')
+      const tooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem.textContent).toBe('70,00 €')
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(tooltipElem().textContent).toBe('70,00 €')
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip'])
       )
 
@@ -187,17 +203,17 @@ describe('Slider component', () => {
 
       simulateMouseMove({ pageX: 80, width: 100, height: 10 })
 
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--active'])
       )
 
-      expect(tooltipElem.textContent).toBe('80,00 €')
+      expect(tooltipElem().textContent).toBe('80,00 €')
 
       fireEvent.mouseOut(thumbElem)
 
       await wait(1)
 
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--hide'])
       )
     })
@@ -206,6 +222,7 @@ describe('Slider component', () => {
       render(
         <Slider
           {...props}
+          id="unique-tooltip-03"
           numberFormat={(value) => format(value, { percent: true })}
           tooltip
           step={null}
@@ -216,10 +233,10 @@ describe('Slider component', () => {
       const thumbElem = mainElem.querySelector(
         '.dnb-slider__thumb .dnb-button'
       )
-      const tooltipElem = document.querySelector('.dnb-tooltip')
+      const tooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem.textContent).toBe('70 %')
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(tooltipElem().textContent).toBe('70 %')
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip'])
       )
 
@@ -227,17 +244,17 @@ describe('Slider component', () => {
 
       simulateMouseMove({ pageX: 80.5, width: 100, height: 10 })
 
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--active'])
       )
 
-      expect(tooltipElem.textContent).toBe('80,5 %')
+      expect(tooltipElem().textContent).toBe('80,5 %')
 
       fireEvent.mouseOut(thumbElem)
 
       await wait(1)
 
-      expect(Array.from(tooltipElem.classList)).toEqual(
+      expect(Array.from(tooltipElem().classList)).toEqual(
         expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--hide'])
       )
     })

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -43,7 +43,7 @@ function Tooltip(localProps: TooltipAllProps) {
     className,
     id, // eslint-disable-line
     tooltip, // eslint-disable-line
-    group,
+    group, // eslint-disable-line
     size,
     animatePosition, // eslint-disable-line
     fixedPosition, // eslint-disable-line
@@ -60,7 +60,6 @@ function Tooltip(localProps: TooltipAllProps) {
 
   const [internalId] = React.useState(() => props.id || makeUniqueId()) // cause we need an id anyway
   props.internalId = internalId
-  props.group = group || localProps.id || 'main-' + props.internalId
 
   const classes = classnames(
     'dnb-tooltip',

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
@@ -92,18 +92,19 @@ export default function TooltipContainer(
   }, [isActive])
 
   React.useLayoutEffect(() => {
+    const element = elementRef?.current
     const { targetElement: target, align, fixedPosition } = props
 
     if (
       typeof window === 'undefined' ||
-      !elementRef.current ||
+      !element ||
       !target?.getBoundingClientRect
     ) {
       return // stop here
     }
 
-    const elementWidth = elementRef.current.offsetWidth
-    const elementHeight = elementRef.current.offsetHeight
+    const elementWidth = element.offsetWidth
+    const elementHeight = element.offsetHeight
 
     let alignOffset = 0
 
@@ -131,7 +132,7 @@ export default function TooltipContainer(
     const mousePos =
       getOffsetLeft(target) +
       rect.left / 2 +
-      (elementRef.current ? elementRef.current.offsetWidth : 0)
+      (element ? element.offsetWidth : 0)
     const widthBased = scrollX + rect.left
     const left =
       useMouseWhen && mousePos < targetBodySize.width
@@ -217,7 +218,7 @@ export default function TooltipContainer(
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActive, hover, arrow, position, children, renewStyles])
+  }, [isActive, arrow, position, children, renewStyles])
 
   const handleMouseEnter = () => {
     if (isTrue(active) && useHover !== false) {

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { combineDescribedBy } from '../../shared/component-helper'
 
 export function injectTooltipSemantic(params) {
   params.tabIndex = '0'
@@ -38,10 +39,62 @@ export const defaultProps = {
   tooltip: null,
 }
 
+export function getTargetElement(target: HTMLElement) {
+  if (typeof document !== 'undefined') {
+    return typeof target === 'string'
+      ? typeof document !== 'undefined' && document.querySelector(target)
+      : target
+  }
+}
+
+export function useHandleAria(
+  targetElement: React.RefObject<HTMLElement>,
+  internalId: string
+) {
+  React.useEffect(() => {
+    try {
+      const elem = getTargetElement(getRefElement(targetElement))
+      if (!elem?.classList.contains('dnb-tooltip__wrapper')) {
+        const existing = {
+          'aria-describedby': elem.getAttribute('aria-describedby'),
+        }
+        elem.setAttribute(
+          'aria-describedby',
+          combineDescribedBy(existing, internalId)
+        )
+      }
+    } catch (e) {
+      //
+    }
+  }, [targetElement, internalId])
+}
+
 export function getPropsFromTooltipProp(localProps) {
   return localProps.tooltip
     ? React.isValidElement(localProps.tooltip) && localProps.tooltip.props
       ? localProps.tooltip.props
       : { children: localProps.tooltip }
     : null
+}
+
+export function getRefElement(target: React.RefObject<HTMLElement>) {
+  const unknownTarget = target as unknown as React.RefObject<{
+    _ref: React.RefObject<HTMLElement>
+  }>
+  let element = target as HTMLElement | React.RefObject<HTMLElement>
+
+  // "_ref" is set inside e.g. the Button component (among many others)
+  if (unknownTarget?.current?._ref) {
+    element = getRefElement(unknownTarget.current._ref)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(element, 'current')) {
+    element = (element as React.RefObject<HTMLElement>).current
+  }
+
+  return element as HTMLElement
+}
+
+export const isTouch = (type: string) => {
+  return /touch/i.test(type)
 }

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -5,7 +5,12 @@
 
 import React from 'react'
 import { combineDescribedBy, warn } from '../../shared/component-helper'
-import { injectTooltipSemantic } from './TooltipHelpers'
+import {
+  getRefElement,
+  injectTooltipSemantic,
+  isTouch,
+  useHandleAria,
+} from './TooltipHelpers'
 import TooltipPortal from './TooltipPortal'
 import { TooltipProps } from './types'
 
@@ -173,6 +178,8 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target])
 
+  useHandleAria(target, props.internalId)
+
   return (
     <>
       {componentWrapper}
@@ -181,6 +188,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
           key="tooltip"
           active={isActive}
           target={targetRef.current}
+          keepInDOM // because of useHandleAria
           {...restProps}
         >
           {children}
@@ -191,25 +199,3 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 }
 
 export default TooltipWithEvents
-
-const isTouch = (type: string) => {
-  return /touch/i.test(type)
-}
-
-function getRefElement(target: React.RefObject<HTMLElement>) {
-  const unknownTarget = target as unknown as React.RefObject<{
-    _ref: React.RefObject<HTMLElement>
-  }>
-  let element = target as HTMLElement | React.RefObject<HTMLElement>
-
-  // "_ref" is set inside e.g. the Button component (among many others)
-  if (unknownTarget?.current?._ref) {
-    element = getRefElement(unknownTarget.current._ref)
-  }
-
-  if (Object.prototype.hasOwnProperty.call(element, 'current')) {
-    element = (element as React.RefObject<HTMLElement>).current
-  }
-
-  return element as HTMLElement
-}

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { wait } from '@testing-library/user-event/dist/utils'
 import OriginalTooltip from '../Tooltip'
 import Anchor from '../../../elements/Anchor'
@@ -226,29 +226,38 @@ describe('Tooltip', () => {
 
       render(<Tooltip />)
 
-      const mainElem = document.body.querySelector('.dnb-tooltip')
+      const getMainElem = () => document.body.querySelector('.dnb-tooltip')
       const buttonElem = document.querySelector('button')
 
       fireEvent.mouseEnter(buttonElem)
 
-      expect(mainElem.classList.contains('dnb-tooltip--active')).toBe(true)
+      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
+        true
+      )
 
       fireEvent.mouseLeave(buttonElem)
       fireEvent.mouseEnter(buttonElem)
 
-      expect(mainElem.classList.contains('dnb-tooltip--active')).toBe(true)
+      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
+        true
+      )
 
       fireEvent.mouseLeave(buttonElem)
 
-      expect(mainElem.classList.contains('dnb-tooltip--hide')).toBe(true)
+      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
+        false
+      )
+      expect(getMainElem().classList.contains('dnb-tooltip--hide')).toBe(
+        true
+      )
     })
 
     it('should set animate_position class', () => {
       render(<Tooltip animatePosition active />)
 
-      const mainElem = document.body.querySelector('.dnb-tooltip')
+      const getMainElem = () => document.body.querySelector('.dnb-tooltip')
 
-      expect(Array.from(mainElem.classList)).toEqual(
+      expect(Array.from(getMainElem().classList)).toEqual(
         expect.arrayContaining([
           'dnb-tooltip',
           'dnb-tooltip--active',
@@ -260,9 +269,9 @@ describe('Tooltip', () => {
     it('should set fixed class', () => {
       render(<Tooltip fixedPosition active />)
 
-      const mainElem = document.body.querySelector('.dnb-tooltip')
+      const getMainElem = () => document.body.querySelector('.dnb-tooltip')
 
-      expect(Array.from(mainElem.classList)).toEqual(
+      expect(Array.from(getMainElem().classList)).toEqual(
         expect.arrayContaining([
           'dnb-tooltip',
           'dnb-tooltip--active',
@@ -302,30 +311,33 @@ describe('Tooltip', () => {
       it('should only have one tooltip', () => {
         render(<GroupTooltip />)
 
-        const allElements = document.body.querySelectorAll('.dnb-tooltip')
-        const mainElem = allElements[0]
+        const allElements = () =>
+          document.body.querySelectorAll('.dnb-tooltip')
+        const getMainElem = () => allElements()[0]
         const buttonA = document.querySelector('button#a')
         const buttonB = document.querySelector('button#b')
 
-        expect(allElements).toHaveLength(1)
+        expect(allElements()).toHaveLength(0)
 
         fireEvent.mouseEnter(buttonA)
 
-        expect(mainElem.textContent).toBe('Tooltip A')
-        expect(mainElem.classList.contains('dnb-tooltip--active')).toBe(
-          true
-        )
+        expect(getMainElem().textContent).toBe('Tooltip A')
+        expect(
+          getMainElem().classList.contains('dnb-tooltip--active')
+        ).toBe(true)
 
         fireEvent.mouseEnter(buttonB)
 
-        expect(mainElem.textContent).toBe('Tooltip B')
-        expect(mainElem.classList.contains('dnb-tooltip--active')).toBe(
-          true
-        )
+        expect(getMainElem().textContent).toBe('Tooltip B')
+        expect(
+          getMainElem().classList.contains('dnb-tooltip--active')
+        ).toBe(true)
 
         fireEvent.mouseLeave(buttonB)
 
-        expect(mainElem.classList.contains('dnb-tooltip--hide')).toBe(true)
+        expect(getMainElem().classList.contains('dnb-tooltip--hide')).toBe(
+          true
+        )
       })
     })
 
@@ -356,34 +368,36 @@ describe('Tooltip', () => {
         </Anchor>
       )
 
-      // hover
-      document
-        .querySelector('a')
-        .dispatchEvent(new MouseEvent('mouseenter'))
+      await act(async () => {
+        // hover
+        document
+          .querySelector('a')
+          .dispatchEvent(new MouseEvent('mouseenter'))
 
-      await wait(100)
+        await wait(100)
 
-      const id = document
-        .querySelector('a')
-        .getAttribute('aria-describedby')
-      expect(
-        document.body
-          .querySelector('#' + id)
-          .parentElement.classList.contains('dnb-tooltip--active')
-      ).toBe(true)
+        const id = document
+          .querySelector('a')
+          .getAttribute('aria-describedby')
+        expect(
+          document.body
+            .querySelector('#' + id)
+            .parentElement.classList.contains('dnb-tooltip--active')
+        ).toBe(true)
 
-      // leave hover
-      document
-        .querySelector('a')
-        .dispatchEvent(new MouseEvent('mouseleave'))
+        // leave hover
+        document
+          .querySelector('a')
+          .dispatchEvent(new MouseEvent('mouseleave'))
 
-      await wait(600)
+        await wait(600)
 
-      expect(
-        document.body
-          .querySelector('#' + id)
-          .parentElement.classList.contains('dnb-tooltip--active')
-      ).toBe(false)
+        expect(
+          document.body
+            .querySelector('#' + id)
+            .parentElement.classList.contains('dnb-tooltip--active')
+        ).toBe(false)
+      })
     })
 
     it('has to be visible on focus event dispatch', async () => {
@@ -393,18 +407,23 @@ describe('Tooltip', () => {
         </Anchor>
       )
 
-      document.documentElement.setAttribute('data-whatintent', 'keyboard')
-      const inst = document.querySelector('a')
-      inst.dispatchEvent(new Event('focus'))
+      await act(async () => {
+        document.documentElement.setAttribute(
+          'data-whatintent',
+          'keyboard'
+        )
+        const inst = document.querySelector('a')
+        inst.dispatchEvent(new Event('focus'))
 
-      await wait(400) // because of visibility delay
+        await wait(400) // because of visibility delay
 
-      const id = inst.getAttribute('aria-describedby')
-      expect(
-        document.body
-          .querySelector('#' + id)
-          .parentElement.classList.contains('dnb-tooltip--active')
-      ).toBe(true)
+        const id = inst.getAttribute('aria-describedby')
+        expect(
+          document.body
+            .querySelector('#' + id)
+            .parentElement.classList.contains('dnb-tooltip--active')
+        ).toBe(true)
+      })
     })
   })
 })


### PR DESCRIPTION
Enhance usage of portal, so we not use `createPortal` and `render`.
This fixes an issue where `mouseOver` and `mouseOut` was not given the wanted/same result:

https://user-images.githubusercontent.com/1501870/193398634-55d2b1ca-1bbd-45a7-92f4-5affd5c40a67.mov

I can imagine that this issue  #1411 can be related.
