### PR TITLE
chore(VisualTests): correctly count failed tests

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerTeardown.js
@@ -36,7 +36,9 @@ module.exports = async function () {
     )
   }
 
-  const countFailures = Object.keys(global.__EVENT_FAILURE_CACHE__).length
+  const countFailures = Object.values(
+    global.__EVENT_FAILURE_CACHE__
+  ).filter(({ failed }) => failed).length
   console.log(
     chalk.green(`Jest screenshot tests had ${countFailures} failures`)
   )


### PR DESCRIPTION
Right now, almost all new PRs will get `countFailures` with at least one, because our retries now gets set inside the `failed` property, instead of being just inside the array/object, like before.

