### PR TITLE
fix(Breadcrumb): make animation work when declarative declared

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -4,20 +4,15 @@ import classnames from 'classnames'
 // Components
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import { createSpacingClasses } from '../space/SpacingHelper'
-import Section, {
-  SectionSpacing,
-  SectionStyleTypes,
-} from '../section/Section'
+import Section from '../section/Section'
 import Button from '../button/Button'
 
 // Shared
 import { useMediaQuery } from '../../shared'
 import Context from '../../shared/Context'
-import { SpacingProps } from '../../shared/types'
-import { SkeletonShow } from '../skeleton/Skeleton'
 
 // Internal
-import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem'
+import BreadcrumbItem, { BreadcrumbItemProvider } from './BreadcrumbItem'
 import {
   convertJsxToString,
   isTrue,
@@ -26,103 +21,11 @@ import {
 } from '../../shared/component-helper'
 import { BreadcrumbMultiple } from './BreadcrumbMultiple'
 
-export interface BreadcrumbProps {
-  /**
-   * Custom className on the component root
-   * Default: null
-   */
-  className?: string
+// Types
+import type { SpacingProps } from '../../shared/types'
+import type { BreadcrumbProps, CurrentVariant } from './types'
 
-  /**
-   * Skeleton should be applied when loading content
-   * Default: null
-   */
-  skeleton?: SkeletonShow
-
-  /**
-   * Pass in a list of your pages as objects of breadcrumbitem to render them as breadcrumbitems.
-   * Default: null
-   */
-  data?: BreadcrumbItemProps[]
-
-  /**
-   * The content of the component. Can be used instead of prop "data".
-   * Default: null
-   */
-  children?: React.ReactNode // ReactNode allows multiple elements, strings, numbers, fragments, portals...
-
-  /**
-   * The variant of the component.
-   * Default: When children and data is not defined, it defaults to "single". If they are defined, the variant depends on the viewport.
-   */
-  variant?: 'single' | 'multiple' | 'collapse'
-
-  /**
-   * Handle the click event on 'single'/'collapse'
-   * Default: null
-   */
-  onClick?: React.MouseEventHandler<HTMLButtonElement>
-
-  /**
-   * For variant 'single', use href (or onClick) to set href when clicking "Back"
-   * Default: null
-   */
-  href?: string
-
-  /**
-   * Every <nav> on a page needs an unique aria-label text
-   * Default: Page hierarchy
-   */
-  navText?: React.ReactNode
-
-  /**
-   * Add custom 'Back' text for variant 'single'
-   * Default: 'Back' or defined by Context translation
-   */
-  goBackText?: React.ReactNode
-
-  /**
-   * Add custom 'Home' text
-   * Default: 'Home' or defined by Context translation
-   */
-  homeText?: React.ReactNode
-
-  /**
-   * Add custom 'Back to...' text, for variant collapse
-   * Default 'Back to...' or defined by Context translation
-   */
-  backToText?: React.ReactNode
-
-  /**
-   * If variant='collapse', you can override isCollapsed for the collapsed content by updating this value.
-   * Default: null
-   */
-  isCollapsed?: boolean
-
-  /**
-   * Use one of the Section component style types (style_type)
-   * Default: transparent
-   */
-  styleType?: SectionStyleTypes
-
-  /**
-   * Use one of the Section component style types (style_type)
-   * Default: pistachio
-   */
-  collapsedStyleType?: SectionStyleTypes
-
-  /**
-   * Include spacing properties from the Section component in breadcrumb. If only `true` is given, the spacing will be `small`.
-   * Default: false
-   */
-  spacing?: SectionSpacing
-
-  /**
-   * Will disable the height animation
-   * Default: false
-   */
-  noAnimation?: boolean
-}
+export type { BreadcrumbProps } from './types'
 
 export const defaultProps = {
   skeleton: false,
@@ -177,7 +80,7 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
     when: { max: 'medium' },
   })
 
-  let currentVariant = variant
+  let currentVariant: CurrentVariant = variant
   if (!variant) {
     if (items || data) {
       currentVariant = isSmallScreen ? 'collapse' : 'multiple'
@@ -195,73 +98,75 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
   const innerSpacing = isTrue(spacing) ? 'small' : spacing
 
   return (
-    <nav
-      aria-label={convertJsxToString(navText)}
-      className={classnames(
-        'dnb-breadcrumb',
-        skeletonClasses,
-        spacingClasses,
-        className
-      )}
-      data-testid="breadcrumb-nav"
-      {...props}
-    >
-      <Section
-        className="dnb-breadcrumb__bar"
-        style_type={styleType || 'transparent'}
-        spacing={isSmallScreen ? innerSpacing : false}
+    <BreadcrumbItemProvider currentVariant={currentVariant}>
+      <nav
+        aria-label={convertJsxToString(navText)}
+        className={classnames(
+          'dnb-breadcrumb',
+          skeletonClasses,
+          spacingClasses,
+          className
+        )}
+        data-testid="breadcrumb-nav"
+        {...props}
       >
-        {currentVariant === 'collapse' && (
-          <Button
-            text={backToText}
-            variant="tertiary"
-            icon="chevron_left"
-            icon_position="left"
-            onClick={
-              onClick ||
-              (() => {
-                setCollapse(!isCollapsed)
-              })
-            }
-            aria-expanded={!isCollapsed}
-          />
-        )}
-
-        {currentVariant === 'single' && (
-          <Button
-            text={goBackText}
-            variant="tertiary"
-            icon="chevron_left"
-            icon_position="left"
-            onClick={onClick}
-            href={href}
-          />
-        )}
-
-        {currentVariant === 'multiple' && (
-          <BreadcrumbMultiple
-            data={data}
-            items={items}
-            isCollapsed={false}
-            noAnimation={noAnimation}
-          />
-        )}
-      </Section>
-
-      {currentVariant === 'collapse' && (
         <Section
-          style_type={collapsedStyleType}
-          className="dnb-breadcrumb__collapse"
+          className="dnb-breadcrumb__bar"
+          style_type={styleType || 'transparent'}
+          spacing={innerSpacing}
         >
-          <BreadcrumbMultiple
-            data={data}
-            items={items}
-            isCollapsed={isCollapsed}
-            noAnimation={noAnimation}
-          />
+          {currentVariant === 'collapse' && (
+            <Button
+              text={backToText}
+              variant="tertiary"
+              icon="chevron_left"
+              icon_position="left"
+              onClick={
+                onClick ||
+                (() => {
+                  setCollapse(!isCollapsed)
+                })
+              }
+              aria-expanded={!isCollapsed}
+            />
+          )}
+
+          {currentVariant === 'single' && (
+            <Button
+              text={goBackText}
+              variant="tertiary"
+              icon="chevron_left"
+              icon_position="left"
+              onClick={onClick}
+              href={href}
+            />
+          )}
+
+          {currentVariant === 'multiple' && (
+            <BreadcrumbMultiple
+              data={data}
+              items={items}
+              isCollapsed={false}
+              noAnimation={noAnimation}
+            />
+          )}
         </Section>
-      )}
-    </nav>
+
+        {currentVariant === 'collapse' && (
+          <Section
+            style_type={collapsedStyleType}
+            className="dnb-breadcrumb__collapse"
+          >
+            <BreadcrumbMultiple
+              data={data}
+              items={items}
+              isCollapsed={isCollapsed}
+              noAnimation={noAnimation}
+            />
+          </Section>
+        )}
+      </nav>
+    </BreadcrumbItemProvider>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import HeightAnimation from '../height-animation/HeightAnimation'
 import Section from '../section/Section'
-import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem'
+import BreadcrumbItem from './BreadcrumbItem'
+
+// Types
+import type { BreadcrumbItemProps } from './types'
 
 type BreadcrumbMultipleProps = {
   isCollapsed: boolean
@@ -29,7 +32,6 @@ export const BreadcrumbMultiple = ({
         style_type="transparent"
       >
         {data?.map((breadcrumbItem, i) => {
-          const style = { '--delay': String(i) } as React.CSSProperties
           return (
             <BreadcrumbItem
               key={`${breadcrumbItem.text}`}
@@ -38,7 +40,6 @@ export const BreadcrumbMultiple = ({
                 (i == data.length - 1 && 'current') ||
                 null
               }
-              style={style}
               {...breadcrumbItem}
             />
           )

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -8,6 +8,10 @@ import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 
 const matchMedia = new MatchMediaMock()
 
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
 describe('Breadcrumb', () => {
   it('renders without properties', () => {
     render(<Breadcrumb />)
@@ -227,6 +231,26 @@ describe('Breadcrumb', () => {
       expect(screen.getByRole('button').className).toMatch(
         skeletonClassName
       )
+    })
+
+    describe('will set animation style', () => {
+      render(
+        <Breadcrumb
+          data={[
+            { href: '/' },
+            { href: '/page1', text: 'Page 1' },
+            { href: '/page1/page2', text: 'Page 2' },
+          ]}
+          variant="collapse"
+          isCollapsed={false}
+        />
+      )
+
+      const items = document.querySelectorAll('.dnb-breadcrumb__item')
+
+      it.each([0, 1, 2])('--delay=%s', (item) => {
+        expect(items[item].getAttribute('style')).toBe(`--delay: ${item};`)
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/breadcrumb/types.ts
+++ b/packages/dnb-eufemia/src/components/breadcrumb/types.ts
@@ -1,0 +1,147 @@
+import { IconPrimaryIcon } from '../IconPrimary'
+import { SectionSpacing, SectionStyleTypes } from '../Section'
+import { SkeletonShow } from '../skeleton/Skeleton'
+
+export type BreadcrumbProps = {
+  /**
+   * Custom className on the component root
+   * Default: null
+   */
+  className?: string
+
+  /**
+   * Skeleton should be applied when loading content
+   * Default: null
+   */
+  skeleton?: SkeletonShow
+
+  /**
+   * Pass in a list of your pages as objects of breadcrumbitem to render them as breadcrumbitems.
+   * Default: null
+   */
+  data?: BreadcrumbItemProps[]
+
+  /**
+   * The content of the component. Can be used instead of prop "data".
+   * Default: null
+   */
+  children?: React.ReactNode // ReactNode allows multiple elements, strings, numbers, fragments, portals...
+
+  /**
+   * The variant of the component.
+   * Default: When children and data is not defined, it defaults to "single". If they are defined, the variant depends on the viewport.
+   */
+  variant?: 'single' | 'multiple' | 'collapse'
+
+  /**
+   * Handle the click event on 'single'/'collapse'
+   * Default: null
+   */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
+
+  /**
+   * For variant 'single', use href (or onClick) to set href when clicking "Back"
+   * Default: null
+   */
+  href?: string
+
+  /**
+   * Every <nav> on a page needs an unique aria-label text
+   * Default: Page hierarchy
+   */
+  navText?: React.ReactNode
+
+  /**
+   * Add custom 'Back' text for variant 'single'
+   * Default: 'Back' or defined by Context translation
+   */
+  goBackText?: React.ReactNode
+
+  /**
+   * Add custom 'Home' text
+   * Default: 'Home' or defined by Context translation
+   */
+  homeText?: React.ReactNode
+
+  /**
+   * Add custom 'Back to...' text, for variant collapse
+   * Default 'Back to...' or defined by Context translation
+   */
+  backToText?: React.ReactNode
+
+  /**
+   * If variant='collapse', you can override isCollapsed for the collapsed content by updating this value.
+   * Default: null
+   */
+  isCollapsed?: boolean
+
+  /**
+   * Use one of the Section component style types (style_type)
+   * Default: transparent
+   */
+  styleType?: SectionStyleTypes
+
+  /**
+   * Use one of the Section component style types (style_type)
+   * Default: pistachio
+   */
+  collapsedStyleType?: SectionStyleTypes
+
+  /**
+   * Include spacing properties from the Section component in breadcrumb. If only `true` is given, the spacing will be `small`.
+   * Default: false
+   */
+  spacing?: SectionSpacing
+
+  /**
+   * Will disable the height animation
+   * Default: false
+   */
+  noAnimation?: boolean
+}
+
+export type BreadcrumbItemProps = {
+  /**
+   * Text displaying the title of the item's corresponding page
+   * Default: If variant='home', default is "Home". Otherwise it is required.
+   */
+  text?: React.ReactNode
+
+  /**
+   * Icon displaying on the left side
+   * Default: HomeIcon / chevron_left
+   */
+  icon?: IconPrimaryIcon
+
+  /**
+   * Href should be the link to the item's corresponding page.
+   * Default: null
+   */
+  href?: string
+
+  /**
+   * Set a custom click event. In this case, you should not define the prop href.
+   * Default: null
+   */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
+
+  /**
+   * The component variant. Variant 'current' should correspond to the current page and 'home' to the root page.
+   * Default: null
+   */
+  variant?: 'home' | 'previous' | 'current'
+
+  /**
+   * Skeleton should be applied when loading content
+   * Default: null
+   */
+  skeleton?: SkeletonShow
+}
+
+export type CurrentVariant = 'single' | 'collapse' | 'multiple'
+export type MemoRef = React.RefObject<{ count: number }>
+export type BreadcrumbItemProviderProps = {
+  currentVariant?: CurrentVariant
+  children?: React.ReactNode
+  memoRef?: MemoRef
+}


### PR DESCRIPTION
When a Breadcrumb was declared like so:

```jsx
    <Breadcrumb>
      <Breadcrumb.Item
        text="Page item 1"
      />
      <Breadcrumb.Item
        text="Page item 2"
      />
    </Breadcrumb>
```

The animation did not work nicely then. Why? We do not know the count of each item.

[CSB](https://codesandbox.io/s/eufemia-breadcrumb-animation-issue-thsgsm?file=/src/App.tsx)



This PR ensures we always know the number of each item during the each render phase, based on the text content – because that's the only reference we have, that will not change, during open/close. 

Because I wanted to share `CurrentVariant` type, I ended up moving all types to a new  `/types.ts` file. Sorry for the noise, it should have been in a separate PR.
