### PR TITLE
fix(Breadcrumb): make animation work properly when declared as JSX

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -43,13 +43,13 @@ export interface BreadcrumbProps {
    * Pass in a list of your pages as objects of breadcrumbitem to render them as breadcrumbitems.
    * Default: null
    */
-  data?: BreadcrumbItemProps[]
+  data?: Array<BreadcrumbItemProps>
 
   /**
    * The content of the component. Can be used instead of prop "data".
    * Default: null
    */
-  children?: React.ReactNode // ReactNode allows multiple elements, strings, numbers, fragments, portals...
+  children?: Array<React.ReactElement<BreadcrumbItemProps>>
 
   /**
    * The variant of the component.

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -52,7 +52,8 @@ export interface BreadcrumbItemProps {
    */
   skeleton?: SkeletonShow
 
-  style?: React.CSSProperties
+  /** Internal */
+  itemNr?: number
 }
 
 const defaultProps = {
@@ -74,17 +75,26 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
   } = context
 
   // Extract additional props from global context
-  const { text, href, icon, onClick, variant, skeleton, style, ...props } =
-    extendPropsWithContext(
-      localProps,
-      defaultProps,
-      context?.BreadcrumbItem
-    )
+  const {
+    text,
+    href,
+    icon,
+    onClick,
+    variant,
+    skeleton,
+    itemNr,
+    ...props
+  } = extendPropsWithContext(
+    localProps,
+    defaultProps,
+    context?.BreadcrumbItem
+  )
 
   const currentIcon: IconPrimaryIcon =
     icon || (variant === 'home' && homeIcon) || 'chevron_left'
   const currentText = text || (variant === 'home' && homeText) || ''
   const isInteractive = (href || onClick) && variant !== 'current'
+  const style = { '--delay': String(itemNr) } as React.CSSProperties
 
   return (
     <li

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -7,7 +7,7 @@ type BreadcrumbMultipleProps = {
   isCollapsed: boolean
   noAnimation: boolean
   data: Array<BreadcrumbItemProps>
-  items: React.ReactNode
+  items: Array<React.ReactElement<BreadcrumbItemProps>>
 }
 
 export const BreadcrumbMultiple = ({
@@ -29,7 +29,6 @@ export const BreadcrumbMultiple = ({
         style_type="transparent"
       >
         {data?.map((breadcrumbItem, i) => {
-          const style = { '--delay': String(i) } as React.CSSProperties
           return (
             <BreadcrumbItem
               key={`${breadcrumbItem.text}`}
@@ -38,13 +37,15 @@ export const BreadcrumbMultiple = ({
                 (i == data.length - 1 && 'current') ||
                 null
               }
-              style={style}
+              itemNr={i}
               {...breadcrumbItem}
             />
           )
         })}
 
-        {items}
+        {items?.map((item, i) =>
+          React.cloneElement(item, { key: i, itemNr: i })
+        )}
       </Section>
     </HeightAnimation>
   )

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -8,6 +8,10 @@ import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 
 const matchMedia = new MatchMediaMock()
 
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
 describe('Breadcrumb', () => {
   it('renders without properties', () => {
     render(<Breadcrumb />)
@@ -227,6 +231,26 @@ describe('Breadcrumb', () => {
       expect(screen.getByRole('button').className).toMatch(
         skeletonClassName
       )
+    })
+
+    describe('will set animation style', () => {
+      render(
+        <Breadcrumb
+          data={[
+            { href: '/' },
+            { href: '/page1', text: 'Page 1' },
+            { href: '/page1/page2', text: 'Page 2' },
+          ]}
+          variant="collapse"
+          isCollapsed={false}
+        />
+      )
+
+      const items = document.querySelectorAll('.dnb-breadcrumb__item')
+
+      it.each([0, 1, 2])('--delay=%s', (item) => {
+        expect(items[item].getAttribute('style')).toBe(`--delay: ${item};`)
+      })
     })
   })
 })


### PR DESCRIPTION
When a Breadcrumb was declared like so:

```jsx
    <Breadcrumb>
      <Breadcrumb.Item
        text="Page item 1"
      />
      <Breadcrumb.Item
        text="Page item 2"
      />
    </Breadcrumb>
```


https://user-images.githubusercontent.com/1501870/193920026-7900d0ce-95fb-46fa-bf91-cde6e67434c1.mov




The animation did not work nicely then. Why? We do not know the count of each item.

[CSB](https://codesandbox.io/s/eufemia-breadcrumb-animation-issue-thsgsm?file=/src/App.tsx)

This PR ensures we always know the number of each item during the each re-render phase.
