### PR TITLE
fix(Tooltip): make skipPortal properly inline and accessible to screen readers

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.md
@@ -9,16 +9,16 @@ showTabs: true
 | `children`                                  | _(optional)_ Provide a string or a React Element to be shown as the tooltip content.                                                             |
 | `active`                                    | _(optional)_ set to `true` the tooltip will show up.                                                                                             |
 | `position`                                  | _(optional)_ defines the offset position to the target element the arrow appears. Can be `top`, `right`, `left` and `bottom`. Defaults to `top`. |
-| `align`                                     | _(optional)_ defines the offset alignment to the target element the arrow appears. Can be `center`, `right` and `left`.Defaults to `center`.     |
+| `align`                                     | _(optional)_ defines the offset alignment to the target element the arrow appears. Can be `center`, `right` and `left`. Defaults to `center`.    |
 | `arrow`                                     | _(optional)_ defines the direction where the arrow appears. Can be `center`, `top`, `right`, `bottom` and `left`. Defaults to `center`.          |
-| `animatePosition`                           | _(optional)_ set to `true` to animate a single Tooltip from one element to another element. You also need to set a unique `group` name.          |
-| `fixedPosition`                             | _(optional)_ If set to `true`, the Tooltip will be fixed in its scroll position by using CSS `position: fixed;`. Defaults to `false`.            |
-| `skipPortal`                                | _(optional)_ set to `true` to disable the React Portal behavior. Defaults to `false`.                                                            |
-| `noAnimation`                               | _(optional)_ set to `true` if no fade-in animation should be used.                                                                               |
+| `skipPortal`                                | _(optional)_ set to `true` to disable the React Portal behavior. Can not be used when `group` is used. Defaults to `false`.                      |
 | `showDelay`                                 | _(optional)_ define the delay until the tooltip should show up after the initial hover / active state.                                           |
 | `hideDelay`                                 | _(optional)_ define the delay until the tooltip should disappear up after initial visibility.                                                    |
+| `size`                                      | _(optional)_ defines the spacing size of the tooltip. Can be `large` or `basis`. Defaults to `basis`.                                            |
 | `targetElement`                             | _(optional)_ provide an element directly as a React Node or a React Ref that will be wrapped and rendered.                                       |
 | `targetSelector`                            | _(optional)_ specify a vanilla HTML selector by a string as the target element.                                                                  |
-| `size`                                      | _(optional)_ defines the spacing size of the tooltip. Can be `large` or `basis`. Defaults to `basis`.                                            |
+| `noAnimation`                               | _(optional)_ set to `true` if no fade-in animation should be used.                                                                               |
+| `fixedPosition`                             | _(optional)_ If set to `true`, the Tooltip will be fixed in its scroll position by using CSS `position: fixed;`. Defaults to `false`.            |
 | `group`                                     | _(optional)_ if the tooltip should animate from one target to the next, define a unique ID.                                                      |
+| `animatePosition`                           | _(optional)_ set to `true` to animate a single Tooltip from one element to another element. You also need to set a unique `group` name.          |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                            |

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -470,6 +470,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
             tooltip="dialog_title"
           >
             <TooltipWithEvents
+              active={null}
               align={null}
               animatePosition={false}
               arrow="center"
@@ -491,45 +492,43 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               size="basis"
               skipPortal={null}
               target={
-                Object {
-                  "current": <button
-                    aria-describedby="dialog_id-tooltip"
-                    aria-label="dialog_title"
-                    aria-roledescription="Hjelp-knapp"
-                    class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                    id="dialog_id"
-                    type="button"
+                <button
+                  aria-describedby="dialog_id-tooltip"
+                  aria-label="dialog_title"
+                  aria-roledescription="Hjelp-knapp"
+                  class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                  id="dialog_id"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="dnb-button__alignment"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="dnb-button__alignment"
+                    ‌
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                    data-testid="question icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      ‌
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-testid="question icon"
-                      role="presentation"
-                    >
-                      <svg
-                        fill="none"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                          stroke="#000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                        />
-                      </svg>
-                    </span>
-                  </button>,
-                }
+                      <path
+                        d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                        stroke="#000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>
               }
               targetElement={
                 Object {
@@ -576,7 +575,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
               tooltip="dialog_title"
             >
               <TooltipPortal
-                active={false}
+                active={null}
                 align={null}
                 animatePosition={false}
                 arrow="center"
@@ -593,7 +592,6 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                 id="dialog_id-tooltip"
                 internalId="dialog_id-tooltip"
                 keepInDOM={true}
-                key="tooltip"
                 noAnimation={false}
                 position="top"
                 showDelay={300}
@@ -639,45 +637,43 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                   </button>
                 }
                 targetElement={
-                  Object {
-                    "current": <button
-                      aria-describedby="dialog_id-tooltip"
-                      aria-label="dialog_title"
-                      aria-roledescription="Hjelp-knapp"
-                      class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                      id="dialog_id"
-                      type="button"
+                  <button
+                    aria-describedby="dialog_id-tooltip"
+                    aria-label="dialog_title"
+                    aria-roledescription="Hjelp-knapp"
+                    class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                    id="dialog_id"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="dnb-button__alignment"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="dnb-button__alignment"
+                      ‌
+                    </span>
+                    <span
+                      aria-hidden="true"
+                      class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                      data-testid="question icon"
+                      role="presentation"
+                    >
+                      <svg
+                        fill="none"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        ‌
-                      </span>
-                      <span
-                        aria-hidden="true"
-                        class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-testid="question icon"
-                        role="presentation"
-                      >
-                        <svg
-                          fill="none"
-                          height="16"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                            stroke="#000"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="1.5"
-                          />
-                        </svg>
-                      </span>
-                    </button>,
-                  }
+                        <path
+                          d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                          stroke="#000"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                    </span>
+                  </button>
                 }
                 targetSelector={null}
                 tooltip="dialog_title"
@@ -706,7 +702,7 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                   }
                 >
                   <TooltipContainer
-                    active={false}
+                    active={null}
                     align={null}
                     animatePosition={false}
                     arrow="center"
@@ -812,8 +808,11 @@ exports[`Dialog component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden={true}
                       className="dnb-tooltip"
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onTouchStart={[Function]}
                       role="tooltip"
                       style={Object {}}
                     >

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -468,6 +468,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
             tooltip="drawer_title"
           >
             <TooltipWithEvents
+              active={null}
               align={null}
               animatePosition={false}
               arrow="center"
@@ -489,45 +490,43 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               size="basis"
               skipPortal={null}
               target={
-                Object {
-                  "current": <button
-                    aria-describedby="drawer_id-tooltip"
-                    aria-label="drawer_title"
-                    aria-roledescription="Hjelp-knapp"
-                    class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                    id="drawer_id"
-                    type="button"
+                <button
+                  aria-describedby="drawer_id-tooltip"
+                  aria-label="drawer_title"
+                  aria-roledescription="Hjelp-knapp"
+                  class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                  id="drawer_id"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="dnb-button__alignment"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="dnb-button__alignment"
+                    ‌
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                    data-testid="question icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      ‌
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-testid="question icon"
-                      role="presentation"
-                    >
-                      <svg
-                        fill="none"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                          stroke="#000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                        />
-                      </svg>
-                    </span>
-                  </button>,
-                }
+                      <path
+                        d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                        stroke="#000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>
               }
               targetElement={
                 Object {
@@ -574,7 +573,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
               tooltip="drawer_title"
             >
               <TooltipPortal
-                active={false}
+                active={null}
                 align={null}
                 animatePosition={false}
                 arrow="center"
@@ -591,7 +590,6 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                 id="drawer_id-tooltip"
                 internalId="drawer_id-tooltip"
                 keepInDOM={true}
-                key="tooltip"
                 noAnimation={false}
                 position="top"
                 showDelay={300}
@@ -637,45 +635,43 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                   </button>
                 }
                 targetElement={
-                  Object {
-                    "current": <button
-                      aria-describedby="drawer_id-tooltip"
-                      aria-label="drawer_title"
-                      aria-roledescription="Hjelp-knapp"
-                      class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                      id="drawer_id"
-                      type="button"
+                  <button
+                    aria-describedby="drawer_id-tooltip"
+                    aria-label="drawer_title"
+                    aria-roledescription="Hjelp-knapp"
+                    class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                    id="drawer_id"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="dnb-button__alignment"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="dnb-button__alignment"
+                      ‌
+                    </span>
+                    <span
+                      aria-hidden="true"
+                      class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                      data-testid="question icon"
+                      role="presentation"
+                    >
+                      <svg
+                        fill="none"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        ‌
-                      </span>
-                      <span
-                        aria-hidden="true"
-                        class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                        data-testid="question icon"
-                        role="presentation"
-                      >
-                        <svg
-                          fill="none"
-                          height="16"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                            stroke="#000"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="1.5"
-                          />
-                        </svg>
-                      </span>
-                    </button>,
-                  }
+                        <path
+                          d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                          stroke="#000"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                    </span>
+                  </button>
                 }
                 targetSelector={null}
                 tooltip="drawer_title"
@@ -704,7 +700,7 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                   }
                 >
                   <TooltipContainer
-                    active={false}
+                    active={null}
                     align={null}
                     animatePosition={false}
                     arrow="center"
@@ -810,8 +806,11 @@ exports[`Drawer component snapshot should match component snapshot 1`] = `
                     <span
                       aria-hidden={true}
                       className="dnb-tooltip"
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onTouchStart={[Function]}
                       role="tooltip"
                       style={Object {}}
                     >

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -459,6 +459,7 @@ exports[`Modal component have to match snapshot 1`] = `
           tooltip="modal_title"
         >
           <TooltipWithEvents
+            active={null}
             align={null}
             animatePosition={false}
             arrow="center"
@@ -480,45 +481,43 @@ exports[`Modal component have to match snapshot 1`] = `
             size="basis"
             skipPortal={null}
             target={
-              Object {
-                "current": <button
-                  aria-describedby="modal_id-tooltip"
-                  aria-label="modal_title"
-                  aria-roledescription="Hjelp-knapp"
-                  class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                  id="modal_id"
-                  type="button"
+              <button
+                aria-describedby="modal_id-tooltip"
+                aria-label="modal_title"
+                aria-roledescription="Hjelp-knapp"
+                class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                id="modal_id"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="dnb-button__alignment"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="dnb-button__alignment"
+                  ‌
+                </span>
+                <span
+                  aria-hidden="true"
+                  class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                  data-testid="question icon"
+                  role="presentation"
+                >
+                  <svg
+                    fill="none"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    ‌
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                    data-testid="question icon"
-                    role="presentation"
-                  >
-                    <svg
-                      fill="none"
-                      height="16"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                        stroke="#000"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="1.5"
-                      />
-                    </svg>
-                  </span>
-                </button>,
-              }
+                    <path
+                      d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                      stroke="#000"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                    />
+                  </svg>
+                </span>
+              </button>
             }
             targetElement={
               Object {
@@ -565,7 +564,7 @@ exports[`Modal component have to match snapshot 1`] = `
             tooltip="modal_title"
           >
             <TooltipPortal
-              active={false}
+              active={null}
               align={null}
               animatePosition={false}
               arrow="center"
@@ -582,7 +581,6 @@ exports[`Modal component have to match snapshot 1`] = `
               id="modal_id-tooltip"
               internalId="modal_id-tooltip"
               keepInDOM={true}
-              key="tooltip"
               noAnimation={false}
               position="top"
               showDelay={300}
@@ -628,45 +626,43 @@ exports[`Modal component have to match snapshot 1`] = `
                 </button>
               }
               targetElement={
-                Object {
-                  "current": <button
-                    aria-describedby="modal_id-tooltip"
-                    aria-label="modal_title"
-                    aria-roledescription="Hjelp-knapp"
-                    class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
-                    id="modal_id"
-                    type="button"
+                <button
+                  aria-describedby="modal_id-tooltip"
+                  aria-label="modal_title"
+                  aria-roledescription="Hjelp-knapp"
+                  class="dnb-button dnb-button--secondary dnb-help-button dnb-modal__trigger dnb-button--icon-position-left dnb-button--has-icon dnb-button--size-medium"
+                  id="modal_id"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="dnb-button__alignment"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="dnb-button__alignment"
+                    ‌
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
+                    data-testid="question icon"
+                    role="presentation"
+                  >
+                    <svg
+                      fill="none"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      ‌
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="dnb-icon dnb-icon--default dnb-button__icon dnb-icon--inherit-color"
-                      data-testid="question icon"
-                      role="presentation"
-                    >
-                      <svg
-                        fill="none"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
-                          stroke="#000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                        />
-                      </svg>
-                    </span>
-                  </button>,
-                }
+                      <path
+                        d="M5.392 4.875c0-1.642 1.452-2.98 3.074-2.868 1.638.113 2.874 1.654 2.65 3.264a2.923 2.923 0 0 1-1.89 2.316c-1.216.43-.958 1.9-.958 2.913m-.177 3.004h.346m.079 0c0 .184-.16.244-.248.244-.092 0-.252-.06-.252-.244 0-.197.16-.256.252-.256.088 0 .248.06.248.256Z"
+                        stroke="#000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                </button>
               }
               targetSelector={null}
               tooltip="modal_title"
@@ -695,7 +691,7 @@ exports[`Modal component have to match snapshot 1`] = `
                 }
               >
                 <TooltipContainer
-                  active={false}
+                  active={null}
                   align={null}
                   animatePosition={false}
                   arrow="center"
@@ -801,8 +797,11 @@ exports[`Modal component have to match snapshot 1`] = `
                   <span
                     aria-hidden={true}
                     className="dnb-tooltip"
+                    onMouseDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    onMouseMove={[Function]}
+                    onTouchStart={[Function]}
                     role="tooltip"
                     style={Object {}}
                   >

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -3,6 +3,7 @@ import {
   combineDescribedBy,
   combineLabelledBy,
   validateDOMAttributes,
+  warn,
 } from '../../shared/component-helper'
 import Button from '../button/Button'
 import Tooltip from '../tooltip/Tooltip'
@@ -72,6 +73,11 @@ function Thumb({ value, currentIndex }: ThumbProps) {
   }
   const onMouseLeaveHandler = () => {
     setShowTooltip(false)
+    try {
+      elemRef.current.dispatchEvent(new Event('mouseleave'))
+    } catch (e) {
+      warn(e)
+    }
   }
 
   const {
@@ -109,15 +115,20 @@ function Thumb({ value, currentIndex }: ThumbProps) {
     helperParams.onFocus = (event) => {
       onHelperFocusHandler(event)
       onMouseEnterHandler()
+      try {
+        elemRef.current.dispatchEvent(new Event('mouseenter'))
+      } catch (e) {
+        warn(e)
+      }
     }
   }
   validateDOMAttributes(allProps, thumbParams) // because we send along rest attributes
 
-  const elemRef = React.useRef()
+  const elemRef = React.useRef<HTMLElement>()
 
   return (
     <>
-      <span className="dnb-slider__thumb" style={style} ref={elemRef}>
+      <span className="dnb-slider__thumb" style={style}>
         <input
           type="range"
           className="dnb-slider__button-helper"
@@ -145,6 +156,7 @@ function Thumb({ value, currentIndex }: ThumbProps) {
           variant="secondary"
           disabled={disabled}
           skeleton={skeleton}
+          innerRef={elemRef}
           {...thumbParams}
         />
 
@@ -153,12 +165,13 @@ function Thumb({ value, currentIndex }: ThumbProps) {
             key={`group-${currentIndex}`}
             targetElement={elemRef}
             animatePosition={shouldAnimate}
-            active={showTooltip || alwaysShowTooltip}
+            active={Boolean(showTooltip || alwaysShowTooltip)}
+            showDelay={1}
             hideDelay={300}
           >
             {number || value}
             {
-              /* Use this only in order to update the position after the thumb animation */ shouldAnimate
+              shouldAnimate /* Use "shouldAnimate" only in order to update the position after the thumb animation */
             }
           </Tooltip>
         )}

--- a/packages/dnb-eufemia/src/components/slider/SliderTrack.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderTrack.tsx
@@ -13,8 +13,7 @@ export function SliderMainTrack({
   const { isMulti, value, allProps, trackRef, animationTimeout } =
     useSliderProps()
   const { id, numberFormat, onInit } = allProps
-  const { onTrackMouseUpHandler, onThumbMouseDownHandler, removeEvents } =
-    useSliderEvents()
+  const { onTrackMouseDownHandler, removeEvents } = useSliderEvents()
 
   React.useEffect(() => {
     // onInit is deprecated
@@ -37,10 +36,8 @@ export function SliderMainTrack({
   }, [])
 
   const trackParams = {
-    onTouchStart: onTrackMouseUpHandler,
-    onTouchStartCapture: onThumbMouseDownHandler,
-    onMouseDown: onTrackMouseUpHandler,
-    onMouseDownCapture: onThumbMouseDownHandler,
+    onTouchStart: onTrackMouseDownHandler,
+    onMouseDown: onTrackMouseDownHandler,
   }
 
   return (

--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -156,18 +156,18 @@ describe('Slider component', () => {
   })
 
   describe('Tooltip', () => {
+    const IS_TEST = globalThis.IS_TEST
     beforeEach(() => {
       document.body.innerHTML = ''
+      globalThis.IS_TEST = false
+    })
+    afterEach(() => {
+      globalThis.IS_TEST = IS_TEST
     })
 
     it('shows always a Tooltip when alwaysShowTooltip is true', () => {
       render(
-        <Slider
-          {...props}
-          id="unique-tooltip-01"
-          tooltip
-          alwaysShowTooltip
-        />
+        <Slider {...props} id="unique-tooltip" tooltip alwaysShowTooltip />
       )
 
       const tooltipElem = document.querySelector('.dnb-tooltip')
@@ -182,7 +182,7 @@ describe('Slider component', () => {
       render(
         <Slider
           {...props}
-          id="unique-tooltip-02"
+          id="unique-tooltip"
           numberFormat={{ currency: 'EUR' }}
           tooltip
         />
@@ -192,37 +192,78 @@ describe('Slider component', () => {
       const thumbElem = mainElem.querySelector(
         '.dnb-slider__thumb .dnb-button'
       )
-      const tooltipElem = () => document.querySelector('.dnb-tooltip')
+      const getTooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem().textContent).toBe('70,00 €')
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip'])
-      )
+      expect(getTooltipElem().textContent).toBe('70,00 €')
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+      ])
 
-      fireEvent.mouseOver(thumbElem)
+      fireEvent.mouseEnter(thumbElem)
 
       simulateMouseMove({ pageX: 80, width: 100, height: 10 })
 
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--active'])
+      await wait(100)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--active',
+      ])
+
+      expect(getTooltipElem().textContent).toBe('80,00 €')
+
+      fireEvent.mouseLeave(thumbElem)
+
+      await wait(300)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--hide',
+      ])
+    })
+
+    it('shows Tooltip on focus', async () => {
+      render(<Slider {...props} id="unique-tooltip" tooltip />)
+
+      const mainElem = document.querySelector('.dnb-slider')
+      const thumbElem = mainElem.querySelector(
+        '.dnb-slider__thumb .dnb-button'
       )
+      const getTooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem().textContent).toBe('80,00 €')
+      expect(getTooltipElem().textContent).toBe('70')
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+      ])
 
-      fireEvent.mouseOut(thumbElem)
+      fireEvent.focus(thumbElem)
 
-      await wait(1)
+      simulateMouseMove({ pageX: 80, width: 100, height: 10 })
 
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--hide'])
-      )
+      await wait(100)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--active',
+      ])
+
+      expect(getTooltipElem().textContent).toBe('80')
+
+      fireEvent.blur(thumbElem)
+
+      await wait(300)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--hide',
+      ])
     })
 
     it('shows Tooltip on hover with custom formatting', async () => {
       render(
         <Slider
           {...props}
-          id="unique-tooltip-03"
+          id="unique-tooltip"
           numberFormat={(value) => format(value, { percent: true })}
           tooltip
           step={null}
@@ -233,30 +274,69 @@ describe('Slider component', () => {
       const thumbElem = mainElem.querySelector(
         '.dnb-slider__thumb .dnb-button'
       )
-      const tooltipElem = () => document.querySelector('.dnb-tooltip')
+      const getTooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem().textContent).toBe('70 %')
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip'])
-      )
+      expect(getTooltipElem().textContent).toBe('70 %')
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+      ])
 
-      fireEvent.mouseOver(thumbElem)
+      fireEvent.mouseEnter(thumbElem)
 
       simulateMouseMove({ pageX: 80.5, width: 100, height: 10 })
 
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--active'])
+      await wait(100)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--active',
+      ])
+
+      expect(getTooltipElem().textContent).toBe('80,5 %')
+
+      fireEvent.mouseLeave(thumbElem)
+
+      await wait(300)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--hide',
+      ])
+    })
+
+    it('text can be selected without disappearing', async () => {
+      render(<Slider {...props} id="unique-tooltip" tooltip />)
+
+      const mainElem = document.querySelector('.dnb-slider')
+      const thumbElem = mainElem.querySelector(
+        '.dnb-slider__thumb .dnb-button'
       )
+      const getTooltipElem = () => document.querySelector('.dnb-tooltip')
 
-      expect(tooltipElem().textContent).toBe('80,5 %')
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+      ])
 
-      fireEvent.mouseOut(thumbElem)
+      fireEvent.mouseEnter(thumbElem)
 
-      await wait(1)
+      await wait(100)
 
-      expect(Array.from(tooltipElem().classList)).toEqual(
-        expect.arrayContaining(['dnb-tooltip', 'dnb-tooltip--hide'])
-      )
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--active',
+      ])
+
+      fireEvent.mouseLeave(thumbElem)
+
+      // Enter Tooltip, and with that, prevent it from hiding/disappearing
+      fireEvent.mouseEnter(getTooltipElem())
+
+      await wait(300)
+
+      expect(Array.from(getTooltipElem().classList)).toEqual([
+        'dnb-tooltip',
+        'dnb-tooltip--active',
+      ])
     })
   })
 

--- a/packages/dnb-eufemia/src/components/slider/hooks/useSliderEvents.tsx
+++ b/packages/dnb-eufemia/src/components/slider/hooks/useSliderEvents.tsx
@@ -24,14 +24,18 @@ export function useSliderEvents() {
   } = React.useContext(SliderContext)
   const { min, max, onDragStart, onDragEnd } = allProps
 
-  const onTrackMouseUpHandler = (event: MouseEvent | TouchEvent) => {
+  const onTrackMouseDownHandler = (event: MouseEvent | TouchEvent) => {
+    onThumbMouseDownHandler(event)
+
     const percent = calculatePercent(trackRef.current, event, isVertical)
 
     emitChange(event, percentToValue(percent, min, max, isReverse))
     setShouldAnimate(true)
   }
 
-  const onThumbMouseDownHandler = (event: React.SyntheticEvent) => {
+  const onThumbMouseDownHandler = (
+    event: MouseEvent | TouchEvent | React.SyntheticEvent
+  ) => {
     const target = event.target as HTMLButtonElement
 
     setThumbIndex(parseFloat(target.dataset.index))
@@ -132,7 +136,7 @@ export function useSliderEvents() {
   return {
     onThumbMouseDownHandler,
     onThumbMouseUpHandler,
-    onTrackMouseUpHandler,
+    onTrackMouseDownHandler,
     onHelperChangeHandler,
     onHelperFocusHandler,
     removeEvents,

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { isTrue } from '../../shared/component-helper'
-import { getOffsetLeft } from '../../shared/helpers'
+import { getOffsetLeft, getOffsetTop } from '../../shared/helpers'
 import classnames from 'classnames'
 import { TooltipProps } from './types'
 
@@ -26,11 +26,16 @@ export default function TooltipContainer(
     attributes,
     arrow,
     position,
+    align,
+    group,
+    hideDelay,
     animatePosition,
     fixedPosition,
     noAnimation,
+    skipPortal,
     useHover,
     children,
+    targetElement: target,
   } = props
 
   const [style, setStyle] = React.useState(null)
@@ -91,9 +96,26 @@ export default function TooltipContainer(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive])
 
+  const offsetLeft = React.useRef(0)
+  const offsetTop = React.useRef(0)
+
   React.useLayoutEffect(() => {
+    if (!isActive) {
+      /**
+       * This "resets" the position between elements,
+       * when not active. Else it will always first show on the older position.
+       */
+      if (group && wasActive) {
+        clearTimeout(debounceTimeout.current)
+        debounceTimeout.current = setTimeout(
+          () => setStyle(null),
+          hideDelay
+        )
+      }
+      return // stop here
+    }
+
     const element = elementRef?.current
-    const { targetElement: target, align, fixedPosition } = props
 
     if (
       typeof window === 'undefined' ||
@@ -103,13 +125,11 @@ export default function TooltipContainer(
       return // stop here
     }
 
-    const elementWidth = element.offsetWidth
-    const elementHeight = element.offsetHeight
-
     let alignOffset = 0
 
+    const elementWidth = element.offsetWidth
+    const elementHeight = element.offsetHeight
     const rect = target.getBoundingClientRect()
-
     const targetBodySize = {
       width: target.offsetWidth,
       height: target.offsetHeight,
@@ -121,11 +141,17 @@ export default function TooltipContainer(
       targetBodySize.height = rect.height
     }
 
+    if (skipPortal && (!offsetLeft.current || !offsetTop.current)) {
+      offsetLeft.current = getOffsetLeft(element) - offset.current
+      offsetTop.current = getOffsetTop(element) - offset.current
+    }
+
     const scrollY =
       window.scrollY !== undefined ? window.scrollY : window.pageYOffset
     const scrollX =
       window.scrollX !== undefined ? window.scrollX : window.pageXOffset
-    const top = (isTrue(fixedPosition) ? 0 : scrollY) + rect.top
+    const top =
+      (isTrue(fixedPosition) ? 0 : scrollY) + rect.top - offsetTop.current
 
     // Use Mouse position when target is too wide
     const useMouseWhen = targetBodySize.width > 400
@@ -135,9 +161,9 @@ export default function TooltipContainer(
       (element ? element.offsetWidth : 0)
     const widthBased = scrollX + rect.left
     const left =
-      useMouseWhen && mousePos < targetBodySize.width
+      (useMouseWhen && mousePos < targetBodySize.width
         ? mousePos
-        : widthBased
+        : widthBased) - offsetLeft.current
 
     const style = { ...props.style }
 
@@ -195,8 +221,7 @@ export default function TooltipContainer(
 
     if (stylesFromPosition[position]) {
       stylesFromPosition[position]()
-    }
-    if (stylesFromArrow[arrow]) {
+    } else if (stylesFromArrow[arrow]) {
       stylesFromArrow[arrow]()
     }
 
@@ -213,12 +238,10 @@ export default function TooltipContainer(
       style.top = 0
     }
 
-    if (isActive) {
-      setStyle(style)
-    }
+    setStyle(style)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActive, arrow, position, children, renewStyles])
+  }, [active, arrow, position, children, renewStyles])
 
   const handleMouseEnter = () => {
     if (isTrue(active) && useHover !== false) {
@@ -232,13 +255,22 @@ export default function TooltipContainer(
     }
   }
 
+  /**
+   * By stopping propagation, we allow the user to select text when Toolip is used in the Slider component
+   */
+  const handlePropagation = (e: React.SyntheticEvent) =>
+    e.stopPropagation()
+
   return (
     <span
       role="tooltip"
-      aria-hidden // make sure SR does not find it in the DOM, because we use "aria-describedby" for that
+      aria-hidden={target ? true : undefined} // make sure SR does not find it in the DOM, because we use "aria-describedby" for that
       ref={elementRef}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onMouseMove={handlePropagation}
+      onMouseDown={handlePropagation}
+      onTouchStart={handlePropagation}
       {...attributes}
       className={classnames(
         attributes?.className,

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
@@ -48,21 +48,19 @@ export function getTargetElement(target: HTMLElement) {
 }
 
 export function useHandleAria(
-  targetElement: React.RefObject<HTMLElement>,
+  targetElement: HTMLElement,
   internalId: string
 ) {
   React.useEffect(() => {
     try {
-      const elem = getTargetElement(getRefElement(targetElement))
-      if (!elem?.classList.contains('dnb-tooltip__wrapper')) {
-        const existing = {
-          'aria-describedby': elem.getAttribute('aria-describedby'),
-        }
-        elem.setAttribute(
-          'aria-describedby',
-          combineDescribedBy(existing, internalId)
-        )
+      // const elem = getTargetElement(getRefElement(targetElement))
+      const existing = {
+        'aria-describedby': targetElement.getAttribute('aria-describedby'),
       }
+      targetElement.setAttribute(
+        'aria-describedby',
+        combineDescribedBy(existing, internalId)
+      )
     } catch (e) {
       //
     }
@@ -88,7 +86,10 @@ export function getRefElement(target: React.RefObject<HTMLElement>) {
     element = getRefElement(unknownTarget.current._ref)
   }
 
-  if (Object.prototype.hasOwnProperty.call(element, 'current')) {
+  if (
+    element &&
+    Object.prototype.hasOwnProperty.call(element, 'current')
+  ) {
     element = (element as React.RefObject<HTMLElement>).current
   }
 

--- a/packages/dnb-eufemia/src/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/stories/Tooltip.stories.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 import styled from '@emotion/styled'
 
-import { NumberFormat, Button, Tooltip } from '../../'
+import { NumberFormat, Button, Tooltip, P } from '../../../'
 
 const StyledTooltip = styled(Tooltip)`
   margin-bottom: 4rem;
@@ -21,6 +21,16 @@ export default {
 export const TooltipSandbox = () => {
   return (
     <Wrapper>
+      <Box>
+        <Tooltip
+          skipPortal
+          hideDelay={1e3}
+          targetElement={<Button right>Skipped Portal</Button>}
+          position="bottom"
+        >
+          Tooltip
+        </Tooltip>
+      </Box>
       <Box>
         <Tooltip
           animatePosition
@@ -42,10 +52,15 @@ export const TooltipSandbox = () => {
       </Box>
       <Box>
         <button className="target-1">Show the Tooltip</button>
+        <button className="target-2">Tooltip</button>
 
         <hr />
 
-        <Tooltip id="unique" active targetSelector=".target-1">
+        <Tooltip id="unique-1" active targetSelector=".target-1">
+          Tooltip
+        </Tooltip>
+
+        <Tooltip id="unique-2" targetSelector=".target-2">
           Tooltip
         </Tooltip>
       </Box>
@@ -115,18 +130,28 @@ export const TooltipSandbox = () => {
         </Button>
       </Box>
       <Box>
-        <Tooltip targetElement={<NumberFormat>1234</NumberFormat>}>
+        <P>
+          <Tooltip targetElement={<NumberFormat>1234</NumberFormat>}>
+            Tooltip
+          </Tooltip>
+        </P>
+
+        <P>
+          <NumberFormat
+            tooltip={
+              <Tooltip position="bottom">
+                Tooltip for this NumberFormat
+              </Tooltip>
+            }
+          >
+            5678
+          </NumberFormat>
+        </P>
+      </Box>
+      <Box>
+        <Tooltip skipPortal active>
           Tooltip
         </Tooltip>
-        <NumberFormat
-          tooltip={
-            <Tooltip position="bottom">
-              Tooltip for this NumberFormat
-            </Tooltip>
-          }
-        >
-          1234
-        </NumberFormat>
       </Box>
     </Wrapper>
   )

--- a/packages/dnb-eufemia/src/components/tooltip/types.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/types.ts
@@ -33,6 +33,7 @@ export type TooltipProps = IncludeSnakeCase<{
   tooltip?: React.ReactNode
   className?: string
   children?: React.ReactNode
+  style?: React.CSSProperties
 }>
 
 export type TooltipAllProps = TooltipProps &

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -560,6 +560,12 @@ describe('"filterProps" should', () => {
 })
 
 describe('"makeUniqueId" should', () => {
+  it('have prepended "id-" by default', () => {
+    expect(makeUniqueId()).toEqual(
+      expect.stringMatching(/^id-[a-z0-9]{8}/g)
+    )
+  })
+
   it('make unique ids', () => {
     const ids = {}
     for (let i = 1, l = 10; i <= l; ++i) {

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -609,7 +609,7 @@ export const filterProps = (props, remove = null, allowed = null) => {
   }, {})
 }
 
-export const makeUniqueId = (prefix = '', length = 8) =>
+export const makeUniqueId = (prefix = 'id-', length = 8) =>
   prefix +
   String(
     Math.random().toString(36).substr(2, length) + idIncrement++


### PR DESCRIPTION
Sorry for the many Tooltip changes. The reason is that I want to optimize it as much as possible, before stripping out parts and make a new/shared component. 

This PR makes the `skipPortal` act as the one with the portal, but just inlines the Tooltip HTML under the component.