### PR TITLE
docs(Components): add description to all component docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge.md
@@ -1,6 +1,6 @@
 ---
 title: 'Badge'
-description: 'The badge component allows the user to focus on new or unread content or notifications'
+description: 'The badge component allows the user to focus on new or unread content or notifications.'
 status: 'new'
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.md
@@ -1,6 +1,6 @@
 ---
 title: 'Breadcrumb'
-description: 'The Breadcrumb component is a bar for navigation showing current web path'
+description: 'The Breadcrumb component is a bar for navigation showing current web path.'
 status: null
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.md
@@ -1,6 +1,6 @@
 ---
 title: 'HelpButton'
-description: 'A help button with custom semantics, helping screen readers determine the meaning of that button'
+description: 'A help button with custom semantics, helping screen readers determine the meaning of that button.'
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo.md
@@ -1,6 +1,6 @@
 ---
 title: 'Logo'
-description: 'A ready to use DNB logo in SVG format'
+description: 'A ready to use DNB logo in SVG format.'
 status: null
 showTabs: true
 hideTabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.md
@@ -1,6 +1,6 @@
 ---
 title: 'NumberFormat'
-description: 'A ready to use DNB number formatter'
+description: 'A ready to use DNB number formatter.'
 # status: 'new'
 showTabs: true
 tabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.md
@@ -1,5 +1,6 @@
 ---
 title: 'InfinityScroller'
+description: 'The InfinityScroller component is a mode of the Pagination component which loads content continuously as the user scrolls down the page.'
 showTabs: true
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch.md
@@ -1,5 +1,6 @@
 ---
 title: 'Switch'
+description: 'The Switch component (toggle) is a digital on/off switch.'
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table.md
@@ -1,6 +1,6 @@
 ---
 title: 'Table'
-description: 'Enhanced HTML Table element'
+description: 'Enhanced HTML Table element.'
 status: 'new'
 showTabs: true
 redirect_from:

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs.md
@@ -1,6 +1,6 @@
 ---
 title: 'Tabs'
-description: 'Tabs are a set of buttons which allow navigation between content that is related and on the same level of hierarch.'
+description: 'Tabs are a set of buttons which allow navigation between content that is related and on the same level of hierarchy.'
 status: null
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag.md
@@ -1,6 +1,6 @@
 ---
 title: 'Tag'
-description: 'The Tag component'
+description: 'The Tag component is a compact element for displaying discrete information.'
 status: null
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/timeline.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/timeline.md
@@ -1,6 +1,6 @@
 ---
 title: 'Timeline'
-description: 'The Timeline component shows events in chronological order and gives a great overview of the overall process'
+description: 'The Timeline component shows events in chronological order and gives a great overview of the overall process.'
 status: null
 showTabs: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip.md
@@ -1,5 +1,6 @@
 ---
 title: 'Tooltip'
+description: 'The Tooltip component is primarily meant to enhance the UX for various and additional information.'
 showTabs: true
 hideTabs:
   - title: Events

--- a/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
@@ -36,6 +36,22 @@ const ListSummaryFromDocs = ({ slug, useAsIndex = false }) => {
         .filter(({ node: { slug: s } }) =>
           s.includes(String(slug).replace(/^\//, ''))
         )
+        .sort(
+          (
+            {
+              node: {
+                frontmatter: { title: titleA },
+              },
+            },
+            {
+              node: {
+                frontmatter: { title: titleB },
+              },
+            }
+          ) => {
+            return (titleA > titleB) - (titleA < titleB)
+          }
+        )
         .map(
           (
             {


### PR DESCRIPTION
This PR makes a few improvements in the following page https://eufemia.dnb.no/uilib/components/:
- Adds missing descriptions to components.
- Edits a few descriptions for components that had poor description.
- Sorts the components/mdx's by their title. 
I think it's better than what it is today, but would be even better if the order would be the same(and shared), using levels like for fragments, as in the sidebar menu. Not sure how easy/quick that would be to do, and it's also not very important 😹 

For comparison: [existing](https://eufemia.dnb.no/uilib/components/) vs. [changes introduced in this PR](https://eufemia-docsadddescriptiontoallcompone.gtsb.io/uilib/components/)