### PR TITLE
chore(AnimateHeight): remove unused/undocumented container support

### DIFF
--- a/packages/dnb-eufemia/src/shared/AnimateHeight.ts
+++ b/packages/dnb-eufemia/src/shared/AnimateHeight.ts
@@ -35,7 +35,6 @@ export default class AnimateHeight {
   events: AnimateHeightEvents
   opts: AnimateHeightOptions
   elem: AnimateHeightElement
-  container: AnimateHeightContainer
   reqId1: number
   reqId2: number
   resizeTimeout: NodeJS.Timeout
@@ -116,10 +115,7 @@ export default class AnimateHeight {
   }
 
   // Public methods
-  setElement(
-    elem: AnimateHeightElement,
-    container: AnimateHeightContainer = null
-  ) {
+  setElement(elem: AnimateHeightElement) {
     this._removeEndEvents() // in case element gets set several times
 
     this.elem =
@@ -129,19 +125,6 @@ export default class AnimateHeight {
     // TODO: remove when responsive tables are supported
     if (String(this.elem?.nodeName).toLowerCase() === 'td') {
       this.elem = this.elem.parentElement
-    }
-
-    this.container = container
-
-    if (this.container && this.isInBrowser) {
-      this.onResize = () => {
-        clearTimeout(this.resizeTimeout)
-        this.resizeTimeout = setTimeout(
-          () => this.setContainerHeight(),
-          300
-        )
-      }
-      window.addEventListener('resize', this.onResize)
     }
   }
   remove() {
@@ -239,25 +222,10 @@ export default class AnimateHeight {
 
         this.elem.style.height = `${fromHeight}px`
 
-        if (this.container) {
-          this.container.style.minHeight = `${fromHeight}px`
-        }
-
         this.reqId2 = window.requestAnimationFrame(() => {
           this.elem.style.height = `${toHeight}px`
-          this.setContainerHeight()
         })
       })
-    }
-  }
-  setContainerHeight() {
-    if (this.container) {
-      const contentElem = this.elem
-      if (contentElem.offsetHeight > 0) {
-        this.container.style.minHeight = `${
-          contentElem.offsetHeight + contentElem.offsetTop
-        }px`
-      }
     }
   }
   stop() {
@@ -307,7 +275,6 @@ export default class AnimateHeight {
 
         this.state = 'adjusted'
         this._callOnEnd()
-        this.setContainerHeight()
       }
     })
 
@@ -333,7 +300,6 @@ export default class AnimateHeight {
 
         this.state = 'opened'
         this._callOnEnd()
-        this.setContainerHeight()
       }
     })
 

--- a/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/AnimateHeight.test.ts
@@ -5,7 +5,7 @@
 
 import AnimateHeight from '../AnimateHeight'
 
-let element, container
+let element: HTMLElement
 
 beforeEach(() => {
   window.requestAnimationFrame = jest.fn((callback) => {
@@ -17,14 +17,11 @@ beforeEach(() => {
   })
 
   element = document.createElement('span')
-  container = document.createElement('div')
-  container.appendChild(element)
-  document.body.appendChild(container)
+  document.body.appendChild(element)
 })
 
 function emulateSetContainerHeight() {
   jest.spyOn(element, 'offsetHeight', 'get').mockImplementation(() => 300)
-  jest.spyOn(container, 'offsetTop', 'get').mockImplementation(() => 100)
 }
 
 describe('AnimateHeight', () => {
@@ -77,17 +74,6 @@ describe('AnimateHeight', () => {
 
     expect(inst.getWidth()).toBe(100)
     expect(_elem).toBe(element)
-  })
-
-  it('setContainerHeight should set correct minHeight on container', () => {
-    const inst = new AnimateHeight()
-    inst.setElement(element, container)
-
-    emulateSetContainerHeight()
-
-    inst.setContainerHeight()
-
-    expect(container.getAttribute('style')).toBe('min-height: 300px;')
   })
 
   it('reset should remove CSS styles', () => {
@@ -227,7 +213,7 @@ describe('AnimateHeight', () => {
 
     it('start with animation should work properly', async () => {
       const inst = new AnimateHeight()
-      inst.setElement(element, container)
+      inst.setElement(element)
 
       emulateSetContainerHeight()
 
@@ -259,12 +245,10 @@ describe('AnimateHeight', () => {
       await wait(1)
 
       expect(element.getAttribute('style')).toBe('height: 100px;')
-      expect(container.getAttribute('style')).toBe('min-height: 100px;')
 
       await wait(1)
 
       expect(element.getAttribute('style')).toBe('height: 200px;')
-      expect(container.getAttribute('style')).toBe('min-height: 300px;')
 
       expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
 
@@ -278,7 +262,7 @@ describe('AnimateHeight', () => {
   describe('adjustTo', () => {
     it('adjustTo with animation should work properly', async () => {
       const inst = new AnimateHeight()
-      inst.setElement(element, container)
+      inst.setElement(element)
 
       emulateSetContainerHeight()
 
@@ -309,12 +293,10 @@ describe('AnimateHeight', () => {
       await wait(1)
 
       expect(element.getAttribute('style')).toBe('height: 100px;')
-      expect(container.getAttribute('style')).toBe('min-height: 100px;')
 
       await wait(1)
 
       expect(element.getAttribute('style')).toBe('height: 200px;')
-      expect(container.getAttribute('style')).toBe('min-height: 300px;')
 
       simulateAnimationEnd()
 


### PR DESCRIPTION
Now that no component uses `setContainerHeight`, and its not documented, I'm glad we can remove this, as it only made the code more complicated to maintain.