### PR TITLE
fix(Icon): fix override of data-testid property when provided

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.js
+++ b/packages/dnb-eufemia/src/components/icon/Icon.js
@@ -358,6 +358,7 @@ export const prepareIcon = (props, context) => {
   }
   if (wrapperParams['aria-hidden']) {
     if (
+      !wrapperParams['data-testid'] &&
       typeof process !== 'undefined' &&
       process.env.NODE_ENV === 'test'
     ) {

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.js
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.js
@@ -114,6 +114,28 @@ describe('Icon component', () => {
     ).toBe(false)
   })
 
+  it('should set data-testid property based on the aria-label', () => {
+    const Comp = mount(
+      <Component icon={question} aria-label="question icon" />
+    )
+    expect(
+      Comp.find('span.dnb-icon').instance().getAttribute('data-testid')
+    ).toBe('question icon')
+  })
+
+  it('should set data-testid when provided', () => {
+    const Comp = mount(
+      <Component
+        icon={question}
+        aria-label="question icon"
+        data-testid="custom-data-testid-value"
+      />
+    )
+    expect(
+      Comp.find('span.dnb-icon').instance().getAttribute('data-testid')
+    ).toBe('custom-data-testid-value')
+  })
+
   it('should validate with ARIA rules', async () => {
     const Comp = mount(<Component {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()


### PR DESCRIPTION
The changes I made in https://github.com/dnbexperience/eufemia/pull/1583 make it pointless to pass a value for `data-testid`to the Icon component, as we always overwrite the `data-testid`.

For example, the following code will end with a `data-testid` that will have the value `question icon`:
`<Icon icon={question} data-testid="custom-data-testid" />,` but in this scenario I would want it to be `custom-data-testid`.


In general, I think I made a a slight mistake with #1583 and that we shouldn't override the value of `data-testid` when provided.