### PR TITLE
chore(Portal): fix src vs build usage during development

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -190,7 +190,7 @@ async function createRedirects({ graphql, actions }) {
   })
 }
 
-exports.onCreateWebpackConfig = ({ actions, plugins }) => {
+exports.onCreateWebpackConfig = ({ stage, actions, plugins }) => {
   const config = {
     resolve: {
       alias: {
@@ -209,7 +209,7 @@ exports.onCreateWebpackConfig = ({ actions, plugins }) => {
     ],
   }
 
-  if (isCI && prebuildExists) {
+  if (isCI && prebuildExists &&    stage === 'build-javascript') {
     config.plugins.push(
       plugins.normalModuleReplacement(/@dnb\/eufemia\/src/, (resource) => {
         resource.request = resource.request.replace(

--- a/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
+++ b/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
@@ -19,7 +19,11 @@ import { isCI } from 'repo-utils'
  * Import Eufemia Styles
  * Use require because Webpack does not import styles after we change /src to /build
  */
-if (isCI && process.env.PREBUILD_EXISTS) {
+if (
+  isCI &&
+  process.env.PREBUILD_EXISTS &&
+  process.env.NODE_ENV === 'production'
+) {
   require('@dnb/eufemia/build/style/dnb-ui-extensions.min.css')
   require('@dnb/eufemia/build/style/dnb-ui-core.min.css')
   require('@dnb/eufemia/build/style/dnb-ui-components.min.css')


### PR DESCRIPTION
It could happen that the some `build` styles where used alongside with styles from `src` when run in dev, if it existed. This PR ensures we do not get this anymore.
