### PR TITLE
feat(HeightAnimation): make the view open by default

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
@@ -76,7 +76,6 @@ const Example = () => {
   return (
     <>
       <HeightAnimation
-        open
         showOverflow
       >
         {showMe ? <Button 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.md
@@ -10,13 +10,17 @@ HeightAnimationKeepInDOM,
 
 ## Demos
 
-### HeightAnimation
+### Animation during height changes
 
-<HeightAnimationDefault />
-
-### Auto resize height
+This example shows how you easily can enhance the user experience. Here we also use `showOverflow` to avoid hidden overflow during the animation.
 
 <HeightAnimationAutosizing />
+
+### Basic open/close
+
+This example removes its given children, when open is `open={false}`.
+
+<HeightAnimationDefault />
 
 ### Keep in DOM
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.md
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-The HeightAnimation component is a helper component to animate from `0` to `height: auto` powered by CSS. It calculates the height on the fly.
+The HeightAnimation component calculates the height, and animates from `auto` to `auto` – or from `0` to `auto` in height – powered by CSS transition. It calculates the height on the fly.
 
 When the animation is done, it sets the element's height to `auto`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/properties.md
@@ -4,13 +4,13 @@ showTabs: true
 
 ## Properties
 
-| Properties                                  | Description                                                                                                 |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `open`                                      | _(optional)_ Set to `true` when the view should animate from 0px to auto. Defaults to `false`.              |
-| `animate`                                   | _(optional)_ Set to `false` to omit the animation. Defaults to `true`.                                      |
-| `keepInDOM`                                 | _(optional)_ Set to `true` ensure the nested children content will be kept in the DOM. Defaults to `false`. |
-| `showOverflow`                              | _(optional)_ Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.                   |
-| `duration`                                  | _(optional)_ Custom duration of the animation in ms.                                                        |
-| `element`                                   | _(optional)_ Custom HTML element for the component. Defaults to `div` HTML Element.                         |
-| `innerRef`                                  | _(optional)_ Send along a custom React Ref.                                                                 |
-| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                       |
+| Properties                                  | Description                                                                                                       |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `open`                                      | _(optional)_ Set to `true` on second re-render when the view should animate from 0px to auto. Defaults to `true`. |
+| `animate`                                   | _(optional)_ Set to `false` to omit the animation. Defaults to `true`.                                            |
+| `keepInDOM`                                 | _(optional)_ Set to `true` ensure the nested children content will be kept in the DOM. Defaults to `false`.       |
+| `showOverflow`                              | _(optional)_ Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.                         |
+| `duration`                                  | _(optional)_ Custom duration of the animation in ms.                                                              |
+| `element`                                   | _(optional)_ Custom HTML element for the component. Defaults to `div` HTML Element.                               |
+| `innerRef`                                  | _(optional)_ Send along a custom React Ref.                                                                       |
+| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                             |

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -46,7 +46,7 @@ export type HeightAnimationAllProps = HeightAnimationProps &
   React.HTMLProps<HTMLElement>
 
 export default function HeightAnimation({
-  open = false,
+  open = true,
   animate = true,
   keepInDOM = false,
   showOverflow = false,

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -106,6 +106,20 @@ describe('HeightAnimation', () => {
     ).toBe('--duration: 1000ms; height: auto;')
   })
 
+  it('should be open by default', () => {
+    render(<HeightAnimation>visible content</HeightAnimation>)
+
+    expect(
+      document.querySelector('.dnb-height-animation').textContent
+    ).toBe('visible content')
+    expect(
+      document.querySelector('.dnb-height-animation--is-visible')
+    ).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-height-animation').getAttribute('style')
+    ).toBe('height: auto;')
+  })
+
   it('should have element in DOM when open property is true (using ToggleButton)', () => {
     render(<Component />)
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { render, act, fireEvent } from '@testing-library/react'
+import { renderHook } from '@testing-library/react-hooks'
 import ToggleButton from '../../ToggleButton'
 import { wait } from '@testing-library/user-event/dist/utils'
 import { useHeightAnimation } from '../useHeightAnimation'
@@ -174,6 +175,40 @@ describe('useHeightAnimation', () => {
     await wait(1)
 
     expect(getStates()).toEqual(['wrapper-element', 'is-in-dom'])
+  })
+
+  it('should be open by default', () => {
+    const current: HTMLDivElement = document.createElement('div')
+    const ref: React.RefObject<HTMLDivElement> = { current }
+
+    const { result } = renderHook(() => useHeightAnimation(ref))
+
+    expect(result.current).toEqual({
+      isAnimating: false,
+      isInDOM: true,
+      isOpen: true,
+      isVisible: true,
+      isVisibleParallax: true,
+      open: true,
+    })
+  })
+
+  it('should be closed if open is false', () => {
+    const current: HTMLDivElement = document.createElement('div')
+    const ref: React.RefObject<HTMLDivElement> = { current }
+
+    const { result } = renderHook(() =>
+      useHeightAnimation(ref, { open: false })
+    )
+
+    expect(result.current).toEqual({
+      isAnimating: false,
+      isInDOM: false,
+      isOpen: false,
+      isVisible: false,
+      isVisibleParallax: false,
+      open: false,
+    })
   })
 })
 

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
@@ -3,8 +3,8 @@ import HeightAnimationInstance from './HeightAnimationInstance'
 
 export type useHeightAnimationOptions = {
   /**
-   * Set to `true` when the view should animate from 0px to auto.
-   * Default: false
+   * Set to `true`, when initially `false` was given, to animate from 0px to auto.
+   * Default: true
    */
   open?: boolean
 
@@ -45,7 +45,7 @@ export type HeightAnimationOnEndTypes = 'opened' | 'closed' | 'adjusted'
 export function useHeightAnimation(
   targetRef: React.RefObject<HTMLElement>,
   {
-    open = null,
+    open = true,
     animate = true,
     children = null,
     onInit = null,


### PR DESCRIPTION
I rethought the purpose of this component and think now that this component will probably mostly be used as a "height change" component, and not always from nothing to auto. 

When someone needs the first render to be nothing/0 then he anyway will send in `false` on the first render cycle. And then change it when needed.

When we have open by default, we do not need to define it anymore to use this component for only a height animation. 