### PR TITLE
feat(useMedia): add React Hook to handle Eufemia layout breakpoints

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/Examples.tsx
@@ -1,0 +1,92 @@
+/**
+ * UI lib Component Example
+ *
+ */
+
+import React from 'react'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
+import MediaQuery from '@dnb/eufemia/src/shared/MediaQuery'
+import { useMedia, useMediaQuery } from '@dnb/eufemia/src/shared'
+
+const useWindowWidth = () => {
+  const [innerWidth, setWidth] = React.useState(
+    typeof window !== 'undefined' ? window.innerWidth : 0
+  )
+
+  React.useEffect(() => {
+    const resizeHandler = () => {
+      setWidth(window.innerWidth)
+    }
+    window.addEventListener('resize', resizeHandler)
+    return () => window.removeEventListener('resize', resizeHandler)
+  }, [])
+
+  return { innerWidth }
+}
+
+export const MediaQueryUseMedia = () => (
+  <ComponentBox scope={{ useMedia, useWindowWidth }} useRender hideCode>
+    {
+      /* jsx */ `
+const Playground = () => {
+  const { isSmall, isMedium, isLarge, isSSR } = useMedia()
+  const { innerWidth } = useWindowWidth()
+  
+  return (<Code>
+    <pre>
+      {JSON.stringify({ isSmall, isMedium, isLarge, isSSR, innerWidth }, null, 2)}
+    </pre>
+  </Code>)
+}
+render(Playground)
+`
+    }
+  </ComponentBox>
+)
+
+export const MediaQueryLiveExample = () => (
+  <ComponentBox scope={{ MediaQuery, useMediaQuery }} useRender hideCode>
+    {
+      /* jsx */ `
+const Playground = () => {
+  const [query, updateQuery] = React.useState({
+    screen: true,
+    not: true,
+    min: 'small',
+    max: 'large',
+  })
+  const match1 = useMediaQuery({
+    matchOnSSR: true,
+    when: query,
+  })
+  const match2 = useMediaQuery({
+    matchOnSSR: true,
+    not: true,
+    when: query,
+  })
+  // console.log('mediaQuery:', match1, match2)
+  return (<>
+    <Button
+      onClick={() => {
+        updateQuery({
+          ...query,
+          screen: !query.screen,
+        })
+      }}
+      right
+    >
+      Switch
+    </Button>
+    <MediaQuery when={query}>
+      <Code>when</Code>
+    </MediaQuery>
+    <MediaQuery not when={query}>
+      <Code>not when</Code>
+    </MediaQuery>
+  </>)
+}
+render(Playground)
+`
+    }
+  </ComponentBox>
+)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/media-queries.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/media-queries.md
@@ -4,8 +4,10 @@ order: 2
 ---
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
-import MediaQuery from '@dnb/eufemia/src/shared/MediaQuery'
-import useMediaQuery from '@dnb/eufemia/src/shared/useMediaQuery'
+import {
+MediaQueryLiveExample,
+MediaQueryUseMedia,
+} from 'dnb-design-system-portal/src/docs/uilib/usage/layout/Examples'
 
 # Media Queries and Breakpoints
 
@@ -25,9 +27,13 @@ UX designers are using a 12 column system during their design processes.
 
 <!-- | 1440  | `xxx-large` | **90em** | `--layout-xxx-large` |             | -->
 
-## MediaQuery component and the useMediaQuery hook
+## MediaQuery component and React Hooks
 
-Both the component and the hook uses the JavaScript API [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
+Both the component and the React Hooks uses the JavaScript API [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
+
+- [useMedia](/uilib/usage/layout/media-queries/#usemedia-hook-usage) React Hook for screen width only.
+- [useMediaQuery](/uilib/usage/layout/media-queries/#usemediaquery-hook-usage) React Hook for all kinds of media queries.
+- [MediaQuery](/uilib/usage/layout/media-queries/#mediaquery-component) Component for all kinds of media queries.
 
 ### Re-render and performance
 
@@ -51,7 +57,64 @@ During a SSR (Server Side Render) we do not have the clients `window.matchMedia`
 
 Numeric values will be handled as an `em` unit.
 
-### `MediaQuery` usage
+### `useMedia` hook usage
+
+```js
+import { useMedia } from '@dnb/eufemia/shared'
+
+function Component() {
+  const { isSmall, isMedium, isLarge, isSSR } = useMedia()
+
+  return isSmall ? 'true' : 'false'
+}
+```
+
+To lower the possibility of CLS (Cumulative Layout Shift) on larger screens – you can make use of the `isSSR` property. Try to use it in combination with `isLarge`, because the negative CLS experience is most recoginzeable on larger screens:
+
+```js
+import { useMedia } from '@dnb/eufemia/shared'
+
+function Component() {
+  const { isSmall, isMedium, isLarge, isSSR } = useMedia()
+
+  return isLarge || isSSR ? 'true' : 'false'
+}
+```
+
+<MediaQueryUseMedia />
+
+You can disable the usage of `window.matchMedia` by providing `useMedia({ disabled: true })`.
+
+You can log the media query by providing `useMedia({ log: true })`.
+
+### `useMediaQuery` hook usage
+
+This React Hook is a more extended version, where you can define all sorts of Media Queries.
+
+```js
+import { useMediaQuery } from '@dnb/eufemia/shared'
+// or
+import useMediaQuery from '@dnb/eufemia/shared/useMediaQuery'
+
+function Component() {
+  const match = useMediaQuery({
+    matchOnSSR: true,
+    when: { min: 'medium' },
+  })
+
+  return match ? 'true' : 'false'
+}
+```
+
+You can disable the usage of `window.matchMedia` by providing `useMedia({ disabled: true })`.
+
+### Live example
+
+This example uses the `not` property to reverse the behavior.
+
+<MediaQueryLiveExample />
+
+### `MediaQuery` component
 
 ```js
 import { MediaQuery } from '@dnb/eufemia/shared'
@@ -106,88 +169,13 @@ const remove = onMediaQueryChange({ min: 'medium' }, (match, event) => {
 remove()
 ```
 
-### `useMediaQuery` hook usage
-
-```js
-import { useMediaQuery } from '@dnb/eufemia/shared'
-// or
-import useMediaQuery from '@dnb/eufemia/shared/useMediaQuery'
-```
-
-```jsx
-function Component() {
-  const match = useMediaQuery({
-    matchOnSSR: true,
-    when: { min: 'medium' },
-  })
-
-  return match ? 'true' : 'false'
-}
-```
-
-You can also disable the usage of `window.matchMedia` temporally by providing `disabled: true` as an option.
-
-### Live example
-
-This example uses the `not` property to reverse the behavior.
-
-<!-- prettier-ignore-start -->
-
-<ComponentBox
-  data-visual-test="media-query"
-  scope={{ MediaQuery, useMediaQuery }}
-  useRender
-  hideCode
->
-{`
-const Playground = () => {
-  const [query, updateQuery] = React.useState({
-    screen: true,
-    not: true,
-    min: 'small',
-    max: 'large',
-  })
-  const match1 = useMediaQuery({
-    matchOnSSR: true,
-    when: query,
-  })
-  const match2 = useMediaQuery({
-    matchOnSSR: true,
-    not: true,
-    when: query,
-  })
-  // console.log('mediaQuery:', match1, match2)
-  return (<>
-    <Button
-      onClick={() => {
-        updateQuery({
-          ...query,
-          screen: !query.screen,
-        })
-      }}
-      right
-    >
-      Switch
-    </Button>
-    <MediaQuery when={query}>
-      <Code>when</Code>
-    </MediaQuery>
-    <MediaQuery not when={query}>
-      <Code>not when</Code>
-    </MediaQuery>
-  </>)
-}
-render(Playground)
-`}
-</ComponentBox>
-
-<!-- prettier-ignore-end -->
-
 ### Use different breakpoints
 
 It is possible to change the used breakpoint types by providing them to the Eufemia Provider.
 
-Both the `MediaQuery` component and the `useMediaQuery` hook will merge and use these custom breakpoints.
+Both the `MediaQuery` component and the hooks `useMedia` and `useMediaQuery` will merge and use these custom breakpoints.
+
+**NB:** It should be done only temporary, because DNB should align on one set of breakpoints for best UX and consistency.
 
 ```jsx
 import { Provider } from '@dnb/eufemia/shared'
@@ -195,17 +183,13 @@ import { Provider } from '@dnb/eufemia/shared'
 <Provider
   value={{
     breakpoints: {
-      xsmall: '20em',
-      medium: '30em',
-      large: '60em',
+      small: '40em',
+      medium: '60em',
+      large: '72em',
     },
   }}
 >
-  ...
-  <MediaQuery when={{ min: 'xsmall' }}>
-    matches all above xsmall screens
-  </MediaQuery>
-  ...
+  <App />
 </Provider>
 ```
 

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -212,6 +212,7 @@
     "lodash.isequalwith": "4.4.0",
     "markdown-tables-to-json": "0.1.7",
     "mkdirp": "1.0.4",
+    "mock-match-media": "0.3.0",
     "node-sass": "5.0.0",
     "node-sass-once-importer": "5.3.2",
     "nodemon": "2.0.15",

--- a/packages/dnb-eufemia/src/shared/MediaQuery.tsx
+++ b/packages/dnb-eufemia/src/shared/MediaQuery.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { isTrue } from './component-helper'
-import Context from './Context'
+import Context, { ContextProps } from './Context'
 import {
   makeMediaQueryList,
   createMediaQueryListener,
@@ -23,13 +23,14 @@ export default class MediaQuery extends React.PureComponent<
 > {
   static contextType = Context
   listener: MediaQueryListener
+  context: ContextProps
 
   state = {
     match: null,
     mediaQueryList: null,
   }
 
-  constructor(props, context) {
+  constructor(props: MediaQueryProps, context: ContextProps) {
     super(props)
 
     if (!isMatchMediaSupported() && isTrue(props.matchOnSSR)) {

--- a/packages/dnb-eufemia/src/shared/__tests__/MediaQueryUtils.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/MediaQueryUtils.test.tsx
@@ -7,7 +7,9 @@ import {
   convertToMediaQuery,
   buildQuery,
   onMediaQueryChange,
+  makeMediaQueryList,
 } from '../MediaQueryUtils'
+import * as helpers from '../helpers'
 import { mockMediaQuery } from './helpers/MediaQueryMocker'
 const matchMedia = mockMediaQuery()
 
@@ -249,6 +251,68 @@ describe('buildQuery', () => {
     expect(buildQuery({ when: { all: true, monochrome: true } })).toBe(
       'all and monochrome'
     )
+  })
+})
+
+describe('makeMediaQueryList', () => {
+  let log = global.console.log
+
+  beforeEach(() => {
+    log = global.console.log
+    global.console.log = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+
+    global.console.log = log
+  })
+
+  it('should return mediaQuery object', () => {
+    const query = '(min-width: 40em)'
+    matchMedia.useMediaQuery(query)
+
+    expect(makeMediaQueryList({ query })).toEqual({
+      matches: true,
+      media: query,
+      addEventListener: expect.any(Function),
+      removeEventListener: expect.any(Function),
+      addListener: expect.any(Function),
+      removeListener: expect.any(Function),
+      dispatchEvent: expect.any(Function),
+      onchange: null,
+    })
+  })
+
+  it('should warn when no mediaQuery is supported', () => {
+    const query = '(min-width: 40em)'
+    matchMedia.useMediaQuery(query)
+
+    jest.spyOn(helpers, 'warn')
+
+    window.matchMedia = undefined
+
+    expect(makeMediaQueryList({ query })).toEqual(null)
+
+    expect(helpers.warn).toHaveBeenCalledTimes(1)
+    expect(helpers.warn).toHaveBeenCalledWith(
+      'window.matchMedia is "undefined"'
+    )
+  })
+
+  it('should dismiss warning', () => {
+    const query = '(min-width: 40em)'
+    matchMedia.useMediaQuery(query)
+
+    jest.spyOn(helpers, 'warn')
+
+    window.matchMedia = undefined
+
+    expect(makeMediaQueryList({ query, dismissWarning: true })).toEqual(
+      null
+    )
+
+    expect(helpers.warn).toHaveBeenCalledTimes(0)
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
@@ -1,0 +1,571 @@
+/**
+ * useMedia Tests
+ *
+ */
+
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-hooks'
+import {
+  render,
+  waitFor,
+  act as actOnRender,
+} from '@testing-library/react'
+import useMedia from '../useMedia'
+import Provider from '../Provider'
+import 'mock-match-media/jest-setup'
+import { setMedia, matchMedia } from 'mock-match-media'
+import { mockMediaQuery } from './helpers/MediaQueryMocker'
+
+describe('useMedia', () => {
+  describe('using mock-match-media mocker', () => {
+    const BELOW = '10em'
+    const ABOVE = '100em'
+
+    const SMALL = '39em' // 40em
+    const MEDIUM = '49em' // 50em
+    const LARGE = '59em' // 60em
+
+    beforeEach(() => {
+      jest.spyOn(window, 'matchMedia').mockImplementation(matchMedia)
+    })
+
+    const matchMediaOriginal = window.matchMedia
+    afterEach(() => {
+      window.matchMedia = matchMediaOriginal
+    })
+
+    it('will return object with ', () => {
+      setMedia({ type: 'print' })
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: false,
+        })
+      )
+    })
+
+    it('will return positive isSmall', async () => {
+      setMedia({ width: SMALL })
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: true,
+          isMedium: false,
+          isLarge: false,
+        })
+      )
+
+      await act(async () => {
+        setMedia({ width: ABOVE })
+
+        await waitFor(() => result.current)
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          })
+        )
+      })
+    })
+
+    it('will return positive isMedium', async () => {
+      setMedia({ width: MEDIUM })
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: true,
+          isLarge: false,
+        })
+      )
+
+      await act(async () => {
+        setMedia({ width: ABOVE })
+
+        await waitFor(() => result.current)
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          })
+        )
+      })
+    })
+
+    it('will return positive isLarge', async () => {
+      setMedia({ width: LARGE })
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: true,
+        })
+      )
+
+      await act(async () => {
+        setMedia({ width: BELOW })
+
+        await waitFor(() => result.current)
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+          })
+        )
+      })
+    })
+
+    it('will react to all possible sizes', async () => {
+      setMedia({ width: ABOVE })
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: true,
+        })
+      )
+
+      const queries = [
+        {
+          width: BELOW,
+          expectResult: expect.objectContaining({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+          }),
+        },
+        {
+          width: ABOVE,
+          expectResult: expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          }),
+        },
+        {
+          width: MEDIUM,
+          expectResult: expect.objectContaining({
+            isSmall: false,
+            isMedium: true,
+            isLarge: false,
+          }),
+        },
+        {
+          width: LARGE,
+          expectResult: expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          }),
+        },
+        {
+          width: SMALL,
+          expectResult: expect.objectContaining({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+          }),
+        },
+        {
+          width: BELOW,
+          expectResult: expect.objectContaining({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+          }),
+        },
+      ]
+
+      for await (const { width, expectResult } of queries) {
+        await act(async () => {
+          setMedia({ width })
+
+          await waitFor(() => result.current)
+
+          expect(result.current).toEqual(expectResult)
+        })
+      }
+    })
+
+    it('can be disabled programmatically', async () => {
+      setMedia({ width: LARGE })
+
+      const { result, rerender } = renderHook(useMedia, {
+        initialProps: { disabled: false },
+      })
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: true,
+        })
+      )
+
+      rerender({ disabled: true })
+
+      await act(async () => {
+        setMedia({ width: BELOW })
+
+        await waitFor(() => result.current)
+
+        /**
+         * Keep the same state as before
+         */
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          })
+        )
+      })
+
+      rerender({ disabled: false })
+
+      await act(async () => {
+        setMedia({ width: SMALL })
+
+        await waitFor(() => result.current)
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+          })
+        )
+
+        /**
+         * Set state before disable
+         */
+        setMedia({ width: LARGE })
+      })
+
+      rerender({ disabled: true })
+
+      await act(async () => {
+        setMedia({ width: BELOW })
+
+        await waitFor(() => result.current)
+
+        /**
+         * Keep the same state as before
+         */
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          })
+        )
+      })
+    })
+
+    it('will return isSSR=true during SSR', () => {
+      setMedia({ width: SMALL })
+
+      window.matchMedia = undefined
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: false,
+          isSSR: true,
+        })
+      )
+    })
+
+    it('will re-render component', async () => {
+      let count = 0
+      const MockComponent = (options = null) => {
+        const { isSmall, isMedium, isLarge, isSSR } = useMedia(options)
+
+        count++
+
+        return <>{JSON.stringify({ isSmall, isMedium, isLarge, isSSR })}</>
+      }
+      const getContent = () =>
+        JSON.parse(document.querySelector('div').textContent)
+
+      setMedia({ width: SMALL })
+
+      const { rerender } = render(<MockComponent />)
+
+      expect(getContent()).toEqual({
+        isSmall: true,
+        isMedium: false,
+        isLarge: false,
+        isSSR: false,
+      })
+
+      await actOnRender(async () => {
+        setMedia({ width: MEDIUM })
+
+        await waitFor(() =>
+          expect(getContent()).toEqual({
+            isSmall: false,
+            isMedium: true,
+            isLarge: false,
+            isSSR: false,
+          })
+        )
+
+        setMedia({ width: LARGE })
+
+        await waitFor(() => {
+          expect(getContent()).toEqual({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+            isSSR: false,
+          })
+        })
+
+        setMedia({ width: BELOW })
+
+        await waitFor(() => {
+          expect(getContent()).toEqual({
+            isSmall: true,
+            isMedium: false,
+            isLarge: false,
+            isSSR: false,
+          })
+        })
+
+        setMedia({ width: ABOVE })
+
+        await waitFor(() => {
+          expect(getContent()).toEqual({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+            isSSR: false,
+          })
+        })
+
+        // reset before re-render
+        setMedia({ width: SMALL })
+      })
+
+      rerender(<MockComponent disabled={true} />)
+
+      // Now it should use the state it has before
+      await actOnRender(async () => {
+        const disabledState = {
+          isSmall: true,
+          isMedium: false,
+          isLarge: false,
+          isSSR: false,
+        }
+
+        setMedia({ width: MEDIUM })
+        await waitFor(() => expect(getContent()).toEqual(disabledState))
+
+        setMedia({ width: LARGE })
+        await waitFor(() => expect(getContent()).toEqual(disabledState))
+      })
+
+      rerender(<MockComponent disabled={false} key="reset-me" />)
+
+      await actOnRender(async () => {
+        setMedia({ width: MEDIUM })
+
+        await waitFor(() =>
+          expect(getContent()).toEqual({
+            isSmall: false,
+            isMedium: true,
+            isLarge: false,
+            isSSR: false,
+          })
+        )
+
+        setMedia({ width: LARGE })
+
+        await waitFor(() =>
+          expect(getContent()).toEqual({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+            isSSR: false,
+          })
+        )
+      })
+
+      expect(count).toBe(10)
+    })
+
+    describe('breakpoints', () => {
+      it('will react to all possible sizes', async () => {
+        setMedia({ width: ABOVE })
+
+        const SMALL = '39em' // 40em
+        const MEDIUM = '59em' // 60em
+        const LARGE = '71em' // 72em
+
+        const wrapper = (props) => (
+          <Provider
+            {...props}
+            value={{
+              breakpoints: {
+                small: '40em',
+                medium: '60em',
+                large: '72em',
+              },
+            }}
+          />
+        )
+        const { result } = renderHook(useMedia, { wrapper })
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            isSmall: false,
+            isMedium: false,
+            isLarge: true,
+          })
+        )
+
+        const queries = [
+          {
+            width: BELOW,
+            expectResult: expect.objectContaining({
+              isSmall: true,
+              isMedium: false,
+              isLarge: false,
+            }),
+          },
+          {
+            width: ABOVE,
+            expectResult: expect.objectContaining({
+              isSmall: false,
+              isMedium: false,
+              isLarge: true,
+            }),
+          },
+          {
+            width: MEDIUM,
+            expectResult: expect.objectContaining({
+              isSmall: false,
+              isMedium: true,
+              isLarge: false,
+            }),
+          },
+          {
+            width: LARGE,
+            expectResult: expect.objectContaining({
+              isSmall: false,
+              isMedium: false,
+              isLarge: true,
+            }),
+          },
+          {
+            width: SMALL,
+            expectResult: expect.objectContaining({
+              isSmall: true,
+              isMedium: false,
+              isLarge: false,
+            }),
+          },
+          {
+            width: BELOW,
+            expectResult: expect.objectContaining({
+              isSmall: true,
+              isMedium: false,
+              isLarge: false,
+            }),
+          },
+        ]
+
+        for await (const { width, expectResult } of queries) {
+          await act(async () => {
+            setMedia({ width })
+
+            await waitFor(() => result.current)
+
+            expect(result.current).toEqual(expectResult)
+          })
+        }
+      })
+    })
+  })
+
+  describe('using jest-matchmedia-mock mocker', () => {
+    const SMALL = '40em'
+    const MEDIUM = '50em'
+
+    const matchMedia = mockMediaQuery()
+    const matchMediaMock = window.matchMedia // set in mockMediaQuery
+
+    beforeEach(() => {
+      jest.spyOn(window, 'matchMedia').mockImplementation(matchMediaMock)
+    })
+
+    it('will return positive isSmall', () => {
+      const query = `(min-width: 0em) and (max-width: ${SMALL})`
+      matchMedia.useMediaQuery(query)
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: true,
+          isMedium: false,
+          isLarge: false,
+        })
+      )
+    })
+
+    it('will return positive isMedium', () => {
+      const query = `(min-width: ${SMALL}) and (max-width: ${MEDIUM})`
+      matchMedia.useMediaQuery(query)
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: true,
+          isLarge: false,
+        })
+      )
+    })
+
+    it('will return positive isLarge', () => {
+      const query = `(min-width: ${MEDIUM})`
+      matchMedia.useMediaQuery(query)
+
+      const { result } = renderHook(useMedia)
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSmall: false,
+          isMedium: false,
+          isLarge: true,
+        })
+      )
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/shared/index.js
+++ b/packages/dnb-eufemia/src/shared/index.js
@@ -7,6 +7,7 @@ import Context from './Context'
 import Provider from './Provider'
 import MediaQuery from './MediaQuery'
 import useMediaQuery from './useMediaQuery'
+import useMedia from './useMedia'
 export * from './SpacingHelper'
 
-export { Context, Provider, MediaQuery, useMediaQuery }
+export { Context, Provider, MediaQuery, useMediaQuery, useMedia }

--- a/packages/dnb-eufemia/src/shared/stories/MediaQuery.stories.tsx
+++ b/packages/dnb-eufemia/src/shared/stories/MediaQuery.stories.tsx
@@ -7,10 +7,43 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 import Button from '../../components/button/Button'
-import { Provider, MediaQuery, useMediaQuery } from '../'
+import { Provider, MediaQuery, useMediaQuery, useMedia } from '../'
 
 export default {
   title: 'Eufemia/Helpers/MediaQuery',
+}
+
+const useWindowWidth = () => {
+  const [innerWidth, setWidth] = React.useState(
+    typeof window !== 'undefined' ? window.innerWidth : 0
+  )
+
+  React.useEffect(() => {
+    const resizeHandler = () => {
+      setWidth(window.innerWidth)
+    }
+    window.addEventListener('resize', resizeHandler)
+    return () => window.removeEventListener('resize', resizeHandler)
+  }, [])
+
+  return { innerWidth }
+}
+
+export const UseMediaHook = () => {
+  const { isSmall, isMedium, isLarge, isSSR } = useMedia()
+  const { innerWidth } = useWindowWidth()
+
+  console.dir({ isSmall, isMedium, isLarge, isSSR, innerWidth })
+
+  return (
+    <pre>
+      {JSON.stringify(
+        { isSmall, isMedium, isLarge, isSSR, innerWidth },
+        null,
+        2
+      )}
+    </pre>
+  )
 }
 
 const Div1 = styled.div`

--- a/packages/dnb-eufemia/src/shared/useMedia.tsx
+++ b/packages/dnb-eufemia/src/shared/useMedia.tsx
@@ -1,0 +1,150 @@
+import React from 'react'
+import Context from './Context'
+import {
+  makeMediaQueryList,
+  createMediaQueryListener,
+  isMatchMediaSupported,
+  MediaQueryCondition,
+} from './MediaQueryUtils'
+import type { MediaQueryListener } from './MediaQueryUtils'
+import { toPascalCase } from './component-helper'
+
+export type UseMediaProps = {
+  /**
+   * If set to true, no MediaQuery will be used.
+   * Default: false
+   */
+  disabled?: boolean
+
+  /**
+   * For debugging
+   */
+  log?: boolean
+}
+
+export type UseMediaQueries = {
+  small: MediaQueryCondition
+  medium: MediaQueryCondition
+  large: MediaQueryCondition
+}
+
+export const queries: UseMediaQueries = {
+  small: { min: 0, max: 'small' },
+  medium: { min: 'small', max: 'medium' },
+  large: { min: 'medium' },
+}
+
+export type UseMediaResult = {
+  isSmall: boolean
+  isMedium: boolean
+  isLarge: boolean
+  isSSR: boolean
+}
+
+/**
+ * Internal stuff
+ */
+
+type UseMediaItem = {
+  event: MediaQueryListener
+  mediaQueryList: MediaQueryList
+}
+
+type UseMediaQueryProps = {
+  name: string
+  when: MediaQueryCondition
+}
+
+export default function useMedia(
+  props: UseMediaProps = {}
+): UseMediaResult {
+  const { disabled, log } = props
+
+  const makeResult = () => {
+    return Object.entries(queries).reduce(
+      (acc, [key, when]) => {
+        const name = `is${toPascalCase(key)}`
+
+        if (disabled) {
+          acc[name] = false
+          return acc
+        }
+
+        defaults.current[name] = false
+
+        const item = runQuery({
+          name,
+          when,
+        })
+
+        acc[name] = item?.mediaQueryList?.matches || false
+
+        refs.current[key] = item
+
+        return acc
+      },
+      { isSSR: !isMatchMediaSupported() }
+    ) as UseMediaResult
+  }
+
+  const runQuery = ({ when, name }: UseMediaQueryProps): UseMediaItem => {
+    if (!isMatchMediaSupported()) {
+      return // do nothing
+    }
+
+    const mediaQueryList = makeMediaQueryList(
+      {
+        when,
+        disabled,
+        log,
+
+        /**
+         * Because it returns fixed variables.
+         * The developer do not need to know the cause of the not working useMedia Hook,
+         * when it's used inside other components.
+         */
+        dismissWarning: true,
+      },
+
+      context.breakpoints
+    )
+
+    const event = createMediaQueryListener(mediaQueryList, (match) => {
+      if (!disabledRef.current && match) {
+        const state = {
+          ...defaults.current,
+          isSSR: result.isSSR,
+        } as UseMediaResult
+        state[name] = match
+        updateRerender(state)
+      }
+    })
+
+    return { event, mediaQueryList }
+  }
+
+  React.useEffect(() => {
+    // If it was disabled before
+    if (disabledRef.current && !disabled) {
+      updateRerender(makeResult())
+    }
+    disabledRef.current = disabled
+  }, [disabled]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => removeListeners, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const context = React.useContext(Context)
+
+  const refs = React.useRef({})
+  const defaults = React.useRef({})
+  const disabledRef = React.useRef(disabled)
+  const [result, updateRerender] =
+    React.useState<UseMediaResult>(makeResult)
+  const removeListeners = () => {
+    Object.values(refs.current).forEach(
+      (item: UseMediaItem) => item?.event && item.event()
+    )
+  }
+
+  return result
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3131,6 +3131,7 @@ __metadata:
     lodash.isequalwith: 4.4.0
     markdown-tables-to-json: 0.1.7
     mkdirp: 1.0.4
+    mock-match-media: 0.3.0
     node-sass: 5.0.0
     node-sass-once-importer: 5.3.2
     nodemon: 2.0.15
@@ -12735,6 +12736,13 @@ __metadata:
   peerDependencies:
     webpack: ^4.27.0 || ^5.0.0
   checksum: fb0742b30ac0919f94b99a323bdefe6d48ae46d66c7d966aae59031350532f368f8bba5951fcd268f2e053c5e6e4655551076268e9073ccb58e453f98ae58f8e
+  languageName: node
+  linkType: hard
+
+"css-mediaquery@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "css-mediaquery@npm:0.1.2"
+  checksum: 8e26ae52d8aaaa71893f82fc485363ff0fab494b7d3b3464572aaed50714b8b538d33dbdaa69f0c02cf7f80d1f4d9a77519306c0492223ce91b3987475031a69
   languageName: node
   linkType: hard
 
@@ -24374,6 +24382,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
+  languageName: node
+  linkType: hard
+
+"mock-match-media@npm:0.3.0":
+  version: 0.3.0
+  resolution: "mock-match-media@npm:0.3.0"
+  dependencies:
+    css-mediaquery: ^0.1.2
+  checksum: b26768348b4c38f3ecaef30345370013965ea76638027dbe3275f405041ea068f994c9cd7a6b15094820809af9dab791e8f9409f98a874f70b59d538516ba569
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a new React Hook that is based on the already existing internals of the existing [`useMediaQuery`](https://eufemia.dnb.no/uilib/usage/layout/media-queries/#usemediaquery-hook-usage) React Hook.

The new `useMedia` hooks is a fixed and simplified version of it. 

Before you would have to do this:

```jsx
  const isSmall = useMediaQuery({ when: { max: 'small' } })
```

While with this hook, you can do this:

```jsx
  const { isSmall, isMedium, isLarge } = useMedia()
```

In v10 of Eufemia the breakpoints will be changed and aligned in this PR #1373 – if you want to use this hook once released, and with v9 – then you may want to define the internally used breakpoints by yourselves.

**NB:** It should be done only temporary, because DNB should align on set of breakpoints to best UX and consistency.

```jsx
<Provider
  value={{
    breakpoints: {
      small: '40em',
      medium: '60em',
      large: '72em',
    },
  }}
 >
 <App /> {/* if app uses useMedia */}
</Provider>
```


