### PR TITLE
fix(Breadcrumb): support null as children

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -43,9 +43,11 @@ export const BreadcrumbMultiple = ({
           )
         })}
 
-        {items?.map((item, i) =>
-          React.cloneElement(item, { key: i, itemNr: i })
-        )}
+        {items
+          ?.filter((item) => React.isValidElement(item))
+          .map((item, i) =>
+            React.cloneElement(item, { key: i, itemNr: i })
+          )}
       </Section>
     </HeightAnimation>
   )

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -45,6 +45,27 @@ describe('Breadcrumb', () => {
     expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(3)
   })
 
+  it('should handle children as null', () => {
+    render(
+      <Breadcrumb>
+        {null}
+        <Breadcrumb.Item text="Page item #1" />
+        {null}
+        {null}
+        <Breadcrumb.Item text="Page item #2" />
+        {null}
+        {null}
+        {null}
+        <Breadcrumb.Item text="Page item #3" />
+        {null}
+        {null}
+        <Breadcrumb.Item text="Page item #4" />
+      </Breadcrumb>
+    )
+
+    expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(4)
+  })
+
   it('renders a breadcrumb with one item', () => {
     render(
       <Provider locale="en-GB">

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -16,7 +16,6 @@ import {
 import Breadcrumb from '../Breadcrumb'
 import { Provider } from '../../../shared'
 import { BreadcrumbItemProps } from '../BreadcrumbItem'
-// import BreadcrumbItem from '../BreadcrumbItem'
 
 export default {
   title: 'Eufemia/Components/Breadcrumb',
@@ -147,5 +146,25 @@ export const CollapsedBreadcrumbWithSpacing = () => {
     <Provider>
       <Breadcrumb data={breadcrumbItems} variant="collapse" spacing />
     </Provider>
+  )
+}
+
+export const SupportsChildrenAsNull = () => {
+  return (
+    <Wrapper>
+      <Box>
+        <Breadcrumb>
+          {null}
+          <Breadcrumb.Item text="Page item#1" />
+          {null}
+          {null}
+          <Breadcrumb.Item text="Page item#2" />
+          <Breadcrumb.Item text="Page item#3" />
+          {null}
+          {null}
+          {null}
+        </Breadcrumb>
+      </Box>
+    </Wrapper>
   )
 }


### PR DESCRIPTION
After the following [change](https://github.com/dnbexperience/eufemia/pull/1605/files#diff-105824c101ceb4b6537e4898deff813846530866c5e7a1040807ba39a7f07d75R47), where we now use React.cloneElement, the following code snippet would result in an error:
```
<Breadcrumb>
   <Breadcrumb.Item />
   <Breadcrumb.Item />
   {null}
</Breadcrumb>
```

The error:
`React.cloneElement(...): The argument must be a React element, but you passed null.`

The suggested fix is just to remove/filter out not valid React elements. before trying to clone them.

This should fix it when passing children, but should we add support for this when passing `null` in `data` as well? 
Or is it just normal(not expected by the consumer) to not be able to pass null in this situation 🤔 
```
<Breadcrumb data={[ { text: "A" }, { text: "B" }, null ]} />
```