### PR TITLE
chore(build): ensure that importing from src is not used inside /src directory

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
         with:
-          persist-credentials: false
+          persist-credentials: true # ensure we "persist-credentials" in order to be able to run "git diff"
+          fetch-depth: 2
 
       - name: Use Node.js
         uses: actions/setup-node@v2

--- a/packages/dnb-eufemia/.eslintrc
+++ b/packages/dnb-eufemia/.eslintrc
@@ -39,13 +39,12 @@
     "no-restricted-imports": [
       "error",
       {
-        "paths": [
+        "patterns": [
           {
-            "name": "@dnb/eufemia",
+            "group": ["@dnb/eufemia/*"],
             "message": "Do not use recursive module @dnb/eufemia!"
           }
-        ],
-        "patterns": ["@dnb/eufemia/*"]
+        ]
       }
     ],
     "no-console": "off",
@@ -118,6 +117,26 @@
         "import/default": "off",
         "import/no-named-as-default-member": "off",
         "import/no-named-as-default": "off"
+      }
+    },
+    {
+      "files": ["**/src/**/*"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["@dnb/eufemia/*"],
+                "message": "Do not use recursive module @dnb/eufemia!"
+              },
+              {
+                "group": ["**/src/*"],
+                "message": "Do not import from src – but rather define correct relative paths!"
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.js
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.js
@@ -7,6 +7,7 @@
 import fs from 'fs-extra'
 import path from 'path'
 import packpath from 'packpath'
+import { getCommittedFiles } from '../../tools/cliTools'
 
 const makeStagePathException = (stage) => (stage === '/esm' ? '' : stage)
 
@@ -88,6 +89,25 @@ describe('type definitions', () => {
 
 describe('babel build', () => {
   const buildStages = ['/es', '/esm', '/cjs']
+
+  it('imports inside "src" should not contain "/src/"', async () => {
+    const files = await getCommittedFiles()
+
+    files
+      .filter((filePath) => {
+        return filePath.includes('/dnb-eufemia/src/')
+      })
+      .map((filePath) => {
+        return filePath.replace('packages/dnb-eufemia/', '')
+      })
+      .forEach((filePath) => {
+        const content = fs.readFileSync(
+          path.resolve(process.cwd(), filePath),
+          'utf-8'
+        )
+        expect(content).not.toMatch(/.*import.*(\/src\/)/)
+      })
+  })
 
   it.each(buildStages)('has correctly compiled on stage "%s"', (stage) => {
     switch (stage) {

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -7,7 +7,7 @@
 // run: yarn nodemon --exec 'babel-node --extensions .js,.ts,.tsx ./scripts/postbuild/getNextReleaseVersion.js' --ext js --watch './scripts/**/*'
 // run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
-const { exec } = require('child_process')
+const { runCommand } = require('../tools/cliTools')
 const getBranchName = require('current-git-branch')
 const dotenv = require('dotenv')
 
@@ -46,24 +46,6 @@ async function getNextReleaseVersion() {
   }
 
   return null
-}
-
-function runCommand(command) {
-  return new Promise((resolve, reject) => {
-    try {
-      exec(command, (error, stdout, stderr) => {
-        if (error) {
-          return reject(error)
-        }
-        if (stderr) {
-          return reject(stderr)
-        }
-        return resolve(stdout)
-      })
-    } catch (e) {
-      reject(e)
-    }
-  })
 }
 
 exports.releaseBranches = releaseBranches

--- a/packages/dnb-eufemia/scripts/tools/cliTools.js
+++ b/packages/dnb-eufemia/scripts/tools/cliTools.js
@@ -19,7 +19,7 @@ function runCommand(command) {
 }
 
 /**
- * Returns a list of files that where changed in the current branch
+ * Returns a list of files that were changed in the current branch
  *
  * NB: In order to use "git diff" fetch-depth: needs to be set to 2 or 0 (0 takes a long time) in GitHub Actions
  *

--- a/packages/dnb-eufemia/scripts/tools/cliTools.js
+++ b/packages/dnb-eufemia/scripts/tools/cliTools.js
@@ -1,0 +1,37 @@
+const { exec } = require('child_process')
+
+function runCommand(command) {
+  return new Promise((resolve, reject) => {
+    try {
+      exec(command, (error, stdout, stderr) => {
+        if (error) {
+          return reject(error)
+        }
+        if (stderr) {
+          return reject(stderr)
+        }
+        return resolve(stdout)
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+/**
+ * Returns a list of files that where changed in the current branch
+ *
+ * NB: In order to use "git diff" fetch-depth: needs to be set to 2 or 0 (0 takes a long time) in GitHub Actions
+ *
+ * @returns {array} List of files
+ */
+const getCommittedFiles = async () => {
+  const files = (await runCommand('git diff HEAD^ --name-only'))
+    .split('\n')
+    .filter(Boolean)
+
+  return files
+}
+
+exports.runCommand = runCommand
+exports.getCommittedFiles = getCommittedFiles


### PR DESCRIPTION
To prevent import path that are invalid in the final build we add:

- eslint rule
- postbuild test

Both are verified to work as expected:

<img width="583" alt="Screenshot 2022-10-24 at 13 04 27" src="https://user-images.githubusercontent.com/1501870/197513880-7433a3ea-21b0-488d-af15-2a318b380ff5.png">

<img width="555" alt="Screenshot 2022-10-24 at 11 18 29" src="https://user-images.githubusercontent.com/1501870/197513874-27d15c0f-4bd0-451a-a448-7592bf9d2e9f.png">


