### PR TITLE
chore(CI): upgrade GitHub Actions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -38,17 +38,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'
@@ -78,17 +78,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ./.yarn/cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,17 +38,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -35,17 +35,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'
@@ -61,7 +61,7 @@ jobs:
         run: echo "::set-output name=timestamp::$(date +'%Y-%W')"
 
       - name: Use Gatsby cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gatsby-cache
         with:
           path: |
@@ -86,17 +86,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.17.0
+          node-version-file: 'package.json'
 
       - name: Use yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ./.yarn/cache

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@storybook/preset-ie11@0.0.1": "patch:@storybook/preset-ie11@npm:0.0.1#.yarn/patches/@storybook-preset-ie11-npm-0.0.1-f80c765898"
   },
   "engines": {
-    "node": ">=12.22.1",
-    "yarn": ">=1.17.0"
+    "node": "14.17.0",
+    "yarn": ">=1.22.10"
   },
   "volta": {
     "node": "14.17.0",


### PR DESCRIPTION
This is nice, small improvement. This way, we define what Node.js version is used in just one single place.

Node.js version will now be used from Volta settings: https://github.com/actions/setup-node/releases/tag/v3.5.0
