### PR TITLE
fix(Breadcrumb): support a single child

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -49,7 +49,9 @@ export interface BreadcrumbProps {
    * The content of the component. Can be used instead of prop "data".
    * Default: null
    */
-  children?: Array<React.ReactElement<BreadcrumbItemProps>>
+  children?:
+    | React.ReactElement<BreadcrumbItemProps>
+    | Array<React.ReactElement<BreadcrumbItemProps>>
 
   /**
    * The variant of the component.

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -7,7 +7,9 @@ type BreadcrumbMultipleProps = {
   isCollapsed: boolean
   noAnimation: boolean
   data: Array<BreadcrumbItemProps>
-  items: Array<React.ReactElement<BreadcrumbItemProps>>
+  items:
+    | React.ReactElement<BreadcrumbItemProps>
+    | Array<React.ReactElement<BreadcrumbItemProps>>
 }
 
 export const BreadcrumbMultiple = ({
@@ -43,9 +45,9 @@ export const BreadcrumbMultiple = ({
           )
         })}
 
-        {items
-          ?.filter((item) => React.isValidElement(item))
-          .map((item, i) =>
+        {React.Children.toArray(items)
+          .filter((item) => React.isValidElement(item))
+          .map((item: React.ReactElement<BreadcrumbItemProps>, i) =>
             React.cloneElement(item, { key: i, itemNr: i })
           )}
       </Section>

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -33,6 +33,14 @@ describe('Breadcrumb', () => {
     expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(3)
   })
 
+  it('renders a breadcrumb with a single item by data prop', () => {
+    render(
+      <Breadcrumb data={[{ href: '/page1/page2', text: 'Page 2' }]} />
+    )
+
+    expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(1)
+  })
+
   it('renders a breadcrumb with multiple items by children', () => {
     render(
       <Breadcrumb>
@@ -43,6 +51,22 @@ describe('Breadcrumb', () => {
     )
 
     expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(3)
+  })
+
+  it('renders a breadcrumb with a single item by children', () => {
+    render(
+      <Breadcrumb>
+        <Breadcrumb.Item text="Page item #1" />
+      </Breadcrumb>
+    )
+
+    expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(1)
+  })
+
+  it('should handle a breadcrumb with a single null as children', () => {
+    render(<Breadcrumb>{null}</Breadcrumb>)
+
+    expect(screen.queryAllByTestId('breadcrumb-item')).toHaveLength(0)
   })
 
   it('should handle children as null', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -149,17 +149,31 @@ export const CollapsedBreadcrumbWithSpacing = () => {
   )
 }
 
+export const SingleBreadcrumb = () => {
+  return (
+    <Wrapper>
+      <Box>
+        <Breadcrumb>
+          <Breadcrumb.Item text="Page item#1" href="/" />
+        </Breadcrumb>
+        <Breadcrumb>{null}</Breadcrumb>
+        <Breadcrumb data={[{ text: 'Page item#1', href: '/' }]} />
+      </Box>
+    </Wrapper>
+  )
+}
+
 export const SupportsChildrenAsNull = () => {
   return (
     <Wrapper>
       <Box>
         <Breadcrumb>
           {null}
-          <Breadcrumb.Item text="Page item#1" />
+          <Breadcrumb.Item text="Page item#1" href="/" />
           {null}
           {null}
-          <Breadcrumb.Item text="Page item#2" />
-          <Breadcrumb.Item text="Page item#3" />
+          <Breadcrumb.Item text="Page item#2" href="/" />
+          <Breadcrumb.Item text="Page item#3" href="/" />
           {null}
           {null}
           {null}


### PR DESCRIPTION
Types and code did not support passing a single child as children to Breadcrumb component.

When only passing a single breadcrumb.item as children the type would report a problem:
<img width="862" alt="image" src="https://user-images.githubusercontent.com/1359205/197760171-65150923-5575-4387-a0a1-3f06a1eb40c6.png">

Also, when only passing a single breadcrumb.item as children, the filter I added [here](https://github.com/dnbexperience/eufemia/pull/1661/files#diff-105824c101ceb4b6537e4898deff813846530866c5e7a1040807ba39a7f07d75R47) will make the code break, as an object can't do "filter".

This PR should fix these two issues.