### PR TITLE
fix(Table Tr): support a single child

### DIFF
--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -6,7 +6,9 @@ export type TableTrProps = {
   /**
    * The content of the component.
    */
-  children: Array<React.ReactElement<TableTdProps>>
+  children:
+    | React.ReactElement<TableTdProps>
+    | Array<React.ReactElement<TableTdProps>>
 
   /**
    * Custom className on the component root


### PR DESCRIPTION
In light of https://github.com/dnbexperience/eufemia/pull/1668, I was looking for other scenarios where our types should also support a single react element, and not only an array/list of react elements.