### PR TITLE
feat(Upload): accept jpeg when only jpg is defined

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/properties.md
@@ -26,4 +26,4 @@ showTabs: true
 
 ## JPG vs JPEG
 
-When `jpg` is define (most commonly used) then the component will also accept `jpeg` files.
+When `jpg` is defined (most commonly used), then the component will also accept `jpeg` files.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/properties.md
@@ -6,7 +6,7 @@ showTabs: true
 
 | Properties                                  | Description                                                                               |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `acceptedFileTypes`                         | _(required)_ List of accepted file types.                                                 |
+| `acceptedFileTypes`                         | _(required)_ List of accepted file types. More details above.                             |
 | `filesAmountLimit`                          | _(optional)_ Defines the amount of files the user can select and upload. Defaults to 100. |
 | `fileMaxSize`                               | _(optional)_ `fileMaxSize` is max size of each file in MB. Defaults to 5 MB.              |
 | `title`                                     | _(optional)_ Custom text property. Replaces the default title.                            |
@@ -23,3 +23,7 @@ showTabs: true
 | `fileListAriaLabel`                         | _(optional)_ Custom text property. Replaces the default list aria label.                  |
 | `skeleton`                                  | _(optional)_ Skeleton should be applied when loading content Default: `null`.             |
 | [Space](/uilib/components/space/properties) | _(optional)_ Spacing properties like `top` or `bottom` are supported.                     |
+
+## JPG vs JPEG
+
+When `jpg` is define (most commonly used) then the component will also accept `jpeg` files.

--- a/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 
 // Components
 import Button from '../button/Button'
@@ -12,6 +12,7 @@ import { makeUniqueId } from '../../shared/component-helper'
 // Internal
 import { UploadContext } from './UploadContext'
 import UploadStatus from './UploadStatus'
+import { extendWithAbbreviation } from './UploadVerify'
 
 const UploadFileInput = () => {
   const fileInput = useRef<HTMLInputElement>(null)
@@ -26,19 +27,12 @@ const UploadFileInput = () => {
     filesAmountLimit,
   } = context
 
-  const accept = acceptedFileTypes.reduce((accept, format, index) => {
-    const previus = index === 0 ? '' : `${accept},`
-    return `${previus} .${format}`
-  }, '')
-
-  useEffect(() => {
-    fileInput.current.value = null
-    fileInput.current.accept = accept
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
   const openFileDialog = () => fileInput.current?.click()
 
   const sharedId = id || makeUniqueId()
+  const accept = extendWithAbbreviation(acceptedFileTypes)
+    .map((type) => `.${type}`)
+    .join(',')
 
   return (
     <div data-testid="upload-file-input">
@@ -62,6 +56,7 @@ const UploadFileInput = () => {
         aria-labelledby={`${sharedId}-input`}
         data-testid="upload-file-input-input"
         ref={fileInput}
+        accept={accept}
         className="dnb-upload__file-input"
         type="file"
         onChange={onChangeHandler}

--- a/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
@@ -1,5 +1,9 @@
 import { format } from '../number-format/NumberUtils'
-import { UploadContextProps, UploadFile } from './types'
+import {
+  UploadFile,
+  UploadContextProps,
+  UploadAcceptedFileTypes,
+} from './types'
 
 const BYTES_IN_A_MEGA_BYTE = 1048576
 
@@ -36,12 +40,14 @@ export function verifyFiles(
     if (acceptedFileTypes.length === 0) {
       return false
     }
-    const foundType = acceptedFileTypes.some((type) => {
-      /**
-       * "file.type" can be e.g. "images/png"
-       */
-      return file.type.includes(type)
-    })
+    const foundType = extendWithAbbreviation(acceptedFileTypes).some(
+      (type) => {
+        /**
+         * "file.type" can be e.g. "images/png"
+         */
+        return file.type.includes(type)
+      }
+    )
     return !foundType ? errorUnsupportedFile : null
   }
 
@@ -58,4 +64,19 @@ export function verifyFiles(
   })
 
   return cleanedFiles
+}
+
+export function extendWithAbbreviation(
+  acceptedFileTypes: UploadAcceptedFileTypes,
+  abbreviations = { jpg: 'jpeg' }
+) {
+  const list = [...acceptedFileTypes]
+
+  Object.entries(abbreviations).forEach(([type, abbr]) => {
+    if (list.some((t) => t === type) && !list.some((t) => t === abbr)) {
+      list.push(abbr)
+    }
+  })
+
+  return list
 }

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -104,7 +104,7 @@ describe('Upload', () => {
     })
 
     it('renders the custom accepted format', () => {
-      const acceptedFileTypes = ['png, jpg']
+      const acceptedFileTypes = ['png', 'jpg']
 
       render(
         <Upload {...defaultProps} acceptedFileTypes={acceptedFileTypes} />

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
@@ -158,6 +158,34 @@ describe('UploadFileInput', () => {
     expect(onInputUpload).toHaveBeenCalledWith([{ file }])
   })
 
+  it('accepts given acceptedFileTypes', async () => {
+    render(<UploadFileInput />, {
+      wrapper: makeWrapper({
+        acceptedFileTypes: ['png', 'pdf'],
+      }),
+    })
+
+    const inputElement = screen.queryByTestId(
+      'upload-file-input-input'
+    ) as HTMLInputElement
+
+    expect(inputElement.accept).toBe('.png,.pdf')
+  })
+
+  it('accepts jpeg when jpg is defined', async () => {
+    render(<UploadFileInput />, {
+      wrapper: makeWrapper({
+        acceptedFileTypes: ['png', 'jpg'],
+      }),
+    })
+
+    const inputElement = screen.queryByTestId(
+      'upload-file-input-input'
+    ) as HTMLInputElement
+
+    expect(inputElement.accept).toBe('.png,.jpg,.jpeg')
+  })
+
   it('can upload multiple files', async () => {
     const file1 = createMockFile('fileName1.png', 100, 'image/png')
     const file2 = createMockFile('fileName2.png', 100, 'image/png')

--- a/packages/dnb-eufemia/src/components/upload/types.ts
+++ b/packages/dnb-eufemia/src/components/upload/types.ts
@@ -2,6 +2,8 @@ import React from 'react'
 import { SkeletonShow } from '../skeleton/Skeleton'
 import { LocaleProps, SpacingProps } from '../../shared/types'
 
+export type UploadAcceptedFileTypes = string[]
+
 export type UploadProps = {
   /**
    * unique id used with the useUpload hook to manage the files
@@ -11,7 +13,7 @@ export type UploadProps = {
   /**
    * list of accepted file types.
    */
-  acceptedFileTypes: string[]
+  acceptedFileTypes: UploadAcceptedFileTypes
 
   /**
    * Skeleton should be applied when loading content


### PR DESCRIPTION
This feature is mostly to prevent potential failures done by devs. Also, the `input` component does this already handle for us. Lets say, this `<input type="file" accept".jpg" />` will make `jpeg` files "select-able".
But we also want the same behavior on the drag&drop feature.