### PR TITLE
chore(release): make "next" releases possible

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -8,11 +8,6 @@ on:
       - '!**--visual-reports'
       - '!wip/**'
       - '!experiments/**'
-      - '!release'
-      - '!portal'
-      - '!beta'
-      - '!alpha'
-      - '!next'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,7 @@ on:
       - '!portal'
       - '!beta'
       - '!alpha'
+      - '!next'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       - 'beta'
       - 'alpha'
       - 'next'
+  workflow_run:
+    workflows: [Verify, Build Check]
+    types: [completed]
 
 jobs:
   action:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - 'portal'
       - 'beta'
       - 'alpha'
+      - 'next'
 
 jobs:
   action:
@@ -32,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+          fetch-depth: 2
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -54,16 +56,9 @@ jobs:
         run: yarn workspace @dnb/eufemia prebuild:ci
 
       - name: Build portal
-        run: yarn workspace dnb-design-system-portal build-ci
-
-      - name: Postbuild Library
-        run: yarn workspace @dnb/eufemia postbuild:ci
-
-      - name: Release
         if: (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/beta' ||
-          github.ref == 'refs/heads/alpha')
-        run: yarn workspace @dnb/eufemia publish:ci
+          github.ref == 'refs/heads/portal')
+        run: yarn workspace dnb-design-system-portal build-ci
 
       - name: Deploy portal
         if: (github.ref == 'refs/heads/release' ||
@@ -72,6 +67,16 @@ jobs:
         with:
           personal_token: ${{ secrets.GH_TOKEN }}
           publish_dir: ./packages/dnb-design-system-portal/public
+
+      - name: Postbuild Library
+        run: yarn workspace @dnb/eufemia postbuild:ci
+
+      - name: Release
+        if: (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/beta' ||
+          github.ref == 'refs/heads/alpha' ||
+          github.ref == 'refs/heads/next')
+        run: yarn workspace @dnb/eufemia publish:ci
 
       - name: Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,11 +8,6 @@ on:
       - '!**--visual-reports'
       - '!wip/**'
       - '!experiments/**'
-      - '!release'
-      - '!portal'
-      - '!beta'
-      - '!alpha'
-      - '!next'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,6 +12,7 @@ on:
       - '!portal'
       - '!beta'
       - '!alpha'
+      - '!next'
   pull_request:
     branches:
       - 'main'

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.md
@@ -20,27 +20,25 @@ The steps, from code changes to production builds, are:
 1. Check the results of the CI tests and builds.
 1. After the _Pull Request_ got approved by one of the authored [maintainers](https://github.com/dnbexperience/eufemia/graphs/contributors),
 1. You can merge your _Pull Request_.
-1. A maintainer will create a _Pull Request_ into one of the release branches (`release`,`alpha` or `beta`).
-1. After a release _Pull Request_ got merged, CI Server will deploy the Portal and release a new version to NPM.
+1. A maintainer will create a _Pull Request_ into one of the release branches (`next`, `alpha`, `beta` or `release`).
+1. After a release _Pull Request_ got merged, the CI Server will deploy the Portal and release a new version to NPM.
 
-### The Release Branch
+### How to make releases
 
 Make sure you only make _Pull Request_ from `origin/main` into `origin/release`.
 The release branch (`origin/release`) is more like a _secondary branch_. It contains the state of the latest version as well as all the git tags – each containing a new version number.
 
-### How to release alpha/beta versions
+#### How to release the first `next`, `alpha` or `beta`?
 
-In order to deal with rebasing and merging of several branches, it may be preferable to do it locally. You would then need git _push to remove_ access (GitHub).
-
-#### How to release the first beta?
-
-First, we need to ensure our beta branch contains the latest git tag :
+First, we need to ensure our beta branch contains the latest git tags:
 
 1. `git fetch`
 2. `git switch origin/beta`
 3. `git reset --hard origin/release`
 
-Now, you may either merge locally or via a pull request on remote (GitHub):
+Now, you may either merge/cherry-pick locally or via a _Pull Request_:
+
+In order to deal with rebasing and merging of several branches, it may be preferable to do it locally. You need git _push to remote_ access (GitHub).
 
 We continue locally:
 
@@ -49,7 +47,7 @@ We continue locally:
 
 Our beta version will now get released.
 
-#### How to release more alpha/beta versions?
+#### How to release another `next`, `alpha` or `beta` version?
 
 1. `git switch {your-feature-branch}`
 2. `git checkout -b {your-feature-branch}-beta`

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.md
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.md
@@ -28,6 +28,8 @@ The steps, from code changes to production builds, are:
 Make sure you only make _Pull Request_ from `origin/main` into `origin/release`.
 The release branch (`origin/release`) is more like a _secondary branch_. It contains the state of the latest version as well as all the git tags – each containing a new version number.
 
+_NB:_ All example steps are for `beta` versions, but will apply for `next` or `alpha` versions as well.
+
 #### How to release the first `next`, `alpha` or `beta`?
 
 First, we need to ensure our beta branch contains the latest git tags:
@@ -57,6 +59,14 @@ Our beta version will now get released.
 6. `git push --force-with-lease`
 
 Our beta version will now get released.
+
+### How run a dry release locally
+
+If you are unsure about what version will be released, you can run a so called dry-run locally.
+
+Run the steps and prepare the git branches as above, but before you push to origin, you can run:
+
+1. `yarn publish:dry`
 
 ## How to create a local package
 

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -271,6 +271,7 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "release",
+      "next",
       {
         "name": "beta",
         "prerelease": true


### PR DESCRIPTION
Make it possible to release versions to the `next` NPM tag. Its very the same as beta and alpha. So we may have a discussion on what should run of tests and if this version "info" should be pushed back to GitHub, like here: https://github.com/dnbexperience/eufemia/releases/tag/v9.35.0