### PR TITLE
fix(StepIndicator): add example on how to use it with a router (browser location)

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
@@ -16,7 +16,7 @@ v10 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 
 1. Find the `active_item` property and replace it with `current_step`.
 1. Find `use_navigation` and remove it or replace it with `mode="strict"` or `mode="loose"`.
-1. URL support has been removed – so props like `active_url`, `url`, `url_future`, and `url_passed` are not supported anymore. You have to handle it by yourself from inside your application.
+1. URL support has been removed – so props like `active_url`, `url`, `url_future`, and `url_passed` are not supported anymore. You have to handle it by yourself from inside your application. Here is [an example](/uilib/components/step-indicator/#stepindicator-with-a-router).
 
 ### Table
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.js
@@ -265,10 +265,55 @@ export const StepIndicatorCustomRenderer = () => (
   </ComponentBox>
 )
 
+export const StepIndicatorRouter = () => (
+  <ComponentBox scope={{ createBrowserHistory }} useRender>
+    {
+      /* jsx */ `
+const StepIndicatorWithRouter = () => {
+  const [currentStep, setCurrentStep] = React.useState(1)
+  const [history, setInstance] = React.useState(null)
+  React.useEffect(()=>{
+    const history = createBrowserHistory()
+    const step = parseFloat(history.location.search?.replace(/[?]/, '')) || 1
+    setCurrentStep(step)
+    setInstance(history)
+  }, [])
+  return (
+    <>
+      <StepIndicator
+        sidebar_id="step-indicator-router"
+        mode="loose"
+        current_step={currentStep - 1}
+        on_change={({ current_step }) => {
+          const step = current_step + 1
+          setCurrentStep(step)
+          history.push('?' + step)
+        }}
+        data={[
+          {
+            title: 'Om din nye bolig',
+          },
+          {
+            title: 'Ditt lån og egenkapital',
+          },
+          {
+            title: 'Oppsummering',
+          },
+        ]}
+        space
+      />
+      <StepIndicator.Sidebar sidebar_id="step-indicator-router" space />
+    </>
+  )
+}
+render(<StepIndicatorWithRouter />)
+`
+    }
+  </ComponentBox>
+)
+
 export const StepIndicatorUrls = () => (
   <ComponentBox
-    sidebar_id="unique-id-urls"
-    mode="strict"
     data-visual-test="step-indicator-urls"
     scope={{ createBrowserHistory }}
     hideCode
@@ -287,10 +332,10 @@ const StepIndicatorWithUrl = () => {
 	}, [])
 	return (<StepIndicator
 		active_url={activeUrl || '?a'}
-		on_change={() => {
+		on_change={({ event, item }) => {
 			try {
-				e.event.preventDefault()
-				history.push(e.item.url)
+				event.preventDefault()
+				history.push(item.url)
 			} catch (e) {
 				//
 			}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.md
@@ -10,7 +10,8 @@ StepIndicatorCustomized,
 StepIndicatorUrls,
 StepIndicatorSidebar,
 StepIndicatorTextOnly,
-StepIndicatorCustomRenderer
+StepIndicatorCustomRenderer,
+StepIndicatorRouter,
 } from 'Docs/uilib/components/step-indicator/Examples'
 
 ## Demos
@@ -42,6 +43,10 @@ You want to place `<StepIndicator.Sidebar sidebar_id="unique-id-static" />` some
 ### StepIndicator with sidebar
 
 <StepIndicatorSidebar />
+
+### StepIndicator with a router
+
+<StepIndicatorRouter />
 
 ### StepIndicator customized
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.md
@@ -10,6 +10,8 @@ If the user should be able to navigate back and forth, use the `mode="loose"` pr
 
 The current active step is set with the `current_step` property or within the data with the `is_current` object property.
 
+**NB:** Ensure, when ever possible, to bind the `current_step` to the browsers path location. See the [example above](/uilib/components/step-indicator/#stepindicator-with-a-router) or [the example on CodeSandbox](https://codesandbox.io/s/eufemia-step-indicator-with-reach-router-mhu0bh?file=/src/App.tsx).
+
 ## Sidebar
 
 The StepIndicator has two layouts. One for larger screens (above [medium](/uilib/usage/layout/media-queries#media-queries-properties-table)) and one for more narrow screens (below [medium](/uilib/usage/layout/media-queries#media-queries-properties-table)).

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -58,12 +58,12 @@ function Element({
   }
 
   if (isTrue(no_collapse)) {
-    const R = E === 'span' || isInline(Element) ? 'span' : 'div'
+    const R = E === 'span' || isInline(element as string) ? 'span' : 'div'
     return (
       <R
         className={classnames(
           'dnb-space--no-collapse',
-          isInline(Element) && 'dnb-space--inline'
+          isInline(element as string) && 'dnb-space--inline'
         )}
       >
         {component}

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.tsx
@@ -95,6 +95,7 @@ describe('createSpacingClasses', () => {
       'dnb-space__right--x-small',
     ])
   })
+
   it('should return a class with zero classes', () => {
     expect(createSpacingClasses({ right: false })).toEqual([
       'dnb-space__right--zero',
@@ -104,6 +105,17 @@ describe('createSpacingClasses', () => {
     ])
     expect(createSpacingClasses({ right: null })).toEqual([])
   })
+
+  it('should handle frozen props', () => {
+    const props = Object.freeze({ space: true })
+    expect(createSpacingClasses(props)).toEqual([
+      'dnb-space__left--small',
+      'dnb-space__bottom--small',
+      'dnb-space__right--small',
+      'dnb-space__top--small',
+    ])
+  })
+
   it('should handle the space prop for in all directions', () => {
     expect(createSpacingClasses({ space: false })).toEqual([]) // we may extend that with all four "--zero" in future
     expect(createSpacingClasses({ space: 0 })).toEqual([


### PR DESCRIPTION
I think it could be good to have this listed in the change logs, because we have found examples in prod where this is not used. So when the user presses the back button, they will be relocated to another page, instead to the previews step.