### PR TITLE
chore(CI): prevent "dead" runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
   workflow_run:
     workflows: [Verify, Build Check]
     types: [completed]
+    branches:
+      - 'release'
+      - 'portal'
+      - 'beta'
+      - 'alpha'
+      - 'next'
 
 jobs:
   action:


### PR DESCRIPTION
The GitHub Action `workflow_run` does run when one of the listed workflows completes. But we also want to restrict this event to only run on certain branches.
