### PR TITLE
chore(CI): remove not needed setting on checkout

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
         with:
-          persist-credentials: true # ensure we "persist-credentials" in order to be able to run "git diff"
+          persist-credentials: false
           fetch-depth: 2
 
       - name: Use Node.js


### PR DESCRIPTION
Yes, it works without having `persist-credentials` enabled:

https://github.com/dnbexperience/eufemia/actions/runs/3345217778/jobs/5540466406

So I think we should revert this setting as it was before.
