### PR TITLE
chore(Release): make "next" tag to a pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,7 @@ on:
       - 'beta'
       - 'alpha'
       - 'next'
-  workflow_run:
-    workflows: [Verify, Build Check]
-    types: [completed]
-    branches:
-      - 'release'
-      - 'portal'
-      - 'beta'
-      - 'alpha'
-      - 'next'
+      - '*.x'
 
 jobs:
   action:
@@ -60,6 +52,18 @@ jobs:
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
+
+      - name: Audit dependencies
+        run: yarn workspace @dnb/eufemia audit:ci
+
+      - name: Run lint
+        run: yarn workspace @dnb/eufemia lint:ci && yarn workspace dnb-design-system-portal lint:ci
+
+      - name: Run type checks
+        run: yarn workspace @dnb/eufemia test:types && yarn workspace dnb-design-system-portal test:types
+
+      - name: Run tests
+        run: yarn workspace @dnb/eufemia test:ci && yarn workspace dnb-design-system-portal test:ci
 
       - name: Prebuild Library
         run: yarn workspace @dnb/eufemia prebuild:ci

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -271,7 +271,10 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "release",
-      "next",
+      {
+        "name": "next",
+        "prerelease": true
+      },
       {
         "name": "beta",
         "prerelease": true


### PR DESCRIPTION
Something is not quite right. We follow the docs from semantic-release with the existing setup, but still, the next version got released under NPM next dist-tag, but without a suffix of `-next` – and also, the git tag did not get it.

So, for now, I think, we should mark it as a pre-release instead and find a way of not publish any release notes in the GitHub release section. But this has to be done in a separate PR.

Also, running the verify tests before release, is not optimal with the current setup, because it runs regardless, and not in band. So I think we want to remove `workflow_run`. And rather include them in the jobs directly.

Attaching also some screenshots:

<img width="585" alt="Screenshot 2022-11-02 at 13 08 00" src="https://user-images.githubusercontent.com/1501870/199487425-7f6beed7-43f5-45fe-ba7e-864bc8cb90f3.png">
<img width="181" alt="Screenshot 2022-11-01 at 12 59 13" src="https://user-images.githubusercontent.com/1501870/199487475-7585b3d3-2878-419b-8c43-8f2ecd4a9fb7.png">
