### PR TITLE
docs(Upload): Upload loading state example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
@@ -141,7 +141,7 @@ const Component = () => {
       <ToggleButton
         top="small"
         disabled={files.length < 1}
-        checkedonChange={({ checked }) =>
+        on_change={({ checked }) =>
           setFiles(
             files.map((fileItem) => {
               return { ...fileItem, isLoading: checked }


### PR DESCRIPTION
Replaces `checkedonChange` with `on_change`.
Reason for doing so is because the example did not work, and I got the following error in the console:
`Warning: React does not recognize the `checkedonChange` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `checkedonchange` instead. If you accidentally passed it from a parent component, remove it from the DOM element.`