### PR TITLE
fix(Anchor): export types as AnchorAllProps and original instance

### DIFF
--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.js.snap
@@ -468,7 +468,7 @@ exports[`Button component have to match href="..." snapshot 1`] = `
       disabled={false}
       href="https://url"
       id="button"
-      inner_ref={
+      innerRef={
         {
           "current": <a
             class="dnb-button dnb-button--primary dnb-button--has-text class className dnb-button--icon-position-right dnb-button--has-icon dnb-button--icon-size-icon_size dnb-button--wrap dnb-a"

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.js.snap
@@ -754,7 +754,7 @@ exports[`GlobalError snapshot have to match component snapshot 1`] = `
             className="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon"
             disabled={false}
             href="href"
-            inner_ref={
+            innerRef={
               {
                 "current": <a
                   class="dnb-button dnb-button--tertiary dnb-button--has-text dnb-global-error__back dnb-button--icon-position-left dnb-button--has-icon dnb-a"

--- a/packages/dnb-eufemia/src/elements/Anchor.tsx
+++ b/packages/dnb-eufemia/src/elements/Anchor.tsx
@@ -22,33 +22,29 @@ export type AnchorProps = {
   target?: string
   tooltip?: React.ReactNode
   skeleton?: boolean
-  className?: string
-  children?: React.ReactNode
   omitClass?: boolean
-  innerRef?: React.ForwardedRef<unknown>
-
-  // HTML Attributes
-  id?: string
-  title?: string
-  lang?: string
+  innerRef?: React.RefObject<HTMLAnchorElement>
 
   /** @deprecated use innerRef instead */
-  inner_ref?: React.ForwardedRef<unknown>
+  inner_ref?: React.RefObject<HTMLAnchorElement>
 
   /** @deprecated use targetBlankTitle instead */
   target_blank_title?: string
-} & Partial<Omit<HTMLAnchorElement, 'children'>> &
+}
+
+export type AnchorAllProps = AnchorProps &
+  React.HTMLAttributes<HTMLAnchorElement> &
   SpacingProps
 
 const defaultProps = {}
 
-function AnchorInstance(localProps: AnchorProps) {
+export function AnchorInstance(localProps: AnchorAllProps) {
   const context = React.useContext(Context)
   const allProps = extendPropsWithContext(
     localProps,
     defaultProps,
     { skeleton: context?.skeleton },
-    context?.getTranslation(localProps as Partial<AnchorProps>).Anchor,
+    context?.getTranslation(localProps as AnchorAllProps).Anchor,
     context?.Anchor
   )
 
@@ -122,8 +118,10 @@ function AnchorInstance(localProps: AnchorProps) {
   )
 }
 
-const Anchor = React.forwardRef((props: AnchorProps, ref) => {
-  return <AnchorInstance inner_ref={ref} {...props} />
-})
+const Anchor = React.forwardRef(
+  (props: AnchorAllProps, ref: React.RefObject<HTMLAnchorElement>) => {
+    return <AnchorInstance innerRef={ref} {...props} />
+  }
+)
 
 export default Anchor

--- a/packages/dnb-eufemia/src/elements/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/elements/__tests__/Anchor.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { fakeProps, axeComponent } from '../../core/jest/jestSetup'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import Anchor from '../Anchor'
 
 const props = fakeProps(require.resolve('../Anchor'), {
@@ -33,6 +33,21 @@ describe('Anchor element', () => {
       </Anchor>
     )
     expect(document.querySelector('.dnb-anchor--no-icon')).toBeTruthy()
+  })
+
+  it('should forward ref', () => {
+    const ref = React.createRef<HTMLAnchorElement>()
+
+    render(
+      <Anchor ref={ref} to="/url">
+        text
+      </Anchor>
+    )
+
+    act(() => {
+      const element = document.querySelector('.dnb-anchor')
+      expect(ref.current).toBe(element)
+    })
   })
 
   it('has aria-describedby when target is blank', () => {


### PR DESCRIPTION
This way, its possible to use the anchor, without `React.forwardRef` – can be of interest when making its own "wrapper" component.