### PR TITLE
fix(Table): align odd/even modifiers with CSS nth

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -171,12 +171,6 @@ export const TableSticky = () => (
             </Th>
           </Tr>
         </thead>
-        <tfoot>
-          <Tr>
-            <Td colSpan={3}>Footer</Td>
-            <Td>Sum</Td>
-          </Tr>
-        </tfoot>
         <tbody>
           <Table.StickyHelper />
           <Tr>
@@ -205,6 +199,12 @@ export const TableSticky = () => (
             <Td>Column 4</Td>
           </Tr>
         </tbody>
+        <tfoot>
+          <Tr>
+            <Td colSpan={3}>Footer</Td>
+            <Td>Sum</Td>
+          </Tr>
+        </tfoot>
       </Table>
     </ComponentBox>
   </>

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -49,12 +49,12 @@ exports[`Table scss have to match default theme snapshot 1`] = `
     color: var(--theme-color-black-80, currentColor); }
   .dnb-table > tbody > tr,
   .dnb-table .dnb-table__tr,
-  .dnb-table .dnb-table__tr--odd {
-    background-color: var(--color-white); }
-  .dnb-table > tbody > tr:not(.dnb-table__tr--odd):nth-of-type(2n),
-  .dnb-table .dnb-table__tr:not(.dnb-table__tr--odd):nth-of-type(2n),
   .dnb-table .dnb-table__tr--even {
     background-color: var(--color-lavender); }
+  .dnb-table > tbody > tr:not(.dnb-table__tr--even):nth-of-type(2n),
+  .dnb-table .dnb-table__tr:not(.dnb-table__tr--even):nth-of-type(2n),
+  .dnb-table .dnb-table__tr--odd {
+    background-color: var(--color-white); }
   .dnb-table > thead > tr > th::after,
   .dnb-table > tbody > tr:last-of-type > td::after,
   .dnb-table > thead > .dnb-table__tr > .dnb-table__th::after,

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -38,12 +38,6 @@ export const StickyBasicTable = () => {
           </Th>
         </Tr>
       </thead>
-      <tfoot>
-        <Tr>
-          <Td colSpan={3}>Footer</Td>
-          <Td>Sum</Td>
-        </Tr>
-      </tfoot>
       <tbody>
         <Table.StickyHelper />
         <Tr>
@@ -84,6 +78,12 @@ export const StickyBasicTable = () => {
           <Td>Column 4</Td>
         </Tr>
       </tbody>
+      <tfoot>
+        <Tr>
+          <Td colSpan={3}>Footer</Td>
+          <Td>Sum</Td>
+        </Tr>
+      </tfoot>
     </Table>
   )
 }

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-ui.scss
@@ -61,15 +61,15 @@
   // Needs a double & & for specificity
   & > tbody > tr,
   & &__tr,
-  & &__tr--odd {
-    background-color: var(--color-white);
+  & &__tr--even {
+    background-color: var(--color-lavender);
   }
 
   // Needs a double & & for specificity
-  & > tbody > tr:not(#{&}__tr--odd):nth-of-type(2n),
-  & &__tr:not(#{&}__tr--odd):nth-of-type(2n),
-  & &__tr--even {
-    background-color: var(--color-lavender);
+  & > tbody > tr:not(#{&}__tr--even):nth-of-type(2n),
+  & &__tr:not(#{&}__tr--even):nth-of-type(2n),
+  & &__tr--odd {
+    background-color: var(--color-white);
   }
 
   // Border


### PR DESCRIPTION
Because we start counting the tr inside `thead` we did not get the same when using "no" modifier. This PR aligns both to start on `<tr>` inside a table header row.
