### PR TITLE
chore(Docs): make heading and paragraph more searchable

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/heading.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/heading.md
@@ -1,5 +1,6 @@
 ---
 showTabs: true
+description: 'Examples of how to use headings'
 ---
 
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/paragraph.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/paragraph.md
@@ -1,5 +1,6 @@
 ---
 showTabs: true
+description: 'Examples of how to use paragraph'
 ---
 
 import { ParagraphDefault, ParagraphSmall, ParagraphAdditional, ParagraphModifiers } from 'Docs/uilib/typography/Examples'


### PR DESCRIPTION
This PR aims to make heading and paragraph more searchable.
It could be nice to get to https://eufemia.dnb.no/uilib/typography/heading/ and/or https://eufemia.dnb.no/uilib/typography/paragraph/ after searching.

Especially for Paragraph, which I've sometimes struggled to find documentation and examples for.

Could/should I also or instead create a page for Paragraph under https://eufemia.dnb.no/uilib/elements/ ?