### PR TITLE
fix(Provider): rewrite to functional component

### DIFF
--- a/packages/dnb-eufemia/src/components/form-row/FormRowHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/form-row/FormRowHelpers.tsx
@@ -1,12 +1,12 @@
 import { isTrue } from '../../shared/component-helper'
 import { filterValidProps } from '../../shared/helpers/filterValidProps'
 
-type FormRowProps = {
+export type FormRowProps = {
   label_direction?: 'vertical' | 'horizontal'
   vertical?: string | boolean
 }
 
-export const prepareFormRowContext = (props: FormRowProps) => {
+export function prepareFormRowContext<Props>(props: Props & FormRowProps) {
   if (typeof props.label_direction === 'undefined') {
     props.label_direction = isTrue(props.vertical)
       ? 'vertical'

--- a/packages/dnb-eufemia/src/shared/Provider.tsx
+++ b/packages/dnb-eufemia/src/shared/Provider.tsx
@@ -6,7 +6,6 @@
 import React from 'react'
 import Context, { prepareContext } from './Context'
 import type { ContextProps } from './Context'
-import { makeUniqueId } from './component-helper'
 import { prepareFormRowContext } from '../components/form-row/FormRowHelpers'
 
 export type ProviderProps = {
@@ -16,183 +15,82 @@ export type ProviderProps = {
   value?: ContextProps
 
   /**
-   * Define the locale used for every Eufemia components inside this Provider. Defaults to nb-NO
-   */
-  locale?: string
-
-  /**
-   * Enable skeleton of every Eufemia component inside this Provider
-   */
-  skeleton?: boolean | string // SkeletonShow
-
-  /**
    * The content
    */
   children: React.ReactNode
 } & ContextProps
 
-export type ProviderState = {
-  /** For internal use */
-  isRoot?: boolean
-  _listenForPropChanges?: boolean
-  _startupProps?: ContextProps
-} & ContextProps
+export default function Provider<Props>(
+  localProps: ProviderProps & Props
+) {
+  const { children, ...props } = localProps
 
-export default class Provider extends React.PureComponent<
-  ProviderProps,
-  ProviderState
-> {
-  static contextType = Context
+  const context = React.useContext(Context)
+  const [localContext, setLocalContext] = React.useState(null)
 
-  // NB! Do not provide any default props, because they would overwrite inherited values in nested provider
-  static defaultProps: Record<string, unknown> = {}
+  let value = mergeContext(context, { ...localContext, ...props })
 
-  static getDerivedStateFromProps(props, state) {
-    if (state._listenForPropChanges) {
-      const {
-        children, // eslint-disable-line
-        ...updatedProps
-      } = props
-
-      // 1. It's not sure that props have been updated, so we check that here
-      if (state._startupProps !== updatedProps) {
-        let hasChanges = false
-        for (const i in updatedProps) {
-          if (
-            state._startupProps[i] !== updatedProps[i] ||
-            typeof updatedProps[i] === 'boolean'
-          ) {
-            hasChanges = true
-            break
-          }
-        }
-
-        // and if so, update these props
-        if (hasChanges) {
-          state = Object.assign(state, updatedProps)
-          state._startupProps = updatedProps
-        }
-      }
-
-      // 2. The reset will extend the Provider Context
-      if (state.FormRow) {
-        state.FormRow = {
-          ...state.FormRow,
-          ...updatedProps.FormRow,
-        }
-        state.FormRow = prepareFormRowContext(state.FormRow)
-      }
-    }
-
-    state._listenForPropChanges = true
-
-    return prepareContext(state)
+  if (context) {
+    value = prepareContext(value)
+    context.updateTranslation(value.locale, value.translation)
   }
 
-  static mergeContext(props, context) {
-    const { value, ...rest } = props
+  value.update = updateAll
+  value.setLocale = setAllLocale
+  value.updateCurrent = updateCurrent
+  value.setCurrentLocale = setCurrentLocale
 
-    // Make sure we create a copy, because we add some custom methods to it
-    const merge = { ...value, ...rest }
+  return <Context.Provider value={value}>{children}</Context.Provider>
 
-    // Merge our new values with an existing context
-    const mergedContext = { ...context, ...merge }
-
-    // Because we don't want to deep merge, we merge FormRow additionally
-    if (context.FormRow && merge.FormRow) {
-      mergedContext.FormRow = { ...context.FormRow, ...merge.FormRow }
-    }
-
-    return mergedContext
+  function updateCurrent(props: ContextProps) {
+    setLocalContext({ __context__: props })
   }
 
-  constructor(props, context) {
-    super(props)
-
-    const {
-      children, // eslint-disable-line
-      ...startupProps
-    } = props
-
-    /**
-     * Deprecated!
-     *
-     * This is only to ensure backwards compatibility, as the docs has showed before year 2021
-     */
-    if (typeof startupProps.formRow !== 'undefined') {
-      startupProps.FormRow = startupProps.formRow
-    }
-
-    // NB: Make sure we create a copy, because we add some custom methods to it
-    const newContext = Provider.mergeContext(startupProps, context)
-    const isRoot = !(newContext && newContext.__providerId)
-    newContext.__providerId = makeUniqueId()
-
-    // 1. Set default context to be overwritten by the provider props
-    const pC = isRoot ? prepareContext(newContext) : newContext
-
-    // change only current context
-    pC.updateCurrent = (props: ContextProps) => this.setNewContext(props)
-    pC.setCurrentLocale = (locale: string) =>
-      this.setNewContext({ locale })
-
-    // change both the root and the current context
-    pC.update = (props: ContextProps) => {
-      // Update the root context
-      if (typeof context.update === 'function') {
-        context.update(props)
-      }
-
-      this.setNewContext(props)
-    }
-    pC.setLocale = (locale: string) => {
-      // Update the root context
-      if (typeof context.update === 'function') {
-        context.update({ locale })
-      }
-
-      this.setNewContext({ locale })
-    }
-
-    pC.isRoot = isRoot
-    pC._listenForPropChanges = true
-    pC._startupProps = startupProps
-    this.state = pC
+  function setCurrentLocale(locale: string) {
+    setLocalContext({ __context__: { locale } })
   }
 
-  setNewContext(__newContext) {
-    this.setState({
-      _listenForPropChanges: false,
-    })
-
-    /**
-     * While we could send in the new state like this:
-     * this.setState(newContext)
-     * – as NO object, we do that for now, because;
-     * This gives us more control on when and how we want to update the new data.
-     *
-     * PS: Initial, the reason was the change locale Dropdown in the Portal,
-     * which has "refresh" problems, in drawer-list animation was enabled
-     */
-    this.setState({ __newContext })
+  function setAllLocale(locale: string) {
+    updateAll({ locale })
   }
 
-  render() {
-    let value = this.state
-
-    // this way we update the translation object
-    if (!this.state.isRoot) {
-      value = Provider.mergeContext(this.state, this.context)
+  function updateAll(props: ContextProps) {
+    if (typeof context.update === 'function') {
+      context.update(props)
     }
 
-    this.context.updateTranslation(value.locale, value.translation)
-
-    return (
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      <Context.Provider value={value}>
-        {this.props.children}
-      </Context.Provider>
-    )
+    setLocalContext({ __context__: props })
   }
+}
+
+type MergeContext = {
+  FormRow?: Pick<ContextProps, 'FormRow'>
+}
+type MergeContextProps = {
+  value: ProviderProps
+} & MergeContext
+
+function mergeContext<ContextT, PropsT>(
+  context: ContextT & ContextProps,
+  props: PropsT & MergeContextProps
+) {
+  // When value is given as so: <Provider value={{}} />
+  const { value, ...rest } = props
+
+  // Make sure we create a copy, because we add some custom methods to it
+  const merge = { ...value, ...rest }
+
+  // Merge our new values with an existing context
+  const mergedContext = { ...context, ...merge }
+
+  // Because we don't want to deep merge, we merge FormRow additionally
+  if (context?.FormRow && merge.FormRow) {
+    mergedContext.FormRow = {
+      ...context.FormRow,
+      ...merge.FormRow,
+    }
+    mergedContext.FormRow = prepareFormRowContext(mergedContext.FormRow)
+  }
+
+  return mergedContext
 }

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import { mount } from '../../core/jest/jestSetup'
+import { fireEvent, render } from '@testing-library/react'
 import useTranslation, {
   getTranslation,
   Translation,
@@ -84,7 +84,7 @@ describe('Translation', () => {
   }
 
   it('"getTranslation" should return requested string inside render', () => {
-    const Comp = mount(
+    render(
       <Provider locales={defaultLocales}>
         <span className="getTranslation">
           {getTranslation('other.string', {
@@ -96,11 +96,13 @@ describe('Translation', () => {
       </Provider>
     )
 
-    expect(Comp.find('span.getTranslation').text()).toBe(expected_nbNO)
+    expect(document.querySelector('span.getTranslation').textContent).toBe(
+      expected_nbNO
+    )
   })
 
   it('"Translation" should return requested string inside render', () => {
-    const Comp = mount(
+    render(
       <Provider locales={defaultLocales}>
         <span className="Translation">
           <Translation id="other.string" foo="foo" bar="bar" max="max" />
@@ -114,14 +116,16 @@ describe('Translation', () => {
       </Provider>
     )
 
-    expect(Comp.find('span.Translation').text()).toBe(expected_nbNO)
-    expect(Comp.find('span.TranslationIdAsChildren').text()).toBe(
+    expect(document.querySelector('span.Translation').textContent).toBe(
       expected_nbNO
     )
+    expect(
+      document.querySelector('span.TranslationIdAsChildren').textContent
+    ).toBe(expected_nbNO)
   })
 
   it('"useTranslation" should have valid strings inside render', () => {
-    const Comp = mount(
+    render(
       <Provider locales={defaultLocales}>
         <span className="useTranslation">
           <RenderGetTranslation />
@@ -129,11 +133,13 @@ describe('Translation', () => {
       </Provider>
     )
 
-    expect(Comp.find('span.useTranslation').text()).toBe(expected_nbNO)
+    expect(document.querySelector('span.useTranslation').textContent).toBe(
+      expected_nbNO
+    )
   })
 
   it('should change to requested locale', () => {
-    const Comp = mount(
+    render(
       <Provider locales={defaultLocales}>
         <span className="useTranslation">
           <RenderGetTranslation />
@@ -142,57 +148,69 @@ describe('Translation', () => {
       </Provider>
     )
 
-    expect(Comp.find('span.useTranslation').text()).toBe(expected_nbNO)
+    expect(document.querySelector('span.useTranslation').textContent).toBe(
+      expected_nbNO
+    )
 
-    Comp.find('button.en-GB').simulate('click')
+    fireEvent.click(document.querySelector('button.en-GB'))
 
-    expect(Comp.find('span.useTranslation').text()).toBe(expected_enGB)
+    expect(document.querySelector('span.useTranslation').textContent).toBe(
+      expected_enGB
+    )
   })
 
   it('should have valid strings inside render', () => {
-    const Comp = mount(
+    render(
       <Provider locales={defaultLocales}>
-        <span className="Translation">
+        <span className="root">
           <Translation id="other.string" foo="foo" bar="bar" max="max" />
         </span>
 
         <Provider locales={nestedLocales}>
-          <span className="useTranslation">
+          <span className="nested">
             <RenderGetTranslation />
           </span>
 
-          <ChangeLocale className="inner" />
+          <ChangeLocale className="nested" />
         </Provider>
 
-        <ChangeLocale className="outer" />
+        <ChangeLocale className="root" />
       </Provider>
     )
 
-    expect(Comp.find('span.Translation').text()).toBe(expected_nbNO)
-    expect(Comp.find('span.useTranslation').text()).toBe(
+    expect(document.querySelector('span.root').textContent).toBe(
+      expected_nbNO
+    )
+    expect(document.querySelector('span.nested').textContent).toBe(
       expected_nbNO_nested
     )
 
-    Comp.find('div.outer button.en-GB').simulate('click')
+    fireEvent.click(document.querySelector('div.root button.en-GB'))
 
-    expect(Comp.find('span.Translation').text()).toBe(expected_enGB)
-    expect(Comp.find('span.useTranslation').text()).toBe(
-      expected_nbNO_nested
+    expect(document.querySelector('span.root').textContent).toBe(
+      expected_enGB
     )
-
-    Comp.find('div.inner button.en-GB').simulate('click')
-
-    expect(Comp.find('span.Translation').text()).toBe(expected_enGB)
-    expect(Comp.find('span.useTranslation').text()).toBe(
+    expect(document.querySelector('span.nested').textContent).toBe(
       expected_enGB_nested
     )
 
-    // if we change the inner locale ...
-    Comp.find('div.inner button.nb-NO').simulate('click')
+    fireEvent.click(document.querySelector('div.nested button.en-GB'))
 
-    // ... we also change the outer
-    expect(Comp.find('span.Translation').text()).toBe(expected_nbNO)
-    expect(Comp.find('span.useTranslation').text()).toBe(
+    expect(document.querySelector('span.root').textContent).toBe(
+      expected_enGB
+    )
+    expect(document.querySelector('span.nested').textContent).toBe(
+      expected_enGB_nested
+    )
+
+    // if we change the nested locale ...
+    fireEvent.click(document.querySelector('div.nested button.nb-NO'))
+
+    // ... we also change the root
+    expect(document.querySelector('span.root').textContent).toBe(
+      expected_nbNO
+    )
+    expect(document.querySelector('span.nested').textContent).toBe(
       expected_nbNO_nested
     )
   })
@@ -211,9 +229,8 @@ describe('Context.getTranslation', () => {
           //   context.setTranslation(props.translation)
           // }
           const title = context.getTranslation(props).HelpButton.title
-          const otherString = context.getTranslation(props).HelpButton[
-            'other.string'
-          ]
+          const otherString =
+            context.getTranslation(props).HelpButton['other.string']
           return (
             <>
               <p className="locale">{context.locale}</p>
@@ -229,67 +246,37 @@ describe('Context.getTranslation', () => {
   }
 
   it('should react on new lang prop', () => {
-    const Comp = mount(<MagicContext />)
+    const { rerender } = render(<MagicContext />)
 
-    expect(Comp.find('p.title').text()).toBe(
+    expect(document.querySelector('p.title').textContent).toBe(
       nbNO['nb-NO'].HelpButton.title
     )
-    expect(Comp.find('p.locale').text()).toBe('nb-NO')
+    expect(document.querySelector('p.locale').textContent).toBe('nb-NO')
 
-    Comp.setProps({
-      lang: 'en-GB',
-    })
+    rerender(<MagicContext lang="en-GB" />)
 
-    expect(Comp.find('p.title').text()).toBe(
+    expect(document.querySelector('p.title').textContent).toBe(
       enGB['en-GB'].HelpButton.title
     )
 
     // locale should not be changed
-    expect(Comp.find('p.locale').text()).not.toBe('en-GB')
-    expect(Comp.find('p.locale').text()).toBe('nb-NO')
+    expect(document.querySelector('p.locale').textContent).not.toBe(
+      'en-GB'
+    )
+    expect(document.querySelector('p.locale').textContent).toBe('nb-NO')
   })
 
   it('should react on new lang prop and prepare other.string', () => {
-    const Comp = mount(<MagicContext />)
+    const { rerender } = render(<MagicContext />)
 
-    expect(Comp.find('p.other-string').text()).toBe(given_nbNO)
+    expect(document.querySelector('p.other-string').textContent).toBe(
+      given_nbNO
+    )
 
-    Comp.setProps({
-      lang: 'en-GB',
-    })
+    rerender(<MagicContext lang="en-GB" />)
 
-    expect(Comp.find('p.other-string').text()).toBe(given_enGB)
+    expect(document.querySelector('p.other-string').textContent).toBe(
+      given_enGB
+    )
   })
-
-  // We may use that in future
-  // it('translation should be mutable, but not locale', () => {
-  //   const Comp = mount(
-  //     <MagicContext
-  //       translation={{
-  //         HelpButton: { title: 'ny-tittle' }
-  //       }}
-  //     />
-  //   )
-
-  //   expect(Comp.find('p.title').text()).toBe('ny-tittle')
-  //   expect(Comp.find('p.locale').text()).toBe('nb-NO')
-
-  //   Comp.setProps({
-  //     translation: {
-  //       HelpButton: { title: 'new-title' }
-  //     }
-  //   })
-
-  //   expect(Comp.find('p.title').text()).toBe('new-title')
-  //   expect(Comp.find('p.locale').text()).toBe('nb-NO')
-
-  //   Comp.setProps({
-  //     lang: 'en-GB',
-  //     translation: {
-  //       HelpButton: { title: 'new-title-update' }
-  //     }
-  //   })
-
-  //   expect(Comp.find('p.title').text()).not.toBe('new-title-update')
-  // })
 })


### PR DESCRIPTION
This fixes also an issue; when the root context changes locale, it did not update its nested contexts, because we stored them in a state.

Here is a [reprod](https://codesandbox.io/s/eufemia-table-context-locale-2nbgkp) that shows the issue. When the locale changes in the "root" context, it did not update its nested contexts with that change.