### PR TITLE
chore(ReactLive): make it possible to use styled components

### DIFF
--- a/tools/babel-plugin-react-live/babelPluginReactLive.js
+++ b/tools/babel-plugin-react-live/babelPluginReactLive.js
@@ -18,7 +18,7 @@ function babelPluginReactLive(babel, options) {
       t.templateLiteral(
         [
           t.templateElement({
-            raw: formattedCode.replace(/^;/, '').replace(/`/g, '\\\\`'),
+            raw: formattedCode.replace(/^;/, '').replace(/`/g, '\\`'),
           }),
         ],
         []


### PR DESCRIPTION
`babel-loader` fails if;

```jsx
const StyledDiv = styled.div`
color: red;
`
```

is used.
