### PR TITLE
chore(eslint): add support for tsx in portal package

### DIFF
--- a/packages/dnb-design-system-portal/.eslintrc
+++ b/packages/dnb-design-system-portal/.eslintrc
@@ -42,5 +42,23 @@
     "react": {
       "version": ">=16.12"
     }
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parser": "@typescript-eslint/parser",
+      "globals": { "JSX": true },
+      "plugins": ["@typescript-eslint"],
+      "extends": ["plugin:@typescript-eslint/recommended"],
+      "rules": {
+        "import/named": "off",
+        "no-unused-vars": [
+          "error",
+          { "args": "none", "ignoreRestSiblings": true }
+        ],
+        "react/prop-types": "off",
+        "react/require-default-props": "off"
+      }
+    }
+  ]
 }

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -65,6 +65,7 @@
     "@babel/eslint-parser": "7.18.2",
     "@babel/node": "7.16.0",
     "@emotion/cache": "11.9.3",
+    "@typescript-eslint/parser": "5.43.0",
     "babel-preset-gatsby": "2.24.0",
     "camelcase": "6.2.0",
     "cross-env": "7.0.3",

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -5,10 +5,8 @@
 
 import React from 'react'
 import { css, Global } from '@emotion/react'
-import styled from '@emotion/styled'
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { P, Code } from '@dnb/eufemia/src/elements'
-import { ScrollView } from '@dnb/eufemia/src/fragments'
 import Table from '@dnb/eufemia/src/components/table/Table'
 import Th from '@dnb/eufemia/src/components/table/TableTh'
 import Td from '@dnb/eufemia/src/components/table/TableTd'

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -73,6 +73,7 @@ const AutoLinkHeader = ({
           #
         </AnchorLink>
       )}
+      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
       {/* @ts-ignore */}
       <Location>
         {({ location }) => {

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -57,6 +57,7 @@ const CodeBlock = ({
     )
   } else {
     return (
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       <Highlight
         {...defaultProps}
@@ -339,6 +340,7 @@ const cleanTokens = (tokens) => {
   return tokens
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 Prism.languages.insertBefore('jsx', 'template-string', {
   'styled-template-string': {

--- a/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
@@ -37,6 +37,7 @@ function ComponentBox(props: ComponentBoxProps) {
   }
 
   return (globalThis.ComponentBoxMemo[hash] = (
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     <CodeBlock
       scope={{

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -160,7 +160,7 @@
     "@types/jest": "29.2.0",
     "@types/jest-axe": "3.5.5",
     "@typescript-eslint/eslint-plugin": "5.28.0",
-    "@typescript-eslint/parser": "5.28.0",
+    "@typescript-eslint/parser": "5.43.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.5",
     "audit-ci": "5.1.2",
     "babel-jest": "29.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,7 +3262,7 @@ __metadata:
     "@types/jest": 29.2.0
     "@types/jest-axe": 3.5.5
     "@typescript-eslint/eslint-plugin": 5.28.0
-    "@typescript-eslint/parser": 5.28.0
+    "@typescript-eslint/parser": 5.43.0
     "@wojtekmaj/enzyme-adapter-react-17": 0.6.5
     audit-ci: 5.1.2
     babel-jest: 29.2.1
@@ -8211,20 +8211,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:5.28.0":
-  version: 5.28.0
-  resolution: "@typescript-eslint/parser@npm:5.28.0"
+"@typescript-eslint/parser@npm:5.43.0":
+  version: 5.43.0
+  resolution: "@typescript-eslint/parser@npm:5.43.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.28.0
-    "@typescript-eslint/types": 5.28.0
-    "@typescript-eslint/typescript-estree": 5.28.0
+    "@typescript-eslint/scope-manager": 5.43.0
+    "@typescript-eslint/types": 5.43.0
+    "@typescript-eslint/typescript-estree": 5.43.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: cb18ff47b0a10373ba1c05c90901d08f5f99180e624f3f2faa85f13d1048fc59601a3cab6b852f72d13287b314d94c4d4997129ff6c639496a9144c762f6d31e
+  checksum: a28e0ef2807f1c3381c6dc1d9ddfd83ea8db657d3f808511adf13023b469ed64fc09619e05d7f68746b05ea68770a0882883c77ce908682965ba266f95e168c9
   languageName: node
   linkType: hard
 
@@ -8265,6 +8265,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.43.0":
+  version: 5.43.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.43.0"
+  dependencies:
+    "@typescript-eslint/types": 5.43.0
+    "@typescript-eslint/visitor-keys": 5.43.0
+  checksum: e594c7a32c3fa29e46dd0b0bc62f97f154bd864682ae7da87a14b6f4336f4cb02f6ed0602bbdb15783e4230ecdf8a0ccc6f7c5820850e8f11240c9e4fb0e388d
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.28.0":
   version: 5.28.0
   resolution: "@typescript-eslint/type-utils@npm:5.28.0"
@@ -8292,6 +8302,13 @@ __metadata:
   version: 5.28.0
   resolution: "@typescript-eslint/types@npm:5.28.0"
   checksum: e948915d6f24ece98043763a48e34ced5e16a1aa88cc86ea7d9057010ed92ce39457a753dd7a140be52f9b546b27f8a3b33bdc7d671427a386aa1aa381d908ef
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:5.43.0":
+  version: 5.43.0
+  resolution: "@typescript-eslint/types@npm:5.43.0"
+  checksum: fc5e5431c305feee4a3faae84f34df482e08d74b910a6f9376b01326c682ceefeeb0e270d03d7778787bc94ef05b3b85ee6d3c9d732290fbdb4a67ae1b110226
   languageName: node
   linkType: hard
 
@@ -8331,6 +8348,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:5.43.0":
+  version: 5.43.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.43.0"
+  dependencies:
+    "@typescript-eslint/types": 5.43.0
+    "@typescript-eslint/visitor-keys": 5.43.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 3479f9413d73369ab3d574580c90a72f74d2ae1ec4afe485eebfad054c3d15c89f23a137bb9d6197dfdae33e444a76a99f6832688787feabbb064e09d39a3f55
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.28.0":
   version: 5.28.0
   resolution: "@typescript-eslint/utils@npm:5.28.0"
@@ -8364,6 +8399,16 @@ __metadata:
     "@typescript-eslint/types": 5.28.0
     eslint-visitor-keys: ^3.3.0
   checksum: e97251968ea273ce33fa0de8a9c04426499b797f6f7800379ff880c4be6e6e02fe023038be0092c595be394a8636f73ee8911974214d5232b3d59492a50771bf
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.43.0":
+  version: 5.43.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.43.0"
+  dependencies:
+    "@typescript-eslint/types": 5.43.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: 4820679e50096dcdaadc7c95d32e5dca3ba8510acf1a865e283822bae3940a2faec02ad8abe793f8a25f75b600f1e7215e1fd3b3ba73779eff737fa90d092550
   languageName: node
   linkType: hard
 
@@ -14407,6 +14452,7 @@ __metadata:
     "@emotion/styled": 11.9.3
     "@mdx-js/mdx": 1.6.22
     "@mdx-js/react": 1.6.22
+    "@typescript-eslint/parser": 5.43.0
     algoliasearch: 4.12.0
     babel-preset-gatsby: 2.24.0
     camelcase: 6.2.0


### PR DESCRIPTION
With that change, unused vars will fail also in the portal package. 
Maybe, at a later time, we should move such logic to a lower lever (root level). I guess its supported now days (It was not 5 years ago).

<img width="623" alt="Screenshot 2022-11-18 at 12 21 47" src="https://user-images.githubusercontent.com/1501870/202694192-802e158b-9f41-4c4e-88c3-81c5e58110a3.png">

<img width="833" alt="Screenshot 2022-11-18 at 12 40 03" src="https://user-images.githubusercontent.com/1501870/202697498-44a789c1-9909-4916-9b0d-ec8b029a8c07.png">

