### PR TITLE
chore(Typography): move table typography

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.js
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import ComponentBox from '../../../../shared/tags/ComponentBox'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import { Global, css } from '@emotion/react'
 import styled from '@emotion/styled'
 import {

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography.md
@@ -5,7 +5,7 @@ icon: 'typography'
 order: 5
 ---
 
-import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
+import { TypographyVariants } from 'Docs/uilib/typography/Examples'
 
 # Typography
 
@@ -25,32 +25,7 @@ You don't need to define the `font-family` ever, but rather use CSS Custom Prope
 
 ### Typography Examples
 
-<ComponentBox data-visual-test="typography-variants" hideCode>
-{`
-<div style={{maxWidth: '30rem'}}>
-  <Code>Heading xx-large</Code>
-  <H4 size="xx-large" space={0}>Dette er en heading på over to linjer</H4>
-  <Code top="large">Heading x-large</Code>
-  <H4 size="x-large" space={0}>Og dette er en heading small tittel som også går over to linjer, nei vent, tre linjer.</H4>
-  <Code top="large">Heading large</Code>
-  <H4 size="large" space={0}>Hva har vi her, en liten heading som mot alle odds går over flere linjer.</H4>
-  <Code top="large">Text Lead</Code>
-  <Lead space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei, appetere oporteat eam te.</Lead>
-  <Code top="large">Text basis</Code>
-  <P space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei, appetere oporteat eam te. Vel in deleniti sensibus, officiis menandri efficiantur no cum. Per et habemus gubergren. Mundi copiosae pertinax ea pro, vidit fierent mentitum in est, ex fabellas senserit inciderint vim.</P>
-  <Code top="large">Text basis (Medium)</Code>
-  <P modifier="medium" space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei, appetere oporteat eam te. Vel in deleniti sensibus, officiis menandri efficiantur no cum. Per et habemus gubergren. Mundi copiosae pertinax ea pro, vidit fierent mentitum in est, ex fabellas senserit inciderint vim.</P>
-  <Code top="large">Text small</Code>
-  <P size="small" space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei, appetere oporteat eam te. Vel in deleniti sensibus, officiis menandri efficiantur no cum. Per et habemus gubergren. Mundi copiosae pertinax ea pro, vidit fierent mentitum in est, ex fabellas senserit inciderint vim.</P>
-  <Code top="large">Text small (Medium)</Code>
-  <P size="small" modifier="medium" space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei, appetere oporteat eam te. Vel in deleniti sensibus, officiis menandri efficiantur no cum. Per et habemus gubergren. Mundi copiosae pertinax ea pro, vidit fierent mentitum in est, ex fabellas senserit inciderint vim.</P>
-  <Code top="large">Text x-small</Code>
-  <P size="x-small" space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei.</P>
-  <Code top="large">Text x-small (Medium)</Code>
-  <P size="x-small" modifier="medium" space={0}>Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei.</P>
-</div>
-`}
-</ComponentBox>
+<TypographyVariants />
 
 ## Font Face
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
@@ -5,6 +5,8 @@
 
 import React from 'react'
 import styled from '@emotion/styled'
+import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
+import { Code, H4, Lead, P } from '@dnb/eufemia/src'
 
 const Wrapper = styled.div`
   margin-bottom: 3rem;
@@ -53,5 +55,73 @@ export function FontWeightExample() {
         typo_class="dnb-typo-mono-regular"
       />
     </Wrapper>
+  )
+}
+
+export function TypographyVariants() {
+  return (
+    <ComponentBox data-visual-test="typography-variants" hideCode>
+      <div style={{ maxWidth: '30rem' }}>
+        <Code>Heading xx-large</Code>
+        <H4 size="xx-large" space={0}>
+          Dette er en heading på over to linjer
+        </H4>
+        <Code top="large">Heading x-large</Code>
+        <H4 size="x-large" space={0}>
+          Og dette er en heading small tittel som også går over to linjer,
+          nei vent, tre linjer.
+        </H4>
+        <Code top="large">Heading large</Code>
+        <H4 size="large" space={0}>
+          Hva har vi her, en liten heading som mot alle odds går over flere
+          linjer.
+        </H4>
+        <Code top="large">Text Lead</Code>
+        <Lead space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei,
+          appetere oporteat eam te.
+        </Lead>
+        <Code top="large">Text basis</Code>
+        <P space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei,
+          appetere oporteat eam te. Vel in deleniti sensibus, officiis
+          menandri efficiantur no cum. Per et habemus gubergren. Mundi
+          copiosae pertinax ea pro, vidit fierent mentitum in est, ex
+          fabellas senserit inciderint vim.
+        </P>
+        <Code top="large">Text basis (Medium)</Code>
+        <P modifier="medium" space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei,
+          appetere oporteat eam te. Vel in deleniti sensibus, officiis
+          menandri efficiantur no cum. Per et habemus gubergren. Mundi
+          copiosae pertinax ea pro, vidit fierent mentitum in est, ex
+          fabellas senserit inciderint vim.
+        </P>
+        <Code top="large">Text small</Code>
+        <P size="small" space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei,
+          appetere oporteat eam te. Vel in deleniti sensibus, officiis
+          menandri efficiantur no cum. Per et habemus gubergren. Mundi
+          copiosae pertinax ea pro, vidit fierent mentitum in est, ex
+          fabellas senserit inciderint vim.
+        </P>
+        <Code top="large">Text small (Medium)</Code>
+        <P size="small" modifier="medium" space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei,
+          appetere oporteat eam te. Vel in deleniti sensibus, officiis
+          menandri efficiantur no cum. Per et habemus gubergren. Mundi
+          copiosae pertinax ea pro, vidit fierent mentitum in est, ex
+          fabellas senserit inciderint vim.
+        </P>
+        <Code top="large">Text x-small</Code>
+        <P size="x-small" space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei.
+        </P>
+        <Code top="large">Text x-small (Medium)</Code>
+        <P size="x-small" modifier="medium" space={0}>
+          Lorem ipsum dolor sit amet, sint quodsi concludaturque nam ei.
+        </P>
+      </div>
+    </ComponentBox>
   )
 }

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -225,9 +225,6 @@ exports[`Table scss have to match snapshot 1`] = `
   .dnb-table > thead > tr > th.dnb-table--x-small,
   .dnb-table > tbody > tr > td.dnb-table--x-small, .dnb-table__th.dnb-table--x-small, .dnb-table__td.dnb-table--x-small {
     font-size: var(--font-size-x-small); }
-  .dnb-table b,
-  .dnb-table strong {
-    font-weight: var(--font-weight-medium); }
   .dnb-table.dnb-skeleton > * {
     -webkit-text-fill-color: var(--skeleton-color); }
   .dnb-table > thead > tr > th.dnb-table--sortable,

--- a/packages/dnb-eufemia/src/components/table/style/_table.scss
+++ b/packages/dnb-eufemia/src/components/table/style/_table.scss
@@ -136,11 +136,6 @@
 
   /* stylelint-enable */
 
-  b,
-  strong {
-    font-weight: var(--font-weight-medium);
-  }
-
   &.dnb-skeleton {
     > * {
       -webkit-text-fill-color: var(--skeleton-color);

--- a/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
+++ b/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
@@ -263,6 +263,10 @@ a.dnb-button {
     line-height: var(--line-height-basis);
     font-style: italic; }
 
+.dnb-table b,
+.dnb-table strong {
+  font-weight: var(--font-weight-medium); }
+
 .dnb-h--xx-large {
   font-size: var(--font-size-xx-large);
   line-height: var(--line-height-x-large); }

--- a/packages/dnb-eufemia/src/style/elements/typography.scss
+++ b/packages/dnb-eufemia/src/style/elements/typography.scss
@@ -305,6 +305,14 @@
   @include paragraphStyle();
 }
 
+// Tables
+.dnb-table {
+  b,
+  strong {
+    font-weight: var(--font-weight-medium);
+  }
+}
+
 // .dnb-h1,/* deprecated */
 .dnb-h--xx-large {
   @include headingSize_xx-large();


### PR DESCRIPTION
Make this change to ensure, inherited typography is handled in one place. E.g. in case there will be bold support later.
Also, move general Typography listings to the Examples files.