### PR TITLE
chore(Portal): fix fullscreen view

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
@@ -2,10 +2,11 @@
 
 :global {
   :root {
-    /* stylelint-disable */
-    --aside-width: 30vw; /* IE fix */
-    --aside-width: var(--aside-width-fullscreen, calc(25vw + 5rem));
-    /* stylelint-enable */
+    --aside-width: calc(25vw + 5rem);
+
+    @include IS_IE {
+      --aside-width: 30vw;
+    }
   }
 
   .dnb-sidebar-menu {

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -270,5 +270,5 @@
 
 .fullscreenStyle {
   /* ensure the sidebar has not left over margin during fullscreen (SSR issue) */
-  --aside-width-fullscreen: 0;
+  --aside-width: 0;
 }


### PR DESCRIPTION
Currently, the [fullscreen mode ](https://eufemia.dnb.no/uilib/components/table/?fullscreen) does not hide the left padding.

<img width="546" alt="Screenshot 2022-11-23 at 11 12 20" src="https://user-images.githubusercontent.com/1501870/203521025-eceb6416-65da-4ebe-a12c-04fd6135b202.png">


This PR should fix that.
