### PR TITLE
fix(HeightAnimation): avoid usage of useLayoutEffect during SSR

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/ToggleGrid.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/ToggleGrid.tsx
@@ -25,7 +25,7 @@ function isGridVisible() {
 }
 
 export function GridActivator() {
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (isGridVisible()) {
       makeGridVisible()
     }

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import HeightAnimationInstance from './HeightAnimationInstance'
 
+// SSR warning fix: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+const useLayoutEffect =
+  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
+
 export type useHeightAnimationOptions = {
   /**
    * Set to `true`, when initially `false` was given, to animate from 0px to auto.
@@ -66,7 +70,7 @@ export function useHeightAnimation(
 
   React.useEffect(() => setIsMounted(false), []) // eslint-disable-line
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     animRef.current = new HeightAnimationInstance({ animate })
 
     if (isInitialRender && onInit) {
@@ -139,7 +143,7 @@ export function useHeightAnimation(
 }
 
 function useOpenClose({ open, animRef, targetRef, isInitialRender }) {
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!targetRef.current) {
       return // stop here
     }
@@ -178,7 +182,7 @@ function useAdjust({ children, animRef, isInitialRender }) {
     }
   }, [children]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (shouldAdjust()) {
       /**
        * Ensure we don't have height, while we get the "toHeight" again


### PR DESCRIPTION
React warns about the usage of `useLayoutEffect` when React renders on the server (SSR).

This behavior can be enabled with the `FAST_DEV` flag in gatsby-config.

One "quick" fix is to use useEffect on the server, which again does nothing there.

The React "team" has [some options](https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85) to that "problem". We basically use option 1, with this approach.

Any other suggestions?

PS: I tried to create a test. But invalidating both the document or the window object (`delete globalThis.window`) makes the testing lib not rendering the component or hook.

