### PR TITLE
fix(NumberFormat): use `dnb-sr-only` instead of `dnb-sr-only--inline`

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
@@ -423,7 +423,7 @@ export default class NumberFormat extends React.PureComponent {
 
         <span
           id={this._id}
-          className="dnb-number-format__sr-only dnb-sr-only--inline"
+          className="dnb-number-format__sr-only dnb-sr-only"
         >
           {aria}
         </span>

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.js.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.js.snap
@@ -52,7 +52,7 @@ exports[`NumberFormat component have to match default number-format snapshot 1`]
         12 345 678,9876
       </span>
       <span
-        className="dnb-number-format__sr-only dnb-sr-only--inline"
+        className="dnb-number-format__sr-only dnb-sr-only"
         id="unique"
       >
         12 345 678,9876

--- a/packages/dnb-eufemia/src/components/number-format/stories/NumberFormat.stories.js
+++ b/packages/dnb-eufemia/src/components/number-format/stories/NumberFormat.stories.js
@@ -187,34 +187,6 @@ export const NumberFormatSandbox = () => {
               identification number
             </P>
           </Box>
-          <Box>
-            <p className="dnb-p">
-              Hidden text:
-              <span className="dnb-sr-only--inline">
-                I am only visible to screen readers, so you probably can't
-                see me.. Unless you're using a screen reader.
-              </span>
-              !
-            </p>
-            <p className="dnb-p dnb-sr-only dnb-not-sr-only">
-              I'm the opposite of .dnb-sr-only, so you should be able to
-              see me.
-            </p>
-            <p className="dnb-sr-only--shadow">hello 1</p>
-            <span className="dnb-sr-only">hello 2</span>
-            <span className="dnb-sr-only--inline">hello 3</span>
-            <p className="dnb-sr-only--shadow">end</p>
-            ---
-            <p className="dnb-sr-only--shadow">hello 1</p>
-            <p className="dnb-sr-only">hello 2</p>
-            <div className="dnb-sr-only--inline">hello 3</div>
-            {/* <span className="dnb-sr-only--inline-wrapper">
-            </span> */}
-            <p className="dnb-sr-only--shadow">end</p>
-            <button className="dnb-button dnb-button--primary">
-              <NumberFormat value={-12345678.9} />
-            </button>
-          </Box>
         </Wrapper>
       </Provider>
     </CustomStyle>


### PR DESCRIPTION
I can't find any reasons anymore why not just use `dnb-sr-only`. Its the only place also, when `--inline` was used.