### PR TITLE
fix:  deprecate `.dnb-not-sr-only` and `.dnb-sr-only--inline`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
@@ -64,7 +64,8 @@ v10 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 ### Deprecations
 
 - `use_scrollwheel` and `on_init` properties, as well as the `raw_value` event value from [Slider](/uilib/components/slider) was removed in order to support multiple buttons.
-- Helper class `.dnb-not-sr-only` and SCSS mixin `@include notSrOnly` was removed.
+- Helper class `.dnb-sr-only--inline` and SCSS mixin `srOnlyInline` was removed.
+- Helper class `.dnb-not-sr-only` and SCSS mixin `notSrOnly` was removed.
 
 ## Install
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.js
@@ -81,7 +81,7 @@ export function ScreenReaderOnlyExample() {
           /* jsx */ `
 <p className="dnb-p">
   Hidden text
-  <span className="dnb-sr-only--inline">
+  <span className="dnb-sr-only">
     I am only visible to screen readers, so you probably can't see
     me. Unless you're using a screen reader.
   </span>!

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.md
@@ -107,13 +107,13 @@ Visually hides an element, but is still reachable by screen readers. (_sr_ stand
 
 ### Screen Reader only: inline
 
-`dnb-sr-only--inline`
+`dnb-sr-only--inline` (deprecated in v10)
 
 Like `dnb-sr-only` - but with flow elements in mind. This enables a set of text (in a paragraph `<p>`) to be enhanced with spans inside without NVDA to split up reading the text.
 
 ### Not Screen Reader only
 
-`dnb-not-sr-only`
+`dnb-not-sr-only` (deprecated in v10)
 
 The opposite of `dnb-sr-only`, so not visible to screen readers.
 

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -43,6 +43,8 @@
 .dnb-sr-only {
   @include srOnly();
 }
+
+// deprecated and can be removed in v10
 .dnb-sr-only--inline {
   @include srOnlyInline();
 }

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -329,6 +329,8 @@ $breakpoints: (
   border: 0;
 }
 
+// deprecated and can be removed in v10
+// Visual test and docs should be removed as well!
 @mixin srOnlyInline() {
   @include srOnly();
 


### PR DESCRIPTION
- deprecate `.dnb-not-sr-only` as it is not of interest in a React/JavaScript driven app world. We rather should remove the original class, than adding a new one.
- deprecate `.dnb-sr-only--inline` as it does not give a real additional value. We should rather change the CSS, when `.dnb-sr-only` would "break" something.
