### PR TITLE
fix(Drawer): ensure nav bar is aligned to left when content is wider than Drawer

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -2273,6 +2273,7 @@ button.dnb-button::-moz-focus-inner {
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section {
     position: sticky;
     top: 0;
+    left: 0;
     z-index: 99;
     margin: var(--drawer-spacing) 0;
     padding: 0 var(--drawer-spacing); }

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -2289,6 +2289,7 @@ button.dnb-button::-moz-focus-inner {
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section {
     position: sticky;
     top: 0;
+    left: 0;
     z-index: 99;
     margin: var(--drawer-spacing) 0;
     padding: 0 var(--drawer-spacing); }

--- a/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/_drawer.scss
@@ -213,6 +213,7 @@
   &--spacing &__navigation.dnb-section {
     position: sticky;
     top: 0;
+    left: 0; // when content is wider, we don't want the bar to scroll horizontal
     z-index: 99; // below #dropdown and #date-picker
 
     // on large screens

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -2260,6 +2260,7 @@ button.dnb-button::-moz-focus-inner {
   .dnb-drawer--spacing .dnb-drawer__navigation.dnb-section {
     position: sticky;
     top: 0;
+    left: 0;
     z-index: 99;
     margin: var(--drawer-spacing) 0;
     padding: 0 var(--drawer-spacing); }


### PR DESCRIPTION
Before


<img width="481" alt="Screenshot 2022-12-04 at 22 32 04" src="https://user-images.githubusercontent.com/1501870/205516899-0ccbac8f-b76d-4cd3-ae15-71f565e63e50.png">

After

<img width="469" alt="Screenshot 2022-12-04 at 22 34 29" src="https://user-images.githubusercontent.com/1501870/205516901-57b76c68-f3be-4e94-b6db-2fef1de7a838.png">
