### PR TITLE
chore(deps): update update to latest because of deprecation warning during NPM install

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@babel/runtime": "7.16.3",
     "classnames": "2.3.1",
-    "core-js": "3.19.1",
+    "core-js": "3.26.1",
     "date-fns": "2.25.0",
     "keycode": "2.2.1",
     "prop-types": "15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,7 +3274,7 @@ __metadata:
     chalk: 4.1.2
     classnames: 2.3.1
     color: 4.0.1
-    core-js: 3.19.1
+    core-js: 3.26.1
     cross-env: 7.0.3
     cssnano: 5.0.10
     current-git-branch: 1.1.0
@@ -12988,10 +12988,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.19.1, core-js@npm:^3.19.0":
-  version: 3.19.1
-  resolution: "core-js@npm:3.19.1"
-  checksum: 2f669061788dc6fea823f0433d871deeaaaacc7d68ef2748859509522a34df5c83e648c3c6a1993fed0ab188081b3cf32b957b2a1f46156a2b20bd775961ade4
+"core-js@npm:3.26.1":
+  version: 3.26.1
+  resolution: "core-js@npm:3.26.1"
+  checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
   languageName: node
   linkType: hard
 
@@ -13006,6 +13006,13 @@ __metadata:
   version: 3.19.0
   resolution: "core-js@npm:3.19.0"
   checksum: 9f03e72f01d9eeafb2724ee5787ab8d6e7dcf0e3b44c4dec23e6a0cfc9e2e0a76460b77ce7d1d0be09db918618b11595fad6838978ff97f2684270738898c5a2
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.19.0":
+  version: 3.19.1
+  resolution: "core-js@npm:3.19.1"
+  checksum: 2f669061788dc6fea823f0433d871deeaaaacc7d68ef2748859509522a34df5c83e648c3c6a1993fed0ab188081b3cf32b957b2a1f46156a2b20bd775961ade4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We got this reported by devs using NPM. But also yarn does say that our current version is not supported anymore.