### PR TITLE
chore(dependabot): Fix misconfiguration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,16 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
-root:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+updates:
+  - package-ecosystem: '' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "monthly"
-
-eufemia:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/packages/dnb-eufemia" # Location of package manifests
+      interval: 'monthly'
+  - package-ecosystem: '' # See documentation for possible values
+    directory: '/packages/dnb-eufemia' # Location of package manifests
     schedule:
-      interval: "monthly"
-
-portal:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/packages/dnb-design-system-portal" # Location of package manifests
+      interval: 'monthly'
+  - package-ecosystem: '' # See documentation for possible values
+    directory: '/packages/dnb-design-system-portal' # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: 'monthly'


### PR DESCRIPTION
Now that we run it, we get a an error that it is not correct configurated.

[Here](https://github.com/dnbexperience/eufemia/pull/1769/checks?check_run_id=9889204014) I got this result:
property '#/' did not contain a required property of 'updates' The property '#/' contains additional properties ["root", "eufemia", "portal"] outside of the schema when none are allowed

PS: Dependabot is not a GitHub Workflow. 
