### PR TITLE
feat(Th): include by default aria-sort for assistive technology

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/properties.md
@@ -27,12 +27,12 @@ showTabs: true
 
 ### Table Header `<Th>`
 
-| Properties | Description                                                                                     |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| `sortable` | _(optional)_ defines the table header as sortable if set to `true`. Defaults to `false`.        |
-| `active`   | _(optional)_ defines the sortable column as the current active. Defaults to `false`.            |
-| `reversed` | _(optional)_ defines the sortable column as in reversed order. Defaults to `false`.             |
-| `noWrap`   | _(optional)_ if set to `true`, the header text will not wrap to new lines. Defaults to `false`. |
+| Properties | Description                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| `sortable` | _(optional)_ defines the table header as sortable if set to `true` (ascending). Defaults to `false`. |
+| `active`   | _(optional)_ defines the sortable column as the current active (ascending). Defaults to `false`.     |
+| `reversed` | _(optional)_ defines the sortable column as in reversed order (descending). Defaults to `false`.     |
+| `noWrap`   | _(optional)_ if set to `true`, the header text will not wrap to new lines. Defaults to `false`.      |
 
 ### Table Data `<Td>`
 

--- a/packages/dnb-eufemia/src/components/table/TableTh.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTh.tsx
@@ -10,19 +10,19 @@ export type TableThChildren =
 
 export type TableThProps = {
   /**
-   * Defines the table header as sortable
+   * Defines the table header as sortable (ascending)
    * Default: false
    */
   sortable?: boolean
 
   /**
-   * Defines the sortable column as the current active
+   * Defines the sortable column as the current active (ascending)
    * Default: false
    */
   active?: boolean
 
   /**
-   * Defines the sortable column as in reversed order
+   * Defines the sortable column as in reversed order (descending)
    * Default: false
    */
   reversed?: boolean
@@ -55,11 +55,17 @@ export default function Th(
 
   const role = props.scope === 'row' ? 'rowheader' : 'columnheader'
   const scope = props.scope === 'row' ? 'row' : 'col'
+  const ariaSort = sortable
+    ? reversed
+      ? 'descending'
+      : 'ascending'
+    : undefined
 
   return (
     <th
       role={role}
       scope={scope}
+      aria-sort={ariaSort}
       className={classnames(
         'dnb-table__th',
         sortable && 'dnb-table--sortable',

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableTh.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableTh.test.tsx
@@ -90,12 +90,30 @@ describe('TableTh', () => {
     expect(element.getAttribute('scope')).toBe('row')
   })
 
+  it('should set correct sortable class', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <TableTh sortable>th content</TableTh>
+          </tr>
+        </thead>
+      </table>
+    )
+
+    const element = document.querySelector('th')
+    expect(Array.from(element.classList)).toContain('dnb-table--sortable')
+    expect(element.getAttribute('aria-sort')).toBe('ascending')
+  })
+
   it('should set correct active class', () => {
     render(
       <table>
         <thead>
           <tr>
-            <TableTh active>th content</TableTh>
+            <TableTh sortable active>
+              th content
+            </TableTh>
           </tr>
         </thead>
       </table>
@@ -103,6 +121,7 @@ describe('TableTh', () => {
 
     const element = document.querySelector('th')
     expect(Array.from(element.classList)).toContain('dnb-table--active')
+    expect(element.getAttribute('aria-sort')).toBe('ascending')
   })
 
   it('should set correct reversed class', () => {
@@ -110,7 +129,9 @@ describe('TableTh', () => {
       <table>
         <thead>
           <tr>
-            <TableTh reversed>th content</TableTh>
+            <TableTh sortable reversed>
+              th content
+            </TableTh>
           </tr>
         </thead>
       </table>
@@ -118,6 +139,7 @@ describe('TableTh', () => {
 
     const element = document.querySelector('th')
     expect(Array.from(element.classList)).toContain('dnb-table--reversed')
+    expect(element.getAttribute('aria-sort')).toBe('descending')
   })
 
   it('should set correct noWrap class', () => {


### PR DESCRIPTION
Add `aria-sort` to be handled by default. More info [about aria-sort](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort).