### PR TITLE
chore: add "dom" to TypeScript libs

### DIFF
--- a/packages/dnb-design-system-portal/tsconfig.json
+++ b/packages/dnb-design-system-portal/tsconfig.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "skipLibCheck": true,
+    "lib": ["es2018", "dom"],
     "types": ["node", "jest"],
     "outDir": "./out",
     "rootDir": ".",

--- a/packages/dnb-eufemia/tsconfig.json
+++ b/packages/dnb-eufemia/tsconfig.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "skipLibCheck": true,
+    "lib": ["es2018", "dom"],
     "types": ["node", "jest"],
     "outDir": "./build",
     "rootDir": ".",


### PR DESCRIPTION
After a macOS re-installation; VSCode complains about global variables, like document. A quick search on the internet, tells me we miss "dom" in `compilerOptions/lib`. 

Any thoughts about this?