### PR TITLE
fix(InputPassword): hide password reveal in Edge

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -2377,6 +2377,9 @@ legend.dnb-form-label {
     .dnb-input--password .dnb-input__placeholder::-ms-clear,
     .dnb-input--password .dnb-input__input::-ms-clear {
       display: none; }
+    .dnb-input--password .dnb-input__placeholder::-ms-reveal,
+    .dnb-input--password .dnb-input__input::-ms-reveal {
+      display: none; }
   .dnb-input--password .dnb-input__placeholder {
     padding-right: 4rem; }
   .dnb-input--password .dnb-input__input {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -2656,6 +2656,9 @@ legend.dnb-form-label {
     .dnb-input--password .dnb-input__placeholder::-ms-clear,
     .dnb-input--password .dnb-input__input::-ms-clear {
       display: none; }
+    .dnb-input--password .dnb-input__placeholder::-ms-reveal,
+    .dnb-input--password .dnb-input__input::-ms-reveal {
+      display: none; }
   .dnb-input--password .dnb-input__placeholder {
     padding-right: 4rem; }
   .dnb-input--password .dnb-input__input {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.js.snap
@@ -1051,6 +1051,9 @@ legend.dnb-form-label {
     .dnb-input--password .dnb-input__placeholder::-ms-clear,
     .dnb-input--password .dnb-input__input::-ms-clear {
       display: none; }
+    .dnb-input--password .dnb-input__placeholder::-ms-reveal,
+    .dnb-input--password .dnb-input__input::-ms-reveal {
+      display: none; }
   .dnb-input--password .dnb-input__placeholder {
     padding-right: 4rem; }
   .dnb-input--password .dnb-input__input {

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.js.snap
@@ -1645,6 +1645,9 @@ legend.dnb-form-label {
     .dnb-input--password .dnb-input__placeholder::-ms-clear,
     .dnb-input--password .dnb-input__input::-ms-clear {
       display: none; }
+    .dnb-input--password .dnb-input__placeholder::-ms-reveal,
+    .dnb-input--password .dnb-input__input::-ms-reveal {
+      display: none; }
   .dnb-input--password .dnb-input__placeholder {
     padding-right: 4rem; }
   .dnb-input--password .dnb-input__input {

--- a/packages/dnb-eufemia/src/components/input/style/_input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/_input.scss
@@ -145,6 +145,10 @@
     &::-ms-clear {
       display: none;
     }
+    // Hiding "password reveal" button in Ms Edge
+    &::-ms-reveal {
+      display: none;
+    }
   }
   &--password &__placeholder {
     padding-right: 4rem;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR hides the "password reveal" button in Microsoft Edge.

Here's a screenshot of how it looked when both our internal password reveal button, and the default one in Microsoft Edge was displayed simultaneously:

![image](https://user-images.githubusercontent.com/1359205/206470312-e69fe64c-7bfa-4984-a2e5-6ab0b0fc8da8.png)
