### PR TITLE
fix(scrollToLocationHashId): omit calling scrollTo when element is not found

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -164,7 +164,14 @@ export function scrollToLocationHashId({
       if (id.length > 0) {
         const handleScroll = () => {
           const runScroll = () => {
-            const top = getOffsetTop(elem) - offset
+            const totalOffset = getOffsetTop(elem)
+
+            if (totalOffset <= 0) {
+              return // stop here
+            }
+
+            const top = totalOffset - offset
+
             try {
               if (typeof IntersectionObserver !== 'undefined') {
                 const intersectionObserver = new IntersectionObserver(


### PR DESCRIPTION
This is a documented helper class. 

But when there was not an element, `scrollTo` was still called. Which has negative effects on default browser location hash handling.