### PR TITLE
chore(Portal): add scroll-padding-top to compensate for sticky header

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -1,5 +1,11 @@
 @import '@dnb/eufemia/src/style/core/utilities.scss';
 
+:global {
+  html {
+    scroll-padding-top: 4rem;
+  }
+}
+
 .headerStyle {
   position: fixed;
 
@@ -22,7 +28,6 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 4rem;
 
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Now that we do not need to support IE, we can use scroll-padding-top to compensate for our sticky header.

This is useful, when a location hash is used to scroll to a certain element with an ID. Does not effect our heading hash handling, there we already deal with a offset (padding).

Also, we do not need (neither should) to set a fixed height to the header. The given padding should be enough.
