### PR TITLE
feat(Table): add useHandleSortState hook

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -21,64 +21,96 @@ import Th from '@dnb/eufemia/src/components/table/TableTh'
 import Td from '@dnb/eufemia/src/components/table/TableTd'
 import Tr from '@dnb/eufemia/src/components/table/TableTr'
 import TableContainer from '@dnb/eufemia/src/components/table/TableContainer'
+import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
 
 export const TableVariantBasic = () => (
-  <ComponentBox hideCode data-visual-test="table-default">
-    <Table.ScrollView>
-      <Table>
-        <caption className="dnb-sr-only">A Table Caption</caption>
-        <thead>
-          <Tr>
-            <Th>Column</Th>
-            <Th>
-              <Th.Horizontal>
-                Help Button
-                <Th.HelpButton>Help Content</Th.HelpButton>
-              </Th.Horizontal>
-            </Th>
-            <Th sortable active>
-              <Th.SortButton
-                text="Sortable Active"
-                title="Sort table column"
-              />
-            </Th>
-            <Th sortable reversed align="right">
-              <Th.SortButton text="Sortable" title="Sort table column" />
-            </Th>
-          </Tr>
-        </thead>
-        <tbody>
-          <Tr>
-            <Td>Row 1</Td>
-            <Td>Row 1</Td>
-            <Td>Row 1</Td>
-            <Td align="right">Row 1</Td>
-          </Tr>
-          <Tr>
-            <Td>Row 2</Td>
-            <Td>Row 2</Td>
-            <Td>Row 2</Td>
-            <Td align="right">Row 2</Td>
-          </Tr>
-          <Tr>
-            <Td>
-              <P>Row 3 with paragraph</P>
-            </Td>
-            <Td>
-              Row 3 with <Code>code</Code>
-            </Td>
-            <Td>
-              <P>
-                Row 3 with <b>medium paragraph</b>
-              </P>
-            </Td>
-            <Td align="right">
-              Row 3 with <b>medium text</b>
-            </Td>
-          </Tr>
-        </tbody>
-      </Table>
-    </Table.ScrollView>
+  <ComponentBox
+    hideCode
+    data-visual-test="table-default"
+    scope={{ useHandleSortState }}
+  >
+    {() => {
+      const BasicTable = () => {
+        const { sortState, sortHandler } = useHandleSortState({
+          one: { active: true },
+          two: { direction: 'desc', modes: ['asc', 'desc'] },
+        })
+
+        return (
+          <Table.ScrollView>
+            <Table>
+              <caption className="dnb-sr-only">A Table Caption</caption>
+              <thead>
+                <Tr>
+                  <Th>Column</Th>
+                  <Th>
+                    <Th.Horizontal>
+                      Help Button
+                      <Th.HelpButton>Help Content</Th.HelpButton>
+                    </Th.Horizontal>
+                  </Th>
+                  <Th
+                    sortable
+                    active={sortState.one.active}
+                    reversed={sortState.one.reversed}
+                  >
+                    <Th.SortButton
+                      text="Sortable Active"
+                      title="Sort table column"
+                      on_click={sortHandler.one}
+                    />
+                  </Th>
+                  <Th
+                    sortable
+                    active={sortState.two.active}
+                    reversed={sortState.two.reversed}
+                    align="right"
+                  >
+                    <Th.SortButton
+                      text="Sortable"
+                      title="Sort table column"
+                      on_click={sortHandler.two}
+                    />
+                  </Th>
+                </Tr>
+              </thead>
+              <tbody>
+                <Tr>
+                  <Td>Row 1</Td>
+                  <Td>Row 1</Td>
+                  <Td>Row 1</Td>
+                  <Td align="right">Row 1</Td>
+                </Tr>
+                <Tr>
+                  <Td>Row 2</Td>
+                  <Td>Row 2</Td>
+                  <Td>Row 2</Td>
+                  <Td align="right">Row 2</Td>
+                </Tr>
+                <Tr>
+                  <Td>
+                    <P>Row 3 with paragraph</P>
+                  </Td>
+                  <Td>
+                    Row 3 with <Code>code</Code>
+                  </Td>
+                  <Td>
+                    <P>
+                      Row 3 with <b>medium paragraph</b>
+                    </P>
+                  </Td>
+                  <Td align="right">
+                    Row 3 with <b>medium text</b>
+                  </Td>
+                </Tr>
+              </tbody>
+            </Table>
+          </Table.ScrollView>
+        )
+      }
+
+      return <BasicTable />
+    }}
   </ComponentBox>
 )
 
@@ -588,12 +620,10 @@ export const TableAccordion = () => (
 
             <thead>
               <Tr>
-                <Th scope="col">Column A</Th>
-                <Th scope="col">Column B</Th>
-                <Th scope="col">Column C</Th>
-                <Th scope="col" align="right">
-                  Column D
-                </Th>
+                <Th>Column A</Th>
+                <Th>Column B</Th>
+                <Th>Column C</Th>
+                <Th align="right">Column D</Th>
               </Tr>
             </thead>
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -32,8 +32,8 @@ export const TableVariantBasic = () => (
     {() => {
       const BasicTable = () => {
         const { sortState, sortHandler } = useHandleSortState({
-          one: { active: true },
-          two: { direction: 'desc', modes: ['asc', 'desc'] },
+          column1: { active: true },
+          column2: { direction: 'desc', modes: ['asc', 'desc'] },
         })
 
         return (
@@ -51,25 +51,25 @@ export const TableVariantBasic = () => (
                   </Th>
                   <Th
                     sortable
-                    active={sortState.one.active}
-                    reversed={sortState.one.reversed}
+                    active={sortState.column1.active}
+                    reversed={sortState.column1.reversed}
                   >
                     <Th.SortButton
                       text="Sortable Active"
                       title="Sort table column"
-                      on_click={sortHandler.one}
+                      on_click={sortHandler.column1}
                     />
                   </Th>
                   <Th
                     sortable
-                    active={sortState.two.active}
-                    reversed={sortState.two.reversed}
+                    active={sortState.column2.active}
+                    reversed={sortState.column2.reversed}
                     align="right"
                   >
                     <Th.SortButton
                       text="Sortable"
                       title="Sort table column"
-                      on_click={sortHandler.two}
+                      on_click={sortHandler.column2}
                     />
                   </Th>
                 </Tr>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.md
@@ -21,6 +21,8 @@ TableAccordion,
 
 ### Basic table
 
+**NB:** In this example, the sort buttons do react on your input. But will not change the table data.
+
 <TableVariantBasic />
 
 ### Complex table

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
@@ -66,7 +66,9 @@ Have a [look at this example](/uilib/components/table/demos/#table-with-a-max-he
 
 ## Sortable table
 
-Optionally, make use of the following React Hook to handle sort directions together with `Th.SortButton`.
+Optionally, make use of the following React Hook to handle the `Th.SortButton` directions.
+
+It can be used as a "controller" for your own sorting logic of your data.
 
 By default, it will cycle trough three stages `['asc', 'desc', 'off']`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
@@ -76,19 +76,23 @@ By default, it will cycle trough three stages `['asc', 'desc', 'off']`.
 import { useHandleSortState } from '@dnb/eufemia/components/table'
 
 // You can also provide a default that will be used as the fallback e.g.
-const defaultOptions = { modes: ['asc', 'desc'] }
+const defaultOptions = { direction: 'asc', modes: ['asc', 'desc', 'off'] }
 
 export const YourComponent = () => {
-  const { sortState, sortHandler } = useHandleSortState(
+  const { sortState, sortHandler, activeName } = useHandleSortState(
     {
-      one: { active: true }, // will cycle only through three modes, including "off"
-      two: { direction: 'desc', modes: ['asc', 'desc'] }, // will cycle only through "asc" or "desc"
-      three: { modes: ['asc'] }, // will always be "asc"
+      // Defiend your column names with options (optional)
+      column1: { active: true }, //
+      column2: { direction: 'desc', modes: ['asc', 'desc'] }, // overwrite the defaultOptions
+      column3: { modes: ['asc', 'off'] }, // will only allow one direciton
+      column4: {}, // etc.
     },
     defaultOptions
   )
 
-  console.log(sortState.one.direction) // returns either "asc", "desc" or "off"
+  // Use these properties for your custom sorting logic
+  console.log(sortState.column1.direction) // returns either "asc", "desc" or "off"
+  console.log(activeName) // returns the current active one: "column1"
 
   return (
     <Table>
@@ -96,13 +100,13 @@ export const YourComponent = () => {
         <Tr>
           <Th
             sortable
-            active={sortState.one.active}
-            reversed={sortState.one.reversed}
+            active={sortState.column1.active}
+            reversed={sortState.column1.reversed}
           >
             <Th.SortButton
               text="Column 1"
               title="Sort this column"
-              on_click={sortHandler.one}
+              on_click={sortHandler.column1}
             />
           </Th>
         </Tr>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
@@ -63,3 +63,49 @@ Method no. 2 should be used when a `max-height` is set to the wrapping `Table.Sc
 ```
 
 Have a [look at this example](/uilib/components/table/demos/#table-with-a-max-height).
+
+## Sortable table
+
+Optionally, make use of the following React Hook to handle sort directions together with `Th.SortButton`.
+
+By default, it will cycle trough three stages `['asc', 'desc', 'off']`.
+
+```jsx
+import { useHandleSortState } from '@dnb/eufemia/components/table'
+
+// You can also provide a default that will be used as the fallback e.g.
+const defaultOptions = { modes: ['asc', 'desc'] }
+
+export const YourComponent = () => {
+  const { sortState, sortHandler } = useHandleSortState(
+    {
+      one: { active: true }, // will cycle only through three modes, including "off"
+      two: { direction: 'desc', modes: ['asc', 'desc'] }, // will cycle only through "asc" or "desc"
+      three: { modes: ['asc'] }, // will always be "asc"
+    },
+    defaultOptions
+  )
+
+  console.log(sortState.one.direction) // returns either "asc", "desc" or "off"
+
+  return (
+    <Table>
+      <thead>
+        <Tr>
+          <Th
+            sortable
+            active={sortState.one.active}
+            reversed={sortState.one.reversed}
+          >
+            <Th.SortButton
+              text="Column 1"
+              title="Sort this column"
+              on_click={sortHandler.one}
+            />
+          </Th>
+        </Tr>
+      </thead>
+    </Table>
+  )
+}
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.md
@@ -79,7 +79,7 @@ import { useHandleSortState } from '@dnb/eufemia/components/table'
 const defaultOptions = { direction: 'asc', modes: ['asc', 'desc', 'off'] }
 
 export const YourComponent = () => {
-  const { sortState, sortHandler, activeName } = useHandleSortState(
+  const { sortState, sortHandler, activeSortName } = useHandleSortState(
     {
       // Defiend your column names with options (optional)
       column1: { active: true }, //
@@ -92,7 +92,7 @@ export const YourComponent = () => {
 
   // Use these properties for your custom sorting logic
   console.log(sortState.column1.direction) // returns either "asc", "desc" or "off"
-  console.log(activeName) // returns the current active one: "column1"
+  console.log(activeSortName) // returns the current active one: "column1" (returns null when nothing is active)
 
   return (
     <Table>

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -257,12 +257,33 @@ exports[`Table scss have to match snapshot 1`] = `
       html:not([data-whatintent='touch'])
       .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before {
         right: -0.5rem; }
-      .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon,
+      html[data-visual-test] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon,
+      :not(.dnb-table--active) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test]
       html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon,
+      :not(.dnb-table--active)
+      html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test]
       .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon,
+      :not(.dnb-table--active)
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test]
       html:not([data-whatintent='touch'])
-      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon {
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon,
+      :not(.dnb-table--active)
+      html:not([data-whatintent='touch'])
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon {
         opacity: 1; }
+      html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test])
+      html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test])
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test])
+      html:not([data-whatintent='touch'])
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
+        opacity: 1;
+        color: inherit; }
+      html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test])
+      html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test])
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test])
+      html:not([data-whatintent='touch'])
+      .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after {
+        visibility: visible; }
       .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled],
       html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled],
       .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled],
@@ -383,6 +404,18 @@ exports[`Table scss have to match snapshot 1`] = `
   .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
     color: var(--color-sea-green);
     opacity: 1; }
+  .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled],
+  html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled],
+  .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled],
+  html:not([data-whatintent='touch'])
+  .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled] {
+    cursor: not-allowed; }
+  .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after,
+  html:not([data-whatintent='touch']) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after,
+  .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after,
+  html:not([data-whatintent='touch'])
+  .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
+    opacity: 0; }
   .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after,
   .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after {
     visibility: visible; }

--- a/packages/dnb-eufemia/src/components/table/__tests__/useHandleSortState.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/useHandleSortState.test.tsx
@@ -1,0 +1,465 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import useHandleSortState from '../useHandleSortState'
+
+describe('useHandleSortState', () => {
+  it('should return empty sortHandler and sortState', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {},
+    })
+
+    expect(result.current).toEqual({ sortHandler: {}, sortState: {} })
+  })
+
+  it('should return default state', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: null,
+      },
+    })
+
+    expect(result.current).toEqual({
+      sortHandler: {
+        one: expect.any(Function),
+      },
+      sortState: {
+        one: {
+          active: undefined,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+  })
+
+  it('should return false on active', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: false, direction: 'desc' },
+      },
+    })
+
+    expect(result.current).toEqual({
+      sortHandler: {
+        one: expect.any(Function),
+      },
+      sortState: {
+        one: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+  })
+
+  it('should return false on active', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: false, direction: 'desc' },
+      },
+    })
+
+    expect(result.current).toEqual({
+      sortHandler: {
+        one: expect.any(Function),
+      },
+      sortState: {
+        one: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+  })
+
+  it('should return active with reverted direction', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true, direction: 'desc' },
+      },
+    })
+
+    expect(result.current).toEqual({
+      sortHandler: {
+        one: expect.any(Function),
+      },
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+  })
+
+  it('should return active with reverted direction', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true },
+      },
+    })
+
+    expect(result.current).toEqual({
+      sortHandler: {
+        one: expect.any(Function),
+      },
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+  })
+
+  it('should cycle through all two given stages when dispatching handler', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true, modes: ['asc', 'desc'] },
+      },
+    })
+
+    const sortHandler = {
+      one: expect.any(Function),
+    }
+
+    const simulate = () => act(() => result.current.sortHandler.one())
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+  })
+
+  it('should not cycle through stages when dispatching handler', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true, modes: ['asc'] },
+      },
+    })
+
+    const sortHandler = {
+      one: expect.any(Function),
+    }
+
+    const simulate = () => act(() => result.current.sortHandler.one())
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+  })
+
+  it('should cycle through "asc" and "off"', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true, modes: ['asc', 'off'] },
+      },
+    })
+
+    const sortHandler = {
+      one: expect.any(Function),
+    }
+
+    const simulate = () => act(() => result.current.sortHandler.one())
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: undefined,
+          direction: 'off',
+        },
+      },
+    })
+
+    simulate()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+  })
+
+  it('should cycle through all three stages when dispatching handler', () => {
+    const { result } = renderHook(useHandleSortState, {
+      initialProps: {
+        one: { active: true },
+        two: { active: false, direction: 'desc', modes: ['asc', 'desc'] },
+      },
+    })
+
+    const sortHandler = {
+      one: expect.any(Function),
+      two: expect.any(Function),
+    }
+
+    const simulateOne = () => act(() => result.current.sortHandler.one())
+    const simulateTwo = () => act(() => result.current.sortHandler.two())
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: undefined,
+          direction: 'off',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateTwo()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateTwo()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+      },
+    })
+
+    simulateTwo()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: false,
+          reversed: undefined,
+          direction: 'off',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: false,
+          direction: 'asc',
+        },
+        two: {
+          active: false,
+          reversed: true,
+          direction: 'desc',
+        },
+      },
+    })
+
+    simulateOne()
+
+    expect(result.current).toEqual({
+      sortHandler,
+      sortState: {
+        one: {
+          active: true,
+          reversed: true,
+          direction: 'desc',
+        },
+        two: {
+          active: false,
+          direction: 'desc',
+          reversed: true,
+        },
+      },
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/components/table/__tests__/useHandleSortState.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/useHandleSortState.test.tsx
@@ -7,7 +7,11 @@ describe('useHandleSortState', () => {
       initialProps: {},
     })
 
-    expect(result.current).toEqual({ sortHandler: {}, sortState: {} })
+    expect(result.current).toEqual({
+      activeSortName: null,
+      sortHandler: {},
+      sortState: {},
+    })
   })
 
   it('should return default state', () => {
@@ -18,6 +22,7 @@ describe('useHandleSortState', () => {
     })
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler: {
         one: expect.any(Function),
       },
@@ -39,6 +44,7 @@ describe('useHandleSortState', () => {
     })
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler: {
         one: expect.any(Function),
       },
@@ -60,6 +66,7 @@ describe('useHandleSortState', () => {
     })
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler: {
         one: expect.any(Function),
       },
@@ -81,6 +88,7 @@ describe('useHandleSortState', () => {
     })
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler: {
         one: expect.any(Function),
       },
@@ -102,6 +110,7 @@ describe('useHandleSortState', () => {
     })
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler: {
         one: expect.any(Function),
       },
@@ -131,6 +140,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -144,6 +154,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -157,6 +168,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -184,6 +196,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -197,6 +210,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -224,6 +238,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler,
       sortState: {
         one: {
@@ -237,6 +252,7 @@ describe('useHandleSortState', () => {
     simulate()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -267,6 +283,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -285,6 +302,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler,
       sortState: {
         one: {
@@ -303,6 +321,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -321,6 +340,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -339,6 +359,7 @@ describe('useHandleSortState', () => {
     simulateTwo()
 
     expect(result.current).toEqual({
+      activeSortName: 'two',
       sortHandler,
       sortState: {
         one: {
@@ -357,6 +378,7 @@ describe('useHandleSortState', () => {
     simulateTwo()
 
     expect(result.current).toEqual({
+      activeSortName: 'two',
       sortHandler,
       sortState: {
         one: {
@@ -375,6 +397,7 @@ describe('useHandleSortState', () => {
     simulateTwo()
 
     expect(result.current).toEqual({
+      activeSortName: 'two',
       sortHandler,
       sortState: {
         one: {
@@ -393,6 +416,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -411,6 +435,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: null,
       sortHandler,
       sortState: {
         one: {
@@ -429,6 +454,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {
@@ -447,6 +473,7 @@ describe('useHandleSortState', () => {
     simulateOne()
 
     expect(result.current).toEqual({
+      activeSortName: 'one',
       sortHandler,
       sortState: {
         one: {

--- a/packages/dnb-eufemia/src/components/table/index.js
+++ b/packages/dnb-eufemia/src/components/table/index.js
@@ -4,5 +4,6 @@
  */
 
 import Table from './Table'
+export { useHandleSortState } from './useHandleSortState'
 export default Table
 export * from './Table'

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -16,6 +16,7 @@ import TableContainer from '../TableContainer'
 import { H2, P, Anchor, Dl, Lead } from '../../../elements'
 import { Button, ToggleButton, NumberFormat, Avatar } from '../../'
 import shopping_cart from '../../../icons/shopping_cart'
+import { useHandleSortState } from '../'
 
 export default {
   title: 'Eufemia/Components/Table',
@@ -34,13 +35,13 @@ export const StickyBasicTable = () => {
       <caption className="dnb-sr-only">A Table Caption</caption>
       <thead>
         <Tr>
-          <Th scope="col" colSpan={2}>
+          <Th colSpan={2}>
             Header <Th.HelpButton>Help content</Th.HelpButton>
           </Th>
-          <Th scope="col" reversed sortable>
+          <Th reversed sortable>
             <Th.SortButton text="Sortable" title="Sort table column" />
           </Th>
-          <Th scope="col" active sortable>
+          <Th active sortable>
             <Th.SortButton text="Active" title="Sort table column" />
           </Th>
         </Tr>
@@ -135,15 +136,15 @@ export const ContainerTable = () => {
           <caption className="dnb-sr-only">Table One</caption>
           <thead>
             <Tr noWrap>
-              <Th scope="col">
+              <Th>
                 I have a superscript{' '}
                 <sup>
                   <Anchor href="#unique-ref-id">1</Anchor>
                 </sup>
               </Th>
-              <Th scope="col">Column 2</Th>
-              <Th scope="col">Column 3</Th>
-              <Th scope="col">Column 4</Th>
+              <Th>Column 2</Th>
+              <Th>Column 3</Th>
+              <Th>Column 4</Th>
             </Tr>
           </thead>
           <tbody>
@@ -195,10 +196,10 @@ export const ContainerTable = () => {
           <caption className="dnb-sr-only">Table Two</caption>
           <thead>
             <Tr noWrap>
-              <Th scope="col">Column 1</Th>
-              <Th scope="col">Column 2</Th>
-              <Th scope="col">Column 3</Th>
-              <Th scope="col">Column 4</Th>
+              <Th>Column 1</Th>
+              <Th>Column 2</Th>
+              <Th>Column 3</Th>
+              <Th>Column 4</Th>
             </Tr>
           </thead>
           <tbody>
@@ -280,22 +281,11 @@ export const ContainerTable = () => {
 }
 
 export const BasicTable = () => {
-  const [activeCol, setActiveCol] = React.useState('col1')
-  const [directionCol1, setSortDirectionCol1] = React.useState(false)
-  const [directionCol2, setSortDirectionCol2] = React.useState(false)
-  const [directionCol3, setSortDirectionCol3] = React.useState(false)
-  const sortCol1 = () => {
-    setActiveCol('col1')
-    setSortDirectionCol1((s) => !s)
-  }
-  const sortCol2 = () => {
-    setActiveCol('col2')
-    setSortDirectionCol2((s) => !s)
-  }
-  const sortCol3 = () => {
-    setActiveCol('col3')
-    setSortDirectionCol3((s) => !s)
-  }
+  const { sortState, sortHandler } = useHandleSortState({
+    one: { active: true, direction: 'desc' },
+    two: { modes: ['asc', 'off'] },
+    three: { modes: ['asc'] },
+  })
 
   return (
     <Table top>
@@ -303,38 +293,35 @@ export const BasicTable = () => {
       <thead>
         <Tr>
           <Th
-            scope="col"
             sortable
-            reversed={directionCol1}
-            active={activeCol === 'col1'}
+            reversed={sortState.one.reversed}
+            active={sortState.one.active}
           >
             <Th.SortButton
-              on_click={sortCol1}
+              on_click={sortHandler.one}
               text="Column 1"
               title="Sort table column"
             />
           </Th>
           <Th
-            scope="col"
             sortable
-            reversed={directionCol2}
-            active={activeCol === 'col2'}
+            reversed={sortState.two.reversed}
+            active={sortState.two.active}
           >
             <Th.SortButton
-              on_click={sortCol2}
+              on_click={sortHandler.two}
               text="Column 2"
               title="Sort table column"
             />
           </Th>
           <Th
-            scope="col"
             align="right"
             sortable
-            reversed={directionCol3}
-            active={activeCol === 'col3'}
+            reversed={sortState.three.reversed}
+            active={sortState.three.active}
           >
             <Th.SortButton
-              on_click={sortCol3}
+              on_click={sortHandler.three}
               text="Column 3"
               title="Sort table column"
             />
@@ -532,26 +519,25 @@ const TableContent = () => {
       <thead>
         <Tr>
           <Th
-            scope="col"
             // colSpan={2}
             sortable
             active
           >
             <HeaderSortButton>Fond</HeaderSortButton>
           </Th>
-          <Th scope="col" sortable reversed>
+          <Th sortable reversed>
             <HeaderSortButton>1 år</HeaderSortButton>
           </Th>
-          <Th scope="col" sortable>
+          <Th sortable>
             <HeaderSortButton>Kostnad</HeaderSortButton>
           </Th>
-          <Th scope="col" sortable>
+          <Th sortable>
             <HeaderSortButton>Kostnad</HeaderSortButton>
           </Th>
-          <Th scope="col" sortable>
+          <Th sortable>
             <HeaderSortButton>Morningstar</HeaderSortButton>
           </Th>
-          <Th scope="col" sortable align="right">
+          <Th sortable align="right">
             <HeaderSortButton>Handlekurv</HeaderSortButton>
           </Th>
         </Tr>

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -281,80 +281,91 @@ export const ContainerTable = () => {
 }
 
 export const BasicTable = () => {
-  const { sortState, sortHandler } = useHandleSortState({
+  const { sortState, sortHandler, activeSortName } = useHandleSortState({
     column1: { active: true, direction: 'desc' },
     column2: { modes: ['asc', 'off'] },
     column3: { modes: ['asc'] },
   })
 
+  console.log('activeSortName', activeSortName)
+
+  const [count, setCount] = React.useState(0)
+
   return (
-    <Table top>
-      <caption className="dnb-sr-only">A Table Caption</caption>
-      <thead>
-        <Tr>
-          <Th
-            sortable
-            reversed={sortState.column1.reversed}
-            active={sortState.column1.active}
-          >
-            <Th.SortButton
-              on_click={sortHandler.column1}
-              text="Column 1"
-              title="Sort table column"
-            />
-          </Th>
-          <Th
-            sortable
-            reversed={sortState.column2.reversed}
-            active={sortState.column2.active}
-          >
-            <Th.SortButton
-              on_click={sortHandler.column2}
-              text="Column 2"
-              title="Sort table column"
-            />
-          </Th>
-          <Th
-            align="right"
-            sortable
-            reversed={sortState.column3.reversed}
-            active={sortState.column3.active}
-          >
-            <Th.SortButton
-              on_click={sortHandler.column3}
-              text="Column 3"
-              title="Sort table column"
-            />
-          </Th>
-        </Tr>
-      </thead>
-      <tbody>
-        <Tr variant="even">
-          <Td>
-            <p className="dnb-p">
-              Row 1 <b>width p</b>
-            </p>
-          </Td>
-          <Td>
-            <span>Row 1 with span</span>
-          </Td>
-          <Td align="right">Row 1</Td>
-        </Tr>
-        <Tr>
-          <Td colSpan={2}>Row 2 which spans over two columns</Td>
-          <Td align="right">Row 2</Td>
-        </Tr>
-        <Tr>
-          <Td>Row 3</Td>
-          <Td>Row 3</Td>
-          <Td align="right">Row 3</Td>
-        </Tr>
-      </tbody>
-    </Table>
+    <React.StrictMode>
+      <button onClick={handleCount}>count {count}</button>
+      <Table top>
+        <caption className="dnb-sr-only">A Table Caption</caption>
+        <thead>
+          <Tr>
+            <Th
+              sortable
+              reversed={sortState.column1.reversed}
+              active={sortState.column1.active}
+            >
+              <Th.SortButton
+                on_click={sortHandler.column1}
+                text="Column 1"
+                title="Sort table column"
+              />
+            </Th>
+            <Th
+              sortable
+              reversed={sortState.column2.reversed}
+              active={sortState.column2.active}
+            >
+              <Th.SortButton
+                on_click={sortHandler.column2}
+                text="Column 2"
+                title="Sort table column"
+              />
+            </Th>
+            <Th
+              align="right"
+              sortable
+              reversed={sortState.column3.reversed}
+              active={sortState.column3.active}
+            >
+              <Th.SortButton
+                on_click={sortHandler.column3}
+                text="Column 3"
+                title="Sort table column"
+              />
+            </Th>
+          </Tr>
+        </thead>
+        <tbody>
+          <Tr variant="even">
+            <Td>
+              <p className="dnb-p">
+                Row 1 <b>width p</b>
+              </p>
+            </Td>
+            <Td>
+              <span>Row 1 with span</span>
+            </Td>
+            <Td align="right">Row 1</Td>
+          </Tr>
+          <Tr>
+            <Td colSpan={2}>Row 2 which spans over two columns</Td>
+            <Td align="right">Row 2</Td>
+          </Tr>
+          <Tr>
+            <Td>Row 3</Td>
+            <Td>Row 3</Td>
+            <Td align="right">Row 3</Td>
+          </Tr>
+        </tbody>
+      </Table>
+    </React.StrictMode>
   )
+
+  function handleCount() {
+    setCount((c) => c + 1)
+  }
 }
 
-export const TableSortable = () => {
+export const TableOddEven = () => {
   const [list, setlist] = React.useState([
     'content cab',
     'content abc',

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -282,9 +282,9 @@ export const ContainerTable = () => {
 
 export const BasicTable = () => {
   const { sortState, sortHandler } = useHandleSortState({
-    one: { active: true, direction: 'desc' },
-    two: { modes: ['asc', 'off'] },
-    three: { modes: ['asc'] },
+    column1: { active: true, direction: 'desc' },
+    column2: { modes: ['asc', 'off'] },
+    column3: { modes: ['asc'] },
   })
 
   return (
@@ -294,22 +294,22 @@ export const BasicTable = () => {
         <Tr>
           <Th
             sortable
-            reversed={sortState.one.reversed}
-            active={sortState.one.active}
+            reversed={sortState.column1.reversed}
+            active={sortState.column1.active}
           >
             <Th.SortButton
-              on_click={sortHandler.one}
+              on_click={sortHandler.column1}
               text="Column 1"
               title="Sort table column"
             />
           </Th>
           <Th
             sortable
-            reversed={sortState.two.reversed}
-            active={sortState.two.active}
+            reversed={sortState.column2.reversed}
+            active={sortState.column2.active}
           >
             <Th.SortButton
-              on_click={sortHandler.two}
+              on_click={sortHandler.column2}
               text="Column 2"
               title="Sort table column"
             />
@@ -317,11 +317,11 @@ export const BasicTable = () => {
           <Th
             align="right"
             sortable
-            reversed={sortState.three.reversed}
-            active={sortState.three.active}
+            reversed={sortState.column3.reversed}
+            active={sortState.column3.active}
           >
             <Th.SortButton
-              on_click={sortHandler.three}
+              on_click={sortHandler.column3}
               text="Column 3"
               title="Sort table column"
             />

--- a/packages/dnb-eufemia/src/components/table/style/_table-header-buttons.scss
+++ b/packages/dnb-eufemia/src/components/table/style/_table-header-buttons.scss
@@ -87,8 +87,20 @@
         &::before {
           right: -0.5rem;
         }
-        .dnb-icon {
+        html[data-visual-test] & .dnb-icon,
+        :not(.dnb-table--active) &:active .dnb-icon {
           opacity: 1;
+        }
+
+        // show underline
+        html:not([data-visual-test]) & {
+          .dnb-button__text::after {
+            opacity: 1;
+            color: inherit;
+          }
+          &:not(:active) .dnb-button__text::after {
+            visibility: visible;
+          }
         }
       }
 
@@ -149,6 +161,13 @@
         .dnb-button__text::after {
           color: var(--color-sea-green);
           opacity: 1;
+        }
+      }
+
+      @include focus() {
+        // hide underline
+        .dnb-button__text::after {
+          opacity: 0;
         }
       }
 

--- a/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
+++ b/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
@@ -107,18 +107,23 @@ export function useHandleSortState(
     }, {})
   }, [internalState]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  let activeSortName = null
   const sortState: SortState = Object.entries(internalState).reduce(
     (acc, [name, { active, direction }]) => {
       const reversed =
         direction === 'off' ? undefined : direction === 'desc'
 
       acc[name] = { active, direction, reversed }
+
+      if (active) {
+        activeSortName = name
+      }
       return acc
     },
     {}
   )
 
-  return { sortState, sortHandler }
+  return { sortState, sortHandler, activeSortName }
 
   function getNextMode({ state, opts, defaults }: GetNextMode) {
     const modes = defaults.modes.filter((mode) => {

--- a/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
+++ b/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+
+export type useHandleSortStateOptions = {
+  /**
+   * Defines if the current column should be active or not.
+   * Defaults to false.
+   */
+  active?: boolean
+
+  /**
+   * Define the sorting direction. Can be "asc" or "desc".
+   * Defaults to "asc".
+   */
+  direction?: useHandleSortStateDirection
+
+  /**
+   * Define the possible modes.
+   * Defaults to ["asc", "desc", "off"].
+   */
+  modes?: Array<useHandleSortStateMode>
+}
+export type useHandleSortStateDirection = 'asc' | 'desc'
+export type useHandleSortStateMode = 'asc' | 'desc' | 'off'
+export type useHandleSortStateName = string
+export type useHandleSortStateConfig = Record<
+  useHandleSortStateName,
+  useHandleSortStateOptions
+>
+export type SortState = Record<
+  useHandleSortStateName,
+  {
+    active: boolean
+    reversed: boolean
+    direction: useHandleSortStateDirection | 'off'
+  }
+>
+export type SortEventHandler = () => void
+export type SortHandler = Record<useHandleSortStateName, SortEventHandler>
+
+type SortStateInternalStateOptions = Omit<
+  useHandleSortStateOptions,
+  'direction'
+> & { direction: useHandleSortStateDirection | 'off' }
+type SortStateInternalState = SortStateInternalStateOptions & {
+  reversed: boolean
+  lastDirection: useHandleSortStateDirection
+}
+type SortStateInternalEntry = Record<
+  useHandleSortStateName,
+  SortStateInternalStateOptions
+>
+type GetNextMode = {
+  state: SortStateInternalState
+  opts: SortStateInternalStateOptions
+  defaults: useHandleSortStateOptions
+}
+
+export function useHandleSortState(
+  config: useHandleSortStateConfig,
+  defaults: useHandleSortStateOptions = {
+    direction: 'asc',
+    modes: ['asc', 'desc', 'off'],
+  }
+) {
+  const initialState = React.useMemo(() => {
+    return Object.entries(config).reduce((acc, [name, opts]) => {
+      acc[name] = { ...defaults, ...opts }
+      if (!acc[name].active && !acc[name].lastDirection) {
+        acc[name].lastDirection = acc[name].direction
+      }
+      return acc
+    }, {})
+  }, [config, defaults])
+
+  const [internalState, setState] = React.useState<SortState>(initialState)
+
+  const sortHandler: SortHandler = React.useMemo(() => {
+    const list = Object.entries(internalState as SortStateInternalEntry)
+
+    return list.reduce((acc, [name, opts]) => {
+      acc[name] = () => {
+        const state = { ...internalState[name] } as SortStateInternalState
+
+        if (!state.active && state.lastDirection) {
+          state.direction = state.lastDirection
+          state.active = true
+          state.lastDirection = null
+        } else {
+          state.direction = getNextMode({ state, opts, defaults })
+          state.active = state.direction !== 'off'
+        }
+
+        setState({
+          ...list.reduce((acc, [name, opts]) => {
+            acc[name] = opts
+            acc[name].active = false
+            if (opts.direction !== 'off') {
+              acc[name].lastDirection = opts.direction
+            }
+            return acc
+          }, {}),
+          [name]: state,
+        })
+      }
+
+      return acc
+    }, {})
+  }, [internalState]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const sortState: SortState = Object.entries(internalState).reduce(
+    (acc, [name, { active, direction }]) => {
+      const reversed =
+        direction === 'off' ? undefined : direction === 'desc'
+
+      acc[name] = { active, direction, reversed }
+      return acc
+    },
+    {}
+  )
+
+  return { sortState, sortHandler }
+
+  function getNextMode({ state, opts, defaults }: GetNextMode) {
+    const modes = defaults.modes.filter((mode) => {
+      return opts.modes.includes(mode)
+    })
+
+    for (let i = 0, l = modes.length; i < l; i++) {
+      const mode = modes[i]
+
+      if (mode === state.direction) {
+        let c = i + 1
+        if (c >= l) {
+          c = 0
+        }
+        state.direction = modes[c]
+        break
+      }
+    }
+
+    return state.direction
+  }
+}
+
+export default useHandleSortState


### PR DESCRIPTION
This PR adds a little React Hook that could be very handy when dealing with three stage sorting, which should be naturally the default behavior.

But we also ensure that the `Th.SortButton` actually reacts correctly as well. This is handled by CSS. Also, for the CSS states, [this CSB](https://codesandbox.io/s/bold-field-glyxq6) was provided.

What do you think about all the option names and the name of the React Hook?