### PR TITLE
fix(ScrollView): ensure an ancestor scroll area (body) can still be scrolled with mouse wheel

### DIFF
--- a/packages/dnb-eufemia/src/fragments/scroll-view/style/_scroll-view.scss
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/style/_scroll-view.scss
@@ -7,6 +7,9 @@
   overflow-x: auto;
   @include scrollY(auto);
 
+  // Ensure the user still can scroll a ancestor scrollarea (body)
+  overscroll-behavior: auto;
+
   // interactive prop
   &[tabindex='0'] {
     &:focus {


### PR DESCRIPTION
When using mousewheel or touchpad while holding the mouse over e.g. a table, you could not scroll the "body" down anymore. With this change, you can do it as expected.

I think, this should be the default behavior.