### PR TITLE
chore(Tag): rewrite tests w/o using data-testid

### DIFF
--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -157,7 +157,6 @@ const Tag = (localProps: TagProps & SpacingProps) => {
 
   return (
     <Button
-      data-testid="tag"
       variant="unstyled"
       size="small"
       icon_position={isRemovable ? 'right' : 'left'}

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -78,12 +78,9 @@ const TagGroup = (localProps: TagGroupProps & SpacingProps) => {
     <TagGroupContext.Provider value={props}>
       <span
         className={classnames('dnb-tag__group', spacingClasses, className)}
-        data-testid="tag-group"
         {...attributes}
       >
-        <span data-testid="tag-group-label" className="dnb-sr-only">
-          {label}
-        </span>
+        <span className="dnb-sr-only">{label}</span>
         {children}
       </span>
     </TagGroupContext.Provider>

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import Tag from '../Tag'
 import nbNO from '../../../shared/locales/nb-NO'
 import {
@@ -15,28 +15,21 @@ describe('Tag Group', () => {
   it('renders without children', () => {
     render(<Tag.Group label="tags" />)
 
-    expect(screen.queryByTestId('tag-group')).not.toBeNull()
-    expect(screen.queryByTestId('tag')).toBeNull()
+    expect(document.querySelector('.dnb-tag__group')).not.toBeNull()
+    expect(document.querySelector('.dnb-tag')).toBeNull()
   })
 
   it('renders the label as string', () => {
     const label = 'tags'
     render(<Tag.Group label={label} />)
-    expect(screen.queryByTestId('tag-group-label')).not.toBeNull()
-    expect(screen.queryByTestId('tag-group-label').textContent).toBe(label)
+    expect(screen.queryByText(label)).toBeTruthy()
   })
 
   it('renders the label as react node', () => {
     const label = <span data-testid="react-node">ReactNode</span>
     render(<Tag.Group label={label} />)
 
-    expect(screen.queryByTestId('tag-group-label')).not.toBeNull()
-
-    expect(
-      within(screen.queryByTestId('tag-group-label')).queryByTestId(
-        'react-node'
-      )
-    ).not.toBeNull()
+    expect(screen.queryByTestId('react-node')).not.toBeNull()
   })
 
   it('renders a tag group with multiple tag elements by children', () => {
@@ -49,7 +42,7 @@ describe('Tag Group', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryAllByTestId('tag')).toHaveLength(4)
+    expect(document.querySelectorAll('.dnb-tag')).toHaveLength(4)
   })
 
   it('renders a tag group with className if className is provided', () => {
@@ -60,8 +53,8 @@ describe('Tag Group', () => {
         ClassName
       </Tag.Group>
     )
-    expect(screen.queryByTestId('tag-group').className).toMatch(
-      customClassName
+    expect(document.getElementsByClassName(customClassName)).toHaveLength(
+      1
     )
   })
 
@@ -74,9 +67,9 @@ describe('Tag Group', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByTestId('tag').className).toMatch(
-      skeletonClassName
-    )
+    expect(
+      document.getElementsByClassName(skeletonClassName)
+    ).toHaveLength(1)
   })
 
   it('should support spacing props', () => {
@@ -86,12 +79,12 @@ describe('Tag Group', () => {
       </Tag.Group>
     )
 
-    const element = screen.getByTestId('tag-group')
+    const element = document.querySelector('.dnb-tag__group')
     const attributes = Array.from(element.attributes).map(
       (attr) => attr.name
     )
 
-    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(attributes).toEqual(['class'])
     expect(Array.from(element.classList)).toEqual([
       'dnb-tag__group',
       'dnb-space__top--large',
@@ -107,7 +100,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByTestId('tag')).not.toBeNull()
+    expect(document.querySelector('.dnb-tag')).not.toBeNull()
   })
 
   it('renders a tag with content by text prop', () => {
@@ -119,13 +112,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-    ).not.toBeNull()
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-        .textContent
-    ).toBe(text)
+    expect(screen.queryByText(text)).toBeTruthy()
   })
 
   it('renders a tag with content by children prop', () => {
@@ -137,13 +124,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-    ).not.toBeNull()
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-        .textContent
-    ).toBe(text)
+    expect(screen.queryByText(text)).toBeTruthy()
   })
 
   it('renders a tag with content if both text and children prop is defined', () => {
@@ -155,13 +136,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-    ).not.toBeNull()
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-        .textContent
-    ).toBe(text)
+    expect(screen.queryByText(text)).toBeTruthy()
   })
 
   it('renders a tag with skeleton if skeleton is true', () => {
@@ -173,9 +148,9 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByTestId('tag').className).toMatch(
-      skeletonClassName
-    )
+    expect(
+      document.getElementsByClassName(skeletonClassName)
+    ).toHaveLength(1)
   })
 
   it('inherits skeleton prop from provider', () => {
@@ -189,20 +164,22 @@ describe('Tag', () => {
       </Provider>
     )
 
-    expect(screen.queryByTestId('tag').className).toMatch(
-      skeletonClassName
-    )
+    expect(
+      document.getElementsByClassName(skeletonClassName)
+    ).toHaveLength(1)
   })
 
   it('does not render a clickable Tag as default', () => {
+    const text = 'Tag with text'
+
     render(
       <Tag.Group label="tags">
-        <Tag text="Tag with text" />
+        <Tag text={text} />
       </Tag.Group>
     )
 
     expect(screen.queryByRole('button')).toBeNull()
-    expect(screen.queryByTestId('tag').textContent).toBe('‌Tag with text')
+    expect(screen.queryByText(text)).toBeTruthy()
   })
 
   it('does support icon', () => {
@@ -212,9 +189,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-icon')
-    ).toBeTruthy()
+    expect(document.querySelector('.dnb-icon')).toBeTruthy()
   })
 
   it('should support spacing props', () => {
@@ -224,12 +199,12 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    const element = screen.getByTestId('tag')
+    const element = document.querySelector('.dnb-tag')
     const attributes = Array.from(element.attributes).map(
       (attr) => attr.name
     )
 
-    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(attributes).toEqual(['class'])
     expect(Array.from(element.classList)).toEqual([
       'dnb-button',
       'dnb-button--unstyled',
@@ -255,9 +230,10 @@ describe('Tag', () => {
           </Tag>
         </Tag.Group>
       )
-      expect(screen.queryByTestId('tag').className).toMatch(
-        clickableClassName
-      )
+
+      expect(
+        document.getElementsByClassName(clickableClassName)
+      ).toHaveLength(1)
       expect(screen.queryByRole('button')).not.toBeNull()
     })
 
@@ -280,9 +256,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(
-        screen.queryByTestId('tag').querySelector('.dnb-icon')
-      ).toBeTruthy()
+      expect(document.querySelector('.dnb-icon')).toBeTruthy()
     })
   })
 
@@ -302,12 +276,13 @@ describe('Tag', () => {
           </Tag>
         </Tag.Group>
       )
-      expect(screen.queryByTestId('tag').className).toMatch(
-        removableClassName
-      )
-      expect(screen.queryByTestId('tag').className).toMatch(
-        clickableClassName
-      )
+
+      expect(
+        document.getElementsByClassName(removableClassName)
+      ).toHaveLength(1)
+      expect(
+        document.getElementsByClassName(clickableClassName)
+      ).toHaveLength(1)
       expect(screen.queryByRole('button')).not.toBeNull()
     })
 
@@ -352,9 +327,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(
-        screen.queryByTestId('tag').querySelector('.dnb-icon')
-      ).toBeTruthy()
+      expect(document.querySelector('.dnb-icon')).toBeTruthy()
     })
 
     it('does not support icon if onDelete', () => {
@@ -364,12 +337,8 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(
-        screen.queryByTestId('tag').querySelector('.dnb-icon')
-      ).toBeTruthy()
-      expect(
-        screen.queryByTestId('tag').querySelectorAll('.dnb-icon').length
-      ).toBe(1)
+      expect(document.querySelector('.dnb-icon')).toBeTruthy()
+      expect(document.querySelectorAll('.dnb-icon').length).toBe(1)
     })
 
     it('renders the delete icon if onDelete is provided', () => {
@@ -444,7 +413,9 @@ describe('Tag', () => {
         <Tag className={customClassName}>ClassName</Tag>
       </Tag.Group>
     )
-    expect(screen.queryByTestId('tag').className).toMatch(customClassName)
+    expect(document.getElementsByClassName(customClassName)).toHaveLength(
+      1
+    )
   })
 
   it('renders a tag with provider', () => {
@@ -456,9 +427,7 @@ describe('Tag', () => {
       </Provider>
     )
 
-    expect(
-      screen.queryByTestId('tag').querySelector('.dnb-button__text')
-    ).not.toBeNull()
+    expect(document.querySelector('.dnb-button__text')).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
Removes the following `data-testid`'s:
- tag
- tag-group
- tag-group-label

I checked in the monorepo, and it exists only a few occurrences of this over there, and have already opened a PR for it 🙏 