### PR TITLE
chore(Upload): rewrite tests w/o using data-testid

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -79,7 +79,6 @@ const Upload = (localProps: UploadAllProps) => {
     >
       <Provider skeleton={skeleton}>
         <UploadDropzone
-          data-testid="upload"
           className={classnames('dnb-upload', spacingClasses, className)}
           {...props}
         >

--- a/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
@@ -35,11 +35,10 @@ const UploadFileInput = () => {
     .join(',')
 
   return (
-    <div data-testid="upload-file-input">
+    <div>
       <Button
         top="medium"
         id={`${sharedId}-input`}
-        data-testid="upload-file-input-button"
         className="dnb-upload__file-input-button"
         icon={FolderIcon}
         icon_position="left"
@@ -54,7 +53,6 @@ const UploadFileInput = () => {
 
       <input
         aria-labelledby={`${sharedId}-input`}
-        data-testid="upload-file-input-input"
         ref={fileInput}
         accept={accept}
         className="dnb-upload__file-input"

--- a/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
@@ -23,11 +23,7 @@ function UploadFileList() {
   }
 
   return (
-    <ul
-      data-testid="upload-file-list"
-      className="dnb-upload__file-list"
-      aria-label={fileListAriaLabel}
-    >
+    <ul className="dnb-upload__file-list" aria-label={fileListAriaLabel}>
       {files.map((uploadFile: UploadFile, index: number) => {
         const onDeleteHandler = () => {
           if (typeof onFileDelete === 'function') {

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -99,7 +99,6 @@ const UploadFileListCell = ({
 
   return (
     <li
-      data-testid="upload-file-list-cell"
       className={classnames(
         'dnb-upload__file-cell',
         hasWarning && 'dnb-upload__file-cell--warning',
@@ -114,7 +113,6 @@ const UploadFileListCell = ({
         </div>
         <div>
           <Button
-            data-testid="upload-delete-button"
             icon={TrashIcon}
             variant="tertiary"
             onClick={onDeleteHandler}
@@ -131,7 +129,7 @@ const UploadFileListCell = ({
 
   function getIcon() {
     if (isLoading) {
-      return <ProgressIndicator data-testid="upload-progress-indicator" />
+      return <ProgressIndicator />
     }
 
     if (hasWarning) return <Icon icon={ExclamationIcon} />
@@ -157,7 +155,6 @@ const UploadFileListCell = ({
     ) : (
       <div className="dnb-upload__file-cell__text-container">
         <a
-          data-testid="upload-file-anchor"
           target="_blank"
           href={imageUrl}
           className={classnames(
@@ -169,7 +166,6 @@ const UploadFileListCell = ({
           {name}
         </a>
         <P
-          data-testid="upload-subtitle"
           className="dnb-upload__file-cell__subtitle"
           size="x-small"
           top="xx-small"
@@ -182,12 +178,7 @@ const UploadFileListCell = ({
 
   function getWarning() {
     return hasWarning ? (
-      <FormStatus
-        data-testid="upload-warning"
-        top="small"
-        text={errorMessage}
-        stretch
-      />
+      <FormStatus top="small" text={errorMessage} stretch />
     ) : null
   }
 }

--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -28,15 +28,9 @@ const UploadInfo = () => {
 
   return (
     <>
-      <Lead data-testid="upload-title" space="0">
-        {title}
-      </Lead>
+      <Lead space="0">{title}</Lead>
 
-      <P
-        data-testid="upload-text"
-        top="xx-small"
-        className="dnb-upload__text"
-      >
+      <P top="xx-small" className="dnb-upload__text">
         {text}
       </P>
 
@@ -47,14 +41,12 @@ const UploadInfo = () => {
         className="dnb-upload__condition-list"
       >
         <Dl.Item>
-          <Dt data-testid="upload-accepted-formats">
-            {fileTypeDescription}
-          </Dt>
+          <Dt>{fileTypeDescription}</Dt>
           <Dd>{prettyfiedAcceptedFileFormats}</Dd>
         </Dl.Item>
 
         <Dl.Item>
-          <Dt data-testid="upload-file-size">{fileSizeDescription}</Dt>
+          <Dt>{fileSizeDescription}</Dt>
           <Dd>
             {String(fileSizeContent).replace(
               '%size',
@@ -65,9 +57,7 @@ const UploadInfo = () => {
 
         {filesAmountLimit < defaultProps.filesAmountLimit && (
           <Dl.Item>
-            <Dt data-testid="upload-file-amount-limit">
-              {fileAmountDescription}
-            </Dt>
+            <Dt>{fileAmountDescription}</Dt>
             <Dd>{filesAmountLimit}</Dd>
           </Dl.Item>
         )}

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -28,24 +28,22 @@ describe('Upload', () => {
   it('renders the component', () => {
     render(<Upload {...defaultProps} />)
 
-    expect(screen.queryByTestId('upload')).not.toBeNull()
+    expect(document.querySelector('.dnb-upload')).not.toBeNull()
   })
 
   it('renders the upload file input section', () => {
     render(<Upload {...defaultProps} />)
 
-    expect(screen.queryByTestId('upload-file-input')).not.toBeNull()
+    expect(
+      document.querySelector('.dnb-upload__file-input')
+    ).not.toBeNull()
   })
 
   describe('Text', () => {
     it('renders the title', () => {
       render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-title')
-
-      expect(element).not.toBeNull()
-
-      expect(element.textContent).toMatch(nb.title)
+      expect(screen.queryByText(nb.title)).toBeTruthy()
     })
 
     it('renders the custom title', () => {
@@ -53,19 +51,13 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} title={customTitle} />)
 
-      const element = screen.queryByTestId('upload-title')
-
-      expect(element.textContent).toMatch(customTitle)
+      expect(screen.queryByText(customTitle)).toBeTruthy()
     })
 
     it('renders the text', () => {
       render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-text')
-
-      expect(element).not.toBeNull()
-
-      expect(element.textContent).toMatch(nb.text)
+      expect(screen.queryByText(nb.text)).toBeTruthy()
     })
 
     it('renders the custom text', () => {
@@ -73,19 +65,13 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} text={customText} />)
 
-      const element = screen.queryByTestId('upload-text')
-
-      expect(element.textContent).toMatch(customText)
+      expect(screen.queryByText(customText)).toBeTruthy()
     })
 
     it('renders the format description', () => {
       render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-accepted-formats')
-
-      expect(element).not.toBeNull()
-
-      expect(element.textContent).toMatch(nb.fileTypeDescription)
+      expect(screen.queryByText(nb.fileTypeDescription)).toBeTruthy()
     })
 
     it('renders the custom format description', () => {
@@ -98,9 +84,7 @@ describe('Upload', () => {
         />
       )
 
-      const element = screen.queryByTestId('upload-accepted-formats')
-
-      expect(element.textContent).toMatch(customFormatDescription)
+      expect(screen.queryByText(customFormatDescription)).toBeTruthy()
     })
 
     it('renders the custom accepted format', () => {
@@ -110,22 +94,15 @@ describe('Upload', () => {
         <Upload {...defaultProps} acceptedFileTypes={acceptedFileTypes} />
       )
 
-      const element = screen.queryByTestId(
-        'upload-accepted-formats'
-      ).nextElementSibling
-
       const formattedFileTypes = acceptedFileTypes.join(', ').toUpperCase()
 
-      expect(element).not.toBeNull()
-      expect(element.textContent).toMatch(formattedFileTypes)
+      expect(screen.queryByText(formattedFileTypes)).toBeTruthy()
     })
 
     it('renders the file size description', () => {
       render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-file-size')
-
-      expect(element).not.toBeNull()
+      expect(screen.queryByText(nb.fileSizeDescription)).toBeTruthy()
     })
 
     it('renders the custom file size description', () => {
@@ -138,22 +115,21 @@ describe('Upload', () => {
         />
       )
 
-      const element = screen.queryByTestId('upload-file-size')
-
-      expect(element.textContent).toMatch(fileSizeDescription)
+      expect(screen.queryByText(fileSizeDescription)).toBeTruthy()
     })
 
     it('renders the file size', () => {
       const fileMaxSize = 2
       render(<Upload {...defaultProps} fileMaxSize={fileMaxSize} />)
 
-      const element =
-        screen.queryByTestId('upload-file-size').nextElementSibling
-
-      expect(element).not.toBeNull()
-      expect(element.textContent).toMatch(
-        String(nb.fileSizeContent).replace('%size', fileMaxSize.toString())
-      )
+      expect(
+        screen.queryByText(
+          String(nb.fileSizeContent).replace(
+            '%size',
+            fileMaxSize.toString()
+          )
+        )
+      ).toBeTruthy()
     })
 
     it('renders the custom file size', () => {
@@ -168,12 +144,11 @@ describe('Upload', () => {
         />
       )
 
-      const element =
-        screen.queryByTestId('upload-file-size').nextElementSibling
-
-      expect(element.textContent).toMatch(
-        String(fileMaxSize).replace('%size', `${fileMaxSize}`)
-      )
+      expect(
+        screen.queryByText(
+          String(fileSizeContent).replace('%size', `${fileMaxSize}`)
+        )
+      ).toBeTruthy()
     })
 
     it('renders the file amount limit description', () => {
@@ -182,21 +157,14 @@ describe('Upload', () => {
         <Upload {...defaultProps} filesAmountLimit={filesAmountLimit} />
       )
 
-      const element = screen.queryByTestId('upload-file-amount-limit')
-
-      expect(element).not.toBeNull()
-      expect(element.textContent).toBe(nb.fileAmountDescription)
-      expect(element.nextElementSibling.textContent).toMatch(
-        String(filesAmountLimit)
-      )
+      expect(screen.queryByText(nb.fileAmountDescription)).toBeTruthy()
+      expect(screen.queryByText(String(filesAmountLimit))).toBeTruthy()
     })
 
     it('renders the upload file input section button text', () => {
       render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-file-input-button')
-
-      expect(element.textContent).toMatch(nb.buttonText)
+      expect(screen.queryByText(nb.buttonText)).toBeTruthy()
     })
 
     it('renders the upload file input section button custom text', () => {
@@ -204,21 +172,17 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} buttonText={buttonText} />)
 
-      const element = screen.queryByTestId('upload-file-input-button')
-
-      expect(element.textContent).toMatch(buttonText)
+      expect(screen.queryByText(buttonText)).toBeTruthy()
     })
 
     it('should support locale prop', () => {
       const { rerender } = render(<Upload {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-title')
-
-      expect(element.textContent).toMatch(nb.title)
+      expect(screen.queryByText(nb.title)).toBeTruthy()
 
       rerender(<Upload {...defaultProps} locale="en-GB" />)
 
-      expect(element.textContent).toMatch(en.title)
+      expect(screen.queryByText(en.title)).toBeTruthy()
     })
 
     it('should support locale from provider', () => {
@@ -228,9 +192,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      const element = screen.queryByTestId('upload-title')
-
-      expect(element.textContent).toMatch(nb.title)
+      expect(screen.queryByText(nb.title)).toBeTruthy()
 
       rerender(
         <Provider locale="en-GB">
@@ -238,7 +200,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      expect(element.textContent).toMatch(en.title)
+      expect(screen.queryByText(en.title)).toBeTruthy()
 
       rerender(
         <Provider locale="nb-NO">
@@ -246,7 +208,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      expect(element.textContent).toMatch(nb.title)
+      expect(screen.queryByText(nb.title)).toBeTruthy()
     })
 
     it('should support spacing props', () => {
@@ -257,7 +219,7 @@ describe('Upload', () => {
         (attr) => attr.name
       )
 
-      expect(attributes).toEqual(['class', 'data-testid', 'style'])
+      expect(attributes).toEqual(['class', 'style'])
       expect(Array.from(element.classList)).toEqual(
         expect.arrayContaining(['dnb-space', 'dnb-space__top--large'])
       )
@@ -294,12 +256,14 @@ describe('Upload', () => {
       expect(result.current.files).toEqual([
         { file: file1, id: expect.any(String), exists: false },
       ])
-      expect(element.querySelector('.dnb-form-status').textContent).toBe(
-        nb.errorAmountLimit.replace('%amount', '1')
-      )
+      expect(
+        screen.queryByText(nb.errorAmountLimit.replace('%amount', '1'))
+      ).toBeTruthy()
       expect(result.current.internalFiles.length).toBe(3)
 
-      const deleteButton = screen.queryByTestId('upload-delete-button')
+      const deleteButton = screen.queryByRole('button', {
+        name: nb.deleteButton,
+      })
 
       fireEvent.click(deleteButton)
 
@@ -307,7 +271,9 @@ describe('Upload', () => {
 
       expect(
         screen
-          .queryByTestId('upload-file-input-button')
+          .queryByRole('button', {
+            name: nb.buttonText,
+          })
           .hasAttribute('disabled')
       ).toBe(false)
     })
@@ -404,7 +370,9 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} id={id} />)
 
-      const inputElement = screen.queryByTestId('upload-file-input-input')
+      const inputElement = document.querySelector(
+        '.dnb-upload__file-input'
+      )
 
       await waitFor(() =>
         fireEvent.change(inputElement, {
@@ -445,7 +413,7 @@ describe('Upload', () => {
 
       render(<MockComponent />)
 
-      const fileCells = screen.queryAllByTestId('upload-file-list-cell')
+      const fileCells = document.querySelectorAll('.dnb-upload__file-cell')
 
       expect(fileCells.length).toBe(files.length)
     })
@@ -455,9 +423,7 @@ describe('Upload', () => {
 
       const id = 'random-id3'
 
-      const { queryByTestId } = render(
-        <Upload {...defaultProps} id={id} />
-      )
+      render(<Upload {...defaultProps} id={id} />)
 
       const MockComponent = () => {
         const { setFiles } = useUpload(id)
@@ -468,7 +434,9 @@ describe('Upload', () => {
       }
       render(<MockComponent />)
 
-      const emptyFileCell = queryByTestId('upload-file-list-cell')
+      const emptyFileCell = document.querySelector(
+        '.dnb-upload__file-cell'
+      )
 
       expect(emptyFileCell).toBeNull()
     })
@@ -490,13 +458,15 @@ describe('Upload', () => {
         return <div />
       }
 
-      const emptyFileCell = screen.queryByTestId('upload-file-list-cell')
+      const emptyFileCell = document.querySelector(
+        '.dnb-upload__file-cell'
+      )
 
       expect(emptyFileCell).toBeNull()
 
       render(<MockComponent />)
 
-      const fileCell = screen.queryByTestId('upload-file-list-cell')
+      const fileCell = document.querySelector('.dnb-upload__file-cell')
 
       expect(fileCell).not.toBeNull()
     })
@@ -508,9 +478,7 @@ describe('Upload', () => {
 
       const id = 'random-id3'
 
-      const { queryByTestId } = render(
-        <Upload {...defaultProps} id={id} />
-      )
+      render(<Upload {...defaultProps} id={id} />)
       const MockComponent = () => {
         const { setFiles } = useUpload(id)
 
@@ -521,15 +489,17 @@ describe('Upload', () => {
 
       render(<MockComponent />)
 
-      const fileCell = queryByTestId('upload-file-list-cell')
+      const fileCell = document.querySelector('.dnb-upload__file-cell')
 
       expect(fileCell).not.toBeNull()
 
-      const deleteButton = queryByTestId('upload-delete-button')
+      const deleteButton = screen.queryByRole('button', {
+        name: nb.deleteButton,
+      })
 
       fireEvent.click(deleteButton)
 
-      expect(queryByTestId('upload-file-list-cell')).toBeNull()
+      expect(document.querySelector('.dnb-upload__file-cell')).toBeNull()
     })
 
     it('sets focus on choose button when clicking delete', () => {
@@ -539,9 +509,7 @@ describe('Upload', () => {
 
       const id = 'random-id3'
 
-      const { queryByTestId } = render(
-        <Upload {...defaultProps} id={id} />
-      )
+      render(<Upload {...defaultProps} id={id} />)
       const MockComponent = () => {
         const { setFiles } = useUpload(id)
 
@@ -552,12 +520,16 @@ describe('Upload', () => {
 
       render(<MockComponent />)
 
-      const deleteButton = queryByTestId('upload-delete-button')
+      const deleteButton = screen.queryByRole('button', {
+        name: nb.deleteButton,
+      })
 
       fireEvent.click(deleteButton)
 
       expect(document.activeElement).toBe(
-        queryByTestId('upload-file-input-button')
+        screen.queryByRole('button', {
+          name: nb.buttonText,
+        })
       )
     })
 
@@ -575,7 +547,9 @@ describe('Upload', () => {
         />
       )
 
-      const inputElement = screen.queryByTestId('upload-file-input-input')
+      const inputElement = document.querySelector(
+        '.dnb-upload__file-input'
+      )
 
       await waitFor(() =>
         fireEvent.change(inputElement, {
@@ -583,9 +557,9 @@ describe('Upload', () => {
         })
       )
 
-      expect(screen.queryByTestId('upload-warning').textContent).toBe(
-        `error message ${fileMaxSize}`
-      )
+      expect(
+        screen.queryByText(`error message ${fileMaxSize}`)
+      ).toBeTruthy()
     })
   })
 
@@ -596,7 +570,9 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} id={id} onChange={onChange} />)
 
-      const inputElement = screen.queryByTestId('upload-file-input-input')
+      const inputElement = document.querySelector(
+        '.dnb-upload__file-input'
+      )
       const file1 = createMockFile('fileName-1.png', 100, 'image/png')
 
       await waitFor(() =>
@@ -610,9 +586,11 @@ describe('Upload', () => {
         files: [{ file: file1, id: expect.any(String), exists: false }],
       })
 
-      const removeButton = screen.queryByTestId('upload-delete-button')
+      const deleteButton = screen.queryByRole('button', {
+        name: nb.deleteButton,
+      })
 
-      await waitFor(() => fireEvent.click(removeButton))
+      await waitFor(() => fireEvent.click(deleteButton))
 
       expect(onChange).toHaveBeenCalledTimes(2)
       expect(onChange).toHaveBeenCalledWith({ files: [] })
@@ -626,7 +604,9 @@ describe('Upload', () => {
         <Upload {...defaultProps} id={id} onFileDelete={onFileDelete} />
       )
 
-      const inputElement = screen.queryByTestId('upload-file-input-input')
+      const inputElement = document.querySelector(
+        '.dnb-upload__file-input'
+      )
       const file1 = createMockFile('fileName-1.png', 100, 'image/png')
 
       await waitFor(() =>
@@ -635,9 +615,11 @@ describe('Upload', () => {
         })
       )
 
-      const removeButton = screen.queryByTestId('upload-delete-button')
+      const deleteButton = screen.queryByRole('button', {
+        name: nb.deleteButton,
+      })
 
-      await waitFor(() => fireEvent.click(removeButton))
+      await waitFor(() => fireEvent.click(deleteButton))
 
       expect(onFileDelete).toHaveBeenCalledTimes(1)
       expect(onFileDelete).toHaveBeenCalledWith({

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
@@ -30,19 +30,11 @@ describe('UploadFileInput', () => {
     }
   }
 
-  it('renders the component', () => {
-    render(<UploadFileInput />, {
-      wrapper: makeWrapper(),
-    })
-
-    expect(screen.queryByTestId('upload-file-input')).not.toBeNull()
-  })
-
   it('renders the upload button', () => {
     render(<UploadFileInput />, {
       wrapper: makeWrapper(),
     })
-    expect(screen.queryByTestId('upload-file-input-button')).not.toBeNull()
+    expect(screen.getByRole('button')).not.toBeNull()
   })
 
   it('renders the upload button text', () => {
@@ -52,9 +44,18 @@ describe('UploadFileInput', () => {
         buttonText: buttonText,
       }),
     })
+
+    expect(screen.queryByText(buttonText)).toBeTruthy()
+  })
+
+  it('renders the upload input', () => {
+    render(<UploadFileInput />, {
+      wrapper: makeWrapper(),
+    })
+
     expect(
-      screen.queryByTestId('upload-file-input-button').textContent
-    ).toMatch(buttonText)
+      document.querySelector('.dnb-upload__file-input')
+    ).not.toBeNull()
   })
 
   it('accepts multiple files by default', () => {
@@ -62,7 +63,7 @@ describe('UploadFileInput', () => {
       wrapper: makeWrapper(),
     })
 
-    const element = screen.queryByTestId('upload-file-input-input')
+    const element = document.querySelector('.dnb-upload__file-input')
 
     expect(element.hasAttribute('multiple')).toBeTruthy()
   })
@@ -74,7 +75,7 @@ describe('UploadFileInput', () => {
       }),
     })
 
-    const element = screen.queryByTestId('upload-file-input-input')
+    const element = document.querySelector('.dnb-upload__file-input')
 
     expect(element.hasAttribute('multiple')).toBeFalsy()
   })
@@ -83,7 +84,7 @@ describe('UploadFileInput', () => {
     render(<UploadFileInput />, {
       wrapper: makeWrapper(),
     })
-    const element = screen.queryByTestId('upload-file-input-input')
+    const element = document.querySelector('.dnb-upload__file-input')
 
     expect(element).not.toBeNull()
     expect(element.getAttribute('class')).toMatch('dnb-upload__file-input')
@@ -94,9 +95,9 @@ describe('UploadFileInput', () => {
       wrapper: makeWrapper(),
     })
 
-    const buttonElement = screen.queryByTestId('upload-file-input-button')
+    const buttonElement = screen.getByRole('button')
 
-    const inputElement = screen.queryByTestId('upload-file-input-input')
+    const inputElement = document.querySelector('.dnb-upload__file-input')
 
     const clickEventListener = jest.fn()
     inputElement.addEventListener('click', clickEventListener)
@@ -115,7 +116,7 @@ describe('UploadFileInput', () => {
       wrapper: makeWrapper({ onInputUpload }),
     })
 
-    const inputElement = screen.queryByTestId('upload-file-input-input')
+    const inputElement = document.querySelector('.dnb-upload__file-input')
 
     await waitFor(() =>
       fireEvent.change(inputElement, {
@@ -135,8 +136,8 @@ describe('UploadFileInput', () => {
       wrapper: makeWrapper({ onInputUpload }),
     })
 
-    const inputElement = screen.queryByTestId(
-      'upload-file-input-input'
+    const inputElement = document.querySelector(
+      '.dnb-upload__file-input'
     ) as HTMLInputElement
 
     Object.defineProperty(inputElement, 'value', {
@@ -165,8 +166,8 @@ describe('UploadFileInput', () => {
       }),
     })
 
-    const inputElement = screen.queryByTestId(
-      'upload-file-input-input'
+    const inputElement = document.querySelector(
+      '.dnb-upload__file-input'
     ) as HTMLInputElement
 
     expect(inputElement.accept).toBe('.png,.pdf')
@@ -179,8 +180,8 @@ describe('UploadFileInput', () => {
       }),
     })
 
-    const inputElement = screen.queryByTestId(
-      'upload-file-input-input'
+    const inputElement = document.querySelector(
+      '.dnb-upload__file-input'
     ) as HTMLInputElement
 
     expect(inputElement.accept).toBe('.png,.jpg,.jpeg')
@@ -196,7 +197,7 @@ describe('UploadFileInput', () => {
       wrapper: makeWrapper({ onInputUpload }),
     })
 
-    const inputElement = screen.queryByTestId('upload-file-input-input')
+    const inputElement = document.querySelector('.dnb-upload__file-input')
 
     await waitFor(() =>
       fireEvent.change(inputElement, {

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
@@ -19,9 +19,7 @@ describe('UploadFileListCell', () => {
   it('renders the component', () => {
     render(<UploadFileListCell {...defaultProps} />)
 
-    const element = screen.queryByTestId('upload-file-list-cell')
-
-    expect(element).not.toBeNull()
+    expect(document.querySelector('.dnb-upload__file-cell')).not.toBeNull()
   })
 
   it('renders the error styling', () => {
@@ -35,7 +33,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    const element = screen.queryByTestId('upload-file-list-cell')
+    const element = document.querySelector('.dnb-upload__file-cell')
 
     expect(element.className).toMatch('dnb-upload__file-cell--warning')
   })
@@ -48,7 +46,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    const element = screen.queryByTestId('upload-file-list-cell')
+    const element = document.querySelector('.dnb-upload__file-cell')
 
     expect(element.className).not.toMatch('dnb-upload__file-cell--error')
     expect(element.className).toMatch('dnb-upload__file-cell')
@@ -62,29 +60,10 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    const element = screen.queryByTestId('upload-subtitle')
-
-    expect(element).not.toBeNull()
-    expect(element.textContent).toMatch('PNG')
+    expect(screen.queryByText('PNG')).toBeTruthy()
   })
 
   it('renders the form errorMessage warning', () => {
-    render(
-      <UploadFileListCell
-        {...defaultProps}
-        uploadFile={{
-          file: createMockFile('file.png', 100, 'image/png'),
-          errorMessage: 'errorMessage',
-        }}
-      />
-    )
-
-    const element = screen.queryByTestId('upload-warning')
-
-    expect(element).not.toBeNull()
-  })
-
-  it('renders the form errorMessage warning message', () => {
     const errorMessage = 'error message'
 
     render(
@@ -97,9 +76,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    const element = screen.queryByTestId('upload-warning')
-
-    expect(element.textContent).toMatch(errorMessage)
+    expect(screen.queryByText(errorMessage)).toBeTruthy()
   })
 
   describe('Icons', () => {
@@ -213,13 +190,6 @@ describe('UploadFileListCell', () => {
 
   describe('File Anchor', () => {
     it('renders the anchor', () => {
-      render(<UploadFileListCell {...defaultProps} />)
-      const anchorElement = screen.queryByTestId('upload-file-anchor')
-
-      expect(anchorElement).not.toBeNull()
-    })
-
-    it('renders the anchor text', () => {
       const fileName = 'file.png'
 
       render(
@@ -228,11 +198,11 @@ describe('UploadFileListCell', () => {
           uploadFile={{ file: createMockFile(fileName, 100, 'image/png') }}
         />
       )
-      const anchorElement = screen.queryByTestId('upload-file-anchor')
-      expect(anchorElement.textContent).toMatch(fileName)
+      expect(screen.queryByText(fileName)).toBeTruthy()
     })
 
     it('renders the anchor href', () => {
+      const fileName = 'file.png'
       const mockUrl = 'mock-url'
 
       global.URL.createObjectURL = jest.fn().mockReturnValueOnce(mockUrl)
@@ -241,27 +211,29 @@ describe('UploadFileListCell', () => {
         <UploadFileListCell
           {...defaultProps}
           uploadFile={{
-            file: createMockFile('file.png', 100, 'image/png'),
+            file: createMockFile(fileName, 100, 'image/png'),
           }}
         />
       )
-      const anchorElement = screen.queryByTestId(
-        'upload-file-anchor'
+      const anchorElement = screen.queryByText(
+        fileName
       ) as HTMLAnchorElement
       expect(anchorElement.href).toMatch(mockUrl)
     })
 
     it('renders without the error style', () => {
+      const fileName = 'file.png'
+
       render(
         <UploadFileListCell
           {...defaultProps}
           uploadFile={{
-            file: createMockFile('file.png', 100, 'image/png'),
+            file: createMockFile(fileName, 100, 'image/png'),
           }}
         />
       )
 
-      const anchorElement = screen.queryByTestId('upload-file-anchor')
+      const anchorElement = screen.queryByText(fileName)
 
       expect(anchorElement.className).not.toMatch(
         'dnb-upload__file-cell--error'
@@ -273,7 +245,7 @@ describe('UploadFileListCell', () => {
     it('renders the delete button', () => {
       render(<UploadFileListCell {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-delete-button')
+      const element = screen.getByRole('button')
 
       expect(element).not.toBeNull()
     })
@@ -288,7 +260,7 @@ describe('UploadFileListCell', () => {
         />
       )
 
-      const element = screen.queryByTestId('upload-delete-button')
+      const element = screen.getByRole('button')
 
       expect(element.textContent).toMatch(deleteButtonText)
     })
@@ -296,7 +268,7 @@ describe('UploadFileListCell', () => {
     it('renders button as tertiary', () => {
       render(<UploadFileListCell {...defaultProps} />)
 
-      const element = screen.queryByTestId('upload-delete-button')
+      const element = screen.getByRole('button')
 
       expect(element.className).toMatch('dnb-button--tertiary')
     })
@@ -312,9 +284,9 @@ describe('UploadFileListCell', () => {
         />
       )
 
-      const element = screen.queryByTestId('upload-progress-indicator')
-
-      expect(element).not.toBeNull()
+      expect(
+        document.querySelector('.dnb-progress-indicator')
+      ).not.toBeNull()
     })
 
     it('does not render the loading state when not loading', () => {
@@ -328,9 +300,7 @@ describe('UploadFileListCell', () => {
         />
       )
 
-      const element = screen.queryByTestId('upload-progress-indicator')
-
-      expect(element).toBeNull()
+      expect(document.querySelector('.dnb-progress-indicator')).toBeNull()
     })
   })
 })


### PR DESCRIPTION
Removes the following `data-testid`'s:
- upload
- upload-file-input
- upload-file-input-button
- upload-file-input-input
- upload-file-list
- upload-file-list-cell
- upload-delete-button
- upload-progress-indicator
- upload-file-anchor
- upload-subtitle
- upload-warning
- upload-title
- upload-text
- upload-accepted-formats
- upload-file-size
- upload-file-amount-limit

I checked in the monorepo, and it exists no occurrences of this over there 🎊 