### PR TITLE
chore(Breadcrumb): rewrite tests w/o data-testid

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -205,7 +205,6 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
         spacingClasses,
         className
       )}
-      data-testid="breadcrumb-nav"
       {...props}
     >
       <Section

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -99,7 +99,6 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
   return (
     <li
       className="dnb-breadcrumb__item"
-      data-testid="breadcrumb-item"
       aria-current={variant === 'current' ? 'page' : undefined}
       style={style}
     >
@@ -120,9 +119,7 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
             icon={currentIcon}
             className="dnb-breadcrumb__item__span__icon"
           />
-          <P left="0" data-testid="breadcrumb-item-text">
-            {currentText}
-          </P>
+          <P left="0">{currentText}</P>
         </span>
       )}
     </li>

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -22,7 +22,6 @@ export const BreadcrumbMultiple = ({
     <HeightAnimation
       open={!isCollapsed}
       animate={!noAnimation}
-      data-testid="breadcrumb-collapse"
       className="dnb-breadcrumb__animation"
     >
       <Section


### PR DESCRIPTION
Removes the following `data-testid`'s:
- breadcrumb-nav
- breadcrumb-item
- breadcrumb-item-text
- breadcrumb-collapse

I checked in the monorepo, and it exists many many occurrences of this(queryByTestId('breadcrumb')) over there  😱 🙀 