### PR TITLE
chore(Timeline): rewrite tests w/o data-testid

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.md
@@ -158,6 +158,7 @@ When you convert from `<Modal />` or `<Modal mode="dialog" />` to `<Dialog />` â
 - [InfoCard](/uilib/components/info-card).
 - [Tag](/uilib/components/tag).
 - [Upload](/uilib/components/upload).
+- [Timeline](/uilib/components/timeline).
 
 ### [Stopped supporting Internet Explorer (IE)](/uilib/usage/#supported-browsers-and-platforms)
 

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -93,7 +93,6 @@ const Timeline = (localProps: TimelineAllProps) => {
         spacingClasses,
         className
       )}
-      data-testid="timeline"
       {...props}
     >
       {data?.map((timelineItem, i) => (

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -126,10 +126,7 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
       (stateIsCurrent && alt_label_current) ||
       (stateIsUpcoming && alt_label_upcoming)
     return (
-      <span
-        className="dnb-timeline__item__label__icon"
-        data-testid="timeline-item-label-icon"
-      >
+      <span className="dnb-timeline__item__label__icon">
         <span key="icon-alignment" aria-hidden>
           &zwnj;
         </span>
@@ -146,12 +143,7 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
 
   const TimelineItemTitle = () => {
     return (
-      <span
-        className="dnb-timeline__item__label__title"
-        data-testid="timeline-item-label-title"
-      >
-        {title}
-      </span>
+      <span className="dnb-timeline__item__label__title">{title}</span>
     )
   }
 
@@ -170,10 +162,7 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
     }: {
       subtitle: React.ReactNode
     }) => (
-      <div
-        className="dnb-timeline__item__content__subtitle"
-        data-testid="timeline-item-content-subtitle"
-      >
+      <div className="dnb-timeline__item__content__subtitle">
         {subtitle}
       </div>
     )
@@ -199,7 +188,6 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
             text={infoMessage}
             state="info"
             className="dnb-timeline__item__content__info"
-            data-testid="timeline-item-content-info"
             stretch
           />
         )}
@@ -210,7 +198,6 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
   return (
     <li
       className={classes}
-      data-testid="timeline-item"
       aria-current={stateIsCurrent ? 'step' : undefined}
       {...props}
     >

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -11,7 +11,7 @@ describe('Timeline', () => {
   it('renders without properties', () => {
     render(<Timeline />)
 
-    expect(screen.queryByTestId('timeline')).not.toBeNull()
+    expect(document.querySelector('.dnb-timeline')).not.toBeNull()
   })
 
   it('renders a timeline with multiple items by data prop', () => {
@@ -28,7 +28,9 @@ describe('Timeline', () => {
       />
     )
 
-    expect(screen.queryAllByTestId('timeline-item')).toHaveLength(3)
+    expect(document.querySelectorAll('.dnb-timeline__item')).toHaveLength(
+      3
+    )
   })
 
   it('renders a timeline with multiple items by children', () => {
@@ -40,7 +42,9 @@ describe('Timeline', () => {
       </Timeline>
     )
 
-    expect(screen.queryAllByTestId('timeline-item')).toHaveLength(3)
+    expect(document.querySelectorAll('.dnb-timeline__item')).toHaveLength(
+      3
+    )
   })
 
   it('current will have aria-current="step"', () => {
@@ -57,8 +61,10 @@ describe('Timeline', () => {
       />
     )
 
-    const lastElem = screen.getAllByTestId('timeline-item').slice(-1)[0]
-    expect(lastElem.getAttribute('aria-current')).toBe('step')
+    const currentItem = screen.getByText('Current')
+    expect(
+      currentItem.parentElement.parentElement.getAttribute('aria-current')
+    ).toBe('step')
   })
 
   it('uses ordered list semantic elements', () => {
@@ -100,9 +106,9 @@ describe('Timeline', () => {
       </Provider>
     )
 
-    expect(screen.queryByTestId('timeline-item').className).toMatch(
-      skeletonClassName
-    )
+    expect(
+      document.getElementsByClassName(skeletonClassName)
+    ).toHaveLength(1)
   })
 
   it('should support spacing props', () => {
@@ -118,12 +124,12 @@ describe('Timeline', () => {
       />
     )
 
-    const element = screen.getByTestId('timeline')
+    const element = document.querySelector('.dnb-timeline')
     const attributes = Array.from(element.attributes).map(
       (attr) => attr.name
     )
 
-    expect(attributes).toEqual(['class', 'data-testid'])
+    expect(attributes).toEqual(['class'])
     expect(Array.from(element.classList)).toEqual([
       'dnb-timeline',
       'dnb-space__reset',
@@ -155,9 +161,7 @@ describe('Timeline', () => {
     it('renders title', () => {
       const title = 'Completed'
       render(<TimelineItem title={title} state="completed" />)
-      expect(
-        screen.queryByTestId('timeline-item-label-title').textContent
-      ).toBe(title)
+      expect(screen.queryByText(title)).toBeTruthy()
     })
 
     it('renders subtitle', () => {
@@ -169,9 +173,7 @@ describe('Timeline', () => {
           state="completed"
         />
       )
-      expect(
-        screen.queryByTestId('timeline-item-content-subtitle').textContent
-      ).toBe(subtitle)
+      expect(screen.queryByText(subtitle)).toBeTruthy()
     })
 
     it('renders subtitles', () => {
@@ -184,18 +186,8 @@ describe('Timeline', () => {
         />
       )
 
-      expect(
-        screen.queryAllByTestId('timeline-item-content-subtitle')
-      ).toHaveLength(2)
-
-      expect(
-        screen.queryAllByTestId('timeline-item-content-subtitle')[0]
-          .textContent
-      ).toBe(subtitles[0])
-      expect(
-        screen.queryAllByTestId('timeline-item-content-subtitle')[1]
-          .textContent
-      ).toBe(subtitles[1])
+      expect(screen.queryByText(subtitles[0])).toBeTruthy()
+      expect(screen.queryByText(subtitles[1])).toBeTruthy()
     })
 
     it('renders info message', () => {
@@ -207,9 +199,7 @@ describe('Timeline', () => {
           state="completed"
         />
       )
-      expect(
-        screen.queryByTestId('timeline-item-content-info').textContent
-      ).toBe(infoMessage)
+      expect(screen.queryByText(infoMessage)).toBeTruthy()
     })
 
     it('renders custom icon', () => {
@@ -245,9 +235,9 @@ describe('Timeline', () => {
 
       render(<TimelineItem skeleton title="title" state="completed" />)
 
-      expect(screen.queryByTestId('timeline-item').className).toMatch(
-        skeletonClassName
-      )
+      expect(
+        document.getElementsByClassName(skeletonClassName)
+      ).toHaveLength(1)
     })
 
     it('inherits skeleton prop from provider', () => {
@@ -259,9 +249,9 @@ describe('Timeline', () => {
         </Provider>
       )
 
-      expect(screen.queryByTestId('timeline-item').className).toMatch(
-        skeletonClassName
-      )
+      expect(
+        document.getElementsByClassName(skeletonClassName)
+      ).toHaveLength(1)
     })
 
     describe('renders default icon based on state property', () => {


### PR DESCRIPTION
Removes the following `data-testid`'s:
- timeline
- timeline-item-label-icon
- timeline-item-label-title
- timeline-item-content-subtitle
- timeline-item-content-info
- timeline-item

I checked in the monorepo, and it exists only a few occurrences of this over there, will have to change there as well.