### PR TITLE
fix(Table): make sticky header work when used in combination with accordion rows

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -10,7 +10,7 @@
 
 .toolbarStyle {
   position: absolute;
-  z-index: 2;
+  z-index: 100; // over generally used z-indexes, like table rows
   bottom: 0;
   left: 0;
   width: 100%;

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -605,7 +605,7 @@ thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus
 .dnb-table--outline thead .dnb-table__tr:first-of-type,
 .dnb-table--outline tbody
 .dnb-table__tr.dnb-table__tr--has-accordion-content:not(.dnb-table__tr--expanded):nth-last-child(2) {
-  clip-path: inset(0 round 0.5rem 0.5rem 0 0); }
+  clip-path: inset(0 0 -1rem 0 round 0.5rem 0.5rem 0 0); }
 
 .dnb-table--outline tbody .dnb-table__tr:last-of-type,
 .dnb-table--outline tbody
@@ -634,15 +634,12 @@ thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus
   padding: 0 !important;
   height: 0; }
 
-.dnb-table tr.sticky:not(.css-position) th {
-  position: relative;
-  z-index: 3;
-  will-change: transform;
+.dnb-table tr.sticky {
+  position: sticky;
+  z-index: 4;
   transform: translate3d(0, var(--table-offset, 0), 0); }
 
 .dnb-table tr.sticky.css-position {
-  position: sticky;
-  z-index: 3;
   top: var(--table-top, 0); }
 
 .dnb-table tr.sticky.is-sticky th::before {

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -601,6 +601,7 @@ export const TableAccordion = () => {
           outline
           border
           size="large"
+          sticky
           // lang="no"
         >
           <TableContent />

--- a/packages/dnb-eufemia/src/components/table/style/_table-sticky.scss
+++ b/packages/dnb-eufemia/src/components/table/style/_table-sticky.scss
@@ -12,18 +12,14 @@
     height: 0;
   }
 
-  // Target th because of Safari transparent issue
-  tr.sticky:not(.css-position) th {
-    position: relative;
-    z-index: 3; // over borders and TDs
+  tr.sticky {
+    position: sticky;
+    z-index: 4; // over borders and TDs
 
-    will-change: transform;
     transform: translate3d(0, var(--table-offset, 0), 0);
   }
 
   tr.sticky.css-position {
-    position: sticky;
-    z-index: 3; // over borders and TDs
     top: var(--table-top, 0); // is set by "stickyOffset" prop
   }
 

--- a/packages/dnb-eufemia/src/components/table/style/_table-tr.scss
+++ b/packages/dnb-eufemia/src/components/table/style/_table-tr.scss
@@ -25,7 +25,8 @@
     tbody
     &__tr#{&}__tr--has-accordion-content:not(#{&}__tr--expanded):nth-last-child(2) {
     // use clip-path, because border-radius does not clip on tr's
-    clip-path: inset(0 round 0.5rem 0.5rem 0 0);
+    // use "-1rem" to add room for sticky shadow
+    clip-path: inset(0 0 -1rem 0 round 0.5rem 0.5rem 0 0);
   }
   &--outline tbody &__tr:last-of-type,
   &--outline


### PR DESCRIPTION
Reported bug.

👉Before
<img width="444" alt="Screenshot 2022-12-19 at 20 20 13" src="https://user-images.githubusercontent.com/1501870/208515446-024a9afd-bda9-45c1-af29-f588440d4add.png">

👉After
<img width="417" alt="Screenshot 2022-12-19 at 21 30 10" src="https://user-images.githubusercontent.com/1501870/208515533-ac1f1df4-b252-4b06-bfeb-e3bc7f7c372d.png">
