### PR TITLE
chore: change VSCode px vs rem tooling recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "darkriszty.markdown-table-prettify",
     "davidanson.vscode-markdownlint",
     "razio.es6-string-jsx",
-    "sainoba.px-to-rem",
+    "cipchk.cssrem",
     "yzhang.markdown-all-in-one"
   ]
 }


### PR DESCRIPTION
Because it works even better than the previews one and shows the actual value when cursor is set on value.

<img width="146" alt="Screenshot 2022-12-21 at 06 17 15" src="https://user-images.githubusercontent.com/1501870/208827226-16571bb1-98ec-4f3f-bcfc-d11eb8470df0.png">

<img width="206" alt="Screenshot 2022-12-21 at 06 17 36" src="https://user-images.githubusercontent.com/1501870/208827267-b0ab5f28-5c04-4899-a36c-fcc1b70477b8.png">

