### PR TITLE
feat(Spacing): add calc helper

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/spacing.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/layout/spacing.md
@@ -61,12 +61,17 @@ const Custom = styled(Space)`
 You may use the internals to build helpers suited to your needs.
 
 ```tsx
-import { sumTypes } from '@dnb/eufemia/components/space/SpacingUtils'
-
-const spacing = (space) => sumTypes(space) + 'rem'
+import { calc } from '@dnb/eufemia/components/space/SpacingUtils'
 
 // With Styled Components
 const StyledDiv = styled.div`
-  margin-top: ${spacing('medium large')};
+  margin-top: ${calc('medium large')};
+  margin-top: ${calc('medium', 'large')};
+  margin-top: ${calc('1.5rem', '2rem')};
+  margin-top: ${calc('24px', '32px')};
 `
 ```
+
+All of the examples do output: `calc(var(--spacing-medium) + var(--spacing-large))`
+
+Invalid values will be corrected to its nearest spacing type (e.g. 17px to `var(--spacing-small)`).

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -5,16 +5,14 @@
 
 import { warn } from '../../shared/component-helper'
 
-import type { SpacingProps } from './types'
+import type {
+  StyleObjectProps,
+  SpaceType,
+  SpacingUnknownProps,
+  SpacingProps,
+} from './types'
 
-type Props = SpacingProps | Record<string, unknown>
-
-type StyleObjectProps = {
-  maxWidth?: string
-  maxHeight?: string
-  width?: string
-  height?: string
-}
+type SpaceNumber = number
 
 export const spacingDefaultProps = {
   space: null,
@@ -35,142 +33,40 @@ export const spacePatterns = {
   'xx-large-x2': 7,
 }
 
-export const translateSpace = (type) => {
-  if (/-x2$/.test(type)) {
-    return spacePatterns[type.replace(/-x2$/, '')] * 2
-  }
-  return spacePatterns[type] || 0
-}
+/**
+ * Helper function to generate a calc(var(--spacing-large) + var(--spacing-small))
+ *
+ * @param types 'small', '16px', '1rem'
+ * @returns e.g. calc(var(--spacing-large) + var(--spacing-small))
+ */
+export const calc = (...types: Array<SpaceType>) => {
+  const result: Array<string> = []
 
-// Splits a string of: "large x-small" into an array of the same
-export const splitTypes = (types) => {
-  if (typeof types === 'string') {
-    types = types.split(/ /g)
-  } else if (typeof types === 'boolean') {
-    return ['small']
-  } else if (typeof types === 'number') {
-    return [types]
-  }
-  return types ? types.filter((r) => r && r.length > 0) : null
-}
-
-// Sums e.g. "large" + "x-small" to be = 2.5rem
-export const sumTypes = (types) =>
-  splitTypes(types)
-    .map((type) => translateSpace(type))
-    .reduce((acc, cur) => {
-      if (cur > 0) {
-        acc += cur
-      } else if (cur < 0) {
-        acc -= cur
-      }
-      return acc
-    }, 0)
-
-// Returns an array with modifiers e.g. ["--large" + "--x-small"]
-export const createTypeModifiers = (types) => {
-  if (typeof types === 'number') {
-    types = String(types)
-  }
-  return (splitTypes(types) || []).reduce((acc, type) => {
-    if (type) {
-      const firstLetter = type[0]
-      if (parseFloat(firstLetter) > -1) {
-        // can be "2rem" or "32px" - but we want only a number
-        let num = parseFloat(type)
-
-        // check if we got pixels
-        if (num >= 8 && /[0-9]px/.test(type)) {
-          num = num / 16
-        }
-
-        // check if the type exists in our extensions
-        const foundType = findType(num)
-
-        // get the type
-        if (foundType) {
-          type = foundType
-        } else {
-          findNearestTypes(num).forEach((type) => {
-            if (type) {
-              acc.push(type)
-            }
-          })
-        }
-      }
-
-      if (!(parseFloat(type) > 0)) {
-        acc.push(type)
-      }
-    }
-    return acc
-  }, [])
-}
-
-// Finds from "2.0" the equivalent type "large"
-export const findType = (num, { returnObject = false } = {}) => {
-  const found =
-    Object.entries(spacePatterns).find(([k, v]) => k && v === num) || null
-
-  if (returnObject) {
-    return found
-  }
-
-  // get the type
-  if (found) {
-    return found[0]
-  }
-
-  return found
-}
-
-// Finds from e.g. a value of "2.5rem" the nearest type = ["large", "x-small"]
-export const findNearestTypes = (num) => {
-  let res = []
-
-  const near = Object.entries(spacePatterns)
-    .reverse()
-    .find(([k, v]) => k && num >= v)
-  const nearNum = (near && near[1]) || num
-
-  const typeObject = findType(nearNum, { returnObject: true })
-
-  if (typeObject) {
-    const nearType = typeObject[0]
-    res.push(nearType)
-    const leftOver = num - parseFloat(String(typeObject[1]))
-    const foundMoreTypes = findNearestTypes(leftOver)
-
-    // if the value already exists, then replace it with an x2
-    foundMoreTypes.forEach((type) => {
-      const index = res.indexOf(type)
-      if (index !== -1) {
-        res[index] = `${type}-x2`
-      }
+  types.forEach((rawTypes) => {
+    createTypeModifiers(rawTypes as SpaceType).forEach((type) => {
+      result.push(`var(--spacing-${type})`)
     })
+  })
 
-    res = [...res, ...foundMoreTypes]
-  }
-
-  return res
+  return result.length ? `calc(${result.join(' + ')})` : null
 }
 
-// Checks if a space prop is a valid string like "top"
-export const isValidSpaceProp = (propName: string) =>
-  propName && ['top', 'right', 'bottom', 'left'].includes(propName)
-
-export const removeSpaceProps = (props: Props) => {
-  const p = Object.isFrozen(props) ? { ...props } : props
-  for (const i in p) {
-    if (isValidSpaceProp(i)) {
-      delete p[i]
-    }
-  }
-  return p
-}
-
-// Creates a valid space CSS class out from given space types
-export const createSpacingClasses = (props: Props, Element = null) => {
+/**
+ * Creates a valid space CSS class out from given space types
+ *
+ * @param props
+ * @param Element to check if it should be handled as inline
+ * @returns "dnb-space__large dnb-space__small"
+ */
+export const createSpacingClasses = (
+  props:
+    | SpacingProps
+    /**
+     * To support typical not defined props form components
+     */
+    | SpacingUnknownProps,
+  Element = null
+) => {
   const p = Object.isFrozen(props) ? { ...props } : props
 
   if (typeof p.space !== 'undefined') {
@@ -196,7 +92,7 @@ export const createSpacingClasses = (props: Props, Element = null) => {
       if (String(cur) === '0' || String(cur) === 'false') {
         acc.push(`dnb-space__${direction}--zero`)
       } else if (cur) {
-        const typeModifiers = createTypeModifiers(cur)
+        const typeModifiers = createTypeModifiers(cur as SpaceType)
 
         // get the total sum
         const sum = sumTypes(typeModifiers)
@@ -208,7 +104,7 @@ export const createSpacingClasses = (props: Props, Element = null) => {
           )
         } else {
           // auto combine classes
-          const nearestTypes = findNearestTypes(sum)
+          const nearestTypes = findNearestTypes(sum, true)
 
           acc = [
             ...acc,
@@ -229,8 +125,150 @@ export const createSpacingClasses = (props: Props, Element = null) => {
   }, [])
 }
 
+// @internal splits types by given string
+export const translateSpace = (type: SpaceType) => {
+  if (/-x2$/.test(String(type))) {
+    return spacePatterns[String(type).replace(/-x2$/, '')] * 2
+  }
+  return spacePatterns[String(type)] || 0
+}
+
+// @internal Splits a string of: "large x-small" into an array of the same
+export const splitTypes = (types: SpaceType | Array<SpaceType>) => {
+  if (typeof types === 'string') {
+    return clean(types.split(/ /g))
+  } else if (typeof types === 'boolean') {
+    return ['small']
+  } else if (typeof types === 'number') {
+    return [types]
+  }
+
+  return clean(types) || null
+
+  function clean(t: Array<SpaceType>) {
+    return t?.filter((r) => r && String(r).length > 0)
+  }
+}
+
+// @internal Sums e.g. "large" + "x-small" to be = 2.5rem
+export const sumTypes = (types: SpaceType | Array<SpaceType>) =>
+  splitTypes(types)
+    .map((type) => translateSpace(type))
+    .reduce((acc, cur) => {
+      if (cur > 0) {
+        acc += cur
+      } else if (cur < 0) {
+        acc -= cur
+      }
+      return acc
+    }, 0)
+
+// @internal Returns an array with modifiers e.g. ["large", "x-small"]
+export const createTypeModifiers = (
+  types: SpaceType
+): Array<SpaceType> => {
+  return (splitTypes(types) || []).reduce((acc, type) => {
+    if (type) {
+      const firstLetter = String(type)[0]
+      if (parseFloat(firstLetter) > -1) {
+        // can be "2rem" or "32px" - but we want only a number
+        let num = parseFloat(String(type))
+
+        // check if we got pixels
+        if (num >= 8 && /[0-9]px/.test(String(type))) {
+          num = num / 16
+        }
+
+        // check if the type exists in our extensions
+        const foundType = findType(num)
+
+        // get the type
+        if (foundType) {
+          type = foundType
+        } else {
+          findNearestTypes(num).forEach((type) => {
+            if (type) {
+              acc.push(type)
+            }
+          })
+        }
+      }
+
+      if (!(parseFloat(String(type)) > 0)) {
+        acc.push(type)
+      }
+    }
+    return acc
+  }, [])
+}
+
+// @internal Finds from "2.0" the equivalent type "large"
+export const findType = (num: SpaceNumber): SpaceType => {
+  const found = findTypeAll(num)
+
+  // get the type
+  if (found) {
+    return found[0]
+  }
+
+  return null
+}
+
+// @internal Finds from "2.0" the equivalent type "large" and returns all results
+export const findTypeAll = (num: SpaceNumber): Array<SpaceType> => {
+  const found =
+    Object.entries(spacePatterns).find(([k, v]) => k && v === num) || null
+
+  return found
+}
+
+// @internal Finds from e.g. a value of "2.5rem" the nearest type = ["large", "x-small"]
+export const findNearestTypes = (num: SpaceNumber, multiply = false) => {
+  let res = []
+
+  const near = Object.entries(spacePatterns)
+    .reverse()
+    .filter((k) => (multiply ? true : !k[0].includes('-x'))) // e.g. -x2
+    .find(([k, v]) => k && num >= v)
+  const nearNum = (near && near[1]) || num
+  const types = findTypeAll(nearNum)
+
+  if (types) {
+    const nearType = types[0]
+    res.push(nearType)
+    const leftOver = num - parseFloat(String(types[1]))
+    const foundMoreTypes = findNearestTypes(leftOver, multiply)
+
+    // if the value already exists, then replace it with an x2
+    foundMoreTypes.forEach((type) => {
+      const index = res.indexOf(type)
+      if (index !== -1) {
+        res[index] = multiply ? `${type}-x2` : type
+      }
+    })
+
+    res = [...res, ...foundMoreTypes]
+  }
+
+  return res
+}
+
+// @internal Checks if a space prop is a valid string like "top"
+export const isValidSpaceProp = (propName: string) =>
+  propName && ['top', 'right', 'bottom', 'left'].includes(propName)
+
+export const removeSpaceProps = (props: StyleObjectProps) => {
+  const p = Object.isFrozen(props) ? { ...props } : props
+  for (const i in p) {
+    if (isValidSpaceProp(i)) {
+      delete p[i]
+    }
+  }
+  return p
+}
+
 // deprecated and can be removed in v10 (remove tests as well)
-export const createStyleObject = (props: Props & StyleObjectProps) => {
+export const createStyleObject = (props: StyleObjectProps) => {
   const p = Object.isFrozen(props) ? { ...props } : props
 
   if (p.top && !(parseFloat(String(p.top)) > 0)) {

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.tsx
@@ -9,6 +9,7 @@ import {
   translateSpace,
   splitTypes,
   sumTypes,
+  calc,
   createTypeModifiers,
   findType,
   findNearestTypes,
@@ -59,6 +60,79 @@ describe('sumTypes', () => {
   })
 })
 
+describe('calc', () => {
+  it('should return null if invalid', () => {
+    expect(calc()).toEqual(null)
+    expect(calc(null)).toEqual(null)
+    expect(calc(undefined)).toEqual(null)
+  })
+
+  it('should output calc based on string types', () => {
+    expect(calc('large x-small')).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should output calc based on argument types', () => {
+    expect(calc('large', 'x-small')).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should output calc based on rem numbers', () => {
+    expect(calc(2, 0.5)).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should output calc based on rem strings', () => {
+    expect(calc('2rem', '0.5rem')).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should output calc based on pixel values', () => {
+    expect(calc('32px', '8px')).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should output calc with mixed spacing types', () => {
+    expect(calc('32px', 'x-small', 1)).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small) + var(--spacing-small))'
+    )
+  })
+
+  it('should correct to its nearest type', () => {
+    expect(calc('17px')).toEqual('calc(var(--spacing-small))')
+    expect(calc('33px')).toEqual('calc(var(--spacing-large))')
+    expect(calc('43px')).toEqual(
+      'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+  })
+
+  it('should sum all types', () => {
+    expect(calc('800px')).toEqual(
+      'calc(var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-small))'
+    )
+  })
+
+  it('should calc documented examples', () => {
+    expect(calc('medium large')).toEqual(
+      'calc(var(--spacing-medium) + var(--spacing-large))'
+    )
+    expect(calc('medium', 'large')).toEqual(
+      'calc(var(--spacing-medium) + var(--spacing-large))'
+    )
+    expect(calc('1.5rem', '2rem')).toEqual(
+      'calc(var(--spacing-medium) + var(--spacing-large))'
+    )
+    expect(calc('24px', '32px')).toEqual(
+      'calc(var(--spacing-medium) + var(--spacing-large))'
+    )
+  })
+})
+
 describe('createTypeModifiers', () => {
   it('should return an array with modifiers', () => {
     expect(createTypeModifiers('0.5 1 2')).toEqual([
@@ -77,7 +151,11 @@ describe('findNearestTypes', () => {
   it('should find the nearest type in correct order', () => {
     expect(findNearestTypes(2.5)).toEqual(['large', 'x-small'])
     expect(findNearestTypes(5)).toEqual(['xx-large', 'medium'])
-    expect(findNearestTypes(8)).toEqual(['xx-large-x2', 'small'])
+    expect(findNearestTypes(8)).toEqual(['xx-large', 'xx-large', 'small'])
+  })
+
+  it('should multiply type duplications', () => {
+    expect(findNearestTypes(8, true)).toEqual(['xx-large-x2', 'small'])
   })
 })
 

--- a/packages/dnb-eufemia/src/components/space/types.ts
+++ b/packages/dnb-eufemia/src/components/space/types.ts
@@ -3,31 +3,38 @@ export type SpacingElementProps = {
    * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
    *
    */
-  top?: SpaceTypes
+  top?: SpaceType
 
   /**
    * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
    *
    */
-  right?: SpaceTypes
+  right?: SpaceType
 
   /**
    * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
    *
    */
-  bottom?: SpaceTypes
+  bottom?: SpaceType
 
   /**
    * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
    *
    */
-  left?: SpaceTypes
+  left?: SpaceType
 }
 
-export type SpaceTypes = string | boolean | number
+export type SpaceType = string | boolean | number
 
 export type SpacingProps = SpacingElementProps & {
-  space?: SpaceTypes | SpacingElementProps
+  space?: SpaceType | SpacingElementProps
+}
+export type SpacingUnknownProps = Record<string, unknown>
+export type StyleObjectProps = SpacingProps & {
+  maxWidth?: string
+  maxHeight?: string
+  width?: string
+  height?: string
 }
 
 /**


### PR DESCRIPTION
With some refactoring (mostly to correct Typescript types) and the addition of 9 lines of code, we get the `calc` function that outputs CSS calc/var based summary of given types.


```tsx
import { calc } from '@dnb/eufemia/components/space/SpacingUtils'

// With Styled Components
const StyledDiv = styled.div`
  margin-top: ${calc('medium large')};
  margin-top: ${calc('medium', 'large')};
  margin-top: ${calc('1.5rem', '2rem')};
  margin-top: ${calc('24px', '32px')};
`
```

All of the examples do output: `calc(var(--spacing-medium) + var(--spacing-large))`

Invalid values will be corrected to its nearest spacing type (e.g. 17px to `var(--spacing-small)`).
