### PR TITLE
fix(Anchor): allow rel property in TS

### DIFF
--- a/packages/dnb-eufemia/src/elements/Anchor.tsx
+++ b/packages/dnb-eufemia/src/elements/Anchor.tsx
@@ -33,7 +33,7 @@ export type AnchorProps = {
 }
 
 export type AnchorAllProps = AnchorProps &
-  React.HTMLAttributes<HTMLAnchorElement> &
+  React.HTMLProps<HTMLAnchorElement> &
   SpacingProps
 
 const defaultProps = {}

--- a/packages/dnb-eufemia/src/elements/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/elements/__tests__/Anchor.test.tsx
@@ -81,6 +81,15 @@ describe('Anchor element', () => {
     expect(document.body.querySelector('#' + id)).toBe(null)
   })
 
+  it('supports rel', () => {
+    render(
+      <Anchor rel="external" href="http://www.externallink.com/">
+        text
+      </Anchor>
+    )
+    expect(document.querySelector('[rel="external"]')).toBeTruthy()
+  })
+
   it('should validate with ARIA rules as a Anchor element', async () => {
     const Component = render(<Anchor {...props} />)
     expect(await axeComponent(Component)).toHaveNoViolations()


### PR DESCRIPTION
Seems like `HTMLProps` includes more props than `HTMLAttributes`, `rel` being one of them.

Or maybe we should use `React.ComponentPropsWithoutRef<"a">`?  🤔 
https://github.com/typescript-cheatsheets/react/blob/main/docs/advanced/patterns_by_usecase.md#componentprops