### PR TITLE
fix(Button): extend HTMLProps, not HTMLAttributes

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -232,7 +232,7 @@ export type ButtonProps = {
   on_click?: ButtonOnClick;
 } & Partial<
   DataAttributeTypes &
-    Partial<React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>>
+    Partial<React.HTMLProps<HTMLButtonElement | HTMLAnchorElement>>
 >;
 
 export default class Button extends React.Component<ButtonProps, any> {


### PR DESCRIPTION
I'm not 100% sure if we "need to to this", but seen in the light of https://github.com/dnbexperience/eufemia/pull/1849, we might miss a few properties for buttons as well, because we use `HTMLAttributes` 🤔 


Seems like `HTMLProps` includes more props than `HTMLAttributes`.

Or maybe we should use React.ComponentPropsWithoutRef<"button">? 🤔
https://github.com/typescript-cheatsheets/react/blob/main/docs/advanced/patterns_by_usecase.md#componentprops