### PR TITLE
chore: change P.test.js to use testing library

### DIFF
--- a/packages/dnb-eufemia/src/elements/__tests__/P.test.js
+++ b/packages/dnb-eufemia/src/elements/__tests__/P.test.js
@@ -11,6 +11,7 @@ import {
   axeComponent,
 } from '../../core/jest/jestSetup'
 import Component from '../P'
+import { render } from '@testing-library/react'
 
 const props = fakeProps(require.resolve('../P'), {
   optional: true,
@@ -24,29 +25,47 @@ describe('P element', () => {
     expect(toJson(Comp)).toMatchSnapshot()
   })
   it('has correct size when size is defined', () => {
-    const Comp = mount(<Component size="large" />)
-    expect(Comp.find('.dnb-p__size--large').exists()).toBe(true)
+    const { container } = render(<Component size="large" />)
+
+    expect(
+      container.firstChild.classList.contains('dnb-p__size--large')
+    ).toBe(true)
   })
   it('has correct style when size and a modifier is defined', () => {
-    const Comp = mount(<Component size="medium" modifier="medium" />)
-    expect(Comp.find('.dnb-p__size--medium').exists()).toBe(true)
-    expect(Comp.find('.dnb-p--medium').exists()).toBe(true)
+    const { container } = render(
+      <Component size="medium" modifier="medium" />
+    )
+    expect(
+      container.firstChild.classList.contains('dnb-p__size--medium')
+    ).toBe(true)
+    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
+      true
+    )
   })
   it('has correct style when several modifiers are defined', () => {
-    const Comp = mount(<Component modifier="medium small" />)
-    expect(Comp.find('.dnb-p__size--small').exists()).toBe(true)
-    expect(Comp.find('.dnb-p--medium').exists()).toBe(true)
+    render(<Component modifier="medium small" />)
+    const { container } = render(<Component modifier="medium small" />)
+    expect(
+      container.firstChild.classList.contains('dnb-p__size--small')
+    ).toBe(true)
+    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
+      true
+    )
   })
   it('has correct style when medium is set to true', () => {
-    const Comp = mount(<Component medium />)
-    expect(Comp.find('.dnb-p--medium').exists()).toBe(true)
+    const { container } = render(<Component medium />)
+    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
+      true
+    )
   })
   it('has correct style when bold is set to true', () => {
-    const Comp = mount(<Component bold />)
-    expect(Comp.find('.dnb-p--bold').exists()).toBe(true)
+    const { container } = render(<Component bold />)
+    expect(container.firstChild.classList.contains('dnb-p--bold')).toBe(
+      true
+    )
   })
   it('should validate with ARIA rules as a p element', async () => {
-    const Comp = mount(<Component {...props} />)
+    const Comp = render(<Component {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/elements/__tests__/P.test.js
+++ b/packages/dnb-eufemia/src/elements/__tests__/P.test.js
@@ -25,44 +25,47 @@ describe('P element', () => {
     expect(toJson(Comp)).toMatchSnapshot()
   })
   it('has correct size when size is defined', () => {
-    const { container } = render(<Component size="large" />)
+    render(<Component size="large" />)
+    const element = document.querySelector('.dnb-p__size--large')
 
-    expect(
-      container.firstChild.classList.contains('dnb-p__size--large')
-    ).toBe(true)
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-p',
+      'dnb-p__size--large',
+    ])
   })
   it('has correct style when size and a modifier is defined', () => {
-    const { container } = render(
-      <Component size="medium" modifier="medium" />
-    )
-    expect(
-      container.firstChild.classList.contains('dnb-p__size--medium')
-    ).toBe(true)
-    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
-      true
-    )
+    render(<Component size="medium" modifier="medium" />)
+    const element = document.querySelector('.dnb-p__size--medium')
+
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-p',
+      'dnb-p--medium',
+      'dnb-p__size--medium',
+    ])
   })
   it('has correct style when several modifiers are defined', () => {
     render(<Component modifier="medium small" />)
-    const { container } = render(<Component modifier="medium small" />)
-    expect(
-      container.firstChild.classList.contains('dnb-p__size--small')
-    ).toBe(true)
-    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
-      true
-    )
+    const element = document.querySelector('.dnb-p__size--small')
+
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-p',
+      'dnb-p--medium',
+      'dnb-p__size--small',
+    ])
   })
   it('has correct style when medium is set to true', () => {
-    const { container } = render(<Component medium />)
-    expect(container.firstChild.classList.contains('dnb-p--medium')).toBe(
-      true
-    )
+    render(<Component medium />)
+    const element = document.querySelector('.dnb-p--medium')
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-p',
+      'dnb-p--medium',
+    ])
   })
   it('has correct style when bold is set to true', () => {
-    const { container } = render(<Component bold />)
-    expect(container.firstChild.classList.contains('dnb-p--bold')).toBe(
-      true
-    )
+    render(<Component bold />)
+    const element = document.querySelector('.dnb-p--bold')
+
+    expect(Array.from(element.classList)).toEqual(['dnb-p', 'dnb-p--bold'])
   })
   it('should validate with ARIA rules as a p element', async () => {
     const Comp = render(<Component {...props} />)


### PR DESCRIPTION
## Summary
Changing the use of enzyme to react testing library.

## Test plan
Changed testing to use testing library standards and some refactoring in the process.
Ran 
`yarn test /P.test.js`
to see that test now works.
