### PR TITLE
chore(Portal): add position relative to example-box

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -121,6 +121,8 @@
     .example-box {
       @include gridStyle(rgb(236, 236, 236), 1);
 
+      position: relative;
+
       padding: 2rem;
 
       &.center {


### PR DESCRIPTION
I can't remember, why we not did set position relative after the Emotion => SCSS conversion. But right now, I can't find any negative issues having it.

This fixes an issue a few places, where the class `example-box` is used, like on this page: https://eufemia.dnb.no/uilib/getting-started/demos/

<img width="477" alt="Screenshot 2023-01-06 at 14 31 47" src="https://user-images.githubusercontent.com/1501870/211022335-075df073-58b2-452d-ba67-9790484d52c2.png">
