### PR TITLE
chore: make Slack step not fail when run from Fork

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -75,4 +75,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        if: ${{ always() && github.repository_owner == 'dnbexperience' }}
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -129,4 +129,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        if: ${{ always() && github.repository_owner == 'dnbexperience' }}
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        if: ${{ always() && github.repository_owner == 'dnbexperience' }}
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,4 +77,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        if: ${{ always() && github.repository_owner == 'dnbexperience' }}
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -143,4 +143,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        if: ${{ always() && github.repository_owner == 'dnbexperience' }}
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
Honestly, I thought we have fixed the issue by checking the "owner". But with the two new fork PRs, I clearly see we did not.

<img width="392" alt="Screenshot 2023-01-06 at 15 20 16" src="https://user-images.githubusercontent.com/1501870/211031074-99a1eaaa-1bed-4ba2-a079-bc6e1df40655.png">


I don't think the issue is gone with that PR. But I don't know what we can do more about it either. 

The [docs](https://docs.github.com/en/actions/learn-github-actions/expressions#always) says clearly, that the step should not fail, when `always` is used. Do they not?

If we would add a env check `if: ${{ always() && secrets.SLACK_WEBHOOK }}`, then we are probably on the same page as before? What do you think? @langz 

I also wander, how we can get the [rest of the actions](https://github.com/dnbexperience/eufemia/pull/1854) to start running?

<img width="938" alt="Screenshot 2023-01-06 at 15 26 06" src="https://user-images.githubusercontent.com/1501870/211031422-b052088b-a7a7-4b34-8eae-e22d5c6ec3bb.png">
