### PR TITLE
chore(P): use className instead of style_type

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/Card.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.js
@@ -54,7 +54,7 @@ export default class Card extends React.PureComponent {
           <Span className={linkInnerStyle}>
             <Span className={boxStyle}>
               {Svg && <Svg />}
-              <P style_type="lead">{title}</P>
+              <P className="dnb-p--lead">{title}</P>
               <P top="x-small">{about}</P>
             </Span>
 


### PR DESCRIPTION
Missed this as part of #1855.

From:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/1359205/211777388-8cf610db-e522-4199-a1ff-f00b8c4956a0.png">

To:
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/1359205/211777276-8a922b03-830c-4a4d-a573-07cf44f8cd2d.png">