### PR TITLE
fix(Table): correct width on medium and small accordion chevron icon cell

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -753,21 +753,22 @@ thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus
   --accordion-border-width: 0.0625rem;
   --accordion-border: var(--accordion-border-width) solid
     var(--color-black-20); }
-  .dnb-table__th.dnb-table__th__accordion-icon {
+  .dnb-table__th.dnb-table__th__accordion-icon.dnb-table__th {
     padding: 0; }
-    .dnb-table__th.dnb-table__th__accordion-icon,
+  .dnb-table__th.dnb-table__th__accordion-icon,
+  .dnb-table__th.dnb-table__th__accordion-icon div {
+    width: 3.5rem;
+    text-indent: -300vw; }
+    .dnb-table__size--medium .dnb-table__th.dnb-table__th__accordion-icon, .dnb-table__size--medium
     .dnb-table__th.dnb-table__th__accordion-icon div {
-      width: 3.5rem;
-      text-indent: -300vw; }
-      .dnb-table__size--medium .dnb-table__th.dnb-table__th__accordion-icon, .dnb-table__size--medium
-      .dnb-table__th.dnb-table__th__accordion-icon div {
-        width: 3rem; }
-      .dnb-table__size--small .dnb-table__th.dnb-table__th__accordion-icon, .dnb-table__size--small
-      .dnb-table__th.dnb-table__th__accordion-icon div {
-        width: 2.5rem; }
+      width: 3rem; }
+    .dnb-table__size--small .dnb-table__th.dnb-table__th__accordion-icon, .dnb-table__size--small
+    .dnb-table__th.dnb-table__th__accordion-icon div {
+      width: 2.5rem; }
   .dnb-table__td.dnb-table__td__accordion-icon {
-    padding: 0;
     user-select: none; }
+    .dnb-table__td.dnb-table__td__accordion-icon.dnb-table__td {
+      padding: 0; }
   .dnb-table__tr--has-accordion-content .dnb-table__toggle-button {
     display: flex;
     justify-content: center; }

--- a/packages/dnb-eufemia/src/components/table/style/_table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/_table-accordion.scss
@@ -21,7 +21,9 @@
     var(--color-black-20);
 
   &__th#{&}__th__accordion-icon {
-    padding: 0;
+    &.dnb-table__th {
+      padding: 0;
+    }
 
     // In case the table-layout is fixed
     &,
@@ -40,7 +42,9 @@
   }
 
   &__td#{&}__td__accordion-icon {
-    padding: 0;
+    &.dnb-table__td {
+      padding: 0;
+    }
     user-select: none; // prevent selection on double-click
   }
 


### PR DESCRIPTION
This PR fixes a css specificity issue on medium and small tables.

Correct (medium)
<img width="207" alt="Screenshot 2023-01-11 at 11 52 27" src="https://user-images.githubusercontent.com/1501870/211788162-aefd2fbc-d333-4e6e-b104-0c4978195a4a.png">

Bug (medium)
<img width="238" alt="Screenshot 2023-01-11 at 11 52 43" src="https://user-images.githubusercontent.com/1501870/211788200-cade68c8-2525-41be-aea6-8295a8ff4826.png">


