### PR TITLE
fix: remove `maintained node versions` from .browserslistrc

### DIFF
--- a/packages/dnb-design-system-portal/.browserslistrc
+++ b/packages/dnb-design-system-portal/.browserslistrc
@@ -1,2 +1,2 @@
 # Should reflect: https://eufemia.dnb.no/uilib/usage#supported-browsers-and-platforms
-defaults and supports es6-module, maintained node versions
+defaults and supports es6-module

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage.md
@@ -40,6 +40,6 @@ Read more in the [First Steps](/uilib/usage/first-steps/) section.
 
 Eufemia uses the following config for the bundle output, defined in `.browserslistrc`:
 
-- `defaults and supports es6-module, maintained node versions`
+- `defaults and supports es6-module`
 
-To see exactly which browsers this config supports, take a look [here](https://browsersl.ist/#q=defaults+and+supports+es6-module%2C+maintained+node+versions).
+To see exactly which browsers this config supports, take a look [here](https://browsersl.ist/#q=defaults+and+supports+es6-module).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/polyfill.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/polyfill.md
@@ -20,7 +20,7 @@ Use [postcss-preset-env](https://github.com/csstools/postcss-preset-env). Exampl
       postcssPresetEnv({
         stage: 0,
         preserve: true,
-        browsers: ['defaults and supports es6-module, maintained node versions'],
+        browsers: ['defaults and supports es6-module'],
         importFrom: [require.resolve('@dnb/eufemia/style/dnb-ui-properties.css')]
       })
     ]

--- a/packages/dnb-eufemia/.browserslistrc
+++ b/packages/dnb-eufemia/.browserslistrc
@@ -1,1 +1,1 @@
-defaults and supports es6-module, maintained node versions
+defaults and supports es6-module

--- a/packages/dnb-eufemia/scripts/prebuild/config/postcssConfig.js
+++ b/packages/dnb-eufemia/scripts/prebuild/config/postcssConfig.js
@@ -9,9 +9,7 @@ module.exports = (options) => {
     // preset-env processes the most of our old legacy browsers
     require('postcss-preset-env')({
       stage: 2,
-      browsers: [
-        'defaults and supports es6-module, maintained node versions',
-      ].filter((i) => i),
+      browsers: ['defaults and supports es6-module'].filter((i) => i),
       ...options,
     }),
   ].filter((i) => i) // remove the first


### PR DESCRIPTION
Fixes #1912

I think, we do not need `maintained node versions`. What do you think? @langz 