### PR TITLE
fix(Anchor): comments Anchor's inner_ref usage

### DIFF
--- a/packages/dnb-eufemia/src/elements/Anchor.tsx
+++ b/packages/dnb-eufemia/src/elements/Anchor.tsx
@@ -45,7 +45,7 @@ export function AnchorInstance(localProps: AnchorAllProps) {
     context?.Anchor
   )
 
-  // deprecated
+  // deprecated: inner_ref is still needed to support Button's usage of Anchor
   if (typeof allProps.inner_ref !== 'undefined') {
     allProps.innerRef = allProps.inner_ref
     delete allProps.inner_ref


### PR DESCRIPTION
I think we have to remove `Button`'s [inner_ref](https://github.com/dnbexperience/eufemia/blob/71f5ee3746f6381eeb72221bac013126a5ea84ad/packages/dnb-eufemia/src/components/button/Button.js#L129), as the  `inner_ref` could be passed down to `Anchor`(which as of this PR only supports `innerRef` and not `inner_ref`):  https://github.com/dnbexperience/eufemia/blob/71f5ee3746f6381eeb72221bac013126a5ea84ad/packages/dnb-eufemia/src/components/button/Button.js#L178-L182

UPDATE: I've now changed this to just improve the comment of why it's not deprecated(easy to remove) as of now. 
I don't think it's easy or better to actually remove/deprecate the `inner_ref` property, since Button is still dependent on the `inner_ref` prop as of now.