### PR TITLE
chore(Modal): fix test error for trigger_attributes

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1019,7 +1019,7 @@ describe('Modal component', () => {
               return (
                 <Component
                   {...props}
-                  trigger_attributes={{ hidden: 'true' }}
+                  trigger_attributes={{ hidden: true }}
                   open_state="opened"
                 >
                   content


### PR DESCRIPTION
Fixes:

```
    console.error
      Warning: Received the string `true` for the boolean attribute `hidden`. Although this works, it will not work as expected if you pass the string "false". Did you mean hidden={true}?
          at button
          at Button (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/button/Button.js:66:5)
          at useContext (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx:23:25)
          at Modal (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/modal/Modal.tsx:158:5)
          at Modal (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/shared/helpers/withCamelCaseProps.tsx:53:30)
          at Button (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/button/Button.js:66:5)
          at useState (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx:1006:39)
          at WrapperComponent (/Users/anderslangseth/dev/eufemia/node_modules/@wojtekmaj/enzyme-adapter-utils/src/createMountWrapper.jsx:48:26)
```