### PR TITLE
chore(Space): fix test error innerRef on DOM elem

### DIFF
--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -37,28 +37,31 @@ function Element({
   innerRef,
   ...props
 }: SpaceAllProps) {
-  const E = element as DynamicElement<any>
+  const ElementDynamic = element as DynamicElement<any>
   let component: React.ReactElement = null
 
-  if (E === Section) {
+  if (ElementDynamic === Section) {
     component = (
-      <E {...props} innerRef={innerRef}>
+      <ElementDynamic {...props} inner_ref={innerRef}>
         {children}
-      </E>
+      </ElementDynamic>
     )
   } else {
     // also used for code markup simulation
     validateDOMAttributes({}, props)
 
     component = (
-      <E {...props} ref={innerRef}>
+      <ElementDynamic {...props} ref={innerRef}>
         {children}
-      </E>
+      </ElementDynamic>
     )
   }
 
   if (isTrue(no_collapse)) {
-    const R = E === 'span' || isInline(element as string) ? 'span' : 'div'
+    const R =
+      ElementDynamic === 'span' || isInline(element as string)
+        ? 'span'
+        : 'div'
     return (
       <R
         className={classnames(


### PR DESCRIPTION
Problem was that I thought `<E `in https://github.com/dnbexperience/eufemia/pull/1859/files#diff-e332dc1ea8b6e76ee4eac5052d69c902e4b58b8e849f9d33a5d384c317c8b088R45 was the same as `import E from './Element'`, but it's not. 

Hence renaming `<E>` in this file to be `<ElementDynamic>`, just to prevent confusion, though it's "not technically needed" as it can be seen by that we don't import `<E>` in this file as well.

Fixes following issue.

```
      at log (src/components/space/Space.tsx:45:13)

  console.error
    Warning: React does not recognize the `innerRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `innerref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
        at section
        at useContext (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/section/Section.tsx:72:25)
        at element (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/space/Space.tsx:34:3)
        at Space (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/space/Space.tsx:121:16)
        at open (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx:49:3)
        at ContentWrapper (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.js:38:5)
        at TabContent
        at div
        at children (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/tabs/Tabs.js:972:27)
        at Tabs (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/tabs/Tabs.js:286:5)

      158 |         return
      159 |       }
    > 160 |       originalError.call(console, ...args)
          |                     ^
      161 |     }
      162 |   })
      163 |

      at console.call [as error] (src/core/jest/jestSetup.js:160:21)
      at printWarning (../../node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (../../node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at validateProperty$1 (../../node_modules/react-dom/cjs/react-dom.development.js:3513:7)
      at warnUnknownProperties (../../node_modules/react-dom/cjs/react-dom.development.js:3559:21)
      at validateProperties$2 (../../node_modules/react-dom/cjs/react-dom.development.js:3583:3)
      at validatePropertiesInDevelopment (../../node_modules/react-dom/cjs/react-dom.development.js:8765:5)
      at setInitialProperties (../../node_modules/react-dom/cjs/react-dom.development.js:9041:5)
      at finalizeInitialChildren (../../node_modules/react-dom/cjs/react-dom.development.js:10201:3)
      at completeWork (../../node_modules/react-dom/cjs/react-dom.development.js:19470:17)
      at completeUnitOfWork (../../node_modules/react-dom/cjs/react-dom.development.js:22812:16)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom.development.js:22787:5)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom.development.js:22707:5)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom.development.js:22670:7)
      at performSyncWorkOnRoot (../../node_modules/react-dom/cjs/react-dom.development.js:22293:18)
      at scheduleUpdateOnFiber (../../node_modules/react-dom/cjs/react-dom.development.js:21881:7)
      at updateContainer (../../node_modules/react-dom/cjs/react-dom.development.js:25482:3)
      at ../../node_modules/react-dom/cjs/react-dom.development.js:26021:7
      at unbatchedUpdates (../../node_modules/react-dom/cjs/react-dom.development.js:22431:12)
      at legacyRenderSubtreeIntoContainer (../../node_modules/react-dom/cjs/react-dom.development.js:26020:5)
      at Object.render (../../node_modules/react-dom/cjs/react-dom.development.js:26103:10)
      at ../../node_modules/@testing-library/react/dist/pure.js:101:25
      at batchedUpdates$1 (../../node_modules/react-dom/cjs/react-dom.development.js:22380:12)
      at act (../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:1042:14)
      at render (../../node_modules/@testing-library/react/dist/pure.js:97:26)
      at Object.<anonymous> (src/components/tabs/__tests__/Tabs.test.js:262:5)
```