### PR TITLE
docs: add correct info about the `clean_copy_value` feature

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.tsx
@@ -6,6 +6,9 @@
 import React from 'react'
 import ComponentBox from 'dnb-design-system-portal/src/shared/tags/ComponentBox'
 import styled from '@emotion/styled'
+import { Provider } from '@dnb/eufemia/src/shared'
+import NumberFormat from '@dnb/eufemia/src/components/NumberFormat'
+import P from '@dnb/eufemia/src/elements/P'
 
 const Style = styled.div`
   *:not([data-visual-test='number-format-spacing'])
@@ -68,6 +71,28 @@ export const NumberCurrency = () => (
 </P>
 `
       }
+    </ComponentBox>
+  </Style>
+)
+
+export const NumberProvider = () => (
+  <Style>
+    <ComponentBox scope={{ Provider }}>
+      <Provider
+        value={{
+          NumberFormat: {
+            currency: true,
+            omit_rounding: true,
+            clean_copy_value: true,
+          },
+        }}
+      >
+        <P>
+          <NumberFormat>12345</NumberFormat>
+          <NumberFormat value={-12345.123} decimals={0} />
+          <NumberFormat value={-12345678.955} currency_position="before" />
+        </P>
+      </Provider>
     </ComponentBox>
   </Style>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.md
@@ -15,6 +15,7 @@ NumberNationalIdentification,
 NumberOrganization,
 NumberLocales,
 NumberSpacing,
+NumberProvider,
 } from 'Docs/uilib/components/number-format/Examples'
 import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
@@ -67,3 +68,9 @@ By using `selectall={false}` you disable the auto-select all feature.
 The NumberFormat uses `display: inline-block;` in order to make the [spacing system](/uilib/components/space) to work.
 
 <NumberSpacing />
+
+### Using the Provider with NumberFormat
+
+In this example every NumberFormat will receive the Provider defined properties, including `clean_copy_value`.
+
+<NumberProvider />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.md
@@ -126,7 +126,7 @@ The number component is style-independent, so it has no visual styles. By defaul
 
 **VoiceOver** on mobile devices (iOS) only supports numbers read out properly to a maximum of `99,999.00`. On amounts above this value, VO reads numbers digit by digit.
 
-To enhance the **Copy & Paste** experience of copying numbers into other applications (Excel), you may use the `clean_copy_value` property – it will then provide a second number, without thousand separators and to have a coma/dot (depending on the locale) as the decimal separator. This number is not visible, but will be used when selecting & coping the whole number on the first click to the system clipboard.
+To enhance the **Copy & Paste** experience of copying numbers into other applications (Excel), you may use the `clean_copy_value` property – it will then provide a second number, without thousand separators and to have a comma/dot (depending on the locale) as the decimal separator. This number is not visible, but will be used when selecting & copying the whole number on the first click to the system clipboard.
 
 You can enable this feature on all your NumberFormat components by using the `Provider`:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.md
@@ -122,11 +122,23 @@ The number component is style-independent, so it has no visual styles. By defaul
 
 ## Accessibility
 
-To enhance the **Copy & Paste** experience of copying numbers into other applications, the NumberFormat component automatically changes the number formatting to be without thousand separators and to have a dot, instead of a comma for the decimal separator.
-
 **NVDA** has also [issues](https://github.com/nvaccess/nvda/issues/8874) on reconciling the `lang` attribute, this makes it hard to have a solid and good solution for reading numbers. VoiceOver on desktop makes a perfect job there.
 
 **VoiceOver** on mobile devices (iOS) only supports numbers read out properly to a maximum of `99,999.00`. On amounts above this value, VO reads numbers digit by digit.
+
+To enhance the **Copy & Paste** experience of copying numbers into other applications (Excel), you may use the `clean_copy_value` property – it will then provide a second number, without thousand separators and to have a coma/dot (depending on the locale) as the decimal separator. This number is not visible, but will be used when selecting & coping the whole number on the first click to the system clipboard.
+
+You can enable this feature on all your NumberFormat components by using the `Provider`:
+
+```jsx
+import { Provider } from '@dnb/eufemia/shared'
+
+render(
+  <Provider value={{ NumberFormat: { clean_copy_value: true } }}>
+    <YourApp />
+  </Provider>
+)
+```
 
 ### More details
 


### PR DESCRIPTION
Fixes #1947
