### PR TITLE
docs: remove examples that shows state by color only

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.js
@@ -119,22 +119,6 @@ export const InputExampleDisabled = () => (
   </Wrapper>
 )
 
-export const InputExampleFailureStatus = () => (
-  <Wrapper>
-    <ComponentBox>
-      {
-        /* jsx */ `
-<Input
-  label="Show status:"
-  status="error"
-  value="Shows status with border only"
-/>
-`
-      }
-    </ComponentBox>
-  </Wrapper>
-)
-
 export const InputExampleFormStatus = () => (
   <Wrapper>
     <ComponentBox data-visual-test="input-error">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.md
@@ -9,7 +9,6 @@ InputExampleSearch,
 InputExampleMedium,
 InputExampleWithIcon,
 InputExampleDisabled,
-InputExampleFailureStatus,
 InputExampleFormStatus,
 InputExampleSuffix,
 InputExampleStretched,
@@ -42,10 +41,6 @@ With left / right aligned text
 ### Disabled input
 
 <InputExampleDisabled />
-
-### Show failure status
-
-<InputExampleFailureStatus />
 
 ### With FormStatus
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.js
@@ -136,22 +136,6 @@ export const TextareaExampleFormStatus = () => (
   </Wrapper>
 )
 
-export const TextareaExampleError = () => (
-  <Wrapper>
-    <ComponentBox>
-      {
-        /* jsx */ `
-<Textarea
-  label="Show status:"
-  status="error"
-  value="Shows status with border only"
-/>
-`
-      }
-    </ComponentBox>
-  </Wrapper>
-)
-
 export const TextareaExampleDisabled = () => (
   <Wrapper>
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.md
@@ -10,7 +10,6 @@ TextareaExampleStretched,
 TextareaExampleAutoresize,
 TextareaExampleMaxLength,
 TextareaExampleFormStatus,
-TextareaExampleError,
 TextareaExampleDisabled,
 TextareaExampleSuffix
 } from 'Docs/uilib/components/textarea/Examples'
@@ -44,10 +43,6 @@ TextareaExampleSuffix
 ### With FormStatus failure message
 
 <TextareaExampleFormStatus />
-
-### Show failure status
-
-<TextareaExampleError />
 
 ### Disabled textarea
 


### PR DESCRIPTION
Because its not good for a11y, we should not have an example like that.