### PR TITLE
fix(Dl): ensure horizontal wrap no matter what available space

### DIFF
--- a/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
+++ b/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
@@ -822,7 +822,7 @@ html[data-whatinput=keyboard] .dnb-blockquote:not(.dnb-blockquote--no-background
     margin-top: 0;
   }
   .dnb-dl dd.dnb-dl__item {
-    width: 100%;
+    flex-basis: 100%;
     height: 0;
     margin: 0;
   }

--- a/packages/dnb-eufemia/src/style/elements/lists.scss
+++ b/packages/dnb-eufemia/src/style/elements/lists.scss
@@ -167,7 +167,7 @@
     }
 
     dd#{&}__item {
-      width: 100%;
+      flex-basis: 100%; // ensures we always break to a new line, no matter what the available space is
       height: 0;
       margin: 0;
     }


### PR DESCRIPTION
The current approach did not work always. When the parent space where to wide, it did not wrap. The new approach does do it. 

Here is my testing case: https://codesandbox.io/s/eufemia-timeline-example-4x7u7n?file=/src/App.tsx

It should not have any impact on our existing visual tests.

Before:
<img width="763" alt="Screenshot 2023-02-01 at 20 58 57" src="https://user-images.githubusercontent.com/1501870/216150309-581359c9-0851-477a-92d8-672ef50093d3.png">



After:

<img width="773" alt="Screenshot 2023-02-01 at 20 59 17" src="https://user-images.githubusercontent.com/1501870/216150323-bb6c0dd8-759c-4b60-95f5-08a02e648405.png">


