### PR TITLE
feat(ScrollView): add interactive=auto to observe the content

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/properties.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/properties.md
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Properties
 
-| Properties                                  | Description                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `interactive`                               | _(optional)_ set to `true` to make the content accessible to keyboard navigation. Defaults to `false`. |
-| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                  |
+| Properties                                  | Description                                                                                                                                                                                                           |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interactive`                               | _(optional)_ to make the content accessible to keyboard navigation. Use `true` or `auto`. Auto will detect if a scrollbar is visible and make the ScrollView accessible for keyboard navigation. Defaults to `false`. |
+| [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                                                                                 |

--- a/packages/dnb-eufemia/src/components/table/TableScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableScrollView.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classnames from 'classnames'
-import ScrollView from '../../fragments/scroll-view/ScrollView'
+import ScrollView, {
+  ScrollViewAllProps,
+} from '../../fragments/scroll-view/ScrollView'
 
 import type { SpacingProps } from '../../shared/types'
 
@@ -13,7 +15,8 @@ export type TableScrollViewProps = {
 
 export type TableScrollViewAllProps = TableScrollViewProps &
   Omit<React.TableHTMLAttributes<HTMLDivElement>, 'children'> &
-  SpacingProps
+  SpacingProps &
+  ScrollViewAllProps
 
 export default function TableScrollView(props: TableScrollViewAllProps) {
   const { className, children, ...rest } = props
@@ -21,7 +24,7 @@ export default function TableScrollView(props: TableScrollViewAllProps) {
   return (
     <ScrollView
       className={classnames('dnb-table__scroll-view', className)}
-      interactive
+      interactive="auto"
       {...rest}
     >
       {children}

--- a/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/__mocks__/ResizeObserver.ts
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/__mocks__/ResizeObserver.ts
@@ -1,0 +1,26 @@
+type ObserverOptions = {
+  init?: (callback: ResizeObserverCallback) => void
+  observe?: (elem: HTMLElement) => void
+}
+
+export const setResizeObserver = ({
+  observe,
+  init,
+}: ObserverOptions = {}) => {
+  class ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      init?.(callback)
+    }
+    observe(elem: HTMLElement) {
+      return observe?.(elem)
+    }
+    unobserve() {
+      // do nothing
+    }
+    disconnect() {
+      // do nothing
+    }
+  }
+
+  globalThis.ResizeObserver = ResizeObserver
+}


### PR DESCRIPTION
When `interactive=auto` is used, and there is a scrollbar, make the scrollview tabbable. 
The screenshot shows, that I was able to focus it:

<img width="519" alt="Screenshot 2023-02-09 at 22 06 07" src="https://user-images.githubusercontent.com/1501870/217939389-a4548f2c-8047-49c3-9f7d-e8bdbf123730.png">
