### PR TITLE
fix(Upload): fix handling of file types in combination with file extension

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileInput.tsx
@@ -12,7 +12,7 @@ import { makeUniqueId } from '../../shared/component-helper'
 // Internal
 import { UploadContext } from './UploadContext'
 import UploadStatus from './UploadStatus'
-import { extendWithAbbreviation } from './UploadVerify'
+import { getAcceptedFileTypes } from './UploadVerify'
 
 const UploadFileInput = () => {
   const fileInput = useRef<HTMLInputElement>(null)
@@ -30,9 +30,7 @@ const UploadFileInput = () => {
   const openFileDialog = () => fileInput.current?.click()
 
   const sharedId = id || makeUniqueId()
-  const accept = extendWithAbbreviation(acceptedFileTypes)
-    .map((type) => `.${type}`)
-    .join(',')
+  const accept = getAcceptedFileTypes(acceptedFileTypes)
 
   return (
     <div>

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -25,6 +25,7 @@ import { UploadFile } from './types'
 // Shared
 import { getPreviousSibling, warn } from '../../shared/component-helper'
 import useUpload from './useUpload'
+import { getFileTypeFromExtension } from './UploadVerify'
 
 const images = {
   pdf,
@@ -64,16 +65,13 @@ const UploadFileListCell = ({
   deleteButtonText,
 }: UploadFileListCellProps) => {
   const { file, errorMessage, isLoading } = uploadFile
-  const { name, type } = file
-
-  const fileType = type.split('/')[1] || ''
-
   const hasWarning = errorMessage != null
 
+  const fileType = getFileTypeFromExtension(file)
+  const humanFileType = fileType.toUpperCase()
+
   const imageUrl = URL.createObjectURL(file)
-
   const cellRef = useRef<HTMLLIElement>()
-
   const exists = useExistsHighlight(id, file)
 
   const handleDisappearFocus = () => {
@@ -136,9 +134,15 @@ const UploadFileListCell = ({
 
     let iconFileType = fileType
 
-    if (!Object.prototype.hasOwnProperty.call(images, fileType)) {
+    if (!iconFileType) {
+      const mimeParts = file.type.split('/')
+      iconFileType = images[mimeParts[0]] || images[mimeParts[1]]
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(images, iconFileType)) {
       iconFileType = 'file'
     }
+
     return <Icon icon={images[iconFileType]} />
   }
 
@@ -163,14 +167,14 @@ const UploadFileListCell = ({
           )}
           rel="noopener noreferrer"
         >
-          {name}
+          {file.name}
         </a>
         <P
           className="dnb-upload__file-cell__subtitle"
           size="x-small"
           top="xx-small"
         >
-          {fileType.toUpperCase()}
+          {humanFileType}
         </P>
       </div>
     )

--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -40,10 +40,12 @@ const UploadInfo = () => {
         direction="horizontal"
         className="dnb-upload__condition-list"
       >
-        <Dl.Item>
-          <Dt>{fileTypeDescription}</Dt>
-          <Dd>{prettyfiedAcceptedFileFormats}</Dd>
-        </Dl.Item>
+        {prettyfiedAcceptedFileFormats && (
+          <Dl.Item>
+            <Dt>{fileTypeDescription}</Dt>
+            <Dd>{prettyfiedAcceptedFileFormats}</Dd>
+          </Dl.Item>
+        )}
 
         <Dl.Item>
           <Dt>{fileSizeDescription}</Dt>

--- a/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
@@ -40,12 +40,15 @@ export function verifyFiles(
     if (acceptedFileTypes.length === 0) {
       return false
     }
+    const fileType = hasPreferredMimeType(acceptedFileTypes, file)
+      ? file.type
+      : getFileTypeFromExtension(file) || file.type
     const foundType = extendWithAbbreviation(acceptedFileTypes).some(
       (type) => {
         /**
          * "file.type" can be e.g. "images/png"
          */
-        return file.type.includes(type)
+        return fileType.includes(type)
       }
     )
     return !foundType ? errorUnsupportedFile : null
@@ -64,6 +67,34 @@ export function verifyFiles(
   })
 
   return cleanedFiles
+}
+
+export function getFileTypeFromExtension(file: File) {
+  return (
+    (file.name.includes('.') && file.name.replace(/.*\.([^.]+)$/, '$1')) ||
+    null
+  )
+}
+
+export function getAcceptedFileTypes(
+  acceptedFileTypes: UploadAcceptedFileTypes
+) {
+  return extendWithAbbreviation(acceptedFileTypes)
+    .map((type) => (type.includes('/') ? type : `.${type}`))
+    .join(',')
+}
+
+export function hasPreferredMimeType(
+  acceptedFileTypes: UploadAcceptedFileTypes,
+  file: File
+) {
+  return (
+    file.type.split('/')[1] &&
+    (!acceptedFileTypes?.length ||
+      acceptedFileTypes?.some(
+        (type) => type.toLowerCase() === file.type.toLowerCase()
+      ))
+  )
 }
 
 export function extendWithAbbreviation(

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -87,6 +87,16 @@ describe('Upload', () => {
       expect(screen.queryByText(customFormatDescription)).toBeTruthy()
     })
 
+    it('does not render fileTypeDescription when acceptedFileTypes is empty', () => {
+      const acceptedFileTypes = []
+
+      render(
+        <Upload {...defaultProps} acceptedFileTypes={acceptedFileTypes} />
+      )
+
+      expect(screen.queryByText(nb.fileTypeDescription)).toBeFalsy()
+    })
+
     it('renders the custom accepted format', () => {
       const acceptedFileTypes = ['png', 'jpg']
 

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
@@ -15,21 +15,21 @@ const defaultProps: UploadContextProps = {
   filesAmountLimit: 2,
 }
 
-describe('UploadFileInput', () => {
-  const makeWrapper = (props = null) => {
-    const defaultContext: UploadContextProps = {
-      ...defaultProps,
-      ...props,
-    }
-    return ({ children }) => {
-      return (
-        <UploadContext.Provider value={defaultContext}>
-          {children}
-        </UploadContext.Provider>
-      )
-    }
+const makeWrapper = (props = null) => {
+  const defaultContext: UploadContextProps = {
+    ...defaultProps,
+    ...props,
   }
+  return ({ children }) => {
+    return (
+      <UploadContext.Provider value={defaultContext}>
+        {children}
+      </UploadContext.Provider>
+    )
+  }
+}
 
+describe('UploadFileInput', () => {
   it('renders the upload button', () => {
     render(<UploadFileInput />, {
       wrapper: makeWrapper(),

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
@@ -4,6 +4,8 @@ import UploadFileListCell, {
 import { createMockFile } from './testHelpers'
 import { render, screen } from '@testing-library/react'
 import React from 'react'
+import { UploadContext } from '../UploadContext'
+import { UploadContextProps } from '../types'
 
 global.URL.createObjectURL = jest.fn(() => 'url')
 
@@ -13,6 +15,20 @@ const defaultProps: UploadFileListCellProps = {
   onDelete: jest.fn(),
   uploadFile: { file: createMockFile('file.png', 100, 'image/png') },
   loadingText: 'loading',
+}
+
+const makeWrapper = (props = null) => {
+  const defaultContext: UploadContextProps = {
+    ...defaultProps,
+    ...props,
+  }
+  return ({ children }) => {
+    return (
+      <UploadContext.Provider value={defaultContext}>
+        {children}
+      </UploadContext.Provider>
+    )
+  }
 }
 
 describe('UploadFileListCell', () => {
@@ -65,12 +81,51 @@ describe('UploadFileListCell', () => {
     expect(element.className).toMatch('dnb-upload__file-cell')
   })
 
-  it('renders the subtitle', () => {
+  it('renders the subtitle and uses the file mime', () => {
     render(
       <UploadFileListCell
         {...defaultProps}
         uploadFile={{ file: createMockFile('file.png', 100, 'image/png') }}
       />
+    )
+
+    expect(screen.queryByText('PNG')).toBeTruthy()
+  })
+
+  it('renders the subtitle and uses the extension if mime is missing', () => {
+    render(
+      <UploadFileListCell
+        {...defaultProps}
+        uploadFile={{ file: createMockFile('file.png', 100, '') }}
+      />
+    )
+
+    expect(screen.queryByText('PNG')).toBeTruthy()
+  })
+
+  it('renders the subtitle with file extension when set by acceptedFileTypes', () => {
+    render(
+      <UploadFileListCell
+        {...defaultProps}
+        uploadFile={{ file: createMockFile('file.png', 100, 'image/png') }}
+      />,
+      {
+        wrapper: makeWrapper({ acceptedFileTypes: ['png'] }),
+      }
+    )
+
+    expect(screen.queryByText('PNG')).toBeTruthy()
+  })
+
+  it('renders the subtitle with file mime when set by acceptedFileTypes', () => {
+    render(
+      <UploadFileListCell
+        {...defaultProps}
+        uploadFile={{ file: createMockFile('file.png', 100, 'image/png') }}
+      />,
+      {
+        wrapper: makeWrapper({ acceptedFileTypes: ['image/png'] }),
+      }
     )
 
     expect(screen.queryByText('PNG')).toBeTruthy()

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadVerify.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadVerify.test.tsx
@@ -1,4 +1,4 @@
-import { verifyFiles } from '../UploadVerify'
+import { verifyFiles, getFileTypeFromExtension } from '../UploadVerify'
 import { createMockFile } from './testHelpers'
 
 describe('verifyFiles', () => {
@@ -61,5 +61,20 @@ describe('verifyFiles', () => {
     expect(files[0]).toEqual({
       file: file1,
     })
+  })
+})
+
+describe('getFileTypeFromExtension', () => {
+  it('returns the file extension when given', () => {
+    const file1 = createMockFile('fileName1.txt', 100, 'text/plain')
+    expect(getFileTypeFromExtension(file1)).toBe('txt')
+
+    const file2 = createMockFile('fileName1.test.txt', 100, 'text/plain')
+    expect(getFileTypeFromExtension(file2)).toBe('txt')
+  })
+
+  it('returns the file type when given', () => {
+    const file1 = createMockFile('fileName1', 100, 'text/plain')
+    expect(getFileTypeFromExtension(file1)).toBe(null)
   })
 })


### PR DESCRIPTION
This PR is based on #1824

Before, we did mix file extension and file mime type:
<img width="486" alt="Screenshot 2023-02-11 at 13 55 34" src="https://user-images.githubusercontent.com/1501870/218259253-4046868a-3e63-44fc-90d6-1f275ec5681c.png">

Now it uses what ever is defined in the `acceptedFileTypes={['txt']}`:
<img width="449" alt="Screenshot 2023-02-11 at 13 56 08" src="https://user-images.githubusercontent.com/1501870/218259272-82dedf14-d345-4015-a830-86e8e0585611.png">

Now it uses what ever is defined in the `acceptedFileTypes={['text/plain']}`:
<img width="434" alt="Screenshot 2023-02-11 at 13 56 24" src="https://user-images.githubusercontent.com/1501870/218259283-cc8468f6-9710-455e-a3c1-2012ad58cba9.png">

