### PR TITLE
chore(Portal): adds margin to right of badge in portal menu

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
@@ -378,7 +378,9 @@ class ListItem extends React.PureComponent {
               {children}
             </span>
           </span>
-          {status && <Badge content={statusTitle} />}
+          {status && (
+            <Badge space={{ right: 'xx-small' }} content={statusTitle} />
+          )}
         </Link>
       </li>
     )


### PR DESCRIPTION
Adds a little bit of margin between the badge and the scrollbar in our menu,

From:
<img width="2560" alt="Screenshot 2023-02-15 at 14 42 29" src="https://user-images.githubusercontent.com/1359205/219043659-742e59de-6712-4420-9408-494915a176d0.png">


To:
<img width="2560" alt="Screenshot 2023-02-15 at 14 39 31" src="https://user-images.githubusercontent.com/1359205/219043646-678624b7-15a9-4e1b-a64c-f35d274a9e65.png">
