### PR TITLE
chore: fix MDX pre v2 issue with usage of contentFilePath

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -159,7 +159,13 @@ async function createPages({ graphql, actions }) {
     if (slug) {
       createPage({
         path: slug,
-        component: `${mdxTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
+
+        // MDX V1
+        component: mdxTemplate,
+
+        // TODO MDX v2: The docs says we should use "node.internal.contentFilePath"
+        // component: `${mdxTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
+
         context: {
           id: node.id,
           slug,

--- a/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/ListSummaryFromPages.js
@@ -12,7 +12,11 @@ const ListSummaryFromDocs = ({ slug, useAsIndex = false }) => {
       allMdx(
         filter: {
           frontmatter: { title: { ne: "" }, draft: { ne: true } }
-          internal: { contentFilePath: { glob: "**/uilib/**" } }
+          # MDX v1
+          fileAbsolutePath: { glob: "**/uilib/**" }
+
+          # TODO MDX v2
+          # internal: { contentFilePath: { glob: "**/uilib/**" } }
         }
       ) {
         edges {


### PR DESCRIPTION
This fixes an issue where summary of docs did not get listed in v10.