### PR TITLE
chore(Upload): Fix TS error in example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
@@ -199,7 +199,7 @@ export const UploadErrorMessage = () => (
             <ToggleButton
               top="small"
               disabled={files.length < 1}
-              onChange={({ checked }) => {
+              on_change={({ checked }) => {
                 setFiles(
                   files.map((fileItem) => {
                     return {


### PR DESCRIPTION
Fixes a small issue, that I believe was introduced in https://github.com/dnbexperience/eufemia/pull/1996

https://github.com/dnbexperience/eufemia/actions/runs/4242957091/jobs/7375099425

```
Run yarn workspace @dnb/eufemia test:types && yarn workspace dnb-design-system-portal test:types
Error: src/docs/uilib/components/upload/Examples.tsx(202,28): error TS2339: Property 'checked' does not exist on type 'FormEvent<HTMLElement>'.
Error: Process completed with exit code 2.
```