### PR TITLE
chore: fix autocomplete visual tests

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.md
@@ -13,8 +13,6 @@ AutocompletePredefinedInput,
 AutocompleteDifferentSizes,
 AutocompleteCustomWidth,
 AutocompleteSuffix,
-AutocompleteOpened,
-AutocompleteDisabledExample,
 AutocompleteStatusExample,
 } from 'Docs/uilib/components/autocomplete/Examples'
 
@@ -85,10 +83,6 @@ const data = [
 ### Custom width
 
 <AutocompleteCustomWidth />
-
-<AutocompleteOpened />
-
-<AutocompleteDisabledExample />
 
 ### Autocomplete with status message
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/visual-tests.md
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/visual-tests.md
@@ -1,0 +1,12 @@
+---
+draft: true
+---
+
+import {
+AutocompleteOpened,
+AutocompleteDisabledExample,
+} from 'Docs/uilib/components/autocomplete/Examples'
+
+<AutocompleteOpened />
+
+<AutocompleteDisabledExample />

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.screenshot.test.ts
@@ -21,6 +21,7 @@ describe('Autocomplete', () => {
   it('have to match disabled state', async () => {
     const screenshot = await makeScreenshot({
       ...defaults,
+      url: '/uilib/components/autocomplete/visual-tests',
       selector: '[data-visual-test="autocomplete-disabled"]',
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -69,6 +70,7 @@ describe('Autocomplete', () => {
   it('have to match autocomplete opened list', async () => {
     const screenshot = await makeScreenshot({
       ...defaults,
+      url: '/uilib/components/autocomplete/visual-tests',
       selector: '[data-visual-test="autocomplete-opened"]',
       simulateSelector:
         '[data-visual-test="autocomplete-opened"] .focus-trigger .dnb-drawer-list:last-of-type li.first-of-type',

--- a/tools/jest-image-snapshot-reporter/jest-reporter.js
+++ b/tools/jest-image-snapshot-reporter/jest-reporter.js
@@ -21,7 +21,7 @@ class JestReporter {
             return status === 'failed'
           })
           .forEach(({ failureDetails, fullName }) => {
-            const failureMessage = failureDetails[0].matcherResult.message
+            const failureMessage = failureDetails[0].matcherResult?.message
 
             if (failureMessage) {
               const regex = `.*${cwd}(.*)diff\\.png.*`


### PR DESCRIPTION
Also, check if `message` is in `matcherResult`. It happened locally during local reproduction, so I got no report.