### PR TITLE
chore(Docs): Badge work in progress -> wip

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.js
@@ -324,7 +324,7 @@ class ListItem extends React.PureComponent {
       {
         new: 'New',
         beta: 'Beta',
-        wip: 'Work in Progress',
+        wip: 'WIP',
         cs: 'Coming soon',
         dep: 'Deprecated',
         imp: 'Needs improvement',


### PR DESCRIPTION
Just trying to minimize this from happening:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/1359205/221566545-9254becf-a7e8-41f4-8f38-8bf5ea6892d0.png">


I also think people understand what WIP means, so I would say it's safe to use the term, or if they don't know, it's a quick Google search.