### PR TITLE
chore(CI): continue on Slack error

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -76,3 +76,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,6 +171,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true
 
   portal-test:
     name: Portal Tests
@@ -246,3 +247,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -130,3 +130,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -78,3 +78,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true


### PR DESCRIPTION
Here are [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) about the `continue-on-error: true` command.