### PR TITLE
chore(Drawer): avoid  SSR error of useLayoutEffect in Jest tests

### DIFF
--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -394,7 +394,7 @@ describe('Drawer component snapshot', () => {
 })
 describe('Drawer aria', () => {
   it('should validate with ARIA rules as a drawer', async () => {
-    const Comp = mount(<Drawer {...props} openState={true} />)
+    const Comp = render(<Drawer {...props} openState={true} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 })


### PR DESCRIPTION
This is the same behavior as in this PR #2012 – now happening in the Drawer component. So we fix it the same way.