### PR TITLE
portal: remove underline when hover badge in menu

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
@@ -137,7 +137,9 @@
 
     .dnb-anchor:hover {
       color: var(--color-black);
-      text-decoration: underline;
+      span:first-child {
+        text-decoration: underline;
+      }
       background-color: transparent;
     }
 


### PR DESCRIPTION
Not sure if this is the best fix for #1989, as I see it was suggested to "fix it in the component itself" - https://github.com/dnbexperience/eufemia/issues/1989#issuecomment-1428450070

To me, it seems like this started happening when adding `text-decoration: underline` in https://github.com/dnbexperience/eufemia/pull/1966/files#diff-f0adfb69cb45eb94b8016448bc17488f3e2ba81514c694b5ce0f34f4e245bc56, hence now I only try to add it to the first span/text of the anchor.


How it will look when hovering now:
<img width="489" alt="image" src="https://user-images.githubusercontent.com/1359205/221818181-70b9e148-e0da-4872-a2dd-8c243cd63c07.png">

Fixes #1989
