### PR TITLE
fix: remove FormRow context support from /elements

### DIFF
--- a/packages/dnb-eufemia/src/elements/Element.tsx
+++ b/packages/dnb-eufemia/src/elements/Element.tsx
@@ -16,7 +16,6 @@ import {
   skeletonDOMAttributes,
   SkeletonMethods,
 } from '../components/skeleton/SkeletonHelper'
-import { includeValidProps } from '../components/form-row/FormRowHelpers'
 
 import type { DynamicElement, SpacingProps } from '../shared/types'
 
@@ -53,12 +52,9 @@ const Element = React.forwardRef((props: ElementAllProps, ref) => {
 
 function ElementInstance(localProps: ElementAllProps) {
   const context = React.useContext(Context)
-  const props = extendPropsWithContext(
-    localProps,
-    defaultProps,
-    { skeleton: context?.skeleton },
-    includeValidProps(context?.FormRow)
-  )
+  const props = extendPropsWithContext(localProps, defaultProps, {
+    skeleton: context?.skeleton,
+  })
 
   const {
     className,

--- a/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
+++ b/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import Element, { defaultProps } from '../Element'
+import { Provider } from '../../shared'
 
 const props = fakeProps(require.resolve('../Element'), {
   optional: true,
@@ -52,6 +53,24 @@ describe('Element', () => {
       'dnb-space__top--medium',
       'dnb-p',
     ])
+
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class'])
+  })
+
+  it('should render children', () => {
+    render(
+      <Element as="p" top="medium">
+        text
+      </Element>
+    )
+
+    const element = document.querySelector('.dnb-p')
+
+    expect(element.textContent).toBe('text')
   })
 
   it('have to support skeleton', () => {
@@ -74,6 +93,33 @@ describe('Element', () => {
     expect(container.querySelector('p').getAttribute('class')).toBe(
       'dnb-skeleton dnb-skeleton--shape dnb-p'
     )
+  })
+
+  it('have inherit skeleton prop from shared Provider', () => {
+    const { container } = render(
+      <Provider skeleton>
+        <Element as="p" className="my-p">
+          text
+        </Element>
+      </Provider>
+    )
+
+    const element = container.querySelector('.my-p')
+
+    expect(element.getAttribute('class')).toBe(
+      'my-p dnb-skeleton dnb-skeleton--font dnb-p'
+    )
+
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual([
+      'class',
+      'disabled', // because its a skeleton
+      'aria-disabled', // because its a skeleton
+      'aria-label', // because its a skeleton
+    ])
   })
 
   it('does not have inner_ref null inside default props', () => {


### PR DESCRIPTION
This PR solves #2021

We can safely do so, because none of our elements do (will) use any of the "FormRow" props.

The internal Element HOC is used by:

- Anchor
- Blockquote
- Code
- Dd
- Dl
- Div
- Td
- H
- Hr
- Img
- Li
- Ol
- P
- Span
- Ul

Also, its not documented that it should support it.
