### PR TITLE
docs: remove `properties.scss` import from docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -48,12 +48,11 @@ Styles that belong to a "theming footprint" – like colors or individual varian
 
 Theming file names ending with `-ui` will during the package release get packed into the global theming package. More details in the [theming section](/uilib/usage/customisation/theming).
 
-#### SCSS utilities and properties
+#### SCSS utilities
 
 Use the same SASS setup as all the other components. You may re-use all the [helper classes](/uilib/helpers/classes):
 
 - `./packages/dnb-eufemia/src/style/core/utilities.scss`
-- `./packages/dnb-eufemia/src/style/core/properties.scss`
 
 ### Create a local build
 


### PR DESCRIPTION
Because it's actually not valid and needed to import these into SASS. They are import by the core package anyway and will not give any value in the SASS world. now that we do not need to use a postcss to support IE11 fallbacks.
