### PR TITLE
chore: require Node.js v18 for the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gatsby/browserslist": "4.21.4"
   },
   "engines": {
-    "node": "14.17.0",
+    "node": "18.13.0",
     "yarn": ">=1.22.10"
   },
   "volta": {


### PR DESCRIPTION
When a new dev uses a different version, he will quickly get a failure message when trying to run Node/yarn install.

Should we mention the change somewhere?

