### PR TITLE
chore(Types): import SpacingProps in d.ts files

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.js
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.js
@@ -57,9 +57,9 @@ describe('type definitions', () => {
       expect(fs.existsSync(file)).toBe(true)
 
       const content = fs.readFileSync(file, 'utf-8')
-      expect(content).toContain(
-        'export interface InputProps extends React.HTMLProps<HTMLElement>'
-      )
+      expect(content).toContain('export interface InputProps')
+      expect(content).toContain('extends React.HTMLProps<HTMLElement>,')
+      expect(content).toContain('SpacingProps')
     }
   )
 

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 import AccordionContent from './AccordionContent';
 import AccordionHeader from './AccordionHeader';
 import AccordionProvider from './AccordionProvider';
@@ -20,37 +21,10 @@ export type AccordionIcon =
 export type AccordionClosed = React.ReactNode | ((...args: any[]) => any);
 export type AccordionIconPosition = 'left' | 'right';
 export type AccordionAttributes = string | Record<string, unknown>;
-export type AccordionSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
 
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type AccordionTop = string | number | boolean;
-export type AccordionRight = string | number | boolean;
-export type AccordionBottom = string | number | boolean;
-export type AccordionLeft = string | number | boolean;
-
-export interface AccordionProps extends React.HTMLProps<HTMLElement> {
+export interface AccordionProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * A title as a string or React element. It will be used as the button text.
    */
@@ -172,31 +146,6 @@ export interface AccordionProps extends React.HTMLProps<HTMLElement> {
   class?: string;
   className?: string;
   children?: React.ReactNode;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: AccordionSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: AccordionTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: AccordionRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: AccordionBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: AccordionLeft;
 
   /**
    * Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, id, event, ...event }`.

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
@@ -1,30 +1,13 @@
 import * as React from 'react';
-export type AccordionContentSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionContentTop = string | number | boolean;
-export type AccordionContentRight = string | number | boolean;
-export type AccordionContentBottom = string | number | boolean;
-export type AccordionContentLeft = string | number | boolean;
+import type { SpacingProps } from '../space/types';
 export type AccordionContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
 export interface AccordionContentProps
-  extends React.HTMLProps<HTMLElement> {
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   instance?: React.LegacyRef;
-  space?: AccordionContentSpace;
-  top?: AccordionContentTop;
-  right?: AccordionContentRight;
-  bottom?: AccordionContentBottom;
-  left?: AccordionContentLeft;
   className?: string;
   children?: AccordionContentChildren;
 }

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
@@ -1,74 +1,18 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
-export type AccordionHeaderTitleSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionHeaderTitleTop = string | number | boolean;
-export type AccordionHeaderTitleRight = string | number | boolean;
-export type AccordionHeaderTitleBottom = string | number | boolean;
-export type AccordionHeaderTitleLeft = string | number | boolean;
+import type { SpacingProps } from '../space/types';
 
-export interface AccordionHeaderTitleProps {
-  space?: AccordionHeaderTitleSpace;
-  top?: AccordionHeaderTitleTop;
-  right?: AccordionHeaderTitleRight;
-  bottom?: AccordionHeaderTitleBottom;
-  left?: AccordionHeaderTitleLeft;
+export interface AccordionHeaderTitleProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderTitle: React.FC<AccordionHeaderTitleProps>;
-export type AccordionHeaderDescriptionSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionHeaderDescriptionTop = string | number | boolean;
-export type AccordionHeaderDescriptionRight = string | number | boolean;
-export type AccordionHeaderDescriptionBottom = string | number | boolean;
-export type AccordionHeaderDescriptionLeft = string | number | boolean;
 
-export interface AccordionHeaderDescriptionProps {
-  space?: AccordionHeaderDescriptionSpace;
-  top?: AccordionHeaderDescriptionTop;
-  right?: AccordionHeaderDescriptionRight;
-  bottom?: AccordionHeaderDescriptionBottom;
-  left?: AccordionHeaderDescriptionLeft;
+export interface AccordionHeaderDescriptionProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderDescription: React.FC<AccordionHeaderDescriptionProps>;
-export type AccordionHeaderContainerSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionHeaderContainerTop = string | number | boolean;
-export type AccordionHeaderContainerRight = string | number | boolean;
-export type AccordionHeaderContainerBottom = string | number | boolean;
-export type AccordionHeaderContainerLeft = string | number | boolean;
 
-export interface AccordionHeaderContainerProps {
-  space?: AccordionHeaderContainerSpace;
-  top?: AccordionHeaderContainerTop;
-  right?: AccordionHeaderContainerRight;
-  bottom?: AccordionHeaderContainerBottom;
-  left?: AccordionHeaderContainerLeft;
+export interface AccordionHeaderContainerProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderContainer: React.FC<AccordionHeaderContainerProps>;
@@ -116,27 +60,14 @@ export type AccordionHeaderIcon =
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
 export type AccordionHeaderIconPosition = 'left' | 'right';
-export type AccordionHeaderSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionHeaderTop = string | number | boolean;
-export type AccordionHeaderRight = string | number | boolean;
-export type AccordionHeaderBottom = string | number | boolean;
-export type AccordionHeaderLeft = string | number | boolean;
 export type AccordionHeaderChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
 
 export interface AccordionHeaderProps
-  extends React.HTMLProps<HTMLElement> {
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   title?: AccordionHeaderTitle;
   description?: AccordionHeaderDescription;
   left_component?: AccordionHeaderLeftComponent;
@@ -149,11 +80,6 @@ export interface AccordionHeaderProps
   disabled?: boolean;
   skeleton?: SkeletonShow;
   no_animation?: boolean;
-  space?: AccordionHeaderSpace;
-  top?: AccordionHeaderTop;
-  right?: AccordionHeaderRight;
-  bottom?: AccordionHeaderBottom;
-  left?: AccordionHeaderLeft;
   className?: string;
   children?: AccordionHeaderChildren;
 }

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type AccordionGroupVariant =
   | 'plain'
   | 'default'
@@ -19,22 +20,10 @@ export type AccordionGroupClosed =
   | ((...args: any[]) => any);
 export type AccordionGroupIconPosition = 'left' | 'right';
 export type AccordionGroupAttributes = string | Record<string, unknown>;
-export type AccordionGroupSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type AccordionGroupTop = string | number | boolean;
-export type AccordionGroupRight = string | number | boolean;
-export type AccordionGroupBottom = string | number | boolean;
-export type AccordionGroupLeft = string | number | boolean;
 
-export interface AccordionGroupProps extends React.HTMLProps<HTMLElement> {
+export interface AccordionGroupProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   title?: React.ReactNode;
   expanded?: boolean;
   no_animation?: boolean;
@@ -64,11 +53,6 @@ export interface AccordionGroupProps extends React.HTMLProps<HTMLElement> {
   class?: string;
   className?: string;
   children?: React.ReactNode;
-  space?: AccordionGroupSpace;
-  top?: AccordionGroupTop;
-  right?: AccordionGroupRight;
-  bottom?: AccordionGroupBottom;
-  left?: AccordionGroupLeft;
 
   /**
    * Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, id, event, ...event }`.
@@ -80,6 +64,7 @@ export interface AccordionGroupProps extends React.HTMLProps<HTMLElement> {
 }
 export default class AccordionGroup extends React.Component<
   AccordionGroupProps,
+  SpacingProps,
   any
 > {
   render(): JSX.Element;

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
@@ -1,34 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
-export type AutocompleteSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type AutocompleteTop = string | number | boolean;
-export type AutocompleteRight = string | number | boolean;
-export type AutocompleteBottom = string | number | boolean;
-export type AutocompleteLeft = string | number | boolean;
+import type { SpacingProps } from '../space/types';
 export type AutocompleteAlignDrawer = 'left' | 'right';
 export type AutocompleteWrapperElement =
   | Record<string, unknown>
@@ -112,31 +84,9 @@ export type AutocompleteChildren =
   | Record<string, unknown>
   | any[];
 
-export interface AutocompleteProps extends React.HTMLProps<HTMLElement> {
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: AutocompleteSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: AutocompleteTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: AutocompleteRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: AutocompleteBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: AutocompleteLeft;
+export interface AutocompleteProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   role?: string;
 
   /**

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -10,7 +10,7 @@ import Img, { ImgProps } from '../../elements/Img'
 
 // Shared
 import Context from '../../shared/Context'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import {
   validateDOMAttributes,

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../skeleton/Skeleton';
 import { IconPrimaryIcon } from '../icon-primary/IconPrimary';
-import { DataAttributeTypes } from '../../shared/types';
+import type { DataAttributeTypes, SpacingProps } from '../../shared/types';
 export type ButtonText = string | React.ReactNode;
 export type ButtonVariant =
   | 'primary'
@@ -32,35 +32,6 @@ export type ButtonElement =
   | ((...args: any[]) => any)
   | any
   | React.ReactNode;
-export type ButtonSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type ButtonTop = string | number | boolean;
-export type ButtonRight = string | number | boolean;
-export type ButtonBottom = string | number | boolean;
-export type ButtonLeft = string | number | boolean;
 export type ButtonOnClick = string | ((...args: any[]) => any);
 
 export type ButtonProps = {
@@ -196,38 +167,14 @@ export type ButtonProps = {
   element?: ButtonElement;
 
   /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: ButtonSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: ButtonTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: ButtonRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: ButtonBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: ButtonLeft;
-
-  /**
    * Will be called on a click event. Returns an object with the native event: `{ event }`.
    */
   on_click?: ButtonOnClick;
 } & Partial<
   DataAttributeTypes &
     Partial<React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>>
->;
+> &
+  SpacingProps;
 export default class Button extends React.Component<ButtonProps, any> {
   render(): JSX.Element;
 }

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type CheckboxLabel =
   | string
   | ((...args: any[]) => any)
@@ -16,38 +17,11 @@ export type CheckboxSuffix =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type CheckboxAttributes = string | Record<string, unknown>;
-export type CheckboxSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type CheckboxTop = string | number | boolean;
-export type CheckboxRight = string | number | boolean;
-export type CheckboxBottom = string | number | boolean;
-export type CheckboxLeft = string | number | boolean;
 export type CheckboxChildren = string | ((...args: any[]) => any);
 
-export interface CheckboxProps extends React.HTMLProps<HTMLElement> {
+export interface CheckboxProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.
    */
@@ -115,31 +89,6 @@ export interface CheckboxProps extends React.HTMLProps<HTMLElement> {
    */
   skeleton?: SkeletonShow;
   class?: string;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: CheckboxSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: CheckboxTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: CheckboxRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: CheckboxBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: CheckboxLeft;
   className?: string;
   children?: CheckboxChildren;
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type DatePickerDate = Date | string;
 export type DatePickerStartDate = Date | string;
 export type DatePickerEndDate = Date | string;
@@ -31,37 +32,10 @@ export type DatePickerSuffix =
   | React.ReactNode;
 export type DatePickerDirection = 'auto' | 'top' | 'bottom';
 export type DatePickerAlignPicker = 'auto' | 'left' | 'right';
-export type DatePickerSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
 
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type DatePickerTop = string | number | boolean;
-export type DatePickerRight = string | number | boolean;
-export type DatePickerBottom = string | number | boolean;
-export type DatePickerLeft = string | number | boolean;
-
-export interface DatePickerProps extends React.HTMLProps<HTMLElement> {
+export interface DatePickerProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
   title?: string;
 
@@ -288,31 +262,6 @@ export interface DatePickerProps extends React.HTMLProps<HTMLElement> {
   align_picker?: DatePickerAlignPicker;
   class?: string;
   className?: string;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: DatePickerSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: DatePickerTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: DatePickerRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: DatePickerBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: DatePickerLeft;
 
   /**
    * Will be called right before every new calendar view gets rendered. See the example above.

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
@@ -1,34 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
-export type DropdownSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type DropdownTop = string | number | boolean;
-export type DropdownRight = string | number | boolean;
-export type DropdownBottom = string | number | boolean;
-export type DropdownLeft = string | number | boolean;
+import type { SpacingProps } from '../space/types';
 export type DropdownAlignDrawer = 'left' | 'right';
 export type DropdownOptionsRender =
   | Record<string, unknown>
@@ -103,31 +75,9 @@ export type DropdownChildren =
   | Record<string, unknown>
   | any[];
 
-export interface DropdownProps extends React.HTMLProps<HTMLElement> {
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: DropdownSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: DropdownTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: DropdownRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: DropdownBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: DropdownLeft;
+export interface DropdownProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   role?: string;
 
   /**

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
@@ -1,45 +1,19 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type FormLabelText =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type FormLabelLabelDirection = 'vertical' | 'horizontal';
-export type FormLabelSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type FormLabelTop = string | number | boolean;
-export type FormLabelRight = string | number | boolean;
-export type FormLabelBottom = string | number | boolean;
-export type FormLabelLeft = string | number | boolean;
 export type FormLabelChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface FormLabelProps extends React.HTMLProps<HTMLElement> {
+export interface FormLabelProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * <em>(required)</em> the `id` of the input.
    */
@@ -74,31 +48,6 @@ export interface FormLabelProps extends React.HTMLProps<HTMLElement> {
    */
   vertical?: boolean;
   sr_only?: boolean;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: FormLabelSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: FormLabelTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: FormLabelRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: FormLabelBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: FormLabelLeft;
   className?: string;
   children?: FormLabelChildren;
 }

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
@@ -1,47 +1,21 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type FormRowLabel =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type FormRowLabelDirection = 'vertical' | 'horizontal';
 export type FormRowDirection = 'vertical' | 'horizontal';
-export type FormRowSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type FormRowTop = string | number | boolean;
-export type FormRowRight = string | number | boolean;
-export type FormRowBottom = string | number | boolean;
-export type FormRowLeft = string | number | boolean;
 export type FormRowChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface FormRowProps extends React.HTMLProps<HTMLElement> {
+export interface FormRowProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
 
   /**
@@ -123,31 +97,6 @@ export interface FormRowProps extends React.HTMLProps<HTMLElement> {
   skeleton?: SkeletonShow;
   class?: string;
   skipContentWrapperIfNested?: boolean;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: FormRowSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: FormRowTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: FormRowRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: FormRowBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: FormRowLeft;
   className?: string;
   children?: FormRowChildren;
 }

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
@@ -1,47 +1,21 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type FormSetLabel =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type FormSetLabelDirection = 'vertical' | 'horizontal';
 export type FormSetDirection = 'vertical' | 'horizontal';
-export type FormSetSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type FormSetTop = string | number | boolean;
-export type FormSetRight = string | number | boolean;
-export type FormSetBottom = string | number | boolean;
-export type FormSetLeft = string | number | boolean;
 export type FormSetChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface FormSetProps extends React.HTMLProps<HTMLElement> {
+export interface FormSetProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Define what HTML element should be used. Defaults to `<form>`.
    */
@@ -137,31 +111,6 @@ export interface FormSetProps extends React.HTMLProps<HTMLElement> {
   responsive?: boolean;
   class?: string;
   skipContentWrapperIfNested?: boolean;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: FormSetSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: FormSetTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: FormSetRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: FormSetBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: FormSetLeft;
   className?: string;
   children?: FormSetChildren;
 

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type FormStatusText =
   | string
   | boolean
@@ -19,41 +20,14 @@ export type FormStatusState =
 export type FormStatusVariant = 'flat' | 'outlined';
 export type FormStatusSize = 'default' | 'large';
 export type FormStatusAttributes = string | Record<string, unknown>;
-export type FormStatusSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type FormStatusTop = string | number | boolean;
-export type FormStatusRight = string | number | boolean;
-export type FormStatusBottom = string | number | boolean;
-export type FormStatusLeft = string | number | boolean;
 export type FormStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface FormStatusProps extends React.HTMLProps<HTMLElement> {
+export interface FormStatusProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
 
   /**
@@ -126,31 +100,6 @@ export interface FormStatusProps extends React.HTMLProps<HTMLElement> {
    * The `role` attribute for accessibility, defaults to `alert`
    */
   role?: string;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: FormStatusSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: FormStatusTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: FormStatusRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: FormStatusBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: FormStatusLeft;
   className?: string;
 
   /**

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
@@ -1,28 +1,17 @@
 import * as React from 'react';
+import type { SpacingProps } from '../space/types';
 export type GlobalErrorStatusContent = string | Record<string, unknown>;
 export type GlobalErrorTitle = string | React.ReactNode;
 export type GlobalErrorText = string | React.ReactNode;
 export type GlobalErrorBack = string | React.ReactNode;
-export type GlobalErrorSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type GlobalErrorTop = string | number | boolean;
-export type GlobalErrorRight = string | number | boolean;
-export type GlobalErrorBottom = string | number | boolean;
-export type GlobalErrorLeft = string | number | boolean;
 export type GlobalErrorChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface GlobalErrorProps extends React.HTMLProps<HTMLElement> {
+export interface GlobalErrorProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Status code defines the view showing up.
    */
@@ -57,11 +46,6 @@ export interface GlobalErrorProps extends React.HTMLProps<HTMLElement> {
    * Defining a `alt` text for the SVG graphic will overwrite the default provided by `status_content`.
    */
   alt?: string;
-  space?: GlobalErrorSpace;
-  top?: GlobalErrorTop;
-  right?: GlobalErrorRight;
-  bottom?: GlobalErrorBottom;
-  left?: GlobalErrorLeft;
   className?: string;
 
   /**

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type GlobalStatusTitle = React.ReactNode | boolean;
 export type GlobalStatusText =
   | string
@@ -13,41 +14,14 @@ export type GlobalStatusIcon =
 export type GlobalStatusState = 'error' | 'info';
 export type GlobalStatusShow = 'auto' | any | any | 'true' | 'false';
 export type GlobalStatusDelay = string | number;
-export type GlobalStatusSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type GlobalStatusTop = string | number | boolean;
-export type GlobalStatusRight = string | number | boolean;
-export type GlobalStatusBottom = string | number | boolean;
-export type GlobalStatusLeft = string | number | boolean;
 export type GlobalStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface GlobalStatusProps extends React.HTMLProps<HTMLElement> {
+export interface GlobalStatusProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * The main ID. Defaults to the prop
    */
@@ -131,31 +105,6 @@ export interface GlobalStatusProps extends React.HTMLProps<HTMLElement> {
    */
   status_anchor_text?: React.ReactNode;
   skeleton?: SkeletonShow;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: GlobalStatusSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: GlobalStatusTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: GlobalStatusRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: GlobalStatusBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: GlobalStatusLeft;
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/heading/Heading.d.ts
+++ b/packages/dnb-eufemia/src/components/heading/Heading.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type HeadingText = React.ReactNode | ((...args: any[]) => any);
 export type HeadingSize =
   | 'auto'
@@ -14,38 +15,11 @@ export type HeadingLevel = number | string;
 export type HeadingDebug = boolean | ((...args: any[]) => any);
 export type HeadingDebugCounter = boolean | ((...args: any[]) => any);
 export type HeadingReset = number | boolean;
-export type HeadingSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type HeadingTop = string | number | boolean;
-export type HeadingRight = string | number | boolean;
-export type HeadingBottom = string | number | boolean;
-export type HeadingLeft = string | number | boolean;
 export type HeadingChildren = React.ReactNode | ((...args: any[]) => any);
 
-export interface HeadingProps extends React.HTMLProps<HTMLElement> {
+export interface HeadingProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
   group?: string;
 
@@ -108,30 +82,6 @@ export interface HeadingProps extends React.HTMLProps<HTMLElement> {
    */
   element?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: HeadingSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: HeadingTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: HeadingRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: HeadingBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: HeadingLeft;
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import {
   useHeightAnimation,
   useHeightAnimationOptions,

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type IconPrimaryIcon =
   | string
   | React.ReactNode
@@ -10,35 +11,6 @@ export type IconPrimarySize =
   | 'default'
   | 'medium'
   | 'large';
-export type IconPrimarySpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type IconPrimaryTop = string | number | boolean;
-export type IconPrimaryRight = string | number | boolean;
-export type IconPrimaryBottom = string | number | boolean;
-export type IconPrimaryLeft = string | number | boolean;
 export type IconPrimaryWidth = string | number;
 export type IconPrimaryHeight = string | number;
 export type IconPrimaryAttributes =
@@ -49,7 +21,8 @@ export type IconPrimaryChildren =
   | ((...args: any[]) => any);
 
 export interface IconPrimaryProps
-  extends Omit<React.HTMLProps<HTMLElement>, 'size'> {
+  extends Omit<React.HTMLProps<HTMLElement>, 'size'>,
+    SpacingProps {
   /**
    * <em>(required)</em> a React SVG Component or the icon name (in case we use `IconPrimary` or `dnb-icon-primary`).
    */
@@ -65,30 +38,6 @@ export interface IconPrimaryProps
    */
   size?: IconPrimarySize;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: IconPrimarySpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: IconPrimaryTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: IconPrimaryRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: IconPrimaryBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: IconPrimaryLeft;
   width?: IconPrimaryWidth;
   height?: IconPrimaryHeight;
 

--- a/packages/dnb-eufemia/src/components/icon/Icon.d.ts
+++ b/packages/dnb-eufemia/src/components/icon/Icon.d.ts
@@ -1,45 +1,19 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type IconIcon =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
 export type IconSize = number | string | 'default' | 'medium' | 'large';
-export type IconSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type IconTop = string | number | boolean;
-export type IconRight = string | number | boolean;
-export type IconBottom = string | number | boolean;
-export type IconLeft = string | number | boolean;
 export type IconWidth = string | number;
 export type IconHeight = string | number;
 export type IconAttributes = string | Record<string, unknown>;
 export type IconChildren = React.ReactNode | ((...args: any[]) => any);
 
-export interface IconProps extends React.HTMLProps<HTMLElement> {
+export interface IconProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * <em>(required)</em> a React SVG Component or the icon name (in case we use `IconPrimary` or `dnb-icon-primary`).
    */
@@ -55,30 +29,6 @@ export interface IconProps extends React.HTMLProps<HTMLElement> {
    */
   size?: IconSize;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: IconSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: IconTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: IconRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: IconBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: IconLeft;
   width?: IconWidth;
   height?: IconHeight;
 

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -16,7 +16,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import {
   extendPropsWithContext,
   validateDOMAttributes,

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type InputMaskedMask =
   | Record<string, unknown>
   | any[]
@@ -54,40 +55,13 @@ export type InputMaskedSubmitButtonIcon =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type InputMaskedSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type InputMaskedTop = string | number | boolean;
-export type InputMaskedRight = string | number | boolean;
-export type InputMaskedBottom = string | number | boolean;
-export type InputMaskedLeft = string | number | boolean;
 export type InputMaskedChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface InputMaskedProps extends React.HTMLProps<HTMLElement> {
+export interface InputMaskedProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * A mask can be defined both as a <a href="https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme">RegExp style of characters</a> or a callback function. Example below.
    */
@@ -335,30 +309,6 @@ export interface InputMaskedProps extends React.HTMLProps<HTMLElement> {
   submit_button_icon?: InputMaskedSubmitButtonIcon;
   submit_button_status?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: InputMaskedSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: InputMaskedTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: InputMaskedRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: InputMaskedBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: InputMaskedLeft;
   className?: string;
   children?: InputMaskedChildren;
   on_state_update?: (...args: any[]) => any;

--- a/packages/dnb-eufemia/src/components/input/Input.d.ts
+++ b/packages/dnb-eufemia/src/components/input/Input.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type InputSize = 'default' | 'small' | 'medium' | 'large' | number;
 export type InputValue = string | number;
 export type InputLabel =
@@ -43,38 +44,11 @@ export type InputSubmitButtonIcon =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type InputSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type InputTop = string | number | boolean;
-export type InputRight = string | number | boolean;
-export type InputBottom = string | number | boolean;
-export type InputLeft = string | number | boolean;
 export type InputChildren = React.ReactNode | ((...args: any[]) => any);
 
-export interface InputProps extends React.HTMLProps<HTMLElement> {
+export interface InputProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Choose between `text`, `number`, `email`, `password`, `url`, `tel` and `search`.
    */
@@ -234,30 +208,6 @@ export interface InputProps extends React.HTMLProps<HTMLElement> {
   submit_button_icon?: InputSubmitButtonIcon;
   submit_button_status?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: InputSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: InputTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: InputRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: InputBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: InputLeft;
   className?: string;
   children?: InputChildren;
 

--- a/packages/dnb-eufemia/src/components/logo/Logo.d.ts
+++ b/packages/dnb-eufemia/src/components/logo/Logo.d.ts
@@ -1,39 +1,13 @@
 import * as React from 'react';
+import type { SpacingProps } from '../space/types';
 export type LogoSize = number | string;
 export type LogoRatio = number | string;
 export type LogoWidth = number | string;
 export type LogoHeight = number | string;
-export type LogoSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
 
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type LogoTop = string | number | boolean;
-export type LogoRight = string | number | boolean;
-export type LogoBottom = string | number | boolean;
-export type LogoLeft = string | number | boolean;
-
-export interface LogoProps extends React.HTMLProps<HTMLElement> {
+export interface LogoProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Define the size of the logo. Sets the height. The width will be calculated by the ratio. Also, `inherit` will use the inherited height. Defaults to `auto`
    */
@@ -61,31 +35,6 @@ export interface LogoProps extends React.HTMLProps<HTMLElement> {
    */
   inherit_color?: boolean;
   class?: string;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: LogoSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: LogoTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: LogoRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: LogoBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: LogoLeft;
   className?: string;
 }
 export default class Logo extends React.Component<LogoProps, any> {

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -26,7 +26,7 @@ import ModalHeaderBar from './parts/ModalHeaderBar'
 import { ScrollViewAllProps } from '../../fragments/scroll-view/ScrollView'
 import CloseButton from './parts/CloseButton'
 import ModalRoot from './ModalRoot'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import {
   classWithCamelCaseProps,
   ToCamelCasePartial,

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type NumberFormatValue = number | string;
 export type NumberFormatPrefix =
   | React.ReactNode
@@ -18,40 +19,13 @@ export type NumberFormatTooltip =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type NumberFormatSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type NumberFormatTop = string | number | boolean;
-export type NumberFormatRight = string | number | boolean;
-export type NumberFormatBottom = string | number | boolean;
-export type NumberFormatLeft = string | number | boolean;
 export type NumberFormatChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface NumberFormatProps extends React.HTMLProps<HTMLElement> {
+export interface NumberFormatProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
 
   /**
@@ -184,30 +158,6 @@ export interface NumberFormatProps extends React.HTMLProps<HTMLElement> {
    */
   skeleton?: SkeletonShow;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: NumberFormatSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: NumberFormatTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: NumberFormatRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: NumberFormatBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: NumberFormatLeft;
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type PaginationStartupPage = string | number;
 export type PaginationCurrentPage = string | number;
 export type PaginationPageCount = string | number;
@@ -39,40 +40,13 @@ export type PaginationIndicatorElement =
   | React.ReactNode
   | ((...args: any[]) => any)
   | string;
-export type PaginationSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type PaginationTop = string | number | boolean;
-export type PaginationRight = string | number | boolean;
-export type PaginationBottom = string | number | boolean;
-export type PaginationLeft = string | number | boolean;
 export type PaginationChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface PaginationProps extends React.HTMLProps<HTMLElement> {
+export interface PaginationProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
@@ -209,30 +183,6 @@ export interface PaginationProps extends React.HTMLProps<HTMLElement> {
    */
   load_button_text?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: PaginationSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: PaginationTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: PaginationRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: PaginationBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: PaginationLeft;
   class?: string;
   className?: string;
 
@@ -307,40 +257,11 @@ export type PaginationInstanceIndicatorElement =
   | React.ReactNode
   | ((...args: any[]) => any)
   | string;
-export type PaginationInstanceSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type PaginationInstanceTop = string | number | boolean;
-export type PaginationInstanceRight = string | number | boolean;
-export type PaginationInstanceBottom = string | number | boolean;
-export type PaginationInstanceLeft = string | number | boolean;
 export type PaginationInstanceChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface PaginationInstanceProps {
+export interface PaginationInstanceProps extends SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
@@ -477,30 +398,6 @@ export interface PaginationInstanceProps {
    */
   load_button_text?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: PaginationInstanceSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: PaginationInstanceTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: PaginationInstanceRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: PaginationInstanceBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: PaginationInstanceLeft;
   class?: string;
   className?: string;
 
@@ -577,40 +474,11 @@ export type InfinityMarkerIndicatorElement =
   | React.ReactNode
   | ((...args: any[]) => any)
   | string;
-export type InfinityMarkerSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type InfinityMarkerTop = string | number | boolean;
-export type InfinityMarkerRight = string | number | boolean;
-export type InfinityMarkerBottom = string | number | boolean;
-export type InfinityMarkerLeft = string | number | boolean;
 export type InfinityMarkerChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface InfinityMarkerProps {
+export interface InfinityMarkerProps extends SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
@@ -747,30 +615,6 @@ export interface InfinityMarkerProps {
    */
   load_button_text?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: InfinityMarkerSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: InfinityMarkerTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: InfinityMarkerRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: InfinityMarkerBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: InfinityMarkerLeft;
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
+import type { SpacingProps } from '../space/types';
 export type ProgressIndicatorType = 'circular' | 'linear';
 export type ProgressIndicatorSize =
   | 'default'
@@ -8,41 +9,13 @@ export type ProgressIndicatorSize =
   | 'large'
   | 'huge';
 export type ProgressIndicatorProgress = string | number;
-export type ProgressIndicatorSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type ProgressIndicatorTop = string | number | boolean;
-export type ProgressIndicatorRight = string | number | boolean;
-export type ProgressIndicatorBottom = string | number | boolean;
-export type ProgressIndicatorLeft = string | number | boolean;
 export type ProgressIndicatorChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
 export interface ProgressIndicatorProps
-  extends React.HTMLProps<HTMLElement> {
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Defines the visibility of the progress. Toggling the `visible` property to false will force a fade-out animation. Defaults to `true`.
    */
@@ -99,30 +72,6 @@ export interface ProgressIndicatorProps
    */
   title?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: ProgressIndicatorSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: ProgressIndicatorTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: ProgressIndicatorRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: ProgressIndicatorBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: ProgressIndicatorLeft;
   class?: string;
   className?: string;
   children?: ProgressIndicatorChildren;

--- a/packages/dnb-eufemia/src/components/radio/Radio.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/Radio.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 import RadioGroup from './RadioGroup';
 export type RadioLabel =
   | string
@@ -17,23 +18,11 @@ export type RadioSuffix =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type RadioAttributes = string | Record<string, unknown>;
-export type RadioSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type RadioTop = string | number | boolean;
-export type RadioRight = string | number | boolean;
-export type RadioBottom = string | number | boolean;
-export type RadioLeft = string | number | boolean;
 export type RadioChildren = string | ((...args: any[]) => any);
 
-export interface RadioProps extends React.HTMLProps<HTMLElement> {
+export interface RadioProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.
    */
@@ -96,11 +85,6 @@ export interface RadioProps extends React.HTMLProps<HTMLElement> {
   attributes?: RadioAttributes;
   skeleton?: SkeletonShow;
   readOnly?: boolean;
-  space?: RadioSpace;
-  top?: RadioTop;
-  right?: RadioRight;
-  bottom?: RadioBottom;
-  left?: RadioLeft;
   class?: string;
   className?: string;
   children?: RadioChildren;

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type RadioGroupLabel =
   | string
   | ((...args: any[]) => any)
@@ -18,26 +19,14 @@ export type RadioGroupSuffix =
   | React.ReactNode;
 export type RadioGroupLayoutDirection = 'column' | 'row';
 export type RadioGroupAttributes = string | Record<string, unknown>;
-export type RadioGroupSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type RadioGroupTop = string | number | boolean;
-export type RadioGroupRight = string | number | boolean;
-export type RadioGroupBottom = string | number | boolean;
-export type RadioGroupLeft = string | number | boolean;
 export type RadioGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface RadioGroupProps extends React.HTMLProps<HTMLElement> {
+export interface RadioGroupProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.
    */
@@ -94,11 +83,6 @@ export interface RadioGroupProps extends React.HTMLProps<HTMLElement> {
    */
   value?: string;
   attributes?: RadioGroupAttributes;
-  space?: RadioGroupSpace;
-  top?: RadioGroupTop;
-  right?: RadioGroupRight;
-  bottom?: RadioGroupBottom;
-  left?: RadioGroupLeft;
   class?: string;
   className?: string;
   children?: RadioGroupChildren;

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -12,7 +12,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import { createSpacingClasses } from '../space/SpacingHelper'
-import { DynamicElement, SpacingProps } from '../../shared/types'
+import type { DynamicElement, SpacingProps } from '../../shared/types'
 
 export type SectionStyleTypes =
   | 'divider'

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
@@ -1,45 +1,19 @@
 import * as React from 'react';
+import type { SpacingProps } from '../space/types';
 export type SkeletonShow = boolean;
 export type SkeletonStyleType = 'lines' | string;
 export type SkeletonFigure =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type SkeletonSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type SkeletonTop = string | number | boolean;
-export type SkeletonRight = string | number | boolean;
-export type SkeletonBottom = string | number | boolean;
-export type SkeletonLeft = string | number | boolean;
 export type SkeletonChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
-export interface SkeletonProps extends React.HTMLProps<HTMLElement> {
+export interface SkeletonProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use `true` to enable/show the skeleton for the component used inside. Defaults to `false`.
    */
@@ -75,30 +49,6 @@ export interface SkeletonProps extends React.HTMLProps<HTMLElement> {
    */
   element?: React.ReactNode;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: SkeletonSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: SkeletonTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: SkeletonRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: SkeletonBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: SkeletonLeft;
   class?: string;
   className?: string;
   children?: SkeletonChildren;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SpacingProps } from '../../shared/types';
+import type { SpacingProps } from '../../shared/types';
 import type { SkeletonShow } from '../Skeleton';
 import StepIndicatorSidebar from './StepIndicatorSidebar';
 export type StepIndicatorMode = 'static' | 'strict' | 'loose';

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SpacingProps } from '../../shared/types';
+import type { SpacingProps } from '../../shared/types';
 export type StepIndicatorSidebarMode = 'static' | 'strict' | 'loose';
 export type StepIndicatorSidebarCurrentStep = string | number;
 export type StepIndicatorSidebarData =

--- a/packages/dnb-eufemia/src/components/switch/Switch.d.ts
+++ b/packages/dnb-eufemia/src/components/switch/Switch.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type SwitchLabel =
   | string
   | ((...args: any[]) => any)
@@ -16,38 +17,11 @@ export type SwitchSuffix =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type SwitchAttributes = string | Record<string, unknown>;
-export type SwitchSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type SwitchTop = string | number | boolean;
-export type SwitchRight = string | number | boolean;
-export type SwitchBottom = string | number | boolean;
-export type SwitchLeft = string | number | boolean;
 export type SwitchChildren = string | ((...args: any[]) => any);
 
-export interface SwitchProps extends React.HTMLProps<HTMLElement> {
+export interface SwitchProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.
    */
@@ -114,30 +88,6 @@ export interface SwitchProps extends React.HTMLProps<HTMLElement> {
    */
   skeleton?: SkeletonShow;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: SwitchSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: SwitchTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: SwitchRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: SwitchBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: SwitchLeft;
   class?: string;
   className?: string;
   children?: SwitchChildren;

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 import ContentWrapper from './TabsContentWrapper';
 import CustomContent from './TabsCustomContent';
 export type TabsData =
@@ -22,41 +23,14 @@ export type TabsTabElement =
   | ((...args: any[]) => any);
 export type TabsSelectedKey = string | number;
 export type TabsAlign = 'left' | 'center' | 'right';
-export type TabsSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type TabsTop = string | number | boolean;
-export type TabsRight = string | number | boolean;
-export type TabsBottom = string | number | boolean;
-export type TabsLeft = string | number | boolean;
 export type TabsChildren =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface TabsProps extends React.HTMLProps<HTMLElement> {
+export interface TabsProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * <em>(required)</em> defines the data structure to load as a JSON. e.g. `[{title: &#39;...&#39;, content: &#39;Current tab&#39;, key: &#39;...&#39;, hash: &#39;...&#39;}]`
    */
@@ -135,30 +109,6 @@ export interface TabsProps extends React.HTMLProps<HTMLElement> {
   skeleton?: SkeletonShow;
   id?: string;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: TabsSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: TabsTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: TabsRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: TabsBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: TabsLeft;
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
@@ -1,72 +1,21 @@
 import * as React from 'react';
+import type { SpacingProps } from '../space/types';
 export type CustomContentTitle =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-export type CustomContentSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type CustomContentTop = string | number | boolean;
-export type CustomContentRight = string | number | boolean;
-export type CustomContentBottom = string | number | boolean;
-export type CustomContentLeft = string | number | boolean;
 export type CustomContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface CustomContentProps extends React.HTMLProps<HTMLElement> {
+export interface CustomContentProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   displayName?: string;
   title?: CustomContentTitle;
   hash?: string;
   selected?: boolean;
   disabled?: boolean;
-
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: CustomContentSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: CustomContentTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: CustomContentRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: CustomContentBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: CustomContentLeft;
 
   /**
    * <em>(required)</em> the content to render. Can be a function, returning the current tab content `(key) => (&#39;Current tab&#39;)`, a React Component or an object with the keys and content `{key1: &#39;Current tab&#39;}`.

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -10,7 +10,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import Context from '../../shared/Context'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import { TagGroupContext } from './TagContext'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type TextareaLabel =
   | string
   | ((...args: any[]) => any)
@@ -22,41 +23,14 @@ export type TextareaCols = number | string;
 export type TextareaInnerRef =
   | ((...args: any[]) => any)
   | Record<string, unknown>;
-export type TextareaSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type TextareaTop = string | number | boolean;
-export type TextareaRight = string | number | boolean;
-export type TextareaBottom = string | number | boolean;
-export type TextareaLeft = string | number | boolean;
 export type TextareaTextareaElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type TextareaChildren = React.ReactNode | ((...args: any[]) => any);
 
-export interface TextareaProps extends React.HTMLProps<HTMLElement> {
+export interface TextareaProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * The content value of the Textarea.
    */
@@ -159,30 +133,6 @@ export interface TextareaProps extends React.HTMLProps<HTMLElement> {
    */
   inner_ref?: TextareaInnerRef;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: TextareaSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: TextareaTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: TextareaRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: TextareaBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: TextareaLeft;
   className?: string;
   textarea_element?: TextareaTextareaElement;
   children?: TextareaChildren;

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -6,7 +6,7 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 
 // Shared
 import Context from '../../shared/Context'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 
 // Internal

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 import ToggleButtonGroup from './ToggleButtonGroup';
 export type ToggleButtonLabel =
   | string
@@ -27,38 +28,11 @@ export type ToggleButtonIcon =
   | ((...args: any[]) => any);
 export type ToggleButtonIconPosition = 'left' | 'right';
 export type ToggleButtonAttributes = string | Record<string, unknown>;
-export type ToggleButtonSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type ToggleButtonTop = string | number | boolean;
-export type ToggleButtonRight = string | number | boolean;
-export type ToggleButtonBottom = string | number | boolean;
-export type ToggleButtonLeft = string | number | boolean;
 export type ToggleButtonChildren = string | ((...args: any[]) => any);
 
-export interface ToggleButtonProps extends React.HTMLProps<HTMLElement> {
+export interface ToggleButtonProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * <em>(required)</em> the text shown in the ToggleButton.
    */
@@ -138,30 +112,6 @@ export interface ToggleButtonProps extends React.HTMLProps<HTMLElement> {
   attributes?: ToggleButtonAttributes;
   readOnly?: boolean;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: ToggleButtonSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: ToggleButtonTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: ToggleButtonRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: ToggleButtonBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: ToggleButtonLeft;
   class?: string;
   className?: string;
   children?: ToggleButtonChildren;

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../Skeleton';
+import type { SpacingProps } from '../space/types';
 export type ToggleButtonGroupLabel =
   | string
   | ((...args: any[]) => any)
@@ -23,42 +24,14 @@ export type ToggleButtonGroupValue =
   | any[];
 export type ToggleButtonGroupValues = string | any[];
 export type ToggleButtonGroupAttributes = string | Record<string, unknown>;
-export type ToggleButtonGroupSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type ToggleButtonGroupTop = string | number | boolean;
-export type ToggleButtonGroupRight = string | number | boolean;
-export type ToggleButtonGroupBottom = string | number | boolean;
-export type ToggleButtonGroupLeft = string | number | boolean;
 export type ToggleButtonGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 
 export interface ToggleButtonGroupProps
-  extends React.HTMLProps<HTMLElement> {
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.
    */
@@ -122,30 +95,6 @@ export interface ToggleButtonGroupProps
   values?: ToggleButtonGroupValues;
   attributes?: ToggleButtonGroupAttributes;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: ToggleButtonGroupSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: ToggleButtonGroupTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: ToggleButtonGroupRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: ToggleButtonGroupBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: ToggleButtonGroupLeft;
   class?: string;
   className?: string;
   children?: ToggleButtonGroupChildren;

--- a/packages/dnb-eufemia/src/components/tooltip/types.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/types.ts
@@ -1,5 +1,5 @@
 import { IncludeSnakeCase } from '../../shared/helpers/withSnakeCaseProps'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 
 export type TooltipPosition = 'top' | 'right' | 'bottom' | 'left'
 

--- a/packages/dnb-eufemia/src/components/upload/types.ts
+++ b/packages/dnb-eufemia/src/components/upload/types.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { SkeletonShow } from '../skeleton/Skeleton'
-import { LocaleProps, SpacingProps } from '../../shared/types'
+import type { LocaleProps, SpacingProps } from '../../shared/types'
 
 export type UploadAcceptedFileTypes = string[]
 

--- a/packages/dnb-eufemia/src/elements/Anchor.tsx
+++ b/packages/dnb-eufemia/src/elements/Anchor.tsx
@@ -13,7 +13,7 @@ import {
 } from '../shared/component-helper'
 import Tooltip from '../components/tooltip/Tooltip'
 import type { SkeletonShow } from '../components/skeleton/Skeleton'
-import { SpacingProps } from '../shared/types'
+import type { SpacingProps } from '../shared/types'
 
 export type AnchorProps = {
   element?: ElementIsType

--- a/packages/dnb-eufemia/src/elements/Blockquote.d.ts
+++ b/packages/dnb-eufemia/src/elements/Blockquote.d.ts
@@ -1,25 +1,9 @@
 import * as React from 'react';
-export type BlockquoteSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type BlockquoteTop = string | number | boolean;
-export type BlockquoteRight = string | number | boolean;
-export type BlockquoteBottom = string | number | boolean;
-export type BlockquoteLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 
-export interface BlockquoteProps extends React.HTMLProps<HTMLElement> {
-  space?: BlockquoteSpace;
-  top?: BlockquoteTop;
-  right?: BlockquoteRight;
-  bottom?: BlockquoteBottom;
-  left?: BlockquoteLeft;
+export interface BlockquoteProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   children?: React.ReactNode;
 }
 declare const Blockquote: React.FC<BlockquoteProps>;

--- a/packages/dnb-eufemia/src/elements/Code.d.ts
+++ b/packages/dnb-eufemia/src/elements/Code.d.ts
@@ -1,25 +1,9 @@
 import * as React from 'react';
-export type CodeSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type CodeTop = string | number | boolean;
-export type CodeRight = string | number | boolean;
-export type CodeBottom = string | number | boolean;
-export type CodeLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 
-export interface CodeProps extends React.HTMLProps<HTMLElement> {
-  space?: CodeSpace;
-  top?: CodeTop;
-  right?: CodeRight;
-  bottom?: CodeBottom;
-  left?: CodeLeft;
+export interface CodeProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   children?: React.ReactNode;
 }
 declare const Code: React.FC<CodeProps>;

--- a/packages/dnb-eufemia/src/elements/Dd.tsx
+++ b/packages/dnb-eufemia/src/elements/Dd.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import { SpacingProps } from '../shared/types'
+import type { SpacingProps } from '../shared/types'
 import E from './Element'
 
 export type DdProps = {

--- a/packages/dnb-eufemia/src/elements/Div.d.ts
+++ b/packages/dnb-eufemia/src/elements/Div.d.ts
@@ -1,25 +1,9 @@
 import * as React from 'react';
-export type DivSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type DivTop = string | number | boolean;
-export type DivRight = string | number | boolean;
-export type DivBottom = string | number | boolean;
-export type DivLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 
-export interface DivProps extends React.HTMLProps<HTMLElement> {
-  space?: DivSpace;
-  top?: DivTop;
-  right?: DivRight;
-  bottom?: DivBottom;
-  left?: DivLeft;
+export interface DivProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   children?: React.ReactNode;
 }
 declare const Div: React.FC<DivProps>;

--- a/packages/dnb-eufemia/src/elements/Dl.tsx
+++ b/packages/dnb-eufemia/src/elements/Dl.tsx
@@ -6,7 +6,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import E, { ElementProps } from './Element'
-import { SpacingProps } from '../shared/types'
+import type { SpacingProps } from '../shared/types'
 
 export type DlProps = {
   /**

--- a/packages/dnb-eufemia/src/elements/Dt.tsx
+++ b/packages/dnb-eufemia/src/elements/Dt.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import { SpacingProps } from '../shared/types'
+import type { SpacingProps } from '../shared/types'
 import E from './Element'
 
 export type DtProps = React.AllHTMLAttributes<HTMLDListElement>

--- a/packages/dnb-eufemia/src/elements/H.d.ts
+++ b/packages/dnb-eufemia/src/elements/H.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type HSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type HTop = string | number | boolean;
-export type HRight = string | number | boolean;
-export type HBottom = string | number | boolean;
-export type HLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type HSize =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type HSize =
   | 'small'
   | 'x-small';
 
-export interface HProps extends React.HTMLProps<HTMLElement> {
-  space?: HSpace;
-  top?: HTop;
-  right?: HRight;
-  bottom?: HBottom;
-  left?: HLeft;
+export interface HProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   className?: string;
   as?: string;
   level?: string;

--- a/packages/dnb-eufemia/src/elements/H1.d.ts
+++ b/packages/dnb-eufemia/src/elements/H1.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type H1Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H1Top = string | number | boolean;
-export type H1Right = string | number | boolean;
-export type H1Bottom = string | number | boolean;
-export type H1Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type H1Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type H1Size =
   | 'small'
   | 'x-small';
 
-export interface H1Props extends React.HTMLProps<HTMLElement> {
-  space?: H1Space;
-  top?: H1Top;
-  right?: H1Right;
-  bottom?: H1Bottom;
-  left?: H1Left;
+export interface H1Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H1Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H2.d.ts
+++ b/packages/dnb-eufemia/src/elements/H2.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type H2Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H2Top = string | number | boolean;
-export type H2Right = string | number | boolean;
-export type H2Bottom = string | number | boolean;
-export type H2Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type H2Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type H2Size =
   | 'small'
   | 'x-small';
 
-export interface H2Props extends React.HTMLProps<HTMLElement> {
-  space?: H2Space;
-  top?: H2Top;
-  right?: H2Right;
-  bottom?: H2Bottom;
-  left?: H2Left;
+export interface H2Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H2Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H3.d.ts
+++ b/packages/dnb-eufemia/src/elements/H3.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type H3Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H3Top = string | number | boolean;
-export type H3Right = string | number | boolean;
-export type H3Bottom = string | number | boolean;
-export type H3Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type H3Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type H3Size =
   | 'small'
   | 'x-small';
 
-export interface H3Props extends React.HTMLProps<HTMLElement> {
-  space?: H3Space;
-  top?: H3Top;
-  right?: H3Right;
-  bottom?: H3Bottom;
-  left?: H3Left;
+export interface H3Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H3Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H4.d.ts
+++ b/packages/dnb-eufemia/src/elements/H4.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type H4Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H4Top = string | number | boolean;
-export type H4Right = string | number | boolean;
-export type H4Bottom = string | number | boolean;
-export type H4Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type H4Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type H4Size =
   | 'small'
   | 'x-small';
 
-export interface H4Props extends React.HTMLProps<HTMLElement> {
-  space?: H4Space;
-  top?: H4Top;
-  right?: H4Right;
-  bottom?: H4Bottom;
-  left?: H4Left;
+export interface H4Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H4Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H5.d.ts
+++ b/packages/dnb-eufemia/src/elements/H5.d.ts
@@ -1,18 +1,5 @@
 import * as React from 'react';
-export type H5Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H5Top = string | number | boolean;
-export type H5Right = string | number | boolean;
-export type H5Bottom = string | number | boolean;
-export type H5Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 export type H5Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +9,9 @@ export type H5Size =
   | 'small'
   | 'x-small';
 
-export interface H5Props extends React.HTMLProps<HTMLElement> {
-  space?: H5Space;
-  top?: H5Top;
-  right?: H5Right;
-  bottom?: H5Bottom;
-  left?: H5Left;
+export interface H5Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H5Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H6.d.ts
+++ b/packages/dnb-eufemia/src/elements/H6.d.ts
@@ -1,18 +1,6 @@
 import * as React from 'react';
-export type H6Space =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type H6Top = string | number | boolean;
-export type H6Right = string | number | boolean;
-export type H6Bottom = string | number | boolean;
-export type H6Left = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
+
 export type H6Size =
   | 'xx-large'
   | 'x-large'
@@ -22,12 +10,9 @@ export type H6Size =
   | 'small'
   | 'x-small';
 
-export interface H6Props extends React.HTMLProps<HTMLElement> {
-  space?: H6Space;
-  top?: H6Top;
-  right?: H6Right;
-  bottom?: H6Bottom;
-  left?: H6Left;
+export interface H6Props
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   level?: string;
   size?: H6Size;
   children?: React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/Hr.d.ts
+++ b/packages/dnb-eufemia/src/elements/Hr.d.ts
@@ -1,25 +1,9 @@
 import * as React from 'react';
-export type HrSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type HrTop = string | number | boolean;
-export type HrRight = string | number | boolean;
-export type HrBottom = string | number | boolean;
-export type HrLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 
-export interface HrProps extends React.HTMLProps<HTMLElement> {
-  space?: HrSpace;
-  top?: HrTop;
-  right?: HrRight;
-  bottom?: HrBottom;
-  left?: HrLeft;
+export interface HrProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   className?: string;
   light?: boolean;
   medium?: boolean;

--- a/packages/dnb-eufemia/src/elements/Img.d.ts
+++ b/packages/dnb-eufemia/src/elements/Img.d.ts
@@ -1,27 +1,11 @@
 import * as React from 'react';
+import type { SpacingProps } from '../shared/types';
 import type { SkeletonShow } from '../components/skeleton/Skeleton';
-export type ImgSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type ImgTop = string | number | boolean;
-export type ImgRight = string | number | boolean;
-export type ImgBottom = string | number | boolean;
-export type ImgLeft = string | number | boolean;
 export type ImgClassName = string | any | any[];
 
-export interface ImgProps extends React.HTMLProps<HTMLElement> {
-  space?: ImgSpace;
-  top?: ImgTop;
-  right?: ImgRight;
-  bottom?: ImgBottom;
-  left?: ImgLeft;
+export interface ImgProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   src: string;
   alt: string;
   skeleton?: SkeletonShow;

--- a/packages/dnb-eufemia/src/elements/P.d.ts
+++ b/packages/dnb-eufemia/src/elements/P.d.ts
@@ -1,18 +1,6 @@
 import * as React from 'react';
-export type PSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type PTop = string | number | boolean;
-export type PRight = string | number | boolean;
-export type PBottom = string | number | boolean;
-export type PLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
+
 export type PSize =
   | 'x-small'
   | 'small'
@@ -23,12 +11,8 @@ export type PSize =
   | 'xx-large';
 
 export interface PProps
-  extends Omit<React.HTMLProps<HTMLElement>, 'size'> {
-  space?: PSpace;
-  top?: PTop;
-  right?: PRight;
-  bottom?: PBottom;
-  left?: PLeft;
+  extends Omit<React.HTMLProps<HTMLElement>, 'size'>,
+    SpacingProps {
   element?: React.ReactNode;
   className?: string;
   small?: boolean;

--- a/packages/dnb-eufemia/src/elements/Span.d.ts
+++ b/packages/dnb-eufemia/src/elements/Span.d.ts
@@ -1,25 +1,9 @@
 import * as React from 'react';
-export type SpanSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type SpanTop = string | number | boolean;
-export type SpanRight = string | number | boolean;
-export type SpanBottom = string | number | boolean;
-export type SpanLeft = string | number | boolean;
+import type { SpacingProps } from '../shared/types';
 
-export interface SpanProps extends React.HTMLProps<HTMLElement> {
-  space?: SpanSpace;
-  top?: SpanTop;
-  right?: SpanRight;
-  bottom?: SpanBottom;
-  left?: SpanLeft;
+export interface SpanProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   children?: React.ReactNode;
 }
 declare const Span: React.FC<SpanProps>;

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { SpacingProps } from '../shared/types';
 import type { SkeletonShow } from '../components/skeleton/Skeleton';
 export type PaymentCardCardStatus = 'active' | 'blocked' | 'expired';
 export type PaymentCardVariant = 'normal' | 'compact';
@@ -12,41 +13,15 @@ export interface PaymentCardRawData {
   cardType: Record<string, unknown>;
   productType: Record<string, unknown>;
 }
-export type PaymentCardSpace =
-  | string
-  | number
-  | boolean
-  | {
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-       */
-      top?: string | number | boolean;
 
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-       */
-      right?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-       */
-      bottom?: string | number | boolean;
-
-      /**
-       * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-       */
-      left?: string | number | boolean;
-    };
-export type PaymentCardTop = string | number | boolean;
-export type PaymentCardRight = string | number | boolean;
-export type PaymentCardBottom = string | number | boolean;
-export type PaymentCardLeft = string | number | boolean;
 export type PaymentCardChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
 
-export interface PaymentCardProps extends React.HTMLProps<HTMLElement> {
+export interface PaymentCardProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   /**
    * <em>(required)</em> if product code matches one of the codes in the list the card will get that design, if no match is found Default design will be used.
    */
@@ -88,30 +63,6 @@ export interface PaymentCardProps extends React.HTMLProps<HTMLElement> {
    */
   skeleton?: SkeletonShow;
 
-  /**
-   * Has to be an object with either: `top`, `right`, `bottom` or `left`. Use spacing values like: `small`, `1rem`, `1` or , `16px`.
-   */
-  space?: PaymentCardSpace;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. Will use `margin-top`.
-   */
-  top?: PaymentCardTop;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-right`.
-   */
-  right?: PaymentCardRight;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-bottom`.
-   */
-  bottom?: PaymentCardBottom;
-
-  /**
-   * Use spacing values like: `small`, `1rem`, `1` or , `16px`. will use `margin-left`.
-   */
-  left?: PaymentCardLeft;
   class?: string;
   className?: string;
   children?: PaymentCardChildren;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { SpacingProps } from '../../shared/types';
 export type DrawerListDirection = 'auto' | 'top' | 'bottom';
 export type DrawerListSize = 'default' | 'small' | 'medium' | 'large';
 export type DrawerListAlignDrawer = 'left' | 'right';
@@ -33,20 +34,6 @@ export type DrawerListRawData =
   | any[]
   | Record<string, unknown>
   | ((...args: any[]) => any);
-export type DrawerListSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type DrawerListTop = string | number | boolean;
-export type DrawerListRight = string | number | boolean;
-export type DrawerListBottom = string | number | boolean;
-export type DrawerListLeft = string | number | boolean;
 export type DrawerListChildren =
   | string
   | ((...args: any[]) => any)
@@ -55,7 +42,9 @@ export type DrawerListChildren =
   | any[];
 export type DrawerListSuffix = React.ReactNode;
 
-export interface DrawerListProps extends React.HTMLProps<HTMLElement> {
+export interface DrawerListProps
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
   role?: string;
   cache_hash?: string;
@@ -93,11 +82,6 @@ export interface DrawerListProps extends React.HTMLProps<HTMLElement> {
   prepared_data?: any[];
   raw_data?: DrawerListRawData;
   ignore_events?: boolean;
-  space?: DrawerListSpace;
-  top?: DrawerListTop;
-  right?: DrawerListRight;
-  bottom?: DrawerListBottom;
-  left?: DrawerListLeft;
   className?: string;
   children?: DrawerListChildren;
   suffix?: DrawerListSuffix;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { SpacingProps } from '../../shared/types';
 export type DrawerListProviderDirection = 'auto' | 'top' | 'bottom';
 export type DrawerListProviderSize =
   | 'default'
@@ -40,26 +41,13 @@ export type DrawerListProviderRawData =
   | any[]
   | Record<string, unknown>
   | ((...args: any[]) => any);
-export type DrawerListProviderSpace =
-  | string
-  | number
-  | boolean
-  | {
-      top?: string | number | boolean;
-      right?: string | number | boolean;
-      bottom?: string | number | boolean;
-      left?: string | number | boolean;
-    };
-export type DrawerListProviderTop = string | number | boolean;
-export type DrawerListProviderRight = string | number | boolean;
-export type DrawerListProviderBottom = string | number | boolean;
-export type DrawerListProviderLeft = string | number | boolean;
 export type DrawerListProviderPageOffset = string | number;
 export type DrawerListProviderObserverElement = string | React.ReactNode;
 export type DrawerListProviderMinHeight = string | number;
 
 export interface DrawerListProviderProps
-  extends React.HTMLProps<HTMLElement> {
+  extends React.HTMLProps<HTMLElement>,
+    SpacingProps {
   id?: string;
   role?: string;
   cache_hash?: string;
@@ -97,11 +85,6 @@ export interface DrawerListProviderProps
   prepared_data?: any[];
   raw_data?: DrawerListProviderRawData;
   ignore_events?: boolean;
-  space?: DrawerListProviderSpace;
-  top?: DrawerListProviderTop;
-  right?: DrawerListProviderRight;
-  bottom?: DrawerListProviderBottom;
-  left?: DrawerListProviderLeft;
   className?: string;
   on_show?: (...args: any[]) => any;
   on_hide?: (...args: any[]) => any;

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../shared/component-helper'
 import Context from '../../shared/Context'
 import { createSpacingClasses } from '../../components/space/SpacingHelper'
-import { SpacingProps } from '../../shared/types'
+import type { SpacingProps } from '../../shared/types'
 
 // SSR warning fix: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
 const useLayoutEffect =


### PR DESCRIPTION
This PR imports and extends SpacingProps instead of "duplicating" props like `space`, `top`, `right`, `left`, `bottom` in each d.ts file.