### PR TITLE
chore(Space): type space types

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/Examples.tsx
@@ -26,6 +26,7 @@ import {
   FormRow,
 } from '@dnb/eufemia/src/components'
 import { Ingress } from '@dnb/eufemia/src/elements'
+import { SpacingElementProps } from '@dnb/eufemia/src/shared/types'
 
 const TestStyles = styled.div`
   /* make sure our input gets an explicit width, because of mac/linux rendering differences */
@@ -426,7 +427,7 @@ export const AllComponents = ({
   showText,
   hideLabel,
 }) => {
-  const params = {
+  const params: SpacingElementProps = {
     left: horizontal ? 'small' : null,
     top: !horizontal || vertical ? 'small' : null,
   }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/info.mdx
@@ -21,8 +21,9 @@ There are a couple of different ways you can define the spacing types and values
 
 - **Types:** `small small x-small` (combine types up to _10rem_)
 - **number:** `2.5` (equivalent to `rem`)
-- **rem:** `2.5rem`
-- **px:** `40px` (gets converted to `rem`)
+- **string(rem):** `2.5rem`
+- **string(px):** `40px` (gets converted to `rem`)
+- **boolean:** `true` (equivalent to `small`), `false` (equivalent to `zero`)
 
 To get a spacing of e.g. **2.5rem** (40px)- you may combine types `large` and `x-small`.
 

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -188,7 +188,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
             type="button"
             className="dnb-info-card__buttons__accept-button"
             variant="secondary"
-            right={!centered && 'small'}
+            right={centered ? 'zero' : 'small'}
             on_click={onAccept}
             text={acceptButtonText}
             {...acceptButtonAttributes}

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -10,11 +10,14 @@ import type {
   SpaceType,
   SpacingUnknownProps,
   SpacingProps,
+  SpaceTypesPositiveValuesType,
+  SpaceTypesPositiveRemValuesType,
+  SpaceStringTypes,
 } from './types'
 
 type SpaceNumber = number
 
-export const spacingDefaultProps = {
+export const spacingDefaultProps: SpacingProps = {
   space: null,
   top: null,
   right: null,
@@ -22,7 +25,10 @@ export const spacingDefaultProps = {
   left: null,
 }
 // IMPORTANT: Keep the shorthand after the long type names
-export const spacePatterns = {
+export const spacePatterns: Record<
+  SpaceTypesPositiveValuesType,
+  SpaceTypesPositiveRemValuesType
+> = {
   'xx-small': 0.25,
   'x-small': 0.5,
   small: 1,
@@ -144,16 +150,17 @@ export const translateSpace = (type: SpaceType) => {
 // @internal Splits a string of: "large x-small" into an array of the same
 export const splitTypes = (types: SpaceType | Array<SpaceType>) => {
   if (typeof types === 'string') {
-    return clean(types.split(/ /g))
+    const test = (types as SpaceStringTypes).split(/ /g)
+    return clean(test as Array<SpaceStringTypes>)
   } else if (typeof types === 'boolean') {
-    return ['small']
+    return ['small' as SpaceTypesPositiveValuesType]
   } else if (typeof types === 'number') {
     return [types]
   }
 
   return clean(types) || null
 
-  function clean(t: Array<SpaceType>) {
+  function clean(t: Array<SpaceType> | Array<SpaceStringTypes>) {
     return t?.filter((r) => r && String(r).length > 0)
   }
 }
@@ -223,10 +230,17 @@ export const findType = (num: SpaceNumber): SpaceType => {
 }
 
 // @internal Finds from "2.0" the equivalent type "large" and returns all results
-export const findTypeAll = (num: SpaceNumber): Array<SpaceType> => {
+export const findTypeAll = (
+  num: SpaceNumber
+): Array<
+  SpaceTypesPositiveValuesType | SpaceTypesPositiveRemValuesType
+> => {
+  const listOfSpacePatterns = Object.entries(spacePatterns) as [
+    SpaceTypesPositiveValuesType,
+    SpaceTypesPositiveRemValuesType
+  ][]
   const found =
-    Object.entries(spacePatterns).find(([k, v]) => k && v === num) || null
-
+    listOfSpacePatterns.find(([k, v]) => k && v === num) || null
   return found
 }
 

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -17,6 +17,7 @@ import {
   createSpacingClasses,
 } from '../SpacingUtils'
 import { spacingPropTypes } from '../SpacingHelper'
+import { SpaceType } from '../types'
 
 describe('spacePatterns', () => {
   it('should be an object with valid keys', () => {
@@ -39,7 +40,18 @@ describe('translateSpace', () => {
   it('should translate and calc types', () => {
     expect(translateSpace('large')).toBe(2)
     expect(translateSpace('xx-large-x2')).toBe(7)
-    expect(translateSpace('medium-x2')).toBe(3)
+  })
+
+  it('should translate and calc types -x2', () => {
+    // These types/values(except xx-large-x2) is not typed, hence the type assertion.
+    // However translateSpace supports adding -x2 as a suffix to types, to double its value.
+    expect(translateSpace('xx-small-x2' as SpaceType)).toBe(0.5)
+    expect(translateSpace('x-small-x2' as SpaceType)).toBe(1)
+    expect(translateSpace('small-x2' as SpaceType)).toBe(2)
+    expect(translateSpace('medium-x2' as SpaceType)).toBe(3)
+    expect(translateSpace('large-x2' as SpaceType)).toBe(4)
+    expect(translateSpace('x-large-x2' as SpaceType)).toBe(6)
+    expect(translateSpace('xx-large-x2-x2' as SpaceType)).toBe(14)
   })
 })
 

--- a/packages/dnb-eufemia/src/components/space/stories/Space.stories.tsx
+++ b/packages/dnb-eufemia/src/components/space/stories/Space.stories.tsx
@@ -4,13 +4,12 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 import styled from '@emotion/styled'
 import { css, Global } from '@emotion/react'
 
 import { Space, Input } from '../../'
-import { H1, H2 } from '../../../elements'
+import { H1, H2, P } from '../../../elements'
 import Provider from '../../../shared/Provider'
 
 export default {
@@ -77,6 +76,418 @@ export const SpaceSandbox = () => (
         </div>
       </Collapsing>
     </Box>
+    <Box>
+      <code>type</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top="zero">zero</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-small">xx-small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="x-small">x-small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="small">small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="medium">medium</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="large">large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="x-large">x-large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-large">xx-large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-large-x2">xx-large-x2</P>
+        </VisualSpace>
+      </CustomStyle>
+      <code>2 types</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top="zero zero">zero zero</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-small xx-small">xx-small xx-small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="x-small x-small">x-small x-small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="small small">small small</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="medium medium">medium medium</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="large large">large large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="x-large x-large">x-large x-large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-large xx-large">xx-large xx-large</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-large-x2 xx-large-x2">
+            xx-large-x2 xx-large-x2(max limit is 10rem)
+          </P>
+        </VisualSpace>
+      </CustomStyle>
+      <code>different type combinations</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top="zero zero xx-small xx-small">
+            zero zero xx-small xx-small
+          </P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small xx-small">
+            xx-small x40
+          </P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="zero xx-small x-small small medium large x-large">
+            zero xx-small x-small small medium large x-large
+          </P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="x-large xx-large-x2">x-large xx-large-x2</P>
+        </VisualSpace>
+      </CustomStyle>
+      <code>rem as number - rem as string(Xrem) - rem as string</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top={0}>0</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={0.25}>0.25</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={0.5}>0.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={1}>1</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={1.5}>1.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={2}>2</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={2.5}>2.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={3}>3</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={3.5}>3.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={4}>4</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={4.5}>4.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={5}>5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={5.5}>5.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={6}>6</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={6.5}>6.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={7}>7</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={7.5}>7.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={8}>8</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={8.5}>8.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={9}>9</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={9.5}>9.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={10}>10</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0rem">0rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0.25rem">0.25rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0.5rem">0.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="1rem">1rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="1.5rem">1.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="2rem">2rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="2.5rem">2.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="3rem">3rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="3.5rem">3.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="4rem">4rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="4.5rem">4.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="5rem">5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="5.5rem">5.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="6rem">6rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="6.5rem">6.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="7rem">7rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="7.5rem">7.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="8rem">8rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="8.5rem">8.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="9rem">9rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="9.5rem">9.5rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="10rem">10rem</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0">0</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0.25rem">0.25</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="0.5">0.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="1">1</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="1.5">1.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="2">2</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="2.5">2.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="3">3</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="3.5">3.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="4">4</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="4.5">4.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="5">5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="5.5">5.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="6">6</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="6.5">6.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="7">7</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="7.5">7.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="8">8</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="8">8</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="9">9</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="9.5">9.5</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="10">10</P>
+        </VisualSpace>
+      </CustomStyle>
+
+      <code>px as string(Xpx) - interval of 10</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top="0px">0px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="10px">10px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="20px">20px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="30px">30px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="40px">40px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="50px">50px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="60px">60px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="70px">70px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="80px">80px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="90px">90px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="100px">100px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="110px">110px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="120px">120px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="130px">130px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="140px">140px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="150px">150px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="160px">160px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="170px">170px(max limit is 10rem)</P>
+        </VisualSpace>
+      </CustomStyle>
+
+      <code>px as string</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top="0.5px">0.5px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="11px">11px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="22px">22px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="33px">33px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="44px">44px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="55px">55px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="66px">66px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="77px">77px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="88px">88px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="99px">99px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="101px">101px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="112px">112px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="123px">123px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="134px">134px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="145px">145px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="156px">156px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="159px">159px</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top="167px">167px(max limit is 10rem)</P>
+        </VisualSpace>
+      </CustomStyle>
+
+      <code>boolean</code>
+      <CustomStyle>
+        <VisualSpace>
+          <P top={true}>true</P>
+        </VisualSpace>
+        <VisualSpace>
+          <P top={false}>false</P>
+        </VisualSpace>
+      </CustomStyle>
+    </Box>
   </Wrapper>
 )
 
@@ -136,7 +547,6 @@ const Margin = styled.div`
 `
 const Label = styled.label`
   display: block;
-  width: 1rem;
   margin-left: 0.25rem;
   font-size: 0.5rem;
   text-align: center;
@@ -168,16 +578,6 @@ const MagicBox = ({ label, ...rest }: { label?: string } = {}) => {
       <Label>{spaceInRem}</Label>
     </Block>
   )
-}
-MagicBox.propTypes = {
-  label: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    PropTypes.node,
-  ]),
-}
-MagicBox.defaultProps = {
-  label: null,
 }
 
 const VisualSpace = ({
@@ -213,18 +613,6 @@ const VisualSpace = ({
       </MarginContainer>
     </Space>
   )
-}
-VisualSpace.propTypes = {
-  label: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    PropTypes.node,
-  ]),
-  children: PropTypes.node,
-}
-VisualSpace.defaultProps = {
-  label: null,
-  children: null,
 }
 
 const Collapsing = styled<any>(Space)`

--- a/packages/dnb-eufemia/src/components/space/types.ts
+++ b/packages/dnb-eufemia/src/components/space/types.ts
@@ -24,7 +24,74 @@ export type SpacingElementProps = {
   left?: SpaceType
 }
 
-export type SpaceType = string | boolean | number
+export type SpaceTypesPositiveValuesType =
+  | 'xx-small'
+  | 'x-small'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'x-large'
+  | 'xx-large'
+  | 'xx-large-x2'
+
+export type SpaceTypesPositiveRemValuesType =
+  | 0.25
+  | 0.5
+  | 1
+  | 1.5
+  | 2
+  | 3
+  | 3.5
+  | 7
+
+export type SpaceTypesType = 'zero' | SpaceTypesPositiveValuesType
+
+type SpaceTypesTypeUnion = `${SpaceTypesType} ${SpaceTypesType}`
+type SpaceTypesTypeUnionInfinite =
+  `${SpaceTypesType} ${SpaceTypesType} ${string}`
+
+export type SpaceRemValuesType =
+  | 0
+  | 0.25
+  | 0.5
+  | 1
+  | 1.5
+  | 2
+  | 2.5
+  | 3
+  | 3.5
+  | 4
+  | 4.5
+  | 5
+  | 5.5
+  | 6
+  | 6.5
+  | 7
+  | 7.5
+  | 8
+  | 8.5
+  | 9
+  | 9.5
+  | 10
+
+type SpaceRemStringType = `${SpaceRemValuesType}rem`
+type SpaceRemStringFallback = `${SpaceRemValuesType}`
+type SpaceRemStringFallbackUnionInfinite =
+  `${SpaceRemValuesType} ${string}`
+type SpacePxStringType = `${number}px`
+
+type SpaceRemNumberType = SpaceRemValuesType
+
+export type SpaceStringTypes =
+  | SpaceRemStringType
+  | SpacePxStringType
+  | SpaceRemStringFallback
+  | SpaceRemStringFallbackUnionInfinite
+  | SpaceTypesType
+  | SpaceTypesTypeUnion
+  | SpaceTypesTypeUnionInfinite
+
+export type SpaceType = SpaceStringTypes | SpaceRemNumberType | boolean
 
 export type SpacingProps = SpacingElementProps & {
   space?: SpaceType | SpacingElementProps


### PR DESCRIPTION
This is just a suggestion up for discussion, and not up for merging as of right now.

In this PR, I've just experimented with typing the `SpaceType` for users(and ourselves) to more easily know which values they can enter, and for us internally to name the the types to match https://eufemia.dnb.no/uilib/components/space/#value-format

The biggest motivation is to get rid of `string` from `export type SpaceType = string | boolean | number`, and replace it with actual values/combinations, as it would help weed out all potential non correct string values("0", "10", wrongly spelled types, etc) that's been used, and also adding intellisense.


I also think when/if we introduce types here, that someone who really understands everything that's going in `SpacingUtils.ts` would have to make sure we use the correct types there.