### PR TITLE
chore(Space): remove PropTypes

### DIFF
--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import {
   isTrue,
@@ -122,29 +121,7 @@ export default class Space extends React.PureComponent<
 > {
   static contextType = Context
 
-  static propTypes = {
-    element: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-      PropTypes.node,
-    ]),
-    inline: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    no_collapse: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-
-    ...spacingPropTypes,
-
-    stretch: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    skeleton: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    innerRef: PropTypes.object,
-    className: PropTypes.string,
-    children: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-      PropTypes.node,
-    ]),
-  }
-
-  static defaultProps = {
+  defaultProps = {
     element: 'div',
     inline: null,
     no_collapse: null, // avoid margin collapsing
@@ -169,7 +146,7 @@ export default class Space extends React.PureComponent<
       ? // use only the props from context, who are available here anyway
         extendPropsWithContextInClassComponent(
           this.props,
-          Space.defaultProps,
+          this.defaultProps,
           { skeleton: this.context?.skeleton },
           this.context.space
         )


### PR DESCRIPTION
I'm not sure if this is the correct way of fixing this.

But the problem I want to fix is that in v10 as of now, for `Space` component in VSCode, we get that it has two definitions(PropTypes and TypeScript), but looks to default to PropTypes.
Is this correct? To me, I would guess we should only use TS?
This is how it looks in VSCode:
<img width="785" alt="Screenshot 2023-03-06 at 13 34 55" src="https://user-images.githubusercontent.com/1359205/223112329-52076610-3779-49c1-a058-caeed1aa1689.png">

<img width="1741" alt="Screenshot 2023-03-06 at 13 35 07" src="https://user-images.githubusercontent.com/1359205/223112423-b8443eb4-063a-4ac1-b404-61f6e2d6437e.png">


After this attempt of an fix(it shows the TS definition):
<img width="1227" alt="Screenshot 2023-03-06 at 13 33 52" src="https://user-images.githubusercontent.com/1359205/223112475-a681160d-8f2e-4762-a841-4c8a2883423c.png">

