### PR TITLE
chore(Portal): make Examples imports relative in mdx files

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
@@ -10,7 +10,7 @@ import {
   AccordionGroupExample,
   AccordionNestedExample,
   AccordionPlainVariant,
-} from 'Docs/uilib/components/accordion/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -14,7 +14,7 @@ import {
   AutocompleteCustomWidth,
   AutocompleteSuffix,
   AutocompleteStatusExample,
-} from 'Docs/uilib/components/autocomplete/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/visual-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/visual-tests.mdx
@@ -5,7 +5,7 @@ draft: true
 import {
   AutocompleteOpened,
   AutocompleteDisabledExample,
-} from 'Docs/uilib/components/autocomplete/Examples'
+} from './Examples'
 
 <AutocompleteOpened />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
@@ -25,7 +25,7 @@ import {
   GroupedAvatarsLarge,
   GroupedAvatarsXLarge,
   GroupedAvatarsImg,
-} from 'Docs/uilib/components/avatar/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge/demos.mdx
@@ -15,7 +15,7 @@ import {
   BadgeBottomRight,
   BadgeImgWithIcon,
   BadgeMailIcon,
-} from 'Docs/uilib/components/badge/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/demos.mdx
@@ -8,7 +8,7 @@ import {
   BreadcrumbMultipleData,
   BreadcrumbVariants,
   BreadcrumbCollapseOpen,
-} from 'Docs/uilib/components/breadcrumb/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
@@ -19,7 +19,7 @@ import {
   ButtonStretch,
   TertiaryWithNoIcon,
   UnstyledVariant,
-} from 'Docs/uilib/components/button/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx
@@ -8,7 +8,7 @@ import {
   TertiaryButtonSizes,
   SignalButtonSizes,
   IconButtonSizes,
-} from 'Docs/uilib/components/button/Examples'
+} from './Examples'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/demos.mdx
@@ -9,7 +9,7 @@ import {
   CheckboxSuffix,
   CheckboxDifferentSizes,
   CheckboxDisabled,
-} from 'Docs/uilib/components/checkbox/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
@@ -16,7 +16,7 @@ import {
   DatePickerErrorStatus,
   DatePickerCalendar,
   DatePickerScreenshotTests,
-} from 'Docs/uilib/components/date-picker/Examples'
+} from './Examples'
 import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
@@ -15,7 +15,7 @@ import {
   DialogConfirmLoggedOut,
   DialogConfirmCookies,
   DialogConfirmScrollableContent,
-} from 'Docs/uilib/components/dialog/Examples'
+} from './Examples'
 
 ## Table of contents
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/demos.mdx
@@ -10,7 +10,7 @@ import {
   DrawerCallbackExample,
   DrawerCustomTriggerExample,
   DrawerNoAnimationNoSpacing,
-} from 'Docs/uilib/components/drawer/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/visual-tests/hidden-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/visual-tests/hidden-tests.mdx
@@ -2,6 +2,6 @@
 draft: true
 ---
 
-import { DrawerScrollViewSetup } from 'Docs/uilib/components/drawer/visual-tests/Examples'
+import { DrawerScrollViewSetup } from './Examples'
 
 <DrawerScrollViewSetup />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
@@ -18,7 +18,7 @@ import {
   DropdownListOpened,
   DropdownDisabledTertiary,
   DropdownEllipsisOverflow,
-} from 'Docs/uilib/components/dropdown/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/demos.mdx
@@ -7,7 +7,7 @@ import {
   FormLabelVerticalExample,
   FormLabelNoForIdExample,
   FormLabelLinkedLabelExample,
-} from 'Docs/uilib/components/form-label/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/demos.mdx
@@ -14,7 +14,7 @@ import FormRowVisualTests, {
   FormRowLegendUsage,
   FormRowInheritContext,
   FormRowDifferentDirections,
-} from 'Docs/uilib/components/form-row/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-row/info.mdx
@@ -9,7 +9,7 @@ import {
   FormRowDefaultInfo,
   FormRowSpacingInfo,
   FormRowResponsiveInfo,
-} from 'Docs/uilib/components/form-row/Examples'
+} from './Examples'
 
 ## Description
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set/demos.mdx
@@ -2,11 +2,7 @@
 showTabs: true
 ---
 
-import {
-  FormSetDefault,
-  FormSetVertical,
-  FormSetSubmit,
-} from 'Docs/uilib/components/form-set/Examples'
+import { FormSetDefault, FormSetVertical, FormSetSubmit } from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/demos.mdx
@@ -14,7 +14,7 @@ import {
   FormStatusCustom,
   FormStatusLarge,
   FormStatusWithIcons,
-} from 'Docs/uilib/components/form-status/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.mdx
@@ -8,7 +8,7 @@ import {
   DrawerListExampleDefault,
   DrawerListExampleSingleItem,
   DrawerListExampleMarkup,
-} from 'Docs/uilib/components/fragments/drawer-list/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/demos.mdx
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import { ScrollViewInteractive } from 'Docs/uilib/components/fragments/scroll-view/Examples'
+import { ScrollViewInteractive } from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/demos.mdx
@@ -2,10 +2,7 @@
 showTabs: true
 ---
 
-import {
-  GlobalError404Example,
-  GlobalError500Example,
-} from 'Docs/uilib/components/global-error/Examples'
+import { GlobalError404Example, GlobalError500Example } from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/demos.mdx
@@ -9,7 +9,7 @@ import {
   GlobalStatusCoupling,
   GlobalStatusAddRemoveItems,
   GlobalStatusScrolling,
-} from 'Docs/uilib/components/global-status/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/demos.mdx
@@ -7,7 +7,7 @@ import {
   HeadingContext,
   HeadingIsolation,
   HeadingMix,
-} from 'Docs/uilib/components/heading/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
@@ -6,7 +6,7 @@ import {
   HeightAnimationDefault,
   HeightAnimationAutosizing,
   HeightAnimationKeepInDOM,
-} from 'Docs/uilib/components/height-animation/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/demos.mdx
@@ -8,7 +8,7 @@ import {
   HelpButtonSizesExample,
   HelpButtonInfoIconExample,
   HelpButtonInsideTextExample,
-} from 'Docs/uilib/components/help-button/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/demos.mdx
@@ -5,7 +5,7 @@ showTabs: true
 import {
   IconPrimaryDefaultExample,
   IconPrimaryFixedSizeExample,
-} from 'Docs/uilib/components/icon-primary/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
@@ -7,7 +7,7 @@ import IconTests, {
   IconBorder,
   IconInheritSized,
   IconColors,
-} from 'Docs/uilib/components/icon/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/demos.mdx
@@ -13,7 +13,7 @@ import {
   InfoCardCentered,
   InfoCardCustomImage,
   InfoCardCustomImageCentered,
-} from 'Docs/uilib/components/info-card/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/demos.mdx
@@ -10,7 +10,7 @@ import {
   InputMaskedExampleNumberMask,
   InputMaskedExamplePrefix,
   InputMaskedExamplePhone,
-} from 'Docs/uilib/components/input-masked/Examples'
+} from './Examples'
 import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.mdx
@@ -16,7 +16,7 @@ import {
   InputExamplePassword,
   InputExampleSubmit,
   InputExampleClear,
-} from 'Docs/uilib/components/input/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
@@ -7,7 +7,7 @@ import {
   LogoInheritSizeExample,
   LogoDefaultExample,
   LogoInheritColorExample,
-} from 'Docs/uilib/components/logo/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/demos.mdx
@@ -6,7 +6,7 @@ import {
   ModalExampleStandard,
   ModalExampleStateOnly,
   ModalExampleCloseByHandler,
-} from 'Docs/uilib/components/modal/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/demos.mdx
@@ -16,7 +16,7 @@ import {
   NumberLocales,
   NumberSpacing,
   NumberProvider,
-} from 'Docs/uilib/components/number-format/Examples'
+} from './Examples'
 import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 ## Demos

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/demos.mdx
@@ -6,7 +6,7 @@ import {
   PaginationExampleDefault,
   PaginationExampleWithCallback,
   PaginationExampleCentered,
-} from 'Docs/uilib/components/pagination/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/demos.mdx
@@ -7,7 +7,7 @@ import {
   PaginationExampleInfinityIndicator,
   PaginationExampleInfinityUnknown,
   PaginationExampleInfinityTable,
-} from 'Docs/uilib/components/pagination/infinity-scroller/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
@@ -23,7 +23,7 @@ import {
   ProgressIndicatorLinearRandomTransitionExample,
   ProgressIndicatorLinearRandomOnCompleteExample,
   ProgressIndicatorLinearDialogExample,
-} from 'Docs/uilib/components/progress-indicator/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/visual-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/visual-tests.mdx
@@ -2,6 +2,6 @@
 draft: true
 ---
 
-import { ProgressIndicatorSizesExample } from 'Docs/uilib/components/progress-indicator/Examples'
+import { ProgressIndicatorSizesExample } from './Examples'
 
 <ProgressIndicatorSizesExample />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/demos.mdx
@@ -12,7 +12,7 @@ import {
   RadioExampleDisabled,
   RadioExampleSuffix,
   RadioVisualTests,
-} from 'Docs/uilib/components/radio/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
@@ -17,7 +17,7 @@ import {
   SectionDemoFireRed,
   SectionDemoFireRed8,
   SectionZIndex,
-} from 'Docs/uilib/components/section/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/demos.mdx
@@ -9,7 +9,7 @@ import {
   SkeletonEufemiaProviderExample,
   SkeletonFiguresExample,
   SkeletonVisualTests,
-} from 'Docs/uilib/components/skeleton/Examples'
+} from './Examples'
 
 import PortalSkeleton from 'dnb-design-system-portal/src/shared/parts/uilib/PortalSkeleton'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/demos.mdx
@@ -2,7 +2,7 @@
 showTabs: true
 ---
 
-import { SkipContentTable } from 'Docs/uilib/components/skip-content/Examples'
+import { SkipContentTable } from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.mdx
@@ -9,7 +9,7 @@ import {
   SliderExampleSuffix,
   SliderExampleMultiButtons,
   SliderExampleMultiButtonsThumbBehavior,
-} from 'Docs/uilib/components/slider/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space/demos.mdx
@@ -11,7 +11,7 @@ import {
   SpaceVisualTestPatterns,
   SpaceVisualTestElements,
   SpaceVisualTestReset,
-} from 'Docs/uilib/components/space/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.mdx
@@ -11,7 +11,7 @@ import {
   StepIndicatorTextOnly,
   StepIndicatorCustomRenderer,
   StepIndicatorRouter,
-} from 'Docs/uilib/components/step-indicator/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/demos.mdx
@@ -9,7 +9,7 @@ import {
   SwitchExampleSuffix,
   SwitchExampleSizes,
   SwitchExampleDisabled,
-} from 'Docs/uilib/components/switch/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
@@ -18,7 +18,7 @@ import {
   TableSizeSmall,
   PaginationTable,
   TableAccordion,
-} from 'Docs/uilib/components/table/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.mdx
@@ -13,7 +13,7 @@ import {
   TabsExampleReachRouterNavigation,
   TabsNoBorder,
   TabsExamplePrerender,
-} from 'Docs/uilib/components/tabs/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag/demos.mdx
@@ -9,7 +9,7 @@ import {
   TagMultipleRemovable,
   TagInline,
   TagSkeleton,
-} from 'Docs/uilib/components/tag/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/demos.mdx
@@ -12,7 +12,7 @@ import {
   TextareaExampleFormStatus,
   TextareaExampleDisabled,
   TextareaExampleSuffix,
-} from 'Docs/uilib/components/textarea/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/demos.mdx
@@ -16,7 +16,7 @@ import {
   TimelineSkeleton,
   TimelineAsChildrenSkeleton,
   TimelineItemSkeleton,
-} from 'Docs/uilib/components/timeline/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/demos.mdx
@@ -13,7 +13,7 @@ import {
   ToggleButtonDisabledGroup,
   ToggleButtonSuffix,
   ToggleButtonIconOnly,
-} from 'Docs/uilib/components/toggle-button/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.mdx
@@ -9,7 +9,7 @@ import {
   TooltipExampleNumberFormatWrapped,
   TooltipExampleLinked,
   TooltipExampleActive,
-} from 'Docs/uilib/components/tooltip/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/demos.mdx
@@ -10,7 +10,7 @@ import {
   UploadIsLoading,
   UploadErrorMessage,
   UploadAcceptedFormats,
-} from 'Docs/uilib/components/upload/Examples'
+} from './Examples'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/demos.mdx
@@ -7,7 +7,7 @@ import {
   VisuallyHiddenFocusable,
   VisuallyHiddenSection,
   VisuallyHiddenUseCase,
-} from 'Docs/uilib/components/visually-hidden/Examples'
+} from './Examples'
 
 ## Demos
 


### PR DESCRIPTION
I'm not sure if this is needed. And beside this change in here, we still have 201 imports like this left: `from 'Docs/` – I still think, maybe it makes sense some places to change, and other places probably not.