### PR TITLE
chore(TypeScript): type icons

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import AccordionContent from './AccordionContent';
@@ -8,8 +10,7 @@ export type AccordionVariant = 'plain' | 'default' | 'outlined' | 'filled';
 export type AccordionHeading = boolean | React.ReactNode;
 export type AccordionHeadingLevel = string | number;
 export type AccordionIcon =
-  | React.ReactNode
-  | ((...args: any[]) => any)
+  | IconPrimaryIcon
   | {
       closed?: React.ReactNode | ((...args: any[]) => any);
 
@@ -19,7 +20,6 @@ export type AccordionIcon =
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
 export type AccordionClosed = React.ReactNode | ((...args: any[]) => any);
-export type AccordionIconPosition = 'left' | 'right';
 export type AccordionAttributes = string | Record<string, unknown>;
 
 export interface AccordionProps
@@ -136,12 +136,12 @@ export interface AccordionProps
   /**
    * Will set the placement of the icon. Defaults to `left`.
    */
-  icon_position?: AccordionIconPosition;
+  icon_position?: ButtonIconPosition;
 
   /**
    * Define a different icon size. Defaults to `medium` (1.5rem).
    */
-  icon_size?: string;
+  icon_size?: IconPrimarySize;
   attributes?: AccordionAttributes;
   class?: string;
   className?: string;

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
+import type { IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
+import type { AccordionIcon } from './Accordion';
 
 export interface AccordionHeaderTitleProps extends SpacingProps {
   children?: React.ReactNode;
@@ -16,13 +19,6 @@ export interface AccordionHeaderContainerProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderContainer: React.FC<AccordionHeaderContainerProps>;
-export type AccordionHeaderIconIcon =
-  | React.ReactNode
-  | ((...args: any[]) => any)
-  | {
-      closed?: React.ReactNode | ((...args: any[]) => any);
-      expanded?: React.ReactNode | ((...args: any[]) => any);
-    };
 
 export interface AccordionHeaderIconProps {
   icon?: AccordionHeaderIconIcon;
@@ -59,7 +55,6 @@ export type AccordionHeaderIcon =
       closed?: React.ReactNode | ((...args: any[]) => any);
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
-export type AccordionHeaderIconPosition = 'left' | 'right';
 export type AccordionHeaderChildren =
   | string
   | React.ReactNode
@@ -74,9 +69,9 @@ export interface AccordionHeaderProps
   element?: AccordionHeaderElement;
   heading?: AccordionHeaderHeading;
   heading_level?: AccordionHeaderHeadingLevel;
-  icon?: AccordionHeaderIcon;
-  icon_position?: AccordionHeaderIconPosition;
-  icon_size?: string;
+  icon?: AccordionIcon;
+  icon_position?: ButtonIconPosition;
+  icon_size?: IconPrimarySize;
   disabled?: boolean;
   skeleton?: SkeletonShow;
   no_animation?: boolean;

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
+import type { IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
+import type { AccordionIcon } from './Accordion';
 export type AccordionGroupVariant =
   | 'plain'
   | 'default'
@@ -8,17 +11,9 @@ export type AccordionGroupVariant =
   | 'filled';
 export type AccordionGroupHeading = boolean | React.ReactNode;
 export type AccordionGroupHeadingLevel = string | number;
-export type AccordionGroupIcon =
-  | React.ReactNode
-  | ((...args: any[]) => any)
-  | {
-      closed?: React.ReactNode | ((...args: any[]) => any);
-      expanded?: React.ReactNode | ((...args: any[]) => any);
-    };
 export type AccordionGroupClosed =
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionGroupIconPosition = 'left' | 'right';
 export type AccordionGroupAttributes = string | Record<string, unknown>;
 
 export interface AccordionGroupProps
@@ -45,10 +40,10 @@ export interface AccordionGroupProps
   element?: React.ReactNode;
   heading?: AccordionGroupHeading;
   heading_level?: AccordionGroupHeadingLevel;
-  icon?: AccordionGroupIcon;
+  icon?: AccordionIcon;
   closed?: AccordionGroupClosed;
-  icon_position?: AccordionGroupIconPosition;
-  icon_size?: string;
+  icon_position?: ButtonIconPosition;
+  icon_size?: IconPrimarySize;
   attributes?: AccordionGroupAttributes;
   class?: string;
   className?: string;

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
 import {
   FormStatusProps,
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type AutocompleteAlignDrawer = 'left' | 'right';
@@ -32,8 +34,6 @@ export type AutocompleteSubmitButtonIcon =
 export type AutocompleteInputRef =
   | ((...args: any[]) => any)
   | Record<string, unknown>;
-export type AutocompleteIcon = string | React.ReactNode;
-export type AutocompleteIconPosition = 'left' | 'right';
 export type AutocompleteTrianglePosition = 'left' | 'right';
 export type AutocompleteInputIcon =
   | string
@@ -200,17 +200,17 @@ export interface AutocompleteProps
   /**
    * To be included in the autocomplete input.
    */
-  icon?: AutocompleteIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * Change the size of the icon pragmatically.
    */
-  icon_size?: string;
+  icon_size?: IconPrimarySize;
 
   /**
    * Position of the icon inside the autocomplete. Set to `left` or `right`. Defaults to `left`.
    */
-  icon_position?: AutocompleteIconPosition;
+  icon_position?: ButtonIconPosition;
 
   /**
    * Position of arrow icon/triangle inside the drawer-list. Set to `left` or `right`. Defaults to `left` if not set.

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import type { SkeletonShow } from '../skeleton/Skeleton';
-import { IconPrimaryIcon } from '../icon-primary/IconPrimary';
+import type {
+  IconPrimaryIcon,
+  IconPrimarySize
+} from '../icon-primary/IconPrimary';
 import type { DataAttributeTypes, SpacingProps } from '../../shared/types';
 import {
   FormStatusProps,
@@ -15,9 +18,12 @@ export type ButtonVariant =
   | 'signal'
   | 'unstyled';
 export type ButtonSize = 'default' | 'small' | 'medium' | 'large';
-export type ButtonIcon = IconPrimaryIcon;
-export type ButtonIconPosition = 'left' | 'right' | 'top';
-export type ButtonIconSize = string | number;
+export type ButtonIconPositionTertiary = 'top';
+export type ButtonIconPosition = 'left' | 'right';
+export type ButtonIconPositionAll =
+  | 'left'
+  | 'right'
+  | ButtonIconPositionTertiary;
 export type ButtonTooltip =
   | string
   | ((...args: any[]) => any)
@@ -63,17 +69,17 @@ export type ButtonProps = {
   /**
    * To be included in the button. <a href="/icons/primary">Primary Icons</a> can be set as a string (e.g. `icon="chevron_right"`), other icons should be set as React elements.
    */
-  icon?: ButtonIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * Position of icon inside the button. Set to `left` or `right`. Tertiary button variant also supports `top`. Defaults to `right` if not set.
    */
-  icon_position?: ButtonIconPosition;
+  icon_position?: ButtonIconPositionAll;
 
   /**
    * Define icon width and height. Defaults to 16px
    */
-  icon_size?: ButtonIconSize;
+  icon_size?: IconPrimarySize;
 
   /**
    * Provide a string or a React Element to be shown as the tooltip content.

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import type { ButtonVariant } from '../button';
-import {
+import type { ButtonIconPosition, ButtonVariant } from '../button';
+import type {
   FormStatusProps,
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type DropdownAlignDrawer = 'left' | 'right';
@@ -27,11 +28,6 @@ export type DropdownPageOffset = string | number;
 export type DropdownObserverElement = string | React.ReactNode;
 export type DropdownMinHeight = string | number;
 export type DropdownTitle = string | React.ReactNode;
-export type DropdownIcon =
-  | string
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type DropdownIconPosition = 'left' | 'right';
 export type DropdownTrianglePosition = 'left' | 'right';
 export type DropdownLabel =
   | string
@@ -152,17 +148,17 @@ export interface DropdownProps
   /**
    * Icon to be included in the dropdown.
    */
-  icon?: DropdownIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * Change the size of the icon pragmatically.
    */
-  icon_size?: string;
+  icon_size?: IconPrimarySize;
 
   /**
    * Position of the icon inside the dropdown. Set to `left` or `right`. Defaults to `right`.
    */
-  icon_position?: DropdownIconPosition;
+  icon_position?: ButtonIconPosition;
 
   /**
    * Position of arrow icon/triangle inside the drawer-list. Set to `left` or `right`. Defaults to `left` if not set.

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
@@ -1,13 +1,10 @@
 import * as React from 'react';
+import type { IconIcon, IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type FormStatusText =
   | string
   | boolean
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type FormStatusIcon =
-  | string
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type FormStatusState =
@@ -49,12 +46,12 @@ export interface FormStatusProps
   /**
    * The `icon` show before the status text. Defaults to `exclamation`.
    */
-  icon?: FormStatusIcon;
+  icon?: IconIcon;
 
   /**
    * The icon size of the icon shows. Defaults to `medium`.
    */
-  icon_size?: string;
+  icon_size?: IconSize;
 
   /**
    * Defines the visual appearance of the status. These are the statuses `error`, `warn`, `info` and `marketing`. The default status is `error`.

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { IconIcon, IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type GlobalStatusTitle = React.ReactNode | boolean;
@@ -7,10 +8,6 @@ export type GlobalStatusText =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type GlobalStatusItems = string | ((...args: any[]) => any) | any[];
-export type GlobalStatusIcon =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
 export type GlobalStatusState = 'error' | 'info';
 export type GlobalStatusShow = 'auto' | any | any | 'true' | 'false';
 export type GlobalStatusDelay = string | number;
@@ -47,12 +44,12 @@ export interface GlobalStatusProps
   /**
    * The icon shown before the status title. Defaults to `exclamation`.
    */
-  icon?: GlobalStatusIcon;
+  icon?: IconIcon;
 
   /**
    * The icon size of the title icon shows. Defaults to `medium`.
    */
-  icon_size?: string;
+  icon_size?: IconSize;
 
   /**
    * Defines the visual appearance of the status. There are two main statuses `error` and `info`. The default status is `error`.

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
 import {
   FormStatusProps,
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type InputMaskedMask =
@@ -42,12 +44,6 @@ export type InputMaskedInputAttributes = string | Record<string, unknown>;
 export type InputMaskedInputElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type InputMaskedIcon =
-  | string
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type InputMaskedIconSize = string | number;
-export type InputMaskedIconPosition = 'left' | 'right';
 export type InputMaskedSubmitElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
@@ -283,17 +279,17 @@ export interface InputMaskedProps
   /**
    * Icon to show before or after the input / placeholder. Can be either a string defining a primary icon or a Component using an SVG icon of either 16px or 24px.
    */
-  icon?: InputMaskedIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * The icon size of the icon shows. Defaults to `medium`.
    */
-  icon_size?: InputMaskedIconSize;
+  icon_size?: IconPrimarySize;
 
   /**
    * Defines the position of icon inside the input. Set to `left` or `right`. Defaults to `left` if not set.
    */
-  icon_position?: InputMaskedIconPosition;
+  icon_position?: ButtonIconPosition;
   readOnly?: boolean;
 
   /**

--- a/packages/dnb-eufemia/src/components/input/Input.d.ts
+++ b/packages/dnb-eufemia/src/components/input/Input.d.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { ButtonVariant } from '../button';
+import type { ButtonIconPosition, ButtonVariant } from '../button';
 import {
   FormStatusProps,
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 export type InputSize = 'default' | 'small' | 'medium' | 'large' | number;
@@ -23,12 +24,6 @@ export type InputInputAttributes = string | Record<string, unknown>;
 export type InputInputElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type InputIcon =
-  | string
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type InputIconSize = string | number;
-export type InputIconPosition = 'left' | 'right';
 export type InputSubmitElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
@@ -169,17 +164,17 @@ export interface InputProps
   /**
    * Icon to show before or after the input / placeholder. Can be either a string defining a primary icon or a Component using an SVG icon of either 16px or 24px.
    */
-  icon?: InputIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * The icon size of the icon shows. Defaults to `medium`.
    */
-  icon_size?: InputIconSize;
+  icon_size?: IconPrimarySize;
 
   /**
    * Defines the position of icon inside the input. Set to `left` or `right`. Defaults to `left` if not set.
    */
-  icon_position?: InputIconPosition;
+  icon_position?: ButtonIconPosition;
 
   /**
    * By providing a React.ref we can get the internally used input element (DOM). E.g. `inner_ref={myRef}` by using `React.createRef()` or `React.useRef()`.
@@ -241,8 +236,8 @@ export interface SubmitButtonProps extends React.HTMLProps<HTMLElement> {
   variant?: ButtonVariant;
   disabled?: boolean;
   skeleton?: SkeletonShow;
-  icon?: InputIcon;
-  icon_size?: InputIconSize;
+  icon?: IconPrimaryIcon;
+  icon_size?: IconPrimarySize;
   status?: FormStatusText;
   status_state?: FormStatusState;
   status_props?: FormStatusProps;

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import type { ButtonIconPosition } from '../button';
 import {
   FormStatusProps,
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
+import type { IconPrimaryIcon, IconPrimarySize } from '../IconPrimary';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import ToggleButtonGroup from './ToggleButtonGroup';
@@ -22,11 +24,6 @@ export type ToggleButtonValue =
   | number
   | Record<string, unknown>
   | any[];
-export type ToggleButtonIcon =
-  | string
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type ToggleButtonIconPosition = 'left' | 'right';
 export type ToggleButtonAttributes = string | Record<string, unknown>;
 export type ToggleButtonChildren = string | ((...args: any[]) => any);
 
@@ -98,17 +95,17 @@ export interface ToggleButtonProps
   /**
    * Icon to be included in the toggle button.
    */
-  icon?: ToggleButtonIcon;
+  icon?: IconPrimaryIcon;
 
   /**
    * Position of the icon inside the toggle button. Set to `left` or `right`. Defaults to `right` if not set.
    */
-  icon_position?: ToggleButtonIconPosition;
+  icon_position?: ButtonIconPosition;
 
   /**
    * Define icon width and height. Defaults to 16px
    */
-  icon_size?: string;
+  icon_size?: IconPrimarySize;
   attributes?: ToggleButtonAttributes;
   readOnly?: boolean;
 


### PR DESCRIPTION
These components all use some kind of icon, but some use `IconPrimary` as they pass the props to the Button component(which uses `IconPrimary`),  and others use `Icon` directly in their component.

As of now, I've referred to the correct types from either `IconPrimary` or `Icon`, for the given property, but could/should it only be one `Icon` type, or does it make sense to have both `IconPrimary` and `Icon`?