### PR TITLE
chore(CI): API rate limit exceeded for installation ID 15060380

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,7 +132,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Build Portal
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 3
+          intervalSeconds: 10
           timeoutSeconds: 900
 
       - name: Re-store portal artifacts
@@ -217,7 +217,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Build Portal
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 3
+          intervalSeconds: 10
           timeoutSeconds: 900
 
       - name: Re-store portal artifacts

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -104,7 +104,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Fetch and Build Icons # Has to be the action name
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 3
+          intervalSeconds: 10
           timeoutSeconds: 1200
 
       - name: Re-store portal artifacts


### PR DESCRIPTION
[This](https://github.com/dnbexperience/eufemia/actions/runs/4402679787/jobs/7710112359) is an issue we can't do much about it. It looks like the GitHub Action we use, uses an GitHub API for checking if its ready to go. But there is a rate limit. Its a [known issue](h).

For nor we can try to increase the interval from 3 sec to 10 sec.
