### PR TITLE
chore(TypeScript): use StepIndicatorItem in StepIndicator

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
@@ -1,28 +1,23 @@
 import * as React from 'react';
 import type { SpacingProps } from '../../shared/types';
-import { FormStatusText } from '../FormStatus';
 import type { SkeletonShow } from '../Skeleton';
+import type { StepIndicatorItemProps } from './StepIndicatorItem';
 import StepIndicatorSidebar from './StepIndicatorSidebar';
 export type StepIndicatorMode = 'static' | 'strict' | 'loose';
 export type StepIndicatorData =
   | string
   | string[]
-  | {
-      title: string | React.ReactNode;
-      is_current?: boolean;
-      inactive?: boolean;
-      disabled?: boolean;
-      status?: FormStatusText;
-      status_state?: StepIndicatorStatusState;
-
-      /**
-       * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ event, item, current_step }`.
-       */
-      on_click?: (...args: any[]) => any;
-      on_render?: (...args: any[]) => any;
-    }[];
-export type StepIndicatorTitle = string | React.ReactNode;
-export type StepIndicatorStatusState = 'warn' | 'info' | 'error';
+  | Pick<
+      StepIndicatorItemProps,
+      | 'title'
+      | 'is_current'
+      | 'inactive'
+      | 'disabled'
+      | 'status'
+      | 'status_state'
+      | 'on_click'
+      | 'on_render'
+    >[];
 export type StepIndicatorCurrentStep = string | number;
 export type StepIndicatorChildren =
   | React.ReactNode
@@ -45,18 +40,11 @@ export interface StepIndicatorProps
    * <em>(required)</em> defines the data/steps showing up in a JavaScript Array or JSON format like `[{title,is_current}]`. See parameters and the example above.
    */
   data?: StepIndicatorData;
-  title?: StepIndicatorTitle;
-  is_current?: boolean;
-  inactive?: boolean;
-  disabled?: boolean;
-  status?: FormStatusText;
-  status_state?: StepIndicatorStatusState;
 
   /**
    * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ event, item, current_step }`.
    */
   on_click?: (...args: any[]) => any;
-  on_render?: (...args: any[]) => any;
   overview_title?: string;
   step_title_extended?: string;
   step_title?: string;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { FormStatusText } from '../FormStatus';
-import { StepIndicatorStatusState } from './StepIndicator';
+import type { FormStatusText } from '../FormStatus';
 export type StepIndicatorItemTitle = string | React.ReactNode;
+export type StepIndicatorItemStatusState = 'warn' | 'info' | 'error';
 
 export interface StepIndicatorItemProps
   extends React.HTMLProps<HTMLElement> {
@@ -36,7 +36,7 @@ export interface StepIndicatorItemProps
   inactive?: boolean;
   disabled?: boolean;
   status?: FormStatusText;
-  status_state?: StepIndicatorStatusState;
+  status_state?: StepIndicatorItemStatusState;
   currentItemNum: number;
 }
 export default class StepIndicatorItem extends React.Component<


### PR DESCRIPTION
This PR:
- Tries to reuse the `StepIndicatorItemProps` as a potential type in `StepIndicator`'s `data` prop.
- Removes some undocumented and what I believe is faulty props for the `StepIndicator` which seems to actually belong to `StepIndicatorItem`: `title`, `is_current`, `inactive`, `disabled`, `status`, `status_state`, `on_render` (not sure how/why they was being generated for the StepIndicator though 🤔 )