### PR TITLE
chore(TypeScript): only export the shared types

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
@@ -7,8 +7,8 @@ import type { SpacingProps } from '../space/types';
 import AccordionContent from './AccordionContent';
 import AccordionHeader from './AccordionHeader';
 import AccordionProvider from './AccordionProvider';
-export type AccordionVariant = 'plain' | 'default' | 'outlined' | 'filled';
-export type AccordionHeading = boolean | React.ReactNode;
+type AccordionVariant = 'plain' | 'default' | 'outlined' | 'filled';
+type AccordionHeading = boolean | React.ReactNode;
 export type AccordionIcon =
   | IconIcon
   | {
@@ -19,8 +19,8 @@ export type AccordionIcon =
        */
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
-export type AccordionClosed = React.ReactNode | ((...args: any[]) => any);
-export type AccordionAttributes = string | Record<string, unknown>;
+type AccordionClosed = React.ReactNode | ((...args: any[]) => any);
+type AccordionAttributes = string | Record<string, unknown>;
 
 export interface AccordionProps
   extends React.HTMLProps<HTMLElement>,
@@ -165,7 +165,7 @@ export default class Accordion extends React.Component<
   render(): JSX.Element;
 }
 
-export type GroupProps = {
+type GroupProps = {
   /**
    * A unique `id` that will be used on the button element. If you use `remember_state`, an id is required.
    */

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../space/types';
-export type AccordionContentChildren =
+type AccordionContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
@@ -27,35 +27,35 @@ export interface AccordionHeaderIconProps {
   expanded?: boolean;
 }
 declare const AccordionHeaderIcon: React.FC<AccordionHeaderIconProps>;
-export type AccordionHeaderTitle =
+type AccordionHeaderTitle =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionHeaderDescription =
+type AccordionHeaderDescription =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionHeaderLeftComponent =
+type AccordionHeaderLeftComponent =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionHeaderElement =
+type AccordionHeaderElement =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionHeaderHeading =
+type AccordionHeaderHeading =
   | boolean
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type AccordionHeaderIcon =
+type AccordionHeaderIcon =
   | React.ReactNode
   | ((...args: any[]) => any)
   | {
       closed?: React.ReactNode | ((...args: any[]) => any);
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
-export type AccordionHeaderChildren =
+type AccordionHeaderChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProvider.d.ts
@@ -5,16 +5,10 @@ import type { IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { AccordionIcon } from './Accordion';
-export type AccordionGroupVariant =
-  | 'plain'
-  | 'default'
-  | 'outlined'
-  | 'filled';
-export type AccordionGroupHeading = boolean | React.ReactNode;
-export type AccordionGroupClosed =
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type AccordionGroupAttributes = string | Record<string, unknown>;
+type AccordionGroupVariant = 'plain' | 'default' | 'outlined' | 'filled';
+type AccordionGroupHeading = boolean | React.ReactNode;
+type AccordionGroupClosed = React.ReactNode | ((...args: any[]) => any);
+type AccordionGroupAttributes = string | Record<string, unknown>;
 
 export interface AccordionGroupProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -7,37 +7,25 @@ import {
   FormStatusState,
   FormStatusText
 } from '../FormStatus';
-export type ButtonText = string | React.ReactNode;
+type ButtonText = string | React.ReactNode;
 export type ButtonVariant =
   | 'primary'
   | 'secondary'
   | 'tertiary'
   | 'signal'
   | 'unstyled';
-export type ButtonSize = 'default' | 'small' | 'medium' | 'large';
-export type ButtonIconPositionTertiary = 'top';
+type ButtonSize = 'default' | 'small' | 'medium' | 'large';
+type ButtonIconPositionTertiary = 'top';
 export type ButtonIconPosition = 'left' | 'right';
-export type ButtonIconPositionAll =
-  | 'left'
-  | 'right'
-  | ButtonIconPositionTertiary;
-export type ButtonTooltip =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type ButtonTo = string | any | ((...args: any[]) => any);
-export type ButtonSkeleton = SkeletonShow;
-export type ButtonChildren =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type ButtonElement =
-  | ((...args: any[]) => any)
-  | any
-  | React.ReactNode;
-export type ButtonOnClick = string | ((...args: any[]) => any);
+type ButtonIconPositionAll = 'left' | 'right' | ButtonIconPositionTertiary;
+type ButtonTooltip = string | ((...args: any[]) => any) | React.ReactNode;
+type ButtonTo = string | any | ((...args: any[]) => any);
+type ButtonSkeleton = SkeletonShow;
+type ButtonChildren = string | ((...args: any[]) => any) | React.ReactNode;
+type ButtonElement = ((...args: any[]) => any) | any | React.ReactNode;
+type ButtonOnClick = string | ((...args: any[]) => any);
 
-export type ButtonProps = {
+type ButtonProps = {
   /**
    * The content of the button can be a string or a React Element.
    */

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
@@ -7,14 +7,11 @@ import type {
 import type { FormLabelText } from '../FormLabel';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type CheckboxLabelPosition = 'left' | 'right';
-export type CheckboxSize = 'default' | 'medium' | 'large';
-export type CheckboxSuffix =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type CheckboxAttributes = string | Record<string, unknown>;
-export type CheckboxChildren = string | ((...args: any[]) => any);
+type CheckboxLabelPosition = 'left' | 'right';
+type CheckboxSize = 'default' | 'medium' | 'large';
+type CheckboxSuffix = string | ((...args: any[]) => any) | React.ReactNode;
+type CheckboxAttributes = string | Record<string, unknown>;
+type CheckboxChildren = string | ((...args: any[]) => any);
 
 export interface CheckboxProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-export type DatePickerAddonShortcuts = any[] | ((...args: any[]) => any);
-export type DatePickerAddonRenderElement =
+type DatePickerAddonShortcuts = any[] | ((...args: any[]) => any);
+type DatePickerAddonRenderElement =
   | React.ReactNode
   | ((...args: any[]) => any);
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type DatePickerRangeViews = number | Record<string, unknown>[];
+type DatePickerRangeViews = number | Record<string, unknown>[];
 
 export interface DatePickerRangeProps
   extends React.HTMLProps<HTMLElement> {

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
@@ -6,7 +6,7 @@ export type FormLabelText =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type FormLabelLabelDirection = 'vertical' | 'horizontal';
-export type FormLabelChildren =
+type FormLabelChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
@@ -4,8 +4,8 @@ import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { Locale } from '../../shared/Context';
-export type FormRowDirection = 'vertical' | 'horizontal';
-export type FormRowChildren =
+type FormRowDirection = 'vertical' | 'horizontal';
+type FormRowChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
@@ -4,8 +4,8 @@ import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
 import type { Locale } from '../../shared/Context';
-export type FormSetDirection = 'vertical' | 'horizontal';
-export type FormSetChildren =
+type FormSetDirection = 'vertical' | 'horizontal';
+type FormSetChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
@@ -14,10 +14,10 @@ export type FormStatusState =
   | 'warn'
   | 'info'
   | 'marketing';
-export type FormStatusVariant = 'flat' | 'outlined';
-export type FormStatusSize = 'default' | 'large';
-export type FormStatusAttributes = string | Record<string, unknown>;
-export type FormStatusChildren =
+type FormStatusVariant = 'flat' | 'outlined';
+type FormStatusSize = 'default' | 'large';
+type FormStatusAttributes = string | Record<string, unknown>;
+type FormStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import type { SpacingProps } from '../space/types';
-export type GlobalErrorStatusContent = string | Record<string, unknown>;
-export type GlobalErrorTitle = string | React.ReactNode;
-export type GlobalErrorText = string | React.ReactNode;
-export type GlobalErrorBack = string | React.ReactNode;
-export type GlobalErrorChildren =
+type GlobalErrorStatusContent = string | Record<string, unknown>;
+type GlobalErrorTitle = string | React.ReactNode;
+type GlobalErrorText = string | React.ReactNode;
+type GlobalErrorBack = string | React.ReactNode;
+type GlobalErrorChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
@@ -2,16 +2,16 @@ import * as React from 'react';
 import type { IconIcon, IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type GlobalStatusTitle = React.ReactNode | boolean;
-export type GlobalStatusText =
+type GlobalStatusTitle = React.ReactNode | boolean;
+type GlobalStatusText =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type GlobalStatusItems = string | ((...args: any[]) => any) | any[];
-export type GlobalStatusState = 'error' | 'info';
-export type GlobalStatusShow = 'auto' | any | any | 'true' | 'false';
-export type GlobalStatusDelay = string | number;
-export type GlobalStatusChildren =
+type GlobalStatusItems = string | ((...args: any[]) => any) | any[];
+type GlobalStatusState = 'error' | 'info';
+type GlobalStatusShow = 'auto' | any | any | 'true' | 'false';
+type GlobalStatusDelay = string | number;
+type GlobalStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
@@ -136,9 +136,9 @@ export interface GlobalStatusProps
   on_hide?: (...args: any[]) => any;
 }
 
-export type GlobalStatusStatusId = string;
+type GlobalStatusStatusId = string;
 
-export type GlobalStatusAddProps = {
+type GlobalStatusAddProps = {
   id: string;
   status_id: GlobalStatusStatusId;
   title?: string;
@@ -147,17 +147,17 @@ export type GlobalStatusAddProps = {
   on_close: ({ status_id }: { status_id: GlobalStatusStatusId }) => void;
 };
 
-export type GlobalStatusUpdateProps = {
+type GlobalStatusUpdateProps = {
   id: string;
   text: string;
 };
 
-export type GlobalStatusRemoveProps = {
+type GlobalStatusRemoveProps = {
   id: string;
   status_id: GlobalStatusStatusId;
 };
 
-export type GlobalStatusInterceptorProps = {
+type GlobalStatusInterceptorProps = {
   id: string;
   title: string;
   text: string;
@@ -165,14 +165,14 @@ export type GlobalStatusInterceptorProps = {
   show: boolean;
 };
 
-export type GlobalStatusInterceptorUpdateEvents = {
+type GlobalStatusInterceptorUpdateEvents = {
   on_show?: () => void;
   on_hide?: () => void;
   on_close?: () => void;
   show?: boolean;
 };
 
-export type GlobalStatusInterceptor = {
+type GlobalStatusInterceptor = {
   update: (props: GlobalStatusInterceptorUpdateEvents) => void;
   remove: () => void;
 };

--- a/packages/dnb-eufemia/src/components/icon/Icon.d.ts
+++ b/packages/dnb-eufemia/src/components/icon/Icon.d.ts
@@ -6,10 +6,10 @@ export type IconIcon =
   | React.ReactNode
   | ((...args: any[]) => any);
 export type IconSize = number | string | 'default' | 'medium' | 'large';
-export type IconWidth = string | number;
-export type IconHeight = string | number;
-export type IconAttributes = string | Record<string, unknown>;
-export type IconChildren = React.ReactNode | ((...args: any[]) => any);
+type IconWidth = string | number;
+type IconHeight = string | number;
+type IconAttributes = string | Record<string, unknown>;
+type IconChildren = React.ReactNode | ((...args: any[]) => any);
 export type IconColor = string;
 
 export interface IconProps

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
@@ -16,36 +16,28 @@ import type {
 import type { NumberFormatProps } from '../NumberFormat';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type InputMaskedMask =
+type InputMaskedMask =
   | Record<string, unknown>
   | any[]
   | ((...args: any[]) => any);
-export type InputMaskedNumberMask =
-  | string
-  | boolean
-  | Record<string, unknown>;
-export type InputMaskedCurrencyMask =
-  | string
-  | boolean
-  | Record<string, unknown>;
-export type InputMaskedMaskOptions = string | Record<string, unknown>;
-export type InputMaskedAsCurrency = string | boolean;
-export type InputMaskedValue = string | number;
-export type InputMaskedSuffix =
+type InputMaskedNumberMask = string | boolean | Record<string, unknown>;
+type InputMaskedCurrencyMask = string | boolean | Record<string, unknown>;
+type InputMaskedMaskOptions = string | Record<string, unknown>;
+type InputMaskedAsCurrency = string | boolean;
+type InputMaskedValue = string | number;
+type InputMaskedSuffix =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type InputMaskedAlign = 'left' | 'center' | 'right';
-export type InputMaskedSubmitElement =
+type InputMaskedAlign = 'left' | 'center' | 'right';
+type InputMaskedSubmitElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type InputMaskedSubmitButtonIcon =
+type InputMaskedSubmitButtonIcon =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type InputMaskedChildren =
-  | React.ReactNode
-  | ((...args: any[]) => any);
+type InputMaskedChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface InputMaskedProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type TextMaskMask =
+type TextMaskMask =
   | any[]
   | ((...args: any[]) => any)
   | boolean
@@ -7,10 +7,8 @@ export type TextMaskMask =
       mask?: any[] | ((...args: any[]) => any);
       pipe?: (...args: any[]) => any;
     };
-export type TextMaskInputElement =
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type TextMaskValue = string | number;
+type TextMaskInputElement = React.ReactNode | ((...args: any[]) => any);
+type TextMaskValue = string | number;
 
 export interface TextMaskProps extends React.HTMLProps<HTMLElement> {
   mask: TextMaskMask;

--- a/packages/dnb-eufemia/src/components/input/Input.d.ts
+++ b/packages/dnb-eufemia/src/components/input/Input.d.ts
@@ -9,25 +9,18 @@ import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
 import type { IconIcon, IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type InputSize = 'default' | 'small' | 'medium' | 'large' | number;
-export type InputValue = string | number;
-export type InputSuffix =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type InputAlign = 'left' | 'center' | 'right';
-export type InputInputAttributes = string | Record<string, unknown>;
-export type InputInputElement =
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type InputSubmitElement =
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type InputSubmitButtonIcon =
+type InputSize = 'default' | 'small' | 'medium' | 'large' | number;
+type InputValue = string | number;
+type InputSuffix = string | ((...args: any[]) => any) | React.ReactNode;
+type InputAlign = 'left' | 'center' | 'right';
+type InputInputAttributes = string | Record<string, unknown>;
+type InputInputElement = ((...args: any[]) => any) | React.ReactNode;
+type InputSubmitElement = ((...args: any[]) => any) | React.ReactNode;
+type InputSubmitButtonIcon =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-export type InputChildren = React.ReactNode | ((...args: any[]) => any);
+type InputChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface InputProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/logo/Logo.d.ts
+++ b/packages/dnb-eufemia/src/components/logo/Logo.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import type { IconColor } from '../Icon';
 import type { SpacingProps } from '../space/types';
-export type LogoSize = number | string;
-export type LogoRatio = number | string;
-export type LogoWidth = number | string;
-export type LogoHeight = number | string;
+type LogoSize = number | string;
+type LogoRatio = number | string;
+type LogoWidth = number | string;
+type LogoHeight = number | string;
 
 export interface LogoProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
@@ -2,27 +2,21 @@ import * as React from 'react';
 import type { Locale } from '../../shared/Context';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type NumberFormatValue = number | string;
-export type NumberFormatPrefix =
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type NumberFormatSuffix =
-  | React.ReactNode
-  | ((...args: any[]) => any);
-export type NumberFormatCurrency = string | boolean;
-export type NumberFormatCurrencyPosition = 'auto' | 'before' | 'after';
-export type NumberFormatCompact = 'short' | 'long' | boolean;
-export type NumberFormatLink = 'tel' | 'sms';
-export type NumberFormatOptions = Record<string, unknown> | string;
-export type NumberFormatDecimals = number | string;
-export type NumberFormatElement = string;
-export type NumberFormatTooltip =
+type NumberFormatValue = number | string;
+type NumberFormatPrefix = React.ReactNode | ((...args: any[]) => any);
+type NumberFormatSuffix = React.ReactNode | ((...args: any[]) => any);
+type NumberFormatCurrency = string | boolean;
+type NumberFormatCurrencyPosition = 'auto' | 'before' | 'after';
+type NumberFormatCompact = 'short' | 'long' | boolean;
+type NumberFormatLink = 'tel' | 'sms';
+type NumberFormatOptions = Record<string, unknown> | string;
+type NumberFormatDecimals = number | string;
+type NumberFormatElement = string;
+type NumberFormatTooltip =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type NumberFormatChildren =
-  | React.ReactNode
-  | ((...args: any[]) => any);
+type NumberFormatChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface NumberFormatProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -1,14 +1,14 @@
 import type { Locale } from '../../shared/Context';
 import type { NumberFormatCurrency } from './NumberFormat';
 
-export type formatTypes =
+type formatTypes =
   | 'phone'
   | 'org'
   | 'ban'
   | 'nin'
   | 'percent'
   | 'currency';
-export type formatCurrencyPosition = 'before' | 'after';
+type formatCurrencyPosition = 'before' | 'after';
 export interface formatReturnValue {
   /** The given number */
   value: number;
@@ -28,8 +28,8 @@ export interface formatReturnValue {
   /** The given type */
   type: formatTypes | string;
 }
-export type formatValue = string | number;
-export type formatReturnType = formatReturnValue | formatValue;
+type formatValue = string | number;
+type formatReturnType = formatReturnValue | formatValue;
 export interface formatOptionParams {
   /** can be "auto" */
   locale?: Locale;

--- a/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type PaginationIndicatorIndicatorElement =
+type PaginationIndicatorIndicatorElement =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any)

--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type InfinityScrollerChildren =
+type InfinityScrollerChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 
@@ -16,12 +16,12 @@ export default class InfinityScroller extends React.Component<
 > {
   render(): JSX.Element;
 }
-export type InfinityLoadButtonElement =
+type InfinityLoadButtonElement =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any)
   | string;
-export type InfinityLoadButtonPressedElement =
+type InfinityLoadButtonPressedElement =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
 import type { SpacingProps } from '../space/types';
-export type ProgressIndicatorType = 'circular' | 'linear';
-export type ProgressIndicatorSize =
+type ProgressIndicatorType = 'circular' | 'linear';
+type ProgressIndicatorSize =
   | 'default'
   | 'small'
   | 'medium'
   | 'large'
   | 'huge';
-export type ProgressIndicatorProgress = string | number;
-export type ProgressIndicatorChildren =
+type ProgressIndicatorProgress = string | number;
+type ProgressIndicatorChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type ProgressIndicatorCircularProgress = string | number;
+type ProgressIndicatorCircularProgress = string | number;
 
 export interface ProgressIndicatorCircularProps
   extends React.HTMLProps<HTMLElement> {

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export type ProgressIndicatorLinearProgress = string | number;
+type ProgressIndicatorLinearProgress = string | number;
 
 export interface ProgressIndicatorLinearProps
   extends React.HTMLProps<HTMLElement> {

--- a/packages/dnb-eufemia/src/components/radio/Radio.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/Radio.d.ts
@@ -7,18 +7,12 @@ import {
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import RadioGroup from './RadioGroup';
-export type RadioLabel =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type RadioLabelPosition = 'left' | 'right';
-export type RadioSize = 'default' | 'medium' | 'large';
-export type RadioSuffix =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type RadioAttributes = string | Record<string, unknown>;
-export type RadioChildren = string | ((...args: any[]) => any);
+type RadioLabel = string | ((...args: any[]) => any) | React.ReactNode;
+type RadioLabelPosition = 'left' | 'right';
+type RadioSize = 'default' | 'medium' | 'large';
+type RadioSuffix = string | ((...args: any[]) => any) | React.ReactNode;
+type RadioAttributes = string | Record<string, unknown>;
+type RadioChildren = string | ((...args: any[]) => any);
 
 export interface RadioProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
@@ -7,15 +7,15 @@ import type {
 import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type RadioGroupLabelPosition = 'left' | 'right';
-export type RadioGroupSize = 'default' | 'medium' | 'large';
-export type RadioGroupSuffix =
+type RadioGroupLabelPosition = 'left' | 'right';
+type RadioGroupSize = 'default' | 'medium' | 'large';
+type RadioGroupSuffix =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type RadioGroupLayoutDirection = 'column' | 'row';
-export type RadioGroupAttributes = string | Record<string, unknown>;
-export type RadioGroupChildren =
+type RadioGroupLayoutDirection = 'column' | 'row';
+type RadioGroupAttributes = string | Record<string, unknown>;
+type RadioGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import type { SpacingProps } from '../space/types';
-export type SkeletonShow = boolean;
-export type SkeletonStyleType = 'lines' | string;
-export type SkeletonFigure =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type SkeletonChildren =
+type SkeletonShow = boolean;
+type SkeletonStyleType = 'lines' | string;
+type SkeletonFigure = string | ((...args: any[]) => any) | React.ReactNode;
+type SkeletonChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Article.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Article.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-export type SkeletonArticleRows = string | number;
-export type SkeletonArticleChildren =
+type SkeletonArticleRows = string | number;
+type SkeletonArticleChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Circle.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Circle.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-export type SkeletonCircleRows = string | number;
-export type SkeletonCircleChildren =
+type SkeletonCircleRows = string | number;
+type SkeletonCircleChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Product.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Product.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-export type SkeletonProductRows = string | number;
-export type SkeletonProductChildren =
+type SkeletonProductRows = string | number;
+type SkeletonProductChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Table.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Table.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-export type SkeletonTableRows = string | number;
-export type SkeletonTableChildren =
+type SkeletonTableRows = string | number;
+type SkeletonTableChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
@@ -3,8 +3,8 @@ import type { SpacingProps } from '../../shared/types';
 import { FormStatusText } from '../FormStatus';
 import type { SkeletonShow } from '../Skeleton';
 import StepIndicatorSidebar from './StepIndicatorSidebar';
-export type StepIndicatorMode = 'static' | 'strict' | 'loose';
-export type StepIndicatorData =
+type StepIndicatorMode = 'static' | 'strict' | 'loose';
+type StepIndicatorData =
   | string
   | string[]
   | {
@@ -21,12 +21,10 @@ export type StepIndicatorData =
       on_click?: (...args: any[]) => any;
       on_render?: (...args: any[]) => any;
     }[];
-export type StepIndicatorTitle = string | React.ReactNode;
-export type StepIndicatorStatusState = 'warn' | 'info' | 'error';
-export type StepIndicatorCurrentStep = string | number;
-export type StepIndicatorChildren =
-  | React.ReactNode
-  | ((...args: any[]) => any);
+type StepIndicatorTitle = string | React.ReactNode;
+type StepIndicatorStatusState = 'warn' | 'info' | 'error';
+type StepIndicatorCurrentStep = string | number;
+type StepIndicatorChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface StepIndicatorProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormStatusText } from '../FormStatus';
 import { StepIndicatorStatusState } from './StepIndicator';
-export type StepIndicatorItemTitle = string | React.ReactNode;
+type StepIndicatorItemTitle = string | React.ReactNode;
 
 export interface StepIndicatorItemProps
   extends React.HTMLProps<HTMLElement> {

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
@@ -5,8 +5,8 @@ import {
   StepIndicatorStatusState,
   StepIndicatorMode
 } from './StepIndicator';
-export type StepIndicatorSidebarCurrentStep = string | number;
-export type StepIndicatorSidebarData =
+type StepIndicatorSidebarCurrentStep = string | number;
+type StepIndicatorSidebarData =
   | string
   | string[]
   | {

--- a/packages/dnb-eufemia/src/components/switch/Switch.d.ts
+++ b/packages/dnb-eufemia/src/components/switch/Switch.d.ts
@@ -2,18 +2,12 @@ import * as React from 'react';
 import { FormStatusState, FormStatusText } from '../FormStatus';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
-export type SwitchLabel =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type SwitchLabelPosition = 'left' | 'right';
-export type SwitchSize = 'default' | 'medium' | 'large';
-export type SwitchSuffix =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type SwitchAttributes = string | Record<string, unknown>;
-export type SwitchChildren = string | ((...args: any[]) => any);
+type SwitchLabel = string | ((...args: any[]) => any) | React.ReactNode;
+type SwitchLabelPosition = 'left' | 'right';
+type SwitchSize = 'default' | 'medium' | 'large';
+type SwitchSuffix = string | ((...args: any[]) => any) | React.ReactNode;
+type SwitchAttributes = string | Record<string, unknown>;
+type SwitchChildren = string | ((...args: any[]) => any);
 
 export interface SwitchProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -4,7 +4,7 @@ import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import ContentWrapper from './TabsContentWrapper';
 import CustomContent from './TabsCustomContent';
-export type TabsData =
+type TabsData =
   | string
   | {
       title: string | React.ReactNode | ((...args: any[]) => any);
@@ -13,17 +13,17 @@ export type TabsData =
       disabled?: boolean;
     }[]
   | any;
-export type TabsContent =
+type TabsContent =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-export type TabsTabElement =
+type TabsTabElement =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-export type TabsSelectedKey = string | number;
-export type TabsAlign = 'left' | 'center' | 'right';
-export type TabsChildren =
+type TabsSelectedKey = string | number;
+type TabsAlign = 'left' | 'center' | 'right';
+type TabsChildren =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.d.ts
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import type { SectionSpacing, SectionStyleTypes } from '../Section';
-export type ContentWrapperSelectedKey = string | number;
-export type ContentWrapperChildren =
-  | React.ReactNode
-  | ((...args: any[]) => any);
+type ContentWrapperSelectedKey = string | number;
+type ContentWrapperChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface ContentWrapperProps extends React.HTMLProps<HTMLElement> {
   id: string;

--- a/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import type { SpacingProps } from '../space/types';
-export type CustomContentTitle =
+type CustomContentTitle =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-export type CustomContentChildren =
-  | React.ReactNode
-  | ((...args: any[]) => any);
+type CustomContentChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface CustomContentProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
@@ -7,22 +7,17 @@ import {
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
-export type TextareaSuffix =
-  | string
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type TextareaAlign = 'left' | 'right';
-export type TextareaAutoresizeMaxRows = string | number;
-export type TextareaTextareaAttributes = string | Record<string, unknown>;
-export type TextareaRows = number | string;
-export type TextareaCols = number | string;
-export type TextareaInnerRef =
+type TextareaSuffix = string | ((...args: any[]) => any) | React.ReactNode;
+type TextareaAlign = 'left' | 'right';
+type TextareaAutoresizeMaxRows = string | number;
+type TextareaTextareaAttributes = string | Record<string, unknown>;
+type TextareaRows = number | string;
+type TextareaCols = number | string;
+type TextareaInnerRef =
   | ((...args: any[]) => any)
   | Record<string, unknown>;
-export type TextareaTextareaElement =
-  | ((...args: any[]) => any)
-  | React.ReactNode;
-export type TextareaChildren = React.ReactNode | ((...args: any[]) => any);
+type TextareaTextareaElement = ((...args: any[]) => any) | React.ReactNode;
+type TextareaChildren = React.ReactNode | ((...args: any[]) => any);
 
 export interface TextareaProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -10,18 +10,14 @@ import type { IconIcon, IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import ToggleButtonGroup from './ToggleButtonGroup';
-export type ToggleButtonVariant = 'default' | 'checkbox' | 'radio';
-export type ToggleButtonSuffix =
+type ToggleButtonVariant = 'default' | 'checkbox' | 'radio';
+type ToggleButtonSuffix =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type ToggleButtonValue =
-  | string
-  | number
-  | Record<string, unknown>
-  | any[];
-export type ToggleButtonAttributes = string | Record<string, unknown>;
-export type ToggleButtonChildren = string | ((...args: any[]) => any);
+type ToggleButtonValue = string | number | Record<string, unknown> | any[];
+type ToggleButtonAttributes = string | Record<string, unknown>;
+type ToggleButtonChildren = string | ((...args: any[]) => any);
 
 export interface ToggleButtonProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
@@ -7,20 +7,20 @@ import type {
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
-export type ToggleButtonGroupVariant = 'default' | 'checkbox' | 'radio';
-export type ToggleButtonGroupSuffix =
+type ToggleButtonGroupVariant = 'default' | 'checkbox' | 'radio';
+type ToggleButtonGroupSuffix =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type ToggleButtonGroupLayoutDirection = 'column' | 'row';
-export type ToggleButtonGroupValue =
+type ToggleButtonGroupLayoutDirection = 'column' | 'row';
+type ToggleButtonGroupValue =
   | string
   | number
   | Record<string, unknown>
   | any[];
-export type ToggleButtonGroupValues = string | any[];
-export type ToggleButtonGroupAttributes = string | Record<string, unknown>;
-export type ToggleButtonGroupChildren =
+type ToggleButtonGroupValues = string | any[];
+type ToggleButtonGroupAttributes = string | Record<string, unknown>;
+type ToggleButtonGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;

--- a/packages/dnb-eufemia/src/elements/H.d.ts
+++ b/packages/dnb-eufemia/src/elements/H.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type HSize =
+type HSize =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H1.d.ts
+++ b/packages/dnb-eufemia/src/elements/H1.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type H1Size =
+type H1Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H2.d.ts
+++ b/packages/dnb-eufemia/src/elements/H2.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type H2Size =
+type H2Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H3.d.ts
+++ b/packages/dnb-eufemia/src/elements/H3.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type H3Size =
+type H3Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H4.d.ts
+++ b/packages/dnb-eufemia/src/elements/H4.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type H4Size =
+type H4Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H5.d.ts
+++ b/packages/dnb-eufemia/src/elements/H5.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
-export type H5Size =
+type H5Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/H6.d.ts
+++ b/packages/dnb-eufemia/src/elements/H6.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
 
-export type H6Size =
+type H6Size =
   | 'xx-large'
   | 'x-large'
   | 'large'

--- a/packages/dnb-eufemia/src/elements/Img.d.ts
+++ b/packages/dnb-eufemia/src/elements/Img.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
 import type { SkeletonShow } from '../components/skeleton/Skeleton';
-export type ImgClassName = string | any | any[];
+type ImgClassName = string | any | any[];
 
 export interface ImgProps
   extends React.HTMLProps<HTMLElement>,

--- a/packages/dnb-eufemia/src/elements/P.d.ts
+++ b/packages/dnb-eufemia/src/elements/P.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
 
-export type PSize =
+type PSize =
   | 'x-small'
   | 'small'
   | 'basis'

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import type { SpacingProps } from '../shared/types';
 import type { SkeletonShow } from '../components/skeleton/Skeleton';
 import type { Locale } from '../../shared/Context';
-export type PaymentCardCardStatus = 'active' | 'blocked' | 'expired';
-export type PaymentCardVariant = 'normal' | 'compact';
-export type PaymentCardDigits = string | number;
+type PaymentCardCardStatus = 'active' | 'blocked' | 'expired';
+type PaymentCardVariant = 'normal' | 'compact';
+type PaymentCardDigits = string | number;
 
 export interface PaymentCardRawData {
   productCode: string;
@@ -15,7 +15,7 @@ export interface PaymentCardRawData {
   productType: Record<string, unknown>;
 }
 
-export type PaymentCardChildren =
+type PaymentCardChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { SpacingProps } from '../../shared/types';
-export type DrawerListDirection = 'auto' | 'top' | 'bottom';
-export type DrawerListSize = 'default' | 'small' | 'medium' | 'large';
-export type DrawerListAlignDrawer = 'left' | 'right';
-export type DrawerListOptionsRender =
+type DrawerListDirection = 'auto' | 'top' | 'bottom';
+type DrawerListSize = 'default' | 'small' | 'medium' | 'large';
+type DrawerListAlignDrawer = 'left' | 'right';
+type DrawerListOptionsRender =
   | Record<string, unknown>
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type DrawerListWrapperElement =
+type DrawerListWrapperElement =
   | Record<string, unknown>
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type DrawerListDefaultValue = string | number;
-export type DrawerListValue = string | number;
+type DrawerListDefaultValue = string | number;
+type DrawerListValue = string | number;
 export type DrawerListData =
   | string
   | ((...args: any[]) => any)
@@ -27,20 +27,20 @@ export type DrawerListData =
           content?: string | React.ReactNode | string[];
         }
     )[];
-export type DrawerListSelectedValue = string | React.ReactNode;
-export type DrawerListSuffixValue = string | React.ReactNode;
-export type DrawerListContent = string | React.ReactNode | string[];
-export type DrawerListRawData =
+type DrawerListSelectedValue = string | React.ReactNode;
+type DrawerListSuffixValue = string | React.ReactNode;
+type DrawerListContent = string | React.ReactNode | string[];
+type DrawerListRawData =
   | any[]
   | Record<string, unknown>
   | ((...args: any[]) => any);
-export type DrawerListChildren =
+type DrawerListChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode
   | Record<string, unknown>
   | any[];
-export type DrawerListSuffix = React.ReactNode;
+type DrawerListSuffix = React.ReactNode;
 
 export interface DrawerListProps
   extends React.HTMLProps<HTMLElement>,
@@ -99,11 +99,11 @@ export interface DrawerListProps
   on_state_update?: (...args: any[]) => any;
 }
 
-export type DrawerListOptionsProps = {
+type DrawerListOptionsProps = {
   children: React.ReactNode;
 };
 
-export type DrawerListItemProps = {
+type DrawerListItemProps = {
   children: React.ReactNode;
   selected: boolean;
   value: string;
@@ -119,9 +119,7 @@ export default class DrawerList extends React.Component<
   static Item: (props: DrawerListItemProps) => JSX.Element;
   render(): JSX.Element;
 }
-export type ItemContentChildren =
-  | React.ReactNode
-  | Record<string, unknown>;
+type ItemContentChildren = React.ReactNode | Record<string, unknown>;
 
 export interface ItemContentProps {
   hash?: string;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.d.ts
@@ -3,9 +3,7 @@ import * as React from 'react';
 export interface DrawerListPortalInnerRef {
   current?: React.ReactNode | Record<string, unknown>;
 }
-export type DrawerListPortalCurrent =
-  | React.ReactNode
-  | Record<string, unknown>;
+type DrawerListPortalCurrent = React.ReactNode | Record<string, unknown>;
 
 export interface DrawerListPortalRootRef {
   current?: React.ReactNode | Record<string, unknown>;


### PR DESCRIPTION
This is just a draft/suggestion as of now(didn't mark it as draft as I wanted the builds/CI to run), and will need some more work to fix TS errors, etc.

The question I'm thinking about is do we want to export all of our types or not?

If we `export` everything I think the eslint rule `no-unused-vars` will not be able to find types that's not used internally, or maybe it's a way of configuring this to assist us a bit more, even if we still `export` all types 🤔 

Or is it super important for the client's(users of eufemia) to be able to build their own types on top of the types we export to them? The more types we export to consumers, the more stuff can also potentially break 🤔 


