### PR TITLE
docs: crate main doc for how to deal with brand

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/brand/development.mdx
+++ b/packages/dnb-design-system-portal/src/docs/brand/development.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Development'
+---
+
+# Development

--- a/packages/dnb-design-system-portal/src/docs/brand/development/import-styles.mdx
+++ b/packages/dnb-design-system-portal/src/docs/brand/development/import-styles.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Import styles'
+level: 1
+---
+
+# Import styles

--- a/packages/dnb-design-system-portal/src/docs/contribute.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute.mdx
@@ -38,20 +38,71 @@ Colors, fonts and logo guidelines are set in the DNB Brandbook and the digital v
 
 ## Dive in
 
-<div align="center" className="dnb-section dnb-section--spacing dnb-section--mint-green">
-	<div style={{display: 'flex', flexWrap: 'wrap', marginBottom: '1rem'}}>
-		<Card url="/contribute/rules" about="Code of conduct and Development principles" title="Ground rules" icon={Principles} />
-		<Card url="/contribute/first-contribution" about="Your first contribution, Pull Requests and Technical information " title="New contributor" icon={NewContributor} />
-		<Card url="/contribute/getting-started" about="Set up environment, Make changes and Run tests " title="Getting started" icon={GettingStarted} />
-	</div>
-
-    <strong>Or go directly to</strong>
-
-    <Button href="/contribute/style-guides" size="large" variant="secondary" text="Style guides" icon="chevron_right" right />
-    <Button href="/contribute/deploy" size="large" variant="secondary" text="Deployment" icon="chevron_right" right />
-    <Button href="/contribute/faq" size="large" variant="secondary" text="FAQ" icon="chevron_right" right />
-    <Button href="/contribute/contact" size="large" variant="secondary" text="Contact" icon="chevron_right" />
-
+<div
+  align="center"
+  className="dnb-section dnb-section--spacing dnb-section--mint-green"
+>
+  <div style={{ display: 'flex', flexWrap: 'wrap', marginBottom: '1rem' }}>
+    <Card
+      url="/contribute/rules"
+      about="Code of conduct and Development principles"
+      title="Ground rules"
+      icon={Principles}
+    />
+    <Card
+      url="/contribute/first-contribution"
+      about="Your first contribution, Pull Requests and Technical information "
+      title="New contributor"
+      icon={NewContributor}
+    />
+    <Card
+      url="/contribute/getting-started"
+      about="Set up environment, Make changes and Run tests "
+      title="Getting started"
+      icon={GettingStarted}
+    />
+  </div>
+  <h3>Or go directly to</h3>
+  <div
+    style={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: '1rem',
+      justifyContent: 'center',
+    }}
+  >
+    <Button
+      href="/contribute/style-guides"
+      size="large"
+      variant="secondary"
+      text="Style guides"
+      icon="chevron_right"
+      right
+    />
+    <Button
+      href="/contribute/deploy"
+      size="large"
+      variant="secondary"
+      text="Deployment"
+      icon="chevron_right"
+      right
+    />
+    <Button
+      href="/contribute/faq"
+      size="large"
+      variant="secondary"
+      text="FAQ"
+      icon="chevron_right"
+      right
+    />
+    <Button
+      href="/contribute/contact"
+      size="large"
+      variant="secondary"
+      text="Contact"
+      icon="chevron_right"
+    />
+  </div>
 </div>
 
 ### Links to important resources

--- a/packages/dnb-design-system-portal/src/docs/contribute/contact.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/contact.mdx
@@ -12,9 +12,10 @@ import { Button } from '@dnb/eufemia/src'
 
 For all discussion topics, ask in Slack:
 
-<Button href="https://dnb-it.slack.com/archives/CMXABCHEY">
-  #eufemia-web
-</Button>
+<Button
+  href="https://dnb-it.slack.com/archives/CMXABCHEY"
+  text="#eufemia-web"
+/>
 
 ### Related channels in [DNB IT](https://dnb-it.slack.com)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -9,7 +9,7 @@ Theming is a umbrella term of a wide range of different ways and needs of custom
 
 This section covers some of the needs we've seen in DNB productions as of now.
 
-You may also check out the section in the contribution docs on [how to maintain and create a theme](/contribute/style-guides/theming/).
+You may also check out the section in the contribution docs on [how to maintain and create a theme](/contribute/style-guides/theming/) or [how to deal with the brand as a developer](/brand/development/).
 
 - [Theming](#theming)
   - [Integrated theming](#integrated-theming)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/deal-with-brand.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/deal-with-brand.mdx
@@ -1,9 +1,0 @@
----
-title: 'How to deal with the brand'
-status: 'wip'
-order: 7
----
-
-# How to deal with the brand
-
--- Long and well thought out explanation comes here --

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/deal-with-brand.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/deal-with-brand.mdx
@@ -1,0 +1,9 @@
+---
+title: 'How to deal with the brand'
+status: 'wip'
+order: 7
+---
+
+# How to deal with the brand
+
+-- Long and well thought out explanation comes here --


### PR DESCRIPTION
Added a draft for the main documentation for "How to deal with the brand". Still not entirely sure where the most optimal home for it would be, so this is still subject to change, and open to better suggestions 😄

As of now it's place under "usage" in the "uilib" portal. The choice was between there or in the "brand" portal, but I'm not sure if either of those are the right choice either 😅 