### PR TITLE
docs(ToggleButton): removes outdated label_position docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/properties.mdx
@@ -42,7 +42,3 @@ showTabs: true
 | `suffix`                                    | _(optional)_ text describing the content of the ToggleButtonGroup more than the label. You can also send in a React component, so it gets wrapped inside the ToggleButtonGroup component.        |
 | `skeleton`                                  | _(optional)_ if set to `true`, an overlaying skeleton with animation will be shown.                                                                                                              |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                                                            |
-
-### ToggleButton group Context
-
-You can also pass through `label_position` and some more **ToggleButton** properties to the Group. This way all nested ToggleButton's will get the properties.


### PR DESCRIPTION
This seems to just be a copy+paste from `Radio`'s properties docs, https://eufemia.dnb.no/uilib/components/radio/properties/#radio-group-context, as `ToggleButton` doesn't have a property named `label_position`. Hence, I removed this documentation.

If the documentation "actually is true" in terms of it actually "_passing through some(which?) of ToggleButton properties to the Group. This way all nested ToggleButton's will get the properties._", then we should rather replace the `label_position` with an actual property `x` that does what it says. But I wasn't quickly able to find "one of these properties".