### PR TITLE
docs: remove docs about importing from /elements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -57,7 +57,6 @@ The Eufemia repository is a monorepo consisting of the following workspaces:
 The only folders you should need to know about to add new features are:
 
 - `src/components`: The folder containing all the components, structured in [component folders](/contribute/first-contribution/before-started#component-folder).
-- `src/elements`: The folder containing all elements, one file for each element.
 - `src/extensions`: The folder containing all extensions, also structured in [component folders](/contribute/first-contribution/before-started#component-folder).
 
 ### dnb-design-system-portal

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -16,7 +16,7 @@ $ git checkout -b feat/my-feature
 
 ### Add changes
 
-Inside `./packages/dnb-eufemia` you will find the directory `/src/components`, `/src/elements` or `/src/extensions`. There you can place a new directory with all the necessary sub folders. As a reference, take a look at Component folder section in [Before getting started](/contribute/first-contribution/before-started#component-folder).
+Inside `./packages/dnb-eufemia` you will find the directory `/src/components` or `/src/extensions`. There you can place a new directory with all the necessary sub folders. As a reference, take a look at Component folder section in [Before getting started](/contribute/first-contribution/before-started#component-folder).
 
 Run an environment with either `yarn dev` (for Storybook) or `yarn start` (for Eufemia Portal). Make sure you follow the [Code guide](/contribute/style-guides/coding) under development.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements.mdx
@@ -33,7 +33,7 @@ In order to apply a style, you have to define a CSS class, like:
 For those using JSX with React, you can simply use the wrapper Components. They also inherit to the [Skeleton](/uilib/components/skeleton) provider.
 
 ```jsx
-import { H1, H2, P, Anchor, Link } from '@dnb/eufemia/elements'
+import { H1, H2, P, Anchor, Link } from '@dnb/eufemia'
 
 render(
   <article>
@@ -56,7 +56,7 @@ They work seamlessly with Styled Components (emotion) as well:
 In order to use the inherited [Skeleton](/uilib/components/skeleton), there are a number of un-styled HTML elements, that do inherit and react to the Skeleton Provider.
 
 ```jsx
-import { Span, Div } from '@dnb/eufemia/elements'
+import { Span, Div } from '@dnb/eufemia'
 ```
 
 - `Span`

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/anchor.mdx
@@ -15,7 +15,7 @@ import {
 The Anchor, also knows as `Link` is used to navigate from one page to the next HTML page.
 
 ```jsx
-import { Link, Anchor } from '@dnb/eufemia/elements'
+import { Link, Anchor } from '@dnb/eufemia'
 render(<Anchor href="/uilib/elements/anchor">Accessible text</Anchor>)
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/heading.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/heading.mdx
@@ -55,7 +55,7 @@ import { Heading } from '@dnb/eufemia/components'
 ## Heading styles in React
 
 ```jsx
-import { H1, H2, ... } from '@dnb/eufemia/elements'
+import { H1, H2, ... } from '@dnb/eufemia'
 ```
 
 ### Heading typography using React JSX

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/image.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/image.mdx
@@ -16,7 +16,7 @@ The image element associated with the class `dnb-img` does not have much opinion
 As of now, the React image "element" (Img) does provide a `figure` element with the `role="img"` and an `img` tag inside. This is mainly to support the [Skeleton](/uilib/components/skeleton) provider.
 
 ```jsx
-import { Img } from '@dnb/eufemia/elements'
+import { Img } from '@dnb/eufemia'
 
 render(<InlineImg alt="..." src="..." width="100" height="100" />)
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/lists.mdx
@@ -23,7 +23,7 @@ import {
 With React you can also send in the modifiers as booleans:
 
 ```jsx
-import { Ol } from '@dnb/eufemia/elements'
+import { Ol } from '@dnb/eufemia'
 
 render(
   <Ol nested inside>

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph.mdx
@@ -36,7 +36,7 @@ Eufemia comes with several styles you can use on paragraphs and other HTML text 
 Paragraphs using React JSX.
 
 ```jsx
-import { P, Lead } from '@dnb/eufemia/elements'
+import { P, Lead } from '@dnb/eufemia'
 ```
 
 <ParagraphModifiers />

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/12-usage-of-components-elements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/12-usage-of-components-elements.mdx
@@ -46,7 +46,6 @@ import MyButton from '@dnb/eufemia/components/Button'
 ```js
 /* or React JSX */
 import { H1, P, Link, ... } from '@dnb/eufemia'
-import { H1, P, Anchor, ... } from '@dnb/eufemia/elements'
 import H1 from '@dnb/eufemia/elements/H1'
 
 render(<H1>Title</H1>)

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography.mdx
@@ -36,7 +36,7 @@ The DNB default Font Family is `DNB`. This font, together with it's weights is l
 You can use the [Spacing properties](/uilib/components/space/properties) inside every Eufemia React Element, but keep in mind, [margin collapsing](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) can some times a little tricky to get right.
 
 ```jsx
-import { H1, H2, ... } from '@dnb/eufemia/elements'
+import { H1, H2, ... } from '@dnb/eufemia'
 
 <H1 bottom="x-large">Heading with bottom margin: x-large</H1>
 <H2 top="x-large">Heading with top margin: x-large</H2>

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -88,7 +88,7 @@ Once you use the `.dnb-core-style` wrapper class, you may in some circumstances,
 For **Styled Components** you do it this way:
 
 ```jsx
-import { P } from '@dnb/eufemia/elements'
+import { P } from '@dnb/eufemia'
 const MyElement = styled(P)`
   .dnb-core-style & {
     margin-top: 3rem;

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/react.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/react.mdx
@@ -28,7 +28,7 @@ And here an example with several imports:
 
 ```js
 import { Button, Icon } from '@dnb/eufemia/components'
-import { H1, P, Link } from '@dnb/eufemia/elements'
+import { H1, P, Link } from '@dnb/eufemia'
 import { hamburger as hamburgerIcon } from '@dnb/eufemia/icons'
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/the-basics.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/the-basics.mdx
@@ -102,7 +102,6 @@ But you can be more specific if you want to:
 
 ```js
 import { Button } from '@dnb/eufemia/components'
-import { Anchor } from '@dnb/eufemia/elements'
 ```
 
 And even go further:


### PR DESCRIPTION
This PR is far from completed, and is just a starting point for now 🏃‍♂️ 

To wait for:
- Making sure all components(previously known as elements) is exported from root `'@dnb/eufemia'`.

TODO:
- Double-check more docs, looking for references to `/elements`.
- Update internal links to from `/uilib/elements/tables` to like `/uilib/components/tables` ?