### PR TITLE
chore: cancel CI runs on new git pushes

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,6 +13,10 @@ on:
       - 'main'
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   action:
     name: Build Check

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,10 @@ on:
   schedule:
     - cron: '44 3 * * 5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,10 @@ on:
       - '!beta'
       - '!alpha'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
   GH_NAME: ${{ secrets.GH_NAME }}

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'icon*/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
   GH_NAME: ${{ secrets.GH_NAME }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,10 @@ on:
       - 'main'
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   action:
     name: Verify tests and types


### PR DESCRIPTION
I think we should try that for now. Because it does most of the time not make sense to continue runs when somethings in the branch changes. I have see that other CI environments, like Gatsby Cloud, do the same.
