### PR TITLE
chore: sync type definition docs from props docs during build

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -90,7 +90,7 @@ As of now, some components are written in TypeScript (`.tsx`) and some in JavaSc
 
 For JavaScript based components, the documentation for properties (`properties.mdx`) is kept as a Markdown Table, they get extracted, parsed, and inserted in the type definition files.
 
-You can still sync/update the documentation of these files (`d.ts`), by running: `yarn @dnb/eufemia build:types:docs`
+You can still sync/update the documentation of these files (`d.ts`), by running: `yarn @dnb/eufemia build:types:docs` or `yarn build`.
 
 **NB:** After you have synced/updated the files, you will see that some newlines where removed. Thats a negative side-effect we have no solution at the moment.
 

--- a/packages/dnb-eufemia/scripts/prebuild/local-prebuild.sh
+++ b/packages/dnb-eufemia/scripts/prebuild/local-prebuild.sh
@@ -5,6 +5,7 @@ set -e # Exit immediately if a command exits with a non-zero status.
 echo 'Prebuild started ...'
 
 yarn build:prebuild
+yarn build:types:docs
 yarn build:esm
 yarn build:types:esm
 yarn build:copy

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes.js
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes.js
@@ -92,6 +92,13 @@ export const createTypes = async (
         return // stop here
       }
 
+      if (
+        String(process.env.npm_config_argv).includes('build:types:docs') &&
+        !(await existsInGit(destFile))
+      ) {
+        return // stop here
+      }
+
       const warnAboutMissingPropTypes = (collectProps, docs) => {
         if (docs) {
           docs.forEach((doc) => {

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.d.ts
@@ -20,7 +20,6 @@ export type AccordionIcon =
       expanded?: React.ReactNode | ((...args: any[]) => any);
     };
 export type AccordionAttributes = string | Record<string, unknown>;
-
 export interface AccordionProps
   extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
@@ -28,10 +27,6 @@ export interface AccordionProps
    * A title as a string or React element. It will be used as the button text.
    */
   title?: React.ReactNode;
-
-  /**
-   * A description as a string or React element. It will be used as an additional text.
-   */
   description?: React.ReactNode;
 
   /**
@@ -162,7 +157,6 @@ export default class Accordion extends React.Component<
   static Store = Store;
   render(): JSX.Element;
 }
-
 export type GroupProps = {
   allow_close_all?: boolean;
   expanded_id?: string;

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.d.ts
@@ -3,7 +3,6 @@ import type { SpacingProps } from '../space/types';
 export type AccordionContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface AccordionContentProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { GroupProps } from './Accordion';
-
 export interface AccordionGroupProps
   extends React.HTMLProps<HTMLElement>,
     GroupProps {

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.d.ts
@@ -5,22 +5,18 @@ import type { IconSize } from '../Icon';
 import type { SkeletonShow } from '../Skeleton';
 import type { SpacingProps } from '../space/types';
 import type { AccordionIcon } from './Accordion';
-
 export interface AccordionHeaderTitleProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderTitle: React.FC<AccordionHeaderTitleProps>;
-
 export interface AccordionHeaderDescriptionProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderDescription: React.FC<AccordionHeaderDescriptionProps>;
-
 export interface AccordionHeaderContainerProps extends SpacingProps {
   children?: React.ReactNode;
 }
 declare const AccordionHeaderContainer: React.FC<AccordionHeaderContainerProps>;
-
 export interface AccordionHeaderIconProps {
   icon?: AccordionHeaderIconIcon;
   size?: string;
@@ -59,7 +55,6 @@ export type AccordionHeaderChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface AccordionHeaderProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
@@ -33,7 +33,6 @@ type AutocompleteInputElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
 type AutocompleteSearchInWordIndex = string | number;
-
 export interface AutocompleteProps
   extends SpacingProps,
     DrawerListProps,
@@ -223,7 +222,6 @@ export interface AutocompleteProps
    * Use `true` to auto open the list once the user is entering the input field with the keyboard.
    */
   open_on_focus?: boolean;
-
   disabled?: boolean;
 
   /**
@@ -240,7 +238,6 @@ export interface AutocompleteProps
    * Define a custom class for the internal drawer-list. This makes it possible more easily customize the drawer-list style with styled-components and the `css` style method. Defaults to `null`.
    */
   drawer_class?: string;
-
   ariaLiveDelay?: number;
 
   /**
@@ -272,6 +269,9 @@ export default class Autocomplete extends React.Component<
   static HorizontalItem: ({
     children
   }: {
+    /**
+     * <em>(required)</em> the data we want to fill the list with. Provide the data as a `JSON string`, `array` or `object` in these <a href="/uilib/components/fragments/drawer-list/info#data-structure">data structure</a>. <br /> If you don&#39;t have to define a `value`, you can also send in a `function` which will be called once the user opens the DrawerList.
+     */
     children: React.ReactNode;
   }) => JSX.Element;
   render(): JSX.Element;

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -36,7 +36,6 @@ export type ButtonElement =
   | any
   | React.ReactNode;
 export type ButtonOnClick = string | ((...args: any[]) => any);
-
 export type ButtonProps = {
   /**
    * The content of the button can be a string or a React Element.
@@ -121,7 +120,7 @@ export type ButtonProps = {
   target?: string;
 
   /**
-   * Used to specify the relationship between a linked resource and the current document. Examples(non-exhaustive list) of values are `nofollow`, `search`, and `tag`.
+   * When button behaves as a link. Used to specify the relationship between a linked resource and the current document. Examples(non-exhaustive list) of values are `nofollow`, `search`, and `tag`.
    */
   rel?: string;
 

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
@@ -15,7 +15,6 @@ export type CheckboxSuffix =
   | React.ReactNode;
 export type CheckboxAttributes = string | Record<string, unknown>;
 export type CheckboxChildren = string | ((...args: any[]) => any);
-
 export interface CheckboxProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -99,7 +98,6 @@ export default class Checkbox extends React.Component<CheckboxProps, any> {
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export interface CheckIconProps {
   /**
    * The size of the checkbox. For now there is "medium" (default) and "large".

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
@@ -24,7 +24,6 @@ type DatePickerSuffix =
   | React.ReactNode;
 type DatePickerDirection = 'auto' | 'top' | 'bottom';
 type DatePickerAlignPicker = 'auto' | 'left' | 'right';
-
 export interface DatePickerProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -37,12 +36,12 @@ export interface DatePickerProps
   date?: DatePickerDate;
 
   /**
-   * To set the pre-filled starting date. Is used if `range={true}` is set to true. Defaults to null, showing the `mask_placeholder`.
+   * To set the pre-filled starting date. Is used if `range={true}` is set to `true`. Defaults to `null`, showing the `mask_placeholder`.
    */
   start_date?: DatePickerStartDate;
 
   /**
-   * To set the pre-filled ending date. Is used if `range={true}` is set to true. Defaults to null, showing the `mask_placeholder`.
+   * To set the pre-filled ending date. Is used if `range={true}` is set to `true`. Defaults to `null`, showing the `mask_placeholder`.
    */
   end_date?: DatePickerEndDate;
 
@@ -62,12 +61,12 @@ export interface DatePickerProps
   end_month?: DatePickerEndMonth;
 
   /**
-   * To limit a date range to a minimum `start_date`. Defaults to null.
+   * To limit a date range to a minimum `start_date`. Defaults to `null`.
    */
   min_date?: DatePickerMinDate;
 
   /**
-   * To limit a date range to a maximum `end_date`. Defaults to null.
+   * To limit a date range to a maximum `end_date`. Defaults to `null`.
    */
   max_date?: DatePickerMaxDate;
   correct_invalid_date?: boolean;
@@ -159,7 +158,7 @@ export interface DatePickerProps
   range?: boolean;
 
   /**
-   * Link both calendars, once to the user is navigating between months. Only meant to use if the range is set to true. Defaults to `false`.
+   * Link both calendars, once to the user is navigating between months. Only meant to use if the range is set to `true`. Defaults to `false`.
    */
   link?: boolean;
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.d.ts
@@ -3,7 +3,6 @@ export type DatePickerAddonShortcuts = any[] | ((...args: any[]) => any);
 export type DatePickerAddonRenderElement =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface DatePickerAddonProps
   extends React.HTMLProps<HTMLElement> {
   /**

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface DatePickerCalendarProps
   extends React.HTMLProps<HTMLElement> {
   id?: string;

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface DatePickerFooterProps
   extends React.HTMLProps<HTMLElement> {
   isRange: boolean;

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.d.ts
@@ -6,7 +6,6 @@ import type {
 } from '../FormStatus';
 import type { InputInputElement, InputSize } from '../Input';
 import type { SkeletonShow } from '../Skeleton';
-
 export interface DatePickerInputProps
   extends React.HTMLProps<HTMLElement> {
   id?: string;

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { DatePickerProps } from './DatePicker';
-
 interface DatePickerProviderProps
   extends React.HTMLProps<HTMLElement>,
     DatePickerProps {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 export type DatePickerRangeViews = number | Record<string, unknown>[];
-
 export interface DatePickerRangeProps
   extends React.HTMLProps<HTMLElement> {
   id?: string;

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
@@ -13,7 +13,6 @@ import type { DrawerListProps } from '../../fragments/DrawerList';
 type DropdownTitle = string | React.ReactNode;
 type DropdownAlignDropdown = 'left' | 'right';
 type DropdownTriggerElement = ((...args: any[]) => any) | React.ReactNode;
-
 export interface DropdownProps
   extends DrawerListProps,
     SpacingProps,
@@ -98,7 +97,6 @@ export interface DropdownProps
    * If set to `true`, the Dropdown will be opened when the users enter the trigger button with a focus action.
    */
   open_on_focus?: boolean;
-
   disabled?: boolean;
 
   /**
@@ -116,6 +114,9 @@ export default class Dropdown extends React.Component<DropdownProps, any> {
   static HorizontalItem: ({
     children
   }: {
+    /**
+     * <em>(required)</em> the data we want to fill the list with. Provide the data as a `JSON string`, `array` or `object` in these <a href="/uilib/components/fragments/drawer-list/info#data-structure">data structure</a>. <br /> If you don&#39;t have to define a `value`, you can also send in a `function` which will be called once the user opens the DrawerList.
+     */
     children: React.ReactNode;
   }) => JSX.Element;
   render(): JSX.Element;

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
@@ -10,7 +10,6 @@ export type FormLabelChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface FormLabelProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -44,7 +43,7 @@ export interface FormLabelProps
   label_direction?: FormLabelLabelDirection;
 
   /**
-   * If set to `true`, will do the same as`label_direction` when set to "vertical".
+   * If set to `true`, will do the same as `label_direction` when set to "vertical".
    */
   vertical?: boolean;
   sr_only?: boolean;

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
@@ -9,7 +9,6 @@ export type FormRowChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface FormRowProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -68,12 +67,12 @@ export interface FormRowProps
   centered?: boolean;
 
   /**
-   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_style?: SectionStyleTypes;
 
   /**
-   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_spacing?: SectionSpacing;
   global_status_id?: string;

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
@@ -9,7 +9,6 @@ export type FormSetChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface FormSetProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -92,12 +91,12 @@ export interface FormSetProps
   centered?: boolean;
 
   /**
-   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_style?: SectionStyleTypes;
 
   /**
-   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_spacing?: SectionSpacing;
   global_status_id?: string;

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
@@ -21,7 +21,6 @@ export type FormStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface FormStatusProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -38,7 +37,7 @@ export interface FormStatusProps
   show?: boolean;
 
   /**
-   * The `text` appears as the status message. Beside plain text, You can send in a React component as well.
+   * The `text` appears as the status message. Beside plain text, you can send in a React component as well.
    */
   text?: FormStatusText;
   label?: React.ReactNode;
@@ -100,7 +99,7 @@ export interface FormStatusProps
   className?: string;
 
   /**
-   * The `text` appears as the status message. Beside plain text, You can send in a React component as well.
+   * The `text` appears as the status message. Beside plain text, you can send in a React component as well.
    */
   children?: FormStatusChildren;
 }
@@ -111,7 +110,6 @@ export default class FormStatus extends React.Component<
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export interface ErrorIconProps {
   /**
    * The `title` attribute in the status.
@@ -119,7 +117,6 @@ export interface ErrorIconProps {
   title?: string;
 }
 export const ErrorIcon: React.FC<ErrorIconProps>;
-
 export interface WarnIconProps {
   /**
    * The `title` attribute in the status.
@@ -127,7 +124,6 @@ export interface WarnIconProps {
   title?: string;
 }
 export const WarnIcon: React.FC<WarnIconProps>;
-
 export interface InfoIconProps {
   /**
    * The `title` attribute in the status.
@@ -135,7 +131,6 @@ export interface InfoIconProps {
   title?: string;
 }
 export const InfoIcon: React.FC<InfoIconProps>;
-
 export interface MarketingIconProps {
   /**
    * The `title` attribute in the status.

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.d.ts
@@ -8,7 +8,6 @@ export type GlobalErrorChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface GlobalErrorProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
@@ -15,7 +15,6 @@ export type GlobalStatusChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface GlobalStatusProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -135,48 +134,95 @@ export interface GlobalStatusProps
    */
   on_hide?: (...args: any[]) => any;
 }
-
 export type GlobalStatusStatusId = string;
-
 export type GlobalStatusAddProps = {
+  /**
+   * The main ID. Defaults to `main`.
+   */
   id: string;
   status_id: GlobalStatusStatusId;
+
+  /**
+   * The title appears as a part of the status content. Use `false` to hide / remove the title and icon. Defaults to `En feil har skjedd`.
+   */
   title?: string;
+
+  /**
+   * The text appears as the status content. Besides plain text, you can send in a React component as well. Defaults to `null`.
+   */
   text: string;
   item: string;
+
+  /**
+   * Gets triggered once the GlobalStatus disappears from the screen. Works only if `no_animation` is not `true`. Returns `{ id, status_id, ...properties }`.
+   */
   on_close: ({ status_id }: { status_id: GlobalStatusStatusId }) => void;
 };
-
 export type GlobalStatusUpdateProps = {
+  /**
+   * The main ID. Defaults to `main`.
+   */
   id: string;
+
+  /**
+   * The text appears as the status content. Besides plain text, you can send in a React component as well. Defaults to `null`.
+   */
   text: string;
 };
-
 export type GlobalStatusRemoveProps = {
+  /**
+   * The main ID. Defaults to `main`.
+   */
   id: string;
   status_id: GlobalStatusStatusId;
 };
-
 export type GlobalStatusInterceptorProps = {
+  /**
+   * The main ID. Defaults to `main`.
+   */
   id: string;
+
+  /**
+   * The title appears as a part of the status content. Use `false` to hide / remove the title and icon. Defaults to `En feil har skjedd`.
+   */
   title: string;
+
+  /**
+   * The text appears as the status content. Besides plain text, you can send in a React component as well. Defaults to `null`.
+   */
   text: string;
   status_id: GlobalStatusStatusId;
+
+  /**
+   * Set to `true` or `false` to manually make the global status visible. Defaults to `true`.
+   */
   show: boolean;
 };
-
 export type GlobalStatusInterceptorUpdateEvents = {
+  /**
+   * Gets triggered for the first time and for every new content update the GlobalStatus gets. Returns `{ id, status_id, ...properties }`.
+   */
   on_show?: () => void;
+
+  /**
+   * Gets triggered once the GlobalStatus is getting closed/hidden by the user. Returns `{ id, status_id, ...properties }`.
+   */
   on_hide?: () => void;
+
+  /**
+   * Gets triggered once the GlobalStatus disappears from the screen. Works only if `no_animation` is not `true`. Returns `{ id, status_id, ...properties }`.
+   */
   on_close?: () => void;
+
+  /**
+   * Set to `true` or `false` to manually make the global status visible. Defaults to `true`.
+   */
   show?: boolean;
 };
-
 export type GlobalStatusInterceptor = {
   update: (props: GlobalStatusInterceptorUpdateEvents) => void;
   remove: () => void;
 };
-
 export default class GlobalStatus extends React.Component<
   GlobalStatusProps,
   any

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface GlobalStatusControllerProps
   extends React.HTMLProps<HTMLElement> {
   /**
@@ -16,7 +15,6 @@ export default class GlobalStatusController extends React.Component<
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export interface GlobalStatusRemoveProps {
   /**
    * The main ID. Defaults to `main`.

--- a/packages/dnb-eufemia/src/components/heading/Heading.d.ts
+++ b/packages/dnb-eufemia/src/components/heading/Heading.d.ts
@@ -16,7 +16,6 @@ type HeadingDebug = boolean | ((...args: any[]) => any);
 type HeadingDebugCounter = boolean | ((...args: any[]) => any);
 type HeadingReset = number | boolean;
 type HeadingChildren = React.ReactNode | ((...args: any[]) => any);
-
 export interface HeadingProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -35,40 +34,40 @@ export interface HeadingProps
   level?: HeadingLevel;
 
   /**
-   * If set to true, the heading level will be incremented by 1.
+   * If set to `true`, the heading level will be incremented by 1.
    */
   increase?: boolean;
 
   /**
-   * If set to true, the heading level will be decremented by 1.
+   * If set to `true`, the heading level will be decremented by 1.
    */
   decrease?: boolean;
   up?: boolean;
   down?: boolean;
 
   /**
-   * If set to true, the heading will not be corrected and warnings will not be shown. Warnings do not show up in "production builds" else either.
+   * If set to `true`, the heading will not be corrected and warnings will not be shown. Warnings do not show up in "production builds" else either.
    */
   skip_correction?: boolean;
 
   /**
-   * If set to true, the content will have a prefix, showing the heading level.
+   * If set to `true`, the content will have a prefix, showing the heading level.
    */
   debug?: HeadingDebug;
 
   /**
-   * If set to true, the content will have both a prefix and a JSON log attached to both headings and level contexts.
+   * If set to `true`, the content will have both a prefix and a JSON log attached to both headings and level contexts.
    */
   debug_counter?: HeadingDebugCounter;
   counter?: any;
 
   /**
-   * If set to true, the heading last used level will be inherited. Also from inside a level context.
+   * If set to `true`, the heading last used level will be inherited. Also from inside a level context.
    */
   inherit?: boolean;
 
   /**
-   * If set to true, the heading level will be reset to 2. You can give it a custom level if you need to, e.g. `reset(1)`.
+   * If set to `true`, the heading level will be reset to 2. You can give it a custom level if you need to, e.g. `reset(1)`.
    */
   reset?: HeadingReset;
 
@@ -81,7 +80,6 @@ export interface HeadingProps
    * Define what HTML element should be used. If you use, e.g. a `span`, then `role="heading"` and `aria-level` gets set. Defaults to semantic heading element.
    */
   element?: string;
-
   class?: string;
   className?: string;
 
@@ -99,7 +97,6 @@ export default class Heading extends React.Component<HeadingProps, any> {
   static setNextLevel: setNextLevel;
   render(): JSX.Element;
 }
-
 export const setNextLevel = (
   level: HeadingLevel,
   { overwriteContext: boolean } = {}

--- a/packages/dnb-eufemia/src/components/heading/HeadingProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/heading/HeadingProvider.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { HeadingProps } from './Heading';
-
 export interface HeadingProviderProps
   extends React.HTMLProps<HTMLElement>,
     HeadingProps {}

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { IconProps } from '../Icon';
-
 export interface IconPrimaryProps
   extends IconProps,
     Omit<React.HTMLProps<HTMLElement>, 'size'> {}

--- a/packages/dnb-eufemia/src/components/icon/Icon.d.ts
+++ b/packages/dnb-eufemia/src/components/icon/Icon.d.ts
@@ -11,7 +11,6 @@ export type IconHeight = string | number;
 export type IconAttributes = string | Record<string, unknown>;
 export type IconChildren = React.ReactNode | ((...args: any[]) => any);
 export type IconColor = string;
-
 export interface IconProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -29,7 +28,6 @@ export interface IconProps
    * The dimension of the icon. This will be the `viewBox` and represent `width` and `height`. Defaults to `16`. You can use `small`,`medium`, `large` or `auto`. Auto will enable that the icon size gets inherited by the parent HTML element if it provides a `font-size`.
    */
   size?: IconSize;
-
   width?: IconWidth;
   height?: IconHeight;
 

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
@@ -46,7 +46,6 @@ export type InputMaskedSubmitButtonIcon =
 export type InputMaskedChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface InputMaskedProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -227,7 +226,7 @@ export interface InputMaskedProps
   keep_placeholder?: boolean;
 
   /**
-   * Text describing the content of the input more than the label. You can also send in a React component, so it gets wrapped inside the Input component.
+   * Text describing the content of the input more than the label. you can also send in a React component, so it gets wrapped inside the Input component.
    */
   suffix?: InputMaskedSuffix;
 
@@ -296,7 +295,6 @@ export interface InputMaskedProps
   submit_button_variant?: any;
   submit_button_icon?: InputMaskedSubmitButtonIcon;
   submit_button_status?: string;
-
   className?: string;
   children?: InputMaskedChildren;
   on_state_update?: (...args: any[]) => any;

--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.d.ts
@@ -11,7 +11,6 @@ export type TextMaskInputElement =
   | React.ReactNode
   | ((...args: any[]) => any);
 export type TextMaskValue = string | number;
-
 export interface TextMaskProps extends React.HTMLProps<HTMLElement> {
   mask: TextMaskMask;
   inputRef?: Record<string, unknown>;

--- a/packages/dnb-eufemia/src/components/input/Input.d.ts
+++ b/packages/dnb-eufemia/src/components/input/Input.d.ts
@@ -28,7 +28,6 @@ export type InputSubmitButtonIcon =
   | React.ReactNode
   | ((...args: any[]) => any);
 export type InputChildren = React.ReactNode | ((...args: any[]) => any);
-
 export interface InputProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -116,7 +115,7 @@ export interface InputProps
   keep_placeholder?: boolean;
 
   /**
-   * Text describing the content of the input more than the label. You can also send in a React component, so it gets wrapped inside the Input component.
+   * Text describing the content of the input more than the label. you can also send in a React component, so it gets wrapped inside the Input component.
    */
   suffix?: InputSuffix;
 
@@ -190,7 +189,6 @@ export interface InputProps
   submit_button_variant?: ButtonVariant;
   submit_button_icon?: InputSubmitButtonIcon;
   submit_button_status?: string;
-
   className?: string;
   children?: InputChildren;
 
@@ -199,6 +197,9 @@ export interface InputProps
    */
   on_change?: (...args: any[]) => any;
 
+  /**
+   * Will be called on key down by the user. Returns `{ value, event }`.
+   */
   on_key_down?: (...args: any[]) => any;
 
   /**
@@ -219,31 +220,59 @@ export interface InputProps
   on_submit_blur?: (...args: any[]) => any;
   on_state_update?: (...args: any[]) => any;
 }
-
 export default class Input extends React.Component<InputProps, any> {
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export interface SubmitButtonProps extends React.HTMLProps<HTMLElement> {
   id?: string;
+
+  /**
+   * The content value of the input.
+   */
   value?: string;
   title?: string;
   variant?: ButtonVariant;
   disabled?: boolean;
+
+  /**
+   * If set to `true`, an overlaying skeleton with animation will be shown.
+   */
   skeleton?: SkeletonShow;
+
+  /**
+   * Icon to show before or after the input / placeholder. Can be either a string defining a primary icon or a Component using an SVG icon of either 16px or 24px.
+   */
   icon?: IconIcon;
+
+  /**
+   * The icon size of the icon shows. Defaults to `medium`.
+   */
   icon_size?: IconSize;
+
+  /**
+   * Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.
+   */
   status?: FormStatusText;
+
+  /**
+   * Defines the state of the status. Currently, there are two statuses `[error, info]`. Defaults to `error`.
+   */
   status_state?: FormStatusState;
+
+  /**
+   * Use an object to define additional FormStatus properties.
+   */
   status_props?: FormStatusProps;
   className?: string;
 
+  /**
+   * Will be called on submit button click. Returns `{ value, event }`.
+   */
   on_submit?: (...args: any[]) => any;
   on_submit_focus?: (...args: any[]) => any;
   on_submit_blur?: (...args: any[]) => any;
 }
-
 export class SubmitButton extends React.Component<SubmitButtonProps, any> {
   static defaultProps: object;
   render(): JSX.Element;

--- a/packages/dnb-eufemia/src/components/input/InputPassword.d.ts
+++ b/packages/dnb-eufemia/src/components/input/InputPassword.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { InputProps } from './Input';
-
 export interface InputPasswordProps
   extends React.HTMLProps<HTMLElement>,
     InputProps {

--- a/packages/dnb-eufemia/src/components/logo/Logo.d.ts
+++ b/packages/dnb-eufemia/src/components/logo/Logo.d.ts
@@ -5,7 +5,6 @@ export type LogoSize = number | string;
 export type LogoRatio = number | string;
 export type LogoWidth = number | string;
 export type LogoHeight = number | string;
-
 export interface LogoProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.d.ts
@@ -23,7 +23,6 @@ export type NumberFormatTooltip =
 export type NumberFormatChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface NumberFormatProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -158,7 +157,6 @@ export interface NumberFormatProps
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow;
-
   class?: string;
   className?: string;
 

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
@@ -33,7 +33,6 @@ type PaginationIndicatorElement =
   | ((...args: any[]) => any)
   | string;
 type PaginationChildren = React.ReactNode | ((...args: any[]) => any);
-
 interface PaginationProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -41,164 +40,163 @@ interface PaginationProps
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
   startup_page?: PaginationStartupPage;
-
   /**
    * The page shown at the moment the component renders. Defaults to `1`.
    */
-  current_page?: PaginationCurrentPage;
 
+  current_page?: PaginationCurrentPage;
   /**
    * The total pages count. Defaults to `1`.
    */
-  page_count?: PaginationPageCount;
 
+  page_count?: PaginationPageCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown on the first render. Defaults to `1`.
    */
-  startup_count?: PaginationStartupCount;
 
+  startup_count?: PaginationStartupCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown once the user scrolls down. Defaults to `1`.
    */
-  parallel_load_count?: PaginationParallelLoadCount;
 
+  parallel_load_count?: PaginationParallelLoadCount;
   /**
    * If set to `true`, the infinity marker will be placed before the content (on top off). This could potentially have negative side effects. But it depends really on the content if this would make more sense to use instead. Defaults to `false`.
    */
-  place_maker_before_content?: boolean;
 
+  place_maker_before_content?: boolean;
   /**
    * The minimum time to wait, if the infinity scroll was invoked under that time threshold. This prevents not intentional infinity scroll loop calls. Defaults to `400` milliseconds.
    */
-  min_wait_time?: PaginationMinWaitTime;
 
+  min_wait_time?: PaginationMinWaitTime;
   /**
    * If set to `true`, all pagination bar buttons are disabled.
    */
-  disabled?: boolean;
 
+  disabled?: boolean;
   /**
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
-  skeleton?: SkeletonShow;
 
+  skeleton?: SkeletonShow;
   /**
    * If set to `infinity`, then the pagination bar will be now shown and but infinity scrolling will do the content presentation. For more information, check out the <a href="https://eufemia.dnb.no/uilib/components/pagination/infinity-scroller">Infinity Scroller</a>. Defaults to `pagination`.
    */
-  mode?: PaginationMode;
 
+  mode?: PaginationMode;
   /**
    * If set to `true` it will disable the automated infinity scrolling, but shows a load more button at the of the content instead.
    */
+
   use_load_button?: boolean;
   items?: PaginationItems;
-
   /**
    * If set to `true` no indicator will be shown.
    */
-  hide_progress_indicator?: boolean;
 
+  hide_progress_indicator?: boolean;
   /**
    * Callback function to get the `setContent` handler from the current pagination instance. e.g. `set_content_handler={fn => (...)}`. Use this handler to insert content during infinity mode.
    */
-  set_content_handler?: PaginationSetContentHandler;
 
+  set_content_handler?: PaginationSetContentHandler;
   /**
    * Callback function to get the `resetContent` handler from the current pagination instance. e.g. `reset_content_handler={fn => (...)}`. Use this handler to reset all the content. You can set it to `true`, to programmatically reset the content.
    */
-  reset_content_handler?: PaginationResetContentHandler;
 
+  reset_content_handler?: PaginationResetContentHandler;
   /**
    * Callback function to get the `resetInfinity` handler from the current pagination instance. e.g. `reset_pagination_handler={fn => (...)}`. Use this handler to reset all the internal states. You can set it to `true`, to programmatically reset the states.
    */
-  reset_pagination_handler?: PaginationResetPaginationHandler;
 
+  reset_pagination_handler?: PaginationResetPaginationHandler;
   /**
    * Callback function to get the `endInfinity` handler from the current pagination instance. e.g. `end_infinity_handler={fn => (...)}`. Use this handler to end the infinity scrolling procedure, in case the `page_count` is unknown.
    */
-  end_infinity_handler?: PaginationEndInfinityHandler;
 
+  end_infinity_handler?: PaginationEndInfinityHandler;
   /**
    * By default a `<div>` is used. Set it to any element you have to use. Adds also a class: `dnb-pagination__page` shown.
    */
-  page_element?: PaginationPageElement;
 
+  page_element?: PaginationPageElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>, <em>load more</em> bar as well as by the marker. Defaults to a `div`.
    */
-  fallback_element?: PaginationFallbackElement;
 
+  fallback_element?: PaginationFallbackElement;
   /**
    * (infinity mode) is used by the internal marker. Falls back to `fallback_element` if not defined.
    */
-  marker_element?: PaginationMarkerElement;
 
+  marker_element?: PaginationMarkerElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>. Falls back to `fallback_element` if not defined.
    */
-  indicator_element?: PaginationIndicatorElement;
 
+  indicator_element?: PaginationIndicatorElement;
   /**
    * Define the alignment of the pagination button bar. Can be `center`, `left` or `right`. Defaults to `left`.
    */
-  align?: string;
 
+  align?: string;
   /**
    * The title used in every button shown in the bar. Defaults to `Side %s`.
    */
-  button_title?: string;
 
+  button_title?: string;
   /**
    * The title used in the previous page button. Defaults to `Forrige side`.
    */
-  prev_title?: string;
 
+  prev_title?: string;
   /**
    * The title used in the next page button. Defaults to `Neste side`.
    */
-  next_title?: string;
 
+  next_title?: string;
   /**
    * The title used in the dots. Relevant for screen-readers. Defaults to `%s flere sider`.
    */
-  more_pages?: string;
 
+  more_pages?: string;
   /**
    * Shown until new content is inserted in to the page. Defaults to `Laster nytt innhold`.
    */
-  is_loading_text?: string;
 
+  is_loading_text?: string;
   /**
    * Used during infinity mode. If `use_load_button` is set to true, then a button is show on the bottom. If the `startup_page` is higher than 1. Defaults to `Vis mer innhold`.
    */
-  load_button_text?: string;
 
+  load_button_text?: string;
   class?: string;
   className?: string;
-
   /**
    * The given content can be either a function or a React node, depending on your needs. A function contains several helper functions. More details down below and have a look at the examples in the demos section.
    */
-  children?: PaginationChildren;
 
+  children?: PaginationChildren;
   /**
    * Will be called for every page change, regardless if the mode is `mode="infinity"` or not. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_change?: (...args: any[]) => any;
 
+  on_change?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once the component is ready for interaction. Returns an object with number of useful properties and methods. See below for more details. "NB:" Will be called again as soon as we reset the content by calling `resetContent()`.
    */
-  on_startup?: (...args: any[]) => any;
 
+  on_startup?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called on every page interaction, also on the very first interaction. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_load?: (...args: any[]) => any;
 
+  on_load?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once `page_count` is reached or `endInfinity` was called.
    */
+
   on_end?: (...args: any[]) => any;
 }
 export default class Pagination extends React.Component<
@@ -250,170 +248,168 @@ type PaginationInstanceIndicatorElement =
 type PaginationInstanceChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 interface PaginationInstanceProps extends SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
   startup_page?: PaginationInstanceStartupPage;
-
   /**
    * The page shown at the moment the component renders. Defaults to `1`.
    */
-  current_page?: PaginationInstanceCurrentPage;
 
+  current_page?: PaginationInstanceCurrentPage;
   /**
    * The total pages count. Defaults to `1`.
    */
-  page_count?: PaginationInstancePageCount;
 
+  page_count?: PaginationInstancePageCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown on the first render. Defaults to `1`.
    */
-  startup_count?: PaginationInstanceStartupCount;
 
+  startup_count?: PaginationInstanceStartupCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown once the user scrolls down. Defaults to `1`.
    */
-  parallel_load_count?: PaginationInstanceParallelLoadCount;
 
+  parallel_load_count?: PaginationInstanceParallelLoadCount;
   /**
    * If set to `true`, the infinity marker will be placed before the content (on top off). This could potentially have negative side effects. But it depends really on the content if this would make more sense to use instead. Defaults to `false`.
    */
-  place_maker_before_content?: boolean;
 
+  place_maker_before_content?: boolean;
   /**
    * The minimum time to wait, if the infinity scroll was invoked under that time threshold. This prevents not intentional infinity scroll loop calls. Defaults to `400` milliseconds.
    */
-  min_wait_time?: PaginationInstanceMinWaitTime;
 
+  min_wait_time?: PaginationInstanceMinWaitTime;
   /**
    * If set to `true`, all pagination bar buttons are disabled.
    */
-  disabled?: boolean;
 
+  disabled?: boolean;
   /**
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
-  skeleton?: SkeletonShow;
 
+  skeleton?: SkeletonShow;
   /**
    * If set to `infinity`, then the pagination bar will be now shown and but infinity scrolling will do the content presentation. For more information, check out the <a href="https://eufemia.dnb.no/uilib/components/pagination/infinity-scroller">Infinity Scroller</a>. Defaults to `pagination`.
    */
-  mode?: PaginationInstanceMode;
 
+  mode?: PaginationInstanceMode;
   /**
    * If set to `true` it will disable the automated infinity scrolling, but shows a load more button at the of the content instead.
    */
+
   use_load_button?: boolean;
   items?: PaginationInstanceItems;
-
   /**
    * If set to `true` no indicator will be shown.
    */
-  hide_progress_indicator?: boolean;
 
+  hide_progress_indicator?: boolean;
   /**
    * Callback function to get the `setContent` handler from the current pagination instance. e.g. `set_content_handler={fn => (...)}`. Use this handler to insert content during infinity mode.
    */
-  set_content_handler?: PaginationInstanceSetContentHandler;
 
+  set_content_handler?: PaginationInstanceSetContentHandler;
   /**
    * Callback function to get the `resetContent` handler from the current pagination instance. e.g. `reset_content_handler={fn => (...)}`. Use this handler to reset all the content. You can set it to `true`, to programmatically reset the content.
    */
-  reset_content_handler?: PaginationInstanceResetContentHandler;
 
+  reset_content_handler?: PaginationInstanceResetContentHandler;
   /**
    * Callback function to get the `resetInfinity` handler from the current pagination instance. e.g. `reset_pagination_handler={fn => (...)}`. Use this handler to reset all the internal states. You can set it to `true`, to programmatically reset the states.
    */
-  reset_pagination_handler?: PaginationInstanceResetPaginationHandler;
 
+  reset_pagination_handler?: PaginationInstanceResetPaginationHandler;
   /**
    * Callback function to get the `endInfinity` handler from the current pagination instance. e.g. `end_infinity_handler={fn => (...)}`. Use this handler to end the infinity scrolling procedure, in case the `page_count` is unknown.
    */
-  end_infinity_handler?: PaginationInstanceEndInfinityHandler;
 
+  end_infinity_handler?: PaginationInstanceEndInfinityHandler;
   /**
    * By default a `<div>` is used. Set it to any element you have to use. Adds also a class: `dnb-pagination__page` shown.
    */
-  page_element?: PaginationInstancePageElement;
 
+  page_element?: PaginationInstancePageElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>, <em>load more</em> bar as well as by the marker. Defaults to a `div`.
    */
-  fallback_element?: PaginationInstanceFallbackElement;
 
+  fallback_element?: PaginationInstanceFallbackElement;
   /**
    * (infinity mode) is used by the internal marker. Falls back to `fallback_element` if not defined.
    */
-  marker_element?: PaginationInstanceMarkerElement;
 
+  marker_element?: PaginationInstanceMarkerElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>. Falls back to `fallback_element` if not defined.
    */
-  indicator_element?: PaginationInstanceIndicatorElement;
 
+  indicator_element?: PaginationInstanceIndicatorElement;
   /**
    * Define the alignment of the pagination button bar. Can be `center`, `left` or `right`. Defaults to `left`.
    */
-  align?: string;
 
+  align?: string;
   /**
    * The title used in every button shown in the bar. Defaults to `Side %s`.
    */
-  button_title?: string;
 
+  button_title?: string;
   /**
    * The title used in the previous page button. Defaults to `Forrige side`.
    */
-  prev_title?: string;
 
+  prev_title?: string;
   /**
    * The title used in the next page button. Defaults to `Neste side`.
    */
-  next_title?: string;
 
+  next_title?: string;
   /**
    * The title used in the dots. Relevant for screen-readers. Defaults to `%s flere sider`.
    */
-  more_pages?: string;
 
+  more_pages?: string;
   /**
    * Shown until new content is inserted in to the page. Defaults to `Laster nytt innhold`.
    */
-  is_loading_text?: string;
 
+  is_loading_text?: string;
   /**
    * Used during infinity mode. If `use_load_button` is set to true, then a button is show on the bottom. If the `startup_page` is higher than 1. Defaults to `Vis mer innhold`.
    */
-  load_button_text?: string;
 
+  load_button_text?: string;
   class?: string;
   className?: string;
-
   /**
    * The given content can be either a function or a React node, depending on your needs. A function contains several helper functions. More details down below and have a look at the examples in the demos section.
    */
-  children?: PaginationInstanceChildren;
 
+  children?: PaginationInstanceChildren;
   /**
    * Will be called for every page change, regardless if the mode is `mode="infinity"` or not. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_change?: (...args: any[]) => any;
 
+  on_change?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once the component is ready for interaction. Returns an object with number of useful properties and methods. See below for more details. "NB:" Will be called again as soon as we reset the content by calling `resetContent()`.
    */
-  on_startup?: (...args: any[]) => any;
 
+  on_startup?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called on every page interaction, also on the very first interaction. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_load?: (...args: any[]) => any;
 
+  on_load?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once `page_count` is reached or `endInfinity` was called.
    */
+
   on_end?: (...args: any[]) => any;
 }
 
@@ -461,170 +457,168 @@ type InfinityMarkerIndicatorElement =
   | ((...args: any[]) => any)
   | string;
 type InfinityMarkerChildren = React.ReactNode | ((...args: any[]) => any);
-
 interface InfinityMarkerProps extends SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.
    */
   startup_page?: InfinityMarkerStartupPage;
-
   /**
    * The page shown at the moment the component renders. Defaults to `1`.
    */
-  current_page?: InfinityMarkerCurrentPage;
 
+  current_page?: InfinityMarkerCurrentPage;
   /**
    * The total pages count. Defaults to `1`.
    */
-  page_count?: InfinityMarkerPageCount;
 
+  page_count?: InfinityMarkerPageCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown on the first render. Defaults to `1`.
    */
-  startup_count?: InfinityMarkerStartupCount;
 
+  startup_count?: InfinityMarkerStartupCount;
   /**
    * Defines how many `infinity` pages should be loaded / shown once the user scrolls down. Defaults to `1`.
    */
-  parallel_load_count?: InfinityMarkerParallelLoadCount;
 
+  parallel_load_count?: InfinityMarkerParallelLoadCount;
   /**
    * If set to `true`, the infinity marker will be placed before the content (on top off). This could potentially have negative side effects. But it depends really on the content if this would make more sense to use instead. Defaults to `false`.
    */
-  place_maker_before_content?: boolean;
 
+  place_maker_before_content?: boolean;
   /**
    * The minimum time to wait, if the infinity scroll was invoked under that time threshold. This prevents not intentional infinity scroll loop calls. Defaults to `400` milliseconds.
    */
-  min_wait_time?: InfinityMarkerMinWaitTime;
 
+  min_wait_time?: InfinityMarkerMinWaitTime;
   /**
    * If set to `true`, all pagination bar buttons are disabled.
    */
-  disabled?: boolean;
 
+  disabled?: boolean;
   /**
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
-  skeleton?: SkeletonShow;
 
+  skeleton?: SkeletonShow;
   /**
    * If set to `infinity`, then the pagination bar will be now shown and but infinity scrolling will do the content presentation. For more information, check out the <a href="https://eufemia.dnb.no/uilib/components/pagination/infinity-scroller">Infinity Scroller</a>. Defaults to `pagination`.
    */
-  mode?: InfinityMarkerMode;
 
+  mode?: InfinityMarkerMode;
   /**
    * If set to `true` it will disable the automated infinity scrolling, but shows a load more button at the of the content instead.
    */
+
   use_load_button?: boolean;
   items?: InfinityMarkerItems;
-
   /**
    * If set to `true` no indicator will be shown.
    */
-  hide_progress_indicator?: boolean;
 
+  hide_progress_indicator?: boolean;
   /**
    * Callback function to get the `setContent` handler from the current pagination instance. e.g. `set_content_handler={fn => (...)}`. Use this handler to insert content during infinity mode.
    */
-  set_content_handler?: InfinityMarkerSetContentHandler;
 
+  set_content_handler?: InfinityMarkerSetContentHandler;
   /**
    * Callback function to get the `resetContent` handler from the current pagination instance. e.g. `reset_content_handler={fn => (...)}`. Use this handler to reset all the content. You can set it to `true`, to programmatically reset the content.
    */
-  reset_content_handler?: InfinityMarkerResetContentHandler;
 
+  reset_content_handler?: InfinityMarkerResetContentHandler;
   /**
    * Callback function to get the `resetInfinity` handler from the current pagination instance. e.g. `reset_pagination_handler={fn => (...)}`. Use this handler to reset all the internal states. You can set it to `true`, to programmatically reset the states.
    */
-  reset_pagination_handler?: InfinityMarkerResetPaginationHandler;
 
+  reset_pagination_handler?: InfinityMarkerResetPaginationHandler;
   /**
    * Callback function to get the `endInfinity` handler from the current pagination instance. e.g. `end_infinity_handler={fn => (...)}`. Use this handler to end the infinity scrolling procedure, in case the `page_count` is unknown.
    */
-  end_infinity_handler?: InfinityMarkerEndInfinityHandler;
 
+  end_infinity_handler?: InfinityMarkerEndInfinityHandler;
   /**
    * By default a `<div>` is used. Set it to any element you have to use. Adds also a class: `dnb-pagination__page` shown.
    */
-  page_element?: InfinityMarkerPageElement;
 
+  page_element?: InfinityMarkerPageElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>, <em>load more</em> bar as well as by the marker. Defaults to a `div`.
    */
-  fallback_element?: InfinityMarkerFallbackElement;
 
+  fallback_element?: InfinityMarkerFallbackElement;
   /**
    * (infinity mode) is used by the internal marker. Falls back to `fallback_element` if not defined.
    */
-  marker_element?: InfinityMarkerMarkerElement;
 
+  marker_element?: InfinityMarkerMarkerElement;
   /**
    * (infinity mode) is used by the <em>indicator</em>. Falls back to `fallback_element` if not defined.
    */
-  indicator_element?: InfinityMarkerIndicatorElement;
 
+  indicator_element?: InfinityMarkerIndicatorElement;
   /**
    * Define the alignment of the pagination button bar. Can be `center`, `left` or `right`. Defaults to `left`.
    */
-  align?: string;
 
+  align?: string;
   /**
    * The title used in every button shown in the bar. Defaults to `Side %s`.
    */
-  button_title?: string;
 
+  button_title?: string;
   /**
    * The title used in the previous page button. Defaults to `Forrige side`.
    */
-  prev_title?: string;
 
+  prev_title?: string;
   /**
    * The title used in the next page button. Defaults to `Neste side`.
    */
-  next_title?: string;
 
+  next_title?: string;
   /**
    * The title used in the dots. Relevant for screen-readers. Defaults to `%s flere sider`.
    */
-  more_pages?: string;
 
+  more_pages?: string;
   /**
    * Shown until new content is inserted in to the page. Defaults to `Laster nytt innhold`.
    */
-  is_loading_text?: string;
 
+  is_loading_text?: string;
   /**
    * Used during infinity mode. If `use_load_button` is set to true, then a button is show on the bottom. If the `startup_page` is higher than 1. Defaults to `Vis mer innhold`.
    */
-  load_button_text?: string;
 
+  load_button_text?: string;
   class?: string;
   className?: string;
-
   /**
    * The given content can be either a function or a React node, depending on your needs. A function contains several helper functions. More details down below and have a look at the examples in the demos section.
    */
-  children?: InfinityMarkerChildren;
 
+  children?: InfinityMarkerChildren;
   /**
    * Will be called for every page change, regardless if the mode is `mode="infinity"` or not. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_change?: (...args: any[]) => any;
 
+  on_change?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once the component is ready for interaction. Returns an object with number of useful properties and methods. See below for more details. "NB:" Will be called again as soon as we reset the content by calling `resetContent()`.
    */
-  on_startup?: (...args: any[]) => any;
 
+  on_startup?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called on every page interaction, also on the very first interaction. Returns an object with number of useful properties and methods. See below for more details.
    */
-  on_load?: (...args: any[]) => any;
 
+  on_load?: (...args: any[]) => any;
   /**
    * Only on "infinity" mode. Will be called once `page_count` is reached or `endInfinity` was called.
    */
+
   on_end?: (...args: any[]) => any;
 }
 export class InfinityMarker extends React.Component<
@@ -637,7 +631,6 @@ export class InfinityMarker extends React.Component<
 type PaginationContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 interface PaginationContentProps {
   /**
    * The given content can be either a function or a React node, depending on your needs. A function contains several helper functions. More details down below and have a look at the examples in the demos section.
@@ -645,7 +638,6 @@ interface PaginationContentProps {
   children: PaginationContentChildren;
 }
 declare const PaginationContent: React.FC<PaginationContentProps>;
-
 type CreatePaginationReturn = {
   Pagination: (props?: Record<string, unknown>) => JSX.Element;
   InfinityMarker: (props?: Record<string, unknown>) => void;
@@ -654,6 +646,5 @@ type CreatePaginationReturn = {
   resetInfinity: () => void;
   endInfinity: () => void;
 };
-
 export const createPagination = (initProps?: Record<string, unknown>) =>
   CreatePaginationReturn;

--- a/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.d.ts
@@ -4,7 +4,6 @@ export type PaginationIndicatorIndicatorElement =
   | React.ReactNode
   | ((...args: any[]) => any)
   | string;
-
 export interface PaginationIndicatorProps {
   /**
    * (infinity mode) is used by the <em>indicator</em>. Falls back to `fallback_element` if not defined.

--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 export type InfinityScrollerChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface InfinityScrollerProps
   extends React.HTMLProps<HTMLElement> {
   /**
@@ -25,7 +24,6 @@ export type InfinityLoadButtonPressedElement =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface InfinityLoadButtonProps {
   element?: InfinityLoadButtonElement;
   pressed_element?: InfinityLoadButtonPressedElement;

--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.d.ts
@@ -3,11 +3,9 @@ import type { PaginationProps } from './Pagination';
 type PaginationProviderStartupPage = string | number;
 type PaginationProviderCurrentPage = string | number;
 type PaginationProviderPageCount = string | number;
-
 interface PaginationProviderRerender {
   current?: (...args: any[]) => any;
 }
-
 interface PaginationProviderStore {
   current?: Record<string, unknown> | ((...args: any[]) => any);
 }
@@ -23,7 +21,6 @@ type PaginationProviderChildren =
   | React.ReactNode
   | Record<string, unknown>
   | any[];
-
 interface PaginationProviderProps
   extends PaginationProps,
     React.HTMLProps<HTMLElement> {
@@ -31,10 +28,10 @@ interface PaginationProviderProps
   store?: PaginationProviderStore;
   useMarkerOnly?: boolean;
   internalContent?: PaginationProviderInternalContent;
-
   /**
    * The given content can be either a function or a React node, depending on your needs. A function contains several helper functions. More details down below and have a look at the examples in the demos section.
    */
+
   children?: PaginationProviderChildren;
 }
 export default class PaginationProvider extends React.Component<

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.d.ts
@@ -12,12 +12,11 @@ export type ProgressIndicatorProgress = string | number;
 export type ProgressIndicatorChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface ProgressIndicatorProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
   /**
-   * Defines the visibility of the progress. Toggling the `visible` property to false will force a fade-out animation. Defaults to `true`.
+   * Defines the visibility of the progress. Toggling the `visible` property to `false` will force a fade-out animation. Defaults to `true`.
    */
   visible?: boolean;
 
@@ -27,7 +26,7 @@ export interface ProgressIndicatorProps
   type?: ProgressIndicatorType;
 
   /**
-   * Disables the fade-in and fade-out animation. Defaults to false.
+   * Disables the fade-in and fade-out animation. Defaults to `false`.
    */
   no_animation?: boolean;
 
@@ -58,12 +57,12 @@ export interface ProgressIndicatorProps
   indicator_label?: string;
 
   /**
-   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_style?: SectionStyleTypes;
 
   /**
-   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to null.
+   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
    */
   section_spacing?: SectionSpacing;
 
@@ -71,13 +70,12 @@ export interface ProgressIndicatorProps
    * Used to set title and aria-label. Defaults to the value of progress property, formatted as a percent.
    */
   title?: string;
-
   class?: string;
   className?: string;
   children?: ProgressIndicatorChildren;
 
   /**
-   * Will be called once the `min_time` has timed out.
+   * Will be called once it&#39;s no longer `visible`.
    */
   on_complete?: (...args: any[]) => any;
 }

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 export type ProgressIndicatorCircularProgress = string | number;
-
 export interface ProgressIndicatorCircularProps
   extends React.HTMLProps<HTMLElement> {
   /**
@@ -9,7 +8,7 @@ export interface ProgressIndicatorCircularProps
   size?: string;
 
   /**
-   * Defines the visibility of the progress. Toggling the `visible` property to false will force a fade-out animation. Defaults to `true`.
+   * Defines the visibility of the progress. Toggling the `visible` property to `false` will force a fade-out animation. Defaults to `true`.
    */
   visible?: boolean;
   complete?: boolean;

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.d.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 export type ProgressIndicatorLinearProgress = string | number;
-
 export interface ProgressIndicatorLinearProps
   extends React.HTMLProps<HTMLElement> {
   /**
@@ -9,7 +8,7 @@ export interface ProgressIndicatorLinearProps
   size?: string;
 
   /**
-   * Defines the visibility of the progress. Toggling the `visible` property to false will force a fade-out animation. Defaults to `true`.
+   * Defines the visibility of the progress. Toggling the `visible` property to `false` will force a fade-out animation. Defaults to `true`.
    */
   visible?: boolean;
   complete?: boolean;

--- a/packages/dnb-eufemia/src/components/radio/Radio.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/Radio.d.ts
@@ -19,7 +19,6 @@ export type RadioSuffix =
   | React.ReactNode;
 export type RadioAttributes = string | Record<string, unknown>;
 export type RadioChildren = string | ((...args: any[]) => any);
-
 export interface RadioProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
@@ -19,7 +19,6 @@ export type RadioGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface RadioGroupProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
@@ -9,7 +9,6 @@ export type SkeletonChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface SkeletonProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -42,7 +41,6 @@ export interface SkeletonProps
    * Set any HTML element type you have to use. A couple of aria attributes will be set on this element while active. Defaults to `div`
    */
   element?: React.ReactNode;
-
   class?: string;
   className?: string;
   children?: SkeletonChildren;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Article.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Article.d.ts
@@ -4,7 +4,6 @@ export type SkeletonArticleChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface SkeletonArticleProps
   extends React.HTMLProps<HTMLElement> {
   rows?: SkeletonArticleRows;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Circle.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Circle.d.ts
@@ -4,7 +4,6 @@ export type SkeletonCircleChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface SkeletonCircleProps extends React.HTMLProps<HTMLElement> {
   rows?: SkeletonCircleRows;
   children?: SkeletonCircleChildren;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Product.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Product.d.ts
@@ -4,7 +4,6 @@ export type SkeletonProductChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface SkeletonProductProps
   extends React.HTMLProps<HTMLElement> {
   rows?: SkeletonProductRows;

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Table.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Table.d.ts
@@ -4,7 +4,6 @@ export type SkeletonTableChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface SkeletonTableProps extends React.HTMLProps<HTMLElement> {
   rows?: SkeletonTableRows;
   children?: SkeletonTableChildren;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
@@ -22,7 +22,6 @@ export type StepIndicatorCurrentStep = string | number;
 export type StepIndicatorChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface StepIndicatorProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -65,11 +64,10 @@ export interface StepIndicatorProps
   on_item_render?: (...args: any[]) => any;
 
   /**
-   * If set to `true`, the height animation on the step items and the drawer button will be omitted. Defaults to false.
+   * If set to `true`, the height animation on the step items and the drawer button will be omitted. Defaults to `false`.
    */
   no_animation?: boolean;
   skeleton?: SkeletonShow;
-
   class?: string;
   className?: string;
   children?: StepIndicatorChildren;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface StepIndicatorProviderProps {
   /**
    * <em>(required)</em> a unique string-based ID in order to bind together the main component and the sidebar (`<StepIndicator.Sidebar />`). Both have to get the same ID.

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import type { FormStatusText } from '../FormStatus';
 export type StepIndicatorItemTitle = string | React.ReactNode;
 export type StepIndicatorItemStatusState = 'warn' | 'info' | 'error';
-
 export interface StepIndicatorItemProps
   extends React.HTMLProps<HTMLElement> {
   /**
@@ -46,7 +45,6 @@ export default class StepIndicatorItem extends React.Component<
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export interface StepItemButtonProps {
   children?: React.ReactNode;
   inner_ref?: Record<string, unknown>;
@@ -55,7 +53,6 @@ export interface StepItemButtonProps {
   status_state?: StepIndicatorStatusState;
 }
 export const StepItemButton: React.FC<StepItemButtonProps>;
-
 export interface StepItemWrapperProps {
   children?: React.ReactNode;
   number?: number;

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../../shared/types';
 import type { StepIndicatorProps } from './StepIndicator';
-
 export interface StepIndicatorSidebarProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface StepIndicatorTriggerButtonProps
   extends React.HTMLProps<HTMLElement> {
   /**

--- a/packages/dnb-eufemia/src/components/switch/Switch.d.ts
+++ b/packages/dnb-eufemia/src/components/switch/Switch.d.ts
@@ -14,7 +14,6 @@ export type SwitchSuffix =
   | React.ReactNode;
 export type SwitchAttributes = string | Record<string, unknown>;
 export type SwitchChildren = string | ((...args: any[]) => any);
-
 export interface SwitchProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -83,7 +82,6 @@ export interface SwitchProps
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow;
-
   class?: string;
   className?: string;
   children?: SwitchChildren;

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -27,7 +27,6 @@ export type TabsChildren =
   | Record<string, unknown>
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface TabsProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -108,7 +107,6 @@ export interface TabsProps
    */
   skeleton?: SkeletonShow;
   id?: string;
-
   class?: string;
   className?: string;
 
@@ -144,7 +142,6 @@ export default class Tabs extends React.Component<TabsProps, any> {
   static Content = CustomContent;
   render(): JSX.Element;
 }
-
 export interface DummyProps {
   /**
    * <em>(required)</em> the content to render. Can be a function, returning the current tab content `(key) => (&#39;Current tab&#39;)`, a React Component or an object with the keys and content `{key1: &#39;Current tab&#39;}`.

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.d.ts
@@ -4,7 +4,6 @@ export type ContentWrapperSelectedKey = string | number;
 export type ContentWrapperChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface ContentWrapperProps extends React.HTMLProps<HTMLElement> {
   id: string;
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.d.ts
@@ -7,7 +7,6 @@ export type CustomContentTitle =
 export type CustomContentChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface CustomContentProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
@@ -23,7 +23,6 @@ export type TextareaTextareaElement =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export type TextareaChildren = React.ReactNode | ((...args: any[]) => any);
-
 export interface TextareaProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -128,7 +127,6 @@ export interface TextareaProps
    * By providing a React.ref we can get the internally used Textarea element (DOM). E.g. `inner_ref={myRef}` by using `React.createRef()` or `React.useRef()`.
    */
   inner_ref?: TextareaInnerRef;
-
   className?: string;
   textarea_element?: TextareaTextareaElement;
   children?: TextareaChildren;

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -22,7 +22,6 @@ export type ToggleButtonValue =
   | any[];
 export type ToggleButtonAttributes = string | Record<string, unknown>;
 export type ToggleButtonChildren = string | ((...args: any[]) => any);
-
 export interface ToggleButtonProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -104,7 +103,6 @@ export interface ToggleButtonProps
   icon_size?: IconSize;
   attributes?: ToggleButtonAttributes;
   readOnly?: boolean;
-
   class?: string;
   className?: string;
   children?: ToggleButtonChildren;

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.d.ts
@@ -24,7 +24,6 @@ export type ToggleButtonGroupChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-
 export interface ToggleButtonGroupProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -90,7 +89,6 @@ export interface ToggleButtonGroupProps
    */
   values?: ToggleButtonGroupValues;
   attributes?: ToggleButtonGroupAttributes;
-
   class?: string;
   className?: string;
   children?: ToggleButtonGroupChildren;

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
@@ -5,7 +5,6 @@ import type { Locale } from '../../shared/Context';
 export type PaymentCardCardStatus = 'active' | 'blocked' | 'expired';
 export type PaymentCardVariant = 'normal' | 'compact';
 export type PaymentCardDigits = string | number;
-
 export interface PaymentCardRawData {
   productCode: string;
   productName: string;
@@ -14,12 +13,10 @@ export interface PaymentCardRawData {
   cardType: Record<string, unknown>;
   productType: Record<string, unknown>;
 }
-
 export type PaymentCardChildren =
   | string
   | React.ReactNode
   | ((...args: any[]) => any);
-
 export interface PaymentCardProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -63,7 +60,6 @@ export interface PaymentCardProps
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow;
-
   class?: string;
   className?: string;
   children?: PaymentCardChildren;
@@ -75,5 +71,4 @@ export default class PaymentCard extends React.Component<
   static defaultProps: object;
   render(): JSX.Element;
 }
-
 export const getCardData = (product_code: string) => PaymentCardRawData;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/BankAxept.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/BankAxept.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface BankAxeptSVGProps extends React.HTMLProps<HTMLElement> {
   /**
    * function fill() { [native code] }

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/Clock.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/Clock.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface ClockSVGProps extends React.HTMLProps<HTMLElement> {
   stroke?: string;
   width?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/DNB.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/DNB.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface DNBLogoSVGProps extends React.HTMLProps<HTMLElement> {
   /**
    * function fill() { [native code] }

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/DNBMetalic.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/DNBMetalic.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface DNBMetalicLogoSVGProps
   extends React.HTMLProps<HTMLElement> {
   /**

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardDefault.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardDefault.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface MastercardSVGProps extends React.HTMLProps<HTMLElement> {
   textFill?: string;
   width?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardMetalic.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardMetalic.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface MastercardSVGProps extends React.HTMLProps<HTMLElement> {
   width?: string;
   height?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardMetalicBlack.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/MastercardMetalicBlack.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface SVGProps extends React.HTMLProps<HTMLElement> {
   width?: string;
   height?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/PB.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/PB.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface PBSVGProps extends React.HTMLProps<HTMLElement> {
   /**
    * function fill() { [native code] }

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/PBPlatinum.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/PBPlatinum.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface PBPlatinumSVGProps extends React.HTMLProps<HTMLElement> {
   width?: string;
   height?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/Padlock.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/Padlock.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface SVGProps extends React.HTMLProps<HTMLElement> {
   stroke?: string;
   width?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/Pluss.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/Pluss.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface PlussProps extends React.HTMLProps<HTMLElement> {
   /**
    * function fill() { [native code] }

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaGold.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaGold.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface SagaGoldSVGProps extends React.HTMLProps<HTMLElement> {
   width?: string;
   height?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaPlatinum.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaPlatinum.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface SagaPlatinumSVGProps
   extends React.HTMLProps<HTMLElement> {
   width?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaVisaPlatinum.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/SagaVisaPlatinum.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface SagaVisaPlatinumSVGProps
   extends React.HTMLProps<HTMLElement> {
   width?: string;

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/VisaDefault.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/VisaDefault.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface VisaSVGProps extends React.HTMLProps<HTMLElement> {
   /**
    * function fill() { [native code] }

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/VisaMetalic.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/VisaMetalic.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface VisaMetalicSVGProps extends React.HTMLProps<HTMLElement> {
   width?: string;
   height?: string;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
@@ -41,7 +41,6 @@ export type DrawerListChildren =
   | Record<string, unknown>
   | any[];
 export type DrawerListSuffix = React.ReactNode;
-
 export interface DrawerListProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps {
@@ -98,18 +97,15 @@ export interface DrawerListProps
   on_select?: (...args: any[]) => any;
   on_state_update?: (...args: any[]) => any;
 }
-
 export type DrawerListOptionsProps = {
   children: React.ReactNode;
 };
-
 export type DrawerListItemProps = {
   children: React.ReactNode;
   selected: boolean;
   value: string;
   on_click: ({ value }: { value: string }) => void;
 };
-
 export default class DrawerList extends React.Component<
   DrawerListProps,
   any
@@ -122,7 +118,6 @@ export default class DrawerList extends React.Component<
 export type ItemContentChildren =
   | React.ReactNode
   | Record<string, unknown>;
-
 export interface ItemContentProps {
   hash?: string;
   children?: ItemContentChildren;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.d.ts
@@ -1,16 +1,13 @@
 import * as React from 'react';
-
 export interface DrawerListPortalInnerRef {
   current?: React.ReactNode | Record<string, unknown>;
 }
 export type DrawerListPortalCurrent =
   | React.ReactNode
   | Record<string, unknown>;
-
 export interface DrawerListPortalRootRef {
   current?: React.ReactNode | Record<string, unknown>;
 }
-
 export interface DrawerListPortalProps
   extends React.HTMLProps<HTMLElement> {
   id: string;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { SpacingProps } from '../../shared/types';
 import type { DrawerListProps } from './DrawerList';
-
 export interface DrawerListProviderProps
   extends React.HTMLProps<HTMLElement>,
     SpacingProps,

--- a/packages/dnb-eufemia/src/shared/AlignmentHelper.d.ts
+++ b/packages/dnb-eufemia/src/shared/AlignmentHelper.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 export interface AlignmentHelperProps
   extends React.HTMLProps<HTMLElement> {
   children?: React.ReactNode;


### PR DESCRIPTION
Check out the two first commits. 

The third one is simply after running: `yarn build` – sadly, we remove a good amount of newlines. But I have investigated this before and could not find any solution. 

Its because we convert the file to AST and back to code again. And sadly we then get it back without the extra newlines. Prettier does not put a newline back again.