### PR TITLE
chore(LiveEditor): remove indenting when tabbing

### DIFF
--- a/tools/react-live-ssr/index.js
+++ b/tools/react-live-ssr/index.js
@@ -565,9 +565,10 @@ var CodeEditor = function CodeEditor(props) {
   var onEditableChange = useCallback(function (_code) {
     setCode(_code.slice(0, -1))
   }, [])
+  const [indentation, setIndentation] = useState(undefined)
   useEditable(editorRef, onEditableChange, {
     disabled: props.disabled,
-    indentation: undefined,
+    indentation,
   })
   useEffect(
     function () {
@@ -615,6 +616,14 @@ var CodeEditor = function CodeEditor(props) {
             id: props.id,
             onFocus: props.onFocus,
             onBlur: props.onBlur,
+            onMouseDown: () => {
+              const focusMode =
+                document.documentElement.getAttribute('data-whatinput')
+              setIndentation(focusMode === 'mouse' ? 2 : undefined)
+            },
+            onBlurCapture: () => {
+              setIndentation(undefined)
+            },
           },
           tokens.map(function (line, lineIndex) {
             return (

--- a/tools/react-live-ssr/index.js
+++ b/tools/react-live-ssr/index.js
@@ -567,7 +567,7 @@ var CodeEditor = function CodeEditor(props) {
   }, [])
   useEditable(editorRef, onEditableChange, {
     disabled: props.disabled,
-    indentation: 2,
+    indentation: undefined,
   })
   useEffect(
     function () {


### PR DESCRIPTION
## Motivation

The motivation behind this change is that I find it difficult to navigate our demos and pages when tabbing.
A lot of times, I as a Eufemia developer, test tabbing and tab order of different components, and when tabbing between demos or back and forth, I get stuck in an "infinite loop" when encountering a LiveEditor where tabbing results in indentation, which I have to "click myself out of"(video from v9):

https://user-images.githubusercontent.com/1359205/232060030-cc4235d3-7196-4be5-81f7-2020b0cc8063.mov


## Details

This PR removes the indenting when tabbing, when the LiveEditor is in focus(video with changes suggested in this PR):

https://user-images.githubusercontent.com/1359205/232060287-d6e90609-2a7c-415e-ae1d-8db43dc0888e.mov




## Thoughts

I did consider removing tabbing to focus the LiveEditor(tabIndex="-1") as well, but I assume the proposed solution here is better in terms of accessibility, as it's still possible to focus the LiveEditor 🤔 

Maybe my view as a "Eufemia developer" is a bit different than "Eufemia consumers"(which perhaps rather would want the LiveEditor to indent when tabbing 🤔 )
