### PR TITLE
chore: some tiny docs/build improvements/fixes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/properties.mdx
@@ -2,11 +2,7 @@
 showTabs: true
 ---
 
-import DrawerListProperties from 'Docs/uilib/components/fragments/drawer-list/properties'
-
 ## Properties
-
-You may check out the [DrawerList Properties](#drawerlist-properties) down below as well as the [Data structure examples](#data-structure).
 
 | Properties                                  | Description                                                                                                                                                                                                                                                                                        |
 | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes.js
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes.js
@@ -23,6 +23,8 @@ import { babelPluginExtendTypes } from './generateTypes/babelPluginExtendTypes'
 import { babelPluginIncludeDocs } from './generateTypes/babelPluginIncludeDocs'
 import { babelPluginPropTypesRelations } from './generateTypes/babelPluginPropTypesRelations'
 
+const sharedProps = ['space', 'top', 'left', 'bottom', 'right']
+
 export default async function generateTypes({
   paths = [
     './src/*.js',
@@ -105,9 +107,11 @@ export const createTypes = async (
             if (doc) {
               Object.keys(doc).forEach((key) => {
                 if (collectProps.findIndex((k) => k === key) === -1) {
-                  log.fail(
-                    `The property "${key}" is not defined in PropTypes!\nComponent: ${componentName}\nFile: ${file}\n\n`
-                  )
+                  if (!sharedProps.includes(key)) {
+                    log.fail(
+                      `The property "${key}" is not defined in PropTypes!\nComponent: ${componentName}\nFile: ${file}\n\n`
+                    )
+                  }
                 }
               })
             }


### PR DESCRIPTION
- Omit warning about the missing properties during build.
- Remove unused import.