### PR TITLE
chore: avoid CLI logs where we get several of the same brands

### DIFF
--- a/packages/gatsby-plugin-eufemia-theme-handler/gatsby-node.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/gatsby-node.js
@@ -69,7 +69,9 @@ exports.onCreateWebpackConfig = (
         if (micromatch.isMatch(context, glob)) {
           const moduleName = context.match(/\/.*theme-([^/]*)$/)[1]
 
-          global.themeNames.push(moduleName)
+          if (!global.themeNames.includes(moduleName)) {
+            global.themeNames.push(moduleName)
+          }
 
           return moduleName
         }


### PR DESCRIPTION
Happens only during build.