### PR TITLE
chore: put sb properties inside a theme wrapper

### DIFF
--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -41,8 +41,8 @@ export const pageElement =
 
 export const rootElement =
   (type: string) =>
-  ({ element }) =>
-    (
+  ({ element }) => {
+    return (
       <CacheProvider
         value={type === 'ssr' ? createCacheInstance() : emotionCache}
       >
@@ -57,9 +57,27 @@ export const rootElement =
         </Provider>
       </CacheProvider>
     )
+  }
 
 function ThemeProvider({ children }) {
   const themeName = useThemeName()
+
+  // Deprecated (can be removed when we are full and 100% officially using Reavt v18)
+  // When using React v17,
+  // we need to ovecome a hydration issue.
+  // The JS app gets the correct themeName,
+  // but React does not change it in the HTML
+  React.useLayoutEffect(() => {
+    const element = document.querySelector('.eufemia-theme')
+    const htmlName = element?.getAttribute('data-name')
+
+    if (htmlName !== themeName) {
+      element.setAttribute('data-name', themeName)
+      element.classList.remove(`eufemia-theme__${htmlName}`)
+      element.classList.add(`eufemia-theme__${themeName}`)
+    }
+  }, [themeName])
+
   return <Theme name={themeName}>{children}</Theme>
 }
 

--- a/packages/dnb-design-system-portal/src/docs/brand/development.mdx
+++ b/packages/dnb-design-system-portal/src/docs/brand/development.mdx
@@ -1,5 +1,7 @@
 ---
-title: 'Development'
+title: 'Sbanken Development'
 ---
 
-# Development
+# Development with the Sbanken brand
+
+WIP

--- a/packages/dnb-design-system-portal/src/docs/brand/development/import-styles.mdx
+++ b/packages/dnb-design-system-portal/src/docs/brand/development/import-styles.mdx
@@ -4,3 +4,25 @@ level: 1
 ---
 
 # Import styles
+
+In order to apply the Sbanken styles, you need to both define;
+
+the CSS package:
+
+```diff
+import '@dnb/eufemia/style/core' // or /basis, when "dnb-core-style" is used
+- import '@dnb/eufemia/style/themes/ui'
++ import '@dnb/eufemia/style/themes/sbanken'
+```
+
+and the Theme:
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme name="sbanken">
+    <App />
+  </Theme>
+)
+```

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -26,21 +26,40 @@ export default function Theme(themeProps: ThemeAllProps) {
   const context = React.useContext(Context)
   const { children, element, ...theme } = themeProps
   const currentTheme = { ...context?.theme, ...theme }
+
+  return (
+    <Provider theme={currentTheme}>
+      <ThemeWrapper element={element} currentTheme={currentTheme}>
+        {children}
+      </ThemeWrapper>
+    </Provider>
+  )
+}
+
+function ThemeWrapper({ children, element, currentTheme }) {
   const { name, variant, size, ...rest } = currentTheme
 
   const Wrapper = element || 'div'
 
+  const ref = React.useRef<HTMLElement>(null)
+  rest['ref'] = ref
+
+  const className = classnames(
+    'eufemia-theme',
+    name && `eufemia-theme__${name}`,
+    name && variant && `eufemia-theme__${name}--${variant}`,
+    size && `eufemia-theme__size--${size}`
+  )
+
   return (
     <Wrapper
-      className={classnames(
-        'eufemia-theme',
-        name && `eufemia-theme__${name}`,
-        name && variant && `eufemia-theme__${name}--${variant}`,
-        size && `eufemia-theme__size--${size}`
-      )}
+      data-name={name}
+      data-variant={variant}
+      data-size={size}
+      className={className}
       {...(rest as Record<string, unknown>)}
     >
-      <Provider theme={currentTheme}>{children}</Provider>
+      {children}
     </Wrapper>
   )
 }

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -5,13 +5,17 @@
 
 @import './reset.scss';
 
-@mixin coreDefault() {
+@mixin typographyBasis() {
   font-family: var(--font-family-default);
   font-weight: var(--font-weight-basis);
   font-size: var(--font-size-small); // has to be 16px
   font-style: normal;
   line-height: var(--line-height-basis);
   color: var(--color-black-80, #333);
+}
+
+@mixin coreDefault() {
+  @include typographyBasis();
 
   // The new DNB font needs font smoothing to be thinner on webkit and FF
   /* stylelint-disable-next-line */
@@ -53,6 +57,10 @@
     color: black;
   }
 
+  .eufemia-theme {
+    @include typographyBasis();
+  }
+
   @content;
 }
 
@@ -69,8 +77,6 @@
         font: -apple-system-body; /* stylelint-disable-line */
       }
     }
-
-    // @include scrollbarAppearance();
   }
 
   // reset ePlatform css

--- a/packages/dnb-eufemia/src/style/themes/theme-sbanken/customisations.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-sbanken/customisations.scss
@@ -4,52 +4,26 @@
  */
 
 @mixin anchorDefaultStyleCustomisation() {
-  // WIP
+  // WIP – should be moved inside an Anchor theme
   color: var(--color-emerald-green);
 }
 
 @mixin anchorHoverStyleCustomisation() {
-  // WIP
+  // WIP – should be moved inside an Anchor theme
   color: var(--color-sea-green);
   background-color: transparent;
 }
 
 @mixin anchorActiveStyleCustomisation() {
-  // WIP
+  // WIP – should be moved inside an Anchor theme
   color: var(--color-sea-green);
   background-color: var(--color-pistachio);
 }
 
-// change some properties
-@mixin propertiesCustomisation() {
-  // WIP: for now we replace all usage of "--font-family-default"
-  --font-family-default: var(--sb-font-family-default);
-
-  // Sbanken has no medium weight, so we overwrite it with bold
-  --font-weight-medium: var(--sb-font-weight-bold);
-
-  // WIP: for now we replace all sizes
-  --font-size-x-small: var(--sb-font-size-x-small);
-  --font-size-small: var(--sb-font-size-small);
-  --font-size-basis: var(--sb-font-size-basis);
-  --font-size-basis--em: var(--sb-font-size-basis--em);
-  --font-size-lead: var(--sb-font-size-lead);
-  --font-size-large: var(--sb-font-size-large);
-  --font-size-x-large: var(--sb-font-size-x-large);
-  --font-size-xx-large: var(--sb-font-size-xx-large);
-
-  // WIP: for now we replace all heights
-  --line-height-x-small: var(--sb-line-height-x-small);
-  --line-height-small: var(--sb-line-height-small);
-  --line-height-basis: var(--sb-line-height-basis);
-  --line-height-basis--em: var(--sb-line-height-basis--em);
-  --line-height-lead: var(--sb-line-height-lead);
-  --line-height-medium: var(--sb-line-height-medium);
-  --line-height-large: var(--sb-line-height-large);
-  --line-height-x-large: var(--sb-line-height-x-large);
-}
-
 // change heading to use MaisonNeueHeadings
 @mixin headingDefaultsCustomisation() {
-  --font-family-default: var(--sb-font-family-headings);
+  // WIP – should "probably" be moved inside an typography theme
+  .eufemia-theme__sbanken & {
+    --font-family-default: var(--sb-font-family-headings);
+  }
 }

--- a/packages/dnb-eufemia/src/style/themes/theme-sbanken/sbanken-theme-basis.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-sbanken/sbanken-theme-basis.scss
@@ -3,15 +3,22 @@
  *
  */
 
-// import the default theme, and go from there
-// it will also have all the component themes included
-@import './customisations.scss'; // before "theme-ui"
+// WIP: Remove this import as soon as we have a mapping for all existing properties
+@import '../theme-ui/properties.scss';
 
-// WIP: We may remove this as soon as all Sbanken styles are ready
-@import '../theme-ui/ui-theme-basis.scss';
-
-@import './properties.scss';
+@import './customisations.scss'; // WIP: remove when styles are removed
 @import './fonts.scss';
+@import './properties.scss';
+@import './theme-mapping.scss'; // after "properties"
+
 @import './sbanken-theme-elements.scss';
 
-@import './theme-mapping.scss'; // after "properties"
+// ::selection appearance helper
+.dnb-selection::selection,
+.dnb-selection ::selection,
+[class^='dnb-']::selection,
+[class^='dnb-'] ::selection {
+  background-color: var(--sb-color-blue-light-2);
+  color: var(--sb-color-black);
+  text-shadow: none;
+}

--- a/packages/dnb-eufemia/src/style/themes/theme-sbanken/theme-mapping.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-sbanken/theme-mapping.scss
@@ -3,16 +3,35 @@
  *
  */
 
-:root {
+.eufemia-theme__sbanken {
+  // font-family
+  --font-family-default: var(--sb-font-family-default);
+
+  // font-weight
+  --font-weight-medium: var(--sb-font-weight-bold);
+
+  // font-size
+  --font-size-x-small: var(--sb-font-size-x-small);
+  --font-size-small: var(--sb-font-size-small);
+  --font-size-basis: var(--sb-font-size-basis);
+  // --font-size-basis: 20rem;
+  --font-size-basis--em: var(--sb-font-size-basis--em);
+  --font-size-lead: var(--sb-font-size-lead);
+  --font-size-large: var(--sb-font-size-large);
+  --font-size-x-large: var(--sb-font-size-x-large);
+  --font-size-xx-large: var(--sb-font-size-xx-large);
+
+  // line-height
+  --line-height-x-small: var(--sb-line-height-x-small);
+  --line-height-small: var(--sb-line-height-small);
+  --line-height-basis: var(--sb-line-height-basis);
+  --line-height-basis--em: var(--sb-line-height-basis--em);
+  --line-height-lead: var(--sb-line-height-lead);
+  --line-height-medium: var(--sb-line-height-medium);
+  --line-height-large: var(--sb-line-height-large);
+  --line-height-x-large: var(--sb-line-height-x-large);
+
+  // Form properties
   --focus-ring-width: 0.25rem;
   --focus-ring-color: var(--sb-color-blue-dark);
-}
-
-.eufemia-theme {
-  &__sbanken {
-    // WIP Example
-    &--blue {
-      --color-sea-green: blue;
-    }
-  }
 }

--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
@@ -27,6 +27,22 @@ export function useThemeName() {
     })
   }, [])
 
+  // Deprecated (can be removed when we are full and 100% officially using Reavt v18)
+  // When using React v17,
+  // we need to ovecome a hydration issue.
+  // The JS app gets the correct themeName,
+  // but React does not change it in the HTML
+  React.useEffect(() => {
+    const element = document.querySelector('.eufemia-theme')
+    const htmlName = element?.getAttribute('data-name')
+
+    if (htmlName !== themeName) {
+      element.setAttribute('data-name', themeName)
+      element.classList.remove(`eufemia-theme__${htmlName}`)
+      element.classList.add(`eufemia-theme__${themeName}`)
+    }
+  }, [themeName])
+
   return themeName
 }
 


### PR DESCRIPTION
The idea behind this is that it will make theming more flexible.

Right now we only make a wrapper for custom properties, and not for style properties (component themes).

In the file `themeHandler.js` we add a "fix" so the theme does switch properly (It works fine with React v18, but its more work to switch over to v18, as there are TypeScript issues related to Context popping up as well).

