### PR TITLE
chore: remove !isCi check from screenshot tests

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.screenshot.test.ts
@@ -11,8 +11,6 @@ import {
 describe('DatePicker', () => {
   setupPageScreenshot({ url: '/uilib/components/date-picker/demos' })
 
-  // skip the input fields, as there is a linux input issue
-
   it('have to match the input fields', async () => {
     const screenshot = await makeScreenshot({
       selector:

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.screenshot.test.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  isCI,
   makeScreenshot,
   setupPageScreenshot,
 } from '../../../core/jest/jestSetupScreenshots'
@@ -12,35 +11,33 @@ import {
 describe('DatePicker', () => {
   setupPageScreenshot({ url: '/uilib/components/date-picker/demos' })
 
-  if (!isCI) {
-    // skip the input fields, as there is a linux input issue
+  // skip the input fields, as there is a linux input issue
 
-    it('have to match the input fields', async () => {
-      const screenshot = await makeScreenshot({
-        selector:
-          '[data-visual-test="date-picker-input"] .dnb-date-picker__inner',
-      })
-      expect(screenshot).toMatchImageSnapshot()
+  it('have to match the input fields', async () => {
+    const screenshot = await makeScreenshot({
+      selector:
+        '[data-visual-test="date-picker-input"] .dnb-date-picker__inner',
     })
+    expect(screenshot).toMatchImageSnapshot()
+  })
 
-    it('have to match the date-picker with input in error state', async () => {
-      const screenshot = await makeScreenshot({
-        style: {
-          width: '400px', // make sure our input gets an explicit width, because of mac/linux rendering differences
-        },
-        selector:
-          '[data-visual-test="date-picker-input-error"] .dnb-date-picker__inner',
-      })
-      expect(screenshot).toMatchImageSnapshot()
+  it('have to match the date-picker with input in error state', async () => {
+    const screenshot = await makeScreenshot({
+      style: {
+        width: '400px', // make sure our input gets an explicit width, because of mac/linux rendering differences
+      },
+      selector:
+        '[data-visual-test="date-picker-input-error"] .dnb-date-picker__inner',
     })
+    expect(screenshot).toMatchImageSnapshot()
+  })
 
-    it('have to match the sizes', async () => {
-      const screenshot = await makeScreenshot({
-        selector: '[data-visual-test="date-picker-sizes"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
+  it('have to match the sizes', async () => {
+    const screenshot = await makeScreenshot({
+      selector: '[data-visual-test="date-picker-sizes"]',
     })
-  }
+    expect(screenshot).toMatchImageSnapshot()
+  })
 
   it('have to match the calendar', async () => {
     const screenshot = await makeScreenshot({

--- a/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.screenshot.test.ts
@@ -70,65 +70,63 @@ describe('FormRow', () => {
     expect(screenshot).toMatchImageSnapshot()
   })
 
-  if (!isCI) {
-    const wrapperStyle = {
-      overflow: 'hidden',
-    }
-
-    it('have to match "horizontal direction" with all components', async () => {
-      const screenshot = await makeScreenshot({
-        wrapperStyle,
-        selector: '[data-visual-test="form-row-all-horizontal-direction"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match "vertical direction" with all components', async () => {
-      const screenshot = await makeScreenshot({
-        wrapperStyle,
-        selector: '[data-visual-test="form-row-all-vertical-direction"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match "vertical everything" with all components', async () => {
-      const screenshot = await makeScreenshot({
-        wrapperStyle,
-        selector: '[data-visual-test="form-row-all-vertical-everything"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match "vertical label direction" with all components', async () => {
-      const screenshot = await makeScreenshot({
-        wrapperStyle,
-        selector:
-          '[data-visual-test="form-row-all-vertical-label-direction"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match "vertical label direction" (no label) with all components', async () => {
-      const screenshot = await makeScreenshot({
-        wrapperStyle,
-        selector:
-          '[data-visual-test="form-row-all-vertical-label-direction-no-label"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match centered form-row', async () => {
-      const screenshot = await makeScreenshot({
-        selector: '[data-visual-test="form-row-centered"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
-
-    it('have to match all stretch components', async () => {
-      const screenshot = await makeScreenshot({
-        selector: '[data-visual-test="form-row-all-stretch-components"]',
-      })
-      expect(screenshot).toMatchImageSnapshot()
-    })
+  const wrapperStyle = {
+    overflow: 'hidden',
   }
+
+  it('have to match "horizontal direction" with all components', async () => {
+    const screenshot = await makeScreenshot({
+      wrapperStyle,
+      selector: '[data-visual-test="form-row-all-horizontal-direction"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match "vertical direction" with all components', async () => {
+    const screenshot = await makeScreenshot({
+      wrapperStyle,
+      selector: '[data-visual-test="form-row-all-vertical-direction"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match "vertical everything" with all components', async () => {
+    const screenshot = await makeScreenshot({
+      wrapperStyle,
+      selector: '[data-visual-test="form-row-all-vertical-everything"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match "vertical label direction" with all components', async () => {
+    const screenshot = await makeScreenshot({
+      wrapperStyle,
+      selector:
+        '[data-visual-test="form-row-all-vertical-label-direction"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match "vertical label direction" (no label) with all components', async () => {
+    const screenshot = await makeScreenshot({
+      wrapperStyle,
+      selector:
+        '[data-visual-test="form-row-all-vertical-label-direction-no-label"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match centered form-row', async () => {
+    const screenshot = await makeScreenshot({
+      selector: '[data-visual-test="form-row-centered"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
+
+  it('have to match all stretch components', async () => {
+    const screenshot = await makeScreenshot({
+      selector: '[data-visual-test="form-row-all-stretch-components"]',
+    })
+    expect(screenshot).toMatchImageSnapshot()
+  })
 })

--- a/packages/dnb-eufemia/src/elements/anchor/__tests__/Anchor.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/elements/anchor/__tests__/Anchor.screenshot.test.ts
@@ -6,7 +6,6 @@
 import {
   makeScreenshot,
   setupPageScreenshot,
-  isCI,
 } from '../../../core/jest/jestSetupScreenshots'
 
 describe('Anchor', () => {
@@ -137,18 +136,16 @@ describe('Anchor target blank', () => {
     expect(screenshot).toMatchImageSnapshot()
   })
 
-  if (!isCI) {
-    it('have to match the target blank with tooltip', async () => {
-      const screenshot = await makeScreenshot({
-        style: {
-          'padding-top': '2rem',
-        },
-        waitBeforeSimulate: 200,
-        selector: '[data-visual-test="anchor-blank"]',
-        simulateSelector: '[data-visual-test="anchor-blank"] a.dnb-anchor',
-        simulate: 'hover',
-      })
-      expect(screenshot).toMatchImageSnapshot()
+  it('have to match the target blank with tooltip', async () => {
+    const screenshot = await makeScreenshot({
+      style: {
+        'padding-top': '2rem',
+      },
+      waitBeforeSimulate: 200,
+      selector: '[data-visual-test="anchor-blank"]',
+      simulateSelector: '[data-visual-test="anchor-blank"] a.dnb-anchor',
+      simulate: 'hover',
     })
-  }
+    expect(screenshot).toMatchImageSnapshot()
+  })
 })


### PR DESCRIPTION
## Summary

Remove !isCi check from screenshot tests, as the new testing setup with playwright and firefox may have invalidated the need for it.