### PR TITLE
chore(Portal): fix Algolia search

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -199,6 +199,7 @@ exports.onCreateWebpackConfig = ({ stage, actions, plugins }) => {
     },
     plugins: [
       plugins.define({
+        'process.env.isCI': JSON.stringify(isCI),
         'process.env.STYLE_THEME': JSON.stringify(getStyleTheme()),
         'process.env.CURRENT_BRANCH': JSON.stringify(currentBranch),
         'process.env.PREBUILD_EXISTS': JSON.stringify(prebuildExists),

--- a/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
+++ b/packages/dnb-design-system-portal/src/core/PortalStylesAndProviders.js
@@ -13,14 +13,13 @@ import { Provider, Context } from '@dnb/eufemia/src/shared'
 import enUS from '@dnb/eufemia/src/shared/locales/en-US'
 import stylisPlugin from '@dnb/eufemia/src/style/stylis'
 import { isTrue } from '@dnb/eufemia/src/shared/component-helper'
-import { isCI } from 'repo-utils'
 
 /**
  * Import Eufemia Styles
  * Use require because Webpack does not import styles after we change /src to /build
  */
 if (
-  isCI &&
+  process.env.isCI &&
   process.env.PREBUILD_EXISTS &&
   process.env.NODE_ENV === 'production'
 ) {

--- a/packages/dnb-design-system-portal/src/uilib/search/searchHelpers.js
+++ b/packages/dnb-design-system-portal/src/uilib/search/searchHelpers.js
@@ -1,12 +1,10 @@
-const { isCI } = require('repo-utils')
-
 // Finds current index name for the Algolia search
 const getIndexName = (currentBranch) => {
-  if (process.env.NODE_ENV !== 'production' || !isCI) {
+  if (process.env.NODE_ENV !== 'production' || !process.env.isCI) {
     return 'dev_eufemia_docs'
   }
 
-  if (currentBranch !== 'release') {
+  if (/^(alpha|beta|next)/.test(currentBranch)) {
     return 'beta_eufemia_docs'
   }
 
@@ -21,7 +19,7 @@ const runQueriesWhen = (currentBranch) => {
     return false
   }
 
-  if (isCI) {
+  if (process.env.isCI) {
     return /^(release|beta|portal)$/.test(currentBranch)
   }
 

--- a/tools/repo-utils/node-utils.js
+++ b/tools/repo-utils/node-utils.js
@@ -1,7 +1,8 @@
-const ciVendors = ['CI', 'GITHUB_ACTIONS', 'CODESANDBOX_SSE']
+const ciVendors = ['CI', 'CODESANDBOX_SSE']
 
 const isCI = ciVendors.some((name) => {
-  return String(process.env[name]) === 'true'
+  const ci = String(process.env[name])
+  return ci === 'true' || ci === '1'
 })
 
 exports.isCI = isCI


### PR DESCRIPTION
In prod vi target the "dev" index. This PR changes the target to be "prod".

The problem was that process.env.CI could not picket up in fornt-end code. We now use the define plugin from Webpack, to do so.

Closes #2253
