### PR TITLE
chore(Portal): add FilterByTheme as a global component

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/brand/development.mdx
+++ b/packages/dnb-design-system-portal/src/docs/brand/development.mdx
@@ -4,4 +4,18 @@ title: 'Sbanken Development'
 
 # Development with the Sbanken brand
 
-WIP
+## Write dedicated documentation
+
+If you need to show some documentation only for when the Sbanken theme is choose, you can do so:
+
+```md
+<FilterByTheme name="sbanken">
+
+## Sbanken examples
+
+Text
+
+<SpecialExample />
+
+</FilterByTheme>
+```

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/documentation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/documentation.mdx
@@ -6,4 +6,20 @@ status: 'wip'
 
 # Documentation
 
-Coming soon
+The documentation is written in enhanced Markdown, called MDX. It allows us to import other Markdown files along with React components and JavaScript logic.
+
+## Handling themes
+
+If you need to show some documentation only for when a certain theme is choose, you can do so:
+
+```md
+<FilterByTheme name="eiendom">
+
+## Eiendom examples
+
+Text
+
+<SpecialExample />
+
+</FilterByTheme>
+```

--- a/packages/dnb-design-system-portal/src/shared/tags/FilterByTheme.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/FilterByTheme.tsx
@@ -1,0 +1,11 @@
+import { useTheme } from '@dnb/eufemia/src/shared'
+
+export default function FilterByTheme({ children, name }) {
+  const themeName = useTheme()?.name
+
+  if (themeName === name) {
+    return children
+  }
+
+  return null
+}

--- a/packages/dnb-design-system-portal/src/shared/tags/index.js
+++ b/packages/dnb-design-system-portal/src/shared/tags/index.js
@@ -20,9 +20,11 @@ import Table from './Table'
 import Anchor from './Anchor'
 import Header from './AutoLinkHeader'
 import Copy from './Copy'
+import FilterByTheme from './FilterByTheme'
 
 export default {
   Copy,
+  FilterByTheme,
   // img: Img, // -> <figure> cannot appear as a descendant of <p>
   h1: (props) => <Header level="1" {...props} />,
   h2: (props) => <Header level="2" {...props} />,


### PR DESCRIPTION
With that, we can show demos/text based on the choose theme. So we can put e.g. this in a MDX file, without importing it:

```mdx

## Demos

<FilterByTheme name="sbanken">

## Sbanken related docs

Text and Demos

</FilterByTheme>

... more shared stuff

```

What component name would you else recommend? (instead of `FilterTheme`)