### PR TITLE
fix(Datepicker): reset and cancel button gap

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.js
@@ -138,6 +138,7 @@ export default class DatePickerFooter extends React.PureComponent {
               variant="tertiary"
               onClick={this.onResetHandler}
               data-testid="reset"
+              right="0.5rem"
             />
           )) || <span />}
 
@@ -149,6 +150,7 @@ export default class DatePickerFooter extends React.PureComponent {
               variant="tertiary"
               onClick={this.onCancelHandler}
               data-testid="cancel"
+              right="0.5rem"
             />
           )) || <span />}
         </span>


### PR DESCRIPTION
## Summary

A proposal to fix [this issue](https://github.com/dnbexperience/eufemia/issues/2268) where the old padding of 0.5rem applied by the `.dnb-button--icon-position-left ` has disappeared for whatever reason. 

Closes #2268

<img width="1455" alt="Screenshot 2023-05-03 at 14 08 43" src="https://user-images.githubusercontent.com/25927156/235912031-fcaf0eed-7cc4-4b51-9945-43a45255fe0e.png">

At the moment solved by adding a `right` prop to the buttons with a value of 0.5rem


<img width="1494" alt="Screenshot 2023-05-03 at 14 16 27" src="https://user-images.githubusercontent.com/25927156/235913179-db2199ba-ac91-4f5e-bab6-f7ed5d6e5161.png">
