### PR TITLE
docs(SkipContent): hide Events tab

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
@@ -3,6 +3,8 @@ title: 'SkipContent'
 description: 'SkipContent gives users – using their keyboard for navigation – the option to skip over content which contains a large amount of interactive elements.'
 status: 'new'
 showTabs: true
+hideTabs:
+  - title: Events
 ---
 
 import SkipContentInfo from 'Docs/uilib/components/skip-content/info'


### PR DESCRIPTION
Hiding the "Events" tab, as it doesn't exist/have any content.