### PR TITLE
chore: disable diff limit on postbuild test

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/cliTools.js
+++ b/packages/dnb-eufemia/scripts/tools/cliTools.js
@@ -26,7 +26,11 @@ function runCommand(command) {
  * @returns {array} List of files
  */
 const getCommittedFiles = async () => {
-  const files = (await runCommand('git diff HEAD^ --name-only'))
+  const files = (
+    await runCommand(
+      'git config diff.renames 0 && git diff HEAD^ --name-only'
+    )
+  )
     .split('\n')
     .filter(Boolean)
 


### PR DESCRIPTION
During the release of a beta, we get a [git error](https://github.com/dnbexperience/eufemia/actions/runs/4892791322/jobs/8734965454) on the postbuild step. This PR disables the limit. That results that the test takes about a minute locally. But we don't run this locally normally, and it only happens now that we have so many file changes from the v10 branch.

<img width="736" alt="Screenshot 2023-05-05 at 13 45 59" src="https://user-images.githubusercontent.com/1501870/236449511-aa8bb559-9c75-4182-9355-fe2993fd7545.png">

