### PR TITLE
feat(Anchor): add `scrollToHash` feature

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
@@ -11,6 +11,7 @@ showTabs: true
 | `to`                                        | _(optional)_ use this prop only if you are using a router Link component as the `element` that uses the `to` property to declare the navigation url. |
 | `target`                                    | _(optional)_ defines the opening method. Use `_blank` to open a new browser window/tab.                                                              |
 | `targetBlankTitle`                          | _(optional)_ the title shown as a tooltip when target is set to `_blank`.                                                                            |
+| `scrollToHash`                              | _(optional)_ When set to true, a click will attempt to use `window.scroll` to support the missing Chromium support.                                  |
 | `tooltip`                                   | _(optional)_ Provide a string or a React Element to be shown as the tooltip content.                                                                 |
 | `skeleton`                                  | _(optional)_ if set to `true`, an overlaying skeleton with animation will be shown.                                                                  |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                |

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
@@ -11,7 +11,6 @@ showTabs: true
 | `to`                                        | _(optional)_ use this prop only if you are using a router Link component as the `element` that uses the `to` property to declare the navigation url. |
 | `target`                                    | _(optional)_ defines the opening method. Use `_blank` to open a new browser window/tab.                                                              |
 | `targetBlankTitle`                          | _(optional)_ the title shown as a tooltip when target is set to `_blank`.                                                                            |
-| `scrollToHash`                              | _(optional)_ When set to true, a click will attempt to use `window.scroll` to support the missing Chromium support.                                  |
 | `tooltip`                                   | _(optional)_ Provide a string or a React Element to be shown as the tooltip content.                                                                 |
 | `skeleton`                                  | _(optional)_ if set to `true`, an overlaying skeleton with animation will be shown.                                                                  |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                |
@@ -27,5 +26,25 @@ render(
   <Anchor to="/url" element={Link}>
     Link
   </Anchor>
+)
+```
+
+### Anchor hash
+
+Some browser like Chrome (behind a flag) does still not support animated anchor hash clicks when CSS `scroll-behavior: smooth;` is set. To make it work, you can provide the `scrollToHashHandler` helper function to the Anchor:
+
+```jsx
+import Anchor, {
+  scrollToHashHandler,
+} from '@dnb/eufemia/components/Anchor'
+
+render(
+  <>
+    <Anchor href="/path#hash-id" onClick={scrollToHashHandler}>
+      {children}
+    </Anchor>
+
+    <div id="hash-id">element to scroll to</div>
+  </>
 )
 ```

--- a/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react'
 import { Link } from '@dnb/eufemia/src'
+import { scrollToHashHandler } from '@dnb/eufemia/src/components/Anchor'
 
 const Anchor = ({ children, href, ...rest }) => {
   if (/^http/.test(href) || href[0] === '!') {
@@ -16,7 +17,7 @@ const Anchor = ({ children, href, ...rest }) => {
   }
 
   return (
-    <Link lang="en-GB" href={href} {...rest} scrollToHash>
+    <Link lang="en-GB" href={href} {...rest} onClick={scrollToHashHandler}>
       {children}
     </Link>
   )

--- a/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
@@ -3,9 +3,8 @@
  *
  */
 
-import React, { MouseEvent } from 'react'
+import React from 'react'
 import { Link } from '@dnb/eufemia/src'
-import { getOffsetTop } from '@dnb/eufemia/src/shared/helpers'
 
 const Anchor = ({ children, href, ...rest }) => {
   if (/^http/.test(href) || href[0] === '!') {
@@ -17,34 +16,10 @@ const Anchor = ({ children, href, ...rest }) => {
   }
 
   return (
-    <Link lang="en-GB" href={href} {...rest} onClick={clickHandler}>
+    <Link lang="en-GB" href={href} {...rest} scrollToHash>
       {children}
     </Link>
   )
-
-  function clickHandler(e: MouseEvent) {
-    /**
-     * What happens here?
-     * When `scroll-behavior: smooth;` in CSS is set,
-     * Blink/Chromium wants the user to click two times in order to actually scroll to the anchor hash.
-     * The first click, sets the hash, the second one, srollts to it.
-     * We want Chromium browsers to scorll to the element on the first click.
-     */
-    const id = e.currentTarget
-      .getAttribute('href')
-      .split(/#/g)
-      .reverse()[0]
-    const anchorElem = document.getElementById(id)
-    if (anchorElem instanceof HTMLElement) {
-      e.preventDefault()
-
-      const scrollPadding = parseFloat(
-        window.getComputedStyle(document.documentElement).scrollPaddingTop
-      )
-      const top = getOffsetTop(anchorElem) - scrollPadding
-      window.scroll({ top })
-    }
-  }
 }
 
 export default Anchor

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -11,6 +11,7 @@ import {
   makeUniqueId,
   extendPropsWithContext,
 } from '../../shared/component-helper'
+import { getOffsetTop } from '../../shared/helpers'
 import Tooltip from '../tooltip/Tooltip'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import type { SpacingProps } from '../../shared/types'
@@ -25,6 +26,13 @@ export type AnchorProps = {
   skeleton?: SkeletonShow
   omitClass?: boolean
   innerRef?: React.RefObject<HTMLAnchorElement>
+
+  /**
+   * When set to true,
+   * and there is a hash with an existing and matching id,
+   * it uses window.scroll to support the missing scroll feature in Chromium browsers.
+   */
+  scrollToHash?: boolean
 
   /** @deprecated use innerRef instead */
   inner_ref?: React.RefObject<HTMLAnchorElement>
@@ -65,6 +73,7 @@ export function AnchorInstance(localProps: AnchorAllProps) {
     omitClass,
     innerRef,
     targetBlankTitle,
+    scrollToHash,
     ...rest
   } = allProps
 
@@ -94,6 +103,13 @@ export function AnchorInstance(localProps: AnchorAllProps) {
             'dnb-anchor--no-icon'
         )}
         {...attributes}
+        onClick={(e) => {
+          attributes?.['onClick']?.(e)
+
+          if (scrollToHash) {
+            scrollToHashHandler(e)
+          }
+        }}
         innerRef={innerRef}
       >
         {children}
@@ -111,6 +127,50 @@ export function AnchorInstance(localProps: AnchorAllProps) {
       )}
     </>
   )
+
+  function scrollToHashHandler(
+    e: React.MouseEvent<HTMLElement, MouseEvent>
+  ) {
+    const element = e.currentTarget as HTMLAnchorElement
+    const href = element.getAttribute('href')
+    if (!href.includes('#') || typeof document === 'undefined') {
+      return // stop here
+    }
+
+    /**
+     * What happens here?
+     * When `scroll-behavior: smooth;` in CSS is set,
+     * Blink/Chromium wants the user to click two times in order to actually scroll to the anchor hash.
+     * The first click, sets the hash, the second one, srollts to it.
+     * We want Chromium browsers to scorll to the element on the first click.
+     */
+    const samePath =
+      href.startsWith('#') ||
+      window.location.href.includes(removeEndingSlash(element.pathname))
+
+    // Only continue, when we are sure we are on the same page,
+    // because, the same ID may exists occasionally on the current page.
+    if (samePath) {
+      const id = href.split(/#/g).reverse()[0]
+      const anchorElem = document.getElementById(id)
+
+      if (anchorElem instanceof HTMLElement) {
+        e.preventDefault()
+
+        const scrollPadding = parseFloat(
+          window.getComputedStyle(document.documentElement)
+            .scrollPaddingTop
+        )
+        const top = getOffsetTop(anchorElem) - scrollPadding || 0
+
+        window.scroll({ top })
+      }
+    }
+  }
+}
+
+const removeEndingSlash = (url: string) => {
+  return url.replace(/\/$/, '')
 }
 
 const Anchor = React.forwardRef(

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
@@ -5,14 +5,13 @@
 
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import Anchor from '../Anchor'
+import Anchor, { scrollToHashHandler } from '../Anchor'
 
-describe('Anchor with scrollToHash', () => {
+describe('Anchor with scrollToHashHandler', () => {
   let location: Location
 
   beforeEach(() => {
     location = window.location
-    // jest.spyOn(window, 'location', 'get').mockRestore()
   })
 
   it('should call window.scroll', () => {
@@ -26,7 +25,7 @@ describe('Anchor with scrollToHash', () => {
 
     render(
       <>
-        <Anchor scrollToHash href="/path/#hash-id">
+        <Anchor onClick={scrollToHashHandler} href="/path/#hash-id">
           text
         </Anchor>
         <span id="hash-id" />
@@ -51,7 +50,10 @@ describe('Anchor with scrollToHash', () => {
 
     render(
       <>
-        <Anchor scrollToHash href="/path/#first-hash#hash-id">
+        <Anchor
+          onClick={scrollToHashHandler}
+          href="/path/#first-hash#hash-id"
+        >
           text
         </Anchor>
         <span id="hash-id" />
@@ -76,7 +78,7 @@ describe('Anchor with scrollToHash', () => {
 
     render(
       <>
-        <Anchor scrollToHash href="/path/#hash-id">
+        <Anchor onClick={scrollToHashHandler} href="/path/#hash-id">
           text
         </Anchor>
         <span id="other-id" />
@@ -99,7 +101,7 @@ describe('Anchor with scrollToHash', () => {
     })
 
     render(
-      <Anchor scrollToHash href="/path">
+      <Anchor onClick={scrollToHashHandler} href="/path">
         text
       </Anchor>
     )
@@ -121,7 +123,7 @@ describe('Anchor with scrollToHash', () => {
 
     render(
       <>
-        <Anchor scrollToHash href="/other-path/#hash-id">
+        <Anchor onClick={scrollToHashHandler} href="/other-path/#hash-id">
           text
         </Anchor>
         <span id="hash-id" />

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Element Test
+ *
+ */
+
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import Anchor from '../Anchor'
+
+describe('Anchor with scrollToHash', () => {
+  let location: Location
+
+  beforeEach(() => {
+    location = window.location
+    // jest.spyOn(window, 'location', 'get').mockRestore()
+  })
+
+  it('should call window.scroll', () => {
+    const onScoll = jest.fn()
+
+    jest.spyOn(window, 'scroll').mockImplementationOnce(onScoll)
+    jest.spyOn(window, 'location', 'get').mockReturnValueOnce({
+      ...location,
+      href: 'http://localhost/path',
+    })
+
+    render(
+      <>
+        <Anchor scrollToHash href="/path/#hash-id">
+          text
+        </Anchor>
+        <span id="hash-id" />
+      </>
+    )
+
+    const element = document.querySelector('a')
+    fireEvent.click(element)
+
+    expect(onScoll).toHaveBeenCalledTimes(1)
+    expect(onScoll).toHaveBeenCalledWith({ top: 0 })
+  })
+
+  it('should use last hash', () => {
+    const onScoll = jest.fn()
+
+    jest.spyOn(window, 'scroll').mockImplementationOnce(onScoll)
+    jest.spyOn(window, 'location', 'get').mockReturnValueOnce({
+      ...location,
+      href: 'http://localhost/path',
+    })
+
+    render(
+      <>
+        <Anchor scrollToHash href="/path/#first-hash#hash-id">
+          text
+        </Anchor>
+        <span id="hash-id" />
+      </>
+    )
+
+    const element = document.querySelector('a')
+    fireEvent.click(element)
+
+    expect(onScoll).toHaveBeenCalledTimes(1)
+    expect(onScoll).toHaveBeenCalledWith({ top: 0 })
+  })
+
+  it('should not call window.scroll when no hash-id found', () => {
+    const onScoll = jest.fn()
+
+    jest.spyOn(window, 'scroll').mockImplementationOnce(onScoll)
+    jest.spyOn(window, 'location', 'get').mockReturnValueOnce({
+      ...location,
+      href: 'http://localhost/path',
+    })
+
+    render(
+      <>
+        <Anchor scrollToHash href="/path/#hash-id">
+          text
+        </Anchor>
+        <span id="other-id" />
+      </>
+    )
+
+    const element = document.querySelector('a')
+    fireEvent.click(element)
+
+    expect(onScoll).toHaveBeenCalledTimes(0)
+  })
+
+  it('will skip when no # exists in href', () => {
+    const onScoll = jest.fn()
+
+    jest.spyOn(window, 'scroll').mockImplementationOnce(onScoll)
+    jest.spyOn(window, 'location', 'get').mockReturnValueOnce({
+      ...location,
+      href: 'http://localhost/path',
+    })
+
+    render(
+      <Anchor scrollToHash href="/path">
+        text
+      </Anchor>
+    )
+
+    const element = document.querySelector('a')
+    fireEvent.click(element)
+
+    expect(onScoll).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not call window.scroll when not on same page', () => {
+    const onScoll = jest.fn()
+
+    jest.spyOn(window, 'scroll').mockImplementationOnce(onScoll)
+    jest.spyOn(window, 'location', 'get').mockReturnValueOnce({
+      ...location,
+      href: 'http://localhost/path',
+    })
+
+    render(
+      <>
+        <Anchor scrollToHash href="/other-path/#hash-id">
+          text
+        </Anchor>
+        <span id="hash-id" />
+      </>
+    )
+
+    const element = document.querySelector('a')
+    fireEvent.click(element)
+
+    expect(onScoll).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
This PR/RFC is regarding Anchor animated scrolling.

Chromium/Blink based browser to not support smooth scrolling by default. And on macOS/iOS it's not supported at all.

<img width="791" alt="Screenshot 2023-05-08 at 14 37 56" src="https://user-images.githubusercontent.com/1501870/236826840-89e04bc1-3df2-40a1-82e8-4495a194c25e.png">


The Eufemia Portal did have code that makes it possible to get this feature. Its a relative small fix. And most of the code has existed as a Portal anchor link for several years already. 

The question is, should we get this in to the Anchor component? I guess yes. But then, how?

**Opt-in**

But this feature may be interesting for projects as well. But we may debate if it should not be available via a prop, be imported and spread to all anchors via a context.

**Opt-out**

On the other hand, it may be interesting to have this as an opt-out feature, as it solves and issue most are not aware of.


Closes #2286
