### PR TITLE
feat(Dialog): adds ReactNode as type for texts

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -17,12 +17,12 @@ export type DialogActionProps = {
   /**
    * For dialog actions, give a custom text for the decline button.
    */
-  declineText?: string
+  declineText?: string | React.ReactNode
 
   /**
    * For dialog actions, give a custom text for the confirm button.
    */
-  confirmText?: string
+  confirmText?: string | React.ReactNode
 
   /**
    * For variant confirmation, handle the confirm action click.


### PR DESCRIPTION
Reason for adding `React.ReactNode` as a type is because a lot of applications sends in a [<FormattedMessage/>](https://formatjs.io/docs/react-intl/components/#formattedmessage) as a text/translation:

![image](https://user-images.githubusercontent.com/1359205/236764111-dcc47763-dea5-43df-8211-2074cc8c6801.png)
