### PR TITLE
chore(DatePicker): fix datepicker shortcut buttons spacing

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -9,6 +9,8 @@ import styled from '@emotion/styled'
 import addDays from 'date-fns/addDays'
 import startOfMonth from 'date-fns/startOfMonth'
 import lastDayOfMonth from 'date-fns/lastDayOfMonth'
+import startOfWeek from 'date-fns/startOfWeek'
+import lastDayOfWeek from 'date-fns/lastDayOfWeek'
 import isWeekend from 'date-fns/isWeekend'
 import { DatePicker, FormRow, HelpButton } from '@dnb/eufemia/src'
 
@@ -25,7 +27,15 @@ const Wrapper = styled.div`
 
 export const DatePickerRange = () =>
   globalThis.IS_TEST ? null : (
-    <ComponentBox scope={{ addDays, startOfMonth, lastDayOfMonth }}>
+    <ComponentBox
+      scope={{
+        addDays,
+        startOfMonth,
+        lastDayOfMonth,
+        startOfWeek,
+        lastDayOfWeek,
+      }}
+    >
       <DatePicker
         label="DatePicker:"
         start_date="2019-04-01"
@@ -46,6 +56,15 @@ export const DatePickerRange = () =>
             title: 'Set date period',
             start_date: '1969-07-15',
             end_date: '1969-08-15',
+          },
+          {
+            title: 'Today',
+            start_date: new Date(),
+          },
+          {
+            title: 'This week',
+            start_date: startOfWeek(new Date()),
+            end_date: lastDayOfWeek(new Date()),
           },
           {
             close_on_select: true,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.js
@@ -98,7 +98,6 @@ export default class DatePickerAddon extends React.PureComponent {
               text={title}
               variant="secondary"
               onClick={(event) => this.setDate({ shortcut, event })}
-              right
             />
           )
         })}

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -5370,7 +5370,10 @@ html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-
   height: 1px;
 }
 .dnb-date-picker__addon {
-  display: block;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  gap: 1rem;
   padding: 1rem;
 }
 .dnb-date-picker__addon::after {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -270,8 +270,12 @@
   }
 
   &__addon {
-    display: block;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+    gap: 1rem;
     padding: 1rem;
+
     &::after {
       left: 1rem;
       width: calc(100% - 2rem);


### PR DESCRIPTION
## Summary

Make it so that the DatePicker addon container controls the shortcut button spacing, instead of using the spacing props on the buttons themselves

Before:
![image (2)](https://user-images.githubusercontent.com/25927156/236815068-e01f7f49-7434-44be-8248-d0cdd4178b49.png)
_All rights reserved @langz_

After:
<img width="768" alt="Screenshot 2023-05-08 at 13 41 01" src="https://user-images.githubusercontent.com/25927156/236815203-35917253-05af-43b4-b137-f0a0be830f8b.png">
