### PR TITLE
chore(Autocomplete): update autocompleteinputref type

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
@@ -29,7 +29,7 @@ type AutocompleteSubmitButtonIcon =
   | ((...args: any[]) => any);
 type AutocompleteInputRef =
   | ((...args: any[]) => any)
-  | Record<string, unknown>;
+  | React.MutableRefObject<HTMLInputElement | undefined>;
 type AutocompleteInputIcon =
   | string
   | React.ReactNode


### PR DESCRIPTION
## Summary

This is just a proposal to solve the typescript error shown in the image below
![image (4)](https://github.com/dnbexperience/eufemia/assets/25927156/b77ad583-f8f9-4e78-9f52-e0d7b073ae64)
 
It might be to correct way to solve this, or it might not need to be solve at all. But I feel that this approach is more specific than using ` Record<string, unknown>`.
`
React.MutableRefObject<HTMLInputElement | undefined>` vs ` Record<string, unknown>`.