### PR TITLE
chore(Theme): send along Theme classes to React Portals

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -29,6 +29,8 @@ import {
   addToIndex,
   removeFromIndex,
 } from './helpers'
+import { getThemeClasses } from '../../shared/Theme'
+import { Context } from '../../shared'
 
 interface ModalContentState {
   triggeredBy: string
@@ -61,6 +63,8 @@ export default class ModalContent extends React.PureComponent<
   _androidFocusTimeout: NodeJS.Timeout
   _ii: InteractionInvalidation
   _iiLocal: InteractionInvalidation
+
+  static contextType = Context
 
   constructor(props: ModalContentProps) {
     super(props)
@@ -420,7 +424,7 @@ export default class ModalContent extends React.PureComponent<
         container_placement
           ? `dnb-modal__content--${container_placement || 'right'}`
           : null,
-
+        getThemeClasses(this.context?.theme),
         content_class
       ),
       onMouseDown: this.onContentMouseDownHandler,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -14,6 +14,7 @@ import {
   validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
+import { getThemeClasses } from '../../shared/Theme'
 import { createSpacingClasses } from '../../components/space/SpacingHelper'
 
 import DrawerListContext from './DrawerListContext'
@@ -390,7 +391,7 @@ class DrawerListInstance extends React.PureComponent {
             include_owner_width={align_drawer === 'right'}
             independent_width={isTrue(independent_width)}
             fixed_position={isTrue(fixed_position)}
-            className={portal_class}
+            className={getThemeClasses(this.context?.theme, portal_class)}
           >
             {mainList}
           </DrawerListPortal>

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import Theme from '../Theme'
+import {
+  Autocomplete,
+  Dialog,
+  Drawer,
+  Dropdown,
+  Tooltip,
+} from '../../components'
 
 describe('Theme', () => {
   it('sets name and variant as HTML classes', () => {
@@ -93,5 +100,123 @@ describe('Theme', () => {
 
     const element = document.querySelector('.eufemia-theme')
     expect(element.tagName).toBe('SECTION')
+  })
+
+  it('will omit element on false or fragment', () => {
+    const { rerender } = render(<Theme element={false}>content</Theme>)
+
+    expect(document.querySelector('.eufemia-theme')).toBeFalsy()
+
+    rerender(<Theme element={React.Fragment}>content</Theme>)
+
+    expect(document.querySelector('.eufemia-theme')).toBeFalsy()
+
+    rerender(<Theme element="div">content</Theme>)
+
+    expect(document.querySelector('.eufemia-theme')).toBeTruthy()
+  })
+})
+
+describe('Portals', () => {
+  it('have correct theme classes in dialog content', () => {
+    render(
+      <Theme name="eiendom" variant="soft" element={false}>
+        <Dialog noAnimation openState="opened">
+          content
+        </Dialog>
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual(
+      expect.arrayContaining([
+        'dnb-dialog__root',
+        'dnb-modal__content',
+        'eufemia-theme',
+        'eufemia-theme__eiendom',
+        'eufemia-theme__eiendom--soft',
+      ])
+    )
+    expect(document.querySelectorAll('.eufemia-theme')).toHaveLength(1)
+  })
+
+  it('have correct theme classes in drawer content', () => {
+    render(
+      <Theme name="eiendom" variant="soft" element={false}>
+        <Drawer noAnimation openState="opened">
+          content
+        </Drawer>
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual(
+      expect.arrayContaining([
+        'dnb-modal__content',
+        'dnb-modal__content--right',
+        'dnb-drawer__root',
+        'eufemia-theme',
+        'eufemia-theme__eiendom',
+        'eufemia-theme__eiendom--soft',
+      ])
+    )
+    expect(document.querySelectorAll('.eufemia-theme')).toHaveLength(1)
+  })
+
+  it('have correct theme classes in dropdown', () => {
+    render(
+      <Theme name="eiendom" variant="soft" element={false}>
+        <Dropdown open no_animation data={['A', 'B']} />
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual(
+      expect.arrayContaining([
+        'dnb-drawer-list__portal__style',
+        'eufemia-theme',
+        'eufemia-theme__eiendom',
+        'eufemia-theme__eiendom--soft',
+      ])
+    )
+    expect(document.querySelectorAll('.eufemia-theme')).toHaveLength(1)
+  })
+
+  it('have correct theme classes in autocomplete', () => {
+    render(
+      <Theme name="eiendom" variant="soft" element={false}>
+        <Autocomplete open no_animation data={['A', 'B']} />
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual(
+      expect.arrayContaining([
+        'dnb-drawer-list__portal__style',
+        'eufemia-theme',
+        'eufemia-theme__eiendom',
+        'eufemia-theme__eiendom--soft',
+      ])
+    )
+    expect(document.querySelectorAll('.eufemia-theme')).toHaveLength(1)
+  })
+
+  it('have correct theme classes in tooltip', () => {
+    render(
+      <Theme name="eiendom" variant="soft" element={false}>
+        <Tooltip open no_animation />
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual(
+      expect.arrayContaining([
+        'dnb-tooltip__portal',
+        'eufemia-theme',
+        'eufemia-theme__eiendom',
+        'eufemia-theme__eiendom--soft',
+      ])
+    )
+    expect(document.querySelectorAll('.eufemia-theme')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Because React Portals are outside of typical app wrappers, we need to ensure, portals also get the correct theme classes.
