### PR TITLE
chore: fix button types in import from /components/Button

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ButtonIconPosition } from '../button';
+import type { ButtonIconPosition } from '../Button';
 import type { FormLabelLabelDirection, FormLabelText } from '../FormLabel';
 import type {
   FormStatusProps,


### PR DESCRIPTION
Continuation of https://github.com/dnbexperience/eufemia/pull/2315/files

Based on what's done in https://github.com/dnbexperience/eufemia/pull/2315/files, I believe the import statement in this file should be `Button` and not `button`. Not 100% sure though.

Or maybe it should be `button/Button`? 🤔 