### PR TITLE
feat: expose package version to Node.js

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -28,4 +28,12 @@ Paste the results here:
 
 ## Eufemia Version
 
-Type `Eufemia.version` in your browser console and include it here.
+**Browser:** Type `Eufemia.version` in your browser console.
+
+**Node.js:** Use import or require to find out what Eufemia version is imported:
+
+```js
+// NB: Use "require" if needed
+import { version } from '@dnb/eufemia/shared/Eufemia'
+console.log('Eufemia version:', version)
+```

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -96,5 +96,9 @@ describe('makeReleaseVersion', () => {
       expect.stringContaining('src/shared/Eufemia.js'),
       expect.stringContaining(`return 'release'`)
     )
+    expect(fs.writeFile).toHaveBeenLastCalledWith(
+      expect.stringContaining('src/shared/Eufemia.js'),
+      expect.stringContaining(`export const version = 'release'`)
+    )
   })
 })

--- a/packages/dnb-eufemia/src/shared/Eufemia.js
+++ b/packages/dnb-eufemia/src/shared/Eufemia.js
@@ -1,3 +1,5 @@
+export const version = '__VERSION__'
+
 export function init() {
   if (typeof window !== 'undefined') {
     class Eufemia {


### PR DESCRIPTION
With that we can with that log what version of the package is imported:

```js
const { version } = require('@dnb/eufemia/shared/Eufemia')
console.log('Eufemia version:', version)
```