### PR TITLE
chore: run React hydration fix only on prod build

### DIFF
--- a/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
+++ b/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
@@ -36,7 +36,9 @@ export default function VisibilityByTheme({
   // When using React v17,
   // we need to ovecome a hydration issue.
   // Later we can change "themeOrig" to "theme" and remove these lines below:
-  const [theme, refresh] = React.useState({})
+  const [theme, refresh] = React.useState(
+    process.env.NODE_ENV === 'production' ? {} : themeOrig
+  )
   React.useLayoutEffect(() => {
     refresh(themeOrig)
   }, [themeOrig])


### PR DESCRIPTION
Right now we get a React warning during development about using useEffect in an unmounted component. 
This PR should fix this.