### PR TITLE
chore: show URL while running visual tests

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerEnvironment.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerEnvironment.js
@@ -27,7 +27,34 @@ class JestEnvironment extends PlaywrightEnvironment {
     return getParrents(currentlyRunningTest).reverse().join(' ')
   }
 
+  reportedPageUrl = []
+
   async handleTestEvent(event, state) {
+    if (
+      this.global.pageUrl &&
+      !this.reportedPageUrl.includes(this.global.pageUrl)
+    ) {
+      this.reportedPageUrl.push(this.global.pageUrl)
+
+      const cliColors = {
+        reset: '\x1b[0m',
+        bold: '\x1b[1m',
+        dim: '\x1b[2m',
+        yellow: '\x1b[33m',
+        red: '\x1b[31m',
+        green: '\x1b[32m',
+        hidden: '\x1b[8m',
+      }
+
+      const themeName = this.global.themeName
+        ? `${cliColors.bold}${this.global.themeName}${cliColors.reset} `
+        : ''
+      console.log(
+        `${cliColors.yellow}URL:`,
+        `${cliColors.reset}${themeName}${this.global.pageUrl}`
+      )
+    }
+
     if (config.retryTimes > 0) {
       if (event.name === 'test_fn_failure') {
         const currentTestName = this.getCurrentTestName(state)

--- a/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
@@ -249,7 +249,10 @@ async function makePageReady({
       await page.setExtraHTTPHeaders(headers)
     }
 
-    await page.goto(createUrl(url, fullscreen, themeName), {
+    global.themeName = themeName
+    global.pageUrl = createUrl(url, fullscreen, themeName)
+    process.env.pageUrl = global.pageUrl
+    await page.goto(global.pageUrl, {
       waitUntil: config.waitUntil,
       timeout: config.timeout,
     })


### PR DESCRIPTION
Not sure if that is useful. But sometimes, its good to quickly check how the page behaves during the slightly different behavior. Like no animations etc.

<img width="1114" alt="Screenshot 2023-05-11 at 10 42 52" src="https://github.com/dnbexperience/eufemia/assets/1501870/bee0aa1c-5e8d-40c5-b440-fcfd370c3f93">
