### PR TITLE
chore(HelpButton): make render example ts

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/Examples.tsx
@@ -6,8 +6,7 @@
 import React from 'react'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 
-import { HelpButton, Input } from '@dnb/eufemia/src'
-import { Dl, Dt, Dd } from '@dnb/eufemia/src'
+import { HelpButton, Input, Dl, Dt, Dd, Dialog } from '@dnb/eufemia/src'
 
 export const HelpButtonDefaultExample = () => (
   <ComponentBox data-visual-test="help-button-default">
@@ -59,5 +58,20 @@ export const HelpButtonInsideTextExample = () => (
     <span>
       Text <HelpButton>Text</HelpButton> Text
     </span>
+  </ComponentBox>
+)
+
+export const HelpButtonRenderExample = () => (
+  <ComponentBox scope={{ Dialog }}>
+    <HelpButton
+      title="Title"
+      render={(children, props) => (
+        <Dialog triggerAttributes={props} className="your-class">
+          {children}
+        </Dialog>
+      )}
+    >
+      Help text
+    </HelpButton>
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/properties.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import { HelpButtonRenderExample } from 'Docs/uilib/components/help-button/Examples'
+
 ## Properties
 
 | Properties                                    | Description                                                                            |
@@ -14,19 +16,4 @@ showTabs: true
 
 ## How to use `render`
 
-```jsx
-import { HelpButton, Dialog } from '@dnb/eufemia'
-
-render(
-  <HelpButton
-    title="Title"
-    render={(children, props) => (
-      <Dialog triggerAttributes={props} className="your-class">
-        {children}
-      </Dialog>
-    )}
-  >
-    Help text
-  </HelpButton>
-)
-```
+<HelpButtonRenderExample />


### PR DESCRIPTION
Reason why I like this, is only because of TypeScript. So that if we change HelpButton or render prop in the future, it's easier to find necessary changes in our docs.