### PR TITLE
chore(TimelineItem): remove redundant string type

### DIFF
--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -32,12 +32,12 @@ export interface TimelineItemProps {
   /**
    * Text displaying the title of the timeline item.
    */
-  title: React.ReactNode | string
+  title: React.ReactNode
 
   /**
    * Text displaying the subtitle of the timeline item.
    */
-  subtitle?: React.ReactNode | React.ReactNode[] | string | string[]
+  subtitle?: React.ReactNode | React.ReactNode[]
 
   /**
    * Text displaying info message of the timeline item.


### PR DESCRIPTION
## Summary

Removed redundant `string` type when `React.ReactNode` is used

copilot:summary

## Details

copilot:walkthrough

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
