### PR TITLE
feat(Theme): add `darkMode` and `contrastMode` props

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
@@ -7,7 +7,7 @@ import {
   setTheme,
 } from 'gatsby-plugin-eufemia-theme-handler'
 
-export default function ChangeStyleTheme() {
+export default function ChangeStyleTheme({ label = null } = {}) {
   const themes = getThemes()
   const { name } = getTheme()
   const { update } = React.useContext(Context)
@@ -24,6 +24,7 @@ export default function ChangeStyleTheme() {
       id="change-theme"
       value={name}
       data={date}
+      label={label}
       on_change={({ data: { value } }) => {
         update({ skeleton: true })
         setTheme({ name: value }, () => {

--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
@@ -34,17 +34,17 @@ export default function ChangeStyleTheme() {
   )
 }
 
-ChangeStyleTheme.ColorMapping = ColorMapping
+ChangeStyleTheme.PropMapping = PropMapping
 
-function ColorMapping({ enabled, ...props }) {
-  const { colorMapping } = getTheme()
+function PropMapping({ enabled, ...props }) {
+  const { propMapping } = getTheme()
   return (
     <Switch
       top
       label="Toggle Color Mapping"
-      checked={colorMapping === 'basis' || enabled}
+      checked={propMapping === 'basis' || enabled}
       on_change={({ checked }) => {
-        setTheme({ colorMapping: checked ? 'basis' : null })
+        setTheme({ propMapping: checked ? 'basis' : null })
       }}
       {...props}
     />

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7.2-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7.2-info.mdx
@@ -61,7 +61,7 @@ Strings where changed/removed and added to the [language files](/uilib/usage/cus
 
 ## New helper functions
 
-- [useTranslation](/usage/customisation/localization#how-to-use-your-own-translation-strings) hook to consume your own translation strings.
+- [useTranslation](/uilib/usage/customisation/localization#how-to-use-your-own-translation-strings) hook to consume your own translation strings.
 - [InteractionInvalidation](/uilib/helpers/functions) method – used by the Modal to invalidate everything outside of the modal to be accessible for keyboard and screen readers.
 - [debounce](/uilib/helpers/functions) method – used by AutoComplete to delay asynchronous typed searches.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -5,87 +5,33 @@ order: 7
 
 # Theming
 
-Theming is a umbrella term of a wide range of different ways and needs of customization.
+**Table of Contents**
 
-This section covers some of the needs we've seen in DNB productions as of now.
-
-You may also check out the section in the contribution docs on [how to maintain and create a theme](/contribute/style-guides/theming/) or [how to deal with the brand as a developer](/brand/development/).
-
----
-
-- [Theming](#theming)
+- [Theming](#themes-and-theming)
   - [Integrated theming](#integrated-theming)
-  - [Theme Component and useTheme Hook](#theme-component-and-usetheme-hook)
+    - [Theme Component and useTheme Hook](#theme-component-and-usetheme-hook)
     - [Brand theming](#brand-theming)
   - [Run your application with a different theme](#run-your-application-with-a-different-theme)
   - [WIP: Ready to use themes](#wip-ready-to-use-themes)
     - [Using `postcss-replace`](#using-postcss-replace)
 
+---
+
+Theming is an umbrella term of a wide range of different ways and needs of customization.
+
+This section covers some of the needs we've seen in DNB productions as of now.
+
+You may also check out the section in the contribution docs on [how to maintain and create a theme](/contribute/style-guides/theming/) or [how to deal with the brand as a developer](/brand/development/).
+
 ## Integrated theming
 
-Eufemia supports theming right inside where all the style-sources lives. Having the ability to control different styles as close to the source as possible, will make it possible to carefully handle continues improvements over time.
+Eufemia supports theming right inside where all the style-sources lives. Having the ability to control different styles as close to the source as possible, will make it possible to carefully handle continuous improvements over time.
 
 Themes are independent style packages, which should not be imported in parallel. But rather either – or.
 
 ### Theme Component and useTheme Hook
 
-Eufemia has a theming helper, that lets us create nested theming solutions. As of now, it does not deliver any extra features beside the principle.
-
-```tsx
-import { Theme, useTheme } from '@dnb/eufemia/shared'
-
-const Component = () => {
-  const { name, variant } = useTheme()
-  return 'My Component'
-}
-
-render(
-  <Theme name="theme-name" variant="theme-variant">
-    <Component />
-  </Theme>
-)
-```
-
-In addition, you can use this helper function to show/hide content based on the theme.
-
-```tsx
-import { Theme, VisibilityByTheme } from '@dnb/eufemia/shared'
-
-render(
-  <Theme>
-    <VisibilityByTheme visible="sbanken">
-      Only shown in Sbanken theme
-    </VisibilityByTheme>
-
-    <VisibilityByTheme hidden="eiendom">
-      Only hidden in Eiendom theme
-    </VisibilityByTheme>
-
-    <VisibilityByTheme visible={['sbanken', 'eiendom']}>
-      Only shown in Sbanken or Eiendom theme
-    </VisibilityByTheme>
-
-    <VisibilityByTheme
-      visible={[{ name: 'sbanken' }, { name: 'eiendom' }]}
-    >
-      Only shown in Sbanken or Eiendom theme
-    </VisibilityByTheme>
-
-    <VisibilityByTheme
-      visible={[{ name: 'sbanken' }, { name: 'eiendom', variant: 'blue' }]}
-    >
-      Only shown in Sbanken then or Eiendom theme – that also includes the
-      fictive variant="blue".
-    </VisibilityByTheme>
-  </Theme>
-)
-```
-
-`<Theme>` Will create a `div` wrapper by default, when no custom element is defined (`element="span"`). It sets these CSS classes:
-
-- `eufemia-theme__{theme-name}`
-- `eufemia-theme__{theme-name}--{theme-variant}`
-
+Eufemia has [theming helpers](/uilib/usage/customisation/theming/theme), that lets you create nested theming solutions.
 
 ### Brand theming
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Theme'
+description: 'The Theme component is a helper component that lets you create nested theming solutions.'
+showTabs: true
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+  - title: Properties
+    key: '/properties'
+---
+
+import ThemeInfo from 'Docs/uilib/usage/customisation/theming/theme/info'
+import ThemeDemos from 'Docs/uilib/usage/customisation/theming/theme/demos'
+
+<ThemeInfo />
+<ThemeDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
@@ -1,0 +1,48 @@
+/**
+ * UI lib Component Example
+ *
+ */
+
+import ComponentBox from '../../../../../../shared/tags/ComponentBox'
+import styled from '@emotion/styled'
+import { P, Logo } from '@dnb/eufemia/src'
+import { Theme } from '@dnb/eufemia/src/shared'
+
+export const ThemeBasis = () => (
+  <ComponentBox scope={{ Theme }} data-visual-test="theme-basis">
+    {() => {
+      return (
+        <Theme name="sbanken">
+          <Logo size={40} />
+        </Theme>
+      )
+    }}
+  </ComponentBox>
+)
+
+export const ThemeMapping = () => (
+  <ComponentBox
+    scope={{ P, Theme }}
+    // data-visual-test="theme-basis"
+  >
+    {() => {
+      const MyMapping = styled.div`
+        .eufemia-theme__sbanken.eufemia-theme__prop-mapping--my-mapping {
+          --color-sea-green: var(--sb-color-purple-alternative);
+        }
+      `
+      const CustomComponent = styled(P)`
+        color: var(--color-sea-green);
+      `
+      return (
+        <MyMapping>
+          <Theme name="sbanken">
+            <Theme propMapping="my-mapping">
+              <CustomComponent>Text with custom color</CustomComponent>
+            </Theme>
+          </Theme>
+        </MyMapping>
+      )
+    }}
+  </ComponentBox>
+)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
@@ -1,0 +1,21 @@
+---
+showTabs: true
+---
+
+import {
+  ThemeBasis,
+  ThemeMapping,
+} from 'Docs/uilib/usage/customisation/theming/theme/Examples'
+import ChangeStyleTheme from '../../../../../../core/ChangeStyleTheme'
+
+## Demos
+
+<ChangeStyleTheme label="Change the brand:" />
+
+### Basis example
+
+<ThemeBasis />
+
+### Basis example `propMapping`
+
+<ThemeMapping />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -1,0 +1,128 @@
+---
+showTabs: true
+---
+
+## Description
+
+The Theme component is a helper component that lets you create nested theming solutions.
+
+`<Theme>` Will by default create a `div` wrapper, when no custom element is defined (e.g. `element="span"`).
+
+```tsx
+import { Theme, useTheme } from '@dnb/eufemia/shared'
+
+const Component = () => {
+  const { name, propMapping } = useTheme()
+  return 'My Component'
+}
+
+render(
+  <Theme name="theme-name">
+    <App>
+      <Theme propMapping="my-class">
+        <MyComponent />
+      </Theme>
+    </App>
+  </Theme>
+)
+```
+
+Will create the following HTML/CSS classes:
+
+**Outer Theme**
+
+- `eufemia-theme__theme-name`
+
+**Nested Theme**
+
+- `eufemia-theme__theme-name`
+- `eufemia-theme__prop-mapping--my-class`
+
+With that, you can create your own styles that contains the wanted style mapping.
+
+### Mapping of properties with `propMapping`
+
+**WIP:** This API may change in future, as it is currently under development. Please get in touch with us before you use it.
+
+In order to change or map CSS properties, you can make use of the `propMapping` solution.
+
+The main motivation of this feature is to provide a set of maps you can use in your app. But it lets you create your own sets as well. To do so;
+
+1. Define an area in your app – it could be your component – and give it a declarative name:
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme propMapping="my-maps">
+    <MyComponent />
+  </Theme>
+)
+```
+
+2. Define the needed CSS properties:
+
+```css
+.eufemia-theme__theme-name.eufemia-theme__prop-mapping--my-maps {
+  --color-sea-green: var(--sb-color-purple-alternative);
+}
+```
+
+#### Use your component as the wrapper element
+
+You can provide your component as the wrapper. This way no additional HTML Element will be created.
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+const Component = ({ classNamem ...props }) => {
+  return <div className={classNamem+' more-classes'}></div>
+}
+
+render(
+  <Theme name="theme-name">
+    <App>
+      <Theme propMapping="my-maps" element={Component}>
+        ...
+      </Theme>
+    </App>
+  </Theme>
+)
+```
+
+### Hide or show parts of your component (filter)
+
+With this helper function you show or hide content based on inherited theme properties.
+
+```tsx
+import { Theme, VisibilityByTheme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme name="...">
+    <VisibilityByTheme visible="sbanken">
+      Only shown in Sbanken theme
+    </VisibilityByTheme>
+
+    <VisibilityByTheme hidden="eiendom">
+      Only hidden in Eiendom theme
+    </VisibilityByTheme>
+
+    <VisibilityByTheme visible={['sbanken', 'eiendom']}>
+      Only shown in Sbanken or Eiendom theme
+    </VisibilityByTheme>
+
+    <VisibilityByTheme
+      visible={[{ name: 'sbanken' }, { name: 'eiendom' }]}
+    >
+      Only shown in Sbanken or Eiendom theme
+    </VisibilityByTheme>
+
+    <VisibilityByTheme
+      visible={[{ name: 'sbanken' }, { name: 'eiendom', variant: 'blue' }]}
+    >
+      Only shown in Sbanken then or Eiendom theme – that also includes the
+      fictive variant="blue".
+    </VisibilityByTheme>
+  </Theme>
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/properties.mdx
@@ -1,0 +1,14 @@
+---
+showTabs: true
+---
+
+## Properties
+
+| Properties          | Description                                                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`              | _(optional)_ The name of a branding theme. Can be `ui` (universal identity), `eiendom` or `sbanken`                                                 |
+| `size` (WIP)        | _(optional)_ Will define what sizes of components are used.                                                                                         |
+| `variant` (WIP)     | _(optional)_ WIP                                                                                                                                    |
+| `propMapping` (WIP) | _(optional)_ Defines a specific CSS class so you get a declarative way of mapping CSS properties. A set of predefined maps will be available (WIP). |
+| `contrastMode`      | _(optional)_ When a component supports a contrast style, it will be used instead for the dedicated area.                                           |
+| `darkMode`          | _(optional)_ When a component supports a dark mode style, it will be used instead for the dedicated area.                                          |

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.js
@@ -65,7 +65,7 @@ export default function PortalToolsMenu({
         {theme.name === 'sbanken' && (
           <Space top="large">
             <H2 size="small">Map colors</H2>
-            <ChangeStyleTheme.ColorMapping enabled={theme.colorMapping} />
+            <ChangeStyleTheme.PropMapping enabled={theme.propMapping} />
           </Space>
         )}
 

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -13,13 +13,13 @@ import { extendPropsWithContext } from './component-helper'
 export type ThemeNames = 'ui' | 'eiendom' | 'sbanken'
 export type ThemeVariants = string
 export type ThemeSizes = 'basis'
-export type ColorMapping = 'basis'
+export type PropMapping = string
 
 export type ThemeProps = {
   name?: ThemeNames
   variant?: ThemeVariants
   size?: ThemeSizes
-  colorMapping?: ColorMapping
+  propMapping?: PropMapping
   element?: DynamicElement | false
 }
 
@@ -34,7 +34,7 @@ export default function Theme(themeProps: ThemeAllProps) {
     name,
     variant,
     size,
-    colorMapping,
+    propMapping,
     ...restProps
   } = themeProps
 
@@ -43,7 +43,7 @@ export default function Theme(themeProps: ThemeAllProps) {
       name,
       variant,
       size,
-      colorMapping,
+      propMapping,
     },
     null,
     context?.theme
@@ -95,14 +95,14 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     return className
   }
 
-  const { name, variant, size, colorMapping } = theme
+  const { name, variant, size, propMapping } = theme
 
   return classnames(
     className,
     'eufemia-theme',
     name && `eufemia-theme__${name}`,
     name && variant && `eufemia-theme__${name}--${variant}`,
-    colorMapping && `eufemia-theme__color-mapping--${colorMapping}`,
+    propMapping && `eufemia-theme__prop-mapping--${propMapping}`,
     size && `eufemia-theme__size--${size}`
   )
 }

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -14,12 +14,16 @@ export type ThemeNames = 'ui' | 'eiendom' | 'sbanken'
 export type ThemeVariants = string
 export type ThemeSizes = 'basis'
 export type PropMapping = string
+export type ContrastMode = boolean
+export type DarkMode = boolean
 
 export type ThemeProps = {
   name?: ThemeNames
   variant?: ThemeVariants
   size?: ThemeSizes
   propMapping?: PropMapping
+  contrastMode?: ContrastMode
+  darkMode?: DarkMode
   element?: DynamicElement | false
 }
 
@@ -35,6 +39,8 @@ export default function Theme(themeProps: ThemeAllProps) {
     variant,
     size,
     propMapping,
+    contrastMode,
+    darkMode,
     ...restProps
   } = themeProps
 
@@ -44,6 +50,8 @@ export default function Theme(themeProps: ThemeAllProps) {
       variant,
       size,
       propMapping,
+      contrastMode,
+      darkMode,
     },
     null,
     context?.theme
@@ -95,7 +103,8 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     return className
   }
 
-  const { name, variant, size, propMapping } = theme
+  const { name, variant, size, propMapping, contrastMode, darkMode } =
+    theme
 
   return classnames(
     className,
@@ -103,6 +112,8 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     name && `eufemia-theme__${name}`,
     name && variant && `eufemia-theme__${name}--${variant}`,
     propMapping && `eufemia-theme__prop-mapping--${propMapping}`,
+    contrastMode && 'eufemia-theme__contrast-mode',
+    darkMode && 'eufemia-theme__dark-mode',
     size && `eufemia-theme__size--${size}`
   )
 }

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -67,6 +67,26 @@ describe('Theme', () => {
     ])
   })
 
+  it('sets contrast-mode as HTML classes', () => {
+    render(<Theme contrastMode>content</Theme>)
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual([
+      'eufemia-theme',
+      'eufemia-theme__contrast-mode',
+    ])
+  })
+
+  it('sets dark-mode as HTML classes', () => {
+    render(<Theme darkMode>content</Theme>)
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(Array.from(element.classList)).toEqual([
+      'eufemia-theme',
+      'eufemia-theme__dark-mode',
+    ])
+  })
+
   it('sets additional attributes', () => {
     render(
       <Theme aria-label="custom label" element="section">

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -57,13 +57,13 @@ describe('Theme', () => {
     ])
   })
 
-  it('sets color-mapping as HTML classes', () => {
-    render(<Theme colorMapping="basis">content</Theme>)
+  it('sets prop-mapping as HTML classes', () => {
+    render(<Theme propMapping="basis">content</Theme>)
 
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual([
       'eufemia-theme',
-      'eufemia-theme__color-mapping--basis',
+      'eufemia-theme__prop-mapping--basis',
     ])
   })
 


### PR DESCRIPTION
+ docs(Theme): create dedicated pages
+ Rename `colorMapping` to `propMapping` because we may map other properties as well