### PR TITLE
chore(FormStatus): remove globalStauts prop from HTML attributes

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -368,11 +368,6 @@ exports[`Autocomplete markup have to match snapshot 1`] = `
           >
             <span
               className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
-              globalStatus={
-                {
-                  "id": "main",
-                }
-              }
               id="autocomplete-id-form-status"
               role="alert"
             >

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -403,11 +403,6 @@ exports[`Dropdown markup have to match snapshot 1`] = `
           >
             <span
               className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
-              globalStatus={
-                {
-                  "id": "main",
-                }
-              }
               id="dropdown-id-form-status"
               role="alert"
             >

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.js
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.js
@@ -352,6 +352,7 @@ export default class FormStatus extends React.PureComponent {
 
       label, // eslint-disable-line
       status_id, // eslint-disable-line
+      globalStatus, // eslint-disable-line
       id, // eslint-disable-line
       text, // eslint-disable-line
       icon, // eslint-disable-line

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/__snapshots__/FormStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/__snapshots__/FormStatus.test.tsx.snap
@@ -96,11 +96,6 @@ exports[`FormStatus component have to match snapshot 1`] = `
 >
   <span
     className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
-    globalStatus={
-      {
-        "id": "main",
-      }
-    }
     hidden={false}
     id="form-status"
     role="alert"

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -1539,11 +1539,6 @@ exports[`GlobalStatus snapshot have to match linked components snapshot 1`] = `
           >
             <span
               className="dnb-form-status dnb-form-status--error dnb-form-status__size--default dnb-form-status--has-content"
-              globalStatus={
-                {
-                  "id": "linked",
-                }
-              }
               id="switch-form-status"
               role="alert"
             >


### PR DESCRIPTION
Reported as such in the CLI when running the tests:

> Warning: React does not recognize the `globalStatus` prop on a DOM element. 