### PR TITLE
chore(Portal): load the DNB UI theme as embedded CSS

### DIFF
--- a/packages/dnb-design-system-portal/cypress/e2e/themeSwitch.cy.ts
+++ b/packages/dnb-design-system-portal/cypress/e2e/themeSwitch.cy.ts
@@ -16,7 +16,13 @@ describe('Theme', () => {
   })
 
   it('should have preload link', () => {
-    cy.get('link[href^="/ui."][rel="preload"]')
+    cy.get('link[href^="/ui."][rel="preload"]').should('not.exist')
+  })
+
+  it('should have one default theme loaded', () => {
+    cy.get('style[data-href^="/ui."]', {
+      timeout: 10000,
+    })
       .should('exist')
       .its('length')
       .should('equal', 1)
@@ -33,6 +39,8 @@ describe('Theme', () => {
       .should('exist')
       .its('length')
       .should('equal', 1)
+
+    cy.get('style[data-href^="/ui."]').should('not.exist')
   })
 
   it('should set local storage', () => {
@@ -64,6 +72,8 @@ describe('Theme', () => {
       .should('exist')
       .its('length')
       .should('equal', 1)
+
+    cy.get('style[data-href^="/ui."]').should('not.exist')
   })
 
   it('should load css file after template', () => {

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -141,7 +141,6 @@ const plugins = [
       filesGlob: shouldUsePrebuild()
         ? '**/build/style/themes/**/*-theme-*.min.css'
         : '**/src/style/themes/**/*-theme-*.scss', // also load the extensions CSS package
-      inlineDefaultTheme: false, // ensures we do not load other theme CSS package when selected
       defaultTheme,
     },
   },

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.screenshot.test.ts
@@ -27,7 +27,7 @@ describe.each(['ui', 'sbanken', 'eiendom'])(
       it('have to match focus state', async () => {
         const screenshot = await makeScreenshot({
           selector: '[data-visual-test="button-primary"]',
-          simulate: 'focus', // should be tested first
+          simulate: 'focus',
         })
         expect(screenshot).toMatchImageSnapshot()
       })
@@ -73,7 +73,7 @@ describe.each(['ui', 'sbanken', 'eiendom'])(
             'padding-right': '2rem',
           },
           selector: '[data-visual-test="button-secondary"]',
-          simulate: 'focus', // should be tested first
+          simulate: 'focus',
         })
         expect(screenshot).toMatchImageSnapshot()
       })
@@ -113,7 +113,7 @@ describe.each(['ui', 'sbanken', 'eiendom'])(
       it('have to match focus state', async () => {
         const screenshot = await makeScreenshot({
           selector: '[data-visual-test="button-tertiary"]',
-          simulate: 'focus', // should be tested first
+          simulate: 'focus',
         })
         expect(screenshot).toMatchImageSnapshot()
       })
@@ -192,7 +192,7 @@ describe.each(['ui', 'sbanken', 'eiendom'])(
       it('have to match icon button with focus state', async () => {
         const screenshot = await makeScreenshot({
           selector: '[data-visual-test="button-icon"]',
-          simulate: 'focus', // should be tested first
+          simulate: 'focus',
         })
         expect(screenshot).toMatchImageSnapshot()
       })
@@ -264,7 +264,7 @@ describe.each(['ui'])('Button for %s', (themeName) => {
     it('have to match focus state', async () => {
       const screenshot = await makeScreenshot({
         selector: '[data-visual-test="button-signal"]',
-        simulate: 'focus', // should be tested first
+        simulate: 'focus',
       })
       expect(screenshot).toMatchImageSnapshot()
     })

--- a/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptProd.mjs
+++ b/packages/gatsby-plugin-eufemia-theme-handler/inlineScriptProd.mjs
@@ -29,9 +29,10 @@ if (typeof window !== 'undefined') {
       const isDefaultTheme = themeName === globalThis.defaultTheme
 
       if (
-        (globalThis.inlineDefaultTheme && !isDefaultTheme) ||
+        globalThis.isDev ||
+        reload ||
         !globalThis.inlineDefaultTheme ||
-        reload
+        (globalThis.inlineDefaultTheme && !isDefaultTheme)
       ) {
         if (!reload) {
           // Preload
@@ -60,7 +61,6 @@ if (typeof window !== 'undefined') {
                   themes[globalThis.defaultTheme].file +
                   '"]'
               )
-
               if (defaultStyleElement) {
                 headElement.removeChild(defaultStyleElement)
               }

--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.tsx
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.tsx
@@ -169,7 +169,7 @@ export const onPreRenderHTML = (
    */
   if (cachedHeadComponents?.length) {
     headComponents.push(...cachedHeadComponents)
-    replaceHeadComponents(headComponents)
+    replaceComponents(headComponents)
     return // stop here
   }
 
@@ -187,6 +187,7 @@ export const onPreRenderHTML = (
 
   const replaceGlobalVars = (code: string) => {
     return code
+      .replace(/globalThis.isDev/g, JSON.stringify(isDev))
       .replace(/globalThis.defaultTheme/g, JSON.stringify(defaultTheme))
       .replace(
         /globalThis.availableThemes/g,
@@ -236,5 +237,23 @@ export const onPreRenderHTML = (
   }
 
   headComponents.push(...cachedHeadComponents)
-  replaceHeadComponents(headComponents)
+
+  replaceComponents(headComponents)
+
+  function replaceComponents(headComponents) {
+    const uniqueHeadComponents = []
+
+    // Remove duplications
+    headComponents.forEach((item) => {
+      const exists = uniqueHeadComponents.some((i) => {
+        const href = i?.props?.['data-href']
+        return href && item?.props?.['data-href'] === href
+      })
+      if (!exists) {
+        uniqueHeadComponents.push(item)
+      }
+    })
+
+    replaceHeadComponents(uniqueHeadComponents)
+  }
 }


### PR DESCRIPTION
This effects only the prod build. From what I'v seen during the period we had this enabled– loading the needed CSS via a file, delays other resources and gives us a much worse UX. For sure, only on the first couple of seconds. So I suggest to rather load a little more CSS, when switching the theme.

Update: Looks like the tests would have to be updated as well.