### PR TITLE
fix(Radio): prevent radio button from shrinking

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -3106,6 +3106,7 @@ legend.dnb-form-label {
     -webkit-user-select: none;
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     justify-content: center;
     width: var(--radio-width--medium);
     height: var(--radio-height--medium); }

--- a/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.js.snap
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.js.snap
@@ -997,6 +997,7 @@ legend.dnb-form-label {
     -webkit-user-select: none;
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     justify-content: center;
     width: var(--radio-width--medium);
     height: var(--radio-height--medium); }

--- a/packages/dnb-eufemia/src/components/radio/style/_radio.scss
+++ b/packages/dnb-eufemia/src/components/radio/style/_radio.scss
@@ -34,6 +34,7 @@
 
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     justify-content: center;
 
     width: var(--radio-width--medium);

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -2588,6 +2588,7 @@ button.dnb-button::-moz-focus-inner {
     -webkit-user-select: none;
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     justify-content: center;
     width: var(--radio-width--medium);
     height: var(--radio-height--medium); }


### PR DESCRIPTION
## Summary

When Radio.Group has props vertical and layout_direction: column long labels causes the radio button to be unaligend. This is caused by width getting shrunk to avoid text overflowing.

![Screenshot 2023-05-24 at 16-44-15 Bli kunde uten BankID Bli kunde Kundeprogram fra A til Å - DNB (1)](https://github.com/dnbexperience/eufemia/assets/1073586/c0608187-7a0a-4a35-9812-b0745849d50c)

## Details

Setting `flex-shrink: 0` on `dnb-radio__shell` will prevent the radio buttons width getting shrunk.

![Screenshot 2023-05-30 at 14-04-30 Bli kunde uten BankID Bli kunde Kundeprogram fra A til Å - DNB](https://github.com/dnbexperience/eufemia/assets/1073586/c9225d0e-7723-46fe-99e8-8ab9e2e8945d)
