### PR TITLE
chore: add configurable timeout for screenshot tests that are not headless

### DIFF
--- a/packages/dnb-eufemia/jest.config.screenshots.js
+++ b/packages/dnb-eufemia/jest.config.screenshots.js
@@ -7,10 +7,11 @@ module.exports = {
       'jest-playwright': {
         launchOptions: {
           headless: true,
-          // headlessTimeout timeout is used in jestSetupScreenshots if headless is set to false
-          // this is to give us more time to inspect the test inside the browser window
-          // before the test suite moves on to the next one. You can change this value to wathever you want it to be.
-          // defaults to 30 seconds (30e3)
+          // headlessTimeout timeout is used in jestSetupScreenshots if headless is set to false.
+          // This is to give us more time to inspect the test inside the browser window,
+          // before the test suite moves on to the next one.
+          // You can change this value to be wathever number you want.
+          // Defaults to 30 seconds (30e3)
           headlessTimeout: 30e3,
         },
         browsers: [

--- a/packages/dnb-eufemia/jest.config.screenshots.js
+++ b/packages/dnb-eufemia/jest.config.screenshots.js
@@ -1,4 +1,5 @@
 const config = require('./jest.config.js')
+
 module.exports = {
   ...{
     preset: 'jest-playwright-preset',
@@ -6,6 +7,11 @@ module.exports = {
       'jest-playwright': {
         launchOptions: {
           headless: true,
+          // headlessTimeout timeout is used in jestSetupScreenshots if headless is set to false
+          // this is to give us more time to inspect the test inside the browser window
+          // before the test suite moves on to the next one. You can change this value to wathever you want it to be.
+          // defaults to 30 seconds (30e3)
+          headlessTimeout: 30e3,
         },
         browsers: [
           // 'chromium',

--- a/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
@@ -11,6 +11,12 @@ const { isCI } = require('repo-utils')
 const { slugify } = require('../../../src/shared/component-helper')
 const { makeUniqueId } = require('../../shared/component-helper')
 const { configureToMatchImageSnapshot } = require('jest-image-snapshot')
+const screenshotConfig = require('../../../jest.config.screenshots')
+
+const playwrightSettings =
+  screenshotConfig.testEnvironmentOptions['jest-playwright']
+const headlessTimeout = playwrightSettings.launchOptions.headlessTimeout
+const isHeadless = playwrightSettings.launchOptions.headless
 
 const log = ora()
 
@@ -117,11 +123,6 @@ const makeScreenshot = async ({
     await page.evaluate(executeBeforeScreenshot)
   }
 
-  // Only for dev
-  // if (!isCI) {
-  //   await page.waitForTimeout(300000)
-  // }
-
   if (simulate && simulate === 'click') {
     await page.mouse.move(0, 0) // reset after click simulations, because the mouse still hovers
   }
@@ -140,6 +141,11 @@ const makeScreenshot = async ({
 
   if (waitBeforeFinish > 0) {
     await page.waitForTimeout(waitBeforeFinish)
+  }
+
+  // Only for dev
+  if (!isCI && !isHeadless) {
+    await page.waitForTimeout(headlessTimeout)
   }
 
   return screenshot


### PR DESCRIPTION
## Summary

Proposal solution for giving developers more time to inspect screenshot tests in the browser window, when not running the tests in headless
