### PR TITLE
feat(Portal): copy icon name to clipboard

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/icons/ListAllIcons.js
+++ b/packages/dnb-design-system-portal/src/shared/parts/icons/ListAllIcons.js
@@ -12,6 +12,7 @@ import * as PrimaryIconsMedium from '@dnb/eufemia/src/icons/dnb/primary_icons_me
 import * as SecondaryIconsMedium from '@dnb/eufemia/src/icons/dnb/secondary_icons_medium'
 import iconsMetaData from '@dnb/eufemia/src/icons/dnb/icons-meta.json'
 import AutoLinkHeader from '../../tags/AutoLinkHeader'
+import Copy from '../../tags/Copy'
 import {
   listStyle,
   listItemStyle,
@@ -115,7 +116,9 @@ export default class ListAllIcons extends React.PureComponent {
               element="figcaption"
               useSlug={iconName}
             >
-              {iconName}
+              <Copy>
+                  {iconName}
+              </Copy>
             </AutoLinkHeader>
 
             <P>{tags.length > 0 ? tags.join(', ') : '(no tags)'}</P>

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes/fetchPropertiesFromDocs.js
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes/fetchPropertiesFromDocs.js
@@ -53,8 +53,7 @@ function extractPathParts({ file }) {
    * we only use it for the warning method: warnAboutMissingPropTypes
    *
    * In other words, do not warn when,
-   *
-   * he component dir is different from the component name
+   * the component dir is different from the component name
    */
   const unsureSituation =
     componentDir.split('-').length !== tmpComponentName.split('-').length


### PR DESCRIPTION
## Summary
A suggested change that allows the user to copy the icon name to the clipboard by clicking on it.
This does not wrap the text element with the `<code>`-tag which would result in a styling change.

copilot:summary

## Details
<img width="980" alt="Skjermbilde 2023-06-04 kl  07 10 13" src="https://github.com/dnbexperience/eufemia/assets/21338570/9a482163-c275-49b7-abe8-a4faaa1a9116">

copilot:walkthrough
