### PR TITLE
chore: make ErrorHandler work with TypeScript

### DIFF
--- a/packages/dnb-eufemia/scripts/figma/FigmaAPI.js
+++ b/packages/dnb-eufemia/scripts/figma/FigmaAPI.js
@@ -36,7 +36,7 @@ export const fetchFigmaIcons = async ({
     })
     log.succeed(`> Figma: Icons conversion done (${icons?.length} icons)`)
   } catch (e) {
-    log.fail(new ErrorHandler('Failed during extractIconsAsSVG', e))
+    log.fail(ErrorHandler('Failed during extractIconsAsSVG', e))
   }
 }
 
@@ -59,6 +59,6 @@ export const fetchFigmaAll = async ({
 
     log.succeed('> Figma: All done')
   } catch (e) {
-    log.fail(new ErrorHandler('Failed during fetchFigmaAll', e))
+    log.fail(ErrorHandler('Failed during fetchFigmaAll', e))
   }
 }

--- a/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
@@ -142,7 +142,7 @@ export const getLiveVersionOfFigmaDoc = async ({ figmaFile }) => {
 
     return versions[0].id
   } catch (e) {
-    new ErrorHandler('Could not get version!', e)
+    ErrorHandler('Could not get version!', e)
   }
 }
 
@@ -180,7 +180,7 @@ export const getLocalVersionFromLockFile = async ({ figmaFile }) => {
       return fileContent[md5(figmaFile)]
     }
   } catch (e) {
-    new ErrorHandler('Could not get version from lock file!', e)
+    ErrorHandler('Could not get version from lock file!', e)
   }
   return null
 }
@@ -195,7 +195,7 @@ export const getFigmaDoc = async ({
     !(typeof figmaFile === 'string' && figmaFile.length > 0) &&
     !localFile
   ) {
-    new ErrorHandler(
+    ErrorHandler(
       'No Figma file defined. Make sure there is a .env file with a valid "figmaFile" defined!'
     )
   }
@@ -269,7 +269,7 @@ export const getFigmaDoc = async ({
       data.isNew = true
       return data
     } catch (e) {
-      new ErrorHandler(
+      ErrorHandler(
         'Failed to client.file(figmaFile) and write the result with writeFile',
         e,
         ERROR_HARMLESS
@@ -282,7 +282,7 @@ export const getFigmaDoc = async ({
   try {
     return JSON.parse(await fs.readFile(localFile))
   } catch (e) {
-    new ErrorHandler('Failed to readFile and parse the result', e)
+    ErrorHandler('Failed to readFile and parse the result', e)
   }
 
   return null
@@ -308,7 +308,7 @@ export const getFigmaUrlByImageIds = async ({
 
     return images
   } catch (e) {
-    new ErrorHandler('Failed on client.fileImages(figmaFile)', e)
+    ErrorHandler('Failed on client.fileImages(figmaFile)', e)
   }
 }
 
@@ -324,7 +324,7 @@ export const streamToDisk = (
         .on('error', (err) => {
           writeStream.end()
           reject(
-            new ErrorHandler(
+            ErrorHandler(
               'Failed on createWriteStream',
               err,
               errorExceptionType
@@ -338,7 +338,7 @@ export const streamToDisk = (
           const isEmpty = String(newContent).trim().length === 0
 
           if (isEmpty) {
-            new ErrorHandler(
+            ErrorHandler(
               `streamToDisk failed because the stream did not end with content by using the url: ${url}`
             )
           }
@@ -347,7 +347,7 @@ export const streamToDisk = (
           if (isEmpty) {
             if (oldContent) {
               await fs.writeFile(localFile, oldContent)
-              new ErrorHandler(`Using the old content for: ${localFile}`)
+              ErrorHandler(`Using the old content for: ${localFile}`)
             } else {
               await fs.unlink(localFile)
             }
@@ -364,16 +364,12 @@ export const streamToDisk = (
             await fs.unlink(localFile)
           } catch (err) {
             reject(
-              new ErrorHandler('Failed on unlink', err, errorExceptionType)
+              ErrorHandler('Failed on unlink', err, errorExceptionType)
             )
           }
 
           reject(
-            new ErrorHandler(
-              'Failed on streamToDisk',
-              err,
-              errorExceptionType
-            )
+            ErrorHandler('Failed on streamToDisk', err, errorExceptionType)
           )
         })
     }
@@ -387,11 +383,7 @@ export const streamToDisk = (
       ? fs.readFile(localFile, 'utf-8', (err, oldContent) => {
           if (err) {
             reject(
-              new ErrorHandler(
-                'Failed on readFile',
-                err,
-                errorExceptionType
-              )
+              ErrorHandler('Failed on readFile', err, errorExceptionType)
             )
           }
 

--- a/packages/dnb-eufemia/scripts/figma/resetIcons.js
+++ b/packages/dnb-eufemia/scripts/figma/resetIcons.js
@@ -33,7 +33,7 @@ export const runFigmaReset = async () => {
     }
   } catch (e) {
     log.fail(e)
-    new ErrorHandler(e)
+    ErrorHandler(e)
   }
 }
 

--- a/packages/dnb-eufemia/scripts/figma/tasks/assetsExtractors.js
+++ b/packages/dnb-eufemia/scripts/figma/tasks/assetsExtractors.js
@@ -57,7 +57,7 @@ const iconPrimaryList = process.env.FIGMA_ICONS_PRIMARY_LIST || [
 export function IconsConfig(overwrite = {}) {
   if (overwrite?.assetsDir && /^\//.test(overwrite.assetsDir)) {
     log.fail(
-      new ErrorHandler('assetsDir should not start with a slash (/dir)')
+      ErrorHandler('assetsDir should not start with a slash (/dir)')
     )
   }
 
@@ -172,7 +172,7 @@ export const extractIconsAsSVG = async ({
 
     return listOfProcessedFiles
   } catch (e) {
-    log.fail(new ErrorHandler('extractIconsAsSVG failed', e))
+    log.fail(ErrorHandler('extractIconsAsSVG failed', e))
   }
 }
 
@@ -501,7 +501,7 @@ const frameIconsFactory = async ({
 
             if (streamResult === 'ACCESS_DENIED') {
               log.fail(
-                new ErrorHandler(
+                ErrorHandler(
                   `> Figma: Failed to stream content of (${iconName}): ${content}`
                 )
               )
@@ -529,7 +529,7 @@ const frameIconsFactory = async ({
 
           return ret
         } catch (e) {
-          log.fail(new ErrorHandler('Failed to process new icons', e))
+          log.fail(ErrorHandler('Failed to process new icons', e))
         }
       }
     )
@@ -847,7 +847,7 @@ const optimizeSVG = async (file) => {
     await fs.writeFile(file, data)
     return data
   } catch (e) {
-    log.fail(new ErrorHandler('Failed during optimizeSVG', e))
+    log.fail(ErrorHandler('Failed during optimizeSVG', e))
   }
 
   return null

--- a/packages/dnb-eufemia/scripts/lib/error.ts
+++ b/packages/dnb-eufemia/scripts/lib/error.ts
@@ -6,7 +6,13 @@
 export const ERROR_HARMLESS = 100
 export const ERROR_FATAL = 500
 
-function ErrorHandler(message, error = null, code = ERROR_HARMLESS) {
+type ErrorHandlerMessage = string
+
+function ErrorHandler(
+  message: ErrorHandlerMessage,
+  error = null,
+  code = ERROR_HARMLESS
+): string {
   if (error === null && typeof message !== 'string') {
     error = message
   }
@@ -24,6 +30,5 @@ function ErrorHandler(message, error = null, code = ERROR_HARMLESS) {
 
   return message
 }
-ErrorHandler.prototype.constructor = function () {}
 
 export { ErrorHandler }

--- a/packages/dnb-eufemia/scripts/prebuild/generateTypes.js
+++ b/packages/dnb-eufemia/scripts/prebuild/generateTypes.js
@@ -16,7 +16,7 @@ const runGenerateTypesTasks = async ({ doRefetch } = {}) => {
     await generateTypes()
     log.succeed('Type definitions are successfully generated!')
   } catch (e) {
-    log.fail(new ErrorHandler('Failed to generate type definitions!', e))
+    log.fail(ErrorHandler('Failed to generate type definitions!', e))
   }
   return true
 }

--- a/packages/dnb-eufemia/scripts/prebuild/index.js
+++ b/packages/dnb-eufemia/scripts/prebuild/index.js
@@ -58,7 +58,7 @@ export const runPrepublishTasks = async ({
     log.succeed('Prepublishing has Succeeded!')
   } catch (e) {
     log.fail('Failed to run prepublish!')
-    new ErrorHandler(e)
+    ErrorHandler(e)
   }
   return true
 }

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/prepareTemplates.js
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/prepareTemplates.js
@@ -355,7 +355,7 @@ export const runFactory = async ({
         )
       } catch (e) {
         log.fail(`There was an error on creating ${destFile}!`)
-        new ErrorHandler(e)
+        ErrorHandler(e)
       }
     })
   }
@@ -417,7 +417,7 @@ export const runFactory = async ({
       )
     } catch (e) {
       log.fail(`There was an error on creating ${destFile}!`)
-      new ErrorHandler(e)
+      ErrorHandler(e)
     }
   }
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/styleFactory.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/styleFactory.ts
@@ -170,7 +170,7 @@ const runFactory = async ({
     )
   } catch (e) {
     log.fail(`There was an error on creating ${scssOutputFile}!`)
-    new ErrorHandler(e)
+    ErrorHandler(e)
   }
 }
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/themeFactory.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/themeFactory.ts
@@ -191,7 +191,7 @@ export const runFactory = async ({
     })
   } catch (e) {
     log.fail(`There was an error when creating ${scssOutputPath}!`)
-    new ErrorHandler(e)
+    ErrorHandler(e)
   }
 
   if (returnResult) {

--- a/packages/dnb-eufemia/src/components/icon/Icon.js
+++ b/packages/dnb-eufemia/src/components/icon/Icon.js
@@ -433,7 +433,7 @@ export const prerenderIcon = ({
     )[icon]
     return mod && mod.default ? mod.default : mod
   } catch (e) {
-    new ErrorHandler(`Icon '${icon}' did not exist!`)
+    ErrorHandler(`Icon '${icon}' did not exist!`)
     return null
   }
 }


### PR DESCRIPTION
- Don't use `new` when we expect a string, as it does not work with TS.
- So go purely with a function, I think is just as  fine.