### PR TITLE
chore(Anchor): better theme compatability

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/style/themes/dnb-anchor-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/anchor/style/themes/dnb-anchor-theme-sbanken.scss
@@ -17,24 +17,25 @@
 }
 
 @mixin anchorFocus() {
+  color: var(--sb-color-blue-dark);
+  background-color: var(--sb-color-blue-light-3);
+  border-radius: 0.25rem;
+
   &:not(:active) {
-    color: var(--sb-color-blue-dark);
     background-color: var(--sb-color-blue-light-3);
+  }
 
-    border-radius: 0.25rem;
-
-    &.dnb-anchor--icon-left {
+  &.dnb-anchor--icon-left {
+    margin-left: 0;
+    .dnb-icon {
       margin-left: 0;
-      .dnb-icon {
-        margin-left: 0;
-      }
     }
+  }
 
-    &.dnb-anchor--icon-right {
+  &.dnb-anchor--icon-right {
+    margin-right: 0;
+    .dnb-icon {
       margin-right: 0;
-      .dnb-icon {
-        margin-right: 0;
-      }
     }
   }
 }
@@ -59,9 +60,7 @@
   }
 
   &:focus {
-    @include utilities.whatInput('keyboard') {
-      @include anchorFocus();
-    }
+    @include anchorFocus();
   }
 
   &.dnb-anchor--icon-left {
@@ -113,6 +112,10 @@
 
 .dnb-anchor--focus {
   @include anchorFocus();
+}
+
+.dnb-anchor--no-radius {
+  @include anchor-mixins.resetBorderRadius();
 }
 
 // TODO: add correct contrast styling when designs are in place


### PR DESCRIPTION
## Summary

Some small changes to increase compatability between anchor themes, reducing css specificity of some sbanken theme rules so they don@t override others. Mainly to make things compatible with eufemia theming in [style/eufemia-site-sbanken-theme](https://github.com/dnbexperience/eufemia/tree/style/eufemia-site-sbanken-theme)