### PR TITLE
chore(tests): removes react-fake-props

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -233,7 +233,6 @@
     "prop-types": "15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-fake-props": "1.0.3",
     "react-to-typescript-definitions": "3.1.0",
     "regenerator-runtime": "0.13.9",
     "repo-utils": "workspace:*",

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -60,7 +60,9 @@ describe('type definitions', () => {
 
       const content = fs.readFileSync(file, 'utf-8')
       expect(content).toContain('export interface InputProps')
-      expect(content).toContain('extends React.HTMLProps<HTMLElement>,')
+      expect(content).toContain(
+        "extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,"
+      )
       expect(content).toContain('SpacingProps')
     }
   )

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -15,12 +15,10 @@ import MatchMediaMock from 'jest-matchmedia-mock'
 
 new MatchMediaMock()
 
-const props = {
-  id: 'accordion',
-  variant: 'default',
+const props: AccordionProps = {
   no_animation: true,
   title: 'title',
-} as AccordionProps
+}
 
 describe('Accordion component', () => {
   it('has correct state after "click" trigger', () => {

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -36,7 +36,7 @@ export type AnchorProps = {
 }
 
 export type AnchorAllProps = AnchorProps &
-  React.HTMLProps<HTMLAnchorElement> &
+  Omit<React.HTMLProps<HTMLAnchorElement>, 'ref'> &
   SpacingProps
 
 const defaultProps = {}

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -4,16 +4,14 @@
  */
 
 import React from 'react'
-import { fakeProps, axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent } from '../../../core/jest/jestSetup'
 import { act, fireEvent, render } from '@testing-library/react'
-import Anchor from '../Anchor'
+import Anchor, { AnchorAllProps } from '../Anchor'
 
-const props = fakeProps(require.resolve('../Anchor'), {
-  all: true,
-})
-props.inner_ref = null
-props.element = 'a'
-props.lang = 'nb-NO'
+const props: AnchorAllProps = {
+  element: 'a',
+  lang: 'nb-NO',
+}
 
 describe('Anchor element', () => {
   it('has dnb-a class', () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4,11 +4,7 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import * as helpers from '../../../shared/helpers'
 import Autocomplete, { AutocompleteProps } from '../Autocomplete'
 import { SubmitButton } from '../../input/Input'
@@ -25,37 +21,9 @@ import {
   DrawerListDataObjectUnion,
 } from '../../../fragments/drawer-list'
 
-const snapshotProps = {
-  ...fakeProps(require.resolve('../Autocomplete'), {
-    optional: true,
-  }),
+const mockProps: AutocompleteProps = {
   id: 'autocomplete-id',
-  mode: 'sync',
-  label: 'Autocomplete Label:',
-  status: 'status',
-  status_state: 'error',
-  status_props: null,
-  direction: 'bottom',
-  label_direction: 'horizontal',
-  value: 2,
-  icon_position: null,
-  triangle_position: null,
-  prevent_selection: null,
-  align_autocomplete: null,
-  input_element: null,
-  size: null,
-  opened: true,
-  show_submit_button: true,
-  no_animation: true,
-  input_ref: null,
-  skip_portal: true,
-  globalStatus: { id: 'main' },
-}
-
-// use no_animation so we don't need to wait
-const mockProps = {
-  id: 'autocomplete-id',
-  no_animation: true,
+  no_animation: true, // use no_animation so we don't need to wait
   skip_portal: true,
 }
 const props: AutocompleteProps = {
@@ -2384,6 +2352,17 @@ describe('Autocomplete component', () => {
 
 describe('Autocomplete markup', () => {
   it('should validate with ARIA rules', async () => {
+    const snapshotProps: AutocompleteProps = {
+      label: 'Autocomplete Label:',
+      status: 'status',
+      status_state: 'error',
+      status_props: null,
+      value: 2,
+      opened: true,
+      show_submit_button: true,
+      no_animation: true,
+      skip_portal: true,
+    }
     const CheckComponent = render(
       <Autocomplete {...snapshotProps} data={mockData} />
     )

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -24,6 +24,8 @@ import AvatarGroup, { AvatarGroupContext } from './AvatarGroup'
 export type AvatarSizes = 'small' | 'medium' | 'large' | 'x-large'
 export type AvatarVariants = 'primary' | 'secondary' | 'tertiary'
 
+export type AvatarImgProps = ImgProps
+
 export interface AvatarProps {
   /**
    * Used in combination with `src` to provide an alt attribute for the `img` element.

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import Avatar from '../Avatar'
+import Avatar, { AvatarImgProps, AvatarProps } from '../Avatar'
 import { confetti as Confetti } from '../../../icons'
 import Icon from '../../Icon'
 
@@ -8,9 +8,10 @@ import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import { Provider } from '../../../shared'
 
 describe('Avatar', () => {
+  const props: AvatarProps = {}
   it('renders without properties', () => {
     render(
-      <Avatar.Group label="label">
+      <Avatar.Group {...props} label="label">
         <Avatar />
       </Avatar.Group>
     )
@@ -92,7 +93,7 @@ describe('Avatar', () => {
     const img_width = '48'
     const img_height = '48'
     const img_alt = 'custom_alt_label'
-    const imgProps = {
+    const imgProps: AvatarImgProps = {
       width: img_width,
       height: img_height,
       src: img_src,

--- a/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
+++ b/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import Badge from '../Badge'
+import Badge, { BadgeProps } from '../Badge'
 import { confetti as Confetti } from '../../../icons'
 import Icon from '../../Icon'
 import Avatar from '../../Avatar'
@@ -10,7 +10,8 @@ import { Provider } from '../../../shared'
 
 describe('Badge', () => {
   it('renders without properties', () => {
-    render(<Badge />)
+    const props: BadgeProps = {}
+    render(<Badge {...props} />)
 
     expect(document.querySelector('.dnb-badge')).not.toBeNull()
   })

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
-import Breadcrumb, { BreadcrumbItem } from '../Breadcrumb'
+import Breadcrumb, { BreadcrumbItem, BreadcrumbProps } from '../Breadcrumb'
 import { Provider } from '../../../shared'
 import MatchMediaMock from 'jest-matchmedia-mock'
 import IconPrimary from '../../icon-primary/IconPrimary'
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
+import { BreadcrumbItemProps } from '../BreadcrumbItem'
 
 const matchMedia = new MatchMediaMock()
 
@@ -14,7 +15,8 @@ beforeEach(() => {
 
 describe('Breadcrumb', () => {
   it('renders without properties', () => {
-    render(<Breadcrumb />)
+    const props: BreadcrumbProps = {}
+    render(<Breadcrumb {...props} />)
 
     expect(screen.queryByRole('button')).not.toBeNull()
   })
@@ -233,6 +235,13 @@ describe('Breadcrumb', () => {
   })
 
   describe('BreadcrumbItem', () => {
+    it('renders without properties', () => {
+      const props: BreadcrumbItemProps = {}
+      render(<BreadcrumbItem {...props} />)
+
+      expect(screen.queryByRole('listitem')).not.toBeNull()
+    })
+
     it('renders breadcrumbitem as a link', () => {
       render(<BreadcrumbItem href="/url" text="Page" />)
 

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -4,32 +4,16 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
-import Button, { ButtonOnClick } from '../Button'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
+import Button, { ButtonOnClick, ButtonProps } from '../Button'
 import IconPrimary from '../../IconPrimary'
 import { fireEvent, render } from '@testing-library/react'
 import FormRow from '../../form-row/FormRow'
 
-const props = fakeProps(require.resolve('../Button'), {
-  optional: true,
-})
-props.id = 'button'
-props.variant = 'primary'
-props.icon = 'question'
-props.title = 'This is a button title'
-props.size = null
-props.status = null
-props.element = null
-props.tooltip = null
-props.to = null
-props.custom_content = null
-props.text = null
-props.icon_position = 'right'
-props.globalStatus = { id: 'main' }
+const props: ButtonProps = {
+  href: 'href',
+  children: 'children',
+}
 
 beforeAll(() => {
   jest.spyOn(global.console, 'log')

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.d.ts
@@ -17,7 +17,7 @@ export type CheckboxSuffix =
 export type CheckboxAttributes = string | Record<string, unknown>;
 export type CheckboxChildren = string | ((...args: any[]) => any);
 export interface CheckboxProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -5,24 +5,13 @@
 
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import FormRow from '../../form-row/FormRow'
-import Checkbox from '../Checkbox'
+import Checkbox, { CheckboxProps } from '../Checkbox'
 
-const props = fakeProps(require.resolve('../Checkbox'), {
-  all: true,
-  optional: true,
-})
-props.id = 'checkbox'
-props.element = 'input'
-props.status = null
-props.readOnly = false
-props.label = 'checkbox'
-props.label_position = 'left'
+const props: CheckboxProps = {
+  label: 'checkbox',
+}
 
 describe('Checkbox component', () => {
   it('has correct state after "change" trigger', () => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
@@ -26,7 +26,7 @@ type DatePickerSuffix =
 type DatePickerDirection = 'auto' | 'top' | 'bottom';
 type DatePickerAlignPicker = 'auto' | 'left' | 'right';
 export interface DatePickerProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   id?: string;
   title?: string;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
-import DatePicker from '../DatePicker'
+import DatePicker, { DatePickerProps } from '../DatePicker'
 
 jest.setTimeout(30e3)
 
@@ -30,18 +30,13 @@ beforeEach(() => {
 
 describe('DatePicker component', () => {
   // for the integration tests
-  const defaultProps = {
-    id: 'date-picker-id',
+  const defaultProps: DatePickerProps = {
     no_animation: true,
     range: true,
     show_input: true,
     date: '1970-01-01T00:00:00.000Z',
     start_date: '2019-01-01T00:00:00.000Z',
     end_date: '2019-02-15T00:00:00.000Z',
-    status: 'status',
-    status_state: 'error',
-    status_props: null,
-    separatorRexExp: null,
   }
 
   it('has a disabled attribute, once we set disabled to true', () => {

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -1,25 +1,15 @@
 import React from 'react'
 import Dialog from '../Dialog'
+import { DialogProps } from '../types'
 import Button from '../../button/Button'
 import Provider from '../../../shared/Provider'
-import {
-  fakeProps,
-  loadScss,
-  axeComponent,
-} from '../../../core/jest/jestSetup'
+import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import * as helpers from '../../../shared/helpers'
 import { fireEvent, render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../Dialog.tsx'), {
-  all: true,
-  // optional: true, // Does not work with Typescript interface props
-})
-props.title = 'dialog_title'
-props.id = 'dialog_id'
-props.contentId = null
-props.modalContent = 'unique_modal_content'
-props.directDomReturn = true
-props.noAnimation = true
+const props: DialogProps = {
+  noAnimation: true,
+}
 
 beforeAll(() => {
   const button = document.createElement('BUTTON')
@@ -185,7 +175,7 @@ describe('Dialog', () => {
       ({ triggeredBy }) => (testTriggeredBy = triggeredBy)
     )
 
-    const props = {
+    const props: DialogProps = {
       directDomReturn: false,
       noAnimation: true,
     }
@@ -203,7 +193,7 @@ describe('Dialog', () => {
   it('is closed by keyboardevent esc by window listener', () => {
     const on_close = jest.fn()
 
-    const props = {
+    const props: DialogProps = {
       directDomReturn: false,
       noAnimation: true,
     }

--- a/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
@@ -13,6 +13,8 @@ import Context from '../../shared/Context'
 import { DrawerProps, DrawerContentProps } from './types'
 import { removeUndefinedProps } from '../../shared/component-helper'
 
+export type DrawerAllProps = DrawerProps & DrawerContentProps
+
 function Drawer({
   id,
   rootId,
@@ -58,7 +60,7 @@ function Drawer({
   space,
 
   ...props
-}: DrawerProps & DrawerContentProps): JSX.Element {
+}: DrawerAllProps): JSX.Element {
   const context = useContext(Context)
 
   const modalProps = removeUndefinedProps({

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -1,25 +1,14 @@
 import React from 'react'
-import Drawer from '../Drawer'
+import Drawer, { DrawerAllProps } from '../Drawer'
 import Button from '../../button/Button'
 import Provider from '../../../shared/Provider'
 
-import {
-  fakeProps,
-  loadScss,
-  axeComponent,
-} from '../../../core/jest/jestSetup'
+import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import { render, fireEvent } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../Drawer.tsx'), {
-  all: true,
-  // optional: true, // Does not work with Typescript interface props
-})
-props.title = 'drawer_title'
-props.id = 'drawer_id'
-props.contentId = null
-props.modalContent = 'unique_modal_content'
-props.directDomReturn = true
-props.noAnimation = true
+const props: DrawerAllProps = {
+  noAnimation: true,
+}
 
 beforeAll(() => {
   const button = document.createElement('BUTTON')
@@ -119,7 +108,7 @@ describe('Drawer', () => {
       ({ triggeredBy }) => (testTriggeredBy = triggeredBy)
     )
 
-    const props = {
+    const props: DrawerAllProps = {
       directDomReturn: false,
       noAnimation: true,
     }
@@ -138,7 +127,7 @@ describe('Drawer', () => {
   it('is closed by keyboardevent esc by window listener', () => {
     const on_close = jest.fn()
 
-    const props = {
+    const props: DrawerAllProps = {
       directDomReturn: false,
       noAnimation: true,
     }
@@ -162,7 +151,7 @@ describe('Drawer', () => {
       third: jest.fn(),
     }
 
-    const props = {
+    const props: DrawerAllProps = {
       directDomReturn: false,
       noAnimation: true,
     }

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
@@ -21,7 +21,7 @@ type DropdownTriggerElement = ((...args: any[]) => any) | React.ReactNode;
 export interface DropdownProps
   extends DrawerListProps,
     SpacingProps,
-    React.HTMLProps<HTMLElement> {
+    Omit<React.HTMLProps<HTMLElement>, 'ref'> {
   /**
    * Give a title to let the users know what they have to do. Defaults to `Valgmeny`.
    */

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -4,13 +4,9 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import Dropdown from '../Dropdown'
+import Dropdown, { DropdownProps } from '../Dropdown'
 import {
   mockImplementationForDirectionObserver,
   testDirectionObserver,
@@ -21,10 +17,10 @@ import {
 } from '../../../fragments/drawer-list'
 
 // use no_animation so we don't need to wait
-const mockProps = {
+const mockProps: DropdownProps = {
   skip_portal: true,
 }
-const props = {
+const props: DropdownProps = {
   id: 'dropdown-id',
   value: 2,
   skip_portal: true,
@@ -91,7 +87,7 @@ describe('Dropdown component', () => {
     open()
 
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
-      props.value + 1
+      (props.value as number) + 1
     ]
     expect(elem.classList.contains('dnb-drawer-list__option--focus')).toBe(
       true
@@ -103,7 +99,8 @@ describe('Dropdown component', () => {
     expect(
       document.querySelector('.dnb-dropdown__text__inner').textContent
     ).toBe(
-      (mockData[props.value + 1] as DrawerListDataObject).selected_value
+      (mockData[(props.value as number) + 1] as DrawerListDataObject)
+        .selected_value
     )
   })
 
@@ -305,12 +302,12 @@ describe('Dropdown component', () => {
         .length
     ).toBe(1)
 
-    const notChangedItem = mockData[props.value + 1]
+    const notChangedItem = mockData[(props.value as number) + 1]
     expect(on_select.mock.calls[0][0].data).toStrictEqual(notChangedItem)
 
     keydown(40) // down
 
-    const selectedItem = mockData[props.value + 2]
+    const selectedItem = mockData[(props.value as number) + 2]
     expect(on_select.mock.calls[1][0].data).toStrictEqual(selectedItem) // second call!
   })
 
@@ -625,12 +622,12 @@ describe('Dropdown component', () => {
     // then simulate changes
     keydown(40) // down
 
-    selectedItem = mockData[props.value + 1]
+    selectedItem = mockData[(props.value as number) + 1]
     expect(on_select.mock.calls[0][0].data).toStrictEqual(selectedItem)
 
     keydown(32) // space
 
-    selectedItem = mockData[props.value + 1]
+    selectedItem = mockData[(props.value as number) + 1]
     expect(on_change).toHaveBeenCalledTimes(1)
     expect(on_select).toHaveBeenCalledTimes(2)
     expect(on_change.mock.calls[0][0].data).toStrictEqual(selectedItem)
@@ -640,8 +637,8 @@ describe('Dropdown component', () => {
       isTrusted: false,
       data: selectedItem,
       event: new KeyboardEvent('keydown', {}),
-      selected_item: props.value + 1,
-      value: props.value + 1,
+      selected_item: (props.value as number) + 1,
+      value: (props.value as number) + 1,
     })
 
     // open first
@@ -651,7 +648,7 @@ describe('Dropdown component', () => {
     keydown(40) // down
     keydown(13) // enter
 
-    selectedItem = mockData[props.value + 2]
+    selectedItem = mockData[(props.value as number) + 2]
     expect(on_change.mock.calls[1][0].data).toStrictEqual(selectedItem) // second call!
     expect(on_select.mock.calls[3][0].data).toStrictEqual(selectedItem) // second call!
     expect(on_change).toHaveBeenCalledTimes(2)
@@ -1022,7 +1019,8 @@ describe('Dropdown component', () => {
     expect(
       document.querySelector('.dnb-dropdown__text__inner').textContent
     ).toBe(
-      (mockData[props.value + 1] as DrawerListDataObject).selected_value
+      (mockData[(props.value as number) + 1] as DrawerListDataObject)
+        .selected_value
     )
   })
 
@@ -1185,30 +1183,17 @@ describe('Dropdown component', () => {
 
 describe('Dropdown markup', () => {
   it('should validate with ARIA rules', async () => {
-    const snapshotProps = {
-      ...fakeProps(require.resolve('../Dropdown'), {
-        optional: true,
-      }),
+    const snapshotProps: DropdownProps = {
+      title: 'title',
+      label: 'label',
       id: 'dropdown-id',
       status: 'status',
       status_state: 'error',
-      status_props: null,
-      direction: 'bottom',
-      label_direction: 'horizontal',
       value: 2,
-      action_menu: null,
-      more_menu: null,
-      icon_position: null,
-      triangle_position: null,
-      prevent_selection: null,
-      align_dropdown: null,
-      trigger_element: null,
-      size: null,
       opened: true,
       skip_portal: true,
       no_animation: true,
       variant: 'secondary',
-      globalStatus: { id: 'main' },
     }
 
     const CheckComponent = render(

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
@@ -11,7 +11,7 @@ export type FormLabelChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface FormLabelProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * <em>(required)</em> the `id` of the input.

--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -4,22 +4,15 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import FormLabel from '../FormLabel'
+import FormLabel, { FormLabelProps } from '../FormLabel'
 import Input from '../../input/Input'
 import FormRow from '../../form-row/FormRow'
 
-const props = fakeProps(require.resolve('../FormLabel'), {
-  optional: true,
-})
-props.element = 'label'
-props.direction = 'horizontal'
-props.label_direction = 'horizontal'
+const props: FormLabelProps = {
+  title: 'title',
+}
 
 describe('FormLabel component', () => {
   it('should forward unlisted attributes like "aria-hidden"', () => {

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
@@ -11,7 +11,7 @@ export type FormRowChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface FormRowProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   id?: string;
 

--- a/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.test.tsx
@@ -4,24 +4,16 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
-import FormRow from '../FormRow'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
+import FormRow, { FormRowProps } from '../FormRow'
 import Input from '../../input/Input'
 import NumberFormat from '../../number-format/NumberFormat'
 import Provider from '../../../shared/Provider'
 import { render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../FormRow'), {
-  optional: true,
-})
-props.id = 'form-row'
-props.direction = 'horizontal'
-props.label_direction = 'horizontal'
-props.globalStatus = { id: 'main' }
+const props: FormRowProps = {
+  label: 'label',
+}
 
 describe('FormRow component', () => {
   it('should have vertical direction class', () => {

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
@@ -11,7 +11,7 @@ export type FormSetChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface FormSetProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Define what HTML element should be used. Defaults to `<form>`.

--- a/packages/dnb-eufemia/src/components/form-set/__tests__/FormSet.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-set/__tests__/FormSet.test.tsx
@@ -4,23 +4,18 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
-import FormSet from '../FormSet'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
+import FormSet, { FormSetProps } from '../FormSet'
 import FormRow from '../../form-row/FormRow'
 import Input from '../../input/Input'
 import NumberFormat from '../../number-format/NumberFormat'
 import Provider from '../../../shared/Provider'
 import { render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../FormSet'), {
-  optional: true,
-})
-props.direction = 'horizontal'
-props.element = 'form'
+const props: FormSetProps = {
+  direction: 'horizontal',
+  element: 'form',
+}
 
 describe('FormSet component', () => {
   it('should have .dnb-form-set class', () => {

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.d.ts
@@ -23,7 +23,7 @@ export type FormStatusChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface FormStatusProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   id?: string;
 

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
@@ -4,26 +4,14 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
-import FormStatus from '../FormStatus'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
+import FormStatus, { FormStatusProps } from '../FormStatus'
 import Input from '../../input/Input'
 import { render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../FormStatus'), {
-  optional: true,
-  all: true,
-})
-props.id = 'form-status'
-props.text = 'text'
-props.state = 'error'
-props.status = null
-props.globalStatus = { id: 'main' }
-props.hidden = false
-props.icon = 'exclamation'
+const props: FormStatusProps = {
+  text: 'text',
+}
 
 describe('FormStatus component', () => {
   it('should set correct max-width', () => {

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -66,7 +66,7 @@ export type GlobalErrorProps = {
 }
 
 export type GlobalErrorAllProps = GlobalErrorProps &
-  React.HTMLProps<HTMLElement> &
+  Omit<React.HTMLProps<HTMLElement>, 'ref'> &
   SpacingProps &
   GetTranslationProps
 

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
@@ -13,11 +13,11 @@ const status = '404'
 const title = 'title'
 const text = 'text'
 
-const props = {
+const props: GlobalErrorAllProps = {
   status,
   text,
   title,
-} as GlobalErrorAllProps
+}
 
 describe('GlobalError', () => {
   it('has default text for 404', () => {

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.d.ts
@@ -24,7 +24,7 @@ export type GlobalStatusChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface GlobalStatusProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * The main ID. Defaults to `main`.

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
-import GlobalStatus from '../GlobalStatus'
+import GlobalStatus, { GlobalStatusProps } from '../GlobalStatus'
 import { GlobalStatusInterceptor } from '../GlobalStatusController'
 import FormSet from '../../form-set/FormSet'
 import Switch from '../../switch/Switch'
@@ -21,7 +21,7 @@ const show = true
 const no_animation = true
 const autoscroll = false
 
-const props = {
+const props: GlobalStatusProps = {
   show,
   no_animation,
   autoscroll,

--- a/packages/dnb-eufemia/src/components/heading/Heading.d.ts
+++ b/packages/dnb-eufemia/src/components/heading/Heading.d.ts
@@ -17,7 +17,7 @@ type HeadingDebugCounter = boolean | ((...args: any[]) => any);
 type HeadingReset = number | boolean;
 type HeadingChildren = React.ReactNode | ((...args: any[]) => any);
 export interface HeadingProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   id?: string;
   group?: string;

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -43,7 +43,7 @@ export type HeightAnimationProps = {
 
 export type HeightAnimationAllProps = HeightAnimationProps &
   SpacingProps &
-  React.HTMLProps<HTMLElement>
+  Omit<React.HTMLProps<HTMLElement>, 'ref'>
 
 export default function HeightAnimation({
   open = true,

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -4,11 +4,7 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import Dialog from '../../dialog/Dialog'
 import HelpButton, { HelpButtonProps } from '../HelpButton'
 import {
@@ -17,11 +13,7 @@ import {
 } from '../../../icons'
 import { fireEvent, render } from '@testing-library/react'
 
-const snapshotProps = fakeProps(require.resolve('../HelpButton'), {})
-snapshotProps.id = 'help-button'
-
-const props: HelpButtonProps = {}
-props.id = 'help-button'
+const props: HelpButtonProps = { id: 'help-button' }
 
 describe('HelpButton', () => {
   it('should have question icon by default', () => {

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { IconProps } from '../Icon';
 export interface IconPrimaryProps
   extends IconProps,
-    Omit<React.HTMLProps<HTMLElement>, 'size'> {}
+    Omit<React.HTMLProps<HTMLElement>, 'size' | 'ref'> {}
 export default class IconPrimary extends React.Component<
   IconPrimaryProps,
   any

--- a/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
@@ -4,14 +4,13 @@
  */
 
 import React from 'react'
-import { fakeProps, axeComponent } from '../../../core/jest/jestSetup'
-import IconPrimary from '../IconPrimary'
+import { axeComponent } from '../../../core/jest/jestSetup'
+import IconPrimary, { IconPrimaryProps } from '../IconPrimary'
 import { render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../IconPrimary'), {
-  optional: true,
-})
-props.icon = 'question'
+const props: IconPrimaryProps = {
+  icon: 'question',
+}
 
 describe('IconPrimary component', () => {
   it('has valid width and height prop', () => {

--- a/packages/dnb-eufemia/src/components/icon/Icon.d.ts
+++ b/packages/dnb-eufemia/src/components/icon/Icon.d.ts
@@ -12,7 +12,7 @@ export type IconAttributes = string | Record<string, unknown>;
 export type IconChildren = React.ReactNode | ((...args: any[]) => any);
 export type IconColor = string;
 export interface IconProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * <em>(required)</em> a React SVG Component or the icon name (in case we use `IconPrimary` or `dnb-icon-primary`).

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -4,22 +4,16 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Icon from '../Icon'
+import Icon, { IconProps } from '../Icon'
 import { question } from './test-files'
 
-const props = fakeProps(require.resolve('../Icon'), {
-  optional: true,
-})
-props.icon = question
-props.alt = 'question mark'
-props.border = false
-props['aria-hidden'] = null
+const props: IconProps = {
+  icon: question,
+  alt: 'question mark',
+  'aria-hidden': null,
+}
 
 describe('Icon component', () => {
   it('has valid width and height prop', () => {

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import InfoCard from '../InfoCard'
+import InfoCard, { InfoCardAllProps } from '../InfoCard'
 import { confetti as Confetti } from '../../../icons'
 
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
@@ -8,7 +8,8 @@ import { Provider } from '../../../shared'
 
 describe('InfoCard', () => {
   it('renders with no props', () => {
-    render(<InfoCard text="text" />)
+    const props: InfoCardAllProps = { text: 'text' }
+    render(<InfoCard {...props} />)
 
     expect(document.querySelector('.dnb-info-card__text')).not.toBeNull()
   })

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.d.ts
@@ -48,7 +48,7 @@ export type InputMaskedChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 export interface InputMaskedProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * A mask can be defined both as a <a href="https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme">RegExp style of characters</a> or a callback function. Example below.

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -6,13 +6,13 @@
 import React from 'react'
 import { loadScss } from '../../../core/jest/jestSetup'
 import { render, fireEvent } from '@testing-library/react'
-import InputMasked from '../InputMasked'
+import InputMasked, { InputMaskedProps } from '../InputMasked'
 import Provider from '../../../shared/Provider'
 import * as helpers from '../../../shared/helpers'
 import FormRow from '../../form-row/FormRow'
 import userEvent from '@testing-library/user-event'
 
-const props = {
+const props: InputMaskedProps = {
   id: 'input-masked',
 }
 

--- a/packages/dnb-eufemia/src/components/input/Input.d.ts
+++ b/packages/dnb-eufemia/src/components/input/Input.d.ts
@@ -30,7 +30,7 @@ export type InputSubmitButtonIcon =
   | ((...args: any[]) => any);
 export type InputChildren = React.ReactNode | ((...args: any[]) => any);
 export interface InputProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Choose between `text`, `number`, `email`, `password`, `url`, `tel` and `search`.
@@ -175,7 +175,7 @@ export interface InputProps
   /**
    * By providing a React.ref we can get the internally used input element (DOM). E.g. `inner_ref={myRef}` by using `React.createRef()` or `React.useRef()`.
    */
-  inner_ref?: React.RefObject<HTMLInputElement>;
+  inner_ref?: React.Ref;
   readOnly?: boolean;
 
   /**

--- a/packages/dnb-eufemia/src/components/input/InputPassword.d.ts
+++ b/packages/dnb-eufemia/src/components/input/InputPassword.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { InputProps } from './Input';
 export interface InputPasswordProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     InputProps {
   show_password?: string;
   hide_password?: string;

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -4,31 +4,18 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import Input from '../Input'
+import Input, { InputProps } from '../Input'
 import { format } from '../../number-format/NumberUtils'
 import FormRow from '../../form-row/FormRow'
 
-const props = {
-  ...fakeProps(require.resolve('../Input'), {
-    all: true,
-    optional: true,
-  }),
-  input_element: null,
-  disabled: false,
+const props: InputProps = {
+  id: 'input',
+  status: null, // to make sure we don't get aria-details
+  suffix: null, // to make sure we don't get aria-details
+  type: 'text',
 }
-props.id = 'input'
-props.autocomplete = 'off'
-props.label = null
-props.submit_button_variant = 'secondary'
-props.status = null // to make sure we don't get aria-details
-props.suffix = null // to make sure we don't get aria-details
-props.type = 'text'
 
 const log = global.console.log
 afterEach(() => {

--- a/packages/dnb-eufemia/src/components/input/__tests__/InputPassword.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/InputPassword.test.tsx
@@ -4,9 +4,9 @@
  */
 
 import React from 'react'
-import { fakeProps, axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import InputPassword from '../InputPassword'
+import InputPassword, { InputPasswordProps } from '../InputPassword'
 import FormRow from '../../form-row/FormRow'
 
 import nbNO from '../../../shared/locales/nb-NO'
@@ -15,20 +15,10 @@ import enGB from '../../../shared/locales/en-GB'
 const nb = nbNO['nb-NO'].Input
 const en = enGB['en-GB'].Input
 
-const snapshotProps = {
-  ...fakeProps(require.resolve('../InputPassword'), {
-    all: true,
-    optional: true,
-  }),
-  input_element: null,
-  disabled: false,
-}
-snapshotProps.id = 'input'
-snapshotProps.autocomplete = 'off'
-
 describe('InputPassword component', () => {
   it('has correct type by default', () => {
-    render(<InputPassword id="input" />)
+    const props: InputPasswordProps = {}
+    render(<InputPassword {...props} id="input" />)
 
     expect(
       document.querySelector('.dnb-input__input').getAttribute('type')

--- a/packages/dnb-eufemia/src/components/logo/Logo.d.ts
+++ b/packages/dnb-eufemia/src/components/logo/Logo.d.ts
@@ -6,7 +6,7 @@ export type LogoRatio = number | string;
 export type LogoWidth = number | string;
 export type LogoHeight = number | string;
 export interface LogoProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Define the size of the logo. Sets the height. The width will be calculated by the ratio. Also, `inherit` will use the inherited height. Defaults to `auto`.

--- a/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
+++ b/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
@@ -4,18 +4,19 @@
  */
 
 import React from 'react'
-import { fakeProps, loadScss } from '../../../core/jest/jestSetup'
-import Logo from '../Logo'
+import { loadScss } from '../../../core/jest/jestSetup'
+import Logo, { LogoProps } from '../Logo'
 import { render } from '@testing-library/react'
 import Provider from '../../../shared/Provider'
 import Theme from '../../../shared/Theme'
 
-const props = fakeProps(require.resolve('../Logo'), {
-  optional: true,
-})
-props.height = 80
-
 describe('Logo component', () => {
+  it('renders with empty props', () => {
+    const props: LogoProps = {}
+    render(<Logo {...props} />)
+    expect(document.querySelector('.dnb-logo')).toBeTruthy()
+  })
+
   it('should set correct class when inherit_color is set', () => {
     render(<Logo inherit_color />)
     expect(document.querySelector('.dnb-logo').classList).toContain(

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -4,14 +4,11 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import Input from '../../input/Input'
 import Modal, { OriginalComponent } from '../Modal'
+import { ModalProps } from '../types'
 import Button from '../../button/Button'
 import DialogContent from '../../dialog/DialogContent'
 import Provider from '../../../shared/Provider'
@@ -20,17 +17,12 @@ import * as helpers from '../../../shared/helpers'
 global.userAgent = jest.spyOn(navigator, 'userAgent', 'get')
 global.appVersion = jest.spyOn(navigator, 'appVersion', 'get')
 
-const props = fakeProps(require.resolve('../Modal.tsx'), {
-  all: true,
-  // optional: true, // Does not work with Typescript interface props
-})
-props.title = 'modal_title'
-props.id = 'modal_id'
-props.content_id = null
-props.style_type = 'button'
-props.modal_content = 'unique_modal_content'
-props.direct_dom_return = true
-props.no_animation = true
+const props: ModalProps = {
+  title: 'modal_title',
+  id: 'modal_id',
+  modal_content: 'unique_modal_content',
+  no_animation: true,
+}
 
 beforeAll(() => {
   const button = document.createElement('BUTTON')
@@ -419,7 +411,7 @@ describe('Modal component', () => {
       third: jest.fn(),
     }
 
-    const props = {
+    const props: ModalProps = {
       direct_dom_return: false,
       no_animation: true,
     }

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -13,7 +13,7 @@ import { fireEvent, render } from '@testing-library/react'
 import { LOCALE } from '../../../shared/defaults'
 import { isMac } from '../../../shared/helpers'
 import Provider from '../../../shared/Provider'
-import NumberFormat from '../NumberFormat'
+import NumberFormat, { NumberFormatProps } from '../NumberFormat'
 import { format, formatReturnValue } from '../NumberUtils'
 
 const Component = (props) => {
@@ -51,6 +51,15 @@ beforeAll(() => {
 describe('NumberFormat component', () => {
   const displaySelector = element + '.dnb-number-format span'
   const ariaSelector = element + '.dnb-number-format span[id]'
+
+  it('renders without properties', () => {
+    const props: NumberFormatProps = {}
+    render(<Component {...props} />)
+
+    expect(
+      document.querySelector(displaySelector).textContent
+    ).toBeTruthy()
+  })
 
   it('have to match default number', () => {
     render(<Component value={value} />)

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.d.ts
@@ -35,7 +35,7 @@ type PaginationIndicatorElement =
   | string;
 type PaginationChildren = React.ReactNode | ((...args: any[]) => any);
 export interface PaginationProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * The page shown in the very beginning. If `current_page` is set, then it may not make too much sense to set this as well.

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -4,31 +4,22 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import Pagination, { createPagination, Bar } from '../Pagination'
+import Pagination, {
+  createPagination,
+  Bar,
+  PaginationProps,
+} from '../Pagination'
 import nbNO from '../../../shared/locales/nb-NO'
 import enGB from '../../../shared/locales/en-GB'
 import Provider from '../../../shared/Provider'
-
-const snapshotProps = {
-  ...fakeProps(require.resolve('../Pagination'), {
-    all: true,
-    optional: true,
-  }),
-}
-snapshotProps.page_count = 4
-snapshotProps.current_page = 2
 
 const nb = nbNO['nb-NO'].Pagination
 const en = enGB['en-GB'].Pagination
 
 describe('Pagination bar', () => {
-  const props = {
+  const props: PaginationProps = {
     page_count: 30,
     current_page: 15,
   }
@@ -266,7 +257,7 @@ describe('Infinity scroller', () => {
     })
   })
 
-  const props = {
+  const props: PaginationProps = {
     page_count: 5,
     current_page: 3,
     min_wait_time: 0,
@@ -760,6 +751,11 @@ describe('Infinity scroller', () => {
 
 describe('Pagination ARIA', () => {
   it('should validate with ARIA rules for pagination bar', async () => {
+    const snapshotProps: PaginationProps = {
+      page_count: 4,
+      current_page: 2,
+    }
+
     const CheckComponent = render(<Pagination {...snapshotProps} />)
     expect(await axeComponent(CheckComponent)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
@@ -4,24 +4,14 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { render, screen } from '@testing-library/react'
 import ProgressIndicator, {
   ProgressIndicatorProps,
 } from '../ProgressIndicator'
 import { format } from '../../number-format/NumberUtils'
 
-const props: ProgressIndicatorProps = fakeProps(
-  require.resolve('../ProgressIndicator'),
-  {
-    all: true,
-    optional: true,
-  }
-)
+const props: ProgressIndicatorProps = {}
 
 describe('Circular ProgressIndicator component', () => {
   const mainLineSelector =

--- a/packages/dnb-eufemia/src/components/radio/Radio.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/Radio.d.ts
@@ -21,7 +21,7 @@ export type RadioSuffix =
 export type RadioAttributes = string | Record<string, unknown>;
 export type RadioChildren = string | ((...args: any[]) => any);
 export interface RadioProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.d.ts
@@ -21,7 +21,7 @@ export type RadioGroupChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface RadioGroupProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -5,26 +5,13 @@
 
 import { fireEvent, render, cleanup } from '@testing-library/react'
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import FormRow from '../../form-row/FormRow'
-import Radio from '../Radio'
+import Radio, { RadioProps } from '../Radio'
 
-const props = fakeProps(require.resolve('../Radio'), {
-  optional: true,
-})
-props.id = 'radio'
-props.element = 'input'
-props.group = null
-props.status = null
-props.size = null
-props.readOnly = false
-props.label_position = 'left'
-props.direction = 'horizontal'
-props.globalStatus = { id: 'main' }
+const props: RadioProps = {
+  label: 'label',
+}
 
 describe('Radio component', () => {
   it('has correct state after "change" trigger', () => {

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -61,7 +61,7 @@ export type SectionProps = {
 
 export type SectionAllProps = SectionProps &
   SpacingProps &
-  React.HTMLProps<HTMLElement>
+  Omit<React.HTMLProps<HTMLElement>, 'ref'>
 
 const defaultProps = {
   element: 'section',

--- a/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
@@ -5,21 +5,13 @@
 
 import React from 'react'
 import { render } from '@testing-library/react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
-import Section from '../Section'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
+import Section, { SectionAllProps } from '../Section'
 import Provider from '../../../shared/Provider'
 
-const props = fakeProps(require.resolve('../Section'), {
-  all: true,
-})
-props.style = null
-props.element = null
-props.inner_ref = null
-props.style_type = 'mint-green-12'
+const props: SectionAllProps = {
+  style_type: 'mint-green-12',
+}
 
 describe('Section component', () => {
   it('should have correct styles', () => {

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.d.ts
@@ -10,7 +10,7 @@ export type SkeletonChildren =
   | ((...args: any[]) => any)
   | React.ReactNode;
 export interface SkeletonProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Use `true` to enable/show the skeleton for the component used inside. Defaults to `false`.

--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/Skeleton.test.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/Skeleton.test.tsx
@@ -5,12 +5,12 @@
 
 import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
-import Skeleton from '../Skeleton'
+import Skeleton, { SkeletonProps } from '../Skeleton'
 import Input from '../../input/Input'
 import P from '../../../elements/P'
 import { render } from '@testing-library/react'
 
-const props = {
+const props: SkeletonProps = {
   children: (
     <>
       <P>paragraph</P>

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { wait } from '@testing-library/user-event/dist/utils'
-import SkipContent from '../SkipContent'
+import SkipContent, { SkipContentAllProps } from '../SkipContent'
 import Section from '../../Section'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 
@@ -10,6 +10,18 @@ beforeEach(() => {
 })
 
 describe('SkipContent', () => {
+  it('renders with properties as object', () => {
+    const props: SkipContentAllProps = { selector: '#unique-id' }
+    render(
+      <>
+        <SkipContent {...props} />
+        <Section id="unique-id">content</Section>
+      </>
+    )
+
+    expect(document.querySelector('.dnb-skip-content')).toBeTruthy()
+  })
+
   it('should have one button child with dnb-sr-only class', () => {
     render(
       <>

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -115,7 +115,8 @@ export type SpaceProps = {
   innerRef?: React.RefObject<HTMLElement>
 } & SpacingProps
 
-export type SpaceAllProps = SpaceProps & React.HTMLProps<HTMLElement>
+export type SpaceAllProps = SpaceProps &
+  Omit<React.HTMLProps<HTMLElement>, 'ref'>
 
 export default class Space extends React.PureComponent<
   SpaceAllProps | React.HTMLProps<HTMLElement>

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -4,16 +4,18 @@
  */
 
 import React from 'react'
-import { fakeProps, loadScss } from '../../../core/jest/jestSetup'
+import { loadScss } from '../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Space from '../Space'
+import Space, { SpaceAllProps } from '../Space'
 
-const snapshotProps = fakeProps(require.resolve('../Space'))
-snapshotProps.id = 'space'
-snapshotProps.element = 'div'
-snapshotProps.no_collapse = false
+const props: SpaceAllProps = {}
 
 describe('Space component', () => {
+  it('renders with empty props', () => {
+    render(<Space {...props} />)
+    expect(document.querySelector('.dnb-space')).toBeTruthy()
+  })
+
   it('should have correct CSS classes', () => {
     render(<Space element="span" top="large" />)
     expect(

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.d.ts
@@ -23,7 +23,7 @@ export type StepIndicatorChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 export interface StepIndicatorProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLAnchorElement>, 'ref'>,
     SpacingProps {
   /**
    * <em>(required)</em> a unique string-based ID in order to bind together the main component and the sidebar (`<StepIndicator.Sidebar />`). Both have to get the same ID.

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
@@ -7,7 +7,7 @@ export interface StepIndicatorSidebarProps
       StepIndicatorProps,
       'sidebar_id' | 'mode' | 'current_step' | 'data'
     >,
-    React.HTMLProps<HTMLElement> {
+    Omit<React.HTMLProps<HTMLAnchorElement>, 'ref'> {
   internalId?: string;
   showInitialData?: boolean;
 }

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -6,9 +6,13 @@
 import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import StepIndicator from '../StepIndicator'
+import StepIndicator, {
+  StepIndicatorData,
+  StepIndicatorProps,
+} from '../StepIndicator'
 import Provider from '../../../shared/Provider'
 import MatchMediaMock from 'jest-matchmedia-mock'
+import { StepIndicatorSidebarProps } from '../StepIndicatorSidebar'
 
 const matchMedia = new MatchMediaMock()
 
@@ -21,7 +25,7 @@ function simulateSmallScreen() {
   matchMedia.useMediaQuery('(min-width: 0) and (max-width: 60em)')
 }
 
-const stepIndicatorListData = [
+const stepIndicatorListData: StepIndicatorData = [
   {
     title: 'Step A',
   },
@@ -37,6 +41,19 @@ const stepIndicatorListData = [
 ]
 
 describe('StepIndicator Sidebar', () => {
+  it('renders with empty props', () => {
+    const props: StepIndicatorSidebarProps = {}
+    render(
+      <Provider StepIndicator={{ data: ['one', 'two', 'three'] }}>
+        <StepIndicator.Sidebar {...props} />
+      </Provider>
+    )
+
+    expect(
+      document.querySelector('.dnb-step-indicator__sidebar')
+    ).toBeTruthy()
+  })
+
   it('has to inherit Provider data for initial SSR render', () => {
     render(
       <Provider StepIndicator={{ data: ['one', 'two', 'three'] }}>
@@ -109,6 +126,22 @@ describe('StepIndicator Sidebar', () => {
 })
 
 describe('StepIndicator in general', () => {
+  it('renders with empty props', () => {
+    const id = 'unique-id-spacing'
+
+    const sidebarProps: StepIndicatorSidebarProps = { id }
+    const stepIndicatorProps: StepIndicatorProps = { sidebar_id: id }
+    render(
+      <>
+        <StepIndicator.Sidebar {...sidebarProps} />
+        <StepIndicator {...stepIndicatorProps} />
+      </>
+    )
+
+    expect(
+      document.querySelector('.dnb-step-indicator-wrapper')
+    ).toBeTruthy()
+  })
   it('should support spacing props', () => {
     const id = 'unique-id-spacing'
     render(

--- a/packages/dnb-eufemia/src/components/switch/Switch.d.ts
+++ b/packages/dnb-eufemia/src/components/switch/Switch.d.ts
@@ -16,7 +16,7 @@ export type SwitchSuffix =
 export type SwitchAttributes = string | Record<string, unknown>;
 export type SwitchChildren = string | ((...args: any[]) => any);
 export interface SwitchProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * Use either the `label` property or provide a custom one.

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -5,23 +5,14 @@
 
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import FormRow from '../../form-row/FormRow'
-import Switch from '../Switch'
+import Switch, { SwitchProps } from '../Switch'
 
-const props = fakeProps(require.resolve('../Switch'), {
-  optional: true,
-})
-props.status = null
-props.size = 'default'
-props.label_position = 'left'
-props.readOnly = false
-props.label_direction = 'horizontal'
-props.globalStatus = { id: 'main' }
+const props: SwitchProps = {
+  title: 'title',
+  label: 'label',
+}
 
 describe('Switch component', () => {
   it('has correct state after "change" trigger', () => {

--- a/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import { BasicTable } from './TableMocks'
-import Table from '../Table'
+import Table, { TableAllProps } from '../Table'
 
 const NODE_ENV = process.env.NODE_ENV
 const log = globalThis.console.log
@@ -24,6 +24,13 @@ afterEach(() => {
 })
 
 describe('Table', () => {
+  it('renders with props as an object', () => {
+    const props: TableAllProps = { children: 'children' }
+    render(<Table {...props} />)
+
+    expect(document.querySelector('.dnb-table')).toBeTruthy()
+  })
+
   it('should contain basis HTML classes by default', () => {
     render(
       <Table>

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -28,7 +28,7 @@ export type TabsChildren =
   | React.ReactNode
   | ((...args: any[]) => any);
 export interface TabsProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * <em>(required)</em> defines the data structure to load as a JSON. e.g. `[{title: &#39;...&#39;, content: &#39;Current tab&#39;, key: &#39;...&#39;, hash: &#39;...&#39;}]`

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -4,21 +4,12 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import Tabs from '../Tabs'
+import Tabs, { TabsProps } from '../Tabs'
 import Input from '../../input/Input'
 
-const props = fakeProps(require.resolve('../Tabs'), {
-  all: true,
-  optional: true,
-})
-delete props.render
-props.id = 'id'
+const props: TabsProps = { id: 'id' }
 
 const startup_selected_key = 'second'
 const tablistData = [
@@ -195,7 +186,7 @@ describe('Tabs component', () => {
 
   it('should support "tabs_spacing" prop', () => {
     render(
-      <Tabs {...props} data={tablistData} tabs_spacing="small">
+      <Tabs {...props} data={tablistData} tabs_spacing={true}>
         {contentWrapperData}
       </Tabs>
     )
@@ -205,7 +196,7 @@ describe('Tabs component', () => {
     expect(Array.from(element.classList)).toEqual([
       'dnb-tabs__tabs',
       'dnb-tabs__tabs--left',
-      'dnb-section--spacing-small',
+      'dnb-section--spacing-large',
     ])
   })
 

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -1,13 +1,21 @@
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
-import Tag from '../Tag'
+import Tag, { TagProps } from '../Tag'
 import nbNO from '../../../shared/locales/nb-NO'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { Provider } from '../../../shared'
+import { TagGroupProps } from '../TagGroup'
 
 const nb = nbNO['nb-NO'].Tag
 
 describe('Tag Group', () => {
+  it('renders with props as an object', () => {
+    const props: TagGroupProps = { label: 'label' }
+
+    render(<Tag.Group {...props} />)
+    expect(document.querySelector('.dnb-tag__group')).not.toBeNull()
+  })
+
   it('renders without children', () => {
     render(<Tag.Group label="tags" />)
 
@@ -89,6 +97,17 @@ describe('Tag Group', () => {
 })
 
 describe('Tag', () => {
+  it('renders with props as an object', () => {
+    const props: TagProps = {}
+
+    render(
+      <Tag.Group label="tags">
+        <Tag {...props} />
+      </Tag.Group>
+    )
+    expect(document.querySelector('.dnb-tag')).not.toBeNull()
+  })
+
   it('renders without properties', () => {
     render(
       <Tag.Group label="tags">

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.d.ts
@@ -25,7 +25,7 @@ export type TextareaTextareaElement =
   | React.ReactNode;
 export type TextareaChildren = React.ReactNode | ((...args: any[]) => any);
 export interface TextareaProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * The content value of the Textarea.

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -5,20 +5,12 @@
 
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import FormRow from '../../form-row/FormRow'
-import Textarea from '../Textarea'
+import Textarea, { TextareaProps } from '../Textarea'
 import userEvent from '@testing-library/user-event'
 
-const props = {
-  ...fakeProps(require.resolve('../Textarea'), {
-    all: true,
-    optional: true,
-  }),
+const props: TextareaProps = {
   id: 'textarea',
   label: null,
   status: null, // to make sure we don't get aria-details

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import Timeline from '../Timeline'
-import TimelineItem from '../TimelineItem'
+import Timeline, { TimelineAllProps } from '../Timeline'
+import TimelineItem, { TimelineItemAllProps } from '../TimelineItem'
 
 import IconPrimary from '../../icon-primary/IconPrimary'
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
@@ -12,6 +12,14 @@ beforeEach(() => {
 })
 
 describe('Timeline', () => {
+  it('renders with props as an object', () => {
+    const props: TimelineAllProps = {}
+
+    render(<Timeline {...props} />)
+
+    expect(document.querySelector('.dnb-timeline')).not.toBeNull()
+  })
+
   it('renders without properties', () => {
     render(<Timeline />)
 
@@ -162,6 +170,17 @@ describe('Timeline', () => {
   })
 
   describe('TimelineItem', () => {
+    it('renders with props as an object', () => {
+      const props: TimelineItemAllProps = {
+        state: 'completed',
+        title: 'title',
+      }
+
+      render(<TimelineItem {...props} />)
+
+      expect(document.querySelector('.dnb-timeline__item')).not.toBeNull()
+    })
+
     it('renders title', () => {
       const title = 'Completed'
       render(<TimelineItem title={title} state="completed" />)

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.d.ts
@@ -24,7 +24,7 @@ export type ToggleButtonValue =
 export type ToggleButtonAttributes = string | Record<string, unknown>;
 export type ToggleButtonChildren = string | ((...args: any[]) => any);
 export interface ToggleButtonProps
-  extends React.HTMLProps<HTMLElement>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   /**
    * <em>(required)</em> the text shown in the ToggleButton.

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
@@ -5,24 +5,15 @@
 
 import { fireEvent, render, cleanup } from '@testing-library/react'
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import FormRow from '../../form-row/FormRow'
-import ToggleButton from '../ToggleButton'
+import ToggleButton, { ToggleButtonProps } from '../ToggleButton'
 
-const props = fakeProps(require.resolve('../ToggleButton'), {
-  optional: true,
-})
-props.id = 'toggle-button'
-props.status = null
-props.icon_position = 'left'
-props.label_direction = 'horizontal'
-props.variant = 'checkbox'
-props.readOnly = false
-props.globalStatus = { id: 'main' }
+const props: ToggleButtonProps = {
+  variant: 'checkbox',
+  title: 'title',
+  label: 'label',
+}
 
 describe('ToggleButton component', () => {
   it('has correct state after "click" trigger', () => {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -10,7 +10,7 @@ import { wait } from '@testing-library/user-event/dist/utils'
 import OriginalTooltip from '../Tooltip'
 import Anchor from '../../anchor/Anchor'
 import NumberFormat from '../../number-format/NumberFormat'
-import { TooltipProps } from '../types'
+import { TooltipAllProps } from '../types'
 
 global.ResizeObserver = class {
   constructor() {
@@ -27,7 +27,7 @@ global.ResizeObserver = class {
   }
 }
 
-const defaultProps = {
+const defaultProps: TooltipAllProps = {
   showDelay: 1,
   hideDelay: 1,
 }
@@ -38,7 +38,7 @@ beforeEach(() => {
 })
 
 describe('Tooltip', () => {
-  const Tooltip = (props: TooltipProps = {}) => (
+  const Tooltip = (props: TooltipAllProps = {}) => (
     <OriginalTooltip
       id="tooltip"
       noAnimation
@@ -209,7 +209,7 @@ describe('Tooltip', () => {
   })
 
   describe('with targetSelector', () => {
-    const Tooltip = (props: TooltipProps) => (
+    const Tooltip = (props: TooltipAllProps) => (
       <>
         <button id="button-id">Button</button>
         <OriginalTooltip
@@ -240,7 +240,7 @@ describe('Tooltip', () => {
   })
 
   describe('with targetElement', () => {
-    const Tooltip = (props: TooltipProps = {}) => (
+    const Tooltip = (props: TooltipAllProps = {}) => (
       <OriginalTooltip
         id="tooltip"
         {...defaultProps}
@@ -417,12 +417,12 @@ describe('Tooltip', () => {
     })
 
     describe('and group', () => {
-      const commonProps: TooltipProps = {
+      const commonProps: TooltipAllProps = {
         group: 'unique-name',
         noAnimation: true,
       }
 
-      const GroupTooltip = (props: TooltipProps) => {
+      const GroupTooltip = (props: TooltipAllProps) => {
         return (
           <>
             <OriginalTooltip

--- a/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import VisuallyHidden from '../VisuallyHidden'
+import VisuallyHidden, { VisuallyHiddenAllProps } from '../VisuallyHidden'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { Provider } from '../../../shared'
 
 describe('VisuallyHidden', () => {
+  it('renders with props as an object', () => {
+    const props: VisuallyHiddenAllProps = {}
+    render(<VisuallyHidden {...props} />)
+
+    expect(document.querySelector('.dnb-visually-hidden')).not.toBeNull()
+  })
+
   it('renders without properties', () => {
     render(<VisuallyHidden />)
 

--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -4,20 +4,13 @@
  */
 
 import { axe, toHaveNoViolations } from 'jest-axe'
-import fakeProps from 'react-fake-props'
 import { mount, render } from './enzyme'
 import fs from 'fs-extra'
 import path from 'path'
 import sass from 'sass'
 import { toBeType } from 'jest-tobetype'
 
-export {
-  fakeProps, // we have also our own replacement function called "fakeAllProps"
-  mount,
-  render,
-  axe,
-  toHaveNoViolations,
-}
+export { mount, render, axe, toHaveNoViolations }
 
 expect.extend({ toBeType })
 expect.extend(toHaveNoViolations)

--- a/packages/dnb-eufemia/src/elements/Element.tsx
+++ b/packages/dnb-eufemia/src/elements/Element.tsx
@@ -39,7 +39,7 @@ export type ElementProps = {
 
 export type ElementAllProps = ElementProps &
   ElementInternalProps &
-  React.HTMLProps<HTMLElement>
+  Omit<React.HTMLProps<HTMLElement>, 'ref'>
 
 type Attributes = Record<string, unknown>
 

--- a/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
+++ b/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
@@ -4,19 +4,16 @@
  */
 
 import React from 'react'
-import { fakeProps, axeComponent } from '../../core/jest/jestSetup'
+import { axeComponent } from '../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Element, { defaultProps } from '../Element'
+import Element, { defaultProps, ElementAllProps } from '../Element'
 import { Provider } from '../../shared'
 
-const props = fakeProps(require.resolve('../Element'), {
-  optional: true,
-})
-props.as = 'p'
-props.innerRef = null
-props.internalClass = null
-props.skeletonMethod = 'font'
-props.skeleton = true
+const props: ElementAllProps = {
+  as: 'p',
+  skeletonMethod: 'font',
+  skeleton: true,
+}
 
 describe('Element', () => {
   it('have to merge className', () => {

--- a/packages/dnb-eufemia/src/elements/lists/__tests__/Lists.test.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/__tests__/Lists.test.tsx
@@ -6,11 +6,18 @@
 import React from 'react'
 import { axeComponent } from '../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Dl from '../Dl'
-import Dt from '../../Dt'
-import Dd from '../../Dd'
+import Dl, { DlAllProps } from '../Dl'
+import Dt, { DtProps } from '../../Dt'
+import Dd, { DdProps } from '../../Dd'
 
 describe('Dl', () => {
+  it('renders with props as an object', () => {
+    const props: DlAllProps = {}
+    render(<Dl {...props} />)
+
+    expect(document.querySelector('.dnb-dl')).not.toBeNull()
+  })
+
   it('should support spacing props', () => {
     render(
       <Dl top="medium" direction="horizontal">
@@ -88,6 +95,24 @@ describe('Dl', () => {
         </Dl>
       )
       expect(await axeComponent(Component)).toHaveNoViolations()
+    })
+  })
+
+  describe('Dt', () => {
+    it('renders with props as an object', () => {
+      const props: DtProps = {}
+      render(<Dt {...props} />)
+
+      expect(document.querySelector('.dnb-dt')).not.toBeNull()
+    })
+  })
+
+  describe('Dd', () => {
+    it('renders with props as an object', () => {
+      const props: DdProps = { children: 'children' }
+      render(<Dd {...props} />)
+
+      expect(document.querySelector('.dnb-dd')).not.toBeNull()
     })
   })
 })

--- a/packages/dnb-eufemia/src/elements/typography/__tests__/P.test.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/__tests__/P.test.tsx
@@ -4,15 +4,14 @@
  */
 
 import React from 'react'
-import { fakeProps, axeComponent } from '../../../core/jest/jestSetup'
-import P from '../P'
+import { axeComponent } from '../../../core/jest/jestSetup'
+import P, { PProps } from '../P'
 import { render } from '@testing-library/react'
 
-const props = fakeProps(require.resolve('../P'), {
-  optional: true,
-})
-props.size = 'x-small'
-props.element = 'p'
+const props: PProps = {
+  size: 'x-small',
+  element: 'p',
+}
 
 describe('P element', () => {
   it('has correct size when size is defined', () => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -4,13 +4,9 @@
  */
 
 import React from 'react'
-import {
-  fakeProps,
-  axeComponent,
-  loadScss,
-} from '../../../core/jest/jestSetup'
+import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { render, screen } from '@testing-library/react'
-import DrawerList from '../DrawerList'
+import DrawerList, { DrawerListProps } from '../DrawerList'
 
 import {
   mockImplementationForDirectionObserver,
@@ -20,10 +16,11 @@ import {
 mockImplementationForDirectionObserver()
 
 // use no_animation so we don't need to wait
-const mockProps = {
+const mockProps: DrawerListProps = {
   skip_portal: true,
 }
-const props = {
+
+const props: DrawerListProps = {
   id: 'drawer-list-id',
   value: 2,
   skip_portal: true,
@@ -117,13 +114,13 @@ describe('DrawerList component', () => {
         default_value={props.value}
         {...mockProps}
         title={title}
-        value={props.value + 1}
+        value={(props.value as number) + 1}
       />
     )
 
     // the selected option got a new position
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
-      props.value + 1
+      (props.value as number) + 1
     ]
     expect(
       elem.classList.contains('dnb-drawer-list__option--selected')
@@ -215,7 +212,7 @@ describe('DrawerList component', () => {
     expect(on_select.mock.calls[1][0].selected_item).toBe(undefined)
     expect(on_select.mock.calls[1][0].active_item).toBe(3)
 
-    const selectedItem = mockData[props.value + 1]
+    const selectedItem = mockData[(props.value as number) + 1]
     expect(on_select.mock.calls[1][0].data).toStrictEqual(selectedItem) // second call!
   })
 
@@ -294,7 +291,7 @@ describe('DrawerList component', () => {
     keydown(40) // down
     keydown(32) // space
 
-    selectedItem = mockData[props.value + 1]
+    selectedItem = mockData[(props.value as number) + 1]
     expect(on_change.mock.calls[0][0].data).toStrictEqual(selectedItem)
     expect(on_select.mock.calls[1][0].data).toStrictEqual(selectedItem)
 
@@ -323,7 +320,7 @@ describe('DrawerList component', () => {
     keydown(40) // down
     keydown(13) // enter
 
-    selectedItem = mockData[props.value + 2]
+    selectedItem = mockData[(props.value as number) + 2]
     expect(on_change.mock.calls[1][0].data).toStrictEqual(selectedItem) // second call!
     expect(on_select.mock.calls[3][0].data).toStrictEqual(selectedItem) // second call!
   })
@@ -464,20 +461,14 @@ describe('DrawerList component', () => {
 
 describe('DrawerList markup', () => {
   it('should validate with ARIA rules', async () => {
-    const snapshotProps = {
-      ...fakeProps(require.resolve('../DrawerList'), {
-        all: true,
-        optional: true,
-      }),
+    const snapshotProps: DrawerListProps = {
       id: 'drawer-list-id',
       direction: 'bottom',
       value: 2,
       skip_portal: true,
       opened: true,
       no_animation: true,
-      prevent_selection: null,
       size: 'default',
-      align_drawer: null,
     }
 
     const CheckComponent = render(

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -593,21 +593,6 @@ describe('"convertJsxToString" should', () => {
       'reachable A reachable B'
     )
   })
-
-  // This is not supported currently
-  // it.only('extracts content from components inside array', () => {
-  //   const Component = () => 'not reachable'
-  //   const Content = () => (
-  //     <>
-  //       <div key="a">reachable A</div>
-  //       <Component key="x" />
-  //       <div key="b">reachable B</div>
-  //     </>
-  //   )
-  //   expect(convertJsxToString(Content, '|')).toBe(
-  //     'reachable A|reachable B'
-  //   )
-  // })
 })
 
 describe('"escapeRegexChars" should', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,7 +3727,6 @@ __metadata:
     prop-types: 15.7.2
     react: 17.0.2
     react-dom: 17.0.2
-    react-fake-props: 1.0.3
     react-to-typescript-definitions: 3.1.0
     regenerator-runtime: 0.13.9
     repo-utils: "workspace:*"
@@ -30508,7 +30507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:5.4.0, react-docgen@npm:^5.0.0":
+"react-docgen@npm:^5.0.0":
   version: 5.4.0
   resolution: "react-docgen@npm:5.4.0"
   dependencies:
@@ -30570,17 +30569,6 @@ __metadata:
   version: 6.0.11
   resolution: "react-error-overlay@npm:6.0.11"
   checksum: ce7b44c38fadba9cedd7c095cf39192e632daeccf1d0747292ed524f17dcb056d16bc197ddee5723f9dd888f0b9b19c3b486c430319e30504289b9296f2d2c42
-  languageName: node
-  linkType: hard
-
-"react-fake-props@npm:1.0.3":
-  version: 1.0.3
-  resolution: "react-fake-props@npm:1.0.3"
-  dependencies:
-    react-docgen: 5.4.0
-  peerDependencies:
-    react: "*"
-  checksum: 947542bb50f4e6439f957f07e860bb77e9dd297ac995e93409897e7b59766c9abacba778a5201279bff6b5b5189c585e2e79443b26c03c13a708b3dc0e815950
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TODO:
- [x] A lot of TypeScript errors now that our props(default props) is typed using `ComponentProps`. Most of it seems to be related to "ref".
- [x] Further try to remove unnecessary props(finding the needle in the haystack).
- [x] Investigate why DrawerProps type gives strange errors.
- [x] Fix postbuild test. 