### PR TITLE
chore: fix existing "/build" check

### DIFF
--- a/packages/dnb-design-system-portal/src/core/BuildTools.cjs
+++ b/packages/dnb-design-system-portal/src/core/BuildTools.cjs
@@ -4,8 +4,8 @@ const fs = require('fs-extra')
 function shouldUsePrebuild() {
   const rootPath = path.dirname(require.resolve('@dnb/eufemia'))
   const buildPath = path.resolve(rootPath, 'build')
-  const packageJsonPath = path.resolve(buildPath, 'package.json')
-  const prebuildExists = fs.existsSync(packageJsonPath)
+  const packageIndex = path.resolve(buildPath, 'index.js')
+  const prebuildExists = fs.existsSync(packageIndex)
 
   return Boolean(prebuildExists && process.env.NODE_ENV === 'production')
 }


### PR DESCRIPTION
Locally, when running a prebuild, no package.json is generated. Therefore, we should check for an index file instead.
