### PR TITLE
chore(convertSvgToJsx): fixes errors running ES6 to ES5 conversion

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/convertSvgToJsx.test.tsx
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/convertSvgToJsx.test.tsx
@@ -27,10 +27,12 @@ beforeAll(async () => {
       './test-files/dnb/icons-svg.lock'
     ),
   })
+  jest.useFakeTimers()
 })
 
 afterAll(async () => {
   await del(path.resolve(__dirname, `./test-files/dist`))
+  jest.useRealTimers()
 })
 
 describe('run convertSvgToJsx to convert ES6 to ES5', () => {


### PR DESCRIPTION
I've had the following errors when running tests locally for quite some time.
Fixes the following errors when running these tests locally:
<img width="805" alt="Screenshot 2023-06-15 at 09 08 17" src="https://github.com/dnbexperience/eufemia/assets/1359205/4cb091b3-3bc3-49b1-8d3a-e3c5bf52a14c">
