### PR TITLE
chore: fixes ts error in stepindicator test

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.d.ts
@@ -3,13 +3,11 @@ import type { SpacingProps } from '../../shared/types';
 import type { StepIndicatorProps } from './StepIndicator';
 export interface StepIndicatorSidebarProps
   extends SpacingProps,
-    Pick<
-      StepIndicatorProps,
-      'sidebar_id' | 'mode' | 'current_step' | 'data'
-    >,
+    Pick<StepIndicatorProps, 'mode' | 'current_step' | 'data'>,
     Omit<React.HTMLProps<HTMLAnchorElement>, 'ref'> {
   internalId?: string;
   showInitialData?: boolean;
+  sidebar_id: string;
 }
 export default class StepIndicatorSidebar extends React.Component<
   StepIndicatorSidebarProps,

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -42,7 +42,7 @@ const stepIndicatorListData: StepIndicatorData = [
 
 describe('StepIndicator Sidebar', () => {
   it('renders with empty props', () => {
-    const props: StepIndicatorSidebarProps = {}
+    const props: StepIndicatorSidebarProps = { sidebar_id: 'id' }
     render(
       <Provider StepIndicator={{ data: ['one', 'two', 'three'] }}>
         <StepIndicator.Sidebar {...props} />
@@ -127,10 +127,10 @@ describe('StepIndicator Sidebar', () => {
 
 describe('StepIndicator in general', () => {
   it('renders with empty props', () => {
-    const id = 'unique-id-spacing'
+    const sidebar_id = 'unique-id-spacing'
 
-    const sidebarProps: StepIndicatorSidebarProps = { id }
-    const stepIndicatorProps: StepIndicatorProps = { sidebar_id: id }
+    const sidebarProps: StepIndicatorSidebarProps = { sidebar_id }
+    const stepIndicatorProps: StepIndicatorProps = { sidebar_id }
     render(
       <>
         <StepIndicator.Sidebar {...sidebarProps} />


### PR DESCRIPTION
Fixes the following ts error:

```
    Warning: Failed prop type: The prop `sidebar_id` is marked as required in `StepIndicatorProvider`, but its value is `undefined`.
        at StepIndicatorProvider (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.js:103:5)
        at StepIndicatorSidebar (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.js:19:71)
        at children (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/shared/Provider.tsx:26:11)
```


Screenshot:
<img width="1162" alt="Screenshot 2023-06-15 at 10 18 04" src="https://github.com/dnbexperience/eufemia/assets/1359205/cd26ef80-4871-476b-ba0b-2ca33071fdf6">
