### PR TITLE
chore(ci): run CodeQL on PRs when branch is dependabot

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,10 +19,14 @@ on:
       - '!**--visual-reports'
       - '!wip/**'
       - '!experiments/**'
+      - '!dependabot/**'
       - '!release'
       - '!portal'
       - '!beta'
       - '!alpha'
+  pull_request:
+    branches:
+      - 'dependabot/**'
   schedule:
     - cron: '44 3 * * 5'
 


### PR DESCRIPTION
Based on info from this PR #2456 action run.

<img width="962" alt="Screenshot 2023-06-16 at 08 52 59" src="https://github.com/dnbexperience/eufemia/assets/1501870/1cbb5496-b3da-49f9-adfb-a8b0c0864caa">
