### PR TITLE
docs(DatePicker): removes disabled from example description

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -153,7 +153,7 @@ export const DatePickerMonthOnly = () =>
     </ComponentBox>
   )
 
-export const DatePickerDisabled = () =>
+export const DatePickerStatusMessage = () =>
   globalThis.IS_TEST ? null : (
     <ComponentBox>
       <DatePicker

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
@@ -8,7 +8,7 @@ import {
   DatePickerWithInput,
   DatePickerHiddenNav,
   DatePickerMonthOnly,
-  DatePickerDisabled,
+  DatePickerStatusMessage,
   DatePickerSuffix,
   DatePickerLinked,
   DatePickerNoInputStatus,
@@ -52,9 +52,9 @@ import enUS from '@dnb/eufemia/shared/locales/en-US'
 
 <DatePickerMonthOnly />
 
-### Disabled with info message
+### With info message
 
-<DatePickerDisabled />
+<DatePickerStatusMessage />
 
 ### With suffix
 


### PR DESCRIPTION
Not sure why this example said "disabled".
As the example code did not render a disabled DatePicker 🤔 👱‍♂️ 