### PR TITLE
feat(Tooltip): remove group property to add React v18 compatibility

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.mdx
@@ -330,12 +330,13 @@ The Anchor was moved from `/elements` to `/components`.
 
 1. Find the `target_element` property and replace it with `targetElement`.
 1. Find the `target_selector` property and replace it with `targetSelector`.
-1. Find the `animate_position` property and replace it with `animatePosition`.
 1. Find the `fixed_position` property and replace it with `fixedPosition`.
 1. Find the `skip_portal` property and replace it with `skipPortal`.
 1. Find the `no_animation` property and replace it with `noAnimation`.
 1. Find the `show_delay` property and replace it with `showDelay`.
 1. Find the `hide_delay` property and replace it with `hideDelay`.
+1. Find the `animate_position` property and remove it.
+1. Find the `group` property and remove it.
 
 ### [Icon](/uilib/components/icon)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/Examples.tsx
@@ -28,23 +28,16 @@ export const TooltipExampleLinked = () => (
   </ComponentBox>
 )
 
-export const TooltipExampleAnimation = () => (
+export const TooltipExampleDelay = () => (
   <ComponentBox data-visual-test="tooltip-large">
     <Tooltip
-      animatePosition
-      group="animatePosition"
       hideDelay={1e3}
       size="large"
       targetElement={<Span right>Top</Span>}
     >
       Tooltip 1
     </Tooltip>
-    <Tooltip
-      animatePosition
-      group="animatePosition"
-      position="bottom"
-      targetElement={<Span>Bottom</Span>}
-    >
+    <Tooltip position="bottom" targetElement={<Span>Bottom</Span>}>
       Tooltip 2
     </Tooltip>
   </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/demos.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 import {
   TooltipExampleDefault,
-  TooltipExampleAnimation,
+  TooltipExampleDelay,
   TooltipExampleNumberFormat,
   TooltipExampleNumberFormatWrapped,
   TooltipExampleLinked,
@@ -29,9 +29,9 @@ import {
 
 <TooltipExampleNumberFormatWrapped />
 
-### Tooltip with position animation
+### Tooltip with delay
 
-<TooltipExampleAnimation />
+<TooltipExampleDelay />
 
 ### Tooltip linked to a vanilla button
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/properties.mdx
@@ -11,7 +11,7 @@ showTabs: true
 | `position`                                  | _(optional)_ defines the offset position to the target element the arrow appears. Can be `top`, `right`, `left` and `bottom`. Defaults to `top`. |
 | `align`                                     | _(optional)_ defines the offset alignment to the target element the arrow appears. Can be `center`, `right` and `left`. Defaults to `center`.    |
 | `arrow`                                     | _(optional)_ defines the direction where the arrow appears. Can be `center`, `top`, `right`, `bottom` and `left`. Defaults to `center`.          |
-| `skipPortal`                                | _(optional)_ set to `true` to disable the React Portal behavior. Can not be used when `group` is used. Defaults to `false`.                      |
+| `skipPortal`                                | _(optional)_ set to `true` to disable the React Portal behavior. Defaults to `false`.                                                            |
 | `showDelay`                                 | _(optional)_ define the delay until the tooltip should show up after the initial hover / active state.                                           |
 | `hideDelay`                                 | _(optional)_ define the delay until the tooltip should disappear up after initial visibility.                                                    |
 | `size`                                      | _(optional)_ defines the spacing size of the tooltip. Can be `large` or `basis`. Defaults to `basis`.                                            |
@@ -19,6 +19,4 @@ showTabs: true
 | `targetSelector`                            | _(optional)_ specify a vanilla HTML selector by a string as the target element.                                                                  |
 | `noAnimation`                               | _(optional)_ set to `true` if no fade-in animation should be used.                                                                               |
 | `fixedPosition`                             | _(optional)_ If set to `true`, the Tooltip will be fixed in its scroll position by using CSS `position: fixed;`. Defaults to `false`.            |
-| `group`                                     | _(optional)_ if the tooltip should animate from one target to the next, define a unique ID.                                                      |
-| `animatePosition`                           | _(optional)_ set to `true` to animate a single Tooltip from one element to another element. You also need to set a unique `group` name.          |
 | [Space](/uilib/components/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                            |

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -123,9 +123,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -137,9 +137,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -676,9 +673,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;
@@ -1459,9 +1453,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -123,9 +123,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -137,9 +137,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -676,9 +673,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;
@@ -1367,9 +1361,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -1963,9 +1954,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -144,9 +144,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -145,9 +145,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -216,9 +216,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -137,9 +137,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -676,9 +673,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -669,9 +666,6 @@ p > .dnb-icon {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -137,9 +137,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
@@ -37,9 +37,6 @@ exports[`NumberFormat scss has to match style dependencies css 1`] = `
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -164,7 +164,6 @@ function Thumb({ value, currentIndex }: ThumbProps) {
           <Tooltip
             key={`group-${currentIndex}`}
             targetElement={elemRef}
-            animatePosition={shouldAnimate}
             active={Boolean(showTooltip || alwaysShowTooltip)}
             showDelay={1}
             hideDelay={300}

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*
@@ -583,9 +580,6 @@ button.dnb-button::-moz-focus-inner {
 }
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
-}
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
 }
 .dnb-tooltip--active {
   visibility: visible;

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -130,9 +130,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -173,9 +173,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -42,9 +42,7 @@ function Tooltip(localProps: TooltipAllProps) {
     className,
     id, // eslint-disable-line
     tooltip, // eslint-disable-line
-    group, // eslint-disable-line
     size,
-    animatePosition, // eslint-disable-line
     fixedPosition, // eslint-disable-line
     skipPortal, // eslint-disable-line
     noAnimation, // eslint-disable-line

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipContainer.tsx
@@ -27,9 +27,7 @@ export default function TooltipContainer(
     arrow,
     position,
     align,
-    group,
     hideDelay,
-    animatePosition,
     fixedPosition,
     noAnimation,
     skipPortal,
@@ -109,7 +107,7 @@ export default function TooltipContainer(
        * This "resets" the position between elements,
        * when not active. Else it will always first show on the older position.
        */
-      if (group && wasActive) {
+      if (wasActive) {
         clearTimeout(debounceTimeout.current)
         debounceTimeout.current = setTimeout(
           () => setStyle(null),
@@ -278,7 +276,6 @@ export default function TooltipContainer(
       {...attributes}
       className={classnames(
         attributes?.className,
-        isTrue(animatePosition) && 'dnb-tooltip--animate_position',
         isTrue(noAnimation) && 'dnb-tooltip--no-animation',
         isTrue(fixedPosition) && 'dnb-tooltip--fixed',
         isActive && 'dnb-tooltip--active',

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
@@ -19,13 +19,11 @@ export function injectTooltipSemantic(params) {
 
 export const defaultProps = {
   id: null,
-  group: null,
   size: 'basis',
   active: null,
   position: 'top',
   arrow: 'center',
   align: null,
-  animatePosition: false,
   fixedPosition: false,
   skipPortal: null,
   noAnimation: false,

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -120,47 +120,6 @@ describe('Tooltip', () => {
     expect(qS('.dnb-tooltip')).toHaveLength(0)
   })
 
-  it('should remove unmounted group parts', () => {
-    const Component = () => {
-      const [mounted, setMounted] = React.useState(true)
-      const onClickHandler = () => {
-        setMounted(!mounted)
-      }
-
-      return (
-        <>
-          <button id="toggle" onClick={onClickHandler}>
-            Toggle
-          </button>
-          {mounted && (
-            <>
-              <Tooltip active group="unique">
-                Tooltip 1
-              </Tooltip>
-              <Tooltip active group="unique">
-                Tooltip 2
-              </Tooltip>
-            </>
-          )}
-        </>
-      )
-    }
-
-    render(<Component />)
-
-    const qS = (s: string) => document.querySelectorAll(s)
-
-    expect(qS('.dnb-tooltip__portal')).toHaveLength(1)
-    expect(qS('.dnb-tooltip__group')).toHaveLength(1)
-    expect(qS('.dnb-tooltip')).toHaveLength(1)
-
-    fireEvent.click(document.querySelector('#toggle'))
-
-    expect(qS('.dnb-tooltip__portal')).toHaveLength(1)
-    expect(qS('.dnb-tooltip__group')).toHaveLength(0)
-    expect(qS('.dnb-tooltip')).toHaveLength(0)
-  })
-
   it('should set fixed position class', () => {
     render(
       <Tooltip active fixedPosition>
@@ -391,18 +350,6 @@ describe('Tooltip', () => {
       )
     })
 
-    it('should set animate_position class', () => {
-      render(<Tooltip animatePosition active />)
-
-      expect(Array.from(getMainElem().classList)).toEqual(
-        expect.arrayContaining([
-          'dnb-tooltip',
-          'dnb-tooltip--active',
-          'dnb-tooltip--animate_position',
-        ])
-      )
-    })
-
     it('should set fixed class', () => {
       render(<Tooltip fixedPosition active />)
 
@@ -413,72 +360,6 @@ describe('Tooltip', () => {
           'dnb-tooltip--fixed',
         ])
       )
-    })
-
-    describe('and group', () => {
-      const commonProps: TooltipAllProps = {
-        group: 'unique-name',
-        noAnimation: true,
-      }
-
-      const GroupTooltip = (props: TooltipAllProps) => {
-        return (
-          <>
-            <OriginalTooltip
-              targetElement={<button id="a">Button A</button>}
-              {...commonProps}
-              {...props}
-            >
-              Tooltip A
-            </OriginalTooltip>
-
-            <OriginalTooltip
-              targetElement={<button id="b">Button B</button>}
-              {...commonProps}
-              {...props}
-            >
-              Tooltip B
-            </OriginalTooltip>
-          </>
-        )
-      }
-
-      it('should only have one tooltip', async () => {
-        render(<GroupTooltip noAnimation={false} {...defaultProps} />)
-
-        const allElements = () =>
-          document.body.querySelectorAll('.dnb-tooltip')
-        const buttonA = document.querySelector('button#a')
-        const buttonB = document.querySelector('button#b')
-
-        expect(allElements()).toHaveLength(0)
-
-        fireEvent.mouseEnter(buttonA)
-
-        await wait(100)
-
-        expect(getMainElem().textContent).toBe('Tooltip A')
-        expect(
-          getMainElem().classList.contains('dnb-tooltip--active')
-        ).toBe(true)
-
-        fireEvent.mouseEnter(buttonB)
-
-        await wait(100)
-
-        expect(getMainElem().textContent).toBe('Tooltip B')
-        expect(
-          getMainElem().classList.contains('dnb-tooltip--active')
-        ).toBe(true)
-
-        fireEvent.mouseLeave(buttonB)
-
-        await wait(1)
-
-        const classList = getMainElem().classList
-        expect(classList.contains('dnb-tooltip--active')).toBe(false)
-        expect(classList.contains('dnb-tooltip--hide')).toBe(true)
-      })
     })
 
     it('should validate with ARIA rules as a tooltip', async () => {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -30,9 +30,6 @@ exports[`Tooltip scss has to match style dependencies css 1`] = `
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*

--- a/packages/dnb-eufemia/src/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/stories/Tooltip.stories.tsx
@@ -32,25 +32,6 @@ export const TooltipSandbox = () => {
         </Tooltip>
       </Box>
       <Box>
-        <Tooltip
-          animatePosition
-          group="animatePosition"
-          hideDelay={1e3}
-          targetElement={<span role="text">Top</span>}
-        >
-          Tooltip 1
-        </Tooltip>
-        <Tooltip
-          animatePosition
-          group="animatePosition"
-          position="bottom"
-          size="large"
-          targetElement={<span role="text">Bottom</span>}
-        >
-          Tooltip 2
-        </Tooltip>
-      </Box>
-      <Box>
         <button className="target-1">Show the Tooltip</button>
         <button className="target-2">Tooltip</button>
 
@@ -66,19 +47,12 @@ export const TooltipSandbox = () => {
       </Box>
       <Box>
         <Tooltip
-          group="animatePosition"
           // hideDelay={1e3}
-          animatePosition
           targetElement={<Button right>Top</Button>}
         >
           Tooltip 1
         </Tooltip>
-        <Tooltip
-          group="animatePosition"
-          position="bottom"
-          animatePosition
-          targetElement={<Button>Bottom</Button>}
-        >
+        <Tooltip position="bottom" targetElement={<Button>Bottom</Button>}>
           Tooltip 2
         </Tooltip>
       </Box>

--- a/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
+++ b/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
@@ -25,11 +25,6 @@
 
   transition: opacity 200ms var(--easing-default);
 
-  &--animate_position {
-    transition: all 200ms var(--easing-default),
-      opacity 200ms var(--easing-default);
-  }
-
   &--active {
     visibility: visible;
 

--- a/packages/dnb-eufemia/src/components/tooltip/types.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/types.ts
@@ -16,13 +16,11 @@ export type TooltipSize = 'basis' | 'large'
 
 export type TooltipProps = IncludeSnakeCase<{
   id?: string
-  group?: string
   size?: TooltipSize
   active?: boolean
   position?: TooltipPosition
   arrow?: TooltipArrow
   align?: TooltipAlign
-  animatePosition?: boolean
   fixedPosition?: boolean
   skipPortal?: boolean
   noAnimation?: boolean

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -216,9 +216,6 @@ p > .dnb-icon {
 .dnb-tooltip--large {
   padding: 0.25rem 1rem;
 }
-.dnb-tooltip--animate_position {
-  transition: all 200ms var(--easing-default), opacity 200ms var(--easing-default);
-}
 .dnb-tooltip--active {
   visibility: visible;
   /*


### PR DESCRIPTION
Not ideal to remove a prop after v10 release, but as it is relative harmless in terms, that the group feature is mostly to enhance a Tooltip with an position animation. The usage must be extremely low, or non existing.

This change is needed in PR #2481


Before:

https://github.com/dnbexperience/eufemia/assets/1501870/06e6828b-3cbf-40b1-a229-b12f962beb2d



After:



https://github.com/dnbexperience/eufemia/assets/1501870/8b68d308-c6b1-4501-b261-a5015f02486c




