### PR TITLE
chore(CI): fix postbuild run in e2e action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,21 +39,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        if: ${{ !env.RUN_POST_BUILD }}
+        if: env.RUN_POST_BUILD == 'false'
         uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Git checkout (with fetch-depth)
-        if: ${{ env.RUN_POST_BUILD }}
+        if: env.RUN_POST_BUILD == 'true'
         uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 20 # The "postbuild:ci" method "getCommittedFiles" needs all history
-
-      - name: Test
-        if: ${{ env.RUN_POST_BUILD }}
-        run: git show --pretty="format:" --name-only HEAD...HEAD~10
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -73,11 +69,11 @@ jobs:
         run: yarn install --immutable
 
       - name: Prebuild Library
-        if: ${{ env.RUN_POST_BUILD }}
+        if: env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia prebuild:ci
 
       - name: Postbuild Library
-        if: ${{ env.RUN_POST_BUILD }}
+        if: env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia postbuild:ci
 
       - name: Get current date


### PR DESCRIPTION
Ensure we actually run the "postbuild" step on the main (and e.g. v10) branch only. This corrects the code as it was intended to be, because we need to check against a string, and not a boolean.

With that change, we should safe about 2.5 min on normal PR branches.

Also, we run the "postbuild" step in the **Verify** action anyway.
