### PR TITLE
chore(Portal): correct heading hash anchor padding

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
@@ -6,6 +6,7 @@
 
       width: 1em;
       margin-left: -1em;
+      padding: 0;
 
       line-height: 1;
       text-align: center;


### PR DESCRIPTION
After the change of this PR:

<img width="239" alt="Screenshot 2023-07-03 at 20 29 45" src="https://github.com/dnbexperience/eufemia/assets/1501870/b8df5ed2-c1c2-4560-a8dc-c96a7322969d">

Before:
<img width="227" alt="Screenshot 2023-07-03 at 20 29 54" src="https://github.com/dnbexperience/eufemia/assets/1501870/5d5b1319-b51a-432e-8213-c37b5a2ae29b">
