### PR TITLE
chore: use @testing-library/jest-dom matchers

### DIFF
--- a/packages/dnb-eufemia/jest.config.js
+++ b/packages/dnb-eufemia/jest.config.js
@@ -23,5 +23,6 @@ const config = {
     '^.+\\.(jpg|jpeg|png)$': '<rootDir>/src/core/jest/fileMock.js',
     '^.+\\.(svg)$': '<rootDir>/src/core/jest/jsxMock.js',
   },
+  setupFilesAfterEnv: ['<rootDir>/src/core/jest/setupJest.js'],
 }
 module.exports = config

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -155,6 +155,7 @@
     "@svgr/plugin-jsx": "6.5.1",
     "@svgr/plugin-svgo": "6.5.1",
     "@testing-library/dom": "9.3.1",
+    "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
     "@types/fs-extra": "11.0.1",

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -97,10 +97,8 @@ describe('Accordion component', () => {
 
     rerender(<Accordion {...props} disabled={true} />)
     expect(
-      document
-        .querySelector('.dnb-accordion__header')
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector('.dnb-accordion__header')
+    ).toHaveAttribute('disabled')
   })
 
   it('has correct classes when no_animation', () => {
@@ -142,20 +140,16 @@ describe('Accordion component', () => {
 
   it('supports default outlined variant', () => {
     render(<Accordion />)
-    expect(
-      document
-        .querySelector('.dnb-accordion')
-        .classList.contains('dnb-accordion__variant--outlined')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-accordion').classList).toContain(
+      'dnb-accordion__variant--outlined'
+    )
   })
 
   it('supports plain variant', () => {
     render(<Accordion {...props} variant="plain" />)
-    expect(
-      document
-        .querySelector('.dnb-accordion')
-        .classList.contains('dnb-accordion__variant--plain')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-accordion').classList).toContain(
+      'dnb-accordion__variant--plain'
+    )
   })
 
   it('should have hidden content when "prerender" is true but closed', () => {
@@ -232,7 +226,7 @@ describe('Accordion group component', () => {
 
     expect(
       document.querySelector('#accordion-1 .dnb-accordion__content')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('#accordion-2 .dnb-accordion__content')
     ).toBeFalsy()

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -16,12 +16,12 @@ const props: AnchorAllProps = {
 describe('Anchor element', () => {
   it('has dnb-a class', () => {
     render(<Anchor>text</Anchor>)
-    expect(document.querySelector('.dnb-a')).toBeTruthy()
+    expect(document.querySelector('.dnb-a')).toBeInTheDocument()
   })
 
   it('has href', () => {
     render(<Anchor href="/url">text</Anchor>)
-    expect(document.querySelector('[href]')).toBeTruthy()
+    expect(document.querySelector('[href]')).toBeInTheDocument()
   })
 
   it('should forward id', () => {
@@ -73,10 +73,9 @@ describe('Anchor element', () => {
     fireEvent.mouseEnter(element)
 
     expect(
-      document
-        .querySelector('#unique-id-tooltip.dnb-tooltip__content')
-        .parentElement.classList.contains('dnb-tooltip--active')
-    ).toBeTruthy()
+      document.querySelector('#unique-id-tooltip.dnb-tooltip__content')
+        .parentElement.classList
+    ).toContain('dnb-tooltip--active')
   })
 
   it('has no-icon class when element was given', () => {
@@ -85,7 +84,9 @@ describe('Anchor element', () => {
         <span>text</span>
       </Anchor>
     )
-    expect(document.querySelector('.dnb-anchor--no-icon')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-anchor--no-icon')
+    ).toBeInTheDocument()
   })
 
   it('should forward ref', () => {
@@ -140,7 +141,7 @@ describe('Anchor element', () => {
         text
       </Anchor>
     )
-    expect(document.querySelector('[rel="external"]')).toBeTruthy()
+    expect(document.querySelector('[rel="external"]')).toBeInTheDocument()
   })
 
   it('should validate with ARIA rules as a Anchor element', async () => {
@@ -154,7 +155,9 @@ describe('Anchor element', () => {
         text
       </Anchor>
     )
-    expect(document.querySelector('.dnb-anchor--icon-left')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-anchor--icon-left')
+    ).toBeInTheDocument()
   })
 
   it('has right icon class when using right icon prop', () => {
@@ -163,7 +166,9 @@ describe('Anchor element', () => {
         text
       </Anchor>
     )
-    expect(document.querySelector('.dnb-anchor--icon-right')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-anchor--icon-right')
+    ).toBeInTheDocument()
   })
 
   it('defaults to left icon when using icon prop', () => {
@@ -172,7 +177,9 @@ describe('Anchor element', () => {
         text
       </Anchor>
     )
-    expect(document.querySelector('.dnb-anchor--icon-left')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-anchor--icon-left')
+    ).toBeInTheDocument()
   })
 
   it('hides launch icon when given a right icon', () => {
@@ -181,7 +188,9 @@ describe('Anchor element', () => {
         text
       </Anchor>
     )
-    expect(document.querySelector('.dnb-anchor--no-icon')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-anchor--no-icon')
+    ).toBeInTheDocument()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -231,10 +231,8 @@ describe('Autocomplete component', () => {
       )
 
       expect(
-        document
-          .querySelector('.dnb-autocomplete')
-          .classList.contains('dnb-autocomplete--opened')
-      ).toBe(false)
+        document.querySelector('.dnb-autocomplete').classList
+      ).not.toContain('dnb-autocomplete--opened')
 
       expect(document.activeElement.tagName).toBe('BODY')
     })
@@ -243,19 +241,15 @@ describe('Autocomplete component', () => {
       render(<Autocomplete {...mockProps} value={1} data={mockData} />)
 
       expect(
-        document
-          .querySelector('.dnb-autocomplete')
-          .classList.contains('dnb-autocomplete--opened')
-      ).toBe(false)
+        document.querySelector('.dnb-autocomplete').classList
+      ).not.toContain('dnb-autocomplete--opened')
 
       fireEvent.click(
         document.querySelector('.dnb-autocomplete__suffix_value')
       )
       expect(
-        document
-          .querySelector('.dnb-autocomplete')
-          .classList.contains('dnb-autocomplete--opened')
-      ).toBe(true)
+        document.querySelector('.dnb-autocomplete').classList
+      ).toContain('dnb-autocomplete--opened')
 
       expect(document.activeElement.tagName).toBe('INPUT')
     })
@@ -275,10 +269,8 @@ describe('Autocomplete component', () => {
       )
 
       expect(
-        document
-          .querySelector('.dnb-autocomplete__inner')
-          .getAttribute('id')
-      ).toBeTruthy()
+        document.querySelector('.dnb-autocomplete__inner')
+      ).toHaveAttribute('id')
     })
   })
 
@@ -738,25 +730,21 @@ describe('Autocomplete component', () => {
     ).toBe(2)
     expect(
       document.querySelector('li.dnb-drawer-list__option--focus')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     // then simulate changes
     keydown(40) // down
 
     expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[0]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[0].classList
+    ).toContain('dnb-drawer-list__option--focus')
 
     // then simulate changes
     keydown(40) // down
 
     expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[1]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[1].classList
+    ).toContain('dnb-drawer-list__option--focus')
     expect(
       document
         .querySelectorAll('li.dnb-drawer-list__option')[1]
@@ -845,7 +833,7 @@ describe('Autocomplete component', () => {
     fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
 
     const elem = document.querySelector('.dnb-autocomplete')
-    expect(elem.classList.contains('dnb-autocomplete--opened')).toBe(true)
+    expect(elem.classList).toContain('dnb-autocomplete--opened')
 
     expect(
       elem.querySelectorAll(
@@ -861,7 +849,7 @@ describe('Autocomplete component', () => {
 
     const elem = document.querySelector('.dnb-autocomplete')
 
-    expect(elem.classList.contains('dnb-autocomplete--opened')).toBe(true)
+    expect(elem.classList).toContain('dnb-autocomplete--opened')
   })
 
   it('has type="button" on submit button', () => {
@@ -943,10 +931,8 @@ describe('Autocomplete component', () => {
     )
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-autocomplete').classList
+    ).not.toContain('dnb-autocomplete--opened')
 
     // ensure we blur only once
     fireEvent.blur(document.querySelector('input'))
@@ -957,18 +943,14 @@ describe('Autocomplete component', () => {
     expect(on_show.mock.calls[1][0].attributes).toMatchObject(params)
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
 
     keydown(27) // esc
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-autocomplete').classList
+    ).not.toContain('dnb-autocomplete--opened')
 
     toggle()
     expect(on_show).toHaveBeenCalledTimes(3)
@@ -1398,7 +1380,7 @@ describe('Autocomplete component', () => {
 
     expect(
       document.querySelector('li.dnb-drawer-list__option--focus')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     closeAndReopen()
 
@@ -1412,13 +1394,13 @@ describe('Autocomplete component', () => {
 
     expect(
       document.querySelector('li.dnb-drawer-list__option--focus')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     keydown(40) // down
 
     expect(
       document.querySelector('li.dnb-drawer-list__option--focus')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     closeAndReopen()
 
@@ -1444,10 +1426,10 @@ describe('Autocomplete component', () => {
     // Now we have a selected item
     expect(
       document.querySelector('li.dnb-drawer-list__option--selected')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('li.dnb-drawer-list__option--focus')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       (document.querySelector('.dnb-input__input') as HTMLInputElement)
         .value
@@ -1465,7 +1447,7 @@ describe('Autocomplete component', () => {
     ).toBe(shouldHaveActiveItemWhenEmpty)
     expect(
       document.querySelector('li.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     cleanup()
   }
@@ -1581,16 +1563,14 @@ describe('Autocomplete component', () => {
     expect(buttonElem.textContent).toBe(
       'Bla gjennom alternativer, lukk med esc knappen'
     )
-    expect(buttonElem).toBeTruthy()
+    expect(buttonElem).toBeInTheDocument()
     expect(buttonElem.getAttribute('tabindex')).toBe('-1')
 
     fireEvent.click(buttonElem)
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
     expect(Array.from(document.activeElement.classList)).toContain(
       'dnb-drawer-list__options'
     )
@@ -1598,10 +1578,8 @@ describe('Autocomplete component', () => {
     fireEvent.click(buttonElem)
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-autocomplete').classList
+    ).not.toContain('dnb-autocomplete--opened')
     expect(Array.from(document.activeElement.classList)).toContain(
       'dnb-input__input'
     )
@@ -1635,10 +1613,8 @@ describe('Autocomplete component', () => {
     )
 
     expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[1]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[1].classList
+    ).toContain('dnb-drawer-list__option--focus')
 
     expect(Array.from(document.activeElement.classList)).toContain(
       'dnb-input__input'
@@ -1666,27 +1642,21 @@ describe('Autocomplete component', () => {
     fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
 
     // close
     keydown(27) // esc
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-autocomplete').classList
+    ).not.toContain('dnb-autocomplete--opened')
 
     fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
   })
 
   it('will open drawer-list when open_on_focus is set to true', () => {
@@ -1707,10 +1677,8 @@ describe('Autocomplete component', () => {
     expect(on_focus).toHaveBeenCalledTimes(1)
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
 
     // Make a selection
     fireEvent.click(
@@ -1737,10 +1705,8 @@ describe('Autocomplete component', () => {
     toggle()
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
 
     act(() => {
       // close
@@ -1749,19 +1715,15 @@ describe('Autocomplete component', () => {
     expect(on_hide).toHaveBeenCalledTimes(1)
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-autocomplete').classList
+    ).not.toContain('dnb-autocomplete--opened')
 
     // reopen
     toggle()
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
 
     preventClose = true
 
@@ -1773,10 +1735,8 @@ describe('Autocomplete component', () => {
 
     // we are still open
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete--opened')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete--opened')
   })
 
   it('has no highlighted value by using "disable_highlighting"', () => {
@@ -2052,12 +2012,10 @@ describe('Autocomplete component', () => {
       />
     )
     expect(
-      document
-        .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
-        )
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector(
+        'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+      )
+    ).toHaveAttribute('disabled')
     expect(
       document
         .querySelector(
@@ -2085,7 +2043,7 @@ describe('Autocomplete component', () => {
       />
     )
 
-    expect(document.querySelector('input')).toBeTruthy()
+    expect(document.querySelector('input')).toBeInTheDocument()
     expect(
       Array.from(document.querySelector('input').classList)
     ).toContain('dnb-autocomplete__input')
@@ -2174,19 +2132,17 @@ describe('Autocomplete component', () => {
       />
     )
     expect(
-      document
-        .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
-        )
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector(
+        'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+      )
+    ).toHaveAttribute('disabled')
     expect(
       document
         .querySelector(
           'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
         )
         .querySelector('.dnb-icon')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     expect(
       document
@@ -2222,25 +2178,18 @@ describe('Autocomplete component', () => {
     )
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete__status--error')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete__status--error')
+    expect(document.querySelector('.dnb-form-status').classList).toContain(
+      'dnb-form-status--error'
+    )
+    expect(document.querySelector('.dnb-input').classList).toContain(
+      'dnb-input__status--error'
+    )
     expect(
-      document
-        .querySelector('.dnb-form-status')
-        .classList.contains('dnb-form-status--error')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('.dnb-input')
-        .classList.contains('dnb-input__status--error')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('button.dnb-input__submit-button__button')
-        .classList.contains('dnb-button__status--error')
-    ).toBe(true)
+      document.querySelector('button.dnb-input__submit-button__button')
+        .classList
+    ).toContain('dnb-button__status--error')
   })
 
   it('has correct status when status_state is error', () => {
@@ -2255,25 +2204,18 @@ describe('Autocomplete component', () => {
     )
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete__status--error')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete__status--error')
+    expect(document.querySelector('.dnb-form-status').classList).toContain(
+      'dnb-form-status--error'
+    )
+    expect(document.querySelector('.dnb-input').classList).toContain(
+      'dnb-input__status--error'
+    )
     expect(
-      document
-        .querySelector('.dnb-form-status')
-        .classList.contains('dnb-form-status--error')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('.dnb-input')
-        .classList.contains('dnb-input__status--error')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('button.dnb-input__submit-button__button')
-        .classList.contains('dnb-button__status--error')
-    ).toBe(true)
+      document.querySelector('button.dnb-input__submit-button__button')
+        .classList
+    ).toContain('dnb-button__status--error')
   })
 
   it('has correct status when status_state is info', () => {
@@ -2288,25 +2230,18 @@ describe('Autocomplete component', () => {
     )
 
     expect(
-      document
-        .querySelector('.dnb-autocomplete')
-        .classList.contains('dnb-autocomplete__status--info')
-    ).toBe(true)
+      document.querySelector('.dnb-autocomplete').classList
+    ).toContain('dnb-autocomplete__status--info')
+    expect(document.querySelector('.dnb-form-status').classList).toContain(
+      'dnb-form-status--info'
+    )
+    expect(document.querySelector('.dnb-input').classList).toContain(
+      'dnb-input__status--info'
+    )
     expect(
-      document
-        .querySelector('.dnb-form-status')
-        .classList.contains('dnb-form-status--info')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('.dnb-input')
-        .classList.contains('dnb-input__status--info')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('button.dnb-input__submit-button__button')
-        .classList.contains('dnb-button__status--info')
-    ).toBe(true)
+      document.querySelector('button.dnb-input__submit-button__button')
+        .classList
+    ).toContain('dnb-button__status--info')
   })
 
   it('should support spacing props', () => {

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -38,7 +38,7 @@ describe('Avatar', () => {
       </Avatar.Group>
     )
 
-    expect(screen.queryByText('E')).toBeTruthy()
+    expect(screen.queryByText('E')).toBeInTheDocument()
   })
 
   it('renders a label for screen readers when passing children as text', () => {
@@ -49,7 +49,7 @@ describe('Avatar', () => {
       </Avatar.Group>
     )
 
-    expect(screen.queryByText(children)).toBeTruthy()
+    expect(screen.queryByText(children)).toBeInTheDocument()
   })
 
   it('renders children as Icon', () => {
@@ -195,7 +195,7 @@ describe('Avatar', () => {
         </Avatar.Group>
       )
 
-      expect(screen.queryByText(label)).toBeTruthy()
+      expect(screen.queryByText(label)).toBeInTheDocument()
     })
 
     it('renders the label as react node', () => {
@@ -222,7 +222,7 @@ describe('Avatar', () => {
       const avatarsDisplayed =
         document.getElementsByClassName('dnb-avatar')
 
-      expect(screen.queryByText('+2')).toBeTruthy()
+      expect(screen.queryByText('+2')).toBeInTheDocument()
 
       expect(avatarsDisplayed).toHaveLength(1)
     })
@@ -239,7 +239,7 @@ describe('Avatar', () => {
       const avatarsDisplayed =
         document.getElementsByClassName('dnb-avatar')
 
-      expect(screen.queryByText('+3')).toBeTruthy()
+      expect(screen.queryByText('+3')).toBeInTheDocument()
 
       expect(avatarsDisplayed).toHaveLength(0)
     })

--- a/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
+++ b/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
@@ -20,7 +20,7 @@ describe('Badge', () => {
     const string = 'A'
     render(<Badge content={string} />)
 
-    expect(screen.queryByText(string)).toBeTruthy()
+    expect(screen.queryByText(string)).toBeInTheDocument()
   })
 
   it('renders content as number', () => {
@@ -28,8 +28,8 @@ describe('Badge', () => {
     const label = 'Notifications:'
     render(<Badge content={number} label={label} />)
 
-    expect(screen.queryByText(number)).toBeTruthy()
-    expect(screen.queryByText(label)).toBeTruthy()
+    expect(screen.queryByText(number)).toBeInTheDocument()
+    expect(screen.queryByText(label)).toBeInTheDocument()
   })
 
   it('renders 9+ when content is a number with value greater than 9', () => {
@@ -37,8 +37,8 @@ describe('Badge', () => {
     const label = 'Notifications:'
     render(<Badge content={number} variant="notification" label={label} />)
 
-    expect(screen.queryByText('9+')).toBeTruthy()
-    expect(screen.queryByText(label)).toBeTruthy()
+    expect(screen.queryByText('9+')).toBeInTheDocument()
+    expect(screen.queryByText(label)).toBeInTheDocument()
   })
 
   it('renders the label as string', () => {
@@ -46,8 +46,8 @@ describe('Badge', () => {
     const content = 100
     render(<Badge label={label} content={content} />)
 
-    expect(screen.queryByText(label)).toBeTruthy()
-    expect(screen.queryByText(content)).toBeTruthy()
+    expect(screen.queryByText(label)).toBeInTheDocument()
+    expect(screen.queryByText(content)).toBeInTheDocument()
   })
 
   it('renders the label as a react node', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -32,9 +32,9 @@ describe('Breadcrumb', () => {
       />
     )
 
-    expect(screen.queryByText('Home')).toBeTruthy()
-    expect(screen.queryByText('Page 1')).toBeTruthy()
-    expect(screen.queryByText('Page 2')).toBeTruthy()
+    expect(screen.queryByText('Home')).toBeInTheDocument()
+    expect(screen.queryByText('Page 1')).toBeInTheDocument()
+    expect(screen.queryByText('Page 2')).toBeInTheDocument()
 
     expect(screen.queryAllByRole('link')).toHaveLength(2)
   })
@@ -44,7 +44,7 @@ describe('Breadcrumb', () => {
       <Breadcrumb data={[{ href: '/page1/page2', text: 'Page 2' }]} />
     )
 
-    expect(screen.queryByText('Page 2')).toBeTruthy()
+    expect(screen.queryByText('Page 2')).toBeInTheDocument()
     expect(screen.queryAllByRole('link')).toHaveLength(1)
   })
 
@@ -57,9 +57,9 @@ describe('Breadcrumb', () => {
       </Breadcrumb>
     )
 
-    expect(screen.queryByText('Home')).toBeTruthy()
-    expect(screen.queryByText('Page 1')).toBeTruthy()
-    expect(screen.queryByText('Page 2')).toBeTruthy()
+    expect(screen.queryByText('Home')).toBeInTheDocument()
+    expect(screen.queryByText('Page 1')).toBeInTheDocument()
+    expect(screen.queryByText('Page 2')).toBeInTheDocument()
 
     expect(screen.queryAllByRole('link')).toHaveLength(3)
   })
@@ -71,7 +71,7 @@ describe('Breadcrumb', () => {
       </Breadcrumb>
     )
 
-    expect(screen.queryByText('Page item #1')).toBeTruthy()
+    expect(screen.queryByText('Page item #1')).toBeInTheDocument()
     expect(screen.queryAllByRole('link')).toHaveLength(1)
   })
 
@@ -99,10 +99,10 @@ describe('Breadcrumb', () => {
       </Breadcrumb>
     )
 
-    expect(screen.queryByText('Page item #1')).toBeTruthy()
-    expect(screen.queryByText('Page item #2')).toBeTruthy()
-    expect(screen.queryByText('Page item #3')).toBeTruthy()
-    expect(screen.queryByText('Page item #4')).toBeTruthy()
+    expect(screen.queryByText('Page item #1')).toBeInTheDocument()
+    expect(screen.queryByText('Page item #2')).toBeInTheDocument()
+    expect(screen.queryByText('Page item #3')).toBeInTheDocument()
+    expect(screen.queryByText('Page item #4')).toBeInTheDocument()
 
     expect(screen.queryAllByRole('link')).toHaveLength(4)
   })
@@ -267,9 +267,9 @@ describe('Breadcrumb', () => {
       const text = 'Just text'
       render(<BreadcrumbItem text={text} />)
 
-      expect(screen.queryByRole('link')).toBeNull()
-      expect(screen.queryByRole('button')).toBeNull()
-      expect(screen.queryByText(text)).toBeTruthy()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+      expect(screen.queryByText(text)).toBeInTheDocument()
     })
 
     it('will render custom icon', () => {

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -33,20 +33,18 @@ describe('Button component', () => {
     const button = document.querySelector('button')
 
     // size "medium" and has icon
-    expect(button.classList.contains('dnb-button--size-medium')).toBe(true)
+    expect(button.classList).toContain('dnb-button--size-medium')
     // has icon class, but not has text
-    expect(button.classList.contains('dnb-button--has-icon')).toBe(true)
-    expect(button.classList.contains('dnb-button--has-text')).toBe(false)
+    expect(button.classList).toContain('dnb-button--has-icon')
+    expect(button.classList).not.toContain('dnb-button--has-text')
   })
 
   it('has size set to medium when button size is default', () => {
     render(<Button icon="question" size="default" />)
     const button = document.querySelector('button')
     const icon = document.querySelector('.dnb-icon')
-    expect(button.classList.contains('dnb-button--icon-size-medium')).toBe(
-      true
-    )
-    expect(icon.classList.contains('dnb-icon--medium')).toBe(true)
+    expect(button.classList).toContain('dnb-button--icon-size-medium')
+    expect(icon.classList).toContain('dnb-icon--medium')
   })
 
   it('has medium icon if button size is large', () => {
@@ -54,26 +52,28 @@ describe('Button component', () => {
     const button = document.querySelector('button')
     const icon = document.querySelector('.dnb-icon')
     // size "large
-    expect(button.classList.contains('dnb-button--size-large')).toBe(true)
-    expect(icon.classList.contains('dnb-icon--default')).toBe(true)
+    expect(button.classList).toContain('dnb-button--size-large')
+    expect(icon.classList).toContain('dnb-icon--default')
   })
 
   it('has to have a bounding tag if property is set', () => {
     render(<Button bounding={true} />)
-    expect(document.querySelector('.dnb-button__bounding')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-button__bounding')
+    ).toBeInTheDocument()
   })
 
   it('has a anchor tag', () => {
     render(<Button {...props} href="https://url" icon={null} />)
-    expect(document.querySelector('a')).toBeTruthy()
-    expect(document.querySelector('svg')).toBeFalsy()
+    expect(document.querySelector('a')).toBeInTheDocument()
+    expect(document.querySelector('svg')).not.toBeInTheDocument()
   })
 
   it('has a anchor tag and includes a launch icon', () => {
     render(
       <Button {...props} href="https://url" target="_blank" icon={null} />
     )
-    expect(document.querySelector('svg')).toBeTruthy()
+    expect(document.querySelector('svg')).toBeInTheDocument()
   })
 
   it('supports anchor rel property', () => {
@@ -83,21 +83,18 @@ describe('Button component', () => {
 
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<Button />)
-    expect(document.querySelector('button').hasAttribute('disabled')).toBe(
-      false
+    expect(document.querySelector('button')).not.toHaveAttribute(
+      'disabled'
     )
     rerender(<Button disabled />)
 
-    expect(document.querySelector('button').hasAttribute('disabled')).toBe(
-      true
-    )
+    expect(document.querySelector('button')).toHaveAttribute('disabled')
   })
 
   it('should be able to omit button type', () => {
     render(<Button type="" />)
-    expect(document.querySelector('button').hasAttribute('type')).toBe(
-      false
-    )
+
+    expect(document.querySelector('button')).not.toHaveAttribute('type')
   })
 
   it('should use span element if defined', () => {
@@ -189,7 +186,9 @@ describe('Button component', () => {
         .querySelector('.dnb-button__alignment')
         .getAttribute('aria-hidden')
     ).toBe('true')
-    expect(document.querySelector('.dnb-button__text')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-button__text')
+    ).not.toBeInTheDocument()
   })
 
   it('should validate with ARIA rules as a button', async () => {
@@ -205,38 +204,38 @@ describe('Button component', () => {
   it('has variant set to primary as default', () => {
     render(<Button />)
     const button = document.querySelector('button')
-    expect(button.classList.contains('dnb-button--primary')).toBe(true)
+    expect(button.classList).toContain('dnb-button--primary')
   })
 
   it('has variant set to primary when only setting text', () => {
     render(<Button text="Button" />)
     const button = document.querySelector('button')
-    expect(button.classList.contains('dnb-button--primary')).toBe(true)
+    expect(button.classList).toContain('dnb-button--primary')
   })
 
   it('has variant set to secondary when only setting icon', () => {
     render(<Button icon="question" />)
     const button = document.querySelector('button')
-    expect(button.classList.contains('dnb-button--secondary')).toBe(true)
+    expect(button.classList).toContain('dnb-button--secondary')
   })
 
   it('has variant tertiary', () => {
     render(<Button text="Button" variant="tertiary" icon="question" />)
     const button = document.querySelector('button')
-    expect(button.classList.contains('dnb-button--tertiary')).toBe(true)
+    expect(button.classList).toContain('dnb-button--tertiary')
   })
 
   it('has variant unstyled', () => {
     render(<Button text="Button" variant="unstyled" />)
     const button = document.querySelector('button')
-    expect(button.classList.contains('dnb-button--unstyled')).toBe(true)
+    expect(button.classList).toContain('dnb-button--unstyled')
   })
 
   it('will replace icon with icon component', () => {
     const { rerender } = render(
       <Button icon={<span className="dnb-icon custom-icon">icon</span>} />
     )
-    expect(document.querySelector('.custom-icon')).toBeTruthy()
+    expect(document.querySelector('.custom-icon')).toBeInTheDocument()
 
     rerender(
       <Button
@@ -246,8 +245,10 @@ describe('Button component', () => {
       />
     )
 
-    expect(document.querySelector('.custom-icon')).toBeFalsy()
-    expect(document.querySelector('.custom-icon-component')).toBeTruthy()
+    expect(document.querySelector('.custom-icon')).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.custom-icon-component')
+    ).toBeInTheDocument()
   })
 
   it('will only have attached event listener if one is given', () => {
@@ -286,8 +287,12 @@ describe('Button component', () => {
 
   it('has no size when only setting text', () => {
     render(<Button text="Button" />)
-    expect(document.querySelector('.dnb-button--size-medium')).toBeFalsy()
-    expect(document.querySelector('.dnb-button--size-large')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-button--size-medium')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-button--size-large')
+    ).not.toBeInTheDocument()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -42,14 +42,12 @@ describe('DatePicker component', () => {
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<DatePicker show_input />)
     rerender(<DatePicker show_input disabled={true} />)
+    expect(document.querySelectorAll('input')[0]).toHaveAttribute(
+      'disabled'
+    )
     expect(
-      document.querySelectorAll('input')[0].hasAttribute('disabled')
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('button.dnb-input__submit-button__button')
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector('button.dnb-input__submit-button__button')
+    ).toHaveAttribute('disabled')
   })
 
   it('has correct state after "click" trigger', () => {
@@ -74,10 +72,8 @@ describe('DatePicker component', () => {
     ).toContain('dnb-date-picker--opened')
 
     expect(
-      document
-        .querySelector('.dnb-date-picker')
-        .classList.contains('dnb-date-picker--closed')
-    ).toBe(false)
+      document.querySelector('.dnb-date-picker').classList
+    ).not.toContain('dnb-date-picker--closed')
   })
 
   it('will close the picker after selection', () => {
@@ -120,10 +116,8 @@ describe('DatePicker component', () => {
     expect(on_change.mock.calls[1][0].end_date).toBe('2019-02-15')
 
     expect(
-      document
-        .querySelector('.dnb-date-picker')
-        .classList.contains('dnb-date-picker--closed')
-    ).toBe(false)
+      document.querySelector('.dnb-date-picker').classList
+    ).not.toContain('dnb-date-picker--closed')
 
     rerender(
       <DatePicker {...defaultProps} on_change={on_change} range={false} />
@@ -225,7 +219,7 @@ describe('DatePicker component', () => {
     const singleLabel = singleButton.getAttribute('aria-label')
 
     expect(singleLabel).toBe('lørdag 12. januar 2019')
-    expect(singleButton.hasAttribute('disabled')).toBe(true)
+    expect(singleButton).toHaveAttribute('disabled')
     expect(singleTd.classList).toContain(customClassName)
   })
 
@@ -254,7 +248,9 @@ describe('DatePicker component', () => {
       document.querySelector('label.dnb-date-picker__header__title')
         .textContent
     ).toBe('mai 2020')
-    expect(document.querySelector('.dnb-date-picker--opened')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-date-picker--opened')
+    ).toBeInTheDocument()
     expect(on_change).toBeCalledTimes(1)
 
     // Now, test "close_on_select"
@@ -268,7 +264,9 @@ describe('DatePicker component', () => {
       document.querySelector('label.dnb-date-picker__header__title')
         .textContent
     ).toBe('april 2020')
-    expect(document.querySelector('.dnb-date-picker--opened')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-date-picker--opened')
+    ).not.toBeInTheDocument()
     expect(on_change).toBeCalledTimes(2)
   })
 
@@ -278,7 +276,9 @@ describe('DatePicker component', () => {
     fireEvent.click(
       document.querySelector('button.dnb-input__submit-button__button')
     )
-    expect(document.querySelector('.dnb-date-picker__views')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-date-picker__views')
+    ).toBeInTheDocument()
     expect(
       document.querySelectorAll('.dnb-date-picker__calendar').length
     ).toBe(2)
@@ -387,19 +387,19 @@ describe('DatePicker component', () => {
     )
 
     const resetElem = document.querySelector('button[data-testid="reset"]')
-    expect(resetElem).toBeTruthy()
+    expect(resetElem).toBeInTheDocument()
     expect(resetElem.textContent).toMatch('Tilbakestill')
 
     const cancelElem = document.querySelector(
       'button[data-testid="cancel"]'
     )
-    expect(cancelElem).toBeTruthy()
+    expect(cancelElem).toBeInTheDocument()
     expect(cancelElem.textContent).toMatch('Avbryt')
 
     const submitElem = document.querySelector(
       'button[data-testid="submit"]'
     )
-    expect(submitElem).toBeTruthy()
+    expect(submitElem).toBeInTheDocument()
     expect(submitElem.textContent).toMatch('Ok')
 
     expect(
@@ -468,7 +468,7 @@ describe('DatePicker component', () => {
     )
 
     const resetElem = document.querySelector('button[data-testid="reset"]')
-    expect(resetElem).toBeTruthy()
+    expect(resetElem).toBeInTheDocument()
     expect(resetElem.textContent).toMatch(reset_button_text)
   })
 
@@ -478,7 +478,7 @@ describe('DatePicker component', () => {
     const datePickerFooter = document.querySelector(
       '.dnb-date-picker__footer'
     )
-    expect(datePickerFooter).toBeTruthy()
+    expect(datePickerFooter).toBeInTheDocument()
   })
 
   it('footer is rendered when show_cancel_button is provided', () => {
@@ -487,7 +487,7 @@ describe('DatePicker component', () => {
     const datePickerFooter = document.querySelector(
       '.dnb-date-picker__footer'
     )
-    expect(datePickerFooter).toBeTruthy()
+    expect(datePickerFooter).toBeInTheDocument()
   })
 
   it('footer is rendered when show_submit_button is provided', () => {
@@ -496,7 +496,7 @@ describe('DatePicker component', () => {
     const datePickerFooter = document.querySelector(
       '.dnb-date-picker__footer'
     )
-    expect(datePickerFooter).toBeTruthy()
+    expect(datePickerFooter).toBeInTheDocument()
   })
 
   it('footer is rendered when range is provided', () => {
@@ -505,7 +505,7 @@ describe('DatePicker component', () => {
     const datePickerFooter = document.querySelector(
       '.dnb-date-picker__footer'
     )
-    expect(datePickerFooter).toBeTruthy()
+    expect(datePickerFooter).toBeInTheDocument()
   })
 
   it('footer is not rendered', () => {
@@ -523,7 +523,7 @@ describe('DatePicker component', () => {
     const datePickerFooter = document.querySelector(
       '.dnb-date-picker__footer'
     )
-    expect(datePickerFooter).toBeFalsy()
+    expect(datePickerFooter).not.toBeInTheDocument()
   })
 
   it('has a working month correction', () => {
@@ -661,13 +661,11 @@ describe('DatePicker component', () => {
     expect(invalidDayElem.getAttribute('aria-label')).toBe(
       'tirsdag 1. januar 2019'
     )
-    expect(invalidDayElem).toBeTruthy()
-    expect(invalidDayElem.hasAttribute('disabled')).toBe(true)
+    expect(invalidDayElem).toBeInTheDocument()
+    expect(invalidDayElem).toHaveAttribute('disabled')
     expect(
-      document
-        .querySelectorAll('.dnb-date-picker__day button')[2]
-        .hasAttribute('disabled')
-    ).toBe(false)
+      document.querySelectorAll('.dnb-date-picker__day button')[2]
+    ).not.toHaveAttribute('disabled')
 
     expect(on_change.mock.calls[2][0].date).toBe(undefined)
     expect(on_change.mock.calls[2][0].is_valid).toBe(undefined)
@@ -842,18 +840,18 @@ describe('DatePicker component', () => {
 
     expect(
       FirstCalendar.querySelector('.dnb-date-picker__day--preview')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       FirstCalendar.querySelector(
         '.dnb-date-picker__day--within-selection'
       )
-    ).toBeFalsy()
-    expect(
-      firstDayElem.classList.contains('dnb-date-picker__day--start-date')
-    ).toBe(false)
-    expect(
-      firstDayElem.classList.contains('dnb-date-picker__day--end-date')
-    ).toBe(false)
+    ).not.toBeInTheDocument()
+    expect(firstDayElem.classList).not.toContain(
+      'dnb-date-picker__day--start-date'
+    )
+    expect(firstDayElem.classList).not.toContain(
+      'dnb-date-picker__day--end-date'
+    )
 
     // 2. Click on start date
 
@@ -861,23 +859,23 @@ describe('DatePicker component', () => {
 
     // 3. Should be marked with start and end date
 
-    expect(
-      firstDayElem.classList.contains('dnb-date-picker__day--start-date')
-    ).toBe(true)
-    expect(
-      firstDayElem.classList.contains('dnb-date-picker__day--end-date')
-    ).toBe(true)
+    expect(firstDayElem.classList).toContain(
+      'dnb-date-picker__day--start-date'
+    )
+    expect(firstDayElem.classList).toContain(
+      'dnb-date-picker__day--end-date'
+    )
 
     // 4. But still no "selection"
 
     expect(
       FirstCalendar.querySelector('.dnb-date-picker__day--preview')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       FirstCalendar.querySelector(
         '.dnb-date-picker__day--within-selection'
       )
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     // 5. Hover on last day
 
@@ -886,14 +884,14 @@ describe('DatePicker component', () => {
     // 6. We should have all TDs in between, marked as "pewview"
     // - and we should have marked it as the end-date
 
-    expect(
-      lastDayElem.classList.contains('dnb-date-picker__day--end-date')
-    ).toBe(true)
+    expect(lastDayElem.classList).toContain(
+      'dnb-date-picker__day--end-date'
+    )
     expect(
       FirstCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
-      )[1].classList.contains('dnb-date-picker__day--preview')
-    ).toBe(true)
+      )[1].classList
+    ).toContain('dnb-date-picker__day--preview')
     expect(
       SecondCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
@@ -901,8 +899,8 @@ describe('DatePicker component', () => {
         SecondCalendar.querySelectorAll(
           'td.dnb-date-picker__day--selectable'
         ).length - 2
-      ].classList.contains('dnb-date-picker__day--preview')
-    ).toBe(true)
+      ].classList
+    ).toContain('dnb-date-picker__day--preview')
 
     // 7. simulate mouse leave the calendar
 
@@ -910,14 +908,14 @@ describe('DatePicker component', () => {
 
     // 8. remove the selection when mouse leaves the calendar
 
-    expect(
-      lastDayElem.classList.contains('dnb-date-picker__day--end-date')
-    ).toBe(false)
+    expect(lastDayElem.classList).not.toContain(
+      'dnb-date-picker__day--end-date'
+    )
     expect(
       FirstCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
-      )[1].classList.contains('dnb-date-picker__day--preview')
-    ).toBe(false)
+      )[1].classList
+    ).not.toContain('dnb-date-picker__day--preview')
     expect(
       SecondCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
@@ -925,8 +923,8 @@ describe('DatePicker component', () => {
         SecondCalendar.querySelectorAll(
           'td.dnb-date-picker__day--selectable'
         ).length - 2
-      ].classList.contains('dnb-date-picker__day--preview')
-    ).toBe(false)
+      ].classList
+    ).not.toContain('dnb-date-picker__day--preview')
 
     // 9. Now, click on the last day as well
 
@@ -937,8 +935,8 @@ describe('DatePicker component', () => {
     expect(
       FirstCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
-      )[1].classList.contains('dnb-date-picker__day--within-selection')
-    ).toBe(true)
+      )[1].classList
+    ).toContain('dnb-date-picker__day--within-selection')
     expect(
       SecondCalendar.querySelectorAll(
         'td.dnb-date-picker__day--selectable'
@@ -946,8 +944,8 @@ describe('DatePicker component', () => {
         SecondCalendar.querySelectorAll(
           'td.dnb-date-picker__day--selectable'
         ).length - 2
-      ].classList.contains('dnb-date-picker__day--within-selection')
-    ).toBe(true)
+      ].classList
+    ).toContain('dnb-date-picker__day--within-selection')
   })
 
   it('resets date correctly between interactions', () => {
@@ -1254,9 +1252,7 @@ describe('DatePicker component', () => {
 
     fireEvent.click(buttonElement)
 
-    expect(
-      element.classList.contains('dnb-date-picker--opened')
-    ).toBeTruthy()
+    expect(element.classList).toContain('dnb-date-picker--opened')
 
     const tableElement = document.querySelector('table')
 
@@ -1284,9 +1280,7 @@ describe('DatePicker component', () => {
     fireEvent.click(buttonElement)
 
     expect(document.activeElement).toBe(document.body)
-    expect(
-      element.classList.contains('dnb-date-picker--opened')
-    ).toBeTruthy()
+    expect(element.classList).toContain('dnb-date-picker--opened')
   })
 
   it('has to react on keydown events', async () => {
@@ -1320,11 +1314,9 @@ describe('DatePicker component', () => {
     await wait(1)
 
     // and check the class of that element
-    expect(
-      document.activeElement.classList.contains(
-        'dnb-date-picker__input--month'
-      )
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-date-picker__input--month'
+    )
 
     // also test the key up to change the value on the month input
     expect((monthElem as HTMLInputElement).value).toBe('01')
@@ -1363,19 +1355,19 @@ describe('DatePicker component', () => {
       render(<DatePicker {...defaultProps} size="small" />)
       expect(
         document.querySelector('.dnb-date-picker--small')
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
     it('has correct medium size', () => {
       render(<DatePicker {...defaultProps} size="medium" />)
       expect(
         document.querySelector('.dnb-date-picker--medium')
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
     it('has correct large size', () => {
       render(<DatePicker {...defaultProps} size="large" />)
       expect(
         document.querySelector('.dnb-date-picker--large')
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -52,13 +52,15 @@ describe('Dialog', () => {
 
     expect(
       document.querySelector('button.dnb-modal__close-button')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('omits trigger button once we set omitTriggerButton', () => {
     render(<Dialog {...props} omitTriggerButton />)
 
-    expect(document.querySelector('button.dnb-modal__trigger')).toBeFalsy()
+    expect(
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toBeInTheDocument()
   })
 
   it('will close by using callback method', () => {
@@ -133,7 +135,7 @@ describe('Dialog', () => {
     )
     const elem = document.querySelector('.dnb-modal__content')
     expect(elem.getAttribute('role')).toBe('dialog')
-    expect(elem.hasAttribute('aria-modal')).toBe(true)
+    expect(elem).toHaveAttribute('aria-modal')
 
     Object.defineProperty(helpers, 'IS_MAC', {
       value: true,
@@ -147,7 +149,7 @@ describe('Dialog', () => {
     )
 
     expect(elem.getAttribute('role')).toBe('region')
-    expect(elem.hasAttribute('aria-modal')).toBe(false)
+    expect(elem).not.toHaveAttribute('aria-modal')
 
     Object.defineProperty(helpers, 'IS_MAC', {
       value: false,
@@ -166,7 +168,7 @@ describe('Dialog', () => {
     )
 
     expect(elem.getAttribute('role')).toBe('alertdialog')
-    expect(elem.hasAttribute('aria-modal')).toBe(true)
+    expect(elem).toHaveAttribute('aria-modal')
   })
 
   it('is closed by keyboardevent esc', () => {
@@ -254,7 +256,9 @@ describe('Dialog', () => {
       })
     )
 
-    expect(document.querySelector('#content-third')).toBeFalsy()
+    expect(
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button#modal-first'))
     expect(
@@ -276,31 +280,24 @@ describe('Dialog', () => {
     expect(
       document.querySelectorAll('button.dnb-modal__close-button').length
     ).toBe(3)
+    expect(document.querySelector('#content-first')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-second')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-third')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document.querySelector('#content-first').hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelector('button.dnb-modal__close-button')
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document.querySelector('#content-second').hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document.querySelector('#content-third').hasAttribute('aria-hidden')
-    ).toBe(false)
-    expect(
-      document
-        .querySelector('button.dnb-modal__close-button')
-
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[2]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[2]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the third one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -313,21 +310,18 @@ describe('Dialog', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-second')
-    expect(document.querySelector('#content-third')).toBeFalsy()
     expect(
-      document.querySelector('#content-second').hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-second')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelector('button.dnb-modal__close-button')
-
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelector('button.dnb-modal__close-button')
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the second one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -340,16 +334,15 @@ describe('Dialog', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-first')
-    expect(document.querySelector('#content-second')).toBeFalsy()
     expect(
-      document.querySelector('#content-first').hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-second')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-first')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelector('button.dnb-modal__close-button')
-
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('button.dnb-modal__close-button')
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the first one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -358,10 +351,12 @@ describe('Dialog', () => {
       expect(on_close.second).toHaveBeenCalledTimes(1)
       expect(on_close.third).toHaveBeenCalledTimes(1)
 
-      expect(document.querySelector('#content-first')).toBeFalsy()
       expect(
-        document.documentElement.hasAttribute('data-dnb-modal-active')
-      ).toBe(false)
+        document.querySelector('#content-first')
+      ).not.toBeInTheDocument()
+      expect(document.documentElement).not.toHaveAttribute(
+        'data-dnb-modal-active'
+      )
     })
   })
 
@@ -416,11 +411,15 @@ describe('Dialog', () => {
     render(<Dialog {...props} variant="confirmation" openState="opened" />)
 
     fireEvent.click(document.querySelector('.dnb-modal__content'))
-    expect(document.querySelector('.dnb-dialog__inner')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-dialog__inner')
+    ).toBeInTheDocument()
 
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
     await waitFor(() => {
-      expect(document.querySelector('.dnb-dialog__inner')).toBeFalsy()
+      expect(
+        document.querySelector('.dnb-dialog__inner')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/DialogAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/DialogAction.test.tsx
@@ -17,7 +17,9 @@ describe('Dialog.Action', () => {
 
     render(<MockComponent />)
 
-    expect(document.querySelector('.dnb-dialog__actions')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-dialog__actions')
+    ).toBeInTheDocument()
   })
 
   it('supports spacing', () => {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -51,13 +51,15 @@ describe('Drawer', () => {
 
     expect(
       document.querySelector('button.dnb-modal__close-button')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('omits trigger button once we set omitTriggerButton', () => {
     render(<Drawer {...props} omitTriggerButton />)
 
-    expect(document.querySelector('button.dnb-modal__trigger')).toBeFalsy()
+    expect(
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toBeInTheDocument()
   })
 
   it('will close by using callback method', async () => {
@@ -188,7 +190,9 @@ describe('Drawer', () => {
       </Drawer>
     )
 
-    expect(document.querySelector('#content-third')).toBeFalsy()
+    expect(
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button#modal-first'))
     expect(
@@ -210,36 +214,28 @@ describe('Drawer', () => {
     expect(
       document.querySelectorAll('button.dnb-modal__close-button').length
     ).toBe(3)
-    expect(
-      document.querySelector('#content-first').hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document.querySelector('#content-second').hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document.querySelector('#content-third').hasAttribute('aria-hidden')
-    ).toBe(false)
+    expect(document.querySelector('#content-first')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-second')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-third')).not.toHaveAttribute(
+      'aria-hidden'
+    )
 
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[2]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[2]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the third one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -252,20 +248,18 @@ describe('Drawer', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-second')
-    expect(document.querySelector('#content-third')).toBeFalsy()
     expect(
-      document.querySelector('#content-second').hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-second')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the second one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -278,15 +272,15 @@ describe('Drawer', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-first')
-    expect(document.querySelector('#content-second')).toBeFalsy()
     expect(
-      document.querySelector('#content-first').hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-second')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-first')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the first one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -296,10 +290,12 @@ describe('Drawer', () => {
       expect(on_close.third).toHaveBeenCalledTimes(1)
     })
 
-    expect(document.querySelector('#content-first')).toBeFalsy()
     expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+      document.querySelector('#content-first')
+    ).not.toBeInTheDocument()
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
   })
 
   it('will accept custom refs', () => {

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -74,12 +74,8 @@ describe('Dropdown component', () => {
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
       props.value
     ]
-    expect(elem.classList.contains('dnb-drawer-list__option--focus')).toBe(
-      true
-    )
-    expect(
-      elem.classList.contains('dnb-drawer-list__option--selected')
-    ).toBe(true)
+    expect(elem.classList).toContain('dnb-drawer-list__option--focus')
+    expect(elem.classList).toContain('dnb-drawer-list__option--selected')
 
     keydown(40) // down
     keydown(13) // enter
@@ -89,12 +85,8 @@ describe('Dropdown component', () => {
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
       (props.value as number) + 1
     ]
-    expect(elem.classList.contains('dnb-drawer-list__option--focus')).toBe(
-      true
-    )
-    expect(
-      elem.classList.contains('dnb-drawer-list__option--selected')
-    ).toBe(true)
+    expect(elem.classList).toContain('dnb-drawer-list__option--focus')
+    expect(elem.classList).toContain('dnb-drawer-list__option--selected')
 
     expect(
       document.querySelector('.dnb-dropdown__text__inner').textContent
@@ -111,7 +103,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--focus')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     keydown(83) // S
 
@@ -119,10 +111,8 @@ describe('Dropdown component', () => {
     rerender(<Dropdown {...props} data={mockData} />)
 
     expect(
-      document
-        .querySelectorAll('.dnb-drawer-list__option')[1]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('.dnb-drawer-list__option')[1].classList
+    ).toContain('dnb-drawer-list__option--focus')
 
     keydown(70) // F
 
@@ -130,10 +120,8 @@ describe('Dropdown component', () => {
     rerender(<Dropdown {...props} data={mockData} />)
 
     expect(
-      document
-        .querySelectorAll('.dnb-drawer-list__option')[2]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('.dnb-drawer-list__option')[2].classList
+    ).toContain('dnb-drawer-list__option--focus')
   })
 
   it('has correct state when opened prop is given', () => {
@@ -161,7 +149,7 @@ describe('Dropdown component', () => {
       />
     )
 
-    expect(document.querySelector('button')).toBeTruthy()
+    expect(document.querySelector('button')).toBeInTheDocument()
     expect(
       Array.from(document.querySelector('button').classList)
     ).toContain('dnb-dropdown__trigger')
@@ -216,7 +204,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     // then simulate changes
     keydown(40) // down
@@ -226,21 +214,17 @@ describe('Dropdown component', () => {
     expect(on_change).toHaveBeenCalledTimes(1)
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeTruthy()
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    ).toBeInTheDocument()
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
     // close
     keydown(27) // esc
 
     expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-dropdown').classList
+    ).not.toContain('dnb-dropdown--opened')
   })
 
   it('will stay open when prevent_close is given, regardless', async () => {
@@ -259,7 +243,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     // then simulate changes
     keydown(40) // down
@@ -269,21 +253,17 @@ describe('Dropdown component', () => {
     expect(on_change).toHaveBeenCalledTimes(1)
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeTruthy()
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    ).toBeInTheDocument()
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
     // try to close it
     keydown(27) // esc
 
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
     expect(on_hide).toHaveBeenCalledTimes(0)
   })
@@ -331,7 +311,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     // then simulate changes
     keydown(40) // down
@@ -343,7 +323,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(
       <Dropdown
@@ -367,7 +347,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     rerender(
       <Dropdown
@@ -392,7 +372,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(
       <Dropdown
@@ -423,7 +403,9 @@ describe('Dropdown component', () => {
     expect(document.querySelector('.dnb-dropdown__text').textContent).toBe(
       title
     )
-    expect(document.querySelector('.dnb-dropdown--is-popup')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-dropdown--is-popup')
+    ).not.toBeInTheDocument()
 
     rerender(
       <Dropdown
@@ -437,8 +419,12 @@ describe('Dropdown component', () => {
       />
     )
 
-    expect(document.querySelector('.dnb-dropdown__text')).toBeFalsy()
-    expect(document.querySelector('.dnb-dropdown--is-popup')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-dropdown__text')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-dropdown--is-popup')
+    ).toBeInTheDocument()
   })
 
   it('can be reset to null', () => {
@@ -590,7 +576,7 @@ describe('Dropdown component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--selected')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     expect(
       document
@@ -599,8 +585,12 @@ describe('Dropdown component', () => {
         .getAttribute('data-testid')
     ).toBe('more icon')
 
-    expect(document.querySelector('.dnb-dropdown__text')).toBeFalsy()
-    expect(document.querySelector('.dnb-dropdown--is-popup')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-dropdown__text')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-dropdown--is-popup')
+    ).toBeInTheDocument()
   })
 
   it('has valid on_change callback', () => {
@@ -829,11 +819,9 @@ describe('Dropdown component', () => {
     // first open
     open()
 
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
     act(() => {
       // close
@@ -843,19 +831,15 @@ describe('Dropdown component', () => {
     expect(on_hide.mock.calls.length).toBe(1)
 
     expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(false)
+      document.querySelector('.dnb-dropdown').classList
+    ).not.toContain('dnb-dropdown--opened')
 
     // reopen
     open()
 
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
     preventClose = true
 
@@ -867,11 +851,9 @@ describe('Dropdown component', () => {
     expect(on_hide.mock.calls.length).toBe(2)
 
     // we are still open
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
   })
 
   it('will set focus on options when key down/up is pressed on first item', async () => {
@@ -882,40 +864,34 @@ describe('Dropdown component', () => {
     // first open
     keydown(40) // down
 
-    expect(
-      document
-        .querySelector('.dnb-dropdown')
-        .classList.contains('dnb-dropdown--opened')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-dropdown').classList).toContain(
+      'dnb-dropdown--opened'
+    )
 
-    expect(
-      document.activeElement.classList.contains('dnb-drawer-list__options')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__options'
+    )
 
     keydown(40) // down
 
     // delay because we want to wait to have the DOM focus to be called
     await wait(1)
 
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__option'
+    )
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__option--focus'
+    )
     expect(
-      document.activeElement.classList.contains('dnb-drawer-list__option')
-    ).toBe(true)
-    expect(
-      document.activeElement.classList.contains(
-        'dnb-drawer-list__option--focus'
-      )
-    ).toBe(true)
-    expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[0]
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[0].classList
+    ).toContain('dnb-drawer-list__option--focus')
 
     keydown(38) // up
 
-    expect(
-      document.activeElement.classList.contains('dnb-drawer-list__options')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__options'
+    )
 
     // then simulate changes
     keydown(38) // up
@@ -923,24 +899,20 @@ describe('Dropdown component', () => {
     // delay because we want to wait to have the DOM focus to be called
     await wait(1)
 
-    expect(
-      document.activeElement.classList.contains('dnb-drawer-list__option')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__option'
+    )
     let options = document.querySelectorAll('li.dnb-drawer-list__option')
-    expect(
-      options[mockData.length - 1].classList.contains(
-        'dnb-drawer-list__option--focus'
-      )
-    ).toBe(true)
+    expect(options[mockData.length - 1].classList).toContain(
+      'dnb-drawer-list__option--focus'
+    )
 
     // then simulate changes
     keydown(40) // down
 
     expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[0] // the first item
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[0].classList // the first item
+    ).toContain('dnb-drawer-list__option--focus')
 
     rerender(
       <Dropdown
@@ -957,8 +929,7 @@ describe('Dropdown component', () => {
     options = document.querySelectorAll('li.dnb-drawer-list__option')
     expect(
       options[mockData.length - 1].classList // the last item
-        .contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+    ).toContain('dnb-drawer-list__option--focus')
 
     // delay because we want to wait to have the DOM focus to be called
     await wait(1)
@@ -966,9 +937,9 @@ describe('Dropdown component', () => {
     // then simulate changes
     keydown(40) // down
 
-    expect(
-      document.activeElement.classList.contains('dnb-drawer-list__options')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-drawer-list__options'
+    )
 
     // then simulate changes
     keydown(38) // up
@@ -976,8 +947,7 @@ describe('Dropdown component', () => {
     options = document.querySelectorAll('li.dnb-drawer-list__option')
     expect(
       options[mockData.length - 1].classList // the last item
-        .contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+    ).toContain('dnb-drawer-list__option--focus')
 
     // then simulate changes
     keydown(38) // up
@@ -985,17 +955,14 @@ describe('Dropdown component', () => {
     options = document.querySelectorAll('li.dnb-drawer-list__option')
     expect(
       options[mockData.length - 2].classList // the second item
-        .contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+    ).toContain('dnb-drawer-list__option--focus')
 
     // then simulate changes
     keydown(33) // pageUp
 
     expect(
-      document
-        .querySelectorAll('li.dnb-drawer-list__option')[0] // the first item
-        .classList.contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+      document.querySelectorAll('li.dnb-drawer-list__option')[0].classList // the first item
+    ).toContain('dnb-drawer-list__option--focus')
 
     // then simulate changes
     keydown(38) // up
@@ -1003,8 +970,7 @@ describe('Dropdown component', () => {
     options = document.querySelectorAll('li.dnb-drawer-list__option')
     expect(
       options[mockData.length - 1].classList // the last item
-        .contains('dnb-drawer-list__option--focus')
-    ).toBe(true)
+    ).toContain('dnb-drawer-list__option--focus')
   })
 
   it('will change the selected value when StrictMode is enabled', () => {
@@ -1069,16 +1035,12 @@ describe('Dropdown component', () => {
     open()
 
     const options = document.querySelectorAll('li.dnb-drawer-list__option')
-    expect(
-      options[newValue].classList.contains(
-        'dnb-drawer-list__option--selected'
-      )
-    ).toBe(true)
-    expect(
-      options[newValue].classList.contains(
-        'dnb-drawer-list__option--focus'
-      )
-    ).toBe(true)
+    expect(options[newValue].classList).toContain(
+      'dnb-drawer-list__option--selected'
+    )
+    expect(options[newValue].classList).toContain(
+      'dnb-drawer-list__option--focus'
+    )
   })
 
   it('has a default title if no value is given', () => {
@@ -1130,10 +1092,8 @@ describe('Dropdown component', () => {
     rerender(<Dropdown data={mockData} {...mockProps} disabled={true} />)
 
     expect(
-      document
-        .querySelector('button.dnb-dropdown__trigger')
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector('button.dnb-dropdown__trigger')
+    ).toHaveAttribute('disabled')
   })
 
   beforeAll(() => {

--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -17,12 +17,12 @@ const props: FormLabelProps = {
 describe('FormLabel component', () => {
   it('should forward unlisted attributes like "aria-hidden"', () => {
     render(<FormLabel {...props} for_id="input" aria-hidden />)
-    expect(document.querySelector('label[aria-hidden]')).toBeTruthy()
     expect(
-      document
-        .querySelector('label[aria-hidden]')
-        .getAttribute('aria-hidden')
-    ).toBeTruthy()
+      document.querySelector('label[aria-hidden]')
+    ).toBeInTheDocument()
+    expect(document.querySelector('label[aria-hidden]')).toHaveAttribute(
+      'aria-hidden'
+    )
   })
 
   it('should support spacing props', () => {

--- a/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-row/__tests__/FormRow.test.tsx
@@ -18,11 +18,9 @@ const props: FormRowProps = {
 describe('FormRow component', () => {
   it('should have vertical direction class', () => {
     render(<FormRow {...props} direction="vertical" />)
-    expect(
-      document
-        .querySelector('.dnb-form-row')
-        .classList.contains('dnb-form-row--vertical')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-form-row').classList).toContain(
+      'dnb-form-row--vertical'
+    )
   })
 
   it('should have an isolated state on nested FormRows', () => {
@@ -36,34 +34,28 @@ describe('FormRow component', () => {
       </FormRow>
     )
     expect(
-      document
-        .querySelectorAll('span.dnb-input')[0]
-        .classList.contains('dnb-input--vertical')
-    ).toBe(true)
+      document.querySelectorAll('span.dnb-input')[0].classList
+    ).toContain('dnb-input--vertical')
     expect(
-      document
-        .querySelectorAll('span.dnb-input')[1]
-        .classList.contains('dnb-input--horizontal')
-    ).toBe(true)
+      document.querySelectorAll('span.dnb-input')[1].classList
+    ).toContain('dnb-input--horizontal')
     expect(
-      document
-        .querySelectorAll('span.dnb-input')[2]
-        .classList.contains('dnb-input--vertical')
-    ).toBe(true)
+      document.querySelectorAll('span.dnb-input')[2].classList
+    ).toContain('dnb-input--vertical')
   })
 
   it('should using formset and legend by default', () => {
     render(<FormRow {...props} />)
 
-    expect(document.querySelector('fieldset')).toBeTruthy()
-    expect(document.querySelector('legend')).toBeTruthy()
+    expect(document.querySelector('fieldset')).toBeInTheDocument()
+    expect(document.querySelector('legend')).toBeInTheDocument()
   })
 
   it('should using formset and legend by default', () => {
     render(<FormRow {...props} no_fieldset />)
-    expect(document.querySelector('label')).toBeTruthy()
-    expect(document.querySelector('fieldset')).toBeFalsy()
-    expect(document.querySelector('legend')).toBeFalsy()
+    expect(document.querySelector('label')).toBeInTheDocument()
+    expect(document.querySelector('fieldset')).not.toBeInTheDocument()
+    expect(document.querySelector('legend')).not.toBeInTheDocument()
   })
 
   it('should support locale context forwarding', () => {
@@ -119,7 +111,7 @@ describe('FormRow component', () => {
         <Input />
       </FormRow>
     )
-    expect(document.querySelector('input[disabled]')).toBeTruthy()
+    expect(document.querySelector('input[disabled]')).toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/form-set/__tests__/FormSet.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-set/__tests__/FormSet.test.tsx
@@ -21,7 +21,7 @@ describe('FormSet component', () => {
   it('should have .dnb-form-set class', () => {
     render(<FormSet {...props} />)
 
-    expect(document.querySelector('.dnb-form-set')).toBeTruthy()
+    expect(document.querySelector('.dnb-form-set')).toBeInTheDocument()
   })
 
   it('should have working provider with vertical direction class on form-row', () => {
@@ -30,11 +30,9 @@ describe('FormSet component', () => {
         <FormRow />
       </FormSet>
     )
-    expect(
-      document
-        .querySelector('.dnb-form-row')
-        .classList.contains('dnb-form-row--vertical')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-form-row').classList).toContain(
+      'dnb-form-row--vertical'
+    )
   })
 
   it('should disable nested components', () => {
@@ -47,7 +45,7 @@ describe('FormSet component', () => {
     )
     expect(
       document.querySelector('input.dnb-input__input[disabled]')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     rerender(
       <FormSet {...props} disabled={false}>
@@ -58,7 +56,7 @@ describe('FormSet component', () => {
     )
     expect(
       document.querySelector('input.dnb-input__input[disabled]')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(
       <FormSet {...props} disabled>
@@ -69,7 +67,7 @@ describe('FormSet component', () => {
     )
     expect(
       document.querySelector('input.dnb-input__input[disabled]')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     rerender(
       <FormSet {...props} disabled>
@@ -81,7 +79,7 @@ describe('FormSet component', () => {
 
     expect(
       document.querySelector('input.dnb-input__input[disabled]')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should support locale context forwarding', () => {

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
@@ -98,11 +98,9 @@ describe('FormStatus component', () => {
         }}
       />
     )
-    expect(
-      document
-        .querySelector('.dnb-form-status')
-        .classList.contains('dnb-form-status__variant--outlined')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-form-status').classList).toContain(
+      'dnb-form-status__variant--outlined'
+    )
   })
 
   it('should update children when they change', () => {
@@ -123,11 +121,15 @@ describe('FormStatus component', () => {
 
   it('should have correct attributes once the "hidden" prop changes', async () => {
     const { rerender } = render(<FormStatus {...props} hidden />)
-    expect(document.querySelector('.dnb-form-status[hidden]')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-form-status[hidden]')
+    ).toBeInTheDocument()
 
     rerender(<FormStatus {...props} hidden={false} />)
 
-    expect(document.querySelector('.dnb-form-status[hidden]')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-form-status[hidden]')
+    ).not.toBeInTheDocument()
   })
 
   it('has to to have a text value as defined in the prop', () => {

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
@@ -143,7 +143,7 @@ describe('GlobalError', () => {
 
     const elem = document.querySelector('.dnb-global-error__links')
 
-    expect(elem).toBeTruthy()
+    expect(elem).toBeInTheDocument()
     expect(elem.previousSibling.textContent).toMatchInlineSnapshot(
       `"Her er noen lenker som kanskje kan hjelpe:"`
     )

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -50,11 +50,13 @@ describe('GlobalStatus component', () => {
     const { rerender } = render(
       <GlobalStatus autoscroll={false} delay={0} />
     )
-    expect(document.querySelector('[aria-live]')).toBeTruthy()
+    expect(document.querySelector('[aria-live]')).toBeInTheDocument()
 
     rerender(<GlobalStatus autoscroll={false} delay={0} show={true} />)
 
-    expect(document.querySelector('[aria-live="assertive"]')).toBeTruthy()
+    expect(
+      document.querySelector('[aria-live="assertive"]')
+    ).toBeInTheDocument()
 
     rerender(<GlobalStatus autoscroll={false} delay={0} show={false} />)
 
@@ -178,7 +180,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__message')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('has to have correct content after a controller remove', () => {
@@ -200,11 +202,8 @@ describe('GlobalStatus component', () => {
       document.querySelector('div.dnb-global-status__shell').innerHTML
     ).toBe('')
     expect(
-      document
-        .querySelector('div.dnb-global-status__shell')
-
-        .hasAttribute('style')
-    ).toBe(false)
+      document.querySelector('div.dnb-global-status__shell')
+    ).not.toHaveAttribute('style')
 
     render(
       <GlobalStatus.Add
@@ -226,7 +225,7 @@ describe('GlobalStatus component', () => {
     ).toBe(startupText)
     expect(
       document.querySelector('div.dnb-global-status__message')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     render(
       <GlobalStatus.Add
@@ -282,7 +281,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__message')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       document
         .querySelector('div.dnb-global-status__shell')
@@ -399,14 +398,18 @@ describe('GlobalStatus component', () => {
     await wait(1)
     fireEvent.blur(document.querySelector('input#autocomplete-3'))
 
-    expect(document.querySelector('.dnb-form-status__text')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).not.toBeInTheDocument()
 
     await refresh()
 
     expect(
       document.querySelector('.dnb-global-status__message p')
-    ).toBeFalsy()
-    expect(document.querySelector('.dnb-form-status__text')).toBeFalsy()
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).not.toBeInTheDocument()
     const inst = document.querySelector('div.dnb-global-status__shell')
 
     expect(inst.innerHTML).toBe('')
@@ -597,7 +600,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('.dnb-global-status__content')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('.dnb-global-status__message p').textContent
     ).toBe('error-message')
@@ -605,7 +608,9 @@ describe('GlobalStatus component', () => {
     fireEvent.click(document.querySelector('input#switch'))
     await refresh()
 
-    expect(document.querySelector('.dnb-form-status__text')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).not.toBeInTheDocument()
     const inst = document.querySelector('div.dnb-global-status__shell')
 
     expect(inst.innerHTML).toBe('')
@@ -758,7 +763,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__message')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('div.dnb-global-status__message').textContent
     ).toBe('text only')
@@ -800,7 +805,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__message')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     render(
       <GlobalStatus.Add
@@ -832,11 +837,11 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__content')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     expect(
       document.querySelector('div.dnb-global-status__message__content')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(
       <GlobalStatus
@@ -850,10 +855,10 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__content')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('div.dnb-global-status__message__content')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     render(
       <GlobalStatus.Add
@@ -866,7 +871,7 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__message__content')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     rerender(
       <GlobalStatus
@@ -887,10 +892,10 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector('div.dnb-global-status__content')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       document.querySelector('div.dnb-global-status__message__content')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
+++ b/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
@@ -21,7 +21,7 @@ describe('Heading component', () => {
     const props: HeadingProps = {}
     render(<Heading {...props} />)
 
-    expect(document.querySelector('.dnb-heading')).toBeTruthy()
+    expect(document.querySelector('.dnb-heading')).toBeInTheDocument()
   })
 
   it('have to match level correction', () => {
@@ -318,7 +318,7 @@ describe('Heading component', () => {
 
     const elem = document.querySelectorAll('.dnb-heading')
     expect(elem[0].textContent).toBe('[h1] Heading #1')
-    expect(elem[0].classList.contains('dnb-h--x-large')).toBe(true)
+    expect(elem[0].classList).toContain('dnb-h--x-large')
     expect(elem[0].getAttribute('class')).toBe(
       'dnb-heading dnb-h--x-large'
     )

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -72,26 +72,28 @@ describe('HeightAnimation', () => {
     render(<Component />)
     expect(
       document.querySelector('.dnb-height-animation--is-visible')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should use given span element', () => {
     render(<Component open animate={false} element="span" />)
     expect(
       document.querySelector('span.dnb-height-animation--is-visible')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should have element in DOM when open property is true', () => {
     const { rerender } = render(<Component />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
     expect(
       document.querySelector('.dnb-height-animation--is-visible')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should set duration', () => {
@@ -110,7 +112,7 @@ describe('HeightAnimation', () => {
     ).toBe('visible content')
     expect(
       document.querySelector('.dnb-height-animation--is-visible')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       document.querySelector('.dnb-height-animation').getAttribute('style')
     ).toBe('height: auto;')
@@ -119,21 +121,25 @@ describe('HeightAnimation', () => {
   it('should have element in DOM when open property is true (using ToggleButton)', () => {
     render(<Component />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button'))
 
     act(() => {
       expect(
         document.querySelector('.dnb-height-animation--is-visible')
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
   })
 
   it('should adjust height when content changes', async () => {
     const { rerender } = render(<Component />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
@@ -175,7 +181,9 @@ describe('HeightAnimation', () => {
     const onOpen = jest.fn()
     const { rerender } = render(<Component onOpen={onOpen} />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
@@ -200,7 +208,9 @@ describe('HeightAnimation', () => {
       <Component onAnimationEnd={onAnimationEnd} />
     )
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
@@ -222,7 +232,9 @@ describe('HeightAnimation', () => {
     const onInit = jest.fn()
     const { rerender } = render(<Component onInit={onInit} />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
@@ -245,16 +257,18 @@ describe('HeightAnimation', () => {
   it('should have content in DOM when keepInDOM is true', () => {
     const { rerender } = render(<Component keepInDOM />)
 
-    expect(document.querySelector('.dnb-height-animation')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).toBeInTheDocument()
     expect(
       document.querySelector('.dnb-height-animation--is-visible')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(<Component keepInDOM open />)
 
     expect(
       document.querySelector('.dnb-height-animation--is-visible')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     rerender(<Component keepInDOM open={false} />)
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
@@ -77,17 +77,17 @@ describe('useHeightAnimation', () => {
 
   it('should be closed by default', () => {
     render(<Component />)
-    expect(document.querySelector('.is-in-dom')).toBeFalsy()
+    expect(document.querySelector('.is-in-dom')).not.toBeInTheDocument()
   })
 
   it('should have element in DOM when open property is true', () => {
     const { rerender } = render(<Component />)
 
-    expect(document.querySelector('.is-in-dom')).toBeFalsy()
+    expect(document.querySelector('.is-in-dom')).not.toBeInTheDocument()
 
     rerender(<Component open />)
 
-    expect(document.querySelector('.is-in-dom')).toBeTruthy()
+    expect(document.querySelector('.is-in-dom')).toBeInTheDocument()
   })
 
   it('should set height style to auto', async () => {

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -75,9 +75,9 @@ describe('HelpButton', () => {
 
     it('should have not aria-label if text is given', () => {
       render(<HelpButton {...props} icon="bell" text="button text" />)
-      expect(
-        document.querySelector('.dnb-button').hasAttribute('aria-label')
-      ).toBe(false)
+      expect(document.querySelector('.dnb-button')).not.toHaveAttribute(
+        'aria-label'
+      )
       expect(
         document.querySelector('.dnb-button').textContent.trim()
       ).toBe('‌button text')

--- a/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
@@ -18,7 +18,7 @@ describe('IconPrimary component', () => {
     const height = '100'
     render(<IconPrimary {...props} width={width} height={height} />)
     const elem = document.querySelector('svg')
-    expect(elem).toBeTruthy()
+    expect(elem).toBeInTheDocument()
     expect(elem.getAttribute('width')).toBe(width)
     expect(elem.getAttribute('height')).toBe(height)
     expect(elem.getAttribute('viewBox')).toBe('0 0 16 16')
@@ -29,8 +29,8 @@ describe('IconPrimary component', () => {
     render(<IconPrimary {...props} icon="question_medium" size="medium" />)
     const svg = document.querySelector('svg')
     const path = svg.querySelector('path')
-    expect(svg).toBeTruthy()
-    expect(path).toBeTruthy()
+    expect(svg).toBeInTheDocument()
+    expect(path).toBeInTheDocument()
     expect(svg.getAttribute('viewBox')).toBe('0 0 24 24')
   })
 
@@ -39,8 +39,8 @@ describe('IconPrimary component', () => {
     render(<IconPrimary {...props} icon="question_medium" size="24" />)
     const svg = document.querySelector('svg')
     const path = svg.querySelector('path')
-    expect(svg).toBeTruthy()
-    expect(path).toBeTruthy()
+    expect(svg).toBeInTheDocument()
+    expect(path).toBeInTheDocument()
     expect(svg.getAttribute('viewBox')).toBe('0 0 24 24')
   })
 

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -21,24 +21,20 @@ describe('Icon component', () => {
     const height = '100'
     render(<Icon {...props} width={width} height={height} />)
     const elem = document.querySelector('svg')
-    expect(elem).toBeTruthy()
+    expect(elem).toBeInTheDocument()
     expect(elem.getAttribute('width')).toBe(width)
     expect(elem.getAttribute('height')).toBe(height)
   })
 
   it('should work with medium size', () => {
     const { rerender } = render(<Icon {...props} size="24" />)
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--medium')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--medium'
+    )
     rerender(<Icon {...props} size={16} />)
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--default')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--default'
+    )
   })
 
   it('should return null if icon was given as null', () => {
@@ -57,36 +53,28 @@ describe('Icon component', () => {
 
   it('should have border class', () => {
     render(<Icon {...props} border={true} />)
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--border')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--border'
+    )
   })
 
   it('should inherit color and vice versa when inherit_color is false', () => {
     const { rerender } = render(<Icon icon={question} />)
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--inherit-color')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--inherit-color'
+    )
 
     rerender(<Icon icon={question} inherit_color={true} />)
 
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--inherit-color')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--inherit-color'
+    )
 
     rerender(<Icon icon={question} inherit_color={false} />)
 
     expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--inherit-color')
-    ).toBe(false)
+      document.querySelector('span.dnb-icon').classList
+    ).not.toContain('dnb-icon--inherit-color')
   })
 
   it('should not be hidden, given aria-hidden={false}', () => {
@@ -98,17 +86,13 @@ describe('Icon component', () => {
 
   it('should work with custom size', () => {
     const { rerender } = render(<Icon {...props} size="100" />)
-    expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--custom-size')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--custom-size'
+    )
     rerender(<Icon {...props} size={16} />)
     expect(
-      document
-        .querySelector('span.dnb-icon')
-        .classList.contains('dnb-icon--custom-size')
-    ).toBe(false)
+      document.querySelector('span.dnb-icon').classList
+    ).not.toContain('dnb-icon--custom-size')
   })
 
   it('should set data-testid property based on the aria-label', () => {

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -281,7 +281,7 @@ describe('InfoCard', () => {
     render(<InfoCard title="heading" text="text" />)
 
     const element = document.querySelector('.dnb-info-card')
-    expect(element.querySelector('h3')).toBeFalsy()
+    expect(element.querySelector('h3')).not.toBeInTheDocument()
   })
 
   describe('InfoCard aria', () => {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -843,7 +843,9 @@ describe('InputMasked component with currency_mask', () => {
       placeholderText
     )
 
-    expect(document.querySelector('.dnb-input__placeholder')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-input__placeholder')
+    ).not.toBeInTheDocument()
   })
 
   it('should change data-input-state based on focus state', () => {

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -267,30 +267,32 @@ describe('Input component', () => {
       />
     )
 
-    expect(document.querySelector('label')).toBeFalsy()
+    expect(document.querySelector('label')).not.toBeInTheDocument()
     expect(
       document.querySelector('input').getAttribute('aria-placeholder')
     ).toContain('Placeholder-text')
-    expect(
-      document.querySelector('input').hasAttribute('aria-labelledby')
-    ).toBe(false)
+    expect(document.querySelector('input')).not.toHaveAttribute(
+      'aria-labelledby'
+    )
 
     rerender(
       <Input id="unique" placeholder={undefined} label={undefined} />
     )
 
-    expect(document.querySelector('label')).toBeFalsy()
-    expect(
-      document.querySelector('input').hasAttribute('aria-placeholder')
-    ).toBe(false)
-    expect(
-      document.querySelector('input').hasAttribute('aria-labelledby')
-    ).toBe(false)
+    expect(document.querySelector('label')).not.toBeInTheDocument()
+    expect(document.querySelector('input')).not.toHaveAttribute(
+      'aria-placeholder'
+    )
+    expect(document.querySelector('input')).not.toHaveAttribute(
+      'aria-labelledby'
+    )
   })
 
   it('has correct medium input size', () => {
     render(<Input size="medium" />)
-    expect(document.querySelector('.dnb-input--medium')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-input--medium')
+    ).toBeInTheDocument()
   })
 
   it('will select the whole input when selectall is set', async () => {
@@ -382,9 +384,7 @@ describe('Input component', () => {
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<Input />)
     rerender(<Input disabled={true} />)
-    expect(document.querySelector('input').hasAttribute('disabled')).toBe(
-      true
-    )
+    expect(document.querySelector('input')).toHaveAttribute('disabled')
   })
 
   it('has a submit button on prop type="search"', () => {
@@ -401,7 +401,7 @@ describe('Input component', () => {
     ).toBe('id input-submit-button')
 
     const Button = document.querySelector('button')
-    expect(Button).toBeTruthy()
+    expect(Button).toBeInTheDocument()
 
     fireEvent.focus(Button)
     expect(
@@ -438,7 +438,7 @@ describe('Input component', () => {
 describe('Input with clear button', () => {
   it('should have the button', () => {
     render(<Input clear={true} />)
-    expect(document.querySelector('.dnb-input--clear')).toBeTruthy()
+    expect(document.querySelector('.dnb-input--clear')).toBeInTheDocument()
   })
 
   it('should clear the value on press', () => {
@@ -470,7 +470,7 @@ describe('Input with clear button', () => {
 
     expect(document.querySelector('input').getAttribute('value')).toBe('')
     expect(clearButton.getAttribute('aria-hidden')).toBe('true')
-    expect(clearButton.hasAttribute('disabled')).toBe(true)
+    expect(clearButton).toHaveAttribute('disabled')
   })
 
   it('should have a disabled clear button when initially empty value is given', () => {
@@ -484,7 +484,7 @@ describe('Input with clear button', () => {
 
     expect(document.querySelector('input').getAttribute('value')).toBe('')
     expect(clearButton.getAttribute('aria-hidden')).toBe('true')
-    expect(clearButton.hasAttribute('disabled')).toBe(true)
+    expect(clearButton).toHaveAttribute('disabled')
   })
 
   it('should clear the value on escape key press', () => {
@@ -558,33 +558,37 @@ describe('Input with clear button', () => {
     const { rerender } = render(<Input clear={true} icon="bell" />)
     expect(
       document.querySelector('.dnb-input__icon').querySelector('svg')
-    ).toBeTruthy()
-    expect(document.querySelector('.dnb-icon--default')).toBeTruthy()
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-icon--default')
+    ).toBeInTheDocument()
     expect(
       document.querySelector('.dnb-input--icon-position-right')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     rerender(<Input clear={true} icon="bell" icon_position="right" />)
 
     expect(
       document.querySelector('.dnb-input--icon-position-right')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     expect(
       document
         .querySelector('.dnb-input')
         .querySelector('.dnb-input__input ~ .dnb-input__icon')
         .querySelector('svg')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should warn about clear button and right icon position', () => {
     global.console.log = jest.fn()
     render(<Input clear={true} icon="bell" icon_position="right" />)
-    expect(document.querySelector('.dnb-input--clear')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-input--clear')
+    ).not.toBeInTheDocument()
     expect(
       document.querySelector('.dnb-input__icon').querySelector('svg')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(global.console.log).toHaveBeenCalledTimes(1)
     expect(global.console.log).toHaveBeenCalledWith(
       expect.stringContaining('Eufemia'),
@@ -608,7 +612,7 @@ describe('Input with clear button', () => {
         .querySelector('.dnb-input')
         .querySelector('.dnb-input__inner__element ~ .dnb-input__icon')
         .querySelector('svg')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 })
 describe('Input ARIA', () => {

--- a/packages/dnb-eufemia/src/components/input/__tests__/InputPassword.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/InputPassword.test.tsx
@@ -85,7 +85,7 @@ describe('InputPassword component', () => {
     render(<InputPassword />)
 
     const Button = document.querySelector('button')
-    expect(Button).toBeTruthy()
+    expect(Button).toBeInTheDocument()
 
     fireEvent.focus(Button)
     expect(
@@ -99,7 +99,7 @@ describe('InputPassword component', () => {
     render(<InputPassword />)
 
     const Button = document.querySelector('button')
-    expect(Button).toBeTruthy()
+    expect(Button).toBeInTheDocument()
 
     fireEvent.click(Button)
     expect(

--- a/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
+++ b/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
@@ -14,7 +14,7 @@ describe('Logo component', () => {
   it('renders with empty props', () => {
     const props: LogoProps = {}
     render(<Logo {...props} />)
-    expect(document.querySelector('.dnb-logo')).toBeTruthy()
+    expect(document.querySelector('.dnb-logo')).toBeInTheDocument()
   })
 
   it('should set correct class when inherit_color is set', () => {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -72,42 +72,33 @@ describe('Modal component', () => {
     fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
 
     // Check the global button
-    expect(
-      document.querySelector('button.bypass-me') instanceof HTMLElement
-    ).toBe(true)
-    expect(
-      document
-        .querySelector('button.bypass-me')
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+    expect(document.querySelector('button.bypass-me')).toBeInTheDocument()
+    expect(document.querySelector('button.bypass-me')).toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
       document.querySelector('button.bypass-me').getAttribute('tabindex')
     ).toBe('-1')
     expect(
-      document
-        .querySelector('.dnb-modal__content')
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('.dnb-modal__content')
+    ).not.toHaveAttribute('aria-hidden')
     expect(
       document
         .querySelector('.dnb-modal__content')
         .querySelector('button.but-not-me')
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+    ).not.toHaveAttribute('aria-hidden')
 
     // And close it again
 
     fireEvent.click(
       document.querySelector('button.dnb-modal__close-button')
     )
-    expect(
-      document
-        .querySelector('button.bypass-me')
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
-    expect(
-      document.querySelector('button.bypass-me').hasAttribute('tabindex')
-    ).toBe(false)
+    expect(document.querySelector('button.bypass-me')).not.toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('button.bypass-me')).not.toHaveAttribute(
+      'tabindex'
+    )
   })
 
   it('should bypass elements defined in bypass_invalidation_selectors', () => {
@@ -122,14 +113,12 @@ describe('Modal component', () => {
     )
 
     fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
-    expect(
-      document
-        .querySelector('button.bypass-me')
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
-    expect(
-      document.querySelector('button.bypass-me').hasAttribute('tabindex')
-    ).toBe(false)
+    expect(document.querySelector('button.bypass-me')).not.toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('button.bypass-me')).not.toHaveAttribute(
+      'tabindex'
+    )
 
     expect(
       document
@@ -176,12 +165,14 @@ describe('Modal component', () => {
   it('has no trigger button once we set omitTriggerButton', () => {
     const { rerender } = render(<Modal {...props} />)
     rerender(<Modal {...props} omitTriggerButton={true} />)
-    expect(document.querySelector('button.dnb-modal__trigger')).toBeFalsy()
+    expect(
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toBeInTheDocument()
 
     rerender(<Modal {...props} omitTriggerButton={false} />)
     expect(
       document.querySelector('button.dnb-modal__trigger')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should act as a help button by default', () => {
@@ -233,11 +224,8 @@ describe('Modal component', () => {
       />
     )
     expect(
-      document
-        .querySelector('button.dnb-modal__trigger')
-
-        .hasAttribute('disabled')
-    ).toBe(true)
+      document.querySelector('button.dnb-modal__trigger')
+    ).toHaveAttribute('disabled')
   })
 
   it('has working open event and close event if "Esc" key gets pressed', () => {
@@ -293,9 +281,7 @@ describe('Modal component', () => {
     await wait(2)
 
     // and check the class of that element
-    expect(
-      document.activeElement.classList.contains('dnb-dialog__inner')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain('dnb-dialog__inner')
 
     fireEvent.keyDown(document.querySelector('div.dnb-dialog'), {
       key: 'Esc',
@@ -303,9 +289,9 @@ describe('Modal component', () => {
     })
 
     // and check the class of that element
-    expect(
-      document.activeElement.classList.contains('dnb-modal__trigger')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-modal__trigger'
+    )
   })
 
   it('will set "data-autofocus" attribute on focusing the trigger when closed', async () => {
@@ -325,15 +311,13 @@ describe('Modal component', () => {
     expect(document.activeElement.getAttribute('data-autofocus')).toBe(
       'true'
     )
-    expect(
-      document.activeElement.classList.contains('dnb-modal__trigger')
-    ).toBe(true)
+    expect(document.activeElement.classList).toContain(
+      'dnb-modal__trigger'
+    )
 
     await wait(1)
 
-    expect(
-      document.activeElement.hasAttribute('data-autofocus')
-    ).toBeFalsy()
+    expect(document.activeElement).not.toHaveAttribute('data-autofocus')
   })
 
   it('will warn if first heading is not h1', async () => {
@@ -449,7 +433,9 @@ describe('Modal component', () => {
       </Modal>
     )
 
-    expect(document.querySelector('#content-third')).toBeFalsy()
+    expect(
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button#modal-first'))
     expect(
@@ -473,30 +459,24 @@ describe('Modal component', () => {
     expect(
       document.querySelectorAll('button.dnb-modal__close-button').length
     ).toBe(3)
+    expect(document.querySelector('#content-first')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-second')).toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(document.querySelector('#content-third')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document.querySelector('#content-first').hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document.querySelector('#content-second').hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document.querySelector('#content-third').hasAttribute('aria-hidden')
-    ).toBe(false)
-    expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
-    expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[2]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[2]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the third one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -509,23 +489,18 @@ describe('Modal component', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-second')
-    expect(document.querySelector('#content-third')).toBeFalsy()
     expect(
-      document
-        .querySelector('#content-second')
-
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-third')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-second')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(true)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).toHaveAttribute('aria-hidden')
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[1]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[1]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the second one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -538,18 +513,15 @@ describe('Modal component', () => {
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')
     ).toBe('modal-first')
-    expect(document.querySelector('#content-second')).toBeFalsy()
     expect(
-      document
-        .querySelector('#content-first')
-
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelector('#content-second')
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('#content-first')).not.toHaveAttribute(
+      'aria-hidden'
+    )
     expect(
-      document
-        .querySelectorAll('button.dnb-modal__close-button')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('button.dnb-modal__close-button')[0]
+    ).not.toHaveAttribute('aria-hidden')
 
     // Close the first one
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 }))
@@ -559,10 +531,12 @@ describe('Modal component', () => {
       expect(on_close.third).toHaveBeenCalledTimes(1)
     })
 
-    expect(document.querySelector('#content-first')).toBeFalsy()
     expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+      document.querySelector('#content-first')
+    ).not.toBeInTheDocument()
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
   })
 
   it('will remove HTML attributes on unmount when open_state is used', () => {
@@ -587,9 +561,9 @@ describe('Modal component', () => {
 
     render(<HandleState />)
 
-    expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
 
     fireEvent.click(document.querySelector('button#toggle'))
 
@@ -599,9 +573,9 @@ describe('Modal component', () => {
 
     fireEvent.click(document.querySelector('button#toggle'))
 
-    expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
   })
 
   it('will animate when open_state is used', async () => {
@@ -734,7 +708,9 @@ describe('Modal component', () => {
     fireEvent.mouseDown(document.querySelector('div.dnb-modal__content'))
     fireEvent.click(document.querySelector('div.dnb-modal__content'))
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     // trigger the close button
     fireEvent.click(
@@ -742,7 +718,9 @@ describe('Modal component', () => {
     )
 
     expect(testTriggeredBy).toBe('button')
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
   })
 
   it('will close the modal on overlay click', () => {
@@ -762,7 +740,9 @@ describe('Modal component', () => {
 
     expect(on_close).toHaveBeenCalledTimes(1)
     expect(testTriggeredBy).toBe('overlay')
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
   })
 
   it('will omit close when no mousedown was fired', () => {
@@ -774,7 +754,9 @@ describe('Modal component', () => {
     fireEvent.click(document.querySelector('div.dnb-modal__content'))
 
     expect(on_close).toHaveBeenCalledTimes(0)
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
   })
 
   it('will only close when mousedown and click DOM targets are the same', () => {
@@ -795,7 +777,9 @@ describe('Modal component', () => {
     })
 
     expect(on_close).toHaveBeenCalledTimes(0)
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     // trigger the close on the overlay
     fireEvent.mouseDown(contentElement, {
@@ -805,7 +789,9 @@ describe('Modal component', () => {
     fireEvent.click(contentElement, { target })
 
     expect(on_close).toHaveBeenCalledTimes(1)
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
   })
 
   it('has working open event and close event on changing the "open_state"', () => {
@@ -892,7 +878,7 @@ describe('Modal component', () => {
     const modalRoot = document.querySelector(id)
     const outsideButton = document.querySelector('#my-button')
 
-    expect(modalRoot.getAttribute('aria-hidden')).toBeFalsy()
+    expect(modalRoot).not.toHaveAttribute('aria-hidden')
     expect(outsideButton.getAttribute('aria-hidden')).toEqual('true')
 
     fireEvent.click(
@@ -908,7 +894,7 @@ describe('Modal component', () => {
     )
     const elem = document.querySelector('button')
 
-    expect(document.body.getAttribute('style')).toBeFalsy()
+    expect(document.body).not.toHaveAttribute('style')
 
     // open modal
     fireEvent.click(elem)
@@ -927,9 +913,9 @@ describe('Modal component', () => {
 
     expect(document.body.getAttribute('style')).toBe('')
     expect(document.documentElement.getAttribute('style')).toBe('')
-    expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
   })
 
   it('runs expected side effects on iOS pre 14', () => {
@@ -955,7 +941,7 @@ describe('Modal component', () => {
     // open modal
     fireEvent.click(elem)
 
-    expect(document.body.getAttribute('style')).toBeFalsy()
+    expect(document.body).not.toHaveAttribute('style')
 
     expect(addEventListener).toBeCalledTimes(2)
     expect(addEventListener).toHaveBeenCalledWith(
@@ -975,12 +961,12 @@ describe('Modal component', () => {
     // close modal
     fireEvent.click(elem)
 
-    expect(document.body.getAttribute('style')).toBeFalsy()
-    expect(document.documentElement.getAttribute('style')).toBeFalsy()
+    expect(document.body).not.toHaveAttribute('style')
+    expect(document.documentElement).not.toHaveAttribute('style')
 
-    expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
 
     expect(removeEventListener).toBeCalledTimes(2)
     expect(removeEventListener).toHaveBeenCalledWith(
@@ -1004,7 +990,7 @@ describe('Modal component', () => {
 
     global.userAgent.mockReturnValue('Android; 7.')
 
-    expect(document.body.getAttribute('style')).toBeFalsy()
+    expect(document.body).not.toHaveAttribute('style')
 
     // open modal
     fireEvent.click(elem)
@@ -1025,30 +1011,38 @@ describe('Modal component', () => {
 
     expect(document.body.getAttribute('style')).toBe('')
     expect(document.documentElement.getAttribute('style')).toBe('')
-    expect(
-      document.documentElement.hasAttribute('data-dnb-modal-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-modal-active'
+    )
   })
 
   it('has correct opened state when "open_state" is used', () => {
     const { rerender } = render(<Modal {...props} />)
 
     rerender(<Modal {...props} open_state="opened" />)
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     rerender(<Modal {...props} open_state="closed" />)
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
   })
 
   it('has correct opened state when "open_state" is used with boolean', () => {
     const { rerender } = render(<Modal {...props} />)
     rerender(<Modal {...props} open_state={true} />)
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     rerender(<Modal {...props} open_state={false} />)
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
   })
 
   it('can be mounted from within another component', () => {
@@ -1089,17 +1083,23 @@ describe('Modal component', () => {
 
     expect(document.querySelector('span.count').textContent).toBe('1')
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button#modal-trigger'))
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     fireEvent.click(
       document.querySelector('button.dnb-modal__close-button')
     )
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button#count-trigger'))
 
@@ -1109,7 +1109,7 @@ describe('Modal component', () => {
 
     // For some reason, in JSDOM, the second open does not work properly.
     // "this.isClosing" is still true at that point. Hard to find the reason. A delay does not help at all.
-    // expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    // expect(document.querySelector('div.dnb-modal__content')).toBeInTheDocument()
   })
 
   it('will keep its internal open_state from within provider', () => {
@@ -1161,14 +1161,18 @@ describe('Modal component', () => {
     // open
     fireEvent.click(document.querySelector('button#modal-trigger'))
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
 
     // close
     fireEvent.click(
       document.querySelector('button.dnb-modal__close-button')
     )
 
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
 
     expect(on_open).toHaveBeenCalledTimes(1)
 
@@ -1177,7 +1181,9 @@ describe('Modal component', () => {
     fireEvent.click(document.querySelector('button#count-trigger'))
 
     expect(document.querySelector('span#count').textContent).toBe('2')
-    expect(document.querySelector('div.dnb-modal__content')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).not.toBeInTheDocument()
     expect(on_close).toHaveBeenCalledTimes(1)
 
     // open again
@@ -1185,7 +1191,9 @@ describe('Modal component', () => {
 
     expect(on_open).toHaveBeenCalledTimes(2)
     expect(on_close).toHaveBeenCalledTimes(1)
-    expect(document.querySelector('div.dnb-modal__content')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-modal__content')
+    ).toBeInTheDocument()
   })
 
   it('should open and close by using external state only', async () => {
@@ -1225,13 +1233,15 @@ describe('Modal component', () => {
 
     expect(on_open).toHaveBeenCalledTimes(1)
     expect(on_close).toHaveBeenCalledTimes(0)
-    expect(document.querySelector('div.dnb-dialog')).toBeTruthy()
+    expect(document.querySelector('div.dnb-dialog')).toBeInTheDocument()
 
     fireEvent.click(document.querySelector('button.close-button'))
 
     expect(on_open).toHaveBeenCalledTimes(1)
     expect(on_close).toHaveBeenCalledTimes(1)
-    expect(document.querySelector('div.dnb-dialog')).toBeFalsy()
+    expect(
+      document.querySelector('div.dnb-dialog')
+    ).not.toBeInTheDocument()
   })
 
   it('has to have the correct aria-describedby', () => {
@@ -1240,7 +1250,7 @@ describe('Modal component', () => {
       document.querySelector(
         `[aria-describedby="dnb-modal-${props.id}-content"]`
       )
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('has to have correct role and aria-modal', () => {
@@ -1248,8 +1258,8 @@ describe('Modal component', () => {
 
     const { rerender } = render(<Modal {...props} open_state={true} />)
     elem = document.querySelector('.dnb-modal__content')
-    expect(elem.getAttribute('role')).toBe('dialog')
-    expect(elem.hasAttribute('aria-modal')).toBe(true)
+    expect(elem).toHaveAttribute('role', 'dialog')
+    expect(elem).toHaveAttribute('aria-modal')
 
     Object.defineProperty(helpers, 'IS_MAC', {
       value: true,
@@ -1259,8 +1269,8 @@ describe('Modal component', () => {
     rerender(<Modal {...props} open_state={true} title="re-render" />)
 
     elem = document.querySelector('.dnb-modal__content')
-    expect(elem.getAttribute('role')).toBe('region')
-    expect(elem.hasAttribute('aria-modal')).toBe(false)
+    expect(elem).toHaveAttribute('role', 'region')
+    expect(elem).not.toHaveAttribute('aria-modal')
 
     Object.defineProperty(helpers, 'IS_MAC', {
       value: false,
@@ -1295,10 +1305,8 @@ describe('Modal component', () => {
 
     rerender(<Modal {...props} title="now there is a title" />)
     expect(
-      document
-        .querySelector('.dnb-modal__content')
-        .hasAttribute('aria-label')
-    ).toBe(false)
+      document.querySelector('.dnb-modal__content')
+    ).not.toHaveAttribute('aria-label')
   })
 
   it('has to have aria-labelledby and aria-describedby', () => {
@@ -1329,7 +1337,7 @@ describe('Modal component', () => {
 
   it('has to have no icon', () => {
     render(<Modal trigger_attributes={{ text: 'Open Modal' }} />)
-    expect(document.querySelector('.dnb-icon')).toBeFalsy()
+    expect(document.querySelector('.dnb-icon')).not.toBeInTheDocument()
 
     render(
       <Modal
@@ -1340,7 +1348,7 @@ describe('Modal component', () => {
         }}
       />
     )
-    expect(document.querySelector('.dnb-icon')).toBeFalsy()
+    expect(document.querySelector('.dnb-icon')).not.toBeInTheDocument()
   })
 
   it('has to have an icon', () => {
@@ -1349,11 +1357,11 @@ describe('Modal component', () => {
         trigger_attributes={{ text: 'Open Modal', variant: 'tertiary' }}
       />
     )
-    expect(document.querySelector('.dnb-icon')).toBeTruthy()
+    expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
     render(
       <Modal trigger_attributes={{ text: 'Open Modal', icon: 'add' }} />
     )
-    expect(document.querySelector('.dnb-icon')).toBeTruthy()
+    expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
   })
 
   it('should render camelcase props', () => {
@@ -1403,16 +1411,13 @@ describe('Modal trigger', () => {
   it('will not act as a HelpButton if only trigger_text was given', () => {
     render(<Modal {...props} trigger_attributes={{ text: 'text' }} />)
     expect(
-      document
-        .querySelector('button.dnb-modal__trigger')
-
-        .hasAttribute('aria-roledescription')
-    ).toBe(false)
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toHaveAttribute('aria-roledescription')
     expect(
       document
         .querySelector('button.dnb-modal__trigger')
         .querySelector('.dnb-button__icon')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       document
         .querySelector('button.dnb-modal__trigger')
@@ -1423,30 +1428,25 @@ describe('Modal trigger', () => {
   it('will not act as a HelpButton if a different icon was given', () => {
     render(<Modal {...props} trigger_attributes={{ icon: 'bell' }} />)
     expect(
-      document
-        .querySelector('button.dnb-modal__trigger')
-        .hasAttribute('aria-roledescription')
-    ).toBe(false)
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toHaveAttribute('aria-roledescription')
     expect(
       document
         .querySelector('button.dnb-modal__trigger')
         .querySelector('.dnb-button__icon')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('will not act as a HelpButton if trigger text was given', () => {
     render(<Modal {...props} trigger_attributes={{ text: 'text' }} />)
     expect(
-      document
-        .querySelector('button.dnb-modal__trigger')
-
-        .hasAttribute('aria-roledescription')
-    ).toBe(false)
+      document.querySelector('button.dnb-modal__trigger')
+    ).not.toHaveAttribute('aria-roledescription')
     expect(
       document
         .querySelector('button.dnb-modal__trigger')
         .querySelector('.dnb-button__icon')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
     expect(
       document
         .querySelector('button.dnb-modal__trigger')

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -118,28 +118,24 @@ describe('NumberFormat component', () => {
   it('will show copy advice', () => {
     render(<Component value={-value} currency />)
 
-    expect(
-      document
-        .querySelector('span')
-        .classList.contains('dnb-number-format--selected')
-    ).toBe(false)
+    expect(document.querySelector('span').classList).not.toContain(
+      'dnb-number-format--selected'
+    )
 
-    expect(document.querySelector('.dnb-tooltip')).toBeFalsy()
+    expect(document.querySelector('.dnb-tooltip')).not.toBeInTheDocument()
 
     fireEvent.click(document.querySelector('.dnb-number-format__visible'))
     fireEvent.copy(document.querySelector('.dnb-number-format__selection'))
 
-    expect(document.querySelector('.dnb-tooltip')).toBeTruthy()
+    expect(document.querySelector('.dnb-tooltip')).toBeInTheDocument()
   })
 
   it('has valid selected number', () => {
     const { rerender } = render(<Component value={-value} currency />)
 
-    expect(
-      document
-        .querySelector('span')
-        .classList.contains('dnb-number-format--selected')
-    ).toBe(false)
+    expect(document.querySelector('span').classList).not.toContain(
+      'dnb-number-format--selected'
+    )
 
     expect(document.activeElement).toBe(document.body)
 
@@ -424,7 +420,7 @@ describe('NumberFormat component', () => {
 
     expect(
       document.querySelector('.dnb-number-format__selection')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -46,7 +46,7 @@ describe('Pagination bar', () => {
       </Pagination>
     )
 
-    expect(document.querySelector('div#page-content')).toBeTruthy()
+    expect(document.querySelector('div#page-content')).toBeInTheDocument()
 
     rerender(
       <Pagination {...props} current_page={1}>
@@ -54,26 +54,22 @@ describe('Pagination bar', () => {
       </Pagination>
     )
 
-    expect(document.querySelector('div#page-content')).toBeTruthy()
+    expect(document.querySelector('div#page-content')).toBeInTheDocument()
 
     const buttonElements = document
       .querySelector('.dnb-pagination__bar__inner')
       .querySelectorAll('button.dnb-pagination__button')
 
     const firstButton = buttonElements[0]
-    expect(firstButton.classList.contains('dnb-button--primary')).toBe(
-      true
-    )
+    expect(firstButton.classList).toContain('dnb-button--primary')
     expect(firstButton.getAttribute('aria-current')).toBe('page')
 
     const secondButton = buttonElements[1]
-    expect(secondButton.classList.contains('dnb-button--secondary')).toBe(
-      true
-    )
-    expect(secondButton.hasAttribute('aria-current')).toBe(false)
+    expect(secondButton.classList).toContain('dnb-button--secondary')
+    expect(secondButton).not.toHaveAttribute('aria-current')
 
     const prevNavButton = document.querySelectorAll('.dnb-button')[0]
-    expect(prevNavButton.hasAttribute('disabled')).toBe(true)
+    expect(prevNavButton).toHaveAttribute('disabled')
     expect(
       prevNavButton
         .querySelector('span.dnb-icon')
@@ -534,7 +530,7 @@ describe('Infinity scroller', () => {
     ).toBe('page-20')
     expect(
       document.querySelector('div.dnb-pagination__loadbar')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should load pages with load more button (before)', async () => {
@@ -583,7 +579,7 @@ describe('Infinity scroller', () => {
     )
     expect(
       document.querySelector('div.dnb-pagination__loadbar')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     expect(on_startup).toHaveBeenCalledTimes(1)
     expect(on_change).toHaveBeenCalledTimes(2)
@@ -597,7 +593,7 @@ describe('Infinity scroller', () => {
       </Pagination>
     )
 
-    expect(document.querySelector('div#page-content')).toBeTruthy()
+    expect(document.querySelector('div#page-content')).toBeInTheDocument()
   })
 
   it('should support locale from provider', () => {
@@ -742,10 +738,12 @@ describe('Infinity scroller', () => {
   it('should show pagination bar using Bar component', () => {
     render(<Bar skeleton={false} />)
 
-    expect(document.querySelector('.dnb-pagination__bar')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-pagination__bar')
+    ).toBeInTheDocument()
     expect(
       document.querySelector('.dnb-pagination__indicator')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
@@ -39,12 +39,12 @@ describe('Circular ProgressIndicator component', () => {
     const { rerender } = render(
       <ProgressIndicator {...props} type="circular" progress={undefined} />
     )
-    expect(screen.queryByRole('alert')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeInTheDocument()
 
     rerender(
       <ProgressIndicator {...props} type="circular" progress={80} />
     )
-    expect(screen.queryByRole('progressbar')).toBeTruthy()
+    expect(screen.queryByRole('progressbar')).toBeInTheDocument()
   })
 
   it('has to react to a progress value of 80%', () => {
@@ -181,10 +181,10 @@ describe('Linear ProgressIndicator component', () => {
     const { rerender } = render(
       <ProgressIndicator {...props} type="linear" progress={undefined} />
     )
-    expect(screen.queryByRole('alert')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeInTheDocument()
 
     rerender(<ProgressIndicator {...props} type="linear" progress={80} />)
-    expect(screen.queryByRole('progressbar')).toBeTruthy()
+    expect(screen.queryByRole('progressbar')).toBeInTheDocument()
   })
 
   it('has to react to a progress value of 80%', () => {

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -119,11 +119,13 @@ describe('Radio component', () => {
   it('will disable a single button', () => {
     const { rerender } = render(<Radio disabled />)
 
-    expect(document.querySelector('input[disabled]')).toBeTruthy()
+    expect(document.querySelector('input[disabled]')).toBeInTheDocument()
 
     rerender(<Radio disabled={false} />)
 
-    expect(document.querySelector('input[disabled]')).toBeFalsy()
+    expect(
+      document.querySelector('input[disabled]')
+    ).not.toBeInTheDocument()
   })
 
   it('should support spacing props', () => {
@@ -202,7 +204,7 @@ describe('Radio group component', () => {
       </Radio.Group>
     )
 
-    expect(document.querySelector('input[disabled]')).toBeTruthy()
+    expect(document.querySelector('input[disabled]')).toBeInTheDocument()
   })
 
   it('will disable a single button, defined in the group', () => {
@@ -212,7 +214,7 @@ describe('Radio group component', () => {
       </Radio.Group>
     )
 
-    expect(document.querySelector('input[disabled]')).toBeTruthy()
+    expect(document.querySelector('input[disabled]')).toBeInTheDocument()
   })
 
   it('will overwrite "disable" state, defined in the group', () => {
@@ -223,12 +225,12 @@ describe('Radio group component', () => {
       </Radio.Group>
     )
 
-    expect(
-      document.querySelectorAll('input')[0].hasAttribute('disabled')
-    ).toBe(false)
-    expect(
-      document.querySelectorAll('input')[1].hasAttribute('disabled')
-    ).toBe(true)
+    expect(document.querySelectorAll('input')[0]).not.toHaveAttribute(
+      'disabled'
+    )
+    expect(document.querySelectorAll('input')[1]).toHaveAttribute(
+      'disabled'
+    )
   })
 
   it('should support spacing props', () => {

--- a/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
@@ -17,19 +17,15 @@ describe('Section component', () => {
   it('should have correct styles', () => {
     render(<Section style_type="divider" />)
     expect(
-      document
-        .querySelector('section.dnb-section')
-        .classList.contains('dnb-section--divider')
-    ).toBe(true)
+      document.querySelector('section.dnb-section').classList
+    ).toContain('dnb-section--divider')
   })
 
   it('should support any string in style_type', () => {
     render(<Section style_type="cucstom" />)
     expect(
-      document
-        .querySelector('section.dnb-section')
-        .classList.contains('dnb-section--cucstom')
-    ).toBe(true)
+      document.querySelector('section.dnb-section').classList
+    ).toContain('dnb-section--cucstom')
   })
 
   it('should support spacing props', () => {
@@ -52,10 +48,8 @@ describe('Section component', () => {
     )
 
     expect(
-      document
-        .querySelector('section.dnb-section')
-        .classList.contains('dnb-section--divider')
-    ).toBe(true)
+      document.querySelector('section.dnb-section').classList
+    ).toContain('dnb-section--divider')
   })
 
   it('should have correct spacing', () => {
@@ -82,7 +76,7 @@ describe('Section component', () => {
 
   it('should have a div as the element tag', () => {
     render(<Section element="div" />)
-    expect(document.querySelector('div.dnb-section')).toBeTruthy()
+    expect(document.querySelector('div.dnb-section')).toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/Skeleton.test.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/Skeleton.test.tsx
@@ -24,9 +24,13 @@ const props: SkeletonProps = {
 describe('Skeleton component', () => {
   it('has to use the provider to enable a skeleton in a component', () => {
     const { rerender } = render(<Skeleton {...props} />)
-    expect(document.querySelector('.dnb-input .dnb-skeleton')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-input .dnb-skeleton')
+    ).not.toBeInTheDocument()
     rerender(<Skeleton {...props} show={true} />)
-    expect(document.querySelector('.dnb-input .dnb-skeleton')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-input .dnb-skeleton')
+    ).toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -18,7 +18,7 @@ describe('SkipContent', () => {
       </>
     )
 
-    expect(document.querySelector('.dnb-skip-content')).toBeTruthy()
+    expect(document.querySelector('.dnb-skip-content')).toBeInTheDocument()
   })
 
   it('should have one button child with dnb-sr-only class', () => {
@@ -48,11 +48,9 @@ describe('SkipContent', () => {
     )
 
     const element = document.querySelector('.dnb-skip-content')
-    expect(
-      (element.childNodes[0] as HTMLButtonElement).hasAttribute(
-        'aria-hidden'
-      )
-    ).toBeFalsy()
+    expect(element.childNodes[0] as HTMLButtonElement).not.toHaveAttribute(
+      'aria-hidden'
+    )
   })
 
   it('should have a certain amount of attributes on button', () => {
@@ -109,7 +107,9 @@ describe('SkipContent', () => {
       keyCode: 'Tab',
     })
 
-    expect(element.querySelector('button.dnb-sr-only')).toBeFalsy()
+    expect(
+      element.querySelector('button.dnb-sr-only')
+    ).not.toBeInTheDocument()
 
     // 2. make focus action
     fireEvent.click(element.querySelector('.dnb-button'))
@@ -117,7 +117,7 @@ describe('SkipContent', () => {
     await waitFor(() => {
       expect(document.activeElement.tagName).toBe('SECTION')
     })
-    expect(element.querySelector('.dnb-button')).toBeFalsy()
+    expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
     expect(document.activeElement.classList).toContain(
       'dnb-skip-content__focus'
     )
@@ -151,7 +151,7 @@ describe('SkipContent', () => {
     // 2. blur the event
     fireEvent.blur(element.querySelector('.dnb-button'))
 
-    expect(element.querySelector('.dnb-button')).toBeFalsy()
+    expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
     expect(document.activeElement.tagName).toBe('BODY')
   })
 
@@ -211,7 +211,9 @@ describe('SkipContent.Return', () => {
       keyCode: 'Tab',
     })
 
-    expect(element.querySelector('button.dnb-sr-only')).toBeFalsy()
+    expect(
+      element.querySelector('button.dnb-sr-only')
+    ).not.toBeInTheDocument()
 
     // 2. make focus action
     fireEvent.click(element.querySelector('.dnb-button'))
@@ -219,7 +221,7 @@ describe('SkipContent.Return', () => {
     await waitFor(() => {
       expect(document.activeElement.tagName).toBe('SECTION')
     })
-    expect(element.querySelector('.dnb-button')).toBeFalsy()
+    expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
     expect(document.activeElement.classList).toContain(
       'dnb-skip-content__focus'
     )
@@ -232,7 +234,9 @@ describe('SkipContent.Return', () => {
       keyCode: 'Tab',
     })
 
-    expect(section.querySelector('button.dnb-sr-only')).toBeFalsy()
+    expect(
+      section.querySelector('button.dnb-sr-only')
+    ).not.toBeInTheDocument()
 
     // 4. make focus action
     fireEvent.click(section.querySelector('.dnb-button'))
@@ -240,7 +244,7 @@ describe('SkipContent.Return', () => {
     await waitFor(() => {
       expect(document.activeElement.tagName).toBe('BUTTON')
     })
-    expect(section.querySelector('.dnb-button')).toBeFalsy()
+    expect(section.querySelector('.dnb-button')).not.toBeInTheDocument()
     expect(
       // First parent is HeightAnimation, second is span.dnb-skip-content
       document.activeElement.parentElement.parentElement.getAttribute('id')

--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -419,10 +419,8 @@ describe('Slider component', () => {
   it('should not have type=button', () => {
     render(<Slider {...props} />)
     expect(
-      document
-        .querySelector('.dnb-slider__thumb .dnb-button')
-        .hasAttribute('type')
-    ).toBe(false)
+      document.querySelector('.dnb-slider__thumb .dnb-button')
+    ).not.toHaveAttribute('type')
   })
 
   describe('multi thumb', () => {

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -13,16 +13,14 @@ const props: SpaceAllProps = {}
 describe('Space component', () => {
   it('renders with empty props', () => {
     render(<Space {...props} />)
-    expect(document.querySelector('.dnb-space')).toBeTruthy()
+    expect(document.querySelector('.dnb-space')).toBeInTheDocument()
   })
 
   it('should have correct CSS classes', () => {
     render(<Space element="span" top="large" />)
-    expect(
-      document
-        .querySelector('span.dnb-space')
-        .classList.contains('dnb-space__top--large')
-    ).toBe(true)
+    expect(document.querySelector('span.dnb-space').classList).toContain(
+      'dnb-space__top--large'
+    )
   })
 
   it('should accept space only prop', () => {
@@ -75,7 +73,9 @@ describe('Space component', () => {
 
   it('should have collapse CSS class', () => {
     render(<Space top="large" no_collapse={true} />)
-    expect(document.querySelector('.dnb-space--no-collapse')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-space--no-collapse')
+    ).toBeInTheDocument()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -57,7 +57,7 @@ describe('StepIndicator Sidebar', () => {
 
     expect(
       document.querySelector('.dnb-step-indicator__sidebar')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('has to inherit Provider data for initial SSR render', () => {
@@ -146,8 +146,9 @@ describe('StepIndicator in general', () => {
 
     expect(
       document.querySelector('.dnb-step-indicator-wrapper')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
+
   it('should support spacing props', () => {
     const id = 'unique-id-spacing'
     render(
@@ -274,7 +275,7 @@ describe('StepIndicator in loose mode', () => {
     simulateSmallScreen()
 
     renderComponent('unique-id-loose-mobile')
-    expect(screen.queryByRole('button')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeInTheDocument()
   })
 
   it('has to keep the current step on re-render', () => {
@@ -293,7 +294,7 @@ describe('StepIndicator in loose mode', () => {
     )
     expect(
       document.querySelector('button.dnb-step-indicator__trigger__button')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     expect(
       document.querySelectorAll('li.dnb-step-indicator__item')
@@ -328,12 +329,12 @@ describe('StepIndicator in loose mode', () => {
     const items = document.querySelectorAll('li.dnb-step-indicator__item')
 
     expect(items.length).toBe(4)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--visited')
-    ).toBe(true)
-    expect(
-      items[1].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(true)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--visited'
+    )
+    expect(items[1].classList).toContain(
+      'dnb-step-indicator__item--current'
+    )
     expect(items[1].getAttribute('aria-current')).toBe('step')
     expect(screen.queryAllByRole('button')).toHaveLength(4)
   })
@@ -346,12 +347,12 @@ describe('StepIndicator in loose mode', () => {
     const items = document.querySelectorAll('li.dnb-step-indicator__item')
 
     expect(items.length).toBe(4)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--visited')
-    ).toBe(true)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(false)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--visited'
+    )
+    expect(items[0].classList).not.toContain(
+      'dnb-step-indicator__item--current'
+    )
 
     fireEvent.click(items[0].querySelector('button'))
 
@@ -360,9 +361,9 @@ describe('StepIndicator in loose mode', () => {
     expect(typeof on_change.mock.calls[0][0].event.preventDefault).toBe(
       'function'
     )
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(true)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--current'
+    )
     expect(
       document.querySelectorAll('li.dnb-step-indicator__item--current')
     ).toHaveLength(1)
@@ -393,7 +394,7 @@ describe('StepIndicator in loose mode', () => {
         'button',
         { name: 'Step C' }
       )
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     act(() => {
       // Make state change
@@ -410,7 +411,7 @@ describe('StepIndicator in loose mode', () => {
         'button',
         { name: 'Step A' }
       )
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should react on current_step prop change', () => {
@@ -507,7 +508,7 @@ describe('StepIndicator in strict mode', () => {
     simulateSmallScreen()
 
     renderComponent('unique-id-strict-mobile')
-    expect(screen.queryByRole('button')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeInTheDocument()
   })
 
   it('has correct states on steps', () => {
@@ -515,12 +516,12 @@ describe('StepIndicator in strict mode', () => {
     const items = document.querySelectorAll('li.dnb-step-indicator__item')
 
     expect(items.length).toBe(4)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--visited')
-    ).toBe(true)
-    expect(
-      items[1].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(true)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--visited'
+    )
+    expect(items[1].classList).toContain(
+      'dnb-step-indicator__item--current'
+    )
     expect(items[1].getAttribute('aria-current')).toBe('step')
 
     expect(screen.queryAllByRole('button')).toHaveLength(2)
@@ -534,21 +535,21 @@ describe('StepIndicator in strict mode', () => {
     const items = document.querySelectorAll('li.dnb-step-indicator__item')
 
     expect(items.length).toBe(4)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--visited')
-    ).toBe(true)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(false)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--visited'
+    )
+    expect(items[0].classList).not.toContain(
+      'dnb-step-indicator__item--current'
+    )
 
     act(() => {
       screen.queryAllByRole('button')[0].click()
     })
 
     expect(on_change).toBeCalledTimes(1)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(true)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--current'
+    )
     expect(
       screen.queryAllByRole('listitem', { current: 'step' })
     ).toHaveLength(1)
@@ -575,7 +576,7 @@ describe('StepIndicator in static mode', () => {
     simulateSmallScreen()
 
     renderComponent('unique-id-static-mobile')
-    expect(screen.queryByRole('button')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeInTheDocument()
   })
 
   it('has correct states on steps', () => {
@@ -583,12 +584,12 @@ describe('StepIndicator in static mode', () => {
     const items = document.querySelectorAll('li.dnb-step-indicator__item')
 
     expect(items.length).toBe(4)
-    expect(
-      items[0].classList.contains('dnb-step-indicator__item--visited')
-    ).toBe(true)
-    expect(
-      items[1].classList.contains('dnb-step-indicator__item--current')
-    ).toBe(true)
+    expect(items[0].classList).toContain(
+      'dnb-step-indicator__item--visited'
+    )
+    expect(items[1].classList).toContain(
+      'dnb-step-indicator__item--current'
+    )
     expect(items[1].getAttribute('aria-current')).toBe('step')
     expect(screen.queryAllByRole('button')).toHaveLength(0)
   })

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -116,7 +116,7 @@ describe('Switch component', () => {
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<Switch />)
     rerender(<Switch disabled={true} />)
-    expect(document.querySelector('input[disabled]')).toBeTruthy()
+    expect(document.querySelector('input[disabled]')).toBeInTheDocument()
   })
 
   it('should support spacing props', () => {

--- a/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
@@ -28,7 +28,7 @@ describe('Table', () => {
     const props: TableAllProps = { children: null }
     render(<Table {...props} />)
 
-    expect(document.querySelector('.dnb-table')).toBeTruthy()
+    expect(document.querySelector('.dnb-table')).toBeInTheDocument()
   })
 
   it('should contain basis HTML classes by default', () => {

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -206,12 +206,12 @@ describe('TableAccordion', () => {
 
     expect(
       element.querySelector('div.dnb-table__tr__accordion_content__inner')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(
       element.querySelector(
         'div.dnb-table__tr__accordion_content__inner__spacing'
       )
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('expanded accordion content content should contain aria-live accounement', () => {
@@ -231,8 +231,8 @@ describe('TableAccordion', () => {
     const accordionElem = trElement.nextSibling as HTMLTableRowElement
     const element = accordionElem.querySelector('td')
 
-    expect(element.querySelector('span.dnb-sr-only')).toBeTruthy()
-    expect(element.querySelector('span[aria-live]')).toBeTruthy()
+    expect(element.querySelector('span.dnb-sr-only')).toBeInTheDocument()
+    expect(element.querySelector('span[aria-live]')).toBeInTheDocument()
     expect(
       element.querySelector('span[aria-live]').getAttribute('aria-live')
     ).toBe('assertive')
@@ -473,7 +473,7 @@ describe('TableAccordion', () => {
     )
 
     const divElement = trElement.querySelector('div')
-    expect(divElement).toBeTruthy()
+    expect(divElement).toBeInTheDocument()
   })
 
   it('chevron header column should contain accordionToggleButtonSR text', () => {

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableContainer.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableContainer.test.tsx
@@ -44,11 +44,11 @@ describe('TableContainer', () => {
 
     expect(
       document.querySelector('.dnb-table__container__head--empty')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
 
     expect(
       document.querySelector('.dnb-table__container__foot--empty')
-    ).toBeFalsy()
+    ).not.toBeInTheDocument()
   })
 
   it('should include custom attributes', () => {
@@ -82,7 +82,7 @@ describe('TableContainer', () => {
 
     expect(
       document.querySelector('.dnb-table__container__head--empty')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should not return table foot if empty modifier', () => {
@@ -90,7 +90,7 @@ describe('TableContainer', () => {
 
     expect(
       document.querySelector('.dnb-table__container__foot--empty')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should handle empty/no table head and foot ', () => {
@@ -110,11 +110,11 @@ describe('TableContainer', () => {
 
     expect(
       document.querySelector('.dnb-table__container__head--empty')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     expect(
       document.querySelector('.dnb-table__container__foot--empty')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should include extra classes in scroll-view', () => {

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableScrollView.test.tsx
@@ -61,6 +61,6 @@ describe('Table.ScrollView', () => {
       renderResizeObserver()
     })
 
-    expect(element.hasAttribute('tabindex')).toBeFalsy()
+    expect(element).not.toHaveAttribute('tabindex')
   })
 })

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -296,10 +296,8 @@ describe('TabList component', () => {
     fireEvent.click(document.querySelector('button[data-tab-key="third"]'))
 
     expect(
-      document
-        .querySelector('button[data-tab-key="third"]')
-        .classList.contains('selected')
-    ).toBe(true)
+      document.querySelector('button[data-tab-key="third"]').classList
+    ).toContain('selected')
 
     const content = document.querySelector('div[role="tabpanel"]')
     const { container } = render(contentWrapperData.third)
@@ -325,10 +323,8 @@ describe('A single Tab component', () => {
         .getAttribute('role')
     ).toBe('tab')
     expect(
-      document
-        .querySelector('button[data-tab-key="second"]')
-        .classList.contains('selected')
-    ).toBe(true)
+      document.querySelector('button[data-tab-key="second"]').classList
+    ).toContain('selected')
   })
 
   it('has to have the right content on a keydown "ArrowRight"', () => {
@@ -363,9 +359,8 @@ describe('A single Tab component', () => {
     expect(
       document
         .querySelectorAll('.dnb-tabs__button__snap')[0]
-        .querySelector('button')
-        .classList.contains('selected')
-    ).toBe(true)
+        .querySelector('button').classList
+    ).toContain('selected')
     expect(
       document.querySelector('div.dnb-tabs__content').textContent
     ).toBe('First')
@@ -396,7 +391,9 @@ describe('A single Tab component', () => {
       />
     )
 
-    expect(document.querySelector('div.dnb-tabs__cached')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-tabs__cached')
+    ).toBeInTheDocument()
 
     // also check a real live rerender scenario
     const value = 'value'
@@ -451,13 +448,13 @@ describe('A single Tab component', () => {
       />
     )
 
-    expect(document.querySelector('div.dnb-tabs__cached')).toBeTruthy()
+    expect(
+      document.querySelector('div.dnb-tabs__cached')
+    ).toBeInTheDocument()
 
     expect(
-      document
-        .querySelectorAll('div.dnb-tabs__cached')[0]
-        .hasAttribute('aria-hidden')
-    ).toBe(false)
+      document.querySelectorAll('div.dnb-tabs__cached')[0]
+    ).not.toHaveAttribute('aria-hidden')
     expect(
       document
         .querySelectorAll('div.dnb-tabs__cached')[1]

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -26,7 +26,7 @@ describe('Tag Group', () => {
   it('renders the label as string', () => {
     const label = 'tags'
     render(<Tag.Group label={label} />)
-    expect(screen.queryByText(label)).toBeTruthy()
+    expect(screen.queryByText(label)).toBeInTheDocument()
   })
 
   it('renders the label as react node', () => {
@@ -127,7 +127,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByText(text)).toBeTruthy()
+    expect(screen.queryByText(text)).toBeInTheDocument()
   })
 
   it('renders a tag with content by children prop', () => {
@@ -139,7 +139,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByText(text)).toBeTruthy()
+    expect(screen.queryByText(text)).toBeInTheDocument()
   })
 
   it('renders a tag with content if both text and children prop is defined', () => {
@@ -151,7 +151,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(screen.queryByText(text)).toBeTruthy()
+    expect(screen.queryByText(text)).toBeInTheDocument()
   })
 
   it('renders a tag with skeleton if skeleton is true', () => {
@@ -194,7 +194,7 @@ describe('Tag', () => {
     )
 
     expect(screen.queryByRole('button')).toBeNull()
-    expect(screen.queryByText(text)).toBeTruthy()
+    expect(screen.queryByText(text)).toBeInTheDocument()
   })
 
   it('does support icon', () => {
@@ -204,7 +204,7 @@ describe('Tag', () => {
       </Tag.Group>
     )
 
-    expect(document.querySelector('.dnb-icon')).toBeTruthy()
+    expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
   })
 
   it('should support spacing props', () => {
@@ -271,7 +271,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(document.querySelector('.dnb-icon')).toBeTruthy()
+      expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
     })
   })
 
@@ -342,7 +342,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(document.querySelector('.dnb-icon')).toBeTruthy()
+      expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
     })
 
     it('does not support icon if onDelete', () => {
@@ -352,7 +352,7 @@ describe('Tag', () => {
         </Tag.Group>
       )
 
-      expect(document.querySelector('.dnb-icon')).toBeTruthy()
+      expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
       expect(document.querySelectorAll('.dnb-icon').length).toBe(1)
     })
 

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -27,11 +27,9 @@ describe('Textarea component', () => {
     )
     fireEvent.focus(document.querySelector('textarea'))
 
-    expect(
-      document
-        .querySelector('.dnb-textarea')
-        .classList.contains('dnb-textarea--focus')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-textarea').classList).toContain(
+      'dnb-textarea--focus'
+    )
   })
 
   it('has correct state after "change" trigger', () => {
@@ -41,10 +39,8 @@ describe('Textarea component', () => {
       </Textarea>
     )
     expect(
-      document
-        .querySelector('.dnb-textarea')
-        .classList.contains('dnb-textarea--has-content')
-    ).toBe(false)
+      document.querySelector('.dnb-textarea').classList
+    ).not.toContain('dnb-textarea--has-content')
 
     const value = 'new value'
 
@@ -52,11 +48,9 @@ describe('Textarea component', () => {
       target: { value },
     })
 
-    expect(
-      document
-        .querySelector('.dnb-textarea')
-        .classList.contains('dnb-textarea--has-content')
-    ).toBe(true)
+    expect(document.querySelector('.dnb-textarea').classList).toContain(
+      'dnb-textarea--has-content'
+    )
     expect(document.querySelector('textarea').value).toBe(value)
   })
 
@@ -188,9 +182,7 @@ describe('Textarea component', () => {
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<Textarea />)
     rerender(<Textarea disabled={true} />)
-    expect(
-      document.querySelector('textarea').hasAttribute('disabled')
-    ).toBe(true)
+    expect(document.querySelector('textarea')).toHaveAttribute('disabled')
   })
 
   it('will correctly auto resize if prop autoresize is used', async () => {

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -184,7 +184,7 @@ describe('Timeline', () => {
     it('renders title', () => {
       const title = 'Completed'
       render(<TimelineItem title={title} state="completed" />)
-      expect(screen.queryByText(title)).toBeTruthy()
+      expect(screen.queryByText(title)).toBeInTheDocument()
     })
 
     it('renders subtitle', () => {
@@ -196,7 +196,7 @@ describe('Timeline', () => {
           state="completed"
         />
       )
-      expect(screen.queryByText(subtitle)).toBeTruthy()
+      expect(screen.queryByText(subtitle)).toBeInTheDocument()
     })
 
     it('renders subtitles', () => {
@@ -209,8 +209,8 @@ describe('Timeline', () => {
         />
       )
 
-      expect(screen.queryByText(subtitles[0])).toBeTruthy()
-      expect(screen.queryByText(subtitles[1])).toBeTruthy()
+      expect(screen.queryByText(subtitles[0])).toBeInTheDocument()
+      expect(screen.queryByText(subtitles[1])).toBeInTheDocument()
     })
 
     it('renders info message', () => {
@@ -222,7 +222,7 @@ describe('Timeline', () => {
           state="completed"
         />
       )
-      expect(screen.queryByText(infoMessage)).toBeTruthy()
+      expect(screen.queryByText(infoMessage)).toBeInTheDocument()
     })
 
     it('renders custom icon', () => {

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
@@ -67,11 +67,15 @@ describe('ToggleButton component', () => {
         .querySelector('.dnb-checkbox__input')
         .getAttribute('data-checked')
     ).toBe('true')
-    expect(document.querySelector('.dnb-checkbox__button')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-checkbox__button')
+    ).toBeInTheDocument()
 
     rerender(<ToggleButton variant="radio" checked={false} />)
 
-    expect(document.querySelector('.dnb-radio__button')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-radio__button')
+    ).toBeInTheDocument()
     expect(
       document
         .querySelector('.dnb-radio__input')
@@ -217,7 +221,7 @@ describe('ToggleButton component', () => {
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<ToggleButton />)
     rerender(<ToggleButton disabled={true} />)
-    expect(document.querySelector('button[disabled]')).toBeTruthy()
+    expect(document.querySelector('button[disabled]')).toBeInTheDocument()
   })
 
   it('should support enter key', () => {
@@ -287,7 +291,9 @@ describe('ToggleButton group component', () => {
         />
       </ToggleButton.Group>
     )
-    expect(document.querySelector('.dnb-radio__button')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-radio__button')
+    ).toBeInTheDocument()
   })
 
   it('has to have correct aria-pressed', () => {
@@ -307,10 +313,8 @@ describe('ToggleButton group component', () => {
       </ToggleButton.Group>
     )
     expect(
-      document
-        .querySelector('button#toggle-button-2')
-        .hasAttribute('aria-pressed')
-    ).toBe(true)
+      document.querySelector('button#toggle-button-2')
+    ).toHaveAttribute('aria-pressed')
   })
 
   it('has "on_change" event which will trigger on a button click', () => {
@@ -533,7 +537,7 @@ describe('ToggleButton group component', () => {
       ).toBe('false')
       expect(
         document.querySelector('.dnb-toggle-button--checked')
-      ).toBeFalsy()
+      ).not.toBeInTheDocument()
       expect(
         document
           .querySelector(sel)

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -212,7 +212,7 @@ describe('Tooltip', () => {
 
       expect(
         document.querySelector('.dnb-tooltip').getAttribute('style')
-      ).toBeFalsy()
+      ).not.toBeInTheDocument()
     })
 
     it('creates a React Portal', () => {
@@ -238,7 +238,7 @@ describe('Tooltip', () => {
       it('will not have aria-hidden', () => {
         render(<OriginalTooltip skipPortal active />)
 
-        expect(getMainElem().getAttribute('aria-hidden')).toBeFalsy()
+        expect(getMainElem()).not.toHaveAttribute('aria-hidden')
       })
 
       it('should stay visible when mouse enters the Tooltip', async () => {
@@ -256,17 +256,15 @@ describe('Tooltip', () => {
 
         await wait(1)
 
-        expect(
-          getMainElem().classList.contains('dnb-tooltip--active')
-        ).toBe(true)
+        expect(getMainElem().classList).toContain('dnb-tooltip--active')
 
         fireEvent.mouseLeave(getMainElem())
 
         await wait(1)
 
-        expect(
-          getMainElem().classList.contains('dnb-tooltip--active')
-        ).toBe(false)
+        expect(getMainElem().classList).not.toContain(
+          'dnb-tooltip--active'
+        )
       })
     })
 
@@ -302,24 +300,20 @@ describe('Tooltip', () => {
 
       await wait(100)
 
-      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
-        true
-      )
+      expect(getMainElem().classList).toContain('dnb-tooltip--active')
 
       fireEvent.mouseLeave(buttonElem)
       fireEvent.mouseEnter(buttonElem)
 
-      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
-        true
-      )
+      expect(getMainElem().classList).toContain('dnb-tooltip--active')
 
       fireEvent.mouseLeave(buttonElem)
 
       await wait(1)
 
       const classList = getMainElem().classList
-      expect(classList.contains('dnb-tooltip--active')).toBe(false)
-      expect(classList.contains('dnb-tooltip--hide')).toBe(true)
+      expect(classList).not.toContain('dnb-tooltip--active')
+      expect(classList).toContain('dnb-tooltip--hide')
     })
 
     it('should stay visible when mouse enters the Tooltip', async () => {
@@ -337,17 +331,13 @@ describe('Tooltip', () => {
 
       await wait(1)
 
-      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
-        true
-      )
+      expect(getMainElem().classList).toContain('dnb-tooltip--active')
 
       fireEvent.mouseLeave(getMainElem())
 
       await wait(1)
 
-      expect(getMainElem().classList.contains('dnb-tooltip--active')).toBe(
-        false
-      )
+      expect(getMainElem().classList).not.toContain('dnb-tooltip--active')
     })
 
     it('should set fixed class', () => {
@@ -426,10 +416,8 @@ describe('Tooltip', () => {
       const id = wrapperElement.getAttribute('aria-describedby')
 
       expect(
-        document.body
-          .querySelector('#' + id)
-          .parentElement.classList.contains('dnb-tooltip--active')
-      ).toBe(true)
+        document.body.querySelector('#' + id).parentElement.classList
+      ).toContain('dnb-tooltip--active')
     })
   })
 
@@ -495,10 +483,8 @@ describe('Tooltip', () => {
 
       const id = element.getAttribute('aria-describedby')
       expect(
-        document.body
-          .querySelector('#' + id)
-          .parentElement.classList.contains('dnb-tooltip--active')
-      ).toBe(true)
+        document.body.querySelector('#' + id).parentElement.classList
+      ).toContain('dnb-tooltip--active')
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -48,7 +48,7 @@ describe('Upload', () => {
     it('renders the title', () => {
       render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.title)).toBeTruthy()
+      expect(screen.queryByText(nb.title)).toBeInTheDocument()
     })
 
     it('renders the custom title', () => {
@@ -56,13 +56,13 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} title={customTitle} />)
 
-      expect(screen.queryByText(customTitle)).toBeTruthy()
+      expect(screen.queryByText(customTitle)).toBeInTheDocument()
     })
 
     it('renders the text', () => {
       render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.text)).toBeTruthy()
+      expect(screen.queryByText(nb.text)).toBeInTheDocument()
     })
 
     it('renders the custom text', () => {
@@ -70,13 +70,15 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} text={customText} />)
 
-      expect(screen.queryByText(customText)).toBeTruthy()
+      expect(screen.queryByText(customText)).toBeInTheDocument()
     })
 
     it('renders the format description', () => {
       render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.fileTypeDescription)).toBeTruthy()
+      expect(
+        screen.queryByText(nb.fileTypeDescription)
+      ).toBeInTheDocument()
     })
 
     it('renders the custom format description', () => {
@@ -89,7 +91,9 @@ describe('Upload', () => {
         />
       )
 
-      expect(screen.queryByText(customFormatDescription)).toBeTruthy()
+      expect(
+        screen.queryByText(customFormatDescription)
+      ).toBeInTheDocument()
     })
 
     it('does not render fileTypeDescription when acceptedFileTypes is empty', () => {
@@ -99,7 +103,9 @@ describe('Upload', () => {
         <Upload {...defaultProps} acceptedFileTypes={acceptedFileTypes} />
       )
 
-      expect(screen.queryByText(nb.fileTypeDescription)).toBeFalsy()
+      expect(
+        screen.queryByText(nb.fileTypeDescription)
+      ).not.toBeInTheDocument()
     })
 
     it('renders the custom accepted format', () => {
@@ -111,13 +117,15 @@ describe('Upload', () => {
 
       const formattedFileTypes = acceptedFileTypes.join(', ').toUpperCase()
 
-      expect(screen.queryByText(formattedFileTypes)).toBeTruthy()
+      expect(screen.queryByText(formattedFileTypes)).toBeInTheDocument()
     })
 
     it('renders the file size description', () => {
       render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.fileSizeDescription)).toBeTruthy()
+      expect(
+        screen.queryByText(nb.fileSizeDescription)
+      ).toBeInTheDocument()
     })
 
     it('renders the custom file size description', () => {
@@ -130,7 +138,7 @@ describe('Upload', () => {
         />
       )
 
-      expect(screen.queryByText(fileSizeDescription)).toBeTruthy()
+      expect(screen.queryByText(fileSizeDescription)).toBeInTheDocument()
     })
 
     it('renders the file size', () => {
@@ -144,7 +152,7 @@ describe('Upload', () => {
             fileMaxSize.toString()
           )
         )
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
 
     it('renders the custom file size', () => {
@@ -163,7 +171,7 @@ describe('Upload', () => {
         screen.queryByText(
           String(fileSizeContent).replace('%size', `${fileMaxSize}`)
         )
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
 
     it('renders the file amount limit description', () => {
@@ -172,14 +180,18 @@ describe('Upload', () => {
         <Upload {...defaultProps} filesAmountLimit={filesAmountLimit} />
       )
 
-      expect(screen.queryByText(nb.fileAmountDescription)).toBeTruthy()
-      expect(screen.queryByText(String(filesAmountLimit))).toBeTruthy()
+      expect(
+        screen.queryByText(nb.fileAmountDescription)
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(String(filesAmountLimit))
+      ).toBeInTheDocument()
     })
 
     it('renders the upload file input section button text', () => {
       render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.buttonText)).toBeTruthy()
+      expect(screen.queryByText(nb.buttonText)).toBeInTheDocument()
     })
 
     it('renders the upload file input section button custom text', () => {
@@ -187,17 +199,17 @@ describe('Upload', () => {
 
       render(<Upload {...defaultProps} buttonText={buttonText} />)
 
-      expect(screen.queryByText(buttonText)).toBeTruthy()
+      expect(screen.queryByText(buttonText)).toBeInTheDocument()
     })
 
     it('should support locale prop', () => {
       const { rerender } = render(<Upload {...defaultProps} />)
 
-      expect(screen.queryByText(nb.title)).toBeTruthy()
+      expect(screen.queryByText(nb.title)).toBeInTheDocument()
 
       rerender(<Upload {...defaultProps} locale="en-GB" />)
 
-      expect(screen.queryByText(en.title)).toBeTruthy()
+      expect(screen.queryByText(en.title)).toBeInTheDocument()
     })
 
     it('should support locale from provider', () => {
@@ -207,7 +219,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      expect(screen.queryByText(nb.title)).toBeTruthy()
+      expect(screen.queryByText(nb.title)).toBeInTheDocument()
 
       rerender(
         <Provider locale="en-GB">
@@ -215,7 +227,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      expect(screen.queryByText(en.title)).toBeTruthy()
+      expect(screen.queryByText(en.title)).toBeInTheDocument()
 
       rerender(
         <Provider locale="nb-NO">
@@ -223,7 +235,7 @@ describe('Upload', () => {
         </Provider>
       )
 
-      expect(screen.queryByText(nb.title)).toBeTruthy()
+      expect(screen.queryByText(nb.title)).toBeInTheDocument()
     })
 
     it('should support spacing props', () => {
@@ -272,7 +284,7 @@ describe('Upload', () => {
     ])
     expect(
       screen.queryByText(nb.errorAmountLimit.replace('%amount', '1'))
-    ).toBeTruthy()
+    ).toBeInTheDocument()
     expect(result.current.internalFiles.length).toBe(3)
 
     const deleteButton = screen.queryByRole('button', {
@@ -281,15 +293,15 @@ describe('Upload', () => {
 
     fireEvent.click(deleteButton)
 
-    expect(element.querySelector('.dnb-form-status')).toBeFalsy()
+    expect(
+      element.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
 
     expect(
-      screen
-        .queryByRole('button', {
-          name: nb.buttonText,
-        })
-        .hasAttribute('disabled')
-    ).toBe(false)
+      screen.queryByRole('button', {
+        name: nb.buttonText,
+      })
+    ).not.toHaveAttribute('disabled')
   })
 
   it('will accept same file only once', async () => {
@@ -568,7 +580,7 @@ describe('Upload', () => {
 
       expect(
         screen.queryByText(`error message ${fileMaxSize}`)
-      ).toBeTruthy()
+      ).toBeInTheDocument()
     })
   })
 

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadDropzone.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadDropzone.test.tsx
@@ -119,9 +119,7 @@ describe('Upload', () => {
 
       unmount()
 
-      expect(document.body.hasAttribute('data-upload-drop-zone')).toBe(
-        false
-      )
+      expect(document.body).not.toHaveAttribute('data-upload-drop-zone')
     })
 
     it('has drop event', async () => {

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
@@ -45,7 +45,7 @@ describe('UploadFileInput', () => {
       }),
     })
 
-    expect(screen.queryByText(buttonText)).toBeTruthy()
+    expect(screen.queryByText(buttonText)).toBeInTheDocument()
   })
 
   it('renders the upload input', () => {
@@ -65,7 +65,7 @@ describe('UploadFileInput', () => {
 
     const element = document.querySelector('.dnb-upload__file-input')
 
-    expect(element.hasAttribute('multiple')).toBeTruthy()
+    expect(element).toHaveAttribute('multiple')
   })
 
   it('accepts ony one file when filesAmountLimit is 1', () => {
@@ -77,7 +77,7 @@ describe('UploadFileInput', () => {
 
     const element = document.querySelector('.dnb-upload__file-input')
 
-    expect(element.hasAttribute('multiple')).toBeFalsy()
+    expect(element).not.toHaveAttribute('multiple')
   })
 
   it('renders the input', () => {

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
@@ -89,7 +89,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    expect(screen.queryByText('PNG')).toBeTruthy()
+    expect(screen.queryByText('PNG')).toBeInTheDocument()
   })
 
   it('renders the subtitle and uses the extension if mime is missing', () => {
@@ -100,7 +100,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    expect(screen.queryByText('PNG')).toBeTruthy()
+    expect(screen.queryByText('PNG')).toBeInTheDocument()
   })
 
   it('renders the subtitle with file extension when set by acceptedFileTypes', () => {
@@ -114,7 +114,7 @@ describe('UploadFileListCell', () => {
       }
     )
 
-    expect(screen.queryByText('PNG')).toBeTruthy()
+    expect(screen.queryByText('PNG')).toBeInTheDocument()
   })
 
   it('renders the subtitle with file mime when set by acceptedFileTypes', () => {
@@ -128,7 +128,7 @@ describe('UploadFileListCell', () => {
       }
     )
 
-    expect(screen.queryByText('PNG')).toBeTruthy()
+    expect(screen.queryByText('PNG')).toBeInTheDocument()
   })
 
   it('renders the form errorMessage warning', () => {
@@ -144,7 +144,7 @@ describe('UploadFileListCell', () => {
       />
     )
 
-    expect(screen.queryByText(errorMessage)).toBeTruthy()
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument()
   })
 
   describe('Icons', () => {
@@ -266,7 +266,7 @@ describe('UploadFileListCell', () => {
           uploadFile={{ file: createMockFile(fileName, 100, 'image/png') }}
         />
       )
-      expect(screen.queryByText(fileName)).toBeTruthy()
+      expect(screen.queryByText(fileName)).toBeInTheDocument()
     })
 
     it('renders the anchor href', () => {

--- a/packages/dnb-eufemia/src/core/jest/setupJest.js
+++ b/packages/dnb-eufemia/src/core/jest/setupJest.js
@@ -1,0 +1,6 @@
+/**
+ * Jest Setup for testing
+ *
+ */
+
+import '@testing-library/jest-dom'

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/PaymentCard.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/PaymentCard.test.tsx
@@ -38,51 +38,51 @@ describe('PaymentCard', () => {
   it('has to have a figcaption', () => {
     render(<PaymentCard {...defaultProps} />)
 
-    expect(screen.queryByText('DNB Kortet')).toBeTruthy()
+    expect(screen.queryByText('DNB Kortet')).toBeInTheDocument()
     expect(screen.queryByText('DNB Kortet').tagName).toEqual('FIGCAPTION')
   })
 
   it('has a valid title in SVG', () => {
     render(<PaymentCard {...defaultProps} />)
 
-    expect(screen.queryByText('DNB logo')).toBeTruthy()
+    expect(screen.queryByText('DNB logo')).toBeInTheDocument()
     expect(screen.queryByText('DNB logo').tagName).toEqual('title')
   })
 
   it('has a correct formatted card number', () => {
     render(<PaymentCard {...defaultProps} />)
 
-    expect(screen.queryByText('**** **** **** 1337')).toBeTruthy()
+    expect(screen.queryByText('**** **** **** 1337')).toBeInTheDocument()
   })
 
   it('has a correct label', () => {
     render(<PaymentCard {...defaultProps} />)
 
-    expect(screen.queryByText(nb.text_card_number)).toBeTruthy()
+    expect(screen.queryByText(nb.text_card_number)).toBeInTheDocument()
   })
 
   it('has correct expired status', () => {
     render(<PaymentCard {...defaultProps} card_status="expired" />)
 
-    expect(screen.queryByText(nb.text_expired)).toBeTruthy()
+    expect(screen.queryByText(nb.text_expired)).toBeInTheDocument()
   })
 
   it('has correct blocked status', () => {
     render(<PaymentCard {...defaultProps} card_status="blocked" />)
 
-    expect(screen.queryByText(nb.text_blocked)).toBeTruthy()
+    expect(screen.queryByText(nb.text_blocked)).toBeInTheDocument()
   })
 
   it('reacts to locale change', () => {
     const { rerender } = render(<PaymentCard {...defaultProps} />)
 
-    expect(screen.queryByText(nb.text_card_number)).toBeTruthy()
+    expect(screen.queryByText(nb.text_card_number)).toBeInTheDocument()
 
     rerender(<PaymentCard {...defaultProps} locale="en-GB" />)
-    expect(screen.queryByText(en.text_card_number)).toBeTruthy()
+    expect(screen.queryByText(en.text_card_number)).toBeInTheDocument()
 
     rerender(<PaymentCard {...defaultProps} locale="nb-NO" />)
-    expect(screen.queryByText(nb.text_card_number)).toBeTruthy()
+    expect(screen.queryByText(nb.text_card_number)).toBeInTheDocument()
   })
 
   it('reacts raw_data with correct rendering', () => {
@@ -105,13 +105,13 @@ describe('PaymentCard', () => {
       />
     )
 
-    expect(screen.queryByText(customData.productName)).toBeTruthy()
+    expect(screen.queryByText(customData.productName)).toBeInTheDocument()
     expect(screen.queryByText(customData.productName).tagName).toEqual(
       'FIGCAPTION'
     )
     expect(
       document.querySelector('div.dnb-payment-card__card--design-gold')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -57,19 +57,27 @@ const mockData: DrawerListDataObjectUnion[] = [
 describe('DrawerList component', () => {
   it('has correct state at startup', () => {
     render(<DrawerList {...props} data={mockData} />)
-    expect(document.querySelector('.dnb-drawer-list--opened')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-drawer-list--opened')
+    ).toBeInTheDocument()
   })
 
   it('has correct state after changing prop to opened', () => {
     const { rerender } = render(<DrawerList {...props} data={mockData} />)
 
-    expect(document.querySelector('.dnb-drawer-list--opened')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-drawer-list--opened')
+    ).toBeInTheDocument()
 
     rerender(<DrawerList {...props} data={mockData} opened={false} />)
-    expect(document.querySelector('.dnb-drawer-list--opened')).toBeFalsy()
+    expect(
+      document.querySelector('.dnb-drawer-list--opened')
+    ).not.toBeInTheDocument()
 
     rerender(<DrawerList {...props} data={mockData} opened={true} />)
-    expect(document.querySelector('.dnb-drawer-list--opened')).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-drawer-list--opened')
+    ).toBeInTheDocument()
   })
 
   it('handles default_value correctly on forcing re-render', () => {
@@ -87,12 +95,8 @@ describe('DrawerList component', () => {
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
       props.value
     ]
-    expect(elem.classList.contains('dnb-drawer-list__option--focus')).toBe(
-      true
-    )
-    expect(
-      elem.classList.contains('dnb-drawer-list__option--selected')
-    ).toBe(true)
+    expect(elem.classList).toContain('dnb-drawer-list__option--focus')
+    expect(elem.classList).toContain('dnb-drawer-list__option--selected')
 
     // force re-render by prop change
     const title = 'show this attribute now'
@@ -106,7 +110,7 @@ describe('DrawerList component', () => {
         title={title}
       />
     )
-    expect(screen.getByTitle(title)).toBeTruthy()
+    expect(screen.getByTitle(title)).toBeInTheDocument()
 
     // force re-render with null as value by prop change
     rerender(
@@ -125,17 +129,13 @@ describe('DrawerList component', () => {
     elem = document.querySelectorAll('.dnb-drawer-list__option')[
       (props.value as number) + 1
     ]
-    expect(
-      elem.classList.contains('dnb-drawer-list__option--selected')
-    ).toBe(true)
+    expect(elem.classList).toContain('dnb-drawer-list__option--selected')
 
     // as well as the focus / active state
-    expect(elem.classList.contains('dnb-drawer-list__option--focus')).toBe(
-      true
-    )
+    expect(elem.classList).toContain('dnb-drawer-list__option--focus')
 
     // and for sure, the title attribute is still the same
-    expect(screen.getByTitle(title)).toBeTruthy()
+    expect(screen.getByTitle(title)).toBeInTheDocument()
   })
 
   it('has correct value on key search', async () => {
@@ -143,7 +143,7 @@ describe('DrawerList component', () => {
 
     expect(
       document.querySelector('.dnb-drawer-list__option--focus')
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     keydown(83) // S
 
@@ -241,9 +241,9 @@ describe('DrawerList component', () => {
 
     rerender(<DrawerList {...props} opened={false} data={mockData} />)
 
-    expect(
-      document.documentElement.hasAttribute('data-dnb-drawer-list-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-drawer-list-active'
+    )
   })
 
   it('will unset data-dnb-drawer-list-active on unmount', () => {
@@ -259,9 +259,9 @@ describe('DrawerList component', () => {
 
     unmount()
 
-    expect(
-      document.documentElement.hasAttribute('data-dnb-drawer-list-active')
-    ).toBe(false)
+    expect(document.documentElement).not.toHaveAttribute(
+      'data-dnb-drawer-list-active'
+    )
   })
 
   it('will lock body scroll when enable_body_lock is true', () => {
@@ -348,7 +348,7 @@ describe('DrawerList component', () => {
 
     expect(
       document.querySelector(`.dnb-drawer-list--${directionTop}`)
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     const directionBottom = 'bottom'
     rerender(
@@ -356,7 +356,7 @@ describe('DrawerList component', () => {
     )
     expect(
       document.querySelector(`.dnb-drawer-list--${directionBottom}`)
-    ).toBeTruthy()
+    ).toBeInTheDocument()
 
     expect(
       document

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerListTestMocks.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerListTestMocks.js
@@ -36,7 +36,9 @@ export function mockImplementationForDirectionObserver() {
 
 export async function testDirectionObserver() {
   // the setDirectionObserver fn is changing this
-  expect(document.querySelector('.dnb-drawer-list--bottom')).toBeTruthy()
+  expect(
+    document.querySelector('.dnb-drawer-list--bottom')
+  ).toBeInTheDocument()
   expect(
     document
       .querySelector('.dnb-drawer-list__options')
@@ -48,7 +50,9 @@ export async function testDirectionObserver() {
   })
   await wait(100)
 
-  expect(document.querySelector('.dnb-drawer-list--bottom')).toBeTruthy()
+  expect(
+    document.querySelector('.dnb-drawer-list--bottom')
+  ).toBeInTheDocument()
   expect(
     document
       .querySelector('.dnb-drawer-list__options')
@@ -60,7 +64,9 @@ export async function testDirectionObserver() {
   })
   await wait(100)
 
-  expect(document.querySelector('.dnb-drawer-list--top')).toBeTruthy()
+  expect(
+    document.querySelector('.dnb-drawer-list--top')
+  ).toBeInTheDocument()
   expect(
     document
       .querySelector('.dnb-drawer-list__options')

--- a/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
@@ -31,7 +31,7 @@ describe('ScrollView', () => {
     )
 
     const element = document.querySelector('.dnb-scroll-view')
-    expect(element.hasAttribute('tabindex')).toBeFalsy()
+    expect(element).not.toHaveAttribute('tabindex')
 
     act(() => {
       jest.spyOn(ref.current, 'scrollWidth', 'get').mockReturnValue(102)
@@ -57,7 +57,7 @@ describe('ScrollView', () => {
       )
     })
 
-    expect(element.hasAttribute('tabindex')).toBeFalsy()
+    expect(element).not.toHaveAttribute('tabindex')
   })
 
   it('should set tabindex based on ResizeObserver when interactive is set to auto', () => {
@@ -77,7 +77,7 @@ describe('ScrollView', () => {
     )
 
     const element = document.querySelector('.dnb-scroll-view')
-    expect(element.hasAttribute('tabindex')).toBeFalsy()
+    expect(element).not.toHaveAttribute('tabindex')
 
     act(() => {
       jest.spyOn(ref.current, 'scrollWidth', 'get').mockReturnValue(102)
@@ -95,7 +95,7 @@ describe('ScrollView', () => {
       renderResizeObserver()
     })
 
-    expect(element.hasAttribute('tabindex')).toBeFalsy()
+    expect(element).not.toHaveAttribute('tabindex')
 
     expect(init).toHaveBeenCalledTimes(1)
     expect(observe).toHaveBeenCalledTimes(1)

--- a/packages/dnb-eufemia/src/shared/__tests__/Context.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Context.test.tsx
@@ -84,37 +84,37 @@ describe('Context', () => {
 
   it('translation (getTranslation) should react on new lang prop', () => {
     const { rerender } = render(<MagicContext />)
-    expect(screen.queryByText(title_nb)).toBeTruthy()
+    expect(screen.queryByText(title_nb)).toBeInTheDocument()
 
     rerender(<MagicContext lang="en-GB" />)
-    expect(screen.queryByText(title_gb)).toBeTruthy()
+    expect(screen.queryByText(title_gb)).toBeInTheDocument()
   })
 
   it('translation (getTranslation) should react on new locale', () => {
     render(<MagicContext />)
-    expect(screen.getByText(title_nb)).toBeTruthy()
+    expect(screen.getByText(title_nb)).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button', { name: 'en-GB' }).click()
     })
-    expect(screen.getByText(title_gb)).toBeTruthy()
+    expect(screen.getByText(title_gb)).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button', { name: 'en-US' }).click()
     })
-    expect(screen.getByText(title_gb)).toBeTruthy()
+    expect(screen.getByText(title_gb)).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button', { name: 'nb-NO' }).click()
     })
-    expect(screen.getByText(title_nb)).toBeTruthy()
+    expect(screen.getByText(title_nb)).toBeInTheDocument()
   })
 
   it('translation should react on locale change', () => {
     const { rerender } = render(<HelpButton>content</HelpButton>)
-    expect(screen.queryByLabelText(title_nb)).toBeTruthy()
+    expect(screen.queryByLabelText(title_nb)).toBeInTheDocument()
 
     rerender(<HelpButton lang="en-GB">content</HelpButton>)
-    expect(screen.queryByLabelText(title_gb)).toBeTruthy()
+    expect(screen.queryByLabelText(title_gb)).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/MediaQuery.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/MediaQuery.test.tsx
@@ -48,7 +48,7 @@ describe('MediaQuery', () => {
         medium
       </MediaQuery>
     )
-    expect(screen.queryByText('medium')).toBeTruthy()
+    expect(screen.queryByText('medium')).toBeInTheDocument()
   })
 
   it('should match for query when different breakpoints are given', () => {
@@ -77,7 +77,7 @@ describe('MediaQuery', () => {
       </Provider>
     )
 
-    expect(screen.queryByText('medium')).toBeTruthy()
+    expect(screen.queryByText('medium')).toBeInTheDocument()
   })
 
   it('should match for query when custom breakpoints are given', () => {
@@ -100,7 +100,7 @@ describe('MediaQuery', () => {
       </Provider>
     )
 
-    expect(screen.queryByText('xsmall')).toBeTruthy()
+    expect(screen.queryByText('xsmall')).toBeInTheDocument()
   })
 
   it('should match for query when breakpoint is got removed', () => {
@@ -129,7 +129,7 @@ describe('MediaQuery', () => {
       </Provider>
     )
 
-    expect(screen.queryByText('xsmall')).toBeTruthy()
+    expect(screen.queryByText('xsmall')).toBeInTheDocument()
   })
 
   it('should match for what ever query is given when matchOnSSR is true', () => {
@@ -141,7 +141,7 @@ describe('MediaQuery', () => {
       </MediaQuery>
     )
 
-    expect(screen.queryByText('medium')).toBeTruthy()
+    expect(screen.queryByText('medium')).toBeInTheDocument()
   })
 
   it('should match for query with medium and large width', () => {
@@ -159,7 +159,7 @@ describe('MediaQuery', () => {
         medium large
       </MediaQuery>
     )
-    expect(screen.queryByText('medium large')).toBeTruthy()
+    expect(screen.queryByText('medium large')).toBeInTheDocument()
   })
 
   it('should handle media query changes', () => {
@@ -200,15 +200,15 @@ describe('MediaQuery', () => {
     }
 
     render(<Playground />)
-    expect(screen.queryByText('when')).toBeTruthy()
+    expect(screen.queryByText('when')).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button').click()
     })
-    expect(screen.queryByText('not when')).toBeTruthy()
+    expect(screen.queryByText('not when')).toBeInTheDocument()
     act(() => {
       screen.getByRole('button').click()
     })
-    expect(screen.queryByText('when')).toBeTruthy()
+    expect(screen.queryByText('when')).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -128,15 +128,19 @@ describe('Theme', () => {
   it('will omit element on false or fragment', () => {
     const { rerender } = render(<Theme element={false}>content</Theme>)
 
-    expect(document.querySelector('.eufemia-theme')).toBeFalsy()
+    expect(
+      document.querySelector('.eufemia-theme')
+    ).not.toBeInTheDocument()
 
     rerender(<Theme element={React.Fragment}>content</Theme>)
 
-    expect(document.querySelector('.eufemia-theme')).toBeFalsy()
+    expect(
+      document.querySelector('.eufemia-theme')
+    ).not.toBeInTheDocument()
 
     rerender(<Theme element="div">content</Theme>)
 
-    expect(document.querySelector('.eufemia-theme')).toBeTruthy()
+    expect(document.querySelector('.eufemia-theme')).toBeInTheDocument()
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
@@ -78,7 +78,7 @@ describe('"applyPageFocus" should', () => {
     applyPageFocus('.focus-button')
 
     const focusElement = document.querySelector('.focus-button')
-    expect(focusElement.hasAttribute('tabindex')).toBeFalsy()
+    expect(focusElement).not.toHaveAttribute('tabindex')
   })
 
   it('set a css class called "dnb-no-focus"', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/InteractionInvalidation.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/InteractionInvalidation.test.ts
@@ -44,23 +44,19 @@ describe('InteractionInvalidation', () => {
         document.querySelector(`${selector} h2`).getAttribute('tabindex')
       ).toBe('-1')
 
-      expect(
-        document
-          .querySelector(`${selector} h3`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
-      expect(
-        document.querySelector(`${selector} h3`).hasAttribute('tabindex')
-      ).toBe(false)
+      expect(document.querySelector(`${selector} h3`)).not.toHaveAttribute(
+        'aria-hidden'
+      )
+      expect(document.querySelector(`${selector} h3`)).not.toHaveAttribute(
+        'tabindex'
+      )
 
       expect(
-        document
-          .querySelector(`${selector} path`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('aria-hidden')
       expect(
-        document.querySelector(`${selector} path`).hasAttribute('tabindex')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('tabindex')
     }
 
     const hasInvalidatedState = (selector: string) => {
@@ -92,13 +88,11 @@ describe('InteractionInvalidation', () => {
       ).toBe('-1')
 
       expect(
-        document
-          .querySelector(`${selector} path`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('aria-hidden')
       expect(
-        document.querySelector(`${selector} path`).hasAttribute('tabindex')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('tabindex')
     }
 
     it('be in its original state', () => {
@@ -171,23 +165,19 @@ describe('InteractionInvalidation', () => {
         document.querySelector(`${selector} h2`).getAttribute('tabindex')
       ).toBe('-1')
 
-      expect(
-        document
-          .querySelector(`${selector} h3`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
-      expect(
-        document.querySelector(`${selector} h3`).hasAttribute('tabindex')
-      ).toBe(false)
+      expect(document.querySelector(`${selector} h3`)).not.toHaveAttribute(
+        'aria-hidden'
+      )
+      expect(document.querySelector(`${selector} h3`)).not.toHaveAttribute(
+        'tabindex'
+      )
 
       expect(
-        document
-          .querySelector(`${selector} path`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('aria-hidden')
       expect(
-        document.querySelector(`${selector} path`).hasAttribute('tabindex')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('tabindex')
     }
 
     const hasInvalidatedState = (selector: string) => {
@@ -206,20 +196,16 @@ describe('InteractionInvalidation', () => {
         document.querySelector(`${selector} h2`).getAttribute('tabindex')
       ).toBe('-1')
 
-      expect(
-        document
-          .querySelector(`${selector} h3`)
-          .getAttribute('aria-hidden')
-      ).toBe(null)
+      expect(document.querySelector(`${selector} h3`)).not.toHaveAttribute(
+        'aria-hidden'
+      )
 
       expect(
-        document
-          .querySelector(`${selector} path`)
-          .hasAttribute('aria-hidden')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('aria-hidden')
       expect(
-        document.querySelector(`${selector} path`).hasAttribute('tabindex')
-      ).toBe(false)
+        document.querySelector(`${selector} path`)
+      ).not.toHaveAttribute('tabindex')
     }
 
     it('be in its original state', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@adobe/css-tools@npm:4.2.0"
+  checksum: dc5cc92ba3d562e7ffddb79d6d222c7e00b65f255fd2725b3d71490ff268844be322f917415d8c4ab39eca646343b632058db8bd5b1d646193fcc94d1d3e420b
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-browser-local-storage@npm:4.12.0":
   version: 4.12.0
   resolution: "@algolia/cache-browser-local-storage@npm:4.12.0"
@@ -2584,6 +2591,7 @@ __metadata:
     "@svgr/plugin-jsx": 6.5.1
     "@svgr/plugin-svgo": 6.5.1
     "@testing-library/dom": 9.3.1
+    "@testing-library/jest-dom": 5.16.5
     "@testing-library/react": 14.0.0
     "@testing-library/user-event": 14.4.3
     "@types/fs-extra": 11.0.1
@@ -6319,6 +6327,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:5.16.5":
+  version: 5.16.5
+  resolution: "@testing-library/jest-dom@npm:5.16.5"
+  dependencies:
+    "@adobe/css-tools": ^4.0.1
+    "@babel/runtime": ^7.9.2
+    "@types/testing-library__jest-dom": ^5.9.1
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  checksum: 94911f901a8031f3e489d04ac057cb5373621230f5d92bed80e514e24b069fb58a3166d1dd86963e55f078a1bd999da595e2ab96ed95f452d477e272937d792a
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:14.0.0":
   version: 14.0.0
   resolution: "@testing-library/react@npm:14.0.0"
@@ -7162,6 +7187,15 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/testing-library__jest-dom@npm:^5.9.1":
+  version: 5.14.8
+  resolution: "@types/testing-library__jest-dom@npm:5.14.8"
+  dependencies:
+    "@types/jest": "*"
+  checksum: 18f5ba7d0db8ebd91667b544537762ce63f11c4fd02b3d57afa92f9457a384d3ecf9bc7b50b6b445af1b3ea38b69862b4f95130720d4dd23621d598ac074d93a
   languageName: node
   linkType: hard
 
@@ -8369,7 +8403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.1.3":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.1.3":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
   dependencies:
@@ -10224,6 +10258,16 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chalk@npm:3.0.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
   languageName: node
   linkType: hard
 
@@ -12532,7 +12576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.9":
+"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248


### PR DESCRIPTION
This PR imports and uses `@testing-library/jest-dom` [matchers](https://github.com/testing-library/jest-dom/#custom-matchers) in a few of our tests.

So far I've found the following matchers to be useful in our codebase:
- https://github.com/testing-library/jest-dom/#tobeinthedocument
- https://github.com/testing-library/jest-dom/#tohaveattribute

Examples of using `toBeInTheDocument`(I like this, as this describes what we test/want to happen, instead of use just using `toBeTruthy` or `toBeFalsy`):
From: 
```
expect(
  document.querySelector('#accordion-1 .dnb-accordion__content')
).toBeTruthy()
```
To: 
```
expect(
  document.querySelector('#accordion-1 .dnb-accordion__content')
).toBeInTheDocument()
```

From: 
```expect(
  document.querySelector('#accordion-1 .dnb-accordion__content')
).toBeFalsy()
```
To: 
```expect(
  document.querySelector('#accordion-1 .dnb-accordion__content')
).not.toBeInTheDocument()
```

Examples of using to `toHaveAttribute`:
From: 
```
expect(document.querySelector('x').hasAttribute('disabled')).toBe(true)
```
To: 
```
expect(document.querySelector('x').toHaveAttribute('disabled')
```

From: 
```
expect(document.querySelector('x').hasAttribute('disabled')).toBe(false)
```
To: 
```
expect(document.querySelector('x').not.toHaveAttribute('disabled')
```