### PR TITLE
chore: fixes breaking globalstatus stories

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
@@ -54,11 +54,13 @@ export default class HeightAnimation {
 
   // Private methods
   _callOnStart() {
-    this.onStartStack.forEach((fn) => {
-      if (typeof fn === 'function') {
-        fn(this.state)
-      }
-    })
+    if (this.onStartStack) {
+      this.onStartStack.forEach((fn) => {
+        if (typeof fn === 'function') {
+          fn(this.state)
+        }
+      })
+    }
   }
   _callOnEnd() {
     this.isAnimating = false
@@ -69,11 +71,13 @@ export default class HeightAnimation {
 
     this._removeEndEvents()
 
-    this.onEndStack.forEach((fn) => {
-      if (typeof fn === 'function') {
-        fn(this.state)
-      }
-    })
+    if (this.onEndStack) {
+      this.onEndStack.forEach((fn) => {
+        if (typeof fn === 'function') {
+          fn(this.state)
+        }
+      })
+    }
   }
   reset() {
     this.state = 'init'


### PR DESCRIPTION
A few of the `GlobalStatus` stories was breaking due to `null` values in `HeightAnimationInstance`.

Errors received when running the stories:
<img width="1792" alt="Screenshot 2023-07-25 at 12 28 55" src="https://github.com/dnbexperience/eufemia/assets/1359205/ac5ebd8b-13bc-4ded-bd78-2e80ee888e21">
