### PR TITLE
chore: removes Storybook's Autodocs

### DIFF
--- a/packages/dnb-eufemia/.storybook/main.js
+++ b/packages/dnb-eufemia/.storybook/main.js
@@ -5,7 +5,4 @@ module.exports = {
     name: '@storybook/react-webpack5',
     options: {},
   },
-  docs: {
-    autodocs: true,
-  },
 }


### PR DESCRIPTION
During migration from Storybook v6 to v7, this line of code was added.

It doesn't seem like we need it or use it, and as of now it results in the following errors when running "yarn dev"/storybook locally:

<img width="1783" alt="Screenshot 2023-08-10 at 14 27 28" src="https://github.com/dnbexperience/eufemia/assets/1359205/12bdd49a-e48e-4fac-a30c-e3e51a2b5508">
