### PR TITLE
docs: add theming link to the contribution guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides.mdx
@@ -15,3 +15,4 @@ To make sure the source code and the overall project is consistent and reliant, 
 - [Issues](/contribute/style-guides/issues): Template for reporting issues and suggesting new features.
 - [Git commits](/contribute/style-guides/git): How to make commit messages, submit PRs, and other git conventions.
 - [Naming](/contribute/style-guides/naming): List of naming conventions for every language and variable types.
+- [Theming](/contribute/style-guides/theming): How to maintain and create a theme.


### PR DESCRIPTION
- Add link to the theming docs in the style-guide main page

## Summary

This page was missing one link
<img width="1481" alt="Screenshot 2023-08-16 at 10 55 46" src="https://github.com/dnbexperience/eufemia/assets/41082005/2fd4d9c5-16dd-4853-a5c5-58e57b3eebf6">


copilot:summary

## Details

copilot:walkthrough
