### PR TITLE
fix(NumberFormat): remove whitespace from suffix and prefix

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/Examples.tsx
@@ -27,7 +27,7 @@ export const NumberDefault = () => (
       <P>
         <NumberFormat value="12345" srLabel="Total:" />
         <NumberFormat>-12345678.9</NumberFormat>
-        <NumberFormat prefix={<b>prefix</b>} suffix="suffix">
+        <NumberFormat prefix={<b>prefix{' '}</b>} suffix=" suffix">
           -12345678.9
         </NumberFormat>
         <NumberFormat decimals={1}>-1234.54321</NumberFormat>
@@ -163,7 +163,7 @@ export const NumberOrganization = () => (
   <Style>
     <ComponentBox data-visual-test="number-format-org">
       <P>
-        <NumberFormat value="123456789" org suffix="MVA" />
+        <NumberFormat value="123456789" org suffix=" MVA" />
       </P>
     </ComponentBox>
   </Style>

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
@@ -371,7 +371,8 @@ export default class NumberFormat extends React.PureComponent {
     if (prefix) {
       display = (
         <>
-          {this.runFix(prefix, 'dnb-number-format__prefix')} {display}
+          {this.runFix(prefix, 'dnb-number-format__prefix')}
+          {display}
         </>
       )
       aria = String(
@@ -383,7 +384,8 @@ export default class NumberFormat extends React.PureComponent {
     if (suffix) {
       display = (
         <>
-          {display} {this.runFix(suffix, 'dnb-number-format__suffix')}
+          {display}
+          {this.runFix(suffix, 'dnb-number-format__suffix')}
         </>
       )
       aria = `${aria} ${convertJsxToString(

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -351,12 +351,12 @@ describe('NumberFormat component', () => {
 
   it('have to match organization number', () => {
     render(
-      <Component org suffix="MVA">
+      <Component org suffix=" MVA">
         123456789
       </Component>
     )
     expect(document.querySelector(displaySelector).textContent).toBe(
-      '123 456 789 MVA'
+      '123 456 789 MVA'
     )
     expect(
       document.querySelector(ariaSelector).getAttribute('data-text')
@@ -365,12 +365,15 @@ describe('NumberFormat component', () => {
 
   it('have to handle prefix and suffix', () => {
     render(
-      <Component prefix={<span>prefix</span>} suffix={<span>suffix</span>}>
+      <Component
+        prefix={<span>prefix{' '}</span>}
+        suffix={<span>{' '}suffix</span>}
+      >
         123456789.5
       </Component>
     )
     expect(document.querySelector(displaySelector).textContent).toBe(
-      'prefix 123 456 789,5 suffix'
+      'prefix 123 456 789,5 suffix'
     )
     expect(
       document.querySelector(ariaSelector).getAttribute('data-text')


### PR DESCRIPTION
Closes #2541

BREAKING CHANGE

The properties suffix and prefix in NumberFormat needs to be added manually and are not added by default.
