### PR TITLE
chore: increase build timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,7 +143,7 @@ jobs:
           checkName: Run portal build
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           intervalSeconds: 10
-          timeoutSeconds: 900
+          timeoutSeconds: 2400
 
       - name: Re-store portal artifacts
         uses: actions/download-artifact@v3
@@ -225,7 +225,7 @@ jobs:
           checkName: Run portal build
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           intervalSeconds: 10
-          timeoutSeconds: 900
+          timeoutSeconds: 2400
 
       - name: Re-store portal artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
It looks like we need more time to wait for the artifacts to be uploaded.
