### PR TITLE
portal: fix active sidebar menu items to only show one at a time

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -61,6 +61,9 @@ export default function SidebarLayout({
               status
               icon
               showTabs
+              tabs {
+                key
+              }
               theme
             }
           }
@@ -336,6 +339,11 @@ function ListItem({
   )
 }
 
+type NavItemTabs = {
+  title: string
+  key: string
+}
+
 type NavItem = {
   id: string
   parentId?: string
@@ -351,6 +359,7 @@ type NavItem = {
   status?: string
   title?: string
   showTabs?: boolean
+  tabs?: NavItemTabs[]
   subheadings?: NavItem[]
 }
 
@@ -543,13 +552,13 @@ function groupNavItems(navItems: NavItem[], location: Location) {
 
 function getActiveStatusForItem(
   currentPath: string,
-  { path: itemPath, showTabs }: NavItem
+  { path: itemPath, showTabs, tabs }: NavItem
 ) {
   const portalSlug = itemPath.split('/').filter(Boolean)[0] ?? ''
   const categorySlug = itemPath.split('/').filter(Boolean)[1] ?? ''
   const startOfCurrentPath = `${portalSlug}/${categorySlug}`
 
-  const isActive = checkIfActiveItem(currentPath, itemPath, showTabs)
+  const isActive = checkIfActiveItem(currentPath, itemPath, showTabs, tabs)
 
   const isInsideActivePath = !isActive && currentPath.startsWith(itemPath)
 
@@ -562,7 +571,8 @@ function getActiveStatusForItem(
 function checkIfActiveItem(
   currentPath: string,
   itemPath: string,
-  showTabs?: boolean
+  showTabs?: boolean,
+  tabs?: NavItemTabs[]
 ) {
   if (!showTabs) {
     return itemPath === currentPath
@@ -580,5 +590,16 @@ function checkIfActiveItem(
   const lastSlug = slugs[slugs.length - 1]
   const currentPathWithoutTabSlug = currentPath.replace(`/${lastSlug}`, '')
 
-  return itemPath === currentPathWithoutTabSlug
+  if (itemPath === currentPathWithoutTabSlug) {
+    // In addition, because we show the info.mdx without /info
+    // we don't want the "parent" to be marked as active as well.
+    // So we get tabs and check for that state as well
+    const found = tabs?.find(({ key }) => {
+      return '/' + lastSlug === key
+    })
+
+    return found
+  }
+
+  return false
 }


### PR DESCRIPTION
It's almost perfect. But I think, its much better as before. Now we do not get the double active (current) items. 

Before:

<img width="173" alt="Screenshot 2023-08-22 at 10 35 46" src="https://github.com/dnbexperience/eufemia/assets/1501870/c5eb14c1-77a6-4b50-ba2f-768e897c525f">

After:
<img width="346" alt="Screenshot 2023-08-22 at 10 36 08" src="https://github.com/dnbexperience/eufemia/assets/1501870/e7f1451c-f6a4-435f-bed4-677517726c2f">


This also fixes a scroll issue, because it used the first active item as a reference "to be in view":

Before:

https://github.com/dnbexperience/eufemia/assets/1501870/c8bb5863-d7ab-4fb3-8242-61c089ed14b7

After:

https://github.com/dnbexperience/eufemia/assets/1501870/cf8f724f-ff6e-4ce0-8d2b-50dd4034a763


