### PR TITLE
chore(Storybook): redundant comment in PaymentCard story

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/stories/PaymentCard.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/stories/PaymentCard.stories.tsx
@@ -45,7 +45,7 @@ export const PaymentCards = () => (
         locale="en-GB"
         product_code="DNB"
         card_number="************1337"
-        card_status="expired" // 👈 can be expired, blocked or active
+        card_status="expired"
         variant="compact"
       />
     </Box>


### PR DESCRIPTION
Redundant as all the alternatives is defined in the type itself, so I don't want to keep updating this when the type/enum gets updated.