### PR TITLE
fix(Forms): sets SubHeading's size to medium

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Layout/SubHeading/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Layout/SubHeading/Examples.tsx
@@ -1,9 +1,18 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Layout } from '@dnb/eufemia/src/extensions/forms'
 
-export const Default = () => {
+export const TextOnly = () => {
   return (
     <ComponentBox scope={{ Layout }}>
+      <Layout.SubHeading>This is a sub heading</Layout.SubHeading>
+    </ComponentBox>
+  )
+}
+
+export const BelowMainHeading = () => {
+  return (
+    <ComponentBox scope={{ Layout }}>
+      <Layout.MainHeading>This is a main heading</Layout.MainHeading>
       <Layout.SubHeading>This is a sub heading</Layout.SubHeading>
     </ComponentBox>
   )
@@ -25,6 +34,16 @@ export const OverSectionWithCard = () => {
       <Layout.Section>
         <Layout.Card>Card contents</Layout.Card>
       </Layout.Section>
+    </ComponentBox>
+  )
+}
+
+export const TwoSubHeadings = () => {
+  return (
+    <ComponentBox scope={{ Layout }}>
+      <Layout.SubHeading>This is sub heading 1</Layout.SubHeading>
+      <Layout.SubHeading>This is sub heading 2</Layout.SubHeading>
+      Other contents
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Layout/SubHeading/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Layout/SubHeading/demos.mdx
@@ -8,7 +8,11 @@ import * as Examples from './Examples'
 
 ### Text only
 
-<Examples.Default />
+<Examples.TextOnly />
+
+### Below MainHeading
+
+<Examples.BelowMainHeading />
 
 ### Over Section
 
@@ -17,3 +21,7 @@ import * as Examples from './Examples'
 ### Over Section with Card
 
 <Examples.OverSectionWithCard />
+
+### Two sub headings
+
+<Examples.TwoSubHeadings />

--- a/packages/dnb-eufemia/src/extensions/forms/Layout/SubHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Layout/SubHeading.tsx
@@ -14,6 +14,7 @@ function SubHeading(props: Props) {
     <Heading
       className={classnames('dnb-forms-sub-heading', className)}
       level="3"
+      size="medium"
       {...forwardSpaceProps(props)}
     >
       {children}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I experienced in an attempt to implement using the SubHeading component that the size of the text was dependent on outside components. The hx-number might need to vary based on surroundings, but the point of having `MainHeading` and `SubHeading` in Eufemia Forms was that it would be predictable what size the text became. For that reason, I set the SubHeading hard coded to "medium" similar to how MainHeading has been coded to "large", and added a few more examples to trigger actual results of these types of combinations for testing purposes.

copilot:summary

## Details

copilot:walkthrough

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
