### PR TITLE
fix(Forms): make PhoneNumber country code searchable by numbers

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber.tsx
@@ -107,6 +107,7 @@ function PhoneNumber(props: Props) {
         disabled={disabled}
         on_change={handleCountryCodeChange}
         independent_width
+        search_numbers
       />
       <Input
         className={classnames(


### PR DESCRIPTION
At least from my tests, its much easier to find e.g. Switzerland with `41`.