### PR TITLE
fix(InputMasked): ensure a value with null does not remove the placeholder

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -65,7 +65,7 @@ export const correctNumberValue = ({
   locale,
   maskParams,
 }) => {
-  let value = String(props.value)
+  let value = props.value === null ? null : String(props.value)
 
   if (isNaN(parseFloat(value))) {
     return value

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -623,6 +623,34 @@ describe('InputMasked component', () => {
     expect(document.querySelector('input').value).toBe('1 2 3')
   })
 
+  it('should show placeholder with both value null and undefined', () => {
+    const { rerender } = render(
+      <InputMasked value={undefined} placeholder="AA" />
+    )
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('AA')
+
+    rerender(<InputMasked placeholder="BB" value={null} />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('BB')
+
+    rerender(<InputMasked placeholder="CC" value="" />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('CC')
+
+    rerender(<InputMasked placeholder="CC" value="new-value" />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder')
+    ).not.toBeInTheDocument()
+  })
+
   it('should show placeholder chars when show_mask is true', () => {
     render(
       <InputMasked

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -224,6 +224,34 @@ describe('Input component', () => {
     expect(document.querySelector('input').value).toBe('')
   })
 
+  it('should show placeholder with both value null and undefined', () => {
+    const { rerender } = render(
+      <Input value={undefined} placeholder="AA" />
+    )
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('AA')
+
+    rerender(<Input placeholder="BB" value={null} />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('BB')
+
+    rerender(<Input placeholder="CC" value="" />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder').textContent
+    ).toBe('CC')
+
+    rerender(<Input placeholder="CC" value="new-value" />)
+
+    expect(
+      document.querySelector('.dnb-input__placeholder')
+    ).not.toBeInTheDocument()
+  })
+
   it('has correct state after setting "value" prop using placeholder (set by getDerivedStateFromProps)', () => {
     const { rerender } = render(<Input placeholder="Placeholder" />)
 


### PR DESCRIPTION
It should behave the same as a normal input.

But when given `<InputMasked value={null} placeholder="should be visible" />` the placeholder was not visible. While it is visible in a normal Input.