### PR TITLE
fix(TimeLine): make it possible to update state of subtitle from another subtitle

### DIFF
--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -123,6 +123,7 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
     </li>
   )
 }
+
 // Label
 
 type TimelineItemLabelProps = TimeLineIconProps & TimelineItemTitleProps

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -17,6 +17,8 @@ import Context from '../../shared/Context'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import { extendPropsWithContext } from '../../shared/component-helper'
 
+export type TimeLineItemStates = 'completed' | 'current' | 'upcoming'
+
 export type TimelineItemProps = {
   /**
    * Icon displaying on the left side.
@@ -46,10 +48,10 @@ export type TimelineItemProps = {
   infoMessage?: React.ReactNode
 
   /**
-   * The component state. State 'completed' or 'current' or 'upcoming'.
+   * The component state. State 'completed', 'current' or 'upcoming'.
    * Default: null
    */
-  state: 'completed' | 'current' | 'upcoming'
+  state: TimeLineItemStates
 
   /**
    * Skeleton should be applied when loading content
@@ -74,15 +76,6 @@ const defaultProps = {
 const TimelineItem = (localProps: TimelineItemAllProps) => {
   // Every component should have a context
   const context = React.useContext(Context)
-  const {
-    translation: {
-      TimelineItem: {
-        alt_label_completed,
-        alt_label_current,
-        alt_label_upcoming,
-      },
-    },
-  } = context
 
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
@@ -103,10 +96,6 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
     ...props
   } = allProps
 
-  const stateIsCompleted = state === 'completed'
-  const stateIsCurrent = state === 'current'
-  const stateIsUpcoming = state === 'upcoming'
-
   const skeletonClasses = createSkeletonClass('font', skeleton, context)
   const classes = classnames(
     'dnb-timeline__item',
@@ -114,60 +103,112 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
     `dnb-timeline__item--${state}`
   )
 
-  const TimelineItemIcon = () => {
-    const currentIcon =
-      icon ||
-      (stateIsCompleted && checkIcon) ||
-      (stateIsCurrent && pinIcon) ||
-      (stateIsUpcoming && calendarIcon)
+  return (
+    <li
+      className={classes}
+      aria-current={state === 'current' ? 'step' : undefined}
+      {...props}
+    >
+      <TimelineItemLabel
+        state={state}
+        title={title}
+        icon={icon}
+        iconAlt={iconAlt}
+        skeleton={skeleton}
+        translations={
+          context.translation.TimelineItem as TimeLineIconAltTranslations
+        }
+      />
+      <TimelineItemContent subtitle={subtitle} infoMessage={infoMessage} />
+    </li>
+  )
+}
+// Label
 
-    const currentAltLabel =
-      iconAlt ||
-      (stateIsCompleted && alt_label_completed) ||
-      (stateIsCurrent && alt_label_current) ||
-      (stateIsUpcoming && alt_label_upcoming)
-    return (
-      <span className="dnb-timeline__item__label__icon">
-        <span key="icon-alignment" aria-hidden>
-          &zwnj;
-        </span>
-        {!skeleton && currentIcon && (
-          <IconPrimary
-            icon={currentIcon}
-            alt={currentAltLabel}
-            size={stateIsCurrent ? undefined : 'small'}
-          />
-        )}
+type TimelineItemLabelProps = TimeLineIconProps & TimelineItemTitleProps
+
+const TimelineItemLabel = ({
+  title,
+  ...iconProps
+}: TimelineItemLabelProps) => {
+  return (
+    <span className="dnb-timeline__item__label">
+      <TimelineItemIcon {...iconProps} />
+      <TimelineItemTitle title={title} />
+    </span>
+  )
+}
+
+type TimeLineIconProps = Pick<
+  TimelineItemProps,
+  'icon' | 'iconAlt' | 'state' | 'skeleton'
+> & { translations: TimeLineIconAltTranslations }
+
+type TimeLineIconAltTranslations = {
+  alt_label_completed: string
+  alt_label_current: string
+  alt_label_upcoming: string
+}
+
+const TimelineItemIcon = ({
+  icon,
+  state,
+  iconAlt,
+  skeleton,
+  translations,
+}: TimeLineIconProps) => {
+  const { alt_label_completed, alt_label_current, alt_label_upcoming } =
+    translations
+
+  const icons: Record<TimeLineItemStates, IconIcon> = {
+    completed: checkIcon,
+    current: pinIcon,
+    upcoming: calendarIcon,
+  }
+
+  const labels: Record<TimeLineItemStates, string> = {
+    completed: alt_label_completed,
+    current: alt_label_current,
+    upcoming: alt_label_upcoming,
+  }
+
+  const currentIcon = icon || icons[state]
+  const currentAltLabel = iconAlt || labels[state]
+
+  return (
+    <span className="dnb-timeline__item__label__icon">
+      <span key="icon-alignment" aria-hidden>
+        &zwnj;
       </span>
-    )
-  }
+      {!skeleton && currentIcon && (
+        <IconPrimary
+          icon={currentIcon}
+          alt={currentAltLabel}
+          size={state === 'current' ? undefined : 'small'}
+        />
+      )}
+    </span>
+  )
+}
 
-  const TimelineItemTitle = () => {
-    return (
-      <span className="dnb-timeline__item__label__title">{title}</span>
-    )
-  }
+type TimelineItemTitleProps = Pick<TimelineItemProps, 'title'>
 
-  const TimelineItemLabel = () => {
-    return (
-      <span className="dnb-timeline__item__label">
-        <TimelineItemIcon />
-        <TimelineItemTitle />
-      </span>
-    )
-  }
+const TimelineItemTitle = ({ title }: TimelineItemTitleProps) => {
+  return <span className="dnb-timeline__item__label__title">{title}</span>
+}
 
-  const getSubtitle = () => {
-    const TimelineItemSubtitle = ({
-      subtitle,
-    }: {
-      subtitle: React.ReactNode
-    }) => (
-      <div className="dnb-timeline__item__content__subtitle">
-        {subtitle}
-      </div>
-    )
+// Content
 
+type TimeLineItemContentProps = Pick<
+  TimelineItemProps,
+  'subtitle' | 'infoMessage'
+>
+
+const TimelineItemContent = ({
+  subtitle,
+  infoMessage,
+}: TimeLineItemContentProps) => {
+  const renderSubtitles = () => {
     if (!subtitle) {
       return null
     }
@@ -180,32 +221,27 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
     return <TimelineItemSubtitle subtitle={subtitle} />
   }
 
-  const TimelineItemContent = () => {
-    return (
-      <div className="dnb-timeline__item__content">
-        {getSubtitle()}
-        {infoMessage && (
-          <FormStatus
-            text={infoMessage}
-            state="info"
-            className="dnb-timeline__item__content__info"
-            stretch
-          />
-        )}
-      </div>
-    )
-  }
-
   return (
-    <li
-      className={classes}
-      aria-current={stateIsCurrent ? 'step' : undefined}
-      {...props}
-    >
-      <TimelineItemLabel />
-      <TimelineItemContent />
-    </li>
+    <div className="dnb-timeline__item__content">
+      {renderSubtitles()}
+      {infoMessage && (
+        <FormStatus
+          text={infoMessage}
+          state="info"
+          className="dnb-timeline__item__content__info"
+          stretch
+        />
+      )}
+    </div>
   )
 }
+
+type TimelineItemSubtitleProps = {
+  subtitle: React.ReactNode
+}
+
+const TimelineItemSubtitle = ({ subtitle }: TimelineItemSubtitleProps) => (
+  <div className="dnb-timeline__item__content__subtitle">{subtitle}</div>
+)
 
 export default TimelineItem

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import Timeline, { TimelineAllProps } from '../Timeline'
 import TimelineItem, { TimelineItemAllProps } from '../TimelineItem'
 
 import IconPrimary from '../../icon-primary/IconPrimary'
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import { Provider } from '../../../shared'
+import Input from '../../input/Input'
 
 beforeEach(() => {
   document.body.innerHTML = ''
@@ -276,6 +277,60 @@ describe('Timeline', () => {
       expect(
         document.getElementsByClassName(skeletonClassName)
       ).toHaveLength(1)
+    })
+
+    it('should rerender sub components', () => {
+      const TimelineMock = () => {
+        const [value, setValue] = React.useState('initial state')
+        return (
+          <>
+            <Timeline>
+              <Timeline.Item
+                title="Current event"
+                state="current"
+                subtitle={
+                  <Input
+                    value={value}
+                    on_change={({ value }) => {
+                      setValue(value)
+                    }}
+                  />
+                }
+              />
+              <Timeline.Item
+                title="Upcoming event"
+                state="upcoming"
+                subtitle={<Input value={value} />}
+              />
+            </Timeline>
+          </>
+        )
+      }
+
+      const { rerender } = render(<TimelineMock />)
+
+      const inputElems = document.querySelectorAll('input')
+      const firstInputElem = inputElems[0]
+      const secondInputElem = inputElems[1]
+
+      const newValue1 = 'new vlaue 1'
+      const newValue2 = 'new vlaue 2'
+
+      fireEvent.change(firstInputElem, { target: { value: newValue1 } })
+
+      expect(firstInputElem.value).toBe(secondInputElem.value)
+      expect(firstInputElem.value).toBe(newValue1)
+      expect(secondInputElem.value).toBe(newValue1)
+
+      rerender(<TimelineMock />)
+
+      expect(firstInputElem.value).toBe(newValue1)
+
+      fireEvent.change(firstInputElem, { target: { value: newValue2 } })
+
+      expect(firstInputElem.value).toBe(secondInputElem.value)
+      expect(firstInputElem.value).toBe(newValue2)
+      expect(secondInputElem.value).toBe(newValue2)
     })
 
     describe('renders default icon based on state property', () => {

--- a/packages/dnb-eufemia/src/components/timeline/stories/Timeline.stories.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/stories/Timeline.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import Section from '../../Section'
+import Timeline from '../Timeline'
+import FormRow from '../../FormRow'
+import Input from '../../Input'
+
+export default {
+  title: 'Eufemia/Components/Timeline',
+}
+
+export const TimelineTest = () => {
+  const [value, setValue] = React.useState('123')
+  return (
+    <>
+      <Section>
+        <Timeline space>
+          <Timeline.Item
+            title="Completed event"
+            subtitle="10. september 2021"
+            state="completed"
+          />
+          <Timeline.Item
+            title="Current event"
+            infoMessage="Additional information about this step if needed."
+            state="current"
+            subtitle={
+              <FormRow top vertical>
+                <Input
+                  value={value}
+                  on_change={({ value }) => {
+                    setValue(value)
+                  }}
+                  label="Should be able to change next subtitle input value from here"
+                />
+              </FormRow>
+            }
+          />
+          <Timeline.Item
+            title="Upcoming event"
+            state="upcoming"
+            subtitle={
+              <FormRow top vertical>
+                <Input value={value} label="Should work" />
+              </FormRow>
+            }
+          />
+        </Timeline>
+      </Section>
+
+      <FormRow top left vertical>
+        <Input
+          value={value}
+          on_change={({ value }) => {
+            setValue(value)
+          }}
+          label="Works"
+        />
+      </FormRow>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Previously it was not possible/difficult to update the state of a component inside a `subtitle` from another component inside a `subtitle`. This was fixed by extracting out all the internally declared components inside the `TimeLineItem`, making them their own standalone components inside the `TimeLineItem` file  
