### PR TITLE
chore(Portal): Mark various components as Sbanken-ready

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-set.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-set.mdx
@@ -2,6 +2,7 @@
 title: 'FormSet'
 description: 'The FormSet component is a helper to more easily achieve often used DNB form layout setups.'
 showTabs: true
+theme: 'sbanken'
 ---
 
 import FormSetInfo from 'Docs/uilib/components/form-set/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.mdx
@@ -2,6 +2,7 @@
 title: 'ScrollView'
 description: 'ScrollView is a tiny helper component helping the user controlling overflowing content horizontally or vertically'
 showTabs: true
+theme: 'sbanken'
 status: null
 hideTabs:
   - title: Events

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
@@ -3,6 +3,7 @@ title: 'HeightAnimation'
 description: 'HeightAnimation is a helper component to animate from 0 to height:auto powered by CSS.'
 status: 'new'
 showTabs: true
+theme: 'sbanken'
 ---
 
 import HeightAnimationInfo from 'Docs/uilib/components/height-animation/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button.mdx
@@ -2,6 +2,7 @@
 title: 'HelpButton'
 description: 'A help button with custom semantics, helping screen readers determine the meaning of that button.'
 showTabs: true
+theme: 'sbanken'
 ---
 
 import HelpButtonInfo from 'Docs/uilib/components/help-button/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.mdx
@@ -2,6 +2,7 @@
 title: 'InfinityScroller'
 description: 'The InfinityScroller component is a mode of the Pagination component which loads content continuously as the user scrolls down the page.'
 showTabs: true
+theme: 'sbanken'
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
@@ -3,6 +3,7 @@ title: 'SkipContent'
 description: 'SkipContent gives users – using their keyboard for navigation – the option to skip over content which contains a large amount of interactive elements.'
 status: 'new'
 showTabs: true
+theme: 'sbanken'
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/space.mdx
@@ -2,6 +2,7 @@
 title: 'Space'
 description: 'The Space component provides margins within the provided spacing patterns.'
 showTabs: true
+theme: 'sbanken'
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
@@ -3,6 +3,7 @@ title: 'VisuallyHidden'
 description: 'VisuallyHidden has all the styles necessary to hide it from visual clients, but keep it for screen readers.'
 status: 'new'
 showTabs: true
+theme: 'sbanken'
 ---
 
 import VisuallyHiddenInfo from 'Docs/uilib/components/visually-hidden/info'

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -218,15 +218,21 @@ const ThemeBadge = ({ theme, ...props }: { theme: ThemeNames }) => {
       sbanken: 'Sbanken',
       eiendom: 'Eiendom',
     }[theme]
+  const themeTitleTitle =
+    theme && `This component is ready for use with the ${themeTitle} theme`
   return (
     <span
+      title={themeTitleTitle}
       className={classnames(
         'dnb-sidebar-menu__theme-badge',
         `dnb-sidebar-menu__theme-badge--${theme}`,
       )}
       {...props}
     >
-      <span className={classnames('dnb-sidebar-menu__theme-badge__title')}>
+      <span
+        title={themeTitleTitle}
+        className={classnames('dnb-sidebar-menu__theme-badge__title')}
+      >
         {themeTitle}
       </span>
     </span>


### PR DESCRIPTION
Several Eufemia components only exist to provide functionality, and does not need theming. This PR marks those components as Sbanken-ready. Below is a complete list.
- FormSet
- ScrollView (under Fragments)
- HeightAnimation
- HelpButton
- InfinityScroller (under Pagination)
- SkipContent
- Space
- VisuallyHidden
