### PR TITLE
fix(Drawer): render Drawer.Navigation when hideCloseButton is true

### DIFF
--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -65,6 +65,7 @@ describe('Drawer', () => {
   it('will close by using callback method', async () => {
     const on_close = jest.fn()
     const on_open = jest.fn()
+
     render(
       <Drawer
         noAnimation={true}
@@ -82,6 +83,62 @@ describe('Drawer', () => {
     await waitFor(() => {
       expect(on_open).toHaveBeenCalledTimes(1)
     })
+
+    fireEvent.click(document.querySelector('button#close-me'))
+    await waitFor(() => {
+      expect(on_close).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('will render Navigation, Header and Body even when hideCloseButton is true', async () => {
+    const on_close = jest.fn()
+    const on_open = jest.fn()
+
+    render(
+      <Drawer
+        noAnimation={true}
+        onOpen={on_open}
+        onClose={on_close}
+        hideCloseButton
+      >
+        {({ close }) => (
+          <>
+            <Drawer.Navigation>Drawer.Navigation</Drawer.Navigation>
+            <Drawer.Header>
+              Drawer.Header
+              <Button id="close-me" on_click={close} />
+            </Drawer.Header>
+            <Drawer.Body>Drawer.Body</Drawer.Body>
+          </>
+        )}
+      </Drawer>
+    )
+
+    fireEvent.click(document.querySelector('button'))
+    await waitFor(() => {
+      expect(on_open).toHaveBeenCalledTimes(1)
+    })
+
+    expect(document.querySelectorAll('.dnb-drawer button')).toHaveLength(1)
+
+    expect(
+      document.querySelector('.dnb-drawer__header')
+    ).toBeInTheDocument()
+    expect(document.querySelector('.dnb-drawer__header').textContent).toBe(
+      'Drawer.Header'
+    )
+
+    expect(document.querySelector('.dnb-drawer__body')).toBeInTheDocument()
+    expect(document.querySelector('.dnb-drawer__body').textContent).toBe(
+      'Drawer.Body'
+    )
+
+    expect(
+      document.querySelector('.dnb-drawer__navigation')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-drawer__navigation').textContent
+    ).toBe('Drawer.Navigation')
 
     fireEvent.click(document.querySelector('button#close-me'))
     await waitFor(() => {

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
@@ -87,16 +87,11 @@ export default class ModalHeaderBar extends React.PureComponent<
     } = this.props
     const { showShadow } = this.state
     const {
-      title,
       hide_close_button = false,
       close_button_attributes,
       onCloseClickHandler,
       close_title,
     } = this.context
-
-    if (!title && isTrue(hide_close_button) && !this._ref.current) {
-      return null
-    }
 
     return (
       <Section


### PR DESCRIPTION
I'm actually not sure why we had this check to prevent it from rendering. Sadly, there was no comment in the code. Also, I can not find any tests proving this behavior. So in worst case, we "break" a layout by adding an additional spacing on top. 
If there is a need to prevent that, we should accommodate that with a more logical approach.