### PR TITLE
feat(Heading): remove font ligatures for sbanken headings

### DIFF
--- a/packages/dnb-eufemia/src/elements/typography/style/themes/dnb-typography-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/themes/dnb-typography-theme-sbanken.scss
@@ -14,6 +14,7 @@
 // Headings
 @include typography.headingClasses() {
   color: var(--sb-color-text);
+  font-variant-ligatures: none;
 }
 
 @include typography.typographySelectors() {


### PR DESCRIPTION
## Summary

Sbanken heading font has a ligature that shows the logo on the word "Sbanken", this should be removed.

Currrent:
<img width="221" alt="Screenshot 2023-09-06 at 10 20 41" src="https://github.com/dnbexperience/eufemia/assets/5329330/47c1bbaa-6e99-4c03-957e-c4de69ecb15f">

New:
<img width="211" alt="Screenshot 2023-09-06 at 10 20 49" src="https://github.com/dnbexperience/eufemia/assets/5329330/b2bad660-aeef-4b4a-8872-1f32b6bbb050">

