### PR TITLE
chore(Portal): add env variable "filter=/component-name" for faster dev builds

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -166,18 +166,18 @@ if (
   !global.pagesPath.includes('_dummy')
 ) {
   const queries = require('./src/uilib/search/searchQuery')
-  if (queries) {
-    plugins.push({
-      resolve: 'gatsby-plugin-algolia',
-      options: {
-        appId: process.env.ALGOLIA_APP_ID,
-        apiKey: process.env.ALGOLIA_API_KEY,
-        indexName: process.env.ALGOLIA_INDEX_NAME, // for all queries
-        queries,
-        chunkSize: 10000, // default: 1000
-      },
-    })
-  }
+  // if (queries) {
+  //   plugins.push({
+  //     resolve: 'gatsby-plugin-algolia',
+  //     options: {
+  //       appId: process.env.ALGOLIA_APP_ID,
+  //       apiKey: process.env.ALGOLIA_API_KEY,
+  //       indexName: process.env.ALGOLIA_INDEX_NAME, // for all queries
+  //       queries,
+  //       chunkSize: 10000, // default: 1000
+  //     },
+  //   })
+  // }
 }
 
 module.exports = {

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -238,9 +238,9 @@ Add new pages to the storybook by adding a new directory `/stories` and a new fi
 
 ### Eufemia portal
 
-The portal is currently handled by [Gatsby](https://www.gatsbyjs.com/), a framework for building static websites.
+The portal is currently handled by [Gatsby](https://www.gatsbyjs.com/), a framework for building pre-rendered SSR websites.
 
-Run the Portal locally
+Run the Portal locally:
 
 ```bash
 $ yarn start
@@ -248,7 +248,17 @@ $ yarn start
 
 This will start the Portal. You can view the portal website by visiting [localhost:8000](http://localhost:8000/).
 
-Content changes to both Markdown files and styles (SCSS) and code changes will be reflected immediately.
+Content changes to both Markdown (MDX) files and styles (SCSS) and code changes will be reflected immediately.
+
+For a faster startup-time, you can decide what pages you need by using the environment variable `filter` e.g.:
+
+```bash
+$ filter=button yarn start
+# - or –
+$ filter="/button /input/" yarn start
+```
+
+And visit e.g. this page: [http://localhost:8000/uilib/components/button/](http://http://localhost:8000/uilib/components/button/)
 
 #### Local build
 

--- a/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
@@ -32,14 +32,14 @@ test.describe('Page Navigation', () => {
       expect(heading).toContain('Button')
     })
 
-    test('should contain button properties page', async ({ page }) => {
-      await page.goto('/uilib/components/button/properties')
+    test('should contain button demos page', async ({ page }) => {
+      await page.goto('/uilib/components/button/demos')
 
       const title = await page.title()
       expect(title).toContain('Button | Eufemia')
 
       const heading = await page.textContent('h2')
-      expect(heading).toContain('Properties')
+      expect(heading).toContain('Demos')
     })
 
     test('components page should include summary list of components', async ({
@@ -100,16 +100,14 @@ test.describe('Page Navigation', () => {
       expect(heading).toContain('Button')
     })
 
-    test('click on properties tab should open /uilib/components/button/properties', async ({
+    test('click on demos tab should open /uilib/components/button/demos', async ({
       page,
     }) => {
       const element = (await page.locator('main nav a').all()).at(1)
       await element?.click()
       await page.click('nav a[href="/uilib/components/button/"]')
-      await page.click(
-        'main a[href="/uilib/components/button/properties/"]',
-      )
-      await page.waitForURL('**/uilib/components/button/properties/')
+      await page.click('main a[href="/uilib/components/button/demos/"]')
+      await page.waitForURL('**/uilib/components/button/demos/')
       await page.waitForSelector('#dnb-drawer-list__portal', {
         state: 'attached',
       })
@@ -118,7 +116,7 @@ test.describe('Page Navigation', () => {
       expect(title).toContain('Button | Eufemia')
 
       const heading = await page.textContent('h2')
-      expect(heading).toContain('Properties')
+      expect(heading).toContain('Demos')
     })
 
     test('components page should include summary list of components', async ({


### PR DESCRIPTION
This PR:

- adds the possibility to start the portal with only some pages e.g.: `filter=/button yarn start`
- and it speeds up our e2e and visual tests by simply not building some docs pages.

The CI speed improvement is for sure only in the "build" step. There we safe 50% of the duration. We go from 16 min to 8 min. Also because the bundle is smaller, the upload and the download process of the artifacts is faster.