### PR TITLE
docs(Dialog): Dialog.Actions to Dialog.Action

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
@@ -72,7 +72,7 @@ Use the `openState` prop to automatically trigger the Dialog, here demonstrated 
 
 ### Cookie concent Dialog
 
-Provide a custom set of buttons, like this cookie concent Dialog that has a `tertiary` "Administrate" button. Notice that the `close` function will be provided for every child of type [Button](/uilib/components/button) given to `Dialog.Actions`.
+Provide a custom set of buttons, like this cookie concent Dialog that has a `tertiary` "Administrate" button. Notice that the `close` function will be provided for every child of type [Button](/uilib/components/button) given to `Dialog.Action`.
 
 <DialogConfirmCookies />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
@@ -39,7 +39,7 @@ To provide custom content to parts of the Dialog, a set of component parts are p
 
 - `<Dialog.Navigation>`: The navigation field at the top of the component, default with a close button (Equal to the prop `navContent`).
 - `<Dialog.Header>`: The header field of the component, where the `title` will appear (Equal to the prop `headerContent`).
-- `<Dialog.Actions>`: An optional field for buttons at the bottom of the component. This field will appear by default for variant `confirmation`.
+- `<Dialog.Action>`: An optional field for buttons at the bottom of the component. This field will appear by default for variant `confirmation`.
 
 ### More detailed information
 


### PR DESCRIPTION
Changed `Dialog.Actions` to `Dialog.Action` in the docs.
