### PR TITLE
fix(ProgressIndicator): ensure correct positioning inside its boundary

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -2317,6 +2317,7 @@ label + .dnb-dropdown[class*=__form-status] .dnb-dropdown__shell {
 }
 .dnb-progress-indicator__circular svg {
   position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -606,6 +606,7 @@ button.dnb-button::-moz-focus-inner {
 }
 .dnb-progress-indicator__circular svg {
   position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`ProgressIndicator scss has to match style dependencies css 1`] = `
 }
 .dnb-progress-indicator__circular svg {
   position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
+++ b/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
@@ -60,6 +60,7 @@
 
     svg {
       position: absolute;
+      inset: 0;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
Re-prod: https://codesandbox.io/s/busy-haibt-fwyzqg?file=/src/App.js

Because of the `position: absolute` used in the `svg` elements. When using special app CSS like `text-align: center`, we need to ensure the position gets not influenced/changed.