### PR TITLE
chore(Modal): safeguarding focusing element

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -252,7 +252,9 @@ export default class ModalContent extends React.PureComponent<
               focusElement = elem.querySelector(focus_selector)
             }
 
-            focusElement.focus()
+            if (focusElement?.focus) {
+              focusElement.focus()
+            }
 
             const noH1Elem = elem.querySelector('h1, h2, h3')
             if (noH1Elem?.tagName !== 'H1') {


### PR DESCRIPTION
When debugging/using the Modal, I often get the following error/warning in the console:

```
Eufemia TypeError: Cannot read properties of null (reading 'focus')
    at ModalContent.tsx:259:1
```

This PR tries to safeguard the usage of .focus(), so that we don't see the error/warning all the time