### PR TITLE
chore: removes label of code editor

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -215,9 +215,7 @@ class LiveCode extends React.PureComponent<
               )}
               ref={this._editorElementRef}
             >
-              <label className="dnb-sr-only" htmlFor={this._id}>
-                Code Editor
-              </label>
+              <span className="dnb-sr-only">Code Editor</span>
               <LiveEditor
                 id={this._id}
                 className="dnb-live-editor__editable dnb-pre"


### PR DESCRIPTION
My console is full of warnings when running the portal(yarn start) locally:
<img width="1792" alt="Screenshot 2023-09-11 at 12 35 37" src="https://github.com/dnbexperience/eufemia/assets/1359205/9af94568-e66a-43c0-bd22-052073041d13">

I believe the reason for this is because label doesn't connect to one of the follow elements(as the code/live editor doesn't use any of these elements):
`Elements that can be associated with a <label> element include <button>, <input> (except for type="hidden"), <meter>, <output>, <progress>, <select> and <textarea>.` - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

