### PR TITLE
chore(Forms): remove data-testid from components

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/advanced-blocks/StepsLayout/NextButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/advanced-blocks/StepsLayout/NextButton/properties.mdx
@@ -4,7 +4,6 @@ showTabs: true
 
 ## Properties
 
-| Property      | Type         | Description               |
-| ------------- | ------------ | ------------------------- |
-| `children`    | `React.Node` | _(required)_ Button text. |
-| `data-testid` | `string`     | _(required)_ Test ID.     |
+| Property   | Type         | Description               |
+| ---------- | ------------ | ------------------------- |
+| `children` | `React.Node` | _(required)_ Button text. |

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/advanced-blocks/StepsLayout/PreviousButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/advanced-blocks/StepsLayout/PreviousButton/properties.mdx
@@ -4,7 +4,6 @@ showTabs: true
 
 ## Properties
 
-| Property      | Type         | Description               |
-| ------------- | ------------ | ------------------------- |
-| `children`    | `React.Node` | _(required)_ Button text. |
-| `data-testid` | `string`     | _(required)_ Test ID.     |
+| Property   | Type         | Description               |
+| ---------- | ------------ | ------------------------- |
+| `children` | `React.Node` | _(required)_ Button text. |

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/DataContext/SubmitButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/DataContext/SubmitButton/properties.mdx
@@ -4,7 +4,6 @@ showTabs: true
 
 ## Properties
 
-| Property      | Type         | Description               |
-| ------------- | ------------ | ------------------------- |
-| `children`    | `React.Node` | _(required)_ Button text. |
-| `data-testid` | `string`     | _(required)_ Test ID.     |
+| Property   | Type         | Description               |
+| ---------- | ------------ | ------------------------- |
+| `children` | `React.Node` | _(required)_ Button text. |


### PR DESCRIPTION
I was not able to find any reference to these properties in any of our tests or actual source code, so I think it's safe to remove from the docs 🙏 