### PR TITLE
fix(Forms): precede children over title in Form.Selection

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection.tsx
@@ -174,7 +174,7 @@ function Selection(props: Props) {
             ? {
                 selected_key: String(child.props.value ?? ''),
                 content: [
-                  child.props.title ?? child.props.children ?? (
+                  child.props.children ?? child.props.title ?? (
                     <em>Untitled</em>
                   ),
                   child.props.text,
@@ -182,7 +182,7 @@ function Selection(props: Props) {
               }
             : {
                 selected_key: child.props.value,
-                content: child.props.title ?? child.props.children,
+                content: child.props.children ?? child.props.title,
               }
         }
 


### PR DESCRIPTION
If a `<Field.Option>` in a `dropdown` `<Field.Selection>` has `title` and `children` properties, the `title` property precedes the `children` property. That is reversed logic from the `<Field.Option>` component, where the `children` property precedes the `title` property.

This commit aligns the logic with the `<Field.Option>` component, making the `children` property precede the `title` property.

