### PR TITLE
demo: remove replaceHydrationFunction

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-browser.tsx
+++ b/packages/dnb-design-system-portal/gatsby-browser.tsx
@@ -5,7 +5,6 @@
 
 import { applyPageFocus } from '@dnb/eufemia/src/shared/helpers'
 import { rootElement, pageElement } from './src/core/PortalProviders'
-import ReactDOM from 'react-dom/client'
 
 if (typeof window !== 'undefined') {
   setIsTest(window.location)
@@ -15,15 +14,6 @@ function setIsTest(location) {
   if (location && location.href.includes('data-visual-test')) {
     globalThis.IS_TEST = true
     document.documentElement.setAttribute('data-visual-test', 'true')
-  }
-}
-
-export const replaceHydrateFunction = () => {
-  // Added to solve the following errors, which prevented us from running screenshot tests
-  // https://github.com/gatsbyjs/gatsby/discussions/36232
-  return (element: React.ReactElement, container: HTMLElement) => {
-    const root = ReactDOM.createRoot(container)
-    root.render(element)
   }
 }
 


### PR DESCRIPTION
This PR is just highlighting the failing builds/jobs and console errors in the portal(deploy preview) that happens when just removing the replaceHydrationFunction:

<img width="1792" alt="image" src="https://github.com/dnbexperience/eufemia/assets/1359205/28e43a35-5606-4ab5-b606-fa180365c82e">
