### PR TITLE
chore(CI): ensure e2e to wait before build is finished

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,7 +141,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
+        uses: fountainhead/action-wait-for-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Run portal build
@@ -223,7 +223,7 @@ jobs:
         run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox
 
       - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
+        uses: fountainhead/action-wait-for-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Run portal build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,6 +103,7 @@ jobs:
           path: ./packages/dnb-design-system-portal/public
 
   visual-test:
+    needs: portal-build
     name: Run visual e2e-tests
 
     runs-on: macos-latest
@@ -139,15 +140,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --immutable
-
-      - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Run portal build
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 10
-          timeoutSeconds: 2400
 
       - name: Re-store portal artifacts
         uses: actions/download-artifact@v3
@@ -188,6 +180,7 @@ jobs:
         continue-on-error: true
 
   portal-test:
+    needs: portal-build
     name: Run portal e2e-tests
 
     runs-on: ubuntu-latest
@@ -221,15 +214,6 @@ jobs:
       - name: Install Playwright
         if: steps.playwright-binary-cache.outputs.cache-hit != 'true'
         run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox
-
-      - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Run portal build
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 10
-          timeoutSeconds: 2400
 
       - name: Re-store portal artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -98,7 +98,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
+        uses: fountainhead/action-wait-for-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Fetch and Build Icons # Has to be the action name

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   process-icons:
-    name: Fetch and Build Icons # this name is used in "checkName"
+    name: Fetch and Build Icons
 
     runs-on: ubuntu-latest
 
@@ -71,6 +71,7 @@ jobs:
         run: yarn workspace @dnb/eufemia postbuild:commit
 
   visual-test:
+    needs: process-icons
     name: Run visual e2e-test for icons
 
     runs-on: macos-latest
@@ -96,15 +97,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --immutable
-
-      - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Fetch and Build Icons # Has to be the action name
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 10
-          timeoutSeconds: 2400
 
       - name: Re-store portal artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Our `action-wait-for-check` did not wait anymore. So build did fail right away. To overcome this, we can simply upgrade the the latest version.

More info about the GitHub API change: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

