### PR TITLE
chore(CI): make e2e run shorter by removing artifacts handling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,41 +35,46 @@ env:
   RUN_POST_BUILD: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
 
 jobs:
-  portal-build:
-    name: Run portal build
+  visual-test:
+    name: Run visual e2e-tests
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Git checkout
-        if: env.RUN_POST_BUILD == 'false'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Git checkout (with fetch-depth)
-        if: env.RUN_POST_BUILD == 'true'
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 20 # The "postbuild:ci" method "getCommittedFiles" needs all history
 
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
 
-      - name: Use node_modules cache
+      - name: Use yarn cache
         uses: actions/cache@v3
-        id: modules-cache
+        id: yarn-cache
         with:
-          path: '**/node_modules'
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
+          path: ./.yarn/cache
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-
 
       - name: Install dependencies
-        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
+
+      - name: Use Playwright cache
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/Library/Caches/ms-playwright
+            ~/.cache/ms-playwright
+            %USERPROFILE%\AppData\Local\ms-playwright
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn dlx playwright install --with-deps firefox
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: yarn dlx playwright install-deps firefox
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Prebuild Library
         if: env.RUN_POST_BUILD == 'true'
@@ -95,57 +100,6 @@ jobs:
 
       - name: Build portal
         run: yarn workspace dnb-design-system-portal build:visual-test
-
-      - name: Store portal artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: portal-build-artifact
-          path: ./packages/dnb-design-system-portal/public
-
-  visual-test:
-    needs: portal-build
-    name: Run visual e2e-tests
-
-    runs-on: macos-latest
-
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-
-      - name: Use yarn cache
-        uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ./.yarn/cache
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-deps-
-
-      - name: Use Playwright cache
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: ~/Library/Caches/ms-playwright
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
-      - run: npx playwright-firefox install --with-deps firefox
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright-firefox install-deps firefox
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Re-store portal artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: portal-build-artifact
-          path: ./packages/dnb-design-system-portal/public
 
       - name: Run visual tests
         run: yarn workspace dnb-design-system-portal test:screenshots:ci
@@ -180,7 +134,6 @@ jobs:
         continue-on-error: true
 
   portal-test:
-    needs: portal-build
     name: Run portal e2e-tests
 
     runs-on: ubuntu-latest
@@ -201,25 +154,47 @@ jobs:
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
 
-      - name: Use Playwright cache
-        uses: actions/cache@v3
-        id: playwright-binary-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-binary-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Install Playwright
-        if: steps.playwright-binary-cache.outputs.cache-hit != 'true'
-        run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox
-
-      - name: Re-store portal artifacts
-        uses: actions/download-artifact@v3
+      - name: Use Playwright cache
+        uses: actions/cache@v3
+        id: playwright-cache
         with:
-          name: portal-build-artifact
-          path: ./packages/dnb-design-system-portal/public
+          path: |
+            ~/Library/Caches/ms-playwright
+            ~/.cache/ms-playwright
+            %USERPROFILE%\AppData\Local\ms-playwright
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn dlx playwright install --with-deps firefox
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: yarn dlx playwright install-deps firefox
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+      - name: Prebuild Library
+        if: env.RUN_POST_BUILD == 'true'
+        run: yarn workspace @dnb/eufemia prebuild:ci
+
+      - name: Postbuild Library
+        if: env.RUN_POST_BUILD == 'true'
+        run: yarn workspace @dnb/eufemia postbuild:ci
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=timestamp::$(date +'%Y-%W')"
+
+      - name: Use Gatsby cache
+        uses: actions/cache@v3
+        id: gatsby-cache
+        with:
+          path: |
+            ./packages/dnb-design-system-portal/.cache
+            ./packages/dnb-design-system-portal/public
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-${{ steps.date.outputs.timestamp }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-
+
+      - name: Build portal
+        run: yarn workspace dnb-design-system-portal build:visual-test
 
       - name: Run Playwright
         run: yarn workspace dnb-design-system-portal test:e2e:ci

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 gatsby build",
     "build:ci": "yarn build:version && gatsby build --prefix-paths",
     "build:version": "node ./scripts/version.js --new-version",
-    "build:visual-test": "SKIP_IMAGE_PROCESSING=1 IS_VISUAL_TEST=1 NODE_OPTIONS=--max-old-space-size=8192 gatsby build --no-uglify",
+    "build:visual-test": "SKIP_IMAGE_PROCESSING=1 IS_VISUAL_TEST=1 gatsby build --no-uglify",
     "clean": "gatsby clean",
     "lint": "eslint --quiet .",
     "lint:ci": "NODE_ENV=test yarn lint:js && yarn lint:styles && yarn prettier:check && yarn prettier:package",


### PR DESCRIPTION
With the problems occurring and the fix for it in [this PR](https://github.com/dnbexperience/eufemia/pull/2681), we now run the e2e tests after the portal build. 
Before, they could at least start the dependency install before they did wait for the build to be finished. 

But also the artifact upload/download was pretty slow. So it added a lot to the total time.

Anyway, all this was only because the macOS runners where so much slower than the one run on Linux. But that looks not be true anymore. So this PR runs all in one job on macOS.

Also, we need to remove the requirement of these runners:

<img width="658" alt="Screenshot 2023-09-27 at 08 59 44" src="https://github.com/dnbexperience/eufemia/assets/1501870/a582fa01-6adf-45ee-b380-94fb58581b97">

⚠️ And add the new one `Run e2e-tests` as required.

📢 And everyone needs to rebase from main, when this PR is merged. 

With this PR we go from around 33m to 24m of total e2e test run duration.