### PR TITLE
fix(Breadcrumb): avoid React warning about duplication of key

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -32,7 +32,7 @@ export const BreadcrumbMultiple = ({
         {data?.map((breadcrumbItem, i) => {
           return (
             <BreadcrumbItem
-              key={`${breadcrumbItem.text}`}
+              key={i}
               variant={
                 (i == 0 && 'home') ||
                 (i == data.length - 1 && 'current') ||


### PR DESCRIPTION
... when same text is used in two items.

<img width="802" alt="Screenshot 2023-09-27 at 08 57 50" src="https://github.com/dnbexperience/eufemia/assets/1501870/37cb59d1-7c72-49d8-bd33-3c5e92b351ad">


