### PR TITLE
docs(First Steps): fixes broken link to installation documentation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.mdx
@@ -12,7 +12,7 @@ import { Icon } from '@dnb/eufemia/src'
 
 To give you an overall picture of the Design System, you may read [Getting Started](/uilib/getting-started) as a first introduction.
 
-## Installation
+## Installing
 
 Check out the `@dnb/eufemia` **[Installation documentation](/uilib/usage/#installation)**.
 


### PR DESCRIPTION
The link did not work, see here https://eufemia.dnb.no/uilib/usage/first-steps/ and try to press the `"installation documentation"`-link.

This fix changes the heading from `Installation` to `Installing`, as it somehow makes the link https://eufemia.dnb.no/uilib/usage/first-steps/#installation work. 

I could also rather kept the existing header(Installation) and added a "/" to the end of the link, like https://eufemia.dnb.no/uilib/usage/first-steps/#installation/

Not sure which solution that's preferred to make the link work 🙏 