### PR TITLE
chore(PostalCodeAndCity): adds support for help prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -69,6 +69,26 @@ export const LabelAndValue = () => {
   )
 }
 
+export const WithHelp = () => {
+  return (
+    <ComponentBox scope={{ Field }}>
+      <Field.PostalCodeAndCity
+        postalCode={{
+          onChange: (value) => console.log('postalCode onChange', value),
+        }}
+        city={{
+          onChange: (value) => console.log('city onChange', value),
+        }}
+        help={{
+          title: 'Help is available',
+          contents:
+            'Helping others, encouraging others, are often acts of being kind that have more meaning that you may realize.',
+        }}
+      />
+    </ComponentBox>
+  )
+}
+
 export const Disabled = () => {
   return (
     <ComponentBox scope={{ Field }}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -26,6 +26,10 @@ import * as Examples from './Examples'
 
 <Examples.Disabled />
 
+### With help
+
+<Examples.WithHelp />
+
 ### Error
 
 <Examples.Error />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
@@ -12,6 +12,7 @@ import DataValueReadwriteProperties from '../../data-value-readwrite-properties.
 
 | Property                                    | Type                | Description                                                                                                            |
 | ------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `help`                                      | `object`            | _(optional)_ Provide a help button. Object consisting of `title` and `contents`                                        |
 | `postalCode`                                | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code. |
 | `city`                                      | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for city.        |
 | `width`                                     | `string` or `false` | _(optional)_ `small`, `medium` or `large` for predefined standard widths.                                              |

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity.tsx
@@ -3,8 +3,10 @@ import classnames from 'classnames'
 import SharedContext from '../../../shared/Context'
 import FieldBlock, { Props as FieldBlockProps } from '../FieldBlock'
 import StringComponent, { Props as StringComponentProps } from './String'
+import { FieldHelpProps } from '../types'
 
-export type Props = Omit<FieldBlockProps, 'children'> &
+export type Props = FieldHelpProps &
+  Omit<FieldBlockProps, 'children'> &
   Record<'postalCode' | 'city', StringComponentProps> & {
     width?: 'small' | 'medium' | 'large'
   }
@@ -16,6 +18,7 @@ function PostalCodeAndCity(props: Props) {
     postalCode = {},
     city = {},
     width = 'large',
+    help,
     ...fieldBlockProps
   } = props
 
@@ -68,6 +71,7 @@ function PostalCodeAndCity(props: Props) {
             ...city.errorMessages,
           }}
           width="stretch"
+          help={help}
         />
       </div>
     </FieldBlock>


### PR DESCRIPTION
Not 100% sure which commit decoration I should use(chore vs. feat), I would normally use feat, but since this is under the "beta flag" 🤔 ....