### PR TITLE
chore(DatePicker): fix no label associated with a form field

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/demos.mdx
@@ -77,7 +77,7 @@ import enUS from '@dnb/eufemia/shared/locales/en-US'
 
 <DatePickerLinked />
 
-### DatePicker with error status
+### DatePicker with error status (no input)
 
 <DatePickerNoInputStatus />
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
@@ -572,7 +572,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'dl' + i}
                   hidden
                   id={`${this.props.id}-${mode}-day-label`}
-                  for={`${this.props.id}-${mode}-day`}
+                  htmlFor={`${this.props.id}-${mode}-day`}
                 >
                   {isRangeLabel + day}
                 </label>
@@ -604,7 +604,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'ml' + i}
                   hidden
                   id={`${this.props.id}-${mode}-month-label`}
-                  for={`${this.props.id}-${mode}-month`}
+                  htmlFor={`${this.props.id}-${mode}-month`}
                 >
                   {isRangeLabel + month}
                 </label>
@@ -636,7 +636,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'yl' + i}
                   hidden
                   id={`${this.props.id}-${mode}-year-label`}
-                  for={`${this.props.id}-${mode}-year`}
+                  htmlFor={`${this.props.id}-${mode}-year`}
                 >
                   {isRangeLabel + year}
                 </label>

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
@@ -572,6 +572,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'dl' + i}
                   hidden
                   id={`${this.props.id}-${mode}-day-label`}
+                  for={`${this.props.id}-${mode}-day`}
                 >
                   {isRangeLabel + day}
                 </label>
@@ -603,6 +604,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'ml' + i}
                   hidden
                   id={`${this.props.id}-${mode}-month-label`}
+                  for={`${this.props.id}-${mode}-month`}
                 >
                   {isRangeLabel + month}
                 </label>
@@ -634,6 +636,7 @@ export default class DatePickerInput extends React.PureComponent {
                   key={'yl' + i}
                   hidden
                   id={`${this.props.id}-${mode}-year-label`}
+                  for={`${this.props.id}-${mode}-year`}
                 >
                   {isRangeLabel + year}
                 </label>

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1575,11 +1575,25 @@ describe('Custom text for buttons', () => {
 })
 
 describe('DatePicker ARIA', () => {
-  it('should validate with ARIA rules', async () => {
+  it('should validate', async () => {
     const Comp = render(
       <DatePicker
         range={true}
         opened={true}
+        disable_autofocus={true}
+        start_date="2019-05-05"
+        end_date="2019-06-05"
+      />
+    )
+    expect(await axeComponent(Comp)).toHaveNoViolations()
+  })
+
+  it('should validate with input', async () => {
+    const Comp = render(
+      <DatePicker
+        range={true}
+        opened={true}
+        show_input={true}
         disable_autofocus={true}
         start_date="2019-05-05"
         end_date="2019-06-05"


### PR DESCRIPTION
Fixes the following "possible improvement" from Chrome's console:

```
No label associated with a form field
A <label> isn't associated with a form field.
To fix this issue, nest the <input> in the <label> or provide a for attribute on the <label> that matches a form field id.
```

<img width="470" alt="Screenshot 2023-09-29 at 12 18 21" src="https://github.com/dnbexperience/eufemia/assets/1359205/f5ecc574-ba39-41fd-bba4-258f3c1943d6">

