### PR TITLE
docs(PaymentCard): adds docs for formatCardNumber function

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card.mdx
@@ -11,6 +11,8 @@ tabs:
     key: /uilib/extensions/payment-card/properties
   - title: Products
     key: /uilib/extensions/payment-card/products
+  - title: Helpers
+    key: /uilib/extensions/payment-card/helpers
 redirect_from:
   - /uilib/patterns/payment-card
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
@@ -1,0 +1,24 @@
+---
+showTabs: true
+---
+
+## Helpers
+
+### formatCardNumber
+
+Formats card number.
+Will by default limit the number of characters in the card number to be of 8 characters.
+Can be specified by using the `digits` param.
+
+```js
+import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'
+
+formatCardNumber(cardNumber: string, digits*: number) // returns string
+
+formatCardNumber('************1337') // returns **** 1337
+formatCardNumber('************1337', 5) // returns * 1337
+```
+
+#### \* Optional values (defaults)
+
+- length = _8_


### PR DESCRIPTION
This PR adds the `formatCardNumber` to our docs in the portal.

Here's a quick link to test/look at the new docs for `formatCardNumber` in the deploy preview:
https://eufemia-git-docs-add-docs-about-the-format-card-580b8c-eufemia.vercel.app/uilib/extensions/payment-card/helpers/