### PR TITLE
chore(CI): makes visual tests less flaky 

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestPuppeteerEnvironment.js
+++ b/packages/dnb-eufemia/src/core/jest/jestPuppeteerEnvironment.js
@@ -56,6 +56,8 @@ class JestEnvironment extends PlaywrightEnvironment {
     }
 
     if (config.retryTimes > 0) {
+      this.global.retryAttempt = 0
+
       if (event.name === 'test_fn_failure') {
         const currentTestName = this.getCurrentTestName(state)
         const slug = slugify(currentTestName)
@@ -69,6 +71,8 @@ class JestEnvironment extends PlaywrightEnvironment {
         }
 
         const retryAttempt = state.currentlyRunningTest.invocations
+        this.global.retryAttempt = retryAttempt
+
         console.log(
           chalk.yellow(
             `Retry attempt #${retryAttempt}: ${currentTestName}`

--- a/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
@@ -32,7 +32,7 @@ const config = {
     height: 2048,
   },
   matchConfig: {
-    failureThreshold: 0.001, // Chromium needs 0.03, while webkit needs 0.04 or even more
+    failureThreshold: isCI ? 0.001 : 0, // Chromium needs 0.03, while webkit needs 0.04 or even more
     failureThresholdType: 'percent',
     comparisonMethod: 'pixelmatch',
     customSnapshotIdentifier: ({ currentTestName }) => {
@@ -294,7 +294,7 @@ async function makePageReady({
 
     global.themeName = themeName
     global.pageUrl = createUrl(url, fullscreen, themeName)
-    process.env.pageUrl = global.pageUrl
+
     await page.goto(global.pageUrl, {
       waitUntil: config.waitUntil,
       timeout: config.timeout,
@@ -304,6 +304,10 @@ async function makePageReady({
       // Remove all stored
       window.localStorage.clear()
     })
+  }
+
+  if (global.retryAttempt) {
+    await page.reload()
   }
 
   global.IS_TEST = true


### PR DESCRIPTION
Probably, after we switched from puppeteer to playwright (PR #1945), our retry mechanism did not work as it should anymore. So retries did nothing more than making a new screenshot.

With this PR, we refresh the page during the retry moment. I hope this will help to make visual tests fail less.