### PR TITLE
chore(CI): make a full build for the playwright e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -188,7 +188,7 @@ jobs:
           restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-gatsby-
 
       - name: Build portal
-        run: yarn workspace dnb-design-system-portal build:visual-test
+        run: yarn workspace dnb-design-system-portal build
 
       - name: Run Playwright
         run: yarn workspace dnb-design-system-portal test:e2e:ci


### PR DESCRIPTION
Just because, we have the time. And with that, we run one stripped build for the visual tests (to save total time) and one full build for the playwright e2e tests. Witch is a perfect match.