### PR TITLE
chore(Portal): remove commons for appearing in the build logs

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -80,7 +80,7 @@
     "gatsby-plugin-babel-react-live": "1.4.2",
     "gatsby-plugin-catch-links": "5.12.0",
     "gatsby-plugin-emotion": "8.12.0",
-    "gatsby-plugin-eufemia-theme-handler": "1.5.0",
+    "gatsby-plugin-eufemia-theme-handler": "1.5.1",
     "gatsby-plugin-gatsby-cloud": "5.12.0",
     "gatsby-plugin-manifest": "5.12.0",
     "gatsby-plugin-mdx": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12605,7 +12605,7 @@ __metadata:
     gatsby-plugin-babel-react-live: 1.4.2
     gatsby-plugin-catch-links: 5.12.0
     gatsby-plugin-emotion: 8.12.0
-    gatsby-plugin-eufemia-theme-handler: 1.5.0
+    gatsby-plugin-eufemia-theme-handler: 1.5.1
     gatsby-plugin-gatsby-cloud: 5.12.0
     gatsby-plugin-manifest: 5.12.0
     gatsby-plugin-mdx: 5.12.0
@@ -15764,9 +15764,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-eufemia-theme-handler@npm:1.5.0":
-  version: 1.5.0
-  resolution: "gatsby-plugin-eufemia-theme-handler@npm:1.5.0"
+"gatsby-plugin-eufemia-theme-handler@npm:1.5.1":
+  version: 1.5.1
+  resolution: "gatsby-plugin-eufemia-theme-handler@npm:1.5.1"
   dependencies:
     gatsby-core-utils: 4.12.0
     globby: 11.0.4
@@ -15777,7 +15777,7 @@ __metadata:
     "@dnb/eufemia": ">=10"
     gatsby: ">=4"
     react: ">=17"
-  checksum: 761f5e8d3dba9daa77e4aa832a0817f7c2e53a81e0d98f956ead80899fc4e9847439ed738c6ff50ed34771f5c7f683bf17d6d5bd5c88523d70159420a107f189
+  checksum: 6b72b1ed191ef565cd0e100055445346225ff457f52fc5f60a409719ad311219cf5b27a3e105d09d06695a22841ca5af211583dec1c6b54b037d40d051ff7fb5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With [this release](https://github.com/dnbexperience/gatsby-plugin-eufemia-theme-handler/pull/14).

<img width="793" alt="Screenshot 2023-10-01 at 17 51 05" src="https://github.com/dnbexperience/eufemia/assets/1501870/3df67e59-98c6-439f-a735-350362673a25">
