### PR TITLE
fix(PhoneNumber): remove default +47 value

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber.tsx
@@ -23,9 +23,6 @@ function PhoneNumber(props: Props) {
   const sharedContext = useContext(SharedContext)
   const preparedProps: Props = {
     ...props,
-    // Important for the default value to be defined here, and not after the useDataValue call, to avoid the UI jumping
-    // back to +47 once the user empty the field so handleChange send out undefined.
-    value: '+47',
     errorMessages: {
       required: sharedContext?.translation.Forms.phoneNumberErrorRequired,
       ...props?.errorMessages,
@@ -104,7 +101,7 @@ function PhoneNumber(props: Props) {
           countryCodeFieldClassName
         )}
         label={countryCodeLabel}
-        value={countryCode ?? '+47'}
+        value={countryCode}
         disabled={disabled}
         onChange={handleCountryCodeChange}
       />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/__tests__/PhoneNumber.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { wait } from '../../../../core/jest/jestSetup'
+import { fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PhoneNumber from '../PhoneNumber'
+
+describe('Field.PhoneNumber', () => {
+  it('should return correct value onFocus and onBlur event', async () => {
+    const onFocus = jest.fn()
+    const onBlur = jest.fn()
+    render(<PhoneNumber onFocus={onFocus} onBlur={onBlur} />)
+
+    const phoneElement = document.querySelector(
+      '.dnb-forms-field-phone-number__number input'
+    )
+
+    fireEvent.focus(phoneElement)
+    expect(onFocus).toHaveBeenLastCalledWith(undefined)
+
+    fireEvent.blur(phoneElement)
+    expect(onBlur).toHaveBeenLastCalledWith(undefined)
+
+    await userEvent.type(phoneElement, '99999999')
+
+    fireEvent.focus(phoneElement)
+    expect(onFocus).toHaveBeenLastCalledWith('99999999')
+
+    fireEvent.blur(phoneElement)
+    expect(onBlur).toHaveBeenLastCalledWith('99999999')
+  })
+
+  it('should return correct value onChange event', async () => {
+    const onChange = jest.fn()
+    const onCountryCodeChange = jest.fn()
+    render(
+      <PhoneNumber
+        onChange={onChange}
+        onCountryCodeChange={onCountryCodeChange}
+      />
+    )
+
+    const phoneElement = document.querySelector(
+      '.dnb-forms-field-phone-number__number input'
+    )
+    await userEvent.type(phoneElement, '99999999')
+    expect(onChange).toHaveBeenLastCalledWith('99999999')
+
+    const codeElement = document.querySelector(
+      '.dnb-forms-field-phone-number__country-code input'
+    )
+
+    await userEvent.type(codeElement, '+41')
+    fireEvent.keyDown(codeElement, {
+      keyCode: 40, // down
+    })
+    fireEvent.keyDown(codeElement, {
+      keyCode: 13, // enter
+    })
+    await wait(1)
+    expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
+    expect(onChange).toHaveBeenLastCalledWith('+41 99999999')
+  })
+})


### PR DESCRIPTION
Link to Slack thread: https://dnb-it.slack.com/archives/CMXABCHEY/p1695840538402859

I do myself find it a bit strange that the value of is +47 when there's no country code selected.
The following video is from `main` branch running locally, showcasing the scenario I wan't to fix/improve with this PR.

https://github.com/dnbexperience/eufemia/assets/1359205/85e67ba9-8295-4a55-b74a-9a0d08d4dffc

