### PR TITLE
docs(ArraySelection): removes redundant/circular link

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection/info.mdx
@@ -5,5 +5,3 @@ showTabs: true
 ## Description
 
 `Field.ArraySelection` is a component for selecting between a fixed set of options using a dropdown, checkboxes or similar, that will produce a value in the form of an array containing the values of selected options.
-
-There is a corresponding [Field.ArraySelection](/uilib/extensions/forms/base-fields/ArraySelection/) component.


### PR DESCRIPTION
1. We don't need to link to the same page as the user is in.
2. I don't think there exists a Value.ArraySelection hence me just removing the link, instead of changing it to link to "Value.ArraySelection".