### PR TITLE
chore(Flex.Container): add spacing support for all components

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
@@ -26,7 +26,7 @@ When a element or component was given, that does not support spacing, it will st
 
 You may else wrap your custom component in a `Flex.Item` – this way, you still can change the spacing per component basis.
 
-Technically, `Flex.Container` checks if a nested component has a property called `_supportsEufemiaSpacingProps`. So if you have a component that supports the [spacing properties](/uilib/layout/space/), you can add this property `ComponentName._supportsEufemiaSpacingProps = true`.
+Technically, `Flex.Container` checks if a nested component has a property called `_supportsSpacingProps`. So if you have a component that supports the [spacing properties](/uilib/layout/space/), you can add this property `ComponentName._supportsSpacingProps = true`.
 
 ### Horizontal and Vertical aliases
 

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -520,4 +520,6 @@ Accordion.Store = (id: string) => {
   return new Store({ id })
 }
 
+Accordion._supportsSpacingProps = true
+
 export default Accordion

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -185,3 +185,5 @@ export default function AccordionContent(props: AccordionContentProps) {
     </HeightAnimation>
   )
 }
+
+AccordionContent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -116,4 +116,6 @@ const AccordionGroup = (props: AccordionGroupProps) => {
   )
 }
 
+AccordionGroup._supportsSpacingProps = true
+
 export default AccordionGroup

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -427,4 +427,6 @@ AccordionHeader.Icon = AccordionHeaderIcon
 AccordionHeader.Title = AccordionHeaderTitle
 AccordionHeader.Description = AccordionHeaderDescription
 
+AccordionHeader._supportsSpacingProps = true
+
 export default AccordionHeader

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -141,6 +141,10 @@ const Anchor = React.forwardRef(
   }
 )
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Anchor._supportsSpacingProps = true
+
 export default Anchor
 
 export function scrollToHashHandler(

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -2050,3 +2050,5 @@ class AutocompleteInstance extends React.PureComponent {
 }
 
 Autocomplete.HorizontalItem = DrawerList.HorizontalItem
+
+Autocomplete._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -165,4 +165,6 @@ Avatar.Group = AvatarGroup
 
 export { AvatarGroup }
 
+Avatar._supportsSpacingProps = true
+
 export default Avatar

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -178,4 +178,6 @@ function ElementsHidden(props: ElementsHiddenProps) {
   )
 }
 
+AvatarGroup._supportsSpacingProps = true
+
 export default AvatarGroup

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -15,7 +15,7 @@ import {
   validateDOMAttributes,
 } from '../../shared/component-helper'
 
-export interface BadgeProps {
+export type BadgeProps = {
   /**
    * Aria label to describe the badge
    * Default: null
@@ -161,5 +161,7 @@ function Badge(localProps: BadgeAndSpacingProps) {
     )
   }
 }
+
+Badge._supportsSpacingProps = true
 
 export default Badge

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -270,4 +270,6 @@ Breadcrumb.Item = BreadcrumbItem
 
 export { BreadcrumbItem }
 
+Breadcrumb._supportsSpacingProps = true
+
 export default Breadcrumb

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -152,4 +152,6 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
   )
 }
 
+BreadcrumbItem._supportsSpacingProps = true
+
 export default BreadcrumbItem

--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -485,3 +485,5 @@ Content.defaultProps = {
   skeleton: null,
   isIconOnly: null,
 }
+
+Button._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/card/Card.tsx
+++ b/packages/dnb-eufemia/src/components/card/Card.tsx
@@ -49,5 +49,6 @@ function Card(props: Props) {
   )
 }
 
-Card._supportsEufemiaSpacingProps = true
+Card._supportsSpacingProps = true
+
 export default Card

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.js
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.js
@@ -369,3 +369,5 @@ CheckIcon.propTypes = {
 CheckIcon.defaultProps = {
   size: 'default',
 }
+
+CheckIcon._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
@@ -737,3 +737,5 @@ export default class DatePicker extends React.PureComponent {
     )
   }
 }
+
+DatePicker._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -157,4 +157,6 @@ Dialog.Header = DialogHeader
 Dialog.Navigation = DialogNavigation
 Dialog.Action = DialogAction
 
+Dialog._supportsSpacingProps = true
+
 export default Dialog

--- a/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
@@ -160,3 +160,5 @@ export default function DialogContent({
     </div>
   )
 }
+
+DialogContent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -131,4 +131,6 @@ const DialogAction = ({
   )
 }
 
+DialogAction._supportsSpacingProps = true
+
 export default DialogAction

--- a/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
@@ -129,4 +129,6 @@ Drawer.Body = DrawerBody
 Drawer.Header = DrawerHeader
 Drawer.Navigation = DrawerNavigation
 
+Drawer._supportsSpacingProps = true
+
 export default Drawer

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -696,3 +696,5 @@ class DropdownInstance extends React.PureComponent {
 }
 
 Dropdown.HorizontalItem = DrawerList.HorizontalItem
+
+Dropdown._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -205,5 +205,6 @@ function FlexContainer(props: Props) {
   )
 }
 
-FlexContainer._supportsEufemiaSpacingProps = true
+FlexContainer._supportsSpacingProps = true
+
 export default FlexContainer

--- a/packages/dnb-eufemia/src/components/flex/Horizontal.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Horizontal.tsx
@@ -12,5 +12,6 @@ function Horizontal({ children, ...props }: Props) {
   )
 }
 
-Horizontal._supportsEufemiaSpacingProps = true
+Horizontal._supportsSpacingProps = true
+
 export default Horizontal

--- a/packages/dnb-eufemia/src/components/flex/Item.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Item.tsx
@@ -104,5 +104,6 @@ function FlexItem(props: Props) {
   }
 }
 
-FlexItem._supportsEufemiaSpacingProps = true
+FlexItem._supportsSpacingProps = true
+
 export default FlexItem

--- a/packages/dnb-eufemia/src/components/flex/Stack.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Stack.tsx
@@ -28,5 +28,6 @@ function Stack(props: Props) {
   )
 }
 
-Stack._supportsEufemiaSpacingProps = true
+Stack._supportsSpacingProps = true
+
 export default Stack

--- a/packages/dnb-eufemia/src/components/flex/Vertical.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Vertical.tsx
@@ -12,5 +12,6 @@ function Vertical({ children, ...props }: Props) {
   )
 }
 
-Vertical._supportsEufemiaSpacingProps = true
+Vertical._supportsSpacingProps = true
+
 export default Vertical

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -3,6 +3,8 @@ import { act, render } from '@testing-library/react'
 import 'mock-match-media/jest-setup'
 import { setMedia, matchMedia } from 'mock-match-media'
 import Flex from '../Flex'
+import { createSpacingClasses } from '../../space/SpacingUtils'
+import { SpaceProps } from '../../Space'
 
 describe('Flex.Container', () => {
   it('should forward HTML attributes', () => {
@@ -316,6 +318,69 @@ describe('Flex.Container', () => {
     const element = document.querySelector('.dnb-flex-container')
 
     expect(element.tagName).toBe('SECTION')
+  })
+
+  it('should not add a wrapper when _supportsSpacingProps is given', () => {
+    const { rerender } = render(
+      <Flex.Vertical>
+        <Flex.Item>content</Flex.Item>
+        <Flex.Item>content</Flex.Item>
+      </Flex.Vertical>
+    )
+
+    const TestComponent = (props: SpaceProps) => {
+      const cn = createSpacingClasses(props)
+      cn.push('test-item')
+      return <div className={cn.join(' ')}>content</div>
+    }
+
+    {
+      rerender(
+        <Flex.Vertical>
+          <TestComponent />
+          <TestComponent bottom="large" />
+        </Flex.Vertical>
+      )
+
+      const elements = document.querySelectorAll(
+        '.dnb-flex-container > div'
+      )
+      expect(elements[0].className).toBe(
+        'dnb-space dnb-space__top--zero dnb-space__bottom--zero'
+      )
+      expect(elements[1].className).toBe(
+        'dnb-space dnb-space__top--small dnb-space__bottom--zero'
+      )
+      expect((elements[0].firstChild as HTMLElement).className).toBe(
+        'test-item'
+      )
+      expect((elements[1].firstChild as HTMLElement).className).toBe(
+        'dnb-space__bottom--large test-item'
+      )
+    }
+
+    {
+      TestComponent._supportsSpacingProps = true
+
+      rerender(
+        <Flex.Vertical>
+          <TestComponent />
+          <TestComponent bottom="x-large" />
+        </Flex.Vertical>
+      )
+
+      const elements = document.querySelectorAll(
+        '.dnb-flex-container > div'
+      )
+      expect(elements[0].className).toBe(
+        'dnb-space__top--zero dnb-space__bottom--zero test-item'
+      )
+      expect(elements[1].className).toBe(
+        'dnb-space__bottom--x-large dnb-space__top--small test-item'
+      )
+      expect((elements[0].firstChild as HTMLElement).className).toBeFalsy()
+      expect((elements[1].firstChild as HTMLElement).className).toBeFalsy()
+    }
   })
 
   describe('size', () => {

--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -35,5 +35,6 @@ describe('isSpacePropsComponent', () => {
     expect(isSpacePropsComponent(<H5>Heading</H5>)).toBeTruthy()
     expect(isSpacePropsComponent(<H6>Heading</H6>)).toBeTruthy()
     expect(isSpacePropsComponent(<Heading>Heading</Heading>)).toBeTruthy()
+    expect(isSpacePropsComponent(<div>div</div>)).toBeFalsy()
   })
 })

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -62,7 +62,7 @@ export const isSpacePropsComponent = (
 ): boolean => {
   return (
     (React.isValidElement(element) &&
-      element?.type?.['_supportsEufemiaSpacingProps'] === true) ||
+      element?.type?.['_supportsSpacingProps'] === true) ||
     isEufemiaElement(element)
   )
 }

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.js
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.js
@@ -144,3 +144,5 @@ export default class FormLabel extends React.PureComponent {
     return <Element {...params} />
   }
 }
+
+FormLabel._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.js
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.js
@@ -320,3 +320,5 @@ Fieldset.defaultProps = {
   useFieldset: false,
   className: null,
 }
+
+FormRow._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.js
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.js
@@ -136,3 +136,5 @@ export default class FormSet extends React.PureComponent {
     )
   }
 }
+
+FormSet._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.js
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.js
@@ -647,3 +647,5 @@ function sumElementWidth({ widthElement, widthSelector }) {
 
   return width
 }
+
+FormStatus._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -180,3 +180,5 @@ export default function GlobalError(localProps: GlobalErrorAllProps) {
     </Skeleton>
   )
 }
+
+GlobalError._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.js
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.js
@@ -831,3 +831,5 @@ const isElementVisible = (elem, callback, delayFallback = 1e3) => {
   }
   return null
 }
+
+GlobalStatus._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.js
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.js
@@ -156,5 +156,7 @@ class GlobalStatusRemove extends React.PureComponent {
 GlobalStatusController.Remove = GlobalStatusRemove
 GlobalStatusController.Update = GlobalStatusController
 
+GlobalStatusController._supportsSpacingProps = true
+
 export default GlobalStatusController
 export { GlobalStatusRemove }

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.js
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.js
@@ -318,4 +318,6 @@ if (typeof window !== 'undefined') {
   window.GlobalStatusProvider = GlobalStatusProvider
 }
 
+GlobalStatusProvider._supportsSpacingProps = true
+
 export default GlobalStatusProvider

--- a/packages/dnb-eufemia/src/components/grid/Container.tsx
+++ b/packages/dnb-eufemia/src/components/grid/Container.tsx
@@ -64,7 +64,7 @@ function GridContainer(props: AllProps) {
   )
 }
 
-GridContainer._supportsEufemiaSpacingProps = true
+GridContainer._supportsSpacingProps = true
 
 export default GridContainer
 

--- a/packages/dnb-eufemia/src/components/grid/Item.tsx
+++ b/packages/dnb-eufemia/src/components/grid/Item.tsx
@@ -44,7 +44,7 @@ function GridItem(props: AllProps) {
   )
 }
 
-GridItem._supportsEufemiaSpacingProps = true
+GridItem._supportsSpacingProps = true
 
 export default GridItem
 

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -337,7 +337,7 @@ Heading.resetLevels = resetLevels
 Heading.setNextLevel = setNextLevel
 
 Heading._isHeadingElement = true
-Heading._supportsEufemiaSpacingProps = true
+Heading._supportsSpacingProps = true
 
 // Interceptor to reset leveling
 export { resetAllLevels, resetLevels, setNextLevel }

--- a/packages/dnb-eufemia/src/components/help-button/HelpButton.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButton.tsx
@@ -46,3 +46,5 @@ export default function HelpButton(localProps: HelpButtonProps) {
 
   return <HelpButtonInstance {...params} />
 }
+
+HelpButton._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.js
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.js
@@ -69,3 +69,5 @@ export default class IconPrimary extends React.PureComponent {
     )
   }
 }
+
+IconPrimary._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/icon/Icon.js
+++ b/packages/dnb-eufemia/src/components/icon/Icon.js
@@ -437,3 +437,5 @@ export const prerenderIcon = ({
     return null
   }
 }
+
+Icon._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -230,4 +230,6 @@ const InfoCard = (localProps: InfoCardAllProps) => {
   }
 }
 
+InfoCard._supportsSpacingProps = true
+
 export default InfoCard

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.js
@@ -46,6 +46,8 @@ const InputMasked = (props) => {
   )
 }
 
+InputMasked._supportsSpacingProps = true
+
 export default InputMasked
 
 InputMasked.propTypes = {

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -762,3 +762,5 @@ InputIcon.propTypes = {
     PropTypes.func,
   ]).isRequired,
 }
+
+Input._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/input/InputPassword.js
+++ b/packages/dnb-eufemia/src/components/input/InputPassword.js
@@ -125,3 +125,5 @@ export default class InputPassword extends React.PureComponent {
     )
   }
 }
+
+InputPassword._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/logo/Logo.js
+++ b/packages/dnb-eufemia/src/components/logo/Logo.js
@@ -267,3 +267,5 @@ export default class Logo extends React.PureComponent {
     return <span {...selectedLogoRootParams}>{selectedLogo}</span>
   }
 }
+
+Logo._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.js
@@ -458,3 +458,5 @@ export default class NumberFormat extends React.PureComponent {
 }
 
 let hasiOSFix = false
+
+NumberFormat._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/pagination/InfinityScroller.js
+++ b/packages/dnb-eufemia/src/components/pagination/InfinityScroller.js
@@ -9,3 +9,5 @@ import Pagination from './Pagination'
 export default function InfinityScroller(props) {
   return <Pagination mode="infinity" {...props} />
 }
+
+InfinityScroller._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.js
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.js
@@ -345,3 +345,5 @@ export const createPagination = (initProps = {}) => {
     endInfinity,
   }
 }
+
+Pagination._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -343,4 +343,6 @@ const getSizeInPx = (size) => {
   return parseFloat(styleSize.replace(/(px)$/, ''))
 }
 
+PaginationBar._supportsSpacingProps = true
+
 export default PaginationBar

--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.js
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.js
@@ -598,3 +598,5 @@ class ScrollToElement extends React.PureComponent {
     return <Element {...props} />
   }
 }
+
+InfinityScroller._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.js
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.js
@@ -197,3 +197,5 @@ function formatProgress(progress) {
   }
   return null
 }
+
+ProgressIndicator._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/radio/Radio.js
+++ b/packages/dnb-eufemia/src/components/radio/Radio.js
@@ -458,3 +458,5 @@ export default class Radio extends React.PureComponent {
     )
   }
 }
+
+Radio._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.js
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.js
@@ -289,3 +289,5 @@ export default class RadioGroup extends React.PureComponent {
     )
   }
 }
+
+RadioGroup._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -130,3 +130,5 @@ export default function Section(localProps: SectionAllProps) {
 
   return <Element {...params}>{children}</Element>
 }
+
+Section._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.js
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.js
@@ -189,3 +189,5 @@ function Exclude(props) {
 }
 
 Skeleton.Exclude = Exclude
+
+Skeleton._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
@@ -160,4 +160,6 @@ const SkipContentReturn = (localProps: SkipContentReturnProps) => {
 
 SkipContent.Return = SkipContentReturn
 
+SkipContent._supportsSpacingProps = true
+
 export default SkipContent

--- a/packages/dnb-eufemia/src/components/slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/Slider.tsx
@@ -20,4 +20,6 @@ function Slider(localProps: SliderAllProps) {
   )
 }
 
+Slider._supportsSpacingProps = true
+
 export default Slider

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -125,7 +125,7 @@ export default function Space(localProps: SpaceAllProps) {
   )
 }
 
-Space._supportsEufemiaSpacingProps = true
+Space._supportsSpacingProps = true
 
 function Element({
   element,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -171,4 +171,6 @@ function StepIndicator({
 
 StepIndicator.Sidebar = StepIndicatorSidebar
 
+StepIndicator._supportsSpacingProps = true
+
 export default StepIndicator

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorSidebar.tsx
@@ -105,4 +105,6 @@ function StepIndicatorSidebar({
   )
 }
 
+StepIndicatorSidebar._supportsSpacingProps = true
+
 export default StepIndicatorSidebar

--- a/packages/dnb-eufemia/src/components/switch/Switch.js
+++ b/packages/dnb-eufemia/src/components/switch/Switch.js
@@ -360,3 +360,5 @@ export default class Switch extends React.PureComponent {
     )
   }
 }
+
+Switch._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -163,6 +163,8 @@ const Table = (componentProps: TableAllProps) => {
   )
 }
 
+Table._supportsSpacingProps = true
+
 export default Table
 
 Table.ScrollView = ScrollView

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.js
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.js
@@ -1255,3 +1255,5 @@ const ScrollNavButton = (props) => {
 ScrollNavButton.propTypes = {
   className: PropTypes.node.isRequired,
 }
+
+Tabs._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -206,4 +206,6 @@ const Tag = (localProps: TagProps & SpacingProps) => {
 
 Tag.Group = TagGroup
 
+Tag._supportsSpacingProps = true
+
 export default Tag

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -87,4 +87,6 @@ const TagGroup = (localProps: TagGroupProps & SpacingProps) => {
   )
 }
 
+TagGroup._supportsSpacingProps = true
+
 export default TagGroup

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.js
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.js
@@ -540,3 +540,5 @@ export default class Textarea extends React.PureComponent {
     )
   }
 }
+
+Textarea._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -108,4 +108,6 @@ Timeline.Item = TimelineItem
 
 export { TimelineItem }
 
+Timeline._supportsSpacingProps = true
+
 export default Timeline

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
@@ -498,3 +498,5 @@ export default class ToggleButton extends React.PureComponent {
     )
   }
 }
+
+ToggleButton._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.js
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.js
@@ -353,3 +353,5 @@ export default class ToggleButtonGroup extends React.PureComponent {
     )
   }
 }
+
+ToggleButtonGroup._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -133,4 +133,6 @@ const Upload = (localProps: UploadAllProps) => {
 
 Upload.useUpload = useUpload
 
+Upload._supportsSpacingProps = true
+
 export default Upload

--- a/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
@@ -57,4 +57,6 @@ const VisuallyHidden = (localProps: VisuallyHiddenAllProps) => {
   )
 }
 
+VisuallyHidden._supportsSpacingProps = true
+
 export default VisuallyHidden

--- a/packages/dnb-eufemia/src/elements/blockquote/Blockquote.tsx
+++ b/packages/dnb-eufemia/src/elements/blockquote/Blockquote.tsx
@@ -45,4 +45,8 @@ const Blockquote = React.forwardRef(
   )
 )
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Blockquote._supportsSpacingProps = true
+
 export default Blockquote

--- a/packages/dnb-eufemia/src/elements/code/Code.tsx
+++ b/packages/dnb-eufemia/src/elements/code/Code.tsx
@@ -13,4 +13,8 @@ const Code = React.forwardRef((props: CodeProps, ref) => (
   <E as="code" innerRef={ref} {...props} />
 ))
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Code._supportsSpacingProps = true
+
 export default Code

--- a/packages/dnb-eufemia/src/elements/div/Div.tsx
+++ b/packages/dnb-eufemia/src/elements/div/Div.tsx
@@ -13,4 +13,8 @@ const Div = React.forwardRef((props: DivProps, ref) => (
   <E as="div" skeletonMethod="shape" innerRef={ref} {...props} />
 ))
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Div._supportsSpacingProps = true
+
 export default Div

--- a/packages/dnb-eufemia/src/elements/hr/Hr.tsx
+++ b/packages/dnb-eufemia/src/elements/hr/Hr.tsx
@@ -36,4 +36,6 @@ const Hr = ({
   )
 }
 
+Hr._supportsSpacingProps = true
+
 export default Hr

--- a/packages/dnb-eufemia/src/elements/img/Img.tsx
+++ b/packages/dnb-eufemia/src/elements/img/Img.tsx
@@ -57,4 +57,6 @@ const Img = ({
   )
 }
 
+Img._supportsSpacingProps = true
+
 export default Img

--- a/packages/dnb-eufemia/src/elements/lists/Dl.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Dl.tsx
@@ -47,4 +47,8 @@ Dl.Item = ({
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Dl._supportsSpacingProps = true
+
 export default Dl

--- a/packages/dnb-eufemia/src/elements/lists/Ol.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ol.tsx
@@ -44,4 +44,8 @@ const Ol = ({ nested, inside, outside, ...p }: OlAllProps = {}) => {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Ol._supportsSpacingProps = true
+
 export default Ol

--- a/packages/dnb-eufemia/src/elements/lists/Ul.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ul.tsx
@@ -44,4 +44,8 @@ const Ul = ({ nested, inside, outside, ...p }: UlAllProps = {}) => {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Ul._supportsSpacingProps = true
+
 export default Ul

--- a/packages/dnb-eufemia/src/elements/span/Span.tsx
+++ b/packages/dnb-eufemia/src/elements/span/Span.tsx
@@ -13,4 +13,8 @@ const Span = React.forwardRef((props: SpanProps, ref) => (
   <E as="span" innerRef={ref} {...props} />
 ))
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Span._supportsSpacingProps = true
+
 export default Span

--- a/packages/dnb-eufemia/src/elements/typography/H.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H.tsx
@@ -70,5 +70,6 @@ const H = ({
 }
 
 H._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H

--- a/packages/dnb-eufemia/src/elements/typography/H1.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H1.tsx
@@ -11,5 +11,6 @@ const H1 = ({ size, ...props }: SharedHProps) => (
 )
 
 H1._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H1

--- a/packages/dnb-eufemia/src/elements/typography/H2.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H2.tsx
@@ -11,5 +11,6 @@ const H2 = ({ size, ...props }: SharedHProps) => (
 )
 
 H2._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H2

--- a/packages/dnb-eufemia/src/elements/typography/H3.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H3.tsx
@@ -11,5 +11,6 @@ const H3 = ({ size, ...props }: SharedHProps) => (
 )
 
 H3._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H3

--- a/packages/dnb-eufemia/src/elements/typography/H4.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H4.tsx
@@ -11,5 +11,6 @@ const H4 = ({ size, ...props }: SharedHProps) => (
 )
 
 H4._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H4

--- a/packages/dnb-eufemia/src/elements/typography/H5.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H5.tsx
@@ -11,5 +11,6 @@ const H5 = ({ size, ...props }: SharedHProps) => (
 )
 
 H5._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H5

--- a/packages/dnb-eufemia/src/elements/typography/H6.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H6.tsx
@@ -11,5 +11,6 @@ const H6 = ({ size, ...props }: SharedHProps) => (
 )
 
 H6._isHeadingElement = true
+H._supportsSpacingProps = true
 
 export default H6

--- a/packages/dnb-eufemia/src/elements/typography/Ingress.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/Ingress.tsx
@@ -6,4 +6,7 @@ import React from 'react'
 import P, { PProps } from './P'
 
 const Ingress = (props: PProps) => <P medium {...props} />
+
+Ingress._supportsSpacingProps = true
+
 export default Ingress

--- a/packages/dnb-eufemia/src/elements/typography/Lead.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/Lead.tsx
@@ -9,4 +9,7 @@ import classnames from 'classnames'
 const Lead = ({ className, ...rest }: PProps) => (
   <P className={classnames('dnb-p--lead', className)} {...rest} />
 )
+
+Lead._supportsSpacingProps = true
+
 export default Lead

--- a/packages/dnb-eufemia/src/elements/typography/P.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/P.tsx
@@ -86,4 +86,6 @@ const P = ({
   )
 }
 
+P._supportsSpacingProps = true
+
 export default P

--- a/packages/dnb-eufemia/src/elements/typography/Paragraph.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/Paragraph.tsx
@@ -6,4 +6,7 @@ import React from 'react'
 import P, { PProps } from './P'
 
 const Paragraph = (props: PProps) => <P {...props} />
+
+Paragraph._supportsSpacingProps = true
+
 export default Paragraph

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
@@ -74,5 +74,5 @@ function At(props: Props) {
   )
 }
 
-At._supportsEufemiaSpacingProps = true
+At._supportsSpacingProps = true
 export default At

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -119,5 +119,5 @@ function ArraySelection(props: Props) {
   }
 }
 
-ArraySelection._supportsEufemiaSpacingProps = true
+ArraySelection._supportsSpacingProps = true
 export default ArraySelection

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -48,5 +48,5 @@ function BankAccountNumber(props: Props) {
   return <StringComponent {...stringComponentProps} />
 }
 
-BankAccountNumber._supportsEufemiaSpacingProps = true
+BankAccountNumber._supportsSpacingProps = true
 export default BankAccountNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -24,5 +24,5 @@ function BooleanComponent(props: Props) {
   )
 }
 
-BooleanComponent._supportsEufemiaSpacingProps = true
+BooleanComponent._supportsSpacingProps = true
 export default BooleanComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Field/CountryCode/CountryCode.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/CountryCode/CountryCode.tsx
@@ -97,5 +97,5 @@ function CountryCode(props: Props) {
   )
 }
 
-CountryCode._supportsEufemiaSpacingProps = true
+CountryCode._supportsSpacingProps = true
 export default CountryCode

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
@@ -23,5 +23,5 @@ function Currency(props: Props) {
   )
 }
 
-Currency._supportsEufemiaSpacingProps = true
+Currency._supportsSpacingProps = true
 export default Currency

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -52,5 +52,5 @@ function DateComponent(props: Props) {
   )
 }
 
-DateComponent._supportsEufemiaSpacingProps = true
+DateComponent._supportsSpacingProps = true
 export default DateComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
@@ -24,5 +24,5 @@ function Email(props: Props) {
   return <StringComponent {...stringComponentProps} />
 }
 
-Email._supportsEufemiaSpacingProps = true
+Email._supportsSpacingProps = true
 export default Email

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -48,5 +48,5 @@ function NationalIdentityNumber(props: Props) {
   return <StringComponent {...stringComponentProps} />
 }
 
-NationalIdentityNumber._supportsEufemiaSpacingProps = true
+NationalIdentityNumber._supportsSpacingProps = true
 export default NationalIdentityNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -182,5 +182,5 @@ function NumberComponent(props: Props) {
   )
 }
 
-NumberComponent._supportsEufemiaSpacingProps = true
+NumberComponent._supportsSpacingProps = true
 export default NumberComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -34,5 +34,5 @@ function OrganizationNumber(props: Props) {
   return <StringComponent {...stringComponentProps} />
 }
 
-OrganizationNumber._supportsEufemiaSpacingProps = true
+OrganizationNumber._supportsSpacingProps = true
 export default OrganizationNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -150,5 +150,5 @@ function PhoneNumber(props: Props) {
   )
 }
 
-PhoneNumber._supportsEufemiaSpacingProps = true
+PhoneNumber._supportsSpacingProps = true
 export default PhoneNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -78,5 +78,5 @@ function PostalCodeAndCity(props: Props) {
   )
 }
 
-PostalCodeAndCity._supportsEufemiaSpacingProps = true
+PostalCodeAndCity._supportsSpacingProps = true
 export default PostalCodeAndCity

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -36,5 +36,5 @@ function SelectCountry(props: Props) {
   )
 }
 
-SelectCountry._supportsEufemiaSpacingProps = true
+SelectCountry._supportsSpacingProps = true
 export default SelectCountry

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -247,5 +247,5 @@ function Selection(props: Props) {
   }
 }
 
-Selection._supportsEufemiaSpacingProps = true
+Selection._supportsSpacingProps = true
 export default Selection

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -205,5 +205,5 @@ function StringComponent(props: Props) {
   )
 }
 
-StringComponent._supportsEufemiaSpacingProps = true
+StringComponent._supportsSpacingProps = true
 export default StringComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -164,5 +164,5 @@ function Toggle(props: Props) {
   }
 }
 
-Toggle._supportsEufemiaSpacingProps = true
+Toggle._supportsSpacingProps = true
 export default Toggle

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -218,5 +218,5 @@ function FieldBlock(props: Props) {
   )
 }
 
-FieldBlock._supportsEufemiaSpacingProps = true
+FieldBlock._supportsSpacingProps = true
 export default FieldBlock

--- a/packages/dnb-eufemia/src/extensions/forms/Form/ButtonRow/ButtonRow.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/ButtonRow/ButtonRow.tsx
@@ -19,5 +19,5 @@ function ButtonRow(props: Props) {
   )
 }
 
-ButtonRow._supportsEufemiaSpacingProps = true
+ButtonRow._supportsSpacingProps = true
 export default ButtonRow

--- a/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
@@ -23,7 +23,7 @@ function MainHeading({ level, ...props }: Props) {
   )
 }
 
-MainHeading._supportsEufemiaSpacingProps = true
+MainHeading._supportsSpacingProps = true
 MainHeading._isHeadingElement = true
 
 export default MainHeading

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
@@ -23,7 +23,7 @@ function SubHeading({ level, ...props }: Props) {
   )
 }
 
-SubHeading._supportsEufemiaSpacingProps = true
+SubHeading._supportsSpacingProps = true
 SubHeading._isHeadingElement = true
 
 export default SubHeading

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -33,5 +33,5 @@ function SubmitButton(props: Props) {
   )
 }
 
-SubmitButton._supportsEufemiaSpacingProps = true
+SubmitButton._supportsSpacingProps = true
 export default SubmitButton

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -134,5 +134,5 @@ function ArrayComponent(props: Props) {
   )
 }
 
-ArrayComponent._supportsEufemiaSpacingProps = true
+ArrayComponent._supportsSpacingProps = true
 export default ArrayComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ArrayPushButton/ArrayPushButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ArrayPushButton/ArrayPushButton.tsx
@@ -51,5 +51,5 @@ function ArrayPushButton(props: Props) {
   )
 }
 
-ArrayPushButton._supportsEufemiaSpacingProps = true
+ArrayPushButton._supportsSpacingProps = true
 export default ArrayPushButton

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ArrayRemoveElementButton/ArrayRemoveElementButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ArrayRemoveElementButton/ArrayRemoveElementButton.tsx
@@ -44,5 +44,5 @@ function ArrayRemoveElementButton(props: Props) {
   )
 }
 
-ArrayRemoveElementButton._supportsEufemiaSpacingProps = true
+ArrayRemoveElementButton._supportsSpacingProps = true
 export default ArrayRemoveElementButton

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/Buttons/Buttons.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/Buttons/Buttons.tsx
@@ -22,5 +22,5 @@ function Buttons(props: Props) {
   )
 }
 
-Buttons._supportsEufemiaSpacingProps = true
+Buttons._supportsSpacingProps = true
 export default Buttons

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/NextButton/NextButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/NextButton/NextButton.tsx
@@ -36,5 +36,5 @@ function NextButton(props: Props) {
   )
 }
 
-NextButton._supportsEufemiaSpacingProps = true
+NextButton._supportsSpacingProps = true
 export default NextButton

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/PreviousButton/PreviousButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/PreviousButton/PreviousButton.tsx
@@ -36,5 +36,5 @@ function PreviousButton(props: Props) {
   )
 }
 
-PreviousButton._supportsEufemiaSpacingProps = true
+PreviousButton._supportsSpacingProps = true
 export default PreviousButton

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/Step/Step.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/Step/Step.tsx
@@ -34,5 +34,5 @@ function Step(props: Props) {
   )
 }
 
-Step._supportsEufemiaSpacingProps = true
+Step._supportsSpacingProps = true
 export default Step

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayout.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayout.tsx
@@ -112,7 +112,7 @@ function StepsLayout(props: Props) {
   )
 }
 
-StepsLayout._supportsEufemiaSpacingProps = true
+StepsLayout._supportsSpacingProps = true
 
 StepsLayout.Step = Step
 StepsLayout.NextButton = NextButton

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
@@ -26,5 +26,5 @@ function BankAccountNumber(props: Props) {
   return <StringComponent {...stringValueProps} />
 }
 
-BankAccountNumber._supportsEufemiaSpacingProps = true
+BankAccountNumber._supportsSpacingProps = true
 export default BankAccountNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Boolean/Boolean.tsx
@@ -30,5 +30,5 @@ function BooleanComponent(props: Props) {
   )
 }
 
-BooleanComponent._supportsEufemiaSpacingProps = true
+BooleanComponent._supportsSpacingProps = true
 export default BooleanComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Currency/Currency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Currency/Currency.tsx
@@ -13,5 +13,5 @@ function Currency(props: Props) {
   return <NumberComponent {...numberProps} />
 }
 
-Currency._supportsEufemiaSpacingProps = true
+Currency._supportsSpacingProps = true
 export default Currency

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
@@ -14,5 +14,5 @@ function DateComponent(props: Props) {
   return <StringComponent {...stringProps} />
 }
 
-DateComponent._supportsEufemiaSpacingProps = true
+DateComponent._supportsSpacingProps = true
 export default DateComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Email/Email.tsx
@@ -14,5 +14,5 @@ function Email(props: Props) {
   return <StringComponent {...stringProps} />
 }
 
-Email._supportsEufemiaSpacingProps = true
+Email._supportsSpacingProps = true
 export default Email

--- a/packages/dnb-eufemia/src/extensions/forms/Value/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -26,5 +26,5 @@ function NationalIdentityNumber(props: Props) {
   return <StringComponent {...stringValueProps} />
 }
 
-NationalIdentityNumber._supportsEufemiaSpacingProps = true
+NationalIdentityNumber._supportsSpacingProps = true
 export default NationalIdentityNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
@@ -52,5 +52,5 @@ function NumberComponent(props: Props) {
   )
 }
 
-NumberComponent._supportsEufemiaSpacingProps = true
+NumberComponent._supportsSpacingProps = true
 export default NumberComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PhoneNumber/PhoneNumber.tsx
@@ -26,5 +26,5 @@ function PhoneNumber(props: Props) {
   return <StringComponent {...stringValueProps} />
 }
 
-PhoneNumber._supportsEufemiaSpacingProps = true
+PhoneNumber._supportsSpacingProps = true
 export default PhoneNumber

--- a/packages/dnb-eufemia/src/extensions/forms/Value/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/String/String.tsx
@@ -31,5 +31,5 @@ function StringComponent(props: Props) {
   )
 }
 
-StringComponent._supportsEufemiaSpacingProps = true
+StringComponent._supportsSpacingProps = true
 export default StringComponent

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -46,5 +46,5 @@ function ValueBlock(props: Props) {
   )
 }
 
-ValueBlock._supportsEufemiaSpacingProps = true
+ValueBlock._supportsSpacingProps = true
 export default ValueBlock

--- a/packages/dnb-eufemia/src/extensions/forms/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Visibility/Visibility.tsx
@@ -82,5 +82,5 @@ function Visibility({
   return <>{children}</>
 }
 
-Visibility._supportsEufemiaSpacingProps = true
+Visibility._supportsSpacingProps = true
 export default Visibility


### PR DESCRIPTION
This PR adds the flag `_supportsSpacingProps` to all components that supports the Eufemia spacing system (e.g. via `createSpacingClasses`), so they not get an additional wrapper (div), when used inside `Flex.Container`.

**The changes in this PR:**

We add a static property to each component, e.g.: `Accordion._supportsSpacingProps = true`

This way the spacing handler knows, that it supports spacing props, such as `top` or `space`.

We already have a [documentation](https://github.com/dnbexperience/eufemia/pull/2754/files#diff-7803d65b46f3e62cb2f575fcd0e1b4a2a89ceb743b8975e67b6c07d75e618162) about this in place. A [new test](https://github.com/dnbexperience/eufemia/pull/2754/files#diff-d8415c63c4fdd9152997df81b1c6adae49591f37ff483d0169a123716c037f74R323) was added.