### PR TITLE
chore: various local build related updates

### DIFF
--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.d.ts
@@ -30,6 +30,9 @@ export interface FormLabelProps
    * The `text` of the label.
    */
   text?: FormLabelText;
+  /**
+   * Define one of the following <a href="/uilib/elements/heading/">heading size</a>: `medium` or `large`.
+   */
   size?: FormLabelSize;
   id?: string;
   class?: string;

--- a/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
+++ b/packages/dnb-eufemia/src/components/form-row/FormRow.d.ts
@@ -14,68 +14,23 @@ export interface FormRowProps
   extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
   id?: string;
-  /**
-   * Use either the `label` property or provide a custom one.
-   */
   label?: FormLabelText;
-  /**
-   * Use `label_direction="vertical"` to change the label/legend layout direction. Defaults to `horizontal`.
-   */
   label_direction?: FormLabelLabelDirection;
-  /**
-   * Use `true` to make the label only readable by screen readers.
-   */
   label_sr_only?: boolean;
   label_id?: string;
-  /**
-   * If you need to style the "legend", then you can either send in a custom Component, like `label={ <H2> }`, or define your styling class with the `label_class` property.
-   */
   label_class?: string;
   no_label?: boolean;
-  /**
-   * If set to `true`, then the internal `legend` element will be a `label` instead, and no `<fieldset>` is used. Keep in mind, that `<legend>` and `<fieldset>` <strong>is only used if a `label` is provided</strong>. Defaults to `false`.
-   */
   no_fieldset?: boolean;
-  /**
-   * Send along a different locale to all nested components.
-   */
   locale?: Locale;
-  /**
-   * Forces the content of a FormRow to wrap. Make sure you always define spacing as `right="..."` and not `left`, this way components will align left once they wrap. Defaults to `false`.
-   */
   wrap?: boolean;
-  /**
-   * To define the layout direction on how the next component should be placed on. Can be either `vertical` or `horizontal`. Defaults to `horizontal`.
-   */
   direction?: FormRowDirection;
-  /**
-   * Will force both `direction` and `label_direction` to be "vertical" if set to `true`.
-   */
   vertical?: boolean;
-  /**
-   * Will center all children vertically as long as the screen does not hit a mobile width.
-   */
   centered?: boolean;
-  /**
-   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
-   */
   section_style?: SectionStyleTypes;
-  /**
-   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
-   */
   section_spacing?: SectionSpacing;
   globalStatus?: GlobalStatusConfigObject;
-  /**
-   * To force responsiveness on form components (like <a href="/uilib/components/input">Input</a> and their labels (<a href="/uilib/components/form-label">FormLabel</a>), set the prop to `true`. Defaults to `false`.
-   */
   responsive?: boolean;
-  /**
-   * If set to `true`, every component inside will be disabled. Defaults to `false`.
-   */
   disabled?: boolean;
-  /**
-   * If set to `true`, it enables skeleton for nested components. Defaults to `false`.
-   */
   skeleton?: SkeletonShow;
   class?: string;
   skipContentWrapperIfNested?: boolean;

--- a/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
+++ b/packages/dnb-eufemia/src/components/form-set/FormSet.d.ts
@@ -13,89 +13,32 @@ export type FormSetChildren =
 export interface FormSetProps
   extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
     SpacingProps {
-  /**
-   * Define what HTML element should be used. Defaults to `<form>`.
-   */
   element?: string;
-  /**
-   * If set to `true`, then a `div` HTML element will be used instead of `form`. Defaults to `false`.
-   */
   no_form?: boolean;
-  /**
-   * If set to `true`, every component inside will be disabled. Defaults to `false`.
-   */
   disabled?: boolean;
-  /**
-   * If set to `true`, it enables skeleton for nested components. Defaults to `false`.
-   */
   skeleton?: SkeletonShow;
-  /**
-   * If set to `true`, components inside can&#39;t cause a page refresh. The event `on_submit` will still be triggered. Defaults to `false`.
-   */
   prevent_submit?: boolean;
   id?: string;
-  /**
-   * Use either the `label` property or provide a custom one.
-   */
   label?: FormLabelText;
-  /**
-   * Use `label_direction="vertical"` to change the label/legend layout direction. Defaults to `horizontal`.
-   */
   label_direction?: FormLabelLabelDirection;
-  /**
-   * Use `true` to make the label only readable by screen readers.
-   */
   label_sr_only?: boolean;
   label_id?: string;
-  /**
-   * If you need to style the "legend", then you can either send in a custom Component, like `label={ <H2> }`, or define your styling class with the `label_class` property.
-   */
   label_class?: string;
   no_label?: boolean;
-  /**
-   * If set to `true`, then the internal `legend` element will be a `label` instead, and no `<fieldset>` is used. Keep in mind, that `<legend>` and `<fieldset>` <strong>is only used if a `label` is provided</strong>. Defaults to `false`.
-   */
   no_fieldset?: boolean;
-  /**
-   * Send along a different locale to all nested components.
-   */
   locale?: Locale;
-  /**
-   * Forces the content of a FormRow to wrap. Make sure you always define spacing as `right="..."` and not `left`, this way components will align left once they wrap. Defaults to `false`.
-   */
   wrap?: boolean;
-  /**
-   * To define the layout direction on how the next component should be placed on. Can be either `vertical` or `horizontal`. Defaults to `horizontal`.
-   */
   direction?: FormSetDirection;
-  /**
-   * Will force both `direction` and `label_direction` to be "vertical" if set to `true`.
-   */
   vertical?: boolean;
-  /**
-   * Will center all children vertically as long as the screen does not hit a mobile width.
-   */
   centered?: boolean;
-  /**
-   * To enable the visual helper `.dnb-section` class. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
-   */
   section_style?: SectionStyleTypes;
-  /**
-   * To modify the `spacing`. Use a supported modifier from the <a href="/uilib/components/section/properties">Section component</a>. Defaults to `null`.
-   */
   section_spacing?: SectionSpacing;
   globalStatus?: GlobalStatusConfigObject;
-  /**
-   * To force responsiveness on form components (like <a href="/uilib/components/input">Input</a> and their labels (<a href="/uilib/components/form-label">FormLabel</a>), set the prop to `true`. Defaults to `false`.
-   */
   responsive?: boolean;
   class?: string;
   skipContentWrapperIfNested?: boolean;
   className?: string;
   children?: FormSetChildren;
-  /**
-   * Will be called on submit. Returns an object with a native event: `{ event }`
-   */
   on_submit?: (...args: any[]) => any;
 }
 export default class FormSet extends React.Component<FormSetProps, any> {

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts
@@ -58,7 +58,6 @@ export interface PaymentCardRawData {
   productType: ProductType;
   bankAxept: BankAxeptType;
 }
-
 export interface CardDesign {
   name: string;
   cardStyle: string;
@@ -69,7 +68,6 @@ export interface CardDesign {
   saga: any;
   privateBanking: any;
 }
-
 export type PaymentCardChildren =
   | string
   | React.ReactNode
@@ -121,10 +119,11 @@ export default class PaymentCard extends React.Component<
   static defaultProps: object;
   render(): JSX.Element;
 }
-export const getCardData: (
-  product_code: string
-) => Omit<PaymentCardRawData, 'cardDesign'> & { cardDesign: CardDesign };
-export const formatCardNumber: (
+type CardDataReturn = Omit<PaymentCardRawData, 'cardDesign'> & {
+  cardDesign: CardDesign;
+};
+export const getCardData = (product_code: string): CardDataReturn => null;
+export const formatCardNumber = (
   cardNumber: string,
   digits?: number
-) => string;
+): string => null;


### PR DESCRIPTION
- Update outdate docs linking; FormRow and FormSet where moved and do not have the same path, as the component, so they can not be found. But I think thats fine as they are deprecated.
- Correct PaymentCard types as they fail during the docs update routine. We still have a valid syntax and it works fine with TypeScript.

<img width="665" alt="Screenshot 2023-10-19 at 08 44 39" src="https://github.com/dnbexperience/eufemia/assets/1501870/3192ff07-753e-4222-a4b5-42048cd61224">

<img width="877" alt="Screenshot 2023-10-19 at 08 46 27" src="https://github.com/dnbexperience/eufemia/assets/1501870/7e443f07-ae94-4314-b523-fc39a4c77952">

