### PR TITLE
feat(breakpoints): media query mixin offset options

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers.mdx
@@ -3,16 +3,6 @@ title: 'Helpers'
 description: 'A couple of helper functions used inside of components and extensions.'
 icon: 'helper_classes'
 order: 4
-showTabs: true
-tabs:
-  - title: Info
-    key: /uilib/helpers/info
-  - title: CSS Classes
-    key: /uilib/helpers/classes
-  - title: Functions
-    key: /uilib/helpers/functions
-  - title: Tools
-    key: /uilib/helpers/tools
 redirect_from:
   - /uilib/helper-classes
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -1,5 +1,6 @@
 ---
-showTabs: true
+title: 'CSS classes'
+order: 1
 ---
 
 import * as Examples from 'Docs/uilib/helpers/Examples'
@@ -145,77 +146,3 @@ text-shadow: none;
 ## HTML class naming
 
 To ensure a consistent class structure and to ensure that the class is owned by the DNB UI Library, all classes in the UI Library are prefixed with `dnb-`. Read more about that in the [Naming conventions](/contribute/naming).
-
-## SASS and mixins
-
-All CSS helper classes are to be found in `src/style/core/helper-classes/helper-classes.scss`
-Most helper classes are SCSS _mixins_ which are then applied to the class when invoked.
-
-You can import Eufemia _mixins_ directly into your SCSS styles:
-
-```scss
-@import '@dnb/eufemia/style/core/utilities.scss';
-
-/** State handling */
-@include hover {
-}
-@include focus {
-}
-@include active {
-}
-
-/** Media Queries and Breakpoints */
-@include allBelow(large) {
-}
-@include allAbove(small) {
-}
-
-/** Screen Reader Only */
-@include srOnly() {
-} // .dnb-sr-only
-
-/** Browser Checks */
-@include IS_EDGE {
-}
-@include IS_FF {
-}
-@include IS_CHROME {
-}
-@include IS_SAFARI_MOBILE {
-}
-@include IS_SAFARI_DESKTOP {
-}
-
-/** Eufemia DropShadow */
-@include defaultDropShadow();
-
-/** Eufemia Border helpers */
-@include focusRing(
-  /* $whatinput: 'keyboard', $color: var(--color-emerald-green), $inset: inset */
-);
-@include extendFocusRing(
-  /* $first-color: null, $second-color: null, width: 0.0625rem */
-);
-@include fakeBorder(
-  /* $color: var(--color-emerald-green), $width: 0.0625rem, $inset: inset */
-);
-
-/** Scroll behavior */
-@include scrollY(/* $mode: scroll */);
-@include scrollX(/* $mode: scroll */);
-@include hideScrollbar();
-@include scrollbarAppearance();
-
-/** Reset fieldset styles */
-@include fieldsetReset();
-```
-
-### Formset reset
-
-Removes default styling on a `fieldset` element.
-
-`@include fieldsetReset($checkSpaceProps: boolean)`
-
-If true is given, it will handle margin gracefully by checking for e.g. `dnb-space__top--` and not reset if this class exists.
-
-<Examples.FormsetReset />

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -6,7 +6,7 @@ order: 1
 import * as Examples from 'Docs/uilib/helpers/Examples'
 import SkipLinkExample from 'Docs/uilib/usage/accessibility/examples/skip-link-example.tsx'
 
-## Description
+## CSS helper classes
 
 Reusing classes in the markup instead of using SCSS extends or _mixins_ will prevent duplication in the `@dnb/eufemia`. So also your application will have good benefits from reusing these helper classes.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -1,5 +1,6 @@
 ---
-showTabs: true
+title: 'Functions'
+order: 3
 ---
 
 ## Component helpers

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -141,7 +141,7 @@ $breakpoints: map-merge(
 }
 ```
 
-## Formset reset
+## `<fieldset>` CSS reset
 
 Removes default styling on a `fieldset` element.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -127,8 +127,11 @@ You can either change the default values in the `$breakpoints` array from `utili
 $breakpoints: map-merge(
   $breakpints,
   (
+    // redefine a size
     'medium': 40em,
-    'large': 90em,
+
+    // add an offset to the original value
+    'large': map-get($breakpoints, large) + 5em
   )
 );
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -5,7 +5,7 @@ order: 2
 
 import * as Examples from 'Docs/uilib/helpers/Examples'
 
-## SASS and mixins
+# SASS and mixins
 
 All CSS helper classes are to be found in `src/style/core/helper-classes/helper-classes.scss`
 Most helper classes are SCSS _mixins_ which are then applied to the class when invoked.
@@ -23,7 +23,10 @@ You can import Eufemia _mixins_ directly into your SCSS styles:
 @include active {
 }
 
-/** Media Queries and Breakpoints */
+/** 
+ * Media Queries and Breakpoints 
+ * More info can be found in the sections below
+ */
 @include allBelow(large) {
 }
 @include allAbove(small) {
@@ -69,38 +72,58 @@ You can import Eufemia _mixins_ directly into your SCSS styles:
 @include fieldsetReset();
 ```
 
-### Media query mixin
+## Media queries and Breakpoints
 
-You can add an offset to the media query mixins, or customize the different sizes directly:
-
-**Add offset to all media queries**:
+Use the `allAbove` or `allBelow` mixins to add media queries to your css.
 
 ```scss
 @import '@dnb/eufemia/style/core/utilities.scss';
 
-// Will add the offset to each use of "allBelow" or "allAbove" (default: 0)
-$breakpoint-offset: -10em;
-```
-
-**Add offset to single media query:**
-
-```scss
-@import '@dnb/eufemia/style/core/utilities.scss';
-
-@include allBelow(large, 10em) {
-  // Adds 10em to this media query
+@include allBelow(large) {
 }
-@include allAbove(small, -5em) {
-  // Subtracts 5em from this media query
+
+@include allAbove(small) {
 }
 ```
 
-**Change value of each size:**
+`$breakpoints` is a key-value map containing all the available sizes for media queries
 
 ```scss
 @import '@dnb/eufemia/style/core/utilities.scss';
 
-// Changes the "medium" and "large" breakpoints
+// getting a size from $breakpoints
+div {
+  max-width: map-get($breakpoints, medium);
+}
+```
+
+### Custom offset
+
+You can either change the default value `$breakpoint-offset` (default: 0) from `utilities.scss`, or send in a custom offset to the mixin.
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+// Change the default offset (default: 0)
+$breakpoint-offset: 10em;
+
+// Will use the new default offset, adding 10em to the size
+@include allBelow(large) {
+}
+
+// You can also simply send in a custom offset
+@include allBelow(large, -5em) {
+}
+```
+
+### Custom size
+
+You can either change the default values in the `$breakpoints` array from `utilities.scss`, or send in a custom size to the mixin.
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+// Change default sizes
 $breakpoints: map-merge(
   $breakpints,
   (
@@ -108,21 +131,17 @@ $breakpoints: map-merge(
     'large': 90em,
   )
 );
-```
 
-**Use custom value:**
-
-```scss
-@import '@dnb/eufemia/style/core/utilities.scss';
-
-// You can also simply send in a custom value
-@include allBelow(10em) {
+// Will use the new default 'large' size of 90em
+@include allBelow(large) {
 }
-@include allAbove(5em) {
+
+// You can also simply send in a custom size
+@include allBelow(90em) {
 }
 ```
 
-### Formset reset
+## Formset reset
 
 Removes default styling on a `fieldset` element.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -1,0 +1,133 @@
+---
+title: 'SASS mixins'
+order: 2
+---
+
+import * as Examples from 'Docs/uilib/helpers/Examples'
+
+## SASS and mixins
+
+All CSS helper classes are to be found in `src/style/core/helper-classes/helper-classes.scss`
+Most helper classes are SCSS _mixins_ which are then applied to the class when invoked.
+
+You can import Eufemia _mixins_ directly into your SCSS styles:
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+/** State handling */
+@include hover {
+}
+@include focus {
+}
+@include active {
+}
+
+/** Media Queries and Breakpoints */
+@include allBelow(large) {
+}
+@include allAbove(small) {
+}
+
+/** Screen Reader Only */
+@include srOnly() {
+} // .dnb-sr-only
+
+/** Browser Checks */
+@include IS_EDGE {
+}
+@include IS_FF {
+}
+@include IS_CHROME {
+}
+@include IS_SAFARI_MOBILE {
+}
+@include IS_SAFARI_DESKTOP {
+}
+
+/** Eufemia DropShadow */
+@include defaultDropShadow();
+
+/** Eufemia Border helpers */
+@include focusRing(
+  /* $whatinput: 'keyboard', $color: var(--color-emerald-green), $inset: inset */
+);
+@include extendFocusRing(
+  /* $first-color: null, $second-color: null, width: 0.0625rem */
+);
+@include fakeBorder(
+  /* $color: var(--color-emerald-green), $width: 0.0625rem, $inset: inset */
+);
+
+/** Scroll behavior */
+@include scrollY(/* $mode: scroll */);
+@include scrollX(/* $mode: scroll */);
+@include hideScrollbar();
+@include scrollbarAppearance();
+
+/** Reset fieldset styles */
+@include fieldsetReset();
+```
+
+### Media query mixin
+
+You can add an offset to the media query mixins, or customize the different sizes directly:
+
+**Add offset to all media queries**:
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+// Will add the offset to each use of "allBelow" or "allAbove" (default: 0)
+$breakpoint-offset: -10em;
+```
+
+**Add offset to single media query:**
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+@include allBelow(large, 10em) {
+  // Adds 10em to this media query
+}
+@include allAbove(small, -5em) {
+  // Subtracts 5em from this media query
+}
+```
+
+**Change value of each size:**
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+// Changes the "medium" and "large" breakpoints
+$breakpoints: map-merge(
+  $breakpints,
+  (
+    'medium': 40em,
+    'large': 90em,
+  )
+);
+```
+
+**Use custom value:**
+
+```scss
+@import '@dnb/eufemia/style/core/utilities.scss';
+
+// You can also simply send in a custom value
+@include allBelow(10em) {
+}
+@include allAbove(5em) {
+}
+```
+
+### Formset reset
+
+Removes default styling on a `fieldset` element.
+
+`@include fieldsetReset($checkSpaceProps: boolean)`
+
+If true is given, it will handle margin gracefully by checking for e.g. `dnb-space__top--` and not reset if this class exists.
+
+<Examples.FormsetReset />

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/tools.mdx
@@ -1,5 +1,6 @@
 ---
-showTabs: true
+title: 'Tools'
+order: 4
 ---
 
 ## Code Editor Extensions

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -286,16 +286,18 @@ $breakpoints: (
   'x-large': 80em /* not documented yet */,
   'xx-large': 90em /* not documented yet */,
 );
+$breakpoint-offset: 0;
 
 // Example usage:
 // @include allAbove(medium){ styles go here.. }
-@mixin allAbove($size) {
-  @media screen and (min-width: if(map-has-key($breakpoints, $size), map-get($breakpoints, $size), #{$size})) {
+// $offset and $list are needed to provide global customization options
+@mixin allAbove($size, $offset: $breakpoint-offset, $list: $breakpoints) {
+  @media screen and (min-width: (if(map-has-key($list, $size), map-get($list, $size), #{$size}) + $offset)) {
     @content;
   }
 }
-@mixin allBelow($size) {
-  @media screen and (max-width: if(map-has-key($breakpoints, $size), map-get($breakpoints, $size), #{$size})) {
+@mixin allBelow($size, $offset: $breakpoint-offset, $list: $breakpoints) {
+  @media screen and (max-width: (if(map-has-key($list, $size), map-get($list, $size), #{$size}) + $offset)) {
     @content;
   }
 }


### PR DESCRIPTION
* Adds global or parameter customization for mixins `allAbove()` and `allBelow()` 

# Global customization:
Will only works for the app's own stylesheets, won't retroactively affect imported Eufemia components.
```scss
@import '@dnb/eufemia/style/core/utilities.scss';

// allAbove() and allBelow() will subtract -10em from the size
$breakpoint-offset: -10em;

// the sizes 'medium' and 'large' for allAbove() and allBelow() are changed.
$breakpoints: map-merge(
  $breakpints,
  (
    'medium': 40em,
    'large': 90em,
  )
);
```

# Mixin parameter
```scss
@import '@dnb/eufemia/style/core/utilities.scss';

@include allAbove($size: small, $offset: 10em) {
  // adds 10em to $size
}
```
