### PR TITLE
fix(useMedia): enhance SSR support by setting state during component mount

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
@@ -60,25 +60,82 @@ Numeric values will be handled as an `em` unit.
 
 ### `useMedia` hook usage
 
-```js
+```tsx
 import { useMedia } from '@dnb/eufemia/shared'
 
 function Component() {
   const { isSmall, isMedium, isLarge, isSSR } = useMedia()
 
-  return isSmall ? 'true' : 'false'
+  return isSmall && <IsVisibleWhenSmall />
 }
 ```
 
 To lower the possibility of CLS (Cumulative Layout Shift) on larger screens – you can make use of the `isSSR` property. Try to use it in combination with `isLarge`, because the negative CLS experience is most recognizable on larger screens:
 
-```js
+```tsx
 import { useMedia } from '@dnb/eufemia/shared'
 
 function Component() {
   const { isSmall, isMedium, isLarge, isSSR } = useMedia()
 
-  return isLarge || isSSR ? 'true' : 'false'
+  return (isLarge || isSSR) && <IsVisibleDuringSsrAndWhenLarge />
+}
+```
+
+During SSR, when no `window` object is available, all results are negative. But you can provide a `initialValue`:
+
+```tsx
+import { useMedia } from '@dnb/eufemia/shared'
+
+function Component() {
+  const { isSmall } = useMedia({
+    initialValue: {
+      isSmall: true,
+    },
+  })
+
+  return isSmall && <IsVisibleDuringSSR />
+}
+```
+
+Here are all the options:
+
+```tsx
+import { useMedia } from '@dnb/eufemia/shared'
+
+function Component() {
+  const { isSmall } = useMedia({
+    /**
+     * Give a initial value, that is used during SSR as well.
+     * Default: null
+     */
+    initialValue?: Partial<UseMediaResult>
+
+    /**
+     * If set to true, no MediaQuery will be used.
+     * Default: false
+     */
+    disabled?: boolean
+
+    /**
+     * Provide a custom breakpoint
+     * Default: defaultBreakpoints
+     */
+    breakpoints?: MediaQueryBreakpoints
+
+    /**
+     * Provide a custom query
+     * Default: defaultQueries
+     */
+    queries?: Record<string, MediaQueryCondition>
+
+    /**
+     * For debugging
+     */
+    log?: boolean
+  })
+
+  return isSmall
 }
 ```
 

--- a/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
@@ -446,7 +446,7 @@ describe('useMedia', () => {
         })
       )
 
-      expect(count).toBe(24)
+      expect(count).toBe(28)
     })
 
     it('will return correct key based on size', async () => {
@@ -873,6 +873,73 @@ describe('useMedia', () => {
       expect(result.current).toEqual(
         expect.objectContaining({
           isSmall: false,
+          isMedium: false,
+          isLarge: true,
+          key: 'large',
+        })
+      )
+    })
+  })
+
+  describe('ssr', () => {
+    beforeAll(() => {
+      global.window['__SSR_TEST__'] = true
+    })
+
+    afterAll(() => {
+      delete global.window['__SSR_TEST__']
+    })
+
+    it('will by default return false on all sizes', () => {
+      const { result } = renderHook(useMedia, { wrapper })
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSSR: true,
+          isSmall: false,
+          isMedium: false,
+          isLarge: false,
+          key: null,
+        })
+      )
+    })
+
+    it('will return positive isSmall when in initialValue', () => {
+      const { result } = renderHook(useMedia, {
+        wrapper,
+        initialProps: {
+          initialValue: {
+            isSmall: true,
+          },
+        },
+      })
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSSR: true,
+          isSmall: true,
+          isMedium: false,
+          isLarge: false,
+          key: 'small',
+        })
+      )
+    })
+
+    it('will return both positive isSmall and isLarge', () => {
+      const { result } = renderHook(useMedia, {
+        wrapper,
+        initialProps: {
+          initialValue: {
+            isSmall: true,
+            isLarge: true,
+          },
+        },
+      })
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isSSR: true,
+          isSmall: true,
           isMedium: false,
           isLarge: true,
           key: 'large',


### PR DESCRIPTION
To avoid rehydration disturbance. The return values like `isSmall` will now always be false to start with. 
This should not be a breaking change, because on the client, it results as before.

I have not tested this hook IRL. Maybe someone can do that for me?