### PR TITLE
fix(forms): Support undefined in toggle and button fields

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
@@ -235,6 +235,18 @@ export const ButtonsFalse = () => {
   )
 }
 
+export const ButtonsUndefined = () => {
+  return (
+    <ComponentBox>
+      <Field.Boolean
+        variant="buttons"
+        label="Label text"
+        onChange={(value) => console.log('onChange', value)}
+      />
+    </ComponentBox>
+  )
+}
+
 export const ButtonsRequired = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
@@ -86,6 +86,10 @@ import * as Examples from './Examples'
 
 <Examples.ButtonsFalse />
 
+#### Button - Value undefined (no option selected)
+
+<Examples.ButtonsUndefined />
+
 #### Buttons - Required
 
 <Examples.ButtonsRequired />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -82,6 +82,7 @@ function Toggle(props: Props) {
   }
 
   const isOn = value === valueOn
+  const isOff = value === valueOff
 
   switch (variant) {
     default:
@@ -134,7 +135,7 @@ function Toggle(props: Props) {
               id={id}
               text={textOff ?? sharedContext?.translation.Forms.booleanNo}
               on_click={setOff}
-              variant={isOn ? 'secondary' : undefined}
+              variant={isOff ? undefined : 'secondary'}
               disabled={disabled}
               status={error ? 'error' : undefined}
             />


### PR DESCRIPTION
Before, passing no value defaulted to the `valueOff` option in `Field.Toggle`, leading to the same in `Field.Button` (false option being chosen). Now, no buttons is selected when value is undefined.

<img width="939" alt="Screenshot 2023-10-20 at 14 38 13" src="https://github.com/dnbexperience/eufemia/assets/2526740/db4cd31f-6fd0-4078-8986-7961eda988eb">
