### PR TITLE
chore(CI): remove upload artefact on e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,12 +118,6 @@ jobs:
         if: failure()
         run: echo '\n\n👉 Download the diff files as a ZIP file. \nIt is called "visual-test-artifact" and you find it in the test "Summary" under "Artifacts".\n\n\n'
 
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: portal-artifact
-          path: ./packages/dnb-design-system-portal/public
-
       - name: Slack
         uses: 8398a7/action-slack@v3
         with:


### PR DESCRIPTION
Because it taks way too long, and we almost never use it. In most cases we should be able to easily reproduce the CI behavior locally.

<img width="990" alt="Screenshot 2023-10-25 at 14 50 36" src="https://github.com/dnbexperience/eufemia/assets/1501870/283f9b38-dd49-46ff-9c06-0da934f00bb2">
