### PR TITLE
fix(Breadcrumb): Pass rest props to item when not interactive

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -52,4 +52,10 @@ For more information on how to replace these, check out [these docs](/uilib/layo
 - Find `FormRow:` and replace with `formElement:`.
 - Find `import { includeValidProps } from '@dnb/eufemia/components/form-row/FormRowHelpers'` and replace with `import { pickFormElementProps } from '@dnb/eufemia/shared/helpers/filterValidProps'`.
 
+## Removal of passing down props to BreadcrumbItem's span
+
+We don't think this has been used for anything other than passing down `data-testid`'s for testing. We believe the potential side effects of passing down props to this span is greater than the advantages it gives for those who want to test this span using data-testid as their way of selecting the span.
+We recommend to [use other methods](/uilib/usage/best-practices/for-testing/) to select and test the inner parts of Eufemia components. You could use e.g. `screen.queryByRole`, `screen.queryByRole` or `document.querySelector`.
+For more context, take a look in this [PR](https://github.com/dnbexperience/eufemia/pull/2798).
+
 _June, 1. 2023_

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -140,7 +140,7 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
           {...props}
         />
       ) : (
-        <span className="dnb-breadcrumb__item__span">
+        <span className="dnb-breadcrumb__item__span" {...props}>
           <IconPrimary
             icon={currentIcon}
             className="dnb-breadcrumb__item__span__icon"

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -145,7 +145,7 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
       ) : (
         <span
           className="dnb-breadcrumb__item__span"
-          //TODO: Consider deprecating passing down props to span in v11
+          // TODO: Consider deprecating passing down props to span in v11
           {...filterProps(props, (key) => !key.includes('-'))}
         >
           <IconPrimary

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -145,6 +145,7 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
       ) : (
         <span
           className="dnb-breadcrumb__item__span"
+          //TODO: Consider deprecating passing down props to span in v11
           {...filterProps(props, (key) => !key.includes('-'))}
         >
           <IconPrimary

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -15,7 +15,10 @@ import homeIcon from '../../icons/home'
 import { useTheme, useMediaQuery } from '../../shared'
 import Context from '../../shared/Context'
 import type { SkeletonShow } from '../skeleton/Skeleton'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  filterProps,
+} from '../../shared/component-helper'
 
 export type BreadcrumbItemProps = {
   /**
@@ -140,7 +143,10 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
           {...props}
         />
       ) : (
-        <span className="dnb-breadcrumb__item__span" {...props}>
+        <span
+          className="dnb-breadcrumb__item__span"
+          {...filterProps(props, (key) => !key.includes('-'))}
+        >
           <IconPrimary
             icon={currentIcon}
             className="dnb-breadcrumb__item__span__icon"

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -69,6 +69,7 @@ describe('Breadcrumb', () => {
     )
   })
 
+  //TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
   it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
     const dataTestId = 'my-test-id'
     render(
@@ -389,6 +390,7 @@ describe('Breadcrumb', () => {
       )
     })
 
+    //TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
     it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
       const dataTestId = 'my-test-id'
       render(

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -76,6 +76,7 @@ describe('Breadcrumb', () => {
         data={[
           {
             text: 'Page 2',
+            role: 'button',
             'data-testid': dataTestId,
           },
         ]}
@@ -86,6 +87,9 @@ describe('Breadcrumb', () => {
     expect(screen.queryByTestId(dataTestId).className).toMatch(
       'dnb-breadcrumb__item__span'
     )
+    expect(
+      document.querySelector('.dnb-breadcrumb__item__span')
+    ).not.toHaveAttribute('role')
   })
 
   it('renders a breadcrumb with multiple items by children', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -391,12 +391,21 @@ describe('Breadcrumb', () => {
 
     it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
       const dataTestId = 'my-test-id'
-      render(<BreadcrumbItem text="Home" data-testid={dataTestId} />)
+      render(
+        <BreadcrumbItem
+          text="Home"
+          data-testid={dataTestId}
+          role="button"
+        />
+      )
 
       expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
       expect(screen.queryByTestId(dataTestId).className).toMatch(
         'dnb-breadcrumb__item__span'
       )
+      expect(
+        document.querySelector('.dnb-breadcrumb__item__span')
+      ).not.toHaveAttribute('role')
     })
 
     describe('will set animation style', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -69,7 +69,7 @@ describe('Breadcrumb', () => {
     )
   })
 
-  //TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+  // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
   it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
     const dataTestId = 'my-test-id'
     render(
@@ -390,7 +390,7 @@ describe('Breadcrumb', () => {
       )
     })
 
-    //TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+    // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
     it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
       const dataTestId = 'my-test-id'
       render(

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -49,6 +49,45 @@ describe('Breadcrumb', () => {
     expect(screen.queryAllByRole('link')).toHaveLength(1)
   })
 
+  it('forwards rest props like data-testid, etc, to the breadcrumb item button when interactive', () => {
+    const dataTestId = 'my-test-id'
+    render(
+      <Breadcrumb
+        data={[
+          {
+            href: '/page1/page2',
+            text: 'Page 2',
+            'data-testid': dataTestId,
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
+    expect(screen.queryByTestId(dataTestId).className).toMatch(
+      'dnb-button'
+    )
+  })
+
+  it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
+    const dataTestId = 'my-test-id'
+    render(
+      <Breadcrumb
+        data={[
+          {
+            text: 'Page 2',
+            'data-testid': dataTestId,
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
+    expect(screen.queryByTestId(dataTestId).className).toMatch(
+      'dnb-breadcrumb__item__span'
+    )
+  })
+
   it('renders a breadcrumb with multiple items by children', () => {
     render(
       <Breadcrumb>
@@ -330,6 +369,29 @@ describe('Breadcrumb', () => {
 
       expect(screen.getByRole('button').className).toMatch(
         skeletonClassName
+      )
+    })
+
+    it('forwards rest props like data-testid, etc, to the breadcrumb item button when interactive', () => {
+      const dataTestId = 'my-test-id'
+      render(
+        <BreadcrumbItem href="/" text="Home" data-testid={dataTestId} />
+      )
+
+      expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
+
+      expect(screen.queryByTestId(dataTestId).className).toMatch(
+        'dnb-button'
+      )
+    })
+
+    it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
+      const dataTestId = 'my-test-id'
+      render(<BreadcrumbItem text="Home" data-testid={dataTestId} />)
+
+      expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
+      expect(screen.queryByTestId(dataTestId).className).toMatch(
+        'dnb-breadcrumb__item__span'
       )
     })
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react'
 import { Box, Wrapper } from 'storybook-utils/helpers'
-import { Skeleton, ToggleButton } from '../../'
+import { Button, Skeleton, ToggleButton } from '../../'
 import Breadcrumb from '../Breadcrumb'
 import { Provider } from '../../../shared'
 import { BreadcrumbItemProps } from '../BreadcrumbItem'
@@ -170,6 +170,26 @@ export const SupportsChildrenAsNull = () => {
           {null}
           {null}
           {null}
+        </Breadcrumb>
+      </Box>
+    </Wrapper>
+  )
+}
+
+export const BreadcrumbItemWithButtonPropsButNotInteractive = () => {
+  const props = {
+    ...Button.defaultProps,
+    text: 'Page',
+    href: null,
+    onClick: null,
+    'data-testid': 'my-testid',
+  }
+  return (
+    <Wrapper>
+      <Box>
+        <Breadcrumb data={[props, props, props]} />
+        <Breadcrumb>
+          <Breadcrumb.Item {...props} />
         </Breadcrumb>
       </Box>
     </Wrapper>

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -176,7 +176,7 @@ export const SupportsChildrenAsNull = () => {
   )
 }
 
-//TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+// TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
 export const BreadcrumbItemWithButtonPropsButNotInteractive = () => {
   const props = {
     ...Button.defaultProps,

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -176,6 +176,7 @@ export const SupportsChildrenAsNull = () => {
   )
 }
 
+//TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
 export const BreadcrumbItemWithButtonPropsButNotInteractive = () => {
   const props = {
     ...Button.defaultProps,

--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -159,5 +159,6 @@ export type ButtonProps = {
 > &
   SpacingProps;
 export default class Button extends React.Component<ButtonProps, any> {
+  static defaultProps: object;
   render(): JSX.Element;
 }


### PR DESCRIPTION
I believe/hope this should fix the reported issue here: https://github.com/dnbexperience/eufemia/pull/2676/files#r1368576095