### PR TITLE
fix(NumberMask): as_number should default to locally given decimalSymbol

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
@@ -12,6 +12,7 @@ import {
 import {
   isTrue,
   dispatchCustomElementEvent,
+  extendPropsWithContext,
 } from '../../shared/component-helper'
 import { safeSetSelection } from './text-mask/createTextMaskInputElement'
 
@@ -482,21 +483,19 @@ const useNumberMaskParams = () => {
     const decimalSymbol = handleDecimalSeparator(locale)
 
     if (isTrue(as_number) || isTrue(as_percent)) {
-      number_mask = {
+      number_mask = extendPropsWithContext(number_mask, null, {
         decimalSymbol,
         thousandsSeparatorSymbol,
-        ...number_mask,
-      }
+      })
     } else if (as_currency) {
-      currency_mask = {
+      currency_mask = extendPropsWithContext(currency_mask, null, {
         decimalSymbol,
         thousandsSeparatorSymbol,
         currency: getCurrencySymbol(
           locale,
           typeof as_currency === 'string' ? as_currency : null
         ),
-        ...currency_mask,
-      }
+      })
     }
   }
 

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -1018,6 +1018,36 @@ describe('InputMasked component as_number', () => {
     expect(document.querySelector('input').value).toBe('12 345,6')
   })
 
+  it('will not overwrite decimalSymbol when undefined was given', () => {
+    const { rerender } = render(
+      <InputMasked
+        value={12345.678}
+        as_number
+        number_mask={{
+          thousandsSeparatorSymbol: '|',
+          decimalSymbol: ':',
+          allowDecimal: true,
+        }}
+      />
+    )
+
+    expect(document.querySelector('input').value).toBe('12|345:67')
+
+    rerender(
+      <InputMasked
+        value={12345.678}
+        as_number
+        number_mask={{
+          thousandsSeparatorSymbol: undefined,
+          decimalSymbol: undefined,
+          allowDecimal: true,
+        }}
+      />
+    )
+
+    expect(document.querySelector('input').value).toBe('12 345,67')
+  })
+
   it('should merge "mask_options" properties', () => {
     render(
       <InputMasked

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -46,7 +46,7 @@ function NumberComponent(props: Props) {
     percent,
     mask,
     thousandSeparator,
-    decimalSymbol = ',',
+    decimalSymbol,
     decimalLimit = 12,
     prefix,
     suffix,


### PR DESCRIPTION
Ensure that when setting `decimalSymbol={undefined}` the default behavior still works, which is e.g. using a coma or dot, based on the given locale.