### PR TITLE
fix: BreadcrumbItem when using to and element props

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -119,7 +119,8 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
     currentIcon = icon || determineSbankenIcon(variant, isSmallScreen)
   }
   const currentText = text || (variant === 'home' && homeText) || ''
-  const isInteractive = (href || onClick) && variant !== 'current'
+  const isInteractive =
+    (href || onClick || props.to) && variant !== 'current'
   const style = { '--delay': String(itemNr) } as React.CSSProperties
 
   return (

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -282,6 +282,23 @@ describe('Breadcrumb', () => {
       ).toBeInTheDocument()
     })
 
+    it('renders breadcrumbitem as a link if the to prop is given and element is a router link', () => {
+      const MockLink = React.forwardRef(
+        (props: { to: string; children: React.ReactNode }, ref) => (
+          <a
+            href={props.to}
+            ref={ref as React.RefObject<HTMLAnchorElement>}
+          >
+            {props.children}
+          </a>
+        )
+      )
+
+      render(<BreadcrumbItem to={'/url'} element={MockLink} text="Page" />)
+
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/url')
+    })
+
     it('fires onClick event', () => {
       const onClick = jest.fn()
       render(<BreadcrumbItem onClick={onClick} text="Page" />)


### PR DESCRIPTION
Small fix to support using router links as breadcrumbs