### PR TITLE
fix(Flex): export Flex correct

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Flex.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Flex.tsx
@@ -1,1 +1,7 @@
-export * as default from './'
+import Container from './Container'
+import Item from './Item'
+import Stack from './Stack'
+import Horizontal from './Horizontal'
+import Vertical from './Vertical'
+
+export default { Container, Item, Stack, Horizontal, Vertical }

--- a/packages/dnb-eufemia/src/components/flex/index.ts
+++ b/packages/dnb-eufemia/src/components/flex/index.ts
@@ -1,5 +1,8 @@
-export { default as Container } from './Container'
-export { default as Item } from './Item'
-export { default as Stack } from './Stack'
-export { default as Horizontal } from './Horizontal'
-export { default as Vertical } from './Vertical'
+/**
+ * Component Entry
+ *
+ */
+
+import Flex from './Flex'
+export default Flex
+export * from './Flex'


### PR DESCRIPTION
https://dnb-it.slack.com/archives/CMXABCHEY/p1698744253915779

Fixes the following error in TS, when trying to import and use Grid.X like `Grid.Item`:
`Property 'Item' does not exist on type 'typeof import("<my_path>/node_modules/@dnb/eufemia/components/grid/Grid")'.`