### PR TITLE
fix(TypeScript): fix Grid and Flex export

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Flex.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Flex.tsx
@@ -1,1 +1,3 @@
-export * as default from './'
+// For TypeScript compatibility we import and export it this way
+import * as _default from './'
+export { _default as default }

--- a/packages/dnb-eufemia/src/components/grid/Grid.ts
+++ b/packages/dnb-eufemia/src/components/grid/Grid.ts
@@ -1,1 +1,4 @@
-export * as default from './'
+import Container from './Container'
+import Item from './Item'
+
+export default { Container, Item }

--- a/packages/dnb-eufemia/src/components/grid/Grid.ts
+++ b/packages/dnb-eufemia/src/components/grid/Grid.ts
@@ -1,4 +1,3 @@
-import Container from './Container'
-import Item from './Item'
-
-export default { Container, Item }
+// For TypeScript compatibility we import and export it this way
+import * as _default from './'
+export { _default as default }

--- a/packages/dnb-eufemia/src/components/grid/index.ts
+++ b/packages/dnb-eufemia/src/components/grid/index.ts
@@ -1,8 +1,2 @@
-/**
- * Component Entry
- *
- */
-
-import Grid from './Grid'
-export default Grid
-export * from './Grid'
+export { default as Container } from './Container'
+export { default as Item } from './Item'

--- a/packages/dnb-eufemia/src/components/grid/index.ts
+++ b/packages/dnb-eufemia/src/components/grid/index.ts
@@ -1,2 +1,8 @@
-export { default as Container } from './Container'
-export { default as Item } from './Item'
+/**
+ * Component Entry
+ *
+ */
+
+import Grid from './Grid'
+export default Grid
+export * from './Grid'

--- a/packages/dnb-eufemia/src/components/grid/stories/Grid.stories.tsx
+++ b/packages/dnb-eufemia/src/components/grid/stories/Grid.stories.tsx
@@ -4,15 +4,13 @@
  */
 
 import React from 'react'
-
 import { Grid } from '../..'
-import '../style'
 
 export default {
   title: 'Eufemia/Components/Layout',
 }
 
-export const colors = [
+const colors = [
   { background: '#babeee' } as React.CSSProperties,
   { background: '#dfe0ee' } as React.CSSProperties,
   { background: '#90d2c3' } as React.CSSProperties,


### PR DESCRIPTION
https://dnb-it.slack.com/archives/CMXABCHEY/p1698744253915779

Fixes the following error in TS, when trying to import and use Flex.X like `Flex.Container`:
`Property 'Container' does not exist on type 'typeof import("<my_path>/node_modules/@dnb/eufemia/components/flex/Flex")'.`

Reprod [CSB](https://codesandbox.io/s/eufemia-grid-jchqg7?file=/src/App.tsx).