### PR TITLE
chore(Section): ensure invalid style_type has still a valid fallback

### DIFF
--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`Section scss have to match default theme snapshot 1`] = `
  * Utilities
  */
 .dnb-section {
+  --background-color: var(--color-white);
   --outline-color--value: var(--color-black-8);
   /** deprecated: default should be white in v11 */
   /** deprecated */

--- a/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-sbanken.scss
@@ -1,4 +1,5 @@
 .dnb-section {
+  --background-color: var(--sb-color-white);
   --outline-color--value: var(--sb-color-gray-light-2);
 
   &--transparent {

--- a/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
@@ -6,6 +6,7 @@
 @import '../../../../components/anchor/style/anchor-mixins.scss';
 
 .dnb-section {
+  --background-color: var(--color-white);
   --outline-color--value: var(--color-black-8);
 
   &--divider {


### PR DESCRIPTION
Whit this PR we do miss out of a valid fallback, when an invalid `style_type` was given (regarding the issue in the Portal Tools on the Sbanken brand theme).

```
<Section style_type="invalid">
  will be white now, instead of black
</Section>
```