### PR TITLE
docs(PaymentCard): sets card_number as required

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/properties.mdx
@@ -7,11 +7,11 @@ showTabs: true
 | Properties                              | Description                                                                                                                                        |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `product_code`                          | _(required)_ if product code matches one of the codes in the list the card will get that design, if no match is found Default design will be used. |
+| `card_number`                           | _(required)_ masked card number.                                                                                                                   |
 | `raw_data`                              | _(optional)_ useful if you want to create custom cards. See Card data properties.                                                                  |
 | `card_status`                           | _(optional)_ use one of these: `active`, `not_active`, `blocked`, `expired`, `renewed`, `replaced`, `order_in_process`. Defaults to `active`.      |
 | `variant`                               | _(optional)_ defines the appearance. Use one of these: `normal` or `compact`. Defaults to `normal`.                                                |
 | `digits`                                | _(optional)_ will use 8 digits if none are specified.                                                                                              |
-| `card_number`                           | _(optional)_ masked card number.                                                                                                                   |
 | `locale`                                | _(optional)_ use `nb-NO` or `en-GB`. Defaults to the Eufemia provider.                                                                             |
 | `skeleton`                              | _(optional)_ if set to `true`, an overlaying skeleton with animation will be shown.                                                                |
 | [Space](/uilib/layout/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                              |


### PR DESCRIPTION
I did a quick analysis, trying to figure out if `card_number` actually is optional(as the docs says) or required.
But it looks to me as `card_number` is actually required from the code's point of view:
- https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js#L63
- https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.d.ts#L88