### PR TITLE
docs: fix font docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/naming-conventions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/naming-conventions.mdx
@@ -36,7 +36,7 @@ The same can apply to components such as cards, form rows, etc. Responsive break
 
 Eufemia for the web uses a simple naming system:
 
-<div className="typography-box">Color name + percentage</div>
+<TypographyBox>Color name + percentage</TypographyBox>
 
 Depending on where the color will be used, its name formation will be different. For example, in Figma (and other design tools), the name is constructed thus:
 
@@ -44,11 +44,11 @@ The color name is written with spaces between words. The first word starts with 
 
 Example:
 
-<div className="typography-box">Fire red 8%</div>
+<TypographyBox>Fire red 8%</TypographyBox>
 
 Whereas in CSS as a custom property this is written:
 
-<div className="typography-box">--color-fire-red-8</div>
+<TypographyBox>--color-fire-red-8</TypographyBox>
 
 Colors have a naming convention across all platforms and formats. Please refer to the table in [colors section](/quickguide-designer/colors).
 
@@ -62,16 +62,16 @@ However, to maintain consistency, in Figma we name Pages and Frames (canvases) w
 
 Example of a Figma Page name:
 
-<div className="typography-box">04 Spacing & Common components</div>
+<TypographyBox>04 Spacing & Common components</TypographyBox>
 
 Example of a Figma Frame name:
 
-<div className="typography-box">02 Spacing components - horizontal</div>
+<TypographyBox>02 Spacing components - horizontal</TypographyBox>
 
 Actual components are written with all small letters.
 
 Example of a Figma component name:
 
-<div className="typography-box">date picker</div>
+<TypographyBox>date picker</TypographyBox>
 
 If in doubt, look at the main Eufemia file - [Eufemia - Web](https://www.figma.com/file/cdtwQD8IJ7pTeE45U148r1/Eufemia-Web?node-id=530%3A49).

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
@@ -1,4 +1,4 @@
-import { H2, H3 } from '@dnb/eufemia/src'
+import { H3 } from '@dnb/eufemia/src'
 
 <VisibilityByTheme hidden="sbanken">
 ## Font Families
@@ -8,49 +8,29 @@ The default font family for all web applications is the `DNB` font.
 ## DNB Regular
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-regular">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 ## DNB Medium
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-medium">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-medium">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 ## DNB Bold
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-bold">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-bold">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 ## DNBMono Regular
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-mono-regular">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-mono-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 </VisibilityByTheme>
 <VisibilityByTheme visible="sbanken">
@@ -67,25 +47,15 @@ The default font family for all web applications is `Roboto`, however for headli
 ### Roboto regular
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-regular">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 ### Roboto bold
 
 <div className="typography-box">
-  <p className="dnb-p dnb-typo-bold">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p dnb-typo-bold">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 </VisibilityByTheme>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
@@ -7,31 +7,51 @@ The default font family for all web applications is the `DNB` font.
 
 ## DNB Regular
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-regular">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 ## DNB Medium
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-medium">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-medium">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 ## DNB Bold
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-bold">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-bold">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 ## DNBMono Regular
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-mono-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-mono-regular">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 </VisibilityByTheme>
 <VisibilityByTheme visible="sbanken">
 ## Font Families
@@ -40,22 +60,32 @@ The default font family for all web applications is `Roboto`, however for headli
 
 ### Maison Neue
 
-<div className="typography-box">
+<TypographyBox>
   <H3>This is a headline in Maison Neue</H3>
-</div>
+</TypographyBox>
 
 ### Roboto regular
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-regular">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 ### Roboto bold
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-typo-bold">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-typo-bold">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 </VisibilityByTheme>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-weights.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-weights.mdx
@@ -8,26 +8,16 @@ Achieved with HTML classes: `.dnb-typo-regular`, <VisibilityByTheme hidden="sban
 no need to use a class.
 
 <div className="typography-box">
-  <p className="dnb-typo-regular">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 
 <VisibilityByTheme hidden="sbanken">
 ### Body Medium
 
 <div className="typography-box">
-  <p className="dnb-typo-medium">
-    Here is a paragraph with some nonsense lipsum text. Contrary to popular
-    belief, Lorem Ipsum passage, and going through the cites of the word in
-    classical literature, discovered the undoubtable source. Lorem Ipsum
-    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
-    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-typo-medium">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
 </div>
 </VisibilityByTheme>
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-weights.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-weights.mdx
@@ -7,23 +7,33 @@ Achieved with HTML classes: `.dnb-typo-regular`, <VisibilityByTheme hidden="sban
 **NB!** body text is automatically set to use **regular** weight so there is
 no need to use a class.
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-typo-regular">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-typo-regular">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 
 <VisibilityByTheme hidden="sbanken">
 ### Body Medium
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-typo-medium">Here is a paragraph with some nonsense lipsum text. Contrary to popular belief, Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-typo-medium">
+    Here is a paragraph with some nonsense lipsum text. Contrary to popular
+    belief, Lorem Ipsum passage, and going through the cites of the word in
+    classical literature, discovered the undoubtable source. Lorem Ipsum
+    comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
+    Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
+  </p>
+</TypographyBox>
 </VisibilityByTheme>
 
 ### Body Bold
 
-<div className="typography-box">
+<TypographyBox>
   <p className="dnb-typo-bold">
     Here is a paragraph with some nonsense lipsum text. Contrary to popular
     belief, Lorem Ipsum passage, and going through the cites of the word in
@@ -31,4 +41,4 @@ no need to use a class.
     comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et
     Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC.
   </p>
-</div>
+</TypographyBox>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/line-height.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/line-height.mdx
@@ -12,24 +12,39 @@ Because their line-height **is** evenly divisible by 8.
 
 ### Line height = 1rem (16px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-16">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-16">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>
 
 ### Line height = 1.5rem (24px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-24">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-24">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>
 
 ### Line height = 2rem (32px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-32">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-32">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>
 
 ### These break alternatively on/off the grid (line heights 0.75rem, 1.25rem and 1.75rem)
 
@@ -38,21 +53,36 @@ Try resizing the browser - you will see the 'off-grid' result.
 
 ### Line height = 0.75rem (12px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-12">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-12">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>
 
 ### Line height = 1.25rem (20px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-20">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-20">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>
 
 ### Line height = 1.75rem (28px)
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p lh-28">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p lh-28">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+</TypographyBox>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/line-height.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/line-height.mdx
@@ -13,37 +13,22 @@ Because their line-height **is** evenly divisible by 8.
 ### Line height = 1rem (16px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-16">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-16">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>
 
 ### Line height = 1.5rem (24px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-24">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-24">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>
 
 ### Line height = 2rem (32px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-32">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-32">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>
 
 ### These break alternatively on/off the grid (line heights 0.75rem, 1.25rem and 1.75rem)
@@ -54,35 +39,20 @@ Try resizing the browser - you will see the 'off-grid' result.
 ### Line height = 0.75rem (12px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-12">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-12">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>
 
 ### Line height = 1.25rem (20px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-20">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-20">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>
 
 ### Line height = 1.75rem (28px)
 
 <div className="typography-box">
-  <p className="dnb-p lh-28">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p lh-28">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
 </div>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/typographic-elements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/typographic-elements.mdx
@@ -17,11 +17,8 @@ This is an overview of the default, basic typographic elements such as **heading
 <div className="typography-box">
   {/* prettier-ignore */}
   <h1 className="dnb-h--xx-large skip-anchor">Quem facilisi moderatius id eam, id tamquam albucius per.</h1>
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
 </div>
 
 ## Heading x-large
@@ -40,11 +37,8 @@ This is an overview of the default, basic typographic elements such as **heading
   {/* prettier-ignore */}
   <h4 className="dnb-h--x-large skip-anchor">Facilisi moderatius id eam, id tamquam albucius per.
   Vel quem congue appareat cu, mei te eros convenire</h4>
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. </p>
 </div>
 
 ## Heading large
@@ -63,11 +57,8 @@ This is an overview of the default, basic typographic elements such as **heading
   {/* prettier-ignore */}
   <h4 className="dnb-h--large skip-anchor">Quem facilisi moderatius id eam, id tamquam albucius per.
   Vel quem congue appareat cu, mei te eros convenire.</h4>
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
 </div>
 
 ## Text lead
@@ -89,11 +80,8 @@ This is an overview of the default, basic typographic elements such as **heading
     exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
     Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
     Dico purto nullam sea an.</h4>
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
 </div>
 
 ## Text basis (paragraph)
@@ -108,18 +96,10 @@ This is an overview of the default, basic typographic elements such as **heading
 ### Example:
 
 <div className="typography-box">
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
-    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.
-  </p>
-  <p className="dnb-p">
-    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
-    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
-    exerci tacimates pro, aliquam pertinacia eu vim.
-  </p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
+  {/* prettier-ignore */}
+  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
 </div>
 
 ## Text basis - small
@@ -139,16 +119,7 @@ There are two methods to create small text. One, is to use the `.dnb-p--small` m
 
 <div className="typography-box">
   {/* prettier-ignore */}
-  <p className="dnb-p dnb-p--small">This is a paragraph with a <b>modifier class</b>. This is the small
-    content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel
-    quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea,
-    ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-  <p className="dnb-p">
-    {/* prettier-ignore */}
-    <small>This is a paragraph with a <b>small tag</b> inserted here: this is
-      the small content. Quem facilisi moderatius id eam, id tamquam
-      albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea
-      bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu
-      vim.</small>
-  </p>
+  <p className="dnb-p dnb-p--small">This is a paragraph with a <b>modifier class</b>. This is the small content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
+  {/* prettier-ignore */}
+  <p className="dnb-p"><small>This is a paragraph with a <b>small tag</b> inserted here: this is the small content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</small></p>
 </div>

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/typographic-elements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/typographic-elements.mdx
@@ -14,12 +14,16 @@ This is an overview of the default, basic typographic elements such as **heading
 
 ### Example:
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <h1 className="dnb-h--xx-large skip-anchor">Quem facilisi moderatius id eam, id tamquam albucius per.</h1>
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-</div>
+<TypographyBox>
+  <h1 className="dnb-h--xx-large skip-anchor">
+    Quem facilisi moderatius id eam, id tamquam albucius per.
+  </h1>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+</TypographyBox>
 
 ## Heading x-large
 
@@ -33,13 +37,17 @@ This is an overview of the default, basic typographic elements such as **heading
 
 ### Example:
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <h4 className="dnb-h--x-large skip-anchor">Facilisi moderatius id eam, id tamquam albucius per.
-  Vel quem congue appareat cu, mei te eros convenire</h4>
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. </p>
-</div>
+<TypographyBox>
+  <h4 className="dnb-h--x-large skip-anchor">
+    Facilisi moderatius id eam, id tamquam albucius per. Vel quem congue
+    appareat cu, mei te eros convenire
+  </h4>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+</TypographyBox>
 
 ## Heading large
 
@@ -53,13 +61,17 @@ This is an overview of the default, basic typographic elements such as **heading
 
 ### Example:
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <h4 className="dnb-h--large skip-anchor">Quem facilisi moderatius id eam, id tamquam albucius per.
-  Vel quem congue appareat cu, mei te eros convenire.</h4>
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-</div>
+<TypographyBox>
+  <h4 className="dnb-h--large skip-anchor">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire.
+  </h4>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+</TypographyBox>
 
 ## Text lead
 
@@ -73,16 +85,20 @@ This is an overview of the default, basic typographic elements such as **heading
 
 ### Example:
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <h4 className="dnb-lead skip-anchor">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+<TypographyBox>
+  <h4 className="dnb-lead skip-anchor">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
     congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
     exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
     Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
-    Dico purto nullam sea an.</h4>
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-</div>
+    Dico purto nullam sea an.
+  </h4>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+</TypographyBox>
 
 ## Text basis (paragraph)
 
@@ -95,12 +111,20 @@ This is an overview of the default, basic typographic elements such as **heading
 
 ### Example:
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus. Est mediocrem reprimique contentiones ei, mea ne primis intellegat. Dico purto nullam sea an.</p>
-  {/* prettier-ignore */}
-  <p className="dnb-p">Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-</div>
+<TypographyBox>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim. Vix ei stet ornatus.
+    Est mediocrem reprimique contentiones ei, mea ne primis intellegat.
+    Dico purto nullam sea an.
+  </p>
+  <p className="dnb-p">
+    Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem
+    congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei
+    exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+</TypographyBox>
 
 ## Text basis - small
 
@@ -117,9 +141,20 @@ There are two methods to create small text. One, is to use the `.dnb-p--small` m
 
 ### Example
 
-<div className="typography-box">
-  {/* prettier-ignore */}
-  <p className="dnb-p dnb-p--small">This is a paragraph with a <b>modifier class</b>. This is the small content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</p>
-  {/* prettier-ignore */}
-  <p className="dnb-p"><small>This is a paragraph with a <b>small tag</b> inserted here: this is the small content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu vim.</small></p>
-</div>
+<TypographyBox>
+  <p className="dnb-p dnb-p--small">
+    This is a paragraph with a <b>modifier class</b>. This is the small
+    content. Quem facilisi moderatius id eam, id tamquam albucius per. Vel
+    quem congue appareat cu, mei te eros convenire. Sea bonorum epicuri ea,
+    ei exerci tacimates pro, aliquam pertinacia eu vim.
+  </p>
+  <p className="dnb-p">
+    <small>
+      This is a paragraph with a <b>small tag</b> inserted here: this is
+      the small content. Quem facilisi moderatius id eam, id tamquam
+      albucius per. Vel quem congue appareat cu, mei te eros convenire. Sea
+      bonorum epicuri ea, ei exerci tacimates pro, aliquam pertinacia eu
+      vim.
+    </small>
+  </p>
+</TypographyBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
@@ -7,13 +7,14 @@ import React from 'react'
 import styled from '@emotion/styled'
 import ComponentBox from '../../../shared/tags/ComponentBox'
 import { Code, H4, Lead, P } from '@dnb/eufemia/src'
+import { TypographyBox } from '../../../shared/parts/TypographyBox'
 
 const Wrapper = styled.div`
   margin-bottom: 3rem;
 `
 
 const FontUsageExample = ({ typo_class, font_family }) => (
-  <div className="typography-box">
+  <TypographyBox>
     <h3 className={typo_class}>{font_family}</h3>
     <p className={typo_class}>
       Here is a paragraph with some nonsense{' '}
@@ -25,7 +26,7 @@ const FontUsageExample = ({ typo_class, font_family }) => (
       <strong>The Extremes</strong> of Good and Evil) by Cicero, written in
       45 BC.
     </p>
-  </div>
+  </TypographyBox>
 )
 
 export function FontWeightExample() {

--- a/packages/dnb-design-system-portal/src/shared/parts/TypographyBox.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/TypographyBox.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import classnames from 'classnames'
+
+export function TypographyBox({ children, className = null, ...props }) {
+  return (
+    <div className={classnames('typography-box', className)} {...props}>
+      {removeNestedParagraphs(children)}
+    </div>
+  )
+}
+
+function removeNestedParagraphs(children: Array<JSX.Element>) {
+  return React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      const jsx = child as JSX.Element
+      if (jsx.type?.name === 'p') {
+        return jsx.props.children
+      } else {
+        return React.cloneElement(
+          child,
+          null,
+          removeNestedParagraphs(jsx.props.children),
+        )
+      }
+    }
+
+    return child
+  })
+}

--- a/packages/dnb-design-system-portal/src/shared/tags/index.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/index.tsx
@@ -22,6 +22,7 @@ import Anchor from './Anchor'
 import Header from './AutoLinkHeader'
 import Copy from './Copy'
 import VisibilityByTheme from '@dnb/eufemia/src/shared/VisibilityByTheme'
+import { TypographyBox } from '../parts/TypographyBox'
 
 export const basicComponents = {
   // img: Img, // -> <figure> cannot appear as a descendant of <p>
@@ -69,6 +70,7 @@ export const basicComponents = {
 
 export default {
   Copy,
+  TypographyBox,
   VisibilityByTheme,
   VisibleWhenVisualTest: ({ children }) => {
     if (typeof globalThis !== 'undefined' && globalThis.IS_TEST) {


### PR DESCRIPTION
When running `/quickguide-designer/fonts/#font-weights` [locally](http://localhost:8000/quickguide-designer/fonts/#font-weights), I get the following errors:
```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
    at p
    at ElementInstance
```

What's happening is that `\n` somehow gets inserted when a prettier formats a `<p>`, leading to the content being wrapped in a `<p>`, so that we get `<p>`'s inside of `<p>`'s.
Here's a link to a related issue: https://github.com/storybookjs/storybook/issues/18921 

If this would only lead to the console error pasted above, it all would be fine, but in some scenarios when wrapping a `p` in a `p`, the visual result is actually different(so what's displayed in the docs is actually not what we want), compare the [fix](https://eufemia-git-docs-fix-font-docs-eufemia.vercel.app/quickguide-designer/fonts/#font-weights) vs. what's on [main](https://eufemia.dnb.no/quickguide-designer/fonts/#font-weights). Screenshot as reference:


<img width="1792" alt="Screenshot 2023-11-06 at 13 39 33" src="https://github.com/dnbexperience/eufemia/assets/1359205/4023b9a1-5c4b-4586-bd9f-2c2122b0e097">
