### PR TITLE
fix(Button): element's type supports Link of react-router-dom

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -38,9 +38,9 @@ export type ButtonChildren =
   | string
   | ((...args: any[]) => any)
   | React.ReactNode;
-export type ButtonElement = DynamicElement<
-  HTMLButtonElement | HTMLAnchorElement | AnchorProps
->;
+export type ButtonElement =
+  | DynamicElement<HTMLButtonElement | HTMLAnchorElement | AnchorProps>
+  | React.ReactNode;
 export type ButtonOnClick = string | ((...args: any[]) => any);
 export type ButtonProps = {
   /**

--- a/packages/dnb-eufemia/src/components/button/stories/Button.stories.tsx
+++ b/packages/dnb-eufemia/src/components/button/stories/Button.stories.tsx
@@ -359,3 +359,11 @@ export const GlobalStatusExample = () => {
     </>
   )
 }
+
+export const TypeScriptElement = () => {
+  const ReactRouterDomLink: React.ForwardRefExoticComponent<
+    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> &
+      React.RefAttributes<HTMLAnchorElement>
+  > = null //This is "simulating" { Link } from 'react-router-dom'
+  return <Button element={ReactRouterDomLink} />
+}


### PR DESCRIPTION
This is just a "quick fix", making it possible in TypeScript to send `Link` of react-router-dom as a value to the `element` prop.

This possibility was removed as part of https://github.com/dnbexperience/eufemia/commit/e030657cd362c42fbb8af79aa11ef4115f511b9e

I'm not 100% sure about this fix(as I've just reverted(added back `any`) from this https://github.com/dnbexperience/eufemia/commit/e030657cd362c42fbb8af79aa11ef4115f511b9e#diff-ece10293b585707067686d660cf459378b2027585fc414e1263e9694b0ed0be2L38

First reported here: https://dnb-it.slack.com/archives/CMXABCHEY/p1699274667145269

I think/hope we could release this as part of v10.11.1(or v10.12.0?), as the reporters are eager for a fix 🙏 
Seems like the "problem" was introduced in v10.10.0, should we also try making a release v10.10.1 for this, or is that too much work perhaps? 🤔 