### PR TITLE
fix(MultiInputMask): incorrect legend hover and focus within effect

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1321,13 +1321,13 @@ html[data-visual-test] .dnb-input__input {
   color: var(--color-black);
 }
 .dnb-multi-input-mask .dnb-input__shell:focus-within {
-  --border-width: 0.125rem;
+  box-shadow: 0 0 0 var(--input-border-width--focus) var(--input-border-color--hover);
 }
 
 .dnb-multi-input-mask__legend--horizontal.dnb-form-label {
   display: contents;
 }
-.dnb-multi-input-mask__legend:not([disabled]):hover ~ .dnb-multi-input-mask__legend .dnb-input__shell {
-  --border-width: 0.125rem;
+.dnb-multi-input-mask__legend:not([disabled]):hover ~ .dnb-multi-input-mask .dnb-input__shell {
+  box-shadow: 0 0 0 var(--input-border-width--focus) var(--input-border-color--hover);
 }"
 `;

--- a/packages/dnb-eufemia/src/components/input-masked/style/dnb-input-masked.scss
+++ b/packages/dnb-eufemia/src/components/input-masked/style/dnb-input-masked.scss
@@ -68,7 +68,8 @@
   }
 
   .dnb-input__shell:focus-within {
-    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--input-border-width--focus)
+      var(--input-border-color--hover);
   }
 }
 
@@ -77,7 +78,8 @@
     display: contents;
   }
 
-  &:not([disabled]):hover ~ & .dnb-input__shell {
-    --border-width: 0.125rem;
+  &:not([disabled]):hover ~ .dnb-multi-input-mask .dnb-input__shell {
+    box-shadow: 0 0 0 var(--input-border-width--focus)
+      var(--input-border-color--hover);
   }
 }


### PR DESCRIPTION
Proposal to fix the incorrect input hover effects when hovering over the `legend` element  the `.dnb-input__shell` focus-within trigger, caused by the `fakeBorder`-mixin applying a `inset` to the `box-shadow` style.

Before:
<img width="280" alt="Screenshot 2023-11-07 at 14 11 33" src="https://github.com/dnbexperience/eufemia/assets/25927156/ff2411b5-0109-406d-948b-550f24f9f95a">
<img width="300" alt="Screenshot 2023-11-07 at 14 11 46" src="https://github.com/dnbexperience/eufemia/assets/25927156/f6bb2acc-0025-4bf7-a802-09eed4bdf98b">

After:
<img width="305" alt="Screenshot 2023-11-07 at 14 11 02" src="https://github.com/dnbexperience/eufemia/assets/25927156/6e2651c9-9702-41c3-abd1-bc0c2d1f373b">
<img width="291" alt="Screenshot 2023-11-07 at 14 12 12" src="https://github.com/dnbexperience/eufemia/assets/25927156/35d5f56a-b472-4d8c-a27a-5be34be0bda6">
