### PR TITLE
fix(Autocomplete): ensure on_change is firered during dataset update

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/methods.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/methods.mdx
@@ -6,6 +6,8 @@ You can manipulate the used data dynamically, either by changing the `data` prop
 
 - `updateData` replace all data entries.
 - `emptyData` remove all data entries.
+- `resetSelectedItem` will invalidate the selected key.
+- `revalidateSelectedItem` will re-validate the selected key on the given `value`.
 - `setInputValue` update the input value.
 - `showIndicator` shows a progress indicator instead of the icon (inside the input).
 - `hideIndicator` hides the progress indicator inside the input.

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -14,13 +14,7 @@ import {
   mockImplementationForDirectionObserver,
   testDirectionObserver,
 } from '../../../fragments/drawer-list/__tests__/DrawerListTestMocks'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  act,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, act, waitFor } from '@testing-library/react'
 import {
   DrawerListData,
   DrawerListDataObject,
@@ -1200,6 +1194,10 @@ describe('Autocomplete component', () => {
       />
     )
 
+    expect(document.querySelector('input').value).toBe(
+      Array.from(mockData[2].content).join(' ')
+    )
+
     // 2. Then update the data
     rerender(
       <Autocomplete
@@ -1209,6 +1207,10 @@ describe('Autocomplete component', () => {
         data={newMockData}
         value={2}
       />
+    )
+
+    expect(document.querySelector('input').value).toBe(
+      Array.from(newMockData[2].content).join(' ')
     )
 
     // 3. And change the value again
@@ -1222,8 +1224,6 @@ describe('Autocomplete component', () => {
       />
     )
 
-    // It should not trigger the resetSelectionItem method
-    expect(on_change).toHaveBeenCalledTimes(0)
     expect(document.querySelector('input').value).toBe(
       newMockData[1].content
     )
@@ -1238,6 +1238,8 @@ describe('Autocomplete component', () => {
         value={null}
       />
     )
+
+    expect(document.querySelector('input').value).toBe('')
 
     fireEvent.change(document.querySelector('input'), {
       target: { value: 'cc' },
@@ -1280,7 +1282,67 @@ describe('Autocomplete component', () => {
     )
   })
 
-  it('will call on_change on each change, when selecting the first option from different data sources', () => {
+  it('should show "no-options" when in sync mode', async () => {
+    const mockData = [
+      { selected_key: 'a', content: 'AA c' },
+      { selected_key: 'b', content: 'BB cc zethx' },
+      { selected_key: 'c', content: ['CC', 'cc'] },
+    ]
+
+    render(<Autocomplete {...mockProps} data={mockData} mode="sync" />)
+
+    const inputElement = document.querySelector('input')
+
+    await userEvent.type(inputElement, 'aa')
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(2)
+    expect(
+      document.querySelector('.dnb-autocomplete__no-options')
+    ).not.toBeInTheDocument()
+
+    await userEvent.type(inputElement, 'invalid')
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(1)
+    expect(
+      document.querySelector('.dnb-autocomplete__no-options')
+    ).toBeInTheDocument()
+  })
+
+  it('should not show "no-options" during async mode', async () => {
+    const mockData = [
+      { selected_key: 'a', content: 'AA c' },
+      { selected_key: 'b', content: 'BB cc zethx' },
+      { selected_key: 'c', content: ['CC', 'cc'] },
+    ]
+
+    render(<Autocomplete {...mockProps} data={mockData} mode="async" />)
+
+    const inputElement = document.querySelector('input')
+
+    await userEvent.type(inputElement, 'aa')
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(2)
+    expect(
+      document.querySelector('.dnb-autocomplete__no-options')
+    ).not.toBeInTheDocument()
+
+    await userEvent.type(inputElement, 'invalid')
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(2)
+    expect(
+      document.querySelector('.dnb-autocomplete__no-options')
+    ).not.toBeInTheDocument()
+  })
+
+  it('will call on_change on each change, when selecting the first option from different data sources', async () => {
     const mockDataA = [{ selected_key: 'a', content: 'A' }]
     const mockDataB = [{ selected_key: 'b', content: 'B' }]
 
@@ -1323,12 +1385,16 @@ describe('Autocomplete component', () => {
     fireEvent.change(document.querySelector('input'), {
       target: { value: 'b' },
     })
+
+    // because the key of the current data item has changed
+    expect(on_change).toHaveBeenCalledTimes(2)
+
     fireEvent.click(
       document.querySelectorAll('li.dnb-drawer-list__option')[0]
     )
 
-    expect(on_change).toHaveBeenCalledTimes(2)
-    expect(on_change.mock.calls[1][0].data).toMatchObject(mockDataB[0])
+    expect(on_change).toHaveBeenCalledTimes(3)
+    expect(on_change.mock.calls[2][0].data).toMatchObject(mockDataB[0])
     expect(document.querySelector('input').value).toBe(
       mockDataB[0].content
     )
@@ -1337,12 +1403,15 @@ describe('Autocomplete component', () => {
     fireEvent.change(document.querySelector('input'), {
       target: { value: 'a' },
     })
+
+    expect(on_change).toHaveBeenCalledTimes(4)
+
     fireEvent.click(
       document.querySelectorAll('li.dnb-drawer-list__option')[0]
     )
 
-    expect(on_change).toHaveBeenCalledTimes(3)
-    expect(on_change.mock.calls[0][0].data).toMatchObject(mockDataA[0])
+    expect(on_change).toHaveBeenCalledTimes(5)
+    expect(on_change.mock.calls[4][0].data).toMatchObject(mockDataA[0])
     expect(document.querySelector('input').value).toBe(
       mockDataA[0].content
     )
@@ -1441,6 +1510,7 @@ describe('Autocomplete component', () => {
         .value
     ).toBe('456 value')
     expect(on_change.mock.calls[2][0].data.selected_key).toBe('id-456')
+
     rerender(
       <Autocomplete
         {...mockProps}
@@ -1458,19 +1528,33 @@ describe('Autocomplete component', () => {
     ).toBe('')
   })
 
-  const runBlurActiveItemTest = ({
-    Comp,
-    shouldHaveActiveItem,
-    shouldHaveActiveItemWhenEmpty,
-  }) => {
-    const closeAndReopen = () => {
-      // Close and open
-      fireEvent.blur(document.querySelector('.dnb-input__input'))
-      fireEvent.focus(document.querySelector('.dnb-input__input'))
-      fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
-    }
+  const closeAndReopen = () => {
+    // Close and open
+    fireEvent.blur(document.querySelector('.dnb-input__input'))
+    fireEvent.focus(document.querySelector('.dnb-input__input'))
+    fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
+  }
 
-    render(Comp)
+  it('should reset selected_item on input blur when no selection is made if "keep_value" and "keep_value_and_selection" is false', () => {
+    const on_show = jest.fn()
+    const on_hide = jest.fn()
+    const on_focus = jest.fn()
+    const on_blur = jest.fn()
+    const on_change = jest.fn()
+    const on_type = jest.fn()
+
+    render(
+      <Autocomplete
+        data={mockData}
+        {...mockProps}
+        on_show={on_show}
+        on_hide={on_hide}
+        on_focus={on_focus}
+        on_blur={on_blur}
+        on_change={on_change}
+        on_type={on_type}
+      />
+    )
 
     // open
     fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
@@ -1494,8 +1578,8 @@ describe('Autocomplete component', () => {
     closeAndReopen()
 
     expect(
-      document.querySelector('li.dnb-drawer-list__option--focus') !== null
-    ).toBe(shouldHaveActiveItem)
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
       target: { value: '' },
@@ -1515,8 +1599,8 @@ describe('Autocomplete component', () => {
 
     // This here is what we expect
     expect(
-      document.querySelector('li.dnb-drawer-list__option--focus') !== null
-    ).toBe(shouldHaveActiveItemWhenEmpty)
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
 
     // This also opens the drawer-list
     fireEvent.change(document.querySelector('.dnb-input__input'), {
@@ -1552,16 +1636,21 @@ describe('Autocomplete component', () => {
 
     // This here is what we expect
     expect(
-      document.querySelector('li.dnb-drawer-list__option--focus') !== null
-    ).toBe(shouldHaveActiveItemWhenEmpty)
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
     expect(
       document.querySelector('li.dnb-drawer-list__option--selected')
     ).not.toBeInTheDocument()
 
-    cleanup()
-  }
+    expect(on_show).toBeCalledTimes(2)
+    expect(on_hide).toBeCalledTimes(2)
+    expect(on_focus).toBeCalledTimes(4)
+    expect(on_blur).toBeCalledTimes(3)
+    expect(on_change).toBeCalledTimes(2)
+    expect(on_type).toBeCalledTimes(4)
+  })
 
-  it('should reset "active_item" on input blur when no selection is made and "keep_value" and "keep_value_and_selection" is false', () => {
+  it('should not reset input value on input blur if "keep_value" is true and value is empty', () => {
     const on_show = jest.fn()
     const on_hide = jest.fn()
     const on_focus = jest.fn()
@@ -1569,22 +1658,105 @@ describe('Autocomplete component', () => {
     const on_change = jest.fn()
     const on_type = jest.fn()
 
-    runBlurActiveItemTest({
-      Comp: (
-        <Autocomplete
-          data={mockData}
-          {...mockProps}
-          on_show={on_show}
-          on_hide={on_hide}
-          on_focus={on_focus}
-          on_blur={on_blur}
-          on_change={on_change}
-          on_type={on_type}
-        />
-      ),
-      shouldHaveActiveItem: false,
-      shouldHaveActiveItemWhenEmpty: false,
+    render(
+      <Autocomplete
+        keep_value
+        data={mockData}
+        {...mockProps}
+        on_show={on_show}
+        on_hide={on_hide}
+        on_focus={on_focus}
+        on_blur={on_blur}
+        on_change={on_change}
+        on_type={on_type}
+      />
+    )
+
+    // open
+    fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option').length
+    ).toBe(3)
+
+    fireEvent.focus(document.querySelector('.dnb-input__input'))
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: 'cc' },
     })
+
+    // Make first item active
+    keydown(40) // down
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+
+    closeAndReopen()
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '' },
+    })
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+
+    keydown(40) // down
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+
+    closeAndReopen()
+
+    // This here is what we expect
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+
+    // This also opens the drawer-list
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: 'cc' },
+    })
+
+    keydown(40) // activate
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        keyCode: 13, // enter
+      })
+    )
+
+    closeAndReopen()
+
+    // Now we have a selected item
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--selected')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+    expect(
+      (document.querySelector('.dnb-input__input') as HTMLInputElement)
+        .value
+    ).toBe('CC cc')
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '' },
+    })
+
+    closeAndReopen()
+
+    // This here is what we expect
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--selected')
+    ).not.toBeInTheDocument()
 
     expect(on_show).toBeCalledTimes(2)
     expect(on_hide).toBeCalledTimes(2)
@@ -1594,7 +1766,7 @@ describe('Autocomplete component', () => {
     expect(on_type).toBeCalledTimes(4)
   })
 
-  it('should only reset "active_item" on input blur and "keep_value" is true and value is empty', () => {
+  it('should not reset selected_item on input blur if "keep_value_and_selection" true', () => {
     const on_show = jest.fn()
     const on_hide = jest.fn()
     const on_focus = jest.fn()
@@ -1602,63 +1774,111 @@ describe('Autocomplete component', () => {
     const on_change = jest.fn()
     const on_type = jest.fn()
 
-    runBlurActiveItemTest({
-      Comp: (
-        <Autocomplete
-          keep_value
-          data={mockData}
-          {...mockProps}
-          on_show={on_show}
-          on_hide={on_hide}
-          on_focus={on_focus}
-          on_blur={on_blur}
-          on_change={on_change}
-          on_type={on_type}
-        />
-      ),
-      shouldHaveActiveItem: true,
-      shouldHaveActiveItemWhenEmpty: false,
+    render(
+      <Autocomplete
+        keep_value_and_selection
+        data={mockData}
+        {...mockProps}
+        on_show={on_show}
+        on_hide={on_hide}
+        on_focus={on_focus}
+        on_blur={on_blur}
+        on_change={on_change}
+        on_type={on_type}
+      />
+    )
+
+    // open
+    fireEvent.mouseDown(document.querySelector('.dnb-input__input'))
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option').length
+    ).toBe(3)
+
+    fireEvent.focus(document.querySelector('.dnb-input__input'))
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: 'cc' },
     })
+
+    // Make first item active
+    keydown(40) // down
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+
+    closeAndReopen()
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '' },
+    })
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+
+    keydown(40) // down
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+
+    closeAndReopen()
+
+    // This here is what we expect
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).not.toBeInTheDocument()
+
+    // This also opens the drawer-list
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: 'cc' },
+    })
+
+    keydown(40) // activate
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        keyCode: 13, // enter
+      })
+    )
+
+    closeAndReopen()
+
+    // Now we have a selected item
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--selected')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+    expect(
+      (document.querySelector('.dnb-input__input') as HTMLInputElement)
+        .value
+    ).toBe('CC cc')
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '' },
+    })
+
+    closeAndReopen()
+
+    // This here is what we expect
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--focus')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--selected')
+    ).toBeInTheDocument()
 
     expect(on_show).toBeCalledTimes(2)
     expect(on_hide).toBeCalledTimes(2)
     expect(on_focus).toBeCalledTimes(4)
     expect(on_blur).toBeCalledTimes(3)
-    expect(on_change).toBeCalledTimes(2)
-    expect(on_type).toBeCalledTimes(4)
-  })
-
-  it('should not reset "active_item" on input blur and "keep_value_and_selection" true', () => {
-    const on_show = jest.fn()
-    const on_hide = jest.fn()
-    const on_focus = jest.fn()
-    const on_blur = jest.fn()
-    const on_change = jest.fn()
-    const on_type = jest.fn()
-
-    runBlurActiveItemTest({
-      Comp: (
-        <Autocomplete
-          keep_value_and_selection
-          data={mockData}
-          {...mockProps}
-          on_show={on_show}
-          on_hide={on_hide}
-          on_focus={on_focus}
-          on_blur={on_blur}
-          on_change={on_change}
-          on_type={on_type}
-        />
-      ),
-      shouldHaveActiveItem: true,
-      shouldHaveActiveItemWhenEmpty: true,
-    })
-
-    expect(on_show).toBeCalledTimes(2)
-    expect(on_hide).toBeCalledTimes(2)
-    expect(on_focus).toBeCalledTimes(4)
-    expect(on_blur).toBeCalledTimes(3)
-    expect(on_change).toBeCalledTimes(2)
+    expect(on_change).toBeCalledTimes(1)
     expect(on_type).toBeCalledTimes(4)
   })
 
@@ -2384,7 +2604,7 @@ describe('Autocomplete component', () => {
     ])
   })
 
-  it('should set correct value in input', () => {
+  it('should set correct value in input', async () => {
     const data = [
       {
         selectedKey: '+93',
@@ -2407,6 +2627,7 @@ describe('Autocomplete component', () => {
         content: '+41 Sveits',
       },
     ]
+
     const MockComponent = () => {
       const [value, setValue] = React.useState('+47')
 
@@ -2415,7 +2636,7 @@ describe('Autocomplete component', () => {
           data={[data[1]]}
           value={value}
           mode="async"
-          on_change={({ data }) => setValue(data.selectedKey)}
+          on_change={({ data }) => setValue(data?.selectedKey)}
           on_focus={({ updateData }) => updateData(data)}
           search_numbers
           no_animation
@@ -2430,10 +2651,20 @@ describe('Autocomplete component', () => {
     expect(inputElement.value).toEqual('NO (+47)')
 
     // open
+    fireEvent.focus(inputElement)
     fireEvent.keyDown(inputElement, {
       key: 'Enter',
       keyCode: 13,
     })
+
+    expect(
+      document.querySelector('li.dnb-drawer-list__option--selected')
+        .textContent
+    ).toBe('+47 Norge')
+
+    await userEvent.type(inputElement, '{Backspace}')
+
+    expect(inputElement.value).toEqual('NO (+47')
 
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0]

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1280,6 +1280,74 @@ describe('Autocomplete component', () => {
     )
   })
 
+  it('will call on_change on each change, when selecting the first option from different data sources', () => {
+    const mockDataA = [{ selected_key: 'a', content: 'A' }]
+    const mockDataB = [{ selected_key: 'b', content: 'B' }]
+
+    const onTypeHandler = ({ value, updateData }) => {
+      if (value === 'a') {
+        updateData(mockDataA)
+      } else if (value === 'b') {
+        updateData(mockDataB)
+      }
+    }
+
+    const on_change = jest.fn()
+    const on_type = jest.fn(onTypeHandler)
+
+    render(
+      <Autocomplete
+        {...mockProps}
+        on_change={on_change}
+        on_type={on_type}
+        data={mockDataA}
+        mode="async"
+      />
+    )
+
+    // Search for a and select the option/result
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: 'a' },
+    })
+    fireEvent.click(
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+    )
+
+    expect(on_change).toHaveBeenCalledTimes(1)
+    expect(on_change.mock.calls[0][0].data).toMatchObject(mockDataA[0])
+    expect(document.querySelector('input').value).toBe(
+      mockDataA[0].content
+    )
+
+    // Search for b and select the option/result
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: 'b' },
+    })
+    fireEvent.click(
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+    )
+
+    expect(on_change).toHaveBeenCalledTimes(2)
+    expect(on_change.mock.calls[1][0].data).toMatchObject(mockDataB[0])
+    expect(document.querySelector('input').value).toBe(
+      mockDataB[0].content
+    )
+
+    // Search for a and select the option/result
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: 'a' },
+    })
+    fireEvent.click(
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+    )
+
+    expect(on_change).toHaveBeenCalledTimes(3)
+    expect(on_change.mock.calls[0][0].data).toMatchObject(mockDataA[0])
+    expect(document.querySelector('input').value).toBe(
+      mockDataA[0].content
+    )
+  })
+
   it('selects correct value and key', () => {
     const mockData = [
       { selected_key: 'a', content: 'A value' },

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 import styled from '@emotion/styled'
 
@@ -14,7 +14,7 @@ import {
   Button,
   GlobalStatus,
 } from '../..'
-import { Anchor } from '../../../'
+import { Anchor, Li, Ol, P, Section, Space } from '../../../'
 import { Context, Provider } from '../../../shared'
 import { SubmitButton } from '../../input/Input'
 import { format } from '../../number-format/NumberUtils'
@@ -926,5 +926,69 @@ export const GlobalStatusExample = () => {
         status="Message"
       />
     </>
+  )
+}
+
+export const AsyncSearchExample = () => {
+  const dataA = [{ selected_id: 1, content: 'AAAAAA' }]
+  const dataB = [{ selected_id: 2, content: 'BBBBBB' }]
+
+  const [onChangeValue, setOnChangeValue] = useState()
+
+  const onTypeHandler = ({
+    value,
+    showIndicator,
+    hideIndicator,
+    updateData,
+    debounce,
+  }) => {
+    showIndicator()
+    debounce(
+      ({ value }) => {
+        let newData = []
+        if (value.toLowerCase() === 'a') {
+          newData = dataA
+        } else if (value.toLowerCase() === 'b') {
+          newData = dataB
+        }
+        // simulate server delay
+        const timeout = setTimeout(() => {
+          // update the drawerList
+          updateData(newData)
+          hideIndicator()
+        }, 600)
+
+        // cancel invocation method
+        return () => clearTimeout(timeout)
+      },
+      { value },
+      250
+    )
+  }
+  return (
+    <Section spacing>
+      <Space left>
+        <P>In this demo/recreation:</P>
+        <Ol>
+          <Li>Type "A" and select the option available</Li>
+          <Li>Type "B" and select the option available</Li>
+        </Ol>
+        <P>on_change is not firing when selecting "B".</P>
+        <Autocomplete
+          top
+          mode="async"
+          on_type={onTypeHandler}
+          no_scroll_animation={true}
+          placeholder="Search ..."
+          on_change={({ data }) => {
+            console.log('on_change', data)
+            if (data) {
+              setOnChangeValue(data.content)
+            }
+          }}
+        />
+        <P top>Value from on_change: {onChangeValue}</P>
+      </Space>
+    </Section>
   )
 }

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -54,10 +54,10 @@ export const SearchNumbers = () => {
 }
 
 const accounts = [
-  { selected_id: 1, content: 'A' },
-  { selected_id: 2, content: 'B' },
-  { selected_id: 3, content: 'C' },
-  { selected_id: 4, content: 'D' },
+  { selectedKey: 1, content: 'A' },
+  { selectedKey: 2, content: 'B' },
+  { selectedKey: 3, content: 'C' },
+  { selectedKey: 4, content: 'D' },
 ]
 export function UpdateEachOther() {
   const [selectedA, setSelectedA] = React.useState(-1)
@@ -67,11 +67,11 @@ export function UpdateEachOther() {
   const [selectedAccountsB, setSelectedAccountsB] =
     React.useState(accounts)
 
-  const indexA = selectedAccountsA.findIndex(({ selected_id }) => {
-    return selected_id === selectedA
+  const indexA = selectedAccountsA.findIndex(({ selectedKey }) => {
+    return selectedKey === selectedA
   })
-  const indexB = selectedAccountsB.findIndex(({ selected_id }) => {
-    return selected_id === selectedB
+  const indexB = selectedAccountsB.findIndex(({ selectedKey }) => {
+    return selectedKey === selectedB
   })
 
   console.log('selectedA', { selectedAccountsA, selectedA, indexA })
@@ -86,10 +86,10 @@ export function UpdateEachOther() {
         data={selectedAccountsA}
         value={indexA}
         on_change={({ data: account }) => {
-          setSelectedA(account?.selected_id)
+          setSelectedA(account?.selectedKey)
           setSelectedAccountsB(
-            accounts.filter(({ selected_id }) => {
-              return selected_id !== account?.selected_id
+            accounts.filter(({ selectedKey }) => {
+              return selectedKey !== account?.selectedKey
             })
           )
         }}
@@ -100,10 +100,10 @@ export function UpdateEachOther() {
         data={selectedAccountsB}
         value={indexB}
         on_change={({ data: account }) => {
-          setSelectedB(account?.selected_id)
+          setSelectedB(account?.selectedKey)
           setSelectedAccountsA(
-            accounts.filter(({ selected_id }) => {
-              return selected_id !== account?.selected_id
+            accounts.filter(({ selectedKey }) => {
+              return selectedKey !== account?.selectedKey
             })
           )
         }}
@@ -930,8 +930,14 @@ export const GlobalStatusExample = () => {
 }
 
 export const AsyncSearchExample = () => {
-  const dataA = [{ selected_id: 1, content: 'AAAAAA' }]
-  const dataB = [{ selected_id: 2, content: 'BBBBBB' }]
+  const dataA = [
+    { selectedKey: 'a', content: 'AAA' },
+    { selectedKey: 'c', content: 'CCC' },
+  ]
+  const dataB = [
+    { selectedKey: 'b', content: 'BBB' },
+    { selectedKey: 'e', content: 'EEE' },
+  ]
 
   const [onChangeValue, setOnChangeValue] = useState()
 
@@ -950,6 +956,8 @@ export const AsyncSearchExample = () => {
           newData = dataA
         } else if (value.toLowerCase() === 'b') {
           newData = dataB
+        } else {
+          newData = [...dataA, ...dataB]
         }
         // simulate server delay
         const timeout = setTimeout(() => {
@@ -962,7 +970,7 @@ export const AsyncSearchExample = () => {
         return () => clearTimeout(timeout)
       },
       { value },
-      250
+      150
     )
   }
   return (
@@ -982,12 +990,10 @@ export const AsyncSearchExample = () => {
           placeholder="Search ..."
           on_change={({ data }) => {
             console.log('on_change', data)
-            if (data) {
-              setOnChangeValue(data.content)
-            }
+            setOnChangeValue(data?.content)
           }}
         />
-        <P top>Value from on_change: {onChangeValue}</P>
+        <P top>Value from on_change: {onChangeValue || '–'}</P>
       </Space>
     </Section>
   )

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -981,7 +981,7 @@ export const AsyncSearchExample = () => {
           <Li>Type "A" and select the option available</Li>
           <Li>Type "B" and select the option available</Li>
         </Ol>
-        <P>on_change is not firing when selecting "B".</P>
+        <P>on_change should also be firing when selecting "B".</P>
         <Autocomplete
           top
           mode="async"


### PR DESCRIPTION
Added a test for the issue https://github.com/dnbexperience/eufemia/issues/2847

Not 100% sure about the actual fix yet 🤔
If someone else has a clue, please give it a go, and add a commit to this branch 🙇


---

- [CSB](https://codesandbox.io/s/hardcore-worker-x5nrv7?file=/src/App.tsx) with a reproduction.
- Will fix #2847