### PR TITLE
fix: typescript react type resolution in monorepos

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -118,8 +118,18 @@
     "what-input": "5.2.10"
   },
   "peerDependencies": {
+    "@types/react": "^17 || ^18",
+    "@types/react-dom": "^17 || ^18",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "7.22.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,8 +3133,15 @@ __metadata:
     wait-on: "npm:6.0.0"
     what-input: "npm:5.2.10"
   peerDependencies:
+    "@types/react": ^17 || ^18
+    "@types/react-dom": ^17 || ^18
     react: ^17 || ^18
     react-dom: ^17 || ^18
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
When typechecking an app or library in a monorepo that uses Eufemia, typechecking can fail in certain scenarios, even if all packages uses the same version of Eufemia.

Example:
app-1 uses:
@dnb/eufemia 10.9.0
react 18.2.0
@types/react 18.2.37

app-2 uses:
@dnb/eufemia 10.9.0
react 17.0.2
@types/react 17.0.70

The use of multiple React versions works fine, since Eufemia has peer dependency on react, so this is linked correctly per app.
But since Eufemia does not define a peerDependency on @types/react, the type information for Typescript can resolve to the wrong @types/react package, which can cause issues when the code is typechecked (during builds, tests or pure typechecking).

----

I have made a fairly simple monorepo reproduction repo here: https://github.com/thebreiflabb/eufemia-react-typecheck-repro

----

This seems to be the recommended approach in libraries that expose type declarations and depends on React, a similar discussion has been had in the React repo: https://github.com/facebook/react/issues/24304#issuecomment-1094565891

----

While testing this, I did pack a local build of Eufemia with these changes, and used it in the reproduction repo, and the correct @types/react package was linked directly to Eufemia and worked