### PR TITLE
docs(PostalCodeAndCity): remove unsupported props

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
@@ -2,18 +2,13 @@
 showTabs: true
 ---
 
-import DataValueReadwriteProperties from '../../data-value-readwrite-properties.mdx'
-
 ## Properties
 
-<DataValueReadwriteProperties type="string" />
-
-### Component-specific props
-
-| Property                                | Type                | Description                                                                                                            |
-| --------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `help`                                  | `object`            | _(optional)_ Provide a help button. Object consisting of `title` and `contents`                                        |
-| `postalCode`                            | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code. |
-| `city`                                  | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for city.        |
-| `width`                                 | `string` or `false` | _(optional)_ `small`, `medium` or `large` for predefined standard widths.                                              |
-| [Space](/uilib/layout/space/properties) | Various             | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                                  |
+| Property                                                                           | Type                | Description                                                                                                            |
+| ---------------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `help`                                                                             | `object`            | _(optional)_ Provide a help button. Object consisting of `title` and `contents`                                        |
+| `postalCode`                                                                       | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code. |
+| `city`                                                                             | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for city.        |
+| `width`                                                                            | `string` or `false` | _(optional)_ `small`, `medium` or `large` for predefined standard widths.                                              |
+| [Space](/uilib/layout/space/properties)                                            | Various             | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                                  |
+| [FieldBlockProps](/uilib/extensions/forms/create-component/FieldBlock/properties/) | Various             | _(optional)_ `FieldBlockProps` properties.                                                                             |


### PR DESCRIPTION
Fixes https://github.com/dnbexperience/eufemia/issues/2884

Turns out that `PostalCodeAndCity` does not inherit `FieldProps` but rather `FieldBlockProps`, hence, it never inherits/extends the `DataValueReadWriteComponentProps` and therefore the `DataValueReadWriteComponentProps` should not be listed in the docs for `PostalCodeAndCity`.