### PR TITLE
docs(PhoneNumber): remove unsupported props

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/data-value-readwrite-properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/data-value-readwrite-properties.mdx
@@ -1,4 +1,8 @@
+import { OmitTableProperties } from 'dnb-design-system-portal/src/shared/tags/Table'
+
 ### Standard data value component props
+
+<OmitTableProperties>
 
 | Property               | Type                        | Description                                                                                                                                                                                                                                                                    |
 | ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -27,3 +31,10 @@
 | `onBlurValidator`      | `function`                  | _(optional)_ Custom validator function that will be called when the user leaves the field (blurring a text input, closing a dropdown etc). Can be asynchronous or synchronous.                                                                                                 |
 | `toInput`              | `function`                  | _(optional)_ Derivate called when the received / active value is sent to the input. Can be used for casting, changing syntax etc.                                                                                                                                              |
 | `fromInput`            | `function`                  | _(optional)_ Derivate called when changes is made by the user, to cast or change syntax back to the original (opposite of `toInput`).                                                                                                                                          |
+
+</OmitTableProperties>
+
+export default function Layout({ omit = null, children }) {
+  globalThis.omitTableProperties = omit
+  return <>{children}</>
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/properties.mdx
@@ -19,4 +19,13 @@ import DataValueReadwriteProperties from '../../data-value-readwrite-properties.
 | `width`                                 | `string` or `false` | _(optional)_ `large` for predefined standard width, `stretch` for fill available width.                     |
 | [Space](/uilib/layout/space/properties) | Various             | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                       |
 
-<DataValueReadwriteProperties type="string" />
+<DataValueReadwriteProperties
+  type="string"
+  omit={[
+    'layout',
+    'label',
+    'labelDescription',
+    'labelSecondary',
+    'emptyValue',
+  ]}
+/>

--- a/packages/dnb-design-system-portal/src/shared/tags/Table.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Table.tsx
@@ -14,6 +14,27 @@ const StyledTable = styled(TableElement)`
   }
 `
 
+export function OmitTableProperties({ children, ...rest }) {
+  const omitProperties = globalThis.omitTableProperties || []
+
+  return recursiveMap(children, (child: React.ReactElement) => {
+    if (child.type === 'tr') {
+      const firstTd = getFirstChild(child)
+
+      if (firstTd.type === 'td') {
+        const tdContent = getFirstChild(firstTd)
+        const name = getFirstChild(tdContent)
+
+        if (omitProperties.includes(name)) {
+          return null
+        }
+      }
+    }
+
+    return child
+  })
+}
+
 export default function Table({ children }) {
   // make sure we get the table children
   children =
@@ -54,6 +75,10 @@ export default function Table({ children }) {
       <StyledTable>{children}</StyledTable>
     </TableElement.ScrollView>
   )
+}
+
+function getFirstChild(children: ChildrenWithChildren) {
+  return children.props.children.at(0)
 }
 
 function getChildren(children: ChildrenWithChildren) {


### PR DESCRIPTION
This way we can simply list props that are not supported for various reasons:

```mdx
<DataValueReadwriteProperties
  type="string"
  omit={[
    'layout',
    'label',
    'labelDescription',
    'labelSecondary',
    'emptyValue',
  ]}
/>
```