### PR TITLE
fix(forms): Field block error handling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/FieldBlock/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/FieldBlock/Examples.tsx
@@ -146,6 +146,19 @@ export const GroupMultipleFields = () => {
   )
 }
 
+export const CombineErrorMessages = () => {
+  return (
+    <ComponentBox>
+      <FieldBlock>
+        <Flex.Horizontal>
+          <Field.Number width="small" label="Num" minimum={100} />
+          <Field.String width="medium" label="Txt" minLength={5} />
+        </Flex.Horizontal>
+      </FieldBlock>
+    </ComponentBox>
+  )
+}
+
 export const HorizontalAutoSize = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/FieldBlock/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/FieldBlock/demos.mdx
@@ -50,6 +50,12 @@ import * as Examples from './Examples'
 
 <Examples.GroupMultipleFields />
 
+### Combine error messages
+
+Error messages from all fields inside the FieldBlock are combined as one message below the whole block
+
+<Examples.CombineErrorMessages />
+
 ### Responsive forms
 
 <Examples.HorizontalAutoSize />

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlockContext.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlockContext.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { screen, render, waitFor } from '@testing-library/react'
+import { Field } from '../..'
+import FieldBlockContext from '../FieldBlockContext'
+
+describe('FieldBlockContext', () => {
+  it('should receive the error instead of inner components rendering it', async () => {
+    const setError = jest.fn()
+    const setShowError = jest.fn()
+
+    render(
+      <FieldBlockContext.Provider value={{ setError, setShowError }}>
+        <Field.String value="ab" minLength={5} validateInitially />
+      </FieldBlockContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalledTimes(1)
+      expect(setShowError).toHaveBeenCalledTimes(1)
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -406,7 +406,6 @@ export default function useDataValue<
       forceUpdate()
     },
     [
-      // id,
       path,
       elementPath,
       iterateElementIndex,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -141,14 +141,15 @@ export default function useDataValue<
   const hasFocusRef = useRef<boolean>(false)
 
   // Error handling
+  // - Should errors received through validation be shown initially. Assume that providing a direct prop to
+  // the component means it is supposed to be shown initially.
+  const showErrorInitially = validateInitially || errorProp
   // - Local errors are errors based on validation instructions received by
   const localErrorRef = useRef<Error | FormError | undefined>()
   // - Context errors are from outer contexts, like validation for this field as part of the whole data set
   const contextErrorRef = useRef<Error | FormError | undefined>()
 
-  const showErrorRef = useRef<boolean>(
-    Boolean(validateInitially || errorProp)
-  )
+  const showErrorRef = useRef<boolean>(Boolean(showErrorInitially))
   const errorMessagesRef = useRef(errorMessages)
   useEffect(() => {
     errorMessagesRef.current = errorMessages
@@ -165,6 +166,16 @@ export default function useDataValue<
   const schemaValidatorRef = useRef<ValidateFunction>(
     schema ? ajv.compile(schema) : undefined
   )
+
+  const showError = useCallback(() => {
+    showErrorRef.current = true
+    setShowFieldBlockError?.(path ?? id, true)
+  }, [path, id, setShowFieldBlockError])
+
+  const hideError = useCallback(() => {
+    showErrorRef.current = false
+    setShowFieldBlockError?.(path ?? id, false)
+  }, [path, id, setShowFieldBlockError])
 
   /**
    * Prepare error from validation logic with correct error messages based on props
@@ -306,10 +317,9 @@ export default function useDataValue<
     if (dataContext.showAllErrors) {
       // If showError on a surrounding data context was changed and set to true, it is because the user clicked next, submit or
       // something else that should lead to showing the user all errors.
-      showErrorRef.current = true
-      setShowFieldBlockError?.(path ?? id, true)
+      showError()
     }
-  }, [id, path, dataContext.showAllErrors, setShowFieldBlockError])
+  }, [dataContext.showAllErrors, showError])
 
   const setHasFocus = useCallback(
     (hasFocus: boolean, valueOverride?: Value) => {
@@ -338,20 +348,17 @@ export default function useDataValue<
         }
 
         // Since the user left the field, show error (if any)
-        showErrorRef.current = true
-        setShowFieldBlockError?.(path ?? id, true)
+        showError()
         forceUpdate()
       }
     },
     [
-      id,
-      path,
       validateUnchanged,
       onFocus,
       onBlur,
       onBlurValidator,
       persistErrorState,
-      setShowFieldBlockError,
+      showError,
       forceUpdate,
     ]
   )
@@ -378,12 +385,10 @@ export default function useDataValue<
         // When there is a change to the value without there having been any focus callback beforehand, it is likely
         // to believe that the blur callback will not be called either, which would trigger the display of the error.
         // The error is therefore displayed immediately (unless instructed not to with continuousValidation set to false).
-        showErrorRef.current = true
-        setShowFieldBlockError?.(path ?? id, true)
+        showError()
       } else {
         // When changing the value, hide errors to avoid annoying the user before they are finished filling in that value
-        showErrorRef.current = false
-        setShowFieldBlockError?.(path ?? id, false)
+        hideError()
       }
       // Always validate the value immediately when it is changed
       validateValue()
@@ -401,7 +406,7 @@ export default function useDataValue<
       forceUpdate()
     },
     [
-      id,
+      // id,
       path,
       elementPath,
       iterateElementIndex,
@@ -409,7 +414,9 @@ export default function useDataValue<
       onChange,
       validateValue,
       dataContextHandlePathChange,
-      setShowFieldBlockError,
+      showError,
+      hideError,
+      // setShowFieldBlockError,
       handleIterateElementChange,
       fromInput,
       forceUpdate,
@@ -421,6 +428,10 @@ export default function useDataValue<
       dataContext?.handleMountField(path)
     }
     validateValue()
+
+    if (showErrorInitially) {
+      showError()
+    }
 
     return () => {
       // Unmount procedure

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -415,7 +415,6 @@ export default function useDataValue<
       dataContextHandlePathChange,
       showError,
       hideError,
-      // setShowFieldBlockError,
       handleIterateElementChange,
       fromInput,
       forceUpdate,

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.js
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.js
@@ -164,6 +164,14 @@ export default {
         'The value cannot be shorter than {minLength} characters',
       stringInputErrorMaxLength:
         'The value cannot be longer than {maxLength} characters',
+      numberFieldErrorMinimum: 'The value must be at lest {minimum}',
+      numberFieldErrorMaximum: 'The value must be a maximum of {maximum}',
+      numberFieldErrorExclusiveMinimum:
+        'The value must be greater than {exclusiveMinimum}',
+      numberFieldErrorExclusiveMaximum:
+        'The value must be less than {exclusiveMaximum}',
+      numberFieldErrorMultipleOf:
+        'The value must be a multiple of {multipleOf}',
       selectionClearSelected: 'Clear the selected value',
       countryCodeLabel: 'Country code',
       dateLabel: 'Date',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.js
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.js
@@ -162,6 +162,14 @@ export default {
         'Verdien kan ikke være kortere enn {minLength} tegn',
       stringInputErrorMaxLength:
         'Verdien kan ikke være lengre enn {maxLength} tegn',
+      numberFieldErrorMinimum: 'Verdien må være minst {minimum}',
+      numberFieldErrorMaximum: 'Verdien må være maksimalt {maximum}',
+      numberFieldErrorExclusiveMinimum:
+        'Verdien må være større enn {exclusiveMinimum}',
+      numberFieldErrorExclusiveMaximum:
+        'Verdien må være mindre enn {exclusiveMaximum}',
+      numberFieldErrorMultipleOf:
+        'Verdien må være et multiplum av {multipleOf}',
       selectionClearSelected: 'Fjern valgt verdi',
       countryCodeLabel: 'Landskode',
       dateLabel: 'Dato',


### PR DESCRIPTION
FieldBlock did not receive errors from initial renders of inner field components, only after change callbacks to the value. Fixed, added example in portal and unit test.