### PR TITLE
fix(forms): Improved message value replacements

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -617,4 +617,29 @@ describe('DataContext.Provider', () => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
   })
+
+  it('should show provided errorMessages based on outer schema validation with injected value', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        val: {
+          type: 'string',
+          minLength: 7,
+        },
+      },
+    }
+
+    render(
+      <DataContext.Provider schema={schema} data={{ val: 'abc' }}>
+        <TestField
+          path="/val"
+          errorMessages={{
+            minLength: 'Minimum {minLength} chars.',
+          }}
+        />
+      </DataContext.Provider>
+    )
+
+    expect(screen.getByText('Minimum 7 chars.')).toBeInTheDocument()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -1,8 +1,12 @@
 import { JSONSchema7 } from 'json-schema'
 import { SpacingProps } from '../../components/space/types'
 
+type ValidationRule = string | string[]
+type MessageValues = Record<string, string>
+
 interface IFormErrorOptions {
-  validationRule?: string | string[]
+  validationRule?: ValidationRule
+  messageValues?: MessageValues
 }
 
 /**
@@ -12,13 +16,20 @@ export class FormError extends Error {
   /**
    * What validation rule did the error occur based on? (i.e: minLength, required or maximum)
    */
-  validationRule?: string | string[]
+  validationRule?: ValidationRule
+
+  /**
+   * Replacement values relevant for this error.
+   * @example { minLength: 3 } to be able to replace values in a message like "Minimum {minLength} charactes"
+   */
+  messageValues?: MessageValues
 
   constructor(message: string, options?: IFormErrorOptions) {
     super(message)
 
     if (options) {
       this.validationRule = options.validationRule
+      this.messageValues = options.messageValues
     }
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
@@ -36,9 +36,38 @@ function getValidationRule(ajvError: ErrorObject): string {
   return ajvError.keyword
 }
 
+function getMessageValues(
+  ajvError: ErrorObject
+): FormError['messageValues'] {
+  const validationRule = getValidationRule(ajvError)
+
+  switch (validationRule) {
+    case 'minLength':
+    case 'maxLength':
+    case 'minimum':
+    case 'maximum':
+    case 'exclusiveMinimum':
+    case 'exclusiveMaximum':
+      return {
+        [validationRule]: ajvError.params?.limit,
+      }
+    case 'multipleOf':
+      return {
+        [validationRule]: ajvError.params?.multipleOf,
+      }
+    case 'pattern':
+      return {
+        [validationRule]: ajvError.params?.pattern,
+      }
+  }
+}
+
 function ajvErrorToFormError(ajvError: ErrorObject): FormError {
   const error = new FormError(ajvError.message ?? 'Unknown error', {
     validationRule: getValidationRule(ajvError),
+    // Keep the message values in the error object instead of injecting them into the message
+    // at once, since an error might be validated one place, and then get a new message before it is displayed.
+    messageValues: getMessageValues(ajvError),
   })
   return error
 }


### PR DESCRIPTION
Errors based on schema validation in the Provider did not get values injected when providing custom error messages. This is now handeled by adding validation values to the error object (when validated in the Provider) and injecting them in the target field component with their specific error messages. With test to ensure it works as intended.