### PR TITLE
chore: remove FieldBlock forId warning

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -3,10 +3,7 @@ import classnames from 'classnames'
 import { Space, FormLabel, FormStatus } from '../../../components'
 import { FormError, ComponentProps, FieldProps } from '../types'
 import FieldBlockContext from './FieldBlockContext'
-import {
-  findElementInChildren,
-  warn,
-} from '../../../shared/component-helper'
+import { findElementInChildren } from '../../../shared/component-helper'
 
 export type Props = Pick<
   FieldProps,
@@ -133,7 +130,6 @@ function FieldBlock(props: Props) {
   // A child component with a label was found, use fieldset/legend instead of div/label
   const enableFieldset = useEnableFieldset({
     label,
-    forId,
     asFieldset,
     children,
     nestedFieldBlockContext,
@@ -233,7 +229,6 @@ function FieldBlock(props: Props) {
 
 function useEnableFieldset({
   label,
-  forId,
   asFieldset,
   children,
   nestedFieldBlockContext,
@@ -255,12 +250,6 @@ function useEnableFieldset({
           return (result = true)
         }
       })
-
-      if (forId && count > 1) {
-        warn(
-          `You may not use forId="${forId}" as there where given several (${count}) form elements as children.`
-        )
-      }
     }
 
     return Boolean(result)

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -89,30 +89,6 @@ describe('FieldBlock', () => {
     )
   })
 
-  it('should warn when "forId" and several form elements where given', () => {
-    const orig = console.log
-    console.log = jest.fn()
-
-    render(
-      <FieldBlock forId="invalid" label="A Label">
-        <MockComponent label="Label" id="foo" />
-        <MockComponent label="Label" id="bar" />
-      </FieldBlock>
-    )
-
-    expect(console.log).toHaveBeenCalledTimes(1)
-    expect(console.log).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.stringContaining('forId="invalid"')
-    )
-
-    expect(document.querySelectorAll('fieldset')).toHaveLength(1)
-    expect(document.querySelectorAll('legend')).toHaveLength(1)
-    expect(document.querySelectorAll('label')).toHaveLength(2)
-
-    console.log = orig
-  })
-
   it('should render a "label"', () => {
     render(<FieldBlock label="A Label">content</FieldBlock>)
 


### PR DESCRIPTION
It was meant to be a DX improvement. But it turns out, its not a valid message to give, as its actually sometimes a requirement to send in `forId` along with two or more form element children. So the warning was false.

