### PR TITLE
chore(forms): refactor width implementation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
@@ -4,11 +4,10 @@ showTabs: true
 
 ## Properties
 
-| Property                                                                           | Type                | Description                                                                                                            |
-| ---------------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `help`                                                                             | `object`            | _(optional)_ Provide a help button. Object consisting of `title` and `contents`                                        |
-| `postalCode`                                                                       | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code. |
-| `city`                                                                             | `object`            | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for city.        |
-| `width`                                                                            | `string` or `false` | _(optional)_ `small`, `medium` or `large` for predefined standard widths.                                              |
-| [Space](/uilib/layout/space/properties)                                            | Various             | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                                  |
-| [FieldBlockProps](/uilib/extensions/forms/create-component/FieldBlock/properties/) | Various             | _(optional)_ `FieldBlockProps` properties.                                                                             |
+| Property                                                                           | Type     | Description                                                                                                            |
+| ---------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `help`                                                                             | `object` | _(optional)_ Provide a help button. Object consisting of `title` and `contents`                                        |
+| `postalCode`                                                                       | `object` | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code. |
+| `city`                                                                             | `object` | _(required)_ Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for city.        |
+| [Space](/uilib/layout/space/properties)                                            | Various  | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                                  |
+| [FieldBlockProps](/uilib/extensions/forms/create-component/FieldBlock/properties/) | Various  | _(optional)_ `FieldBlockProps` properties.                                                                             |

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -7,9 +7,7 @@ import { FieldHelpProps } from '../../types'
 
 export type Props = FieldHelpProps &
   Omit<FieldBlockProps, 'children'> &
-  Record<'postalCode' | 'city', StringComponentProps> & {
-    width?: 'small' | 'medium' | 'large'
-  }
+  Record<'postalCode' | 'city', StringComponentProps>
 
 function PostalCodeAndCity(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -17,8 +15,8 @@ function PostalCodeAndCity(props: Props) {
   const {
     postalCode = {},
     city = {},
-    width = 'large',
     help,
+    width = 'large',
     ...fieldBlockProps
   } = props
 
@@ -29,12 +27,11 @@ function PostalCodeAndCity(props: Props) {
         props.className
       )}
       {...fieldBlockProps}
+      width={width}
     >
       <div
         className={classnames(
-          'dnb-forms-field-postal-code-and-city__fields',
-          width !== undefined &&
-            `dnb-forms-field-postal-code-and-city--width-${width}`
+          'dnb-forms-field-postal-code-and-city__fields'
         )}
       >
         <StringComponent

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/style/dnb-postal-code-and-city.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/style/dnb-postal-code-and-city.scss
@@ -1,22 +1,8 @@
-@import '../../style/field-sizes.scss';
-
 .dnb-forms-field-postal-code-and-city {
   &__fields {
     display: flex;
     flex-flow: row;
     column-gap: var(--spacing-small);
-  }
-
-  &--width {
-    &-small {
-      width: var(--forms-field-width--small);
-    }
-    &-medium {
-      width: var(--forms-field-width--medium);
-    }
-    &-large {
-      width: var(--forms-field-width--large);
-    }
   }
 
   &__postal-code {


### PR DESCRIPTION
Because, width is supported by FieldBlock anyway, we don't need this additional implementation.

