### PR TITLE
fix(PhoneNumber): return country code only when a number is given

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
@@ -8,7 +8,7 @@ export const Empty = () => {
       <Field.PhoneNumber
         onFocus={(value) => console.log('onFocus', value)}
         onBlur={(value) => console.log('onBlur', value)}
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
         onCountryCodeChange={(countryCode) =>
           console.log('onCountryCodeChange', countryCode)
         }
@@ -25,7 +25,7 @@ export const Placeholder = () => {
     <ComponentBox>
       <Field.PhoneNumber
         placeholder="Call this number"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
       />
     </ComponentBox>
   )
@@ -36,7 +36,7 @@ export const Label = () => {
     <ComponentBox>
       <Field.PhoneNumber
         label="Label text"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
       />
     </ComponentBox>
   )
@@ -48,7 +48,7 @@ export const LabelAndValue = () => {
       <Field.PhoneNumber
         label="Label text"
         value="+47 98765432"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
       />
     </ComponentBox>
   )
@@ -58,7 +58,7 @@ export const WithHelp = () => {
   return (
     <ComponentBox>
       <Field.PhoneNumber
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
         help={{
           title: 'Help is available',
           contents:
@@ -75,7 +75,7 @@ export const Disabled = () => {
       <Field.PhoneNumber
         value="+47 12345678"
         label="Label text"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
         disabled
       />
     </ComponentBox>
@@ -88,7 +88,7 @@ export const Error = () => {
       <Field.PhoneNumber
         value="007"
         label="Label text"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
         error={new FormError('This is what is wrong...')}
       />
     </ComponentBox>
@@ -101,7 +101,7 @@ export const ValidationRequired = () => {
       <Field.PhoneNumber
         value="+47 888"
         label="Label text"
-        onChange={(value) => console.log('onChange', value)}
+        onChange={(...args) => console.log('onChange', ...args)}
         required
       />
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/info.mdx
@@ -12,3 +12,15 @@ render(<Field.PhoneNumber />)
 ```
 
 There is a corresponding [Value.PhoneNumber](/uilib/extensions/forms/create-component/Value/PhoneNumber) component.
+
+## Value
+
+This component behaves as "one single component". Therefor it combines the country code and the number to a single string during an event callback.
+
+Also, the `value` property should be a string with the country code, separated from the main number by a space.
+
+The component returns the `emptyValue` when no number is set, which defaults to `undefined`.
+
+### Default country code
+
+The default country code is set to `+47`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/properties.mdx
@@ -21,11 +21,5 @@ import DataValueReadwriteProperties from '../../data-value-readwrite-properties.
 
 <DataValueReadwriteProperties
   type="string"
-  omit={[
-    'layout',
-    'label',
-    'labelDescription',
-    'labelSecondary',
-    'emptyValue',
-  ]}
+  omit={['layout', 'label', 'labelDescription', 'labelSecondary']}
 />

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.d.ts
@@ -125,7 +125,7 @@ export interface AutocompleteProps
    */
   keep_value?: boolean;
   /**
-   * Use `true` to not remove the selected value/key on input blur, if it is invalid. By default, the typed value will disappear / replaced by a selected value from the data list during the input field blur. Defaults to `false`.
+   * Use `true` to not remove selected item on input blur, when the input value is empty. Defaults to `false`.
    */
   keep_selection?: boolean;
   /**

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -124,6 +124,7 @@ function PhoneNumber(props: Props) {
    */
   useMemo(() => {
     if (lang !== langRef.current) {
+      langRef.current = lang
       dataRef.current = getCountryData({
         lang,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -62,7 +62,6 @@ function PhoneNumber(props: Props) {
     label = sharedContext?.translation.Forms.phoneNumberLabel,
     numberMask,
     emptyValue,
-    value,
     info,
     warning,
     error,
@@ -100,14 +99,12 @@ function PhoneNumber(props: Props) {
     ) {
       countryCodeRef.current = countryCode || defaultCountryCode
 
-      if (lang === langRef.current) {
-        dataRef.current = getCountryData({
-          lang,
-          filter: countryCodeRef.current,
-        })
-      }
+      dataRef.current = getCountryData({
+        lang,
+        filter: countryCodeRef.current,
+      })
     }
-  }, [props.value]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [props.value, lang])
 
   /**
    * On external value change, update the internal,
@@ -118,10 +115,8 @@ function PhoneNumber(props: Props) {
     const newValue = phoneNumber
       ? joinValue([countryCode, phoneNumber])
       : emptyValue
-    if (newValue !== value) {
-      updateValue(newValue)
-    }
-  }, [props.value]) // eslint-disable-line react-hooks/exhaustive-deps
+    updateValue(newValue)
+  }, [props.value, emptyValue, updateValue])
 
   /**
    * Update whole contry list when lang changes.
@@ -173,15 +168,18 @@ function PhoneNumber(props: Props) {
     [countryCodeRef, emptyValue, handleChange, onNumberChange]
   )
 
-  const onFocusHandler = ({ updateData }) => {
-    if (dataRef.current.length < 10) {
-      dataRef.current = getCountryData({
-        lang: sharedContext.locale?.split('-')[0],
-      })
-      updateData(dataRef.current)
-    }
-    handleFocus()
-  }
+  const onFocusHandler = useCallback(
+    ({ updateData }) => {
+      if (dataRef.current.length < 10) {
+        dataRef.current = getCountryData({
+          lang: sharedContext.locale?.split('-')[0],
+        })
+        updateData(dataRef.current)
+      }
+      handleFocus()
+    },
+    [handleFocus, sharedContext.locale]
+  )
 
   return (
     <FieldBlock

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -132,40 +132,46 @@ function PhoneNumber(props: Props) {
 
   const handleCountryCodeChange = useCallback(
     ({ data }: { data: { selectedKey: string } }) => {
-      const countryCode = data?.selectedKey?.trim() ?? emptyValue
+      const countryCode = data?.selectedKey?.trim() || emptyValue
+      const phoneNumber = phoneNumberRef.current || emptyValue
       countryCodeRef.current = countryCode
 
-      if (!countryCode && !phoneNumberRef.current) {
-        handleChange(emptyValue)
-        onCountryCodeChange?.(emptyValue)
-        return
-      }
+      /**
+       * To ensure, we actually call onChange every time,
+       * even if the value is undefined
+       */
+      updateValue('invalidate')
 
-      if (countryCode && !phoneNumberRef.current) {
-        onCountryCodeChange?.(countryCode)
-        return
-      }
+      handleChange(
+        phoneNumber ? joinValue([countryCode, phoneNumber]) : emptyValue,
+        {
+          countryCode,
+          phoneNumber,
+        }
+      )
 
-      handleChange(joinValue([countryCode, phoneNumberRef.current]))
       onCountryCodeChange?.(countryCode)
     },
-    [phoneNumberRef, emptyValue, handleChange, onCountryCodeChange]
+    [emptyValue, updateValue, handleChange, onCountryCodeChange]
   )
 
   const handleNumberChange = useCallback(
-    (phoneNumber: string) => {
-      phoneNumberRef.current = phoneNumber
+    (value: string) => {
+      const phoneNumber = value || emptyValue
+      const countryCode = countryCodeRef.current || emptyValue
+      phoneNumberRef.current = phoneNumber || emptyValue
 
-      if (!phoneNumber) {
-        handleChange(emptyValue)
-        onNumberChange?.(emptyValue)
-        return
-      }
+      handleChange(
+        phoneNumber ? joinValue([countryCode, phoneNumber]) : emptyValue,
+        {
+          countryCode,
+          phoneNumber,
+        }
+      )
 
-      handleChange(joinValue([countryCodeRef.current, phoneNumber]))
       onNumberChange?.(phoneNumber)
     },
-    [countryCodeRef, emptyValue, handleChange, onNumberChange]
+    [emptyValue, handleChange, onNumberChange]
   )
 
   const onFocusHandler = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -11,7 +11,7 @@ import { pickSpacingProps } from '../../../../components/flex/utils'
 import SharedContext from '../../../../shared/Context'
 
 export type Props = FieldHelpProps &
-  FieldProps<string, undefined> & {
+  FieldProps<string, undefined | string> & {
     countryCodeFieldClassName?: string
     numberFieldClassName?: string
     countryCodePlaceholder?: string
@@ -45,7 +45,6 @@ function PhoneNumber(props: Props) {
   )
 
   const defaultProps: Partial<Props> = {
-    value: '',
     errorMessages,
   }
   const preparedProps: Props = {
@@ -63,6 +62,7 @@ function PhoneNumber(props: Props) {
     label = sharedContext?.translation.Forms.phoneNumberLabel,
     numberMask,
     emptyValue,
+    value,
     info,
     warning,
     error,
@@ -115,10 +115,10 @@ function PhoneNumber(props: Props) {
    */
   useEffect(() => {
     const [countryCode, phoneNumber] = splitValue(props.value)
-    const newValue = joinValue(
-      phoneNumber ? [countryCode, phoneNumber] : []
-    )
-    if (newValue !== props.value) {
+    const newValue = phoneNumber
+      ? joinValue([countryCode, phoneNumber])
+      : emptyValue
+    if (newValue !== value) {
       updateValue(newValue)
     }
   }, [props.value]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -162,7 +162,7 @@ function PhoneNumber(props: Props) {
       phoneNumberRef.current = phoneNumber
 
       if (!phoneNumber) {
-        handleChange(joinValue([emptyValue, emptyValue]))
+        handleChange(emptyValue)
         onNumberChange?.(emptyValue)
         return
       }
@@ -287,7 +287,7 @@ function getCountryData({ lang = 'en', filter = null } = {}) {
 
 function splitValue(value: string) {
   return (
-    value !== undefined
+    typeof value === 'string'
       ? value.match(/^(\+[^ ]+)? ?(.*)$/)
       : [undefined, '', '']
   ).slice(1)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -69,10 +69,10 @@ describe('Field.PhoneNumber', () => {
     )
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith('+47')
+    expect(onFocus).toHaveBeenLastCalledWith('')
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith('+47')
+    expect(onBlur).toHaveBeenLastCalledWith('')
 
     await userEvent.type(phoneElement, '99999999')
 
@@ -102,9 +102,86 @@ describe('Field.PhoneNumber', () => {
     expect(item.textContent).toBe('+47 Norge')
   })
 
+  it('should update internal state from outside', () => {
+    const onChange = jest.fn()
+    const onFocus = jest.fn()
+    const onCountryCodeChange = jest.fn()
+
+    const MockPhoneNumber = () => {
+      const [state, update] = React.useState('+47 1')
+      React.useEffect(() => {
+        update('+41 2')
+      }, [])
+
+      return (
+        <PhoneNumber
+          value={state}
+          onFocus={onFocus}
+          onCountryCodeChange={onCountryCodeChange}
+          onChange={(value) => {
+            update(value)
+            onChange(value)
+          }}
+          noAnimation
+        />
+      )
+    }
+
+    render(<MockPhoneNumber />)
+
+    const codeElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__country-code input'
+    )
+    const phoneElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__number input'
+    )
+    const firstItemElement = () =>
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('2​ ​​ ​​ ​​')
+
+    // Change PhoneNumber
+    fireEvent.change(phoneElement, { target: { value: '234' } })
+    fireEvent.focus(phoneElement)
+
+    expect(onChange).toHaveBeenNthCalledWith(1, '+41 234')
+    expect(onFocus).toHaveBeenNthCalledWith(1, '+41 234')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('23 4​ ​​ ​​')
+
+    // Change CountryCode
+    fireEvent.focus(codeElement)
+    fireEvent.keyDown(codeElement, {
+      key: 'Enter',
+      keyCode: 13,
+    })
+    fireEvent.change(codeElement, { target: { value: '+47' } })
+    fireEvent.click(firstItemElement())
+
+    expect(onChange).toHaveBeenNthCalledWith(2, '+47 234')
+    expect(onFocus).toHaveBeenNthCalledWith(2, '+41 234')
+    expect(onCountryCodeChange).toHaveBeenCalledWith('+47')
+    expect(codeElement.value).toEqual('NO (+47)')
+    expect(phoneElement.value).toEqual('23 4​ ​​ ​​')
+
+    fireEvent.focus(phoneElement)
+    expect(onFocus).toHaveBeenNthCalledWith(3, '+47 234')
+
+    // Empty PhoneNumber – expect empty value
+    fireEvent.change(phoneElement, { target: { value: '' } })
+    fireEvent.focus(phoneElement)
+
+    expect(onChange).toHaveBeenNthCalledWith(3, '')
+    expect(onFocus).toHaveBeenNthCalledWith(4, '')
+    expect(codeElement.value).toEqual('NO (+47)')
+    expect(phoneElement.value).toEqual('')
+  })
+
   it('should return correct value onChange event', async () => {
     const onChange = jest.fn()
     const onCountryCodeChange = jest.fn()
+
     render(
       <PhoneNumber
         onChange={onChange}
@@ -113,17 +190,20 @@ describe('Field.PhoneNumber', () => {
       />
     )
 
-    const phoneElement = document.querySelector(
+    const phoneElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__number input'
     )
-    await userEvent.type(phoneElement, '99999999')
-    expect(onChange).toHaveBeenLastCalledWith('+47 99999999')
-
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
     )
+    const firstItemElement = () =>
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
 
+    await userEvent.type(phoneElement, '99999999')
+
+    expect(onChange).toHaveBeenLastCalledWith('+47 99999999')
     expect(codeElement.value).toEqual('NO (+47)')
+    expect(phoneElement.value).toEqual('99 99 99 99')
 
     // open
     fireEvent.focus(codeElement)
@@ -139,26 +219,118 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(codeElement, '{Backspace}')
 
+    expect(firstItemElement().textContent).toBe('+47 Norge')
     expect(codeElement.value).toEqual('NO (+47')
+    expect(phoneElement.value).toEqual('99 99 99 99')
 
-    expect(
-      document.querySelectorAll('li.dnb-drawer-list__option')[0]
-        .textContent
-    ).toBe('+47 Norge')
-
-    fireEvent.focus(codeElement)
     fireEvent.change(codeElement, { target: { value: '+41' } })
-    fireEvent.click(
-      document.querySelectorAll('li.dnb-drawer-list__option')[0]
-    )
-
-    expect(codeElement.value).toEqual('CH (+41)')
+    fireEvent.click(firstItemElement())
 
     await wait(1)
 
     expect(onCountryCodeChange).toHaveBeenCalledTimes(1)
     expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
     expect(onChange).toHaveBeenLastCalledWith('+41 99999999')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('99 99 99 99')
+
+    await userEvent.type(phoneElement, '{Backspace>8}')
+
+    expect(onChange).toHaveBeenLastCalledWith('')
+  })
+
+  it('should handle events correctly with initial value', async () => {
+    const onChange = jest.fn()
+    const onCountryCodeChange = jest.fn()
+
+    render(
+      <PhoneNumber
+        onChange={onChange}
+        onCountryCodeChange={onCountryCodeChange}
+        value="+47 12"
+      />
+    )
+
+    const codeElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__country-code input'
+    )
+    const phoneElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__number input'
+    )
+    const firstItemElement = () =>
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+
+    fireEvent.change(phoneElement, { target: { value: '1' } })
+
+    expect(onChange).toHaveBeenLastCalledWith('+47 1')
+
+    fireEvent.change(phoneElement, { target: { value: '' } })
+
+    expect(onChange).toHaveBeenLastCalledWith('')
+    expect(codeElement.value).toEqual('NO (+47)')
+    expect(phoneElement.value).toEqual('')
+
+    fireEvent.focus(codeElement)
+    fireEvent.keyDown(codeElement, {
+      key: 'Enter',
+      keyCode: 13,
+    })
+    fireEvent.change(codeElement, { target: { value: '+41' } })
+    fireEvent.click(firstItemElement())
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+
+    expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('')
+
+    await userEvent.type(phoneElement, '456')
+
+    expect(onChange).toHaveBeenLastCalledWith('+41 456')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('45 6​ ​​ ​​')
+  })
+
+  it('should handle events correctly', async () => {
+    const onChange = jest.fn()
+    const onCountryCodeChange = jest.fn()
+
+    render(
+      <PhoneNumber
+        onChange={onChange}
+        onCountryCodeChange={onCountryCodeChange}
+        noAnimation
+      />
+    )
+
+    const codeElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__country-code input'
+    )
+    const phoneElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__number input'
+    )
+    const firstItemElement = () =>
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+
+    fireEvent.focus(codeElement)
+    fireEvent.keyDown(codeElement, {
+      key: 'Enter',
+      keyCode: 13,
+    })
+    fireEvent.change(codeElement, { target: { value: '+41' } })
+    fireEvent.click(firstItemElement())
+
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('')
+
+    await userEvent.type(phoneElement, '456')
+
+    expect(onChange).toHaveBeenLastCalledWith('+41 456')
+    expect(codeElement.value).toEqual('CH (+41)')
+    expect(phoneElement.value).toEqual('45 6​ ​​ ​​')
   })
 
   it('should support spacing props', () => {
@@ -182,17 +354,17 @@ describe('Field.PhoneNumber', () => {
   it('should require one number', async () => {
     render(<PhoneNumber required />)
 
-    const inputElement = document.querySelector(
+    const phoneElement = document.querySelector(
       '.dnb-forms-field-phone-number__number input'
-    ) as HTMLInputElement
+    )
 
-    await userEvent.type(inputElement, '1{Backspace}')
-    fireEvent.blur(inputElement)
+    await userEvent.type(phoneElement, '1{Backspace}')
+    fireEvent.blur(phoneElement)
 
     expect(document.querySelector('[role="alert"]')).toBeInTheDocument()
 
-    await userEvent.type(inputElement, '1')
-    fireEvent.blur(inputElement)
+    await userEvent.type(phoneElement, '1')
+    fireEvent.blur(phoneElement)
 
     expect(
       document.querySelector('[role="alert"]')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -40,7 +40,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should change locale', () => {
-    render(
+    const { rerender } = render(
       <Provider locale="en-GB">
         <PhoneNumber />
       </Provider>
@@ -52,11 +52,22 @@ describe('Field.PhoneNumber', () => {
 
     fireEvent.mouseDown(codeElement)
 
-    const selectedItemElement = document.querySelector(
-      '.dnb-drawer-list__option.dnb-drawer-list__option--selected'
+    const selectedItemElement = () =>
+      document.querySelector(
+        '.dnb-drawer-list__option.dnb-drawer-list__option--selected'
+      )
+
+    expect(selectedItemElement().textContent).toBe('+47 Norway')
+
+    rerender(
+      <Provider locale="nb-NO">
+        <PhoneNumber />
+      </Provider>
     )
 
-    expect(selectedItemElement.textContent).toBe('+47 Norway')
+    fireEvent.mouseDown(codeElement)
+
+    expect(selectedItemElement().textContent).toBe('+47 Norge')
   })
 
   it('should return correct value onFocus and onBlur event', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -41,7 +41,7 @@ describe('Field.PhoneNumber', () => {
 
   it('should change locale', () => {
     const { rerender } = render(
-      <Provider locale="en-GB">
+      <Provider>
         <PhoneNumber />
       </Provider>
     )
@@ -56,6 +56,16 @@ describe('Field.PhoneNumber', () => {
       document.querySelector(
         '.dnb-drawer-list__option.dnb-drawer-list__option--selected'
       )
+
+    expect(selectedItemElement().textContent).toBe('+47 Norge')
+
+    rerender(
+      <Provider locale="en-GB">
+        <PhoneNumber />
+      </Provider>
+    )
+
+    fireEvent.mouseDown(codeElement)
 
     expect(selectedItemElement().textContent).toBe('+47 Norway')
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -69,10 +69,10 @@ describe('Field.PhoneNumber', () => {
     )
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith('')
+    expect(onFocus).toHaveBeenLastCalledWith(undefined)
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith('')
+    expect(onBlur).toHaveBeenLastCalledWith(undefined)
 
     await userEvent.type(phoneElement, '99999999')
 
@@ -172,8 +172,8 @@ describe('Field.PhoneNumber', () => {
     fireEvent.change(phoneElement, { target: { value: '' } })
     fireEvent.focus(phoneElement)
 
-    expect(onChange).toHaveBeenNthCalledWith(3, '')
-    expect(onFocus).toHaveBeenNthCalledWith(4, '')
+    expect(onChange).toHaveBeenNthCalledWith(3, undefined)
+    expect(onFocus).toHaveBeenNthCalledWith(4, undefined)
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('')
   })
@@ -236,7 +236,7 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '{Backspace>8}')
 
-    expect(onChange).toHaveBeenLastCalledWith('')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
   })
 
   it('should handle events correctly with initial value', async () => {
@@ -266,7 +266,7 @@ describe('Field.PhoneNumber', () => {
 
     fireEvent.change(phoneElement, { target: { value: '' } })
 
-    expect(onChange).toHaveBeenLastCalledWith('')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('')
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -212,7 +212,10 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '99999999')
 
-    expect(onChange).toHaveBeenLastCalledWith('+47 99999999')
+    expect(onChange).toHaveBeenLastCalledWith('+47 99999999', {
+      countryCode: '+47',
+      phoneNumber: '99999999',
+    })
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('99 99 99 99')
 
@@ -241,13 +244,19 @@ describe('Field.PhoneNumber', () => {
 
     expect(onCountryCodeChange).toHaveBeenCalledTimes(1)
     expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
-    expect(onChange).toHaveBeenLastCalledWith('+41 99999999')
+    expect(onChange).toHaveBeenLastCalledWith('+41 99999999', {
+      countryCode: '+41',
+      phoneNumber: '99999999',
+    })
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('99 99 99 99')
 
     await userEvent.type(phoneElement, '{Backspace>8}')
 
-    expect(onChange).toHaveBeenLastCalledWith(undefined)
+    expect(onChange).toHaveBeenLastCalledWith(undefined, {
+      countryCode: '+41',
+      phoneNumber: undefined,
+    })
   })
 
   it('should handle events correctly with initial value', async () => {
@@ -273,11 +282,17 @@ describe('Field.PhoneNumber', () => {
 
     fireEvent.change(phoneElement, { target: { value: '1' } })
 
-    expect(onChange).toHaveBeenLastCalledWith('+47 1')
+    expect(onChange).toHaveBeenLastCalledWith('+47 1', {
+      countryCode: '+47',
+      phoneNumber: '1',
+    })
 
     fireEvent.change(phoneElement, { target: { value: '' } })
 
-    expect(onChange).toHaveBeenLastCalledWith(undefined)
+    expect(onChange).toHaveBeenLastCalledWith(undefined, {
+      countryCode: '+47',
+      phoneNumber: undefined,
+    })
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('')
 
@@ -289,7 +304,7 @@ describe('Field.PhoneNumber', () => {
     fireEvent.change(codeElement, { target: { value: '+41' } })
     fireEvent.click(firstItemElement())
 
-    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenCalledTimes(3)
 
     expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
     expect(codeElement.value).toEqual('CH (+41)')
@@ -297,7 +312,10 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '456')
 
-    expect(onChange).toHaveBeenLastCalledWith('+41 456')
+    expect(onChange).toHaveBeenLastCalledWith('+41 456', {
+      countryCode: '+41',
+      phoneNumber: '456',
+    })
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('45 6​ ​​ ​​')
   })
@@ -331,7 +349,7 @@ describe('Field.PhoneNumber', () => {
     fireEvent.change(codeElement, { target: { value: '+41' } })
     fireEvent.click(firstItemElement())
 
-    expect(onChange).toHaveBeenCalledTimes(0)
+    expect(onChange).toHaveBeenCalledTimes(1)
 
     expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
     expect(codeElement.value).toEqual('CH (+41)')
@@ -339,7 +357,10 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '456')
 
-    expect(onChange).toHaveBeenLastCalledWith('+41 456')
+    expect(onChange).toHaveBeenLastCalledWith('+41 456', {
+      countryCode: '+41',
+      phoneNumber: '456',
+    })
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('45 6​ ​​ ​​')
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
@@ -6,8 +6,15 @@ export default {
 
 export function PhoneNumber() {
   return (
-    <Form.Handler onSubmit={console.log}>
-      <Field.PhoneNumber required validateInitially path="/phoneNumber" />
+    <Form.Handler onSubmit={console.log} onChange={console.log}>
+      <Field.PhoneNumber
+        required
+        // value="+47 1"
+        validateInitially
+        onBlur={console.log}
+        onFocus={console.log}
+        path="/phoneNumber"
+      />
       <Form.SubmitButton top />
     </Form.Handler>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
@@ -16,7 +16,6 @@ export function PhoneNumber() {
     <Field.PhoneNumber
       required
       value={state}
-      // validateInitially
       onBlur={console.log}
       onFocus={console.log}
       onChange={(value) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/stories/PhoneNumber.stories.tsx
@@ -1,21 +1,28 @@
-import { Field, Form } from '../../..'
+import React from 'react'
+import { Field } from '../../..'
 
 export default {
   title: 'Eufemia/Forms/PhoneNumber',
 }
 
 export function PhoneNumber() {
+  const [state, update] = React.useState('+47 1')
+  // const [state, update] = React.useState(undefined)
+  React.useEffect(() => {
+    // update('+41 1')
+    update('+45')
+  }, [])
   return (
-    <Form.Handler onSubmit={console.log} onChange={console.log}>
-      <Field.PhoneNumber
-        required
-        // value="+47 1"
-        validateInitially
-        onBlur={console.log}
-        onFocus={console.log}
-        path="/phoneNumber"
-      />
-      <Form.SubmitButton top />
-    </Form.Handler>
+    <Field.PhoneNumber
+      required
+      value={state}
+      // validateInitially
+      onBlur={console.log}
+      onFocus={console.log}
+      onChange={(value) => {
+        console.log('onChange', value)
+        update(value)
+      }}
+    />
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -10,7 +10,7 @@ import pointer from 'json-pointer'
 import { ValidateFunction } from 'ajv'
 import { errorChanged } from '../utils'
 import ajv, { ajvErrorsToOneFormError } from '../utils/ajv'
-import { FormError, FieldProps } from '../types'
+import { FormError, FieldProps, AdditionalEventArgs } from '../types'
 import { Context } from '../DataContext'
 import FieldBlockContext from '../FieldBlock/FieldBlockContext'
 import IterateElementContext from '../Iterate/IterateElementContext'
@@ -420,7 +420,10 @@ export default function useDataValue<
   )
 
   const handleChange = useCallback(
-    (argFromInput: Value) => {
+    (
+      argFromInput: Value,
+      additionalArgs: AdditionalEventArgs = undefined
+    ) => {
       const newValue = fromInput(argFromInput)
 
       if (newValue === valueRef.current) {
@@ -432,7 +435,12 @@ export default function useDataValue<
       updateValue(newValue)
 
       changedRef.current = true
-      onChange?.(newValue)
+      onChange?.apply(
+        this,
+        typeof additionalArgs !== 'undefined'
+          ? [newValue, additionalArgs]
+          : [newValue]
+      )
 
       if (elementPath) {
         const iterateValuePath = `/${iterateElementIndex}${

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -77,7 +77,10 @@ export interface DataValueWriteProps<
   emptyValue?: EmptyValue
   onFocus?: (value: Value | EmptyValue) => void
   onBlur?: (value: Value | EmptyValue) => void
-  onChange?: (value: Value | EmptyValue) => void
+  onChange?: (
+    value: Value | EmptyValue,
+    additionalArgs?: AdditionalEventArgs
+  ) => void
 }
 
 const dataValueWriteProps = ['emptyValue', 'onFocus', 'onBlur', 'onChange']
@@ -136,6 +139,8 @@ export function omitDataValueReadWriteProps<
 export type ComponentProps = SpacingProps & {
   className?: string
 }
+
+export type AdditionalEventArgs = Record<string, unknown>
 
 export type DataValueReadComponentProps<Value = unknown> = ComponentProps &
   DataValueReadProps<Value>


### PR DESCRIPTION
- With this change, we only return country code when a phone number exists (`onChange`). This effects also the `onFocus` and `onBlur` event. Else `emptyValue` is returned.
- [x] Needs this change from PR #2922 and #2923
