### PR TITLE
fix(Dropdown): error message when passing a function to innerRef

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.d.ts
+++ b/packages/dnb-eufemia/src/components/button/Button.d.ts
@@ -138,7 +138,7 @@ export type ButtonProps = {
    */
   skeleton?: ButtonSkeleton;
   disabled?: boolean;
-  inner_ref?: any;
+  inner_ref?: React.Ref<HTMLButtonElement>;
   className?: string;
   innerRef?: any;
   /**

--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -67,10 +67,14 @@ export default class Button extends React.PureComponent {
 
   componentDidMount() {
     if (this.props.innerRef) {
-      this.props.innerRef.current = this._ref.current
+      typeof this.props.innerRef === 'function'
+        ? this.props.innerRef(this._ref.current)
+        : (this.props.innerRef.current = this._ref.current)
     }
     if (this.props.inner_ref) {
-      this.props.inner_ref.current = this._ref.current
+      typeof this.props.innerRef === 'function'
+        ? this.props.inner_ref(this._ref.current)
+        : (this.props.inner_ref.current = this._ref.current)
     }
   }
 
@@ -313,10 +317,10 @@ Button.propTypes = {
   stretch: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   skeleton: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   disabled: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  inner_ref: PropTypes.object,
+  inner_ref: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 
   className: PropTypes.string,
-  innerRef: PropTypes.object,
+  innerRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   children: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.d.ts
@@ -74,11 +74,11 @@ export interface DropdownProps
   /**
    * By providing a React.ref you can get the internally used main element (DOM). E.g. `innerRef={myRef}` by using `React.createRef()` or `React.useRef()`.
    */
-  innerRef?: React.Ref;
+  innerRef?: React.Ref<HTMLSpanElement>;
   /**
    * By providing a React.ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.createRef()` or `React.useRef()`.
    */
-  buttonRef?: React.Ref;
+  buttonRef?: React.Ref<HtmlButtonElement>;
   /**
    * Same as `prevent_selection`, but the "selection area" (given title) will not be visible and the icon `more` (three dots) is used. Defaults to `false`.
    */

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -75,8 +75,8 @@ export default class Dropdown extends React.PureComponent {
       PropTypes.string,
       PropTypes.bool,
     ]),
-    innerRef: PropTypes.object,
-    buttonRef: PropTypes.object,
+    innerRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    buttonRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     globalStatus: PropTypes.shape({
       id: PropTypes.string,
       message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),


### PR DESCRIPTION
The `Dropdown` component is throwing a `Failed prop type: Invalid prop 'innerRef' of type `function` supplied to 'Dropdown', expected `object`.` message if the user supplies a function to the `innerRef` prop. This was caused by a mismatch between the `innerRef` `type` definition and `PropType` definition.

[Slack](https://dnb-it.slack.com/archives/CMXABCHEY/p1701095348365899)

[CSB](https://codesandbox.io/p/sandbox/gifted-gates-xml57z)