### PR TITLE
chore(Icon): removes tag recieve for hand_money

### DIFF
--- a/packages/dnb-eufemia/src/icons/dnb/icons-meta.json
+++ b/packages/dnb-eufemia/src/icons/dnb/icons-meta.json
@@ -182,14 +182,14 @@
     "category": "essentials"
   },
   "hand_money_medium": {
-    "tags": ["recieve", "receive"],
+    "tags": ["receive"],
     "created": 1668066353797,
     "name": "hand_money",
     "variant": "secondary",
     "category": "essentials"
   },
   "hand_money": {
-    "tags": ["recieve", "receive"],
+    "tags": ["receive"],
     "created": 1668066354615,
     "name": "hand_money",
     "variant": "secondary",

--- a/packages/dnb-eufemia/src/icons/icons-meta.json
+++ b/packages/dnb-eufemia/src/icons/icons-meta.json
@@ -182,14 +182,14 @@
     "category": "essentials"
   },
   "hand_money_medium": {
-    "tags": ["recieve", "receive"],
+    "tags": ["receive"],
     "created": 1668066353797,
     "name": "hand_money",
     "variant": "secondary",
     "category": "essentials"
   },
   "hand_money": {
-    "tags": ["recieve", "receive"],
+    "tags": ["receive"],
     "created": 1668066354615,
     "name": "hand_money",
     "variant": "secondary",


### PR DESCRIPTION
Just a suggestion, as `recieve` is "not a word".

But this is perhaps "breaking"? in a sense if `recieve` was used to get the hand_money icon previously.
I quickly searched through the monorepo, and could not find any occurrences of `recieve`.

Also, not 100% sure which commit decorator to use(fix, chore, feat)...