### PR TITLE
docs(FAQ): removes stylelint as dependency issue

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
@@ -17,10 +17,6 @@ LINT_STAGED=1
 
 ## Dependency issues
 
-### Stylelint
-
-- v14 has changed a good amount of their default styling rules. Updating would require us to refactor a good amount of SCSS code. We are currently on v13.
-
 ## Babel
 
 Due to this bug: https://github.com/babel/babel/issues/11394 we add `.png,.snap` so they not get copied: `--extensions '.js,.ts,.tsx,.png,.snap'`


### PR DESCRIPTION
I'm suggesting to remove this section, as I believe/think it's outdated.

We could perhaps change/update some other information on this page as well?
I guess somethings are outdated.

https://eufemia.dnb.no/contribute/faq/