### PR TITLE
fix(DatePicker): renders mask_placeholder from locale w/o provider

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
@@ -471,7 +471,10 @@ export default class DatePicker extends React.PureComponent {
       this.props,
       DatePicker.defaultProps,
       { skeleton: this.context?.skeleton },
-      this.context.getTranslation(this.props).DatePicker,
+      this.context.getTranslation({
+        lang: this.props.lang,
+        locale: this.props.locale.code,
+      }).DatePicker,
       // Deprecated – can be removed in v11
       pickFormElementProps(this.context?.FormRow),
       pickFormElementProps(this.context?.formElement),

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -13,6 +13,7 @@ import addDays from 'date-fns/addDays'
 import addMonths from 'date-fns/addMonths'
 import getDaysInMonth from 'date-fns/getDaysInMonth'
 import isWeekend from 'date-fns/isWeekend'
+import enLocale from 'date-fns/locale/en-GB'
 import {
   toRange,
   dayOffset,
@@ -1288,6 +1289,35 @@ describe('DatePicker component', () => {
 
     expect(document.activeElement).toBe(document.body)
     expect(element.classList).toContain('dnb-date-picker--opened')
+  })
+
+  it('renders correct placeholder when setting locale', () => {
+    const props: DatePickerProps = {}
+
+    render(<DatePicker {...props} show_input={true} locale={enLocale} />)
+
+    const dayElem = document.querySelectorAll(
+      'input.dnb-date-picker__input--day'
+    )[0] as HTMLInputElement
+    const monthElem = document.querySelectorAll(
+      'input.dnb-date-picker__input--month'
+    )[0] as HTMLInputElement
+    const yearElem = document.querySelectorAll(
+      'input.dnb-date-picker__input--year'
+    )[0] as HTMLInputElement
+
+    const seperator1 = document.querySelectorAll(
+      '.dnb-date-picker--separator'
+    )[0]
+    const seperator2 = document.querySelectorAll(
+      '.dnb-date-picker--separator'
+    )[0]
+
+    expect(dayElem.value).toBe('dd')
+    expect(monthElem.value).toBe('mm')
+    expect(yearElem.value).toBe('yyyy')
+    expect(seperator1.textContent).toBe('/')
+    expect(seperator2.textContent).toBe('/')
   })
 
   it('has to react on keydown events', async () => {

--- a/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
@@ -544,3 +544,14 @@ export const GlobalStatusExample = () => {
     </>
   )
 }
+
+export const LocalePropExample = () => {
+  return (
+    <>
+      <DatePicker show_input={true} locale={enLocale} />
+      {/* <Provider locale="en-GB">
+        <DatePicker show_input={true} />
+      </Provider> */}
+    </>
+  )
+}


### PR DESCRIPTION
`mask_placeholder` shows `dd.mm.yyyy` and not `dd/mm/yyyy` which is the expected result, when setting locale to be `en-GB`.

[Slack thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1701329166313829)
[CSB reproducing the issue](https://codesandbox.io/p/sandbox/optimistic-bassi-gsn7hw)
Expected result in the [CSB](https://codesandbox.io/p/sandbox/optimistic-bassi-gsn7hw) would be that the `mask_placeholder` should be `dd/mm/yyyy` as seen when [wrapping the DatePicker in an Eufemia Provider](https://codesandbox.io/p/sandbox/vigorous-williamson-km4rc7?file=%2Fsrc%2FApp.tsx).