### PR TITLE
chore(FormLabel): add support for labelDirection via shared Provider

### DIFF
--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -98,12 +98,47 @@ describe('FormLabel component', () => {
     expect(element.getAttribute('for')).toBe('unique-id')
   })
 
-  it('should inherit formElement vertical label', () => {
+  /** @deprecated can be removed in v11 */
+  it('should inherit formElement label_direction', () => {
     render(
       <Provider formElement={{ label_direction: 'vertical' }}>
         <FormLabel />
       </Provider>
     )
+
+    const element = document.querySelector('.dnb-form-label')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-form-label',
+      'dnb-form-label--vertical',
+    ])
+  })
+
+  it('should inherit formElement labelDirection', () => {
+    render(
+      <Provider formElement={{ labelDirection: 'vertical' }}>
+        <FormLabel />
+      </Provider>
+    )
+
+    const element = document.querySelector('.dnb-form-label')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['class'])
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-form-label',
+      'dnb-form-label--vertical',
+    ])
+  })
+
+  it('should support vertical class', () => {
+    render(<FormLabel vertical />)
 
     const element = document.querySelector('.dnb-form-label')
     const attributes = Array.from(element.attributes).map(

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
@@ -1,4 +1,9 @@
-import { filterValidProps } from '../filterValidProps'
+import {
+  FormElementProps,
+  filterValidProps,
+  pickFormElementProps,
+  prepareFormElementContext,
+} from '../filterValidProps'
 
 describe('filterValidProps', () => {
   it('should return only declared props', () => {
@@ -30,7 +35,7 @@ describe('filterValidProps', () => {
     })
   })
 
-  it('should exclude unwanted props', () => {
+  it('should exclude unwanted props even when validKeys is not set', () => {
     type Props = {
       key: string
       foo: string
@@ -41,6 +46,49 @@ describe('filterValidProps', () => {
     const result = filterValidProps(props, null, excludeKeys)
     expect(result).toEqual({
       key: 'only-me',
+    })
+  })
+
+  it('should pick FormElement props', () => {
+    type Props = FormElementProps & {
+      label_direction?: 'vertical' | 'horizontal'
+      vertical?: boolean
+      foo: string
+      bar: boolean
+      fizz: number
+    }
+
+    const props: Props = {
+      label_direction: 'horizontal',
+      vertical: true,
+      foo: 'test',
+      bar: false,
+      fizz: 123,
+    }
+
+    const elementProps = pickFormElementProps(props)
+
+    expect(elementProps).toEqual({
+      label_direction: 'horizontal',
+      vertical: true,
+    })
+  })
+
+  it('should prepeare FormElement direction', () => {
+    const verticalTrue = prepareFormElementContext({ vertical: true })
+
+    expect(verticalTrue).toEqual({
+      labelDirection: 'vertical',
+      label_direction: 'vertical',
+      vertical: true,
+    })
+
+    const verticalFalse = prepareFormElementContext({ vertical: false })
+
+    expect(verticalFalse).toEqual({
+      labelDirection: undefined,
+      label_direction: undefined,
+      vertical: false,
     })
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/withCamelCaseProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/withCamelCaseProps.test.tsx
@@ -6,6 +6,7 @@ import {
   withCamelCaseProps,
   classWithCamelCaseProps,
   IncludeCamelCase,
+  convertCamelCaseProps,
 } from '../withCamelCaseProps'
 
 type CustomType = {
@@ -365,5 +366,30 @@ describe('classWithCamelCaseProps', () => {
       <Component snake_case={true} camelCase={1} update_comp={on_update} />
     )
     expect(on_update).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('convertCamelCaseProps', () => {
+  it('will convert', () => {
+    const props = {
+      fooBar: 'value',
+      snakeCase: { fooBar: 123 },
+    }
+    const result = convertCamelCaseProps(props)
+
+    expect(result).toEqual({
+      foo_bar: 'value',
+      snake_case: { fooBar: 123 },
+    })
+  })
+
+  it('will keep frozen object as frozen', () => {
+    const props = Object.freeze({
+      fooBar: 'value',
+      snakeCase: { fooBar: 123 },
+    })
+    const result = convertCamelCaseProps(props)
+
+    expect(Object.isFrozen(result)).toBe(true)
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/withSnakeCaseProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/withSnakeCaseProps.test.tsx
@@ -338,4 +338,14 @@ describe('convertSnakeCaseProps', () => {
       snakeCase: { foo_bar: 123 },
     })
   })
+
+  it('will keep frozen object as frozen', () => {
+    const props = Object.freeze({
+      foo_bar: 'value',
+      snake_case: { foo_bar: 123 },
+    })
+    const result = convertSnakeCaseProps(props)
+
+    expect(Object.isFrozen(result)).toBe(true)
+  })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
@@ -57,12 +57,18 @@ export function prepareFormElementContext<Props>(
   return props
 }
 export type FormElementProps = {
-  label_direction?: 'vertical' | 'horizontal'
   vertical?: boolean
+  labelDirection?: 'vertical' | 'horizontal'
+
+  /** @deprecated use labelDirection instead */
+  label_direction?: 'vertical' | 'horizontal'
 }
-export const validFormElementProps = {
+const validFormElementProps = {
   skeleton: null,
   disabled: null,
   vertical: null,
+  labelDirection: null,
+
+  /** @deprecated use labelDirection instead */
   label_direction: null,
 }

--- a/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/filterValidProps.tsx
@@ -46,10 +46,13 @@ export function pickFormElementProps(
 export function prepareFormElementContext<Props>(
   props: Props & FormElementProps
 ) {
-  if (typeof props.label_direction === 'undefined') {
-    props.label_direction = isTrue(props.vertical)
-      ? 'vertical'
-      : props.label_direction
+  if (isTrue(props.vertical)) {
+    if (typeof props.labelDirection === 'undefined') {
+      props.labelDirection = 'vertical'
+    }
+    if (typeof props.label_direction === 'undefined') {
+      props.label_direction = 'vertical'
+    }
   }
   return props
 }

--- a/packages/dnb-eufemia/src/shared/helpers/withCamelCaseProps.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/withCamelCaseProps.tsx
@@ -17,7 +17,7 @@ export function withCamelCaseProps<TBase, P>(
   const Component: React.ComponentType = Base
 
   const Derived = (props: P) => {
-    return <Component {...Object.freeze(convertCamelCaseProps(props))} />
+    return <Component {...convertCamelCaseProps(props)} />
   }
 
   Object.defineProperty(Derived, 'name', {
@@ -63,9 +63,7 @@ export function classWithCamelCaseProps<
         this._prevProps = this.props
         this._elem = (
           // @ts-ignore
-          <Component
-            {...Object.freeze(convertCamelCaseProps(this.props))}
-          />
+          <Component {...convertCamelCaseProps(this.props)} />
         )
       }
 
@@ -84,8 +82,9 @@ export function classWithCamelCaseProps<
   return Derived
 }
 
-function convertCamelCaseProps<P>(props: P) {
-  const newProps = { ...props }
+export function convertCamelCaseProps<P>(props: P) {
+  const isFrozen = Object.isFrozen(props)
+  const newProps = isFrozen ? { ...props } : props
 
   for (const key in props) {
     switch (key) {
@@ -100,7 +99,7 @@ function convertCamelCaseProps<P>(props: P) {
     }
   }
 
-  return newProps
+  return isFrozen ? Object.freeze(newProps) : newProps
 }
 
 /**

--- a/packages/dnb-eufemia/src/shared/helpers/withSnakeCaseProps.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/withSnakeCaseProps.tsx
@@ -17,7 +17,7 @@ export function withSnakeCaseProps<TBase, P>(
   const Component: React.ComponentType = Base
 
   const Derived = (props: P) => {
-    return <Component {...Object.freeze(convertSnakeCaseProps(props))} />
+    return <Component {...convertSnakeCaseProps(props)} />
   }
 
   Object.defineProperty(Derived, 'name', {
@@ -63,9 +63,7 @@ export function classWithSnakeCaseProps<
         this._prevProps = this.props
         this._elem = (
           // @ts-ignore
-          <Component
-            {...Object.freeze(convertSnakeCaseProps(this.props))}
-          />
+          <Component {...convertSnakeCaseProps(this.props)} />
         )
       }
 
@@ -85,7 +83,8 @@ export function classWithSnakeCaseProps<
 }
 
 export function convertSnakeCaseProps<P>(props: P) {
-  const newProps = { ...props }
+  const isFrozen = Object.isFrozen(props)
+  const newProps = isFrozen ? { ...props } : props
 
   for (const key in props) {
     if (key.includes('_') && /^[a-z]+/.test(key) && !/[A-Z]/.test(key)) {
@@ -94,7 +93,7 @@ export function convertSnakeCaseProps<P>(props: P) {
     }
   }
 
-  return newProps
+  return isFrozen ? Object.freeze(newProps) : newProps
 }
 
 /**


### PR DESCRIPTION
the new `labelDirection` that is suppose to replace the old `label_direction` prop seems to be missing from FormLabel.

Or is it meant to be replaced by the `vertical`? 🤔