### PR TITLE
chore: fix wait on non-headless local visual tests

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.js
@@ -25,7 +25,7 @@ const config = {
   testScreenshotOnHost: 'localhost',
   testScreenshotOnPort: 8000,
   retryTimes: isCI ? 5 : 0,
-  timeout: isHeadless ? headlessTimeout : 30e3,
+  timeout: isHeadless ? 30e3 : headlessTimeout,
   pixelGrid: 8,
   pageViewport: {
     width: 1280,
@@ -133,6 +133,11 @@ const makeScreenshot = async ({
     screenshotSelector,
   })
 
+  // Only for dev
+  if (!isCI && !isHeadless) {
+    await page.waitForTimeout(headlessTimeout)
+  }
+
   if (simulate && simulate === 'active') {
     await page.mouse.up() // reset mouse.down() for subsequent tests
   }
@@ -151,11 +156,6 @@ const makeScreenshot = async ({
 
   if (waitBeforeFinish > 0) {
     await page.waitForTimeout(waitBeforeFinish)
-  }
-
-  // Only for dev
-  if (!isCI && !isHeadless) {
-    await page.waitForTimeout(headlessTimeout)
   }
 
   return screenshot


### PR DESCRIPTION
The custom `headlessTimeout` did not work the way it was implemented. Also, moving the wait action upwards makes more sense.