### PR TITLE
chore(PaymentCard): adds unknown to proptypes

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
@@ -70,6 +70,7 @@ export default class PaymentCard extends React.PureComponent {
       'order_in_process',
       'renewed',
       'replaced',
+      'unknown',
     ]),
     variant: PropTypes.oneOf(['normal', 'compact']),
     digits: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
Forgot to add it as part of https://github.com/dnbexperience/eufemia/pull/2934

Thanks to @tujoworker for figuring it out 🧙 