### PR TITLE
chore(ToggleButton): remove left-over to fix Sbanken styling issue

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3447,15 +3447,8 @@ button .dnb-form-status__text {
   width: calc(var(--radio-width--medium) - 1rem);
   height: calc(var(--radio-height--medium) - 1rem);
 }
-.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled], :active).dnb-button--secondary, .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled], :active).dnb-button--secondary:hover {
-  background-color: var(--color-emerald-green);
-  color: var(--color-mint-green);
-}
 :not(.dnb-toggle-button-group) > .dnb-form-label + .dnb-toggle-button {
   vertical-align: top;
-}
-.dnb-toggle-button-group__suffix {
-  font-size: var(--font-size-basis);
 }
 .dnb-toggle-button .dnb-form-status {
   order: 2;
@@ -3507,6 +3500,9 @@ button .dnb-form-status__text {
 }
 .dnb-toggle-button-group .dnb-alignment-helper {
   line-height: 2.5rem;
+}
+.dnb-toggle-button-group__suffix {
+  font-size: var(--font-size-basis);
 }
 @media screen and (min-width: 40em) {
   .dnb-form-label + .dnb-toggle-button {

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -1630,15 +1630,8 @@ button .dnb-form-status__text {
   width: calc(var(--radio-width--medium) - 1rem);
   height: calc(var(--radio-height--medium) - 1rem);
 }
-.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled], :active).dnb-button--secondary, .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled], :active).dnb-button--secondary:hover {
-  background-color: var(--color-emerald-green);
-  color: var(--color-mint-green);
-}
 :not(.dnb-toggle-button-group) > .dnb-form-label + .dnb-toggle-button {
   vertical-align: top;
-}
-.dnb-toggle-button-group__suffix {
-  font-size: var(--font-size-basis);
 }
 .dnb-toggle-button .dnb-form-status {
   order: 2;
@@ -1690,6 +1683,9 @@ button .dnb-form-status__text {
 }
 .dnb-toggle-button-group .dnb-alignment-helper {
   line-height: 2.5rem;
+}
+.dnb-toggle-button-group__suffix {
+  font-size: var(--font-size-basis);
 }
 @media screen and (min-width: 40em) {
   .dnb-form-label + .dnb-toggle-button {
@@ -1769,8 +1765,6 @@ html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__bu
 html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus {
   color: var(--color-emerald-green);
   background-color: var(--color-mint-green);
-}
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus {
   outline: none;
 }
 html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus {

--- a/packages/dnb-eufemia/src/components/toggle-button/style/dnb-toggle-button.scss
+++ b/packages/dnb-eufemia/src/components/toggle-button/style/dnb-toggle-button.scss
@@ -97,24 +97,10 @@
     }
   }
 
-  // default "active" style
-  &--checked &__button:not([disabled], :active) {
-    &.dnb-button--secondary,
-    &.dnb-button--secondary:hover {
-      background-color: var(--color-emerald-green);
-      color: var(--color-mint-green);
-    }
-  }
-
   // in case we don't define a wrapping group
   // and have a custom label component before the toggle-button (and not inside)
   :not(#{&}-group) > .dnb-form-label + & {
     vertical-align: top;
-  }
-
-  // &__suffix,
-  &-group__suffix {
-    font-size: var(--font-size-basis);
   }
 
   // status
@@ -186,6 +172,10 @@
     // vertical alignment - if no label is given
     .dnb-alignment-helper {
       line-height: 2.5rem;
+    }
+
+    &__suffix {
+      font-size: var(--font-size-basis);
     }
   }
 

--- a/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-ui.scss
@@ -100,9 +100,6 @@
       &:not([disabled]):not(:active):not(:hover):focus {
       color: var(--color-emerald-green);
       background-color: var(--color-mint-green);
-    }
-    html[data-whatinput='keyboard']
-      &:not([disabled]):not(:active):not(:hover):focus {
       @include focusRing(null, var(--color-emerald-green), inset);
     }
   }


### PR DESCRIPTION
To fix the issue on failing e2e tests on the main branch, like below;

![tabs-for-sbanken-have-to-match-horizontally-aligned-tabs snap-diff](https://github.com/dnbexperience/eufemia/assets/1501870
/7ccb7ab2-7463-41d4-8143-ee9f896e1de7)

we should remove an left-over style that did influence the Sbanken styles with a higher specificity.

<img width="1037" alt="Screenshot 2023-12-04 at 20 58 59" src="https://github.com/dnbexperience/eufemia/assets/1501870/de127553-c014-4f3f-b5fe-5ad3628ed125">

Why did this only happen on the main branch? Because the CSS is only there completely bundled, which creates some times a different CSS specificity.

Here is a [test-run](https://github.com/dnbexperience/eufemia/actions/runs/7091720735/job/19301471826) with the fix. The branch name starts (`startsWith(github.ref, 'refs/heads/main')`) with `main`, therefore it will run like the main branch.