### PR TITLE
fix(forms): Fix bug on replacing error message values

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -61,37 +61,14 @@ function NumberComponent(props: Props) {
   const errorMessages = useMemo(
     () => ({
       required: tr.inputErrorRequired,
-      minimum: tr.numberFieldErrorMinimum.replace(
-        '{minimum}',
-        props.minimum?.toString()
-      ),
-      maximum: tr.numberFieldErrorMaximum.replace(
-        '{maximum}',
-        props.maximum?.toString()
-      ),
-      exclusiveMinimum: tr.numberFieldErrorExclusiveMinimum.replace(
-        '{exclusiveMinimum}',
-        props.exclusiveMinimum?.toString()
-      ),
-      exclusiveMaximum: tr.numberFieldErrorExclusiveMaximum.replace(
-        '{exclusiveMaximum}',
-        props.exclusiveMaximum?.toString()
-      ),
-      multipleOf: tr.numberFieldErrorMultipleOf.replace(
-        '{multipleOf}',
-        props.multipleOf?.toString()
-      ),
+      minimum: tr.numberFieldErrorMinimum,
+      maximum: tr.numberFieldErrorMaximum,
+      exclusiveMinimum: tr.numberFieldErrorExclusiveMinimum,
+      exclusiveMaximum: tr.numberFieldErrorExclusiveMaximum,
+      multipleOf: tr.numberFieldErrorMultipleOf,
       ...props.errorMessages,
     }),
-    [
-      tr,
-      props.errorMessages,
-      props.minimum,
-      props.maximum,
-      props.exclusiveMinimum,
-      props.exclusiveMaximum,
-      props.multipleOf,
-    ]
+    [tr, props.errorMessages]
   )
   const schema = useMemo<JSONSchema7>(
     () =>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -48,18 +48,12 @@ function StringComponent(props: Props) {
   const errorMessages = useMemo(
     () => ({
       required: tr.inputErrorRequired,
-      minLength: tr.stringInputErrorMinLength.replace(
-        '{minLength}',
-        props.minLength?.toString()
-      ),
-      maxLength: tr.stringInputErrorMaxLength.replace(
-        '{maxLength}',
-        props.maxLength?.toString()
-      ),
+      minLength: tr.stringInputErrorMinLength,
+      maxLength: tr.stringInputErrorMaxLength,
       pattern: tr.inputErrorPattern,
       ...props.errorMessages,
     }),
-    [tr, props.errorMessages, props.minLength, props.maxLength]
+    [tr, props.errorMessages]
   )
   const schema = useMemo<JSONSchema7>(
     () =>


### PR DESCRIPTION
Replacing error messages with injected values like "Minimum {minLength} characters" some times lead to "Minimum undefined characters" because the value was replaced inside the field component, but the value that was supposed to be injected was part of the surrounding data context validation schema and not available inside each field component. The replacing in the component was removed, so the central replacing happening inside `useDataValue` based on the value added to the error object inside the ajv validator function is used instead.