### PR TITLE
chore: removes new status from components older than 10 months

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Badge'
 description: 'The Badge component allows the user to focus on new or unread content or notifications.'
-status: 'new'
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Dialog'
 description: 'The Dialog component is a Modal variation that appears at the center of the screen.'
-status: 'new'
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Drawer'
 description: 'The Drawer component is a Modal variation that appears as a side panel at any chosen side of the page.'
-status: 'new'
 showTabs: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'HeightAnimation'
 description: 'HeightAnimation is a helper component to animate from 0 to height:auto powered by CSS.'
-status: 'new'
 showTabs: true
 theme: 'sbanken'
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'NumberFormat'
 description: 'A ready to use DNB number formatter.'
-# status: 'new'
 showTabs: true
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'SkipContent'
 description: 'SkipContent gives users – using their keyboard for navigation – the option to skip over content which contains a large amount of interactive elements.'
-status: 'new'
 showTabs: true
 theme: 'sbanken'
 hideTabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Table'
 description: 'Enhanced HTML Table element.'
-status: 'new'
 showTabs: true
 redirect_from:
   - /uilib/elements/tables

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Upload'
 description: 'The Upload widget should be used in scenarios where the user has to upload files. Files can be uploaded by clicking button. You also have the opportunity to add descriptive texts below the title where you could put max file size, allowed file formats etc.'
-status: 'new'
 showTabs: true
 theme: 'sbanken'
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'VisuallyHidden'
 description: 'VisuallyHidden has all the styles necessary to hide it from visual clients, but keep it for screen readers.'
-status: 'new'
 showTabs: true
 theme: 'sbanken'
 ---


### PR DESCRIPTION
This PR removes `new` status from components older than 10 months(based on git blame).
The only component left with `new` status now is the Layout component.