### PR TITLE
chore(forms): export/import of types

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/index.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/index.ts
@@ -1,4 +1,4 @@
-export type * from './types'
+export * from './types'
 export * from './utils'
 export * from './hooks'
 export * as Field from './Field'


### PR DESCRIPTION
Ensure non TypeScript parts such as FormError are importable without custom import path

