### PR TITLE
docs(Field.PhoneNumber): document event handlers argument value

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
@@ -7,3 +7,7 @@ import DataValueWriteEvents from 'Docs/uilib/extensions/forms/data-value-write-e
 ## Events
 
 <DataValueWriteEvents />
+
+## Argument value
+
+The argument value returned by the event handlers is a string where the country code and phonenumber is seperated by a space, e.g. `+47 9123457`. If the `omitCountryCodeField` is set to `true`, then only the phonenumber will be used, so the argument would be `9123457` without the leading country code.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
@@ -8,6 +8,6 @@ import DataValueWriteEvents from 'Docs/uilib/extensions/forms/data-value-write-e
 
 <DataValueWriteEvents />
 
-## Argument value
+### Argument value
 
 The argument value returned by the event handlers is a string where the country code and phonenumber is seperated by a space, e.g. `+47 9123457`. If the `omitCountryCodeField` is set to `true`, then only the phonenumber will be used, so the argument would be `9123457` without the leading country code.


### PR DESCRIPTION
proposal for this enhancement https://github.com/dnbexperience/eufemia/issues/3036

Not sure if its the best way to to do it, but I put the documentation for the argument value below the event handler table, to prevent having to cram in the description of the value itself at the end of each table row.