### PR TITLE
fix(forms): add Faroe islands and Greenland to Nordics in countrylist

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
@@ -669,6 +669,7 @@ const countries: Array<CountryType> = [
     cdc: '298',
     iso: 'FO',
     continent: 'Europe',
+    regions: ['Nordic'],
   },
   {
     i18n: {
@@ -787,6 +788,7 @@ const countries: Array<CountryType> = [
     cdc: '299',
     iso: 'GL',
     continent: 'North America',
+    regions: ['Nordic'],
   },
   {
     i18n: {


### PR DESCRIPTION
Adding the Faroe Island and Greenland to the Nordic group in the country code dropdown as they are part of the nordics, as stated by the [nordic council](https://www.norden.org/en/information/facts-about-nordic-countries)