### PR TITLE
chore(Forms): improve heading levels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseInputComponents.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseInputComponents.tsx
@@ -43,7 +43,7 @@ export default function ListBaseInputComponents() {
   return (
     <ListSummaryFromEdges
       space={{ top: 'x-small' }}
-      level={4}
+      level={3}
       description=""
       edges={edges}
     />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseSelectionComponents.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseSelectionComponents.tsx
@@ -43,7 +43,7 @@ export default function ListBaseSelectionComponents() {
   return (
     <ListSummaryFromEdges
       space={{ top: 'x-small' }}
-      level={4}
+      level={3}
       description=""
       edges={edges}
     />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseToggleComponents.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields/ListBaseToggleComponents.tsx
@@ -43,7 +43,7 @@ export default function ListBaseToggleComponents() {
   return (
     <ListSummaryFromEdges
       space={{ top: 'x-small' }}
-      level={4}
+      level={3}
       description=""
       edges={edges}
     />


### PR DESCRIPTION
Fixes/removes the following warning:
```
Eufemia Heading levels can only be changed by factor one! Got: 4 and had before 2 - The new level is 3 
NB: This warning was triggered by:  #String
```

Also improves the looks of the heading levels used.
Screenshot from [main](https://eufemia.dnb.no/uilib/extensions/forms/fields/#categorized-base-components)(where you can see the the heading levels are different):

<img width="1228" alt="Screenshot 2023-12-13 at 10 43 31" src="https://github.com/dnbexperience/eufemia/assets/1359205/5e3a8113-1bcb-46c3-9db4-042d9b93754e">

Screenshot after the fix(having the same heading levels):

<img width="772" alt="Screenshot 2023-12-13 at 10 44 09" src="https://github.com/dnbexperience/eufemia/assets/1359205/b6161c35-ed0e-489b-bb3e-4a8104412145">

