### PR TITLE
fix(Textarea): suffix spacing

### DIFF
--- a/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -176,8 +176,8 @@ button .dnb-form-status__text {
 .dnb-textarea__row {
   display: inline-flex;
 }
-.dnb-textarea__suffix {
-  padding-left: 1.5rem;
+.dnb-textarea__suffix.dnb-suffix {
+  padding-left: 1rem;
 }
 .dnb-textarea__textarea {
   position: relative;

--- a/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
@@ -60,8 +60,8 @@
     display: inline-flex;
   }
 
-  &__suffix {
-    padding-left: 1.5rem;
+  &__suffix.dnb-suffix {
+    padding-left: 1rem;
   }
 
   &__textarea {


### PR DESCRIPTION
Fixes https://github.com/dnbexperience/eufemia/issues/3044

Changed the textarea-suffix to use margin instead of padding for spacing. Also adjusted the value to be the same as input_suffix, `0.5rem'

Before: 
<img width="441" alt="Screenshot 2023-12-13 at 12 11 24" src="https://github.com/dnbexperience/eufemia/assets/25927156/5e0088dc-ca18-4c57-a82e-7a7585cee30e">

After:
<img width="397" alt="Screenshot 2023-12-13 at 12 11 03" src="https://github.com/dnbexperience/eufemia/assets/25927156/396ecd81-227b-4deb-aedc-8cc0720b42c9">

