### PR TITLE
fix(Tooltip): text alignment for short text

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -121,6 +121,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -135,6 +135,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -682,6 +683,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -1481,6 +1483,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -121,6 +121,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -135,6 +135,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -682,6 +683,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -1388,6 +1390,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -1990,6 +1993,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -142,6 +142,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -143,6 +143,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -214,6 +214,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -135,6 +135,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -682,6 +683,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -675,6 +676,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -135,6 +135,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`NumberFormat scss has to match style dependencies css 1`] = `
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);
@@ -589,6 +590,7 @@ button.dnb-button::-moz-focus-inner {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -128,6 +128,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -169,6 +169,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Tooltip scss has to match style dependencies css 1`] = `
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);

--- a/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
+++ b/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
@@ -22,6 +22,8 @@
   padding: 0 1rem;
   color: var(--tooltip-color);
 
+  text-align: center;
+
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   @include defaultDropShadow();

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -214,6 +214,7 @@ p > .dnb-icon {
   align-items: center;
   padding: 0 1rem;
   color: var(--tooltip-color);
+  text-align: center;
   background-color: var(--tooltip-background-color);
   border-radius: var(--tooltip-border-radius);
   box-shadow: var(--shadow-default);


### PR DESCRIPTION
Fixes https://github.com/dnbexperience/eufemia/issues/2982

Adds `text-align: center` to center align short texts

Before:
<img width="508" alt="Screenshot 2023-12-14 at 14 35 17" src="https://github.com/dnbexperience/eufemia/assets/25927156/57ca6108-f71a-4a88-bb6e-6f88f7b6bf4f">


After:
<img width="467" alt="Screenshot 2023-12-14 at 14 36 03" src="https://github.com/dnbexperience/eufemia/assets/25927156/f188b2a5-400a-48b4-9bf6-413a7d0badec">
