### PR TITLE
chore(Field.BankAccountNumber): make numeric keyboard default for mobile

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -64,6 +64,7 @@ function BankAccountNumber(props: Props) {
     errorMessages,
     mask,
     width: props.width ?? 'medium',
+    inputMode: 'numeric',
   }
 
   return <StringComponent {...stringComponentProps} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -33,6 +33,7 @@ export type Props = FieldHelpProps &
     autoresizeMaxRows?: number
     characterCounter?: boolean
     mask?: InputMaskedProps['mask']
+    inputMode?: React.HTMLProps<HTMLInputElement>['inputMode']
     // Validation
     minLength?: number
     maxLength?: number

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -113,6 +113,7 @@ function StringComponent(props: Props) {
     characterCounter,
     mask,
     width,
+    inputMode,
     handleFocus,
     handleBlur,
     handleChange,
@@ -142,6 +143,7 @@ function StringComponent(props: Props) {
     inner_ref: innerRef,
     status: error ? 'error' : undefined,
     value: value?.toString() ?? '',
+    inputMode,
   }
 
   return (


### PR DESCRIPTION
Proposal to implement this feature https://github.com/dnbexperience/eufemia/issues/3098

Had to add an `inputMode` prop to the `String` component to make it work, but we should probably discuss if that is the best way to add the `inputMode` prop 🙏