### PR TITLE
chore(Field.Number): make numeric keyboard default on mobile

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -209,6 +209,7 @@ function NumberComponent(props: Props) {
         disabled={disabled}
         status={error ? 'error' : undefined}
         stretch={width !== undefined}
+        inputMode="numeric"
         suffix={
           help ? (
             <HelpButton title={help.title}>{help.contents}</HelpButton>


### PR DESCRIPTION
Implementation of this feature proposal https://github.com/dnbexperience/eufemia/issues/3093, this should also solve https://github.com/dnbexperience/eufemia/issues/3097

Tested on android in preview portal, and it works. Need confirmation for iOS 🙏