### PR TITLE
chore(Portal): upgrade to latest theme handler

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -80,7 +80,7 @@
     "gatsby-plugin-babel-react-live": "1.4.2",
     "gatsby-plugin-catch-links": "5.12.0",
     "gatsby-plugin-emotion": "8.12.0",
-    "gatsby-plugin-eufemia-theme-handler": "1.7.0",
+    "gatsby-plugin-eufemia-theme-handler": "1.8.0",
     "gatsby-plugin-gatsby-cloud": "5.12.0",
     "gatsby-plugin-manifest": "5.12.0",
     "gatsby-plugin-mdx": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14016,7 +14016,7 @@ __metadata:
     gatsby-plugin-babel-react-live: "npm:1.4.2"
     gatsby-plugin-catch-links: "npm:5.12.0"
     gatsby-plugin-emotion: "npm:8.12.0"
-    gatsby-plugin-eufemia-theme-handler: "npm:1.7.0"
+    gatsby-plugin-eufemia-theme-handler: "npm:1.8.0"
     gatsby-plugin-gatsby-cloud: "npm:5.12.0"
     gatsby-plugin-manifest: "npm:5.12.0"
     gatsby-plugin-mdx: "npm:5.12.0"
@@ -17089,7 +17089,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-core-utils@npm:4.12.0, gatsby-core-utils@npm:^4.12.0":
+"gatsby-core-utils@npm:4.12.1":
+  version: 4.12.1
+  resolution: "gatsby-core-utils@npm:4.12.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.20.13"
+    ci-info: "npm:2.0.0"
+    configstore: "npm:^5.0.1"
+    fastq: "npm:^1.15.0"
+    file-type: "npm:^16.5.4"
+    fs-extra: "npm:^11.1.1"
+    got: "npm:^11.8.6"
+    hash-wasm: "npm:^4.9.0"
+    import-from: "npm:^4.0.0"
+    lmdb: "npm:2.5.3"
+    lock: "npm:^1.1.0"
+    node-object-hash: "npm:^2.3.10"
+    proper-lockfile: "npm:^4.1.2"
+    resolve-from: "npm:^5.0.0"
+    tmp: "npm:^0.2.1"
+    xdg-basedir: "npm:^4.0.0"
+  checksum: a464bdc79393c9e172632d339b311112b45407153d5ab529e2ba9da00d4966799bc36731677399e297778610e1d752177610b987edc5fd9c4704af124e7436de
+  languageName: node
+  linkType: hard
+
+"gatsby-core-utils@npm:^4.12.0":
   version: 4.12.0
   resolution: "gatsby-core-utils@npm:4.12.0"
   dependencies:
@@ -17230,11 +17254,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-eufemia-theme-handler@npm:1.7.0":
-  version: 1.7.0
-  resolution: "gatsby-plugin-eufemia-theme-handler@npm:1.7.0"
+"gatsby-plugin-eufemia-theme-handler@npm:1.8.0":
+  version: 1.8.0
+  resolution: "gatsby-plugin-eufemia-theme-handler@npm:1.8.0"
   dependencies:
-    gatsby-core-utils: "npm:4.12.0"
+    gatsby-core-utils: "npm:4.12.1"
     globby: "npm:11.0.4"
     micromatch: "npm:4.0.5"
     raw-loader: "npm:4.0.2"
@@ -17243,7 +17267,7 @@ __metadata:
     "@dnb/eufemia": ">=10"
     gatsby: ">=4"
     react: ">=17"
-  checksum: 15607696602e5ca26bbd8d5eef47498edac55c19a7e719665aefcb10b82548eb643de4c81811debe998438ba202d2a1d7a9107154ec372c790a0488cf9e93328
+  checksum: 8b217565ffeba193c1c3276415a3202a9961c0c79a60f2111777ea77a3fdcef25e2b42e6ae64354cdedd2bbc1108b9dec0b72d3a12dd11811e42d6eebf381bdd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes an issue, where theme styles where not loaded when changed (after some changes).

Here is the [fix PR](https://github.com/dnbexperience/gatsby-plugin-eufemia-theme-handler/pull/27).

