### PR TITLE
fix(Field.String): validated empty value when required

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -328,6 +328,20 @@ describe('Field.String', () => {
         })
         expect(screen.queryByRole('alert')).not.toBeInTheDocument()
       })
+
+      it('should show error for initially empty value when required and validateInitially is set', async () => {
+        render(<Field.String value="" required validateInitially />)
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
+
+      it('should show error for initially empty value when required and blur event', async () => {
+        render(<Field.String value="" required />)
+        const input = document.querySelector('input')
+        act(() => {
+          input.blur()
+        })
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
     })
 
     describe('validation based on minLength-prop', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -312,7 +312,7 @@ describe('Field.String', () => {
       it('should show error for empty value', async () => {
         render(<Field.String value="a" required />)
         const input = document.querySelector('input')
-        await userEvent.type(input, '{backspace}')
+        await userEvent.type(input, '{Backspace}')
         act(() => {
           input.blur()
         })
@@ -334,9 +334,10 @@ describe('Field.String', () => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
       })
 
-      it('should show error for initially empty value when required and blur event', async () => {
-        render(<Field.String value="" required />)
+      it('should show error for initially empty value when required and blur event when validateUnchanged is set', async () => {
+        render(<Field.String value="" required validateUnchanged />)
         const input = document.querySelector('input')
+        input.focus()
         act(() => {
           input.blur()
         })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { Form, Field } from '../../..'
 import type { Props as StringProps } from '../../../Field/String'
 import userEvent from '@testing-library/user-event'
@@ -348,5 +348,21 @@ describe('Form.Handler', () => {
     expect(window.sessionStorage.getItem('test-data')).toBe(null)
 
     setItem.mockRestore()
+  })
+
+  it('should show errors if form is invalid on submit', () => {
+    const onSubmit = jest.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String value="" required />
+      </Form.Handler>
+    )
+
+    const formElement = document.querySelector('form')
+    fireEvent.submit(formElement)
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useDataValue.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useDataValue.test.tsx
@@ -199,7 +199,7 @@ describe('useDataValue', () => {
       })
     })
 
-    it('should show error message', async () => {
+    it('should show given error message', () => {
       const { result } = renderHook(() =>
         useDataValue({
           value: undefined,
@@ -210,12 +210,21 @@ describe('useDataValue', () => {
           },
         })
       )
-      await waitFor(() => {
-        expect(result.current.error).toBeInstanceOf(Error)
-        expect(result.current.error.toString()).toBe(
-          'Error: Show this message'
-        )
-      })
+      expect(result.current.error).toBeInstanceOf(Error)
+      expect(result.current.error.toString()).toBe(
+        'Error: Show this message'
+      )
+    })
+
+    it('should validate required when value is empty string', () => {
+      const { result } = renderHook(() =>
+        useDataValue({
+          value: '',
+          required: true,
+          validateInitially: true,
+        })
+      )
+      expect(result.current.error).toBeInstanceOf(Error)
     })
 
     it('should validate "validateRequired"', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -56,12 +56,17 @@ export default function useDataValue<
     fromInput = (value: Value) => value,
     toEvent = (value: Value) => value,
     fromExternal = (value: Value) => value,
-    validateRequired = (value: Value, { emptyValue, required }) =>
-      required && value === emptyValue
-        ? new FormError('The value is required', {
-            validationRule: 'required',
-          })
-        : undefined,
+    validateRequired = (value: Value, { emptyValue, required }) => {
+      const res =
+        required &&
+        (value === emptyValue ||
+          (typeof emptyValue === 'undefined' && value === ''))
+          ? new FormError('The value is required', {
+              validationRule: 'required',
+            })
+          : undefined
+      return res
+    },
   } = props
 
   const [, forceUpdate] = useReducer(() => ({}), {})


### PR DESCRIPTION
If the form is submitted without filling out any any fields, I expect errors messages to be displayed and form submission to be prevented if the form is invalid.

I've not tested if this affects other validation rules, but at least it fails when using the `required` property.