### PR TITLE
fix(Section): ensure overlay is behind content

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -588,7 +588,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  box-shadow: var(--outline, none);
   color: var(--text-color, black);
   border-radius: var(--rounded-corner, 0);
 }
@@ -599,7 +598,8 @@ button.dnb-button::-moz-focus-inner {
   content: "";
   position: absolute;
   inset: 0;
-  box-shadow: var(--drop-shadow, none);
+  z-index: -1;
+  box-shadow: var(--drop-shadow, none), var(--outline, none);
   border-radius: var(--rounded-corner, 0);
 }
 .dnb-section::after {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -588,7 +588,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  box-shadow: var(--outline, none);
   color: var(--text-color, black);
   border-radius: var(--rounded-corner, 0);
 }
@@ -599,7 +598,8 @@ button.dnb-button::-moz-focus-inner {
   content: "";
   position: absolute;
   inset: 0;
-  box-shadow: var(--drop-shadow, none);
+  z-index: -1;
+  box-shadow: var(--drop-shadow, none), var(--outline, none);
   border-radius: var(--rounded-corner, 0);
 }
 .dnb-section::after {

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`Section scss has to match style dependencies css 1`] = `
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  box-shadow: var(--outline, none);
   color: var(--text-color, black);
   border-radius: var(--rounded-corner, 0);
 }
@@ -37,7 +36,8 @@ exports[`Section scss has to match style dependencies css 1`] = `
   content: "";
   position: absolute;
   inset: 0;
-  box-shadow: var(--drop-shadow, none);
+  z-index: -1;
+  box-shadow: var(--drop-shadow, none), var(--outline, none);
   border-radius: var(--rounded-corner, 0);
 }
 .dnb-section::after {

--- a/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
@@ -21,7 +21,6 @@
   --width: 100vw;
   --height: 100%;
 
-  box-shadow: var(--outline, none);
   color: var(--text-color, black);
   border-radius: var(--rounded-corner, 0);
 
@@ -33,7 +32,8 @@
     content: '';
     position: absolute;
     inset: 0;
-    box-shadow: var(--drop-shadow, none);
+    z-index: -1;
+    box-shadow: var(--drop-shadow, none), var(--outline, none);
     border-radius: var(--rounded-corner, 0);
   }
 

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -588,7 +588,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  box-shadow: var(--outline, none);
   color: var(--text-color, black);
   border-radius: var(--rounded-corner, 0);
 }
@@ -599,7 +598,8 @@ button.dnb-button::-moz-focus-inner {
   content: "";
   position: absolute;
   inset: 0;
-  box-shadow: var(--drop-shadow, none);
+  z-index: -1;
+  box-shadow: var(--drop-shadow, none), var(--outline, none);
   border-radius: var(--rounded-corner, 0);
 }
 .dnb-section::after {


### PR DESCRIPTION
- We do that by adding a needed negative z-index.
- Move both the outline and the shadow in the same pseudo element for better flexibility.

