### PR TITLE
fix(Field.Expiry): should handle values of non existing months

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -112,18 +112,18 @@ function Expiry(props: ExpiryProps) {
 
     const [firstMask, secondMask] = getMonthMask(month)
 
-    const first = month?.charAt(0)
-    const isFirstValid = firstMask.test(first)
+    const firstDigit = month?.charAt(0)
+    const isFirstDigitValid = firstMask.test(firstDigit)
 
-    if (first && !isFirstValid) {
+    if (firstDigit && !isFirstDigitValid) {
       // Return empty value if the first digit is invalid
       return ''
     }
 
-    const second = month?.charAt(1)
-    const isSecondValid = secondMask.test(second)
+    const seconDigit = month?.charAt(1)
+    const isSecondDigitValid = secondMask.test(seconDigit)
 
-    if (second && !isSecondValid) {
+    if (seconDigit && !isSecondDigitValid) {
       // Return empty value if the second digit is invalid
       return ''
     }
@@ -133,11 +133,11 @@ function Expiry(props: ExpiryProps) {
   }
 
   function getMonthMask(month: string) {
+    const firstDigit = month?.charAt(0)
+
     return [
       /[0-1]/,
-      month?.charAt(0) === '0' || month?.charAt(0) === ''
-        ? /[1-9]/
-        : /[0-2]/,
+      firstDigit === '0' || firstDigit === '' ? /[1-9]/ : /[0-2]/,
     ]
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -42,7 +42,7 @@ function Expiry(props: ExpiryProps) {
   })
 
   const expiry: ExpiryValue = {
-    month: value?.substring(0, 2) ?? '',
+    month: ensureValidMonth(value?.substring(0, 2)),
     year: value?.substring(2, 4) ?? '',
   }
 
@@ -79,13 +79,7 @@ function Expiry(props: ExpiryProps) {
           {
             id: 'month',
             label: sharedContext?.translation.DatePicker['month'],
-            mask: [
-              /[0-1]/,
-              expiry.month.charAt(0) === '0' ||
-              expiry.month.charAt(0) === ''
-                ? /[1-9]/
-                : /[0-2]/,
-            ],
+            mask: getMonthMask(expiry?.month),
             placeholderCharacter: placeholders['month'],
             autoComplete: 'cc-exp-month',
           },
@@ -108,6 +102,43 @@ function Expiry(props: ExpiryProps) {
 
   function expiryToString(values: ExpiryValue) {
     return Object.values(values).join('')
+  }
+
+  function ensureValidMonth(month: string) {
+    // Return empty value if no month is given
+    if (!month) {
+      return ''
+    }
+
+    const [firstMask, secondMask] = getMonthMask(month)
+
+    const first = month?.charAt(0)
+    const isFirstValid = firstMask.test(first)
+
+    if (first && !isFirstValid) {
+      // Return empty value if the first digit is invalid
+      return ''
+    }
+
+    const second = month?.charAt(1)
+    const isSecondValid = secondMask.test(second)
+
+    if (second && !isSecondValid) {
+      // Return empty value if the second digit is invalid
+      return ''
+    }
+
+    // Return given month of month value is valid
+    return month
+  }
+
+  function getMonthMask(month: string) {
+    return [
+      /[0-1]/,
+      month?.charAt(0) === '0' || month?.charAt(0) === ''
+        ? /[1-9]/
+        : /[0-2]/,
+    ]
   }
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -44,6 +44,48 @@ describe('Field.Expiry', () => {
     expect(yearInput.value).toBe('åå')
   })
 
+  describe('should handle non existing values for month', () => {
+    it('when month is 90', () => {
+      render(<Field.Expiry value="9022" />)
+
+      const monthInput = document.querySelectorAll('input')[0]
+      const yearInput = document.querySelectorAll('input')[1]
+
+      expect(monthInput.value).toBe('mm')
+      expect(yearInput.value).toBe('22')
+    })
+
+    it('when month is 23', () => {
+      render(<Field.Expiry value="2335" />)
+
+      const monthInput = document.querySelectorAll('input')[0]
+      const yearInput = document.querySelectorAll('input')[1]
+
+      expect(monthInput.value).toBe('mm')
+      expect(yearInput.value).toBe('35')
+    })
+
+    it('when month is 13', () => {
+      render(<Field.Expiry value="1312" />)
+
+      const monthInput = document.querySelectorAll('input')[0]
+      const yearInput = document.querySelectorAll('input')[1]
+
+      expect(monthInput.value).toBe('mm')
+      expect(yearInput.value).toBe('12')
+    })
+
+    it('when month is 00', () => {
+      render(<Field.Expiry value="0000" />)
+
+      const monthInput = document.querySelectorAll('input')[0]
+      const yearInput = document.querySelectorAll('input')[1]
+
+      expect(monthInput.value).toBe('mm')
+      expect(yearInput.value).toBe('00')
+    })
+  })
+
   it('should return month and year values as a concatenated string', async () => {
     const onChange = jest.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -269,10 +269,6 @@ describe('Field.Expiry', () => {
       const input = document.querySelector('input')
       const inputWrapper = document.querySelector('.dnb-input')
 
-      act(() => {
-        input.focus()
-      })
-
       expect(inputWrapper.classList).not.toContain(
         'dnb-input__status--error'
       )
@@ -280,7 +276,7 @@ describe('Field.Expiry', () => {
         document.querySelector('.dnb-form-status__text')
       ).not.toBeInTheDocument()
 
-      await userEvent.keyboard('1')
+      await userEvent.type(input, '1')
 
       expect(inputWrapper.classList).not.toContain(
         'dnb-input__status--error'
@@ -299,7 +295,7 @@ describe('Field.Expiry', () => {
       expect(formStatusText).toBeInTheDocument()
       expect(formStatusText).toHaveTextContent('The value is required')
 
-      await userEvent.keyboard('12')
+      await userEvent.type(input, '12')
 
       expect(inputWrapper.classList).not.toContain(
         'dnb-input__status--error'


### PR DESCRIPTION
This PR doesn't actually fix anything, it just adds tests for scenarios I believe the Expiry field should handle in the same manner. But sometimes when value has a non existing month as a value, it returns different values, and I believe it should/could return the same:

Here are a few examples:
- value `0000` results in `0m / 00`
- value `1300` results in `1m / 00`
- value `9900` results in `mm / 00`
- etc etc.

So, consider this an issue, which includes a few tests 🤷‍♂️ 