### PR TITLE
chore(DatePicker): add onBlur event

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/events.mdx
@@ -16,6 +16,7 @@ import { DatePickerDateFnsRangeIsWeekend } from 'Docs/uilib/components/date-pick
 | `on_show`        | _(optional)_ will be called once date-picker is visible.                                                                |
 | `on_hide`        | _(optional)_ will be called once date-picker is hidden.                                                                 |
 | `on_days_render` | _(optional)_ will be called right before every new calendar view gets rendered. See the example above.                  |
+| `onBlur`         | _(optional)_ will be called once the input lose focus.                                                                  |
 
 ## Returned Object
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.d.ts
@@ -26,7 +26,7 @@ type DatePickerSuffix =
 type DatePickerDirection = 'auto' | 'top' | 'bottom';
 type DatePickerAlignPicker = 'auto' | 'left' | 'right';
 export interface DatePickerProps
-  extends Omit<React.HTMLProps<HTMLElement>, 'ref'>,
+  extends Omit<React.HTMLProps<HTMLElement>, 'ref', 'onBlur'>,
     SpacingProps {
   id?: string;
   title?: string;
@@ -244,6 +244,10 @@ export interface DatePickerProps
    * Will be called once a user presses the reset button.
    */
   on_reset?: (...args: any[]) => any;
+  /**
+   * Will be called once the input loses focus.
+   */
+  onBlur?: (event: React.FocusEventHandler<HTMLInputElement>) => void;
 }
 export default class DatePicker extends React.Component<
   DatePickerProps,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.js
@@ -187,6 +187,7 @@ export default class DatePicker extends React.PureComponent {
     on_submit: PropTypes.func,
     on_cancel: PropTypes.func,
     on_reset: PropTypes.func,
+    onBlur: PropTypes.func,
   }
 
   static defaultProps = {
@@ -257,6 +258,7 @@ export default class DatePicker extends React.PureComponent {
     on_submit: null,
     on_cancel: null,
     on_reset: null,
+    onBlur: null,
   }
 
   static blurDelay = 201 // some ms more than "dropdownSlideDown 200ms"

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.js
@@ -60,6 +60,7 @@ export default class DatePickerInput extends React.PureComponent {
     onChange: PropTypes.func,
     onSubmit: PropTypes.func,
     onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
   }
 
   static defaultProps = {
@@ -84,6 +85,7 @@ export default class DatePickerInput extends React.PureComponent {
     onChange: null,
     onSubmit: null,
     onFocus: null,
+    onBlur: null,
   }
 
   state = {
@@ -325,12 +327,16 @@ export default class DatePickerInput extends React.PureComponent {
     })
   }
 
-  onBlurHandler = () => {
+  onBlurHandler = (e) => {
     this.focusMode = null
     this.setState({
       focusState: 'blur',
       _listenForPropChanges: false,
     })
+
+    if (this.props.onBlur) {
+      this.props.onBlur(e)
+    }
   }
 
   onKeyDownHandler = async (event) => {
@@ -679,6 +685,7 @@ export default class DatePickerInput extends React.PureComponent {
       onChange, // eslint-disable-line
       onFocus, // eslint-disable-line
       onSubmit, // eslint-disable-line
+      onBlur, // eslint-disable-line
       selectedDateTitle, // eslint-disable-line
       showInput, // eslint-disable-line
       input_element,

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1498,7 +1498,7 @@ describe('DatePicker component', () => {
     expect(thirdDateButton.children[2]).toHaveTextContent('24')
   })
 
-  it.only('should fire blur event when input loses focus', async () => {
+  it('should fire blur event when input loses focus', async () => {
     const onBlur = jest.fn()
     render(<DatePicker show_input onBlur={onBlur} />)
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1497,6 +1497,41 @@ describe('DatePicker component', () => {
     )
     expect(thirdDateButton.children[2]).toHaveTextContent('24')
   })
+
+  it.only('should fire blur event when input loses focus', async () => {
+    const onBlur = jest.fn()
+    render(<DatePicker show_input onBlur={onBlur} />)
+
+    const [firstInput, secondInput]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-input__input')
+    )
+
+    await userEvent.click(firstInput)
+
+    expect(onBlur).toHaveBeenCalledTimes(0)
+    expect(document.activeElement).toBe(firstInput)
+
+    await userEvent.click(document.body)
+
+    expect(document.activeElement).not.toBe(firstInput)
+    expect(onBlur).toHaveBeenCalledTimes(1)
+    expect(onBlur).toHaveBeenCalledWith(
+      expect.objectContaining({ target: firstInput })
+    )
+
+    await userEvent.click(secondInput)
+
+    expect(onBlur).toHaveBeenCalledTimes(1)
+    expect(document.activeElement).toBe(secondInput)
+
+    await userEvent.click(document.body)
+
+    expect(document.activeElement).not.toBe(secondInput)
+    expect(onBlur).toHaveBeenCalledTimes(2)
+    expect(onBlur).toHaveBeenCalledWith(
+      expect.objectContaining({ target: secondInput })
+    )
+  })
 })
 
 // for the unit calc tests


### PR DESCRIPTION
Proposal to add onBlur event prop for the `DatePicker`

This could be solve by either hooking the onBlur event to the `fieldset` wrapping the inputs, or adding it to the existing internal `DatePickerInput` `onBlur` handler. 

I went with the latter approach, as adding it to the `fieldset` would requrie adding a check for if the `InputButton` is being clicked to abort the onBlur event, preventing the onBlur from firing every time the user clicks the `InputButton`