### PR TITLE
fix(DatePicker): fix bug where minDate set to today is disabled

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
@@ -170,12 +170,19 @@ const isWithinSelectionCalc = (date, startDate, endDate) => {
 // date is before minDate or after maxDate
 const isDisabledCalc = (date, minDate, maxDate) => {
   // isBefore and isAfter return false if comparison date is undefined, which is useful here in case minDate and maxDate aren't supplied
+  // resetting the the `minDate` and `maxDate` hours for comparison, as the `date` param comes with a time of 00:00:00
   return (
-    (minDate && isBefore(date, minDate)) ||
-    (maxDate && isAfter(date, maxDate))
+    (minDate && isBefore(date, resetHours(minDate))) ||
+    (maxDate && isAfter(date, resetHours(maxDate)))
   )
 }
 export { isDisabledCalc as isDisabled }
+
+// useful for comparing dates that strictly speaking are the same, but differs in time (hours, minutes, seconds)
+const resetHours = (date) => {
+  const dateCopy = new Date(date)
+  return dateCopy.setHours(0, 0, 0, 0)
+}
 
 // date selected is start date
 const isStartDateCalc = (date, range) => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
@@ -171,7 +171,6 @@ const isWithinSelectionCalc = (date, startDate, endDate) => {
 // date is before minDate or after maxDate
 const isDisabledCalc = (date, minDate, maxDate) => {
   // isBefore and isAfter return false if comparison date is undefined, which is useful here in case minDate and maxDate aren't supplied
-
   return (
     (minDate && isBefore(date, startOfDay(minDate))) ||
     (maxDate && isAfter(date, startOfDay(maxDate)))

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
@@ -179,6 +179,7 @@ const isDisabledCalc = (date, minDate, maxDate) => {
 export { isDisabledCalc as isDisabled }
 
 // useful for comparing dates that strictly speaking are the same, but differs in time (hours, minutes, seconds)
+// returns a new Date object to prevent mutation
 const resetHours = (date) => {
   const dateCopy = new Date(date)
   return dateCopy.setHours(0, 0, 0, 0)

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.js
@@ -21,6 +21,7 @@ import getDaysInMonth from 'date-fns/getDaysInMonth'
 import toDate from 'date-fns/toDate'
 import parseISO from 'date-fns/parseISO'
 import parse from 'date-fns/parse'
+import startOfDay from 'date-fns/startOfDay'
 
 import { warn } from '../../shared/component-helper'
 
@@ -170,20 +171,13 @@ const isWithinSelectionCalc = (date, startDate, endDate) => {
 // date is before minDate or after maxDate
 const isDisabledCalc = (date, minDate, maxDate) => {
   // isBefore and isAfter return false if comparison date is undefined, which is useful here in case minDate and maxDate aren't supplied
-  // resetting the the `minDate` and `maxDate` hours for comparison, as the `date` param comes with a time of 00:00:00
+
   return (
-    (minDate && isBefore(date, resetHours(minDate))) ||
-    (maxDate && isAfter(date, resetHours(maxDate)))
+    (minDate && isBefore(date, startOfDay(minDate))) ||
+    (maxDate && isAfter(date, startOfDay(maxDate)))
   )
 }
 export { isDisabledCalc as isDisabled }
-
-// useful for comparing dates that strictly speaking are the same, but differs in time (hours, minutes, seconds)
-// returns a new Date object to prevent mutation
-const resetHours = (date) => {
-  const dateCopy = new Date(date)
-  return dateCopy.setHours(0, 0, 0, 0)
-}
 
 // date selected is start date
 const isStartDateCalc = (date, range) => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1528,6 +1528,24 @@ describe('DatePicker component', () => {
       expect.objectContaining({ target: secondInput })
     )
   })
+
+  it('should have todays date enabled in calendar if minDate is today', async () => {
+    const minDate = new Date()
+
+    render(<DatePicker min_date={minDate} />)
+
+    const button = document.querySelector(
+      '.dnb-input__submit-element > button'
+    )
+
+    await userEvent.click(button)
+
+    const todayButton = document.querySelector(
+      '.dnb-date-picker__day--today > button'
+    )
+
+    expect(todayButton).not.toBeDisabled()
+  })
 })
 
 // for the unit calc tests


### PR DESCRIPTION
`minDate` would be disabled was set to be `new Date()`, since the `isAfter` function that does the comparison to determine of the date should disabled in the calendar, also compares time. The calendar `date` param passed down to the `isDisabledCalc` has time set to `00:00:00` meaning that `date` is after `minDate` if its set to `new Date()` since `minDate` can have a time of `16:57:13`

Before:
<img width="359" alt="Screenshot 2024-01-05 at 09 41 01" src="https://github.com/dnbexperience/eufemia/assets/25927156/e83a2ef3-e4da-4f11-83b7-5b47dd5d110b">


After:
<img width="369" alt="Screenshot 2024-01-05 at 09 40 44" src="https://github.com/dnbexperience/eufemia/assets/25927156/b952a6be-39c0-402a-bc75-c59be58acbb0">

