### PR TITLE
chore(Dropdown): close on suffix click

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -685,6 +685,7 @@ class DropdownInstance extends React.PureComponent {
                 className="dnb-dropdown__suffix"
                 id={id + '-suffix'} // used for "aria-describedby"
                 context={props}
+                onClick={this.setHidden}
               >
                 {suffix}
               </Suffix>

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react'
 import { axeComponent, loadScss, wait } from '../../../core/jest/jestSetup'
 import { fireEvent, render, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import Dropdown, { DropdownProps } from '../Dropdown'
 import {
   mockImplementationForDirectionObserver,
@@ -1294,6 +1295,26 @@ describe('Dropdown component', () => {
     open()
 
     await testDirectionObserver()
+  })
+
+  it('should close dropdown on suffix click', async () => {
+    render(
+      <Dropdown {...props} data={['One', 'Two']} suffix={'Click me'} />
+    )
+
+    const dropdown = document.querySelector('.dnb-dropdown')
+    const trigger = document.querySelector('.dnb-dropdown__trigger')
+    const suffix = document.querySelector('.dnb-dropdown__suffix')
+
+    await userEvent.click(trigger)
+
+    expect(dropdown).toHaveClass('dnb-dropdown--opened')
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+    await userEvent.click(suffix)
+
+    expect(dropdown).not.toHaveClass('dnb-dropdown--opened')
+    expect(trigger).not.toHaveAttribute('aria-expanded', 'true')
   })
 })
 


### PR DESCRIPTION
proposal to fix https://github.com/dnbexperience/eufemia/issues/2981

This solution makes the `Dropdown` close regardless if the suffix is a button or not. So if the `suffix` is just plane text, it will close the `Dropdown` if clicked. Should we perhaps add logic that checks if the trigger is a `button` or not before deciding to close, or is that unnecessary?  