### PR TITLE
fix(Textarea): ensure correct height based on rows for Firefox browser

### DIFF
--- a/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -217,6 +217,11 @@ html:not([data-visual-test]) .dnb-textarea__textarea {
     background-color: var(--scrollbar-thumb-hover-color, #666);
   }
 }
+@-moz-document url-prefix() {
+  .dnb-textarea__textarea {
+    overflow-x: clip;
+  }
+}
 .dnb-textarea__input:autofill {
   box-shadow: 0 0 0 var(--border-width) var(--border-color), 0 0 0 10em var(--textarea-background-color) inset;
 }

--- a/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
@@ -71,6 +71,10 @@
     @include textareaStyleCommon();
 
     @include scrollY(auto);
+
+    @include IS_FF() {
+      overflow-x: clip;
+    }
   }
 
   // change the autocomplete appearance once filled out

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -248,8 +248,7 @@
 
 // Firefox fix
 @mixin IS_FF() {
-  @supports (-moz-appearance: meterbar) and
-    (background-blend-mode: difference, normal) {
+  @-moz-document url-prefix() {
     @content;
   }
 }


### PR DESCRIPTION
Before:
<img width="377" alt="Screenshot 2024-01-10 at 15 08 15" src="https://github.com/dnbexperience/eufemia/assets/1501870/2827fd59-4431-408e-b87d-dc57e52b0374">

After:
<img width="383" alt="Screenshot 2024-01-10 at 15 08 28" src="https://github.com/dnbexperience/eufemia/assets/1501870/af10174e-7b59-47b7-919c-a32b458d5b70">


