### PR TITLE
fix(Field): show error state without error object if parent FieldBlock has error

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, screen } from '@testing-library/react'
 import ArraySelection from '../ArraySelection'
 import Option from '../../Option'
 import { FormError } from '../../../types'
+import { FieldBlock } from '../../..'
 
 describe('ArraySelection', () => {
   it('renders correctly', () => {
@@ -197,6 +198,110 @@ describe('ArraySelection', () => {
 
       expect(option1).toBeDisabled()
       expect(option2).toBeDisabled()
+    })
+  })
+
+  describe('checkbox', () => {
+    it('renders error', () => {
+      render(
+        <ArraySelection error={new FormError('Error message')}>
+          <Option value="A" title="Fooo!" />
+          <Option value="B" title="Baar!" />
+          <Option value="C" title="Bazz!" />
+          <Option value="D" title="Quxx!" />
+        </ArraySelection>
+      )
+
+      const element = document.querySelector('.dnb-form-status')
+      expect(element).toHaveTextContent('Error message')
+
+      const [optionA, optionB, optionC, optionD]: Array<HTMLElement> =
+        Array.from(document.querySelectorAll('.dnb-checkbox'))
+      expect(optionA).toHaveClass('dnb-checkbox__status--error')
+      expect(optionB).toHaveClass('dnb-checkbox__status--error')
+      expect(optionC).toHaveClass('dnb-checkbox__status--error')
+      expect(optionD).toHaveClass('dnb-checkbox__status--error')
+    })
+
+    it('shows error style in FieldBlock', () => {
+      render(
+        <FieldBlock>
+          <ArraySelection error={new FormError('Error message')}>
+            <Option value="A" title="Fooo!" />
+            <Option value="B" title="Baar!" />
+            <Option value="C" title="Bazz!" />
+            <Option value="D" title="Quxx!" />
+          </ArraySelection>
+        </FieldBlock>
+      )
+
+      const [optionA, optionB, optionC, optionD]: Array<HTMLElement> =
+        Array.from(document.querySelectorAll('.dnb-checkbox'))
+      expect(optionA).toHaveClass('dnb-checkbox__status--error')
+      expect(optionB).toHaveClass('dnb-checkbox__status--error')
+      expect(optionC).toHaveClass('dnb-checkbox__status--error')
+      expect(optionD).toHaveClass('dnb-checkbox__status--error')
+    })
+  })
+
+  describe('button', () => {
+    it('renders error', () => {
+      render(
+        <ArraySelection
+          variant="button"
+          error={new FormError('Error message')}
+        >
+          <Option value="A" title="Fooo!" />
+          <Option value="B" title="Baar!" />
+          <Option value="C" title="Bazz!" />
+          <Option value="D" title="Quxx!" />
+        </ArraySelection>
+      )
+
+      const element = document.querySelector('.dnb-form-status')
+      expect(element).toHaveTextContent('Error message')
+
+      const [
+        optionA,
+        optionB,
+        optionC,
+        optionD,
+      ]: Array<HTMLButtonElement> = Array.from(
+        document.querySelectorAll('.dnb-toggle-button')
+      )
+      expect(optionA).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionB).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionC).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionD).toHaveClass('dnb-toggle-button__status--error')
+    })
+
+    it('shows error style in FieldBlock', () => {
+      render(
+        <FieldBlock>
+          <ArraySelection
+            variant="button"
+            error={new FormError('Error message')}
+          >
+            <Option value="A" title="Fooo!" />
+            <Option value="B" title="Baar!" />
+            <Option value="C" title="Bazz!" />
+            <Option value="D" title="Quxx!" />
+          </ArraySelection>
+        </FieldBlock>
+      )
+
+      const [
+        optionA,
+        optionB,
+        optionC,
+        optionD,
+      ]: Array<HTMLButtonElement> = Array.from(
+        document.querySelectorAll('.dnb-toggle-button')
+      )
+      expect(optionA).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionB).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionC).toHaveClass('dnb-toggle-button__status--error')
+      expect(optionD).toHaveClass('dnb-toggle-button__status--error')
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -3,6 +3,7 @@ import { render, waitFor, screen, fireEvent } from '@testing-library/react'
 import Date from '..'
 import userEvent from '@testing-library/user-event'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
+import { FormError, FieldBlock } from '../../..'
 
 describe('Field.Date', () => {
   it('should render with props', () => {
@@ -88,5 +89,26 @@ describe('Field.Date', () => {
 
       expect(await axeComponent(result)).toHaveNoViolations()
     })
+  })
+
+  it('renders error', () => {
+    render(<Date error={new FormError('Error message')} />)
+
+    const element = document.querySelector('.dnb-form-status')
+    expect(element).toHaveTextContent('Error message')
+
+    const input = document.querySelector('.dnb-date-picker')
+    expect(input).toHaveClass('dnb-date-picker__status--error')
+  })
+
+  it('shows error style in FieldBlock', () => {
+    render(
+      <FieldBlock>
+        <Date error={new FormError('Error message')} />
+      </FieldBlock>
+    )
+
+    const input = document.querySelector('.dnb-date-picker')
+    expect(input).toHaveClass('dnb-date-picker__status--error')
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -47,6 +47,7 @@ function Expiry(props: ExpiryProps) {
     className,
     label = translations.expiryLabel,
     error,
+    hasError,
     info,
     warning,
     help,
@@ -68,7 +69,13 @@ function Expiry(props: ExpiryProps) {
 
   const idRef = useRef(propsId || makeUniqueId()).current
 
-  const status = error ? 'error' : warning ? 'warn' : info ? 'info' : null
+  const status = hasError
+    ? 'error'
+    : warning
+    ? 'warn'
+    : info
+    ? 'info'
+    : null
 
   return (
     <FieldBlock

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -3,6 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { act, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as Field from '../..'
+import { FormError, FieldBlock } from '../../..'
 
 describe('Field.Expiry', () => {
   beforeEach(() => {
@@ -310,5 +311,26 @@ describe('Field.Expiry', () => {
     const result = render(<Field.Expiry />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
+  })
+
+  it('renders error', () => {
+    render(<Field.Expiry error={new FormError('Error message')} />)
+
+    const element = document.querySelector('.dnb-form-status')
+    expect(element).toHaveTextContent('Error message')
+
+    const input = document.querySelector('.dnb-input')
+    expect(input).toHaveClass('dnb-input__status--error')
+  })
+
+  it('shows error style in FieldBlock', () => {
+    render(
+      <FieldBlock>
+        <Field.Expiry error={new FormError('Error message')} />
+      </FieldBlock>
+    )
+
+    const input = document.querySelector('.dnb-input')
+    expect(input).toHaveClass('dnb-input__status--error')
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -187,6 +187,7 @@ function NumberComponent(props: Props) {
     info,
     warning,
     error,
+    hasError,
     help,
     size,
     width,
@@ -228,7 +229,7 @@ function NumberComponent(props: Props) {
       'dnb-forms-field-number__contents',
       showStepControls && 'dnb-forms-field-number__contents--has-controls',
       disabled && 'dnb-forms-field-number__contents--is-disabled',
-      error && 'dnb-forms-field-number__contents--has-error'
+      hasError && 'dnb-forms-field-number__contents--has-error'
     ),
     forId: id,
     layout,
@@ -305,7 +306,7 @@ function NumberComponent(props: Props) {
     onBlur: handleBlur,
     onChange: handleChange,
     disabled,
-    status: error ? 'error' : undefined,
+    status: hasError ? 'error' : undefined,
     stretch: width !== undefined,
     suffix:
       help && !showStepControls ? (

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -3,6 +3,7 @@ import { axeComponent, wait } from '../../../../../core/jest/jestSetup'
 import { screen, render, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as Field from '../../'
+import { FormError, FieldBlock } from '../../..'
 
 describe('Field.Number', () => {
   describe('props', () => {
@@ -109,6 +110,20 @@ describe('Field.Number', () => {
       render(<Field.Number error={new Error('This is what went wrong')} />)
       const element = document.querySelector('.dnb-input')
       expect(element.className).toContain('dnb-input__status--error')
+    })
+
+    it('shows error style in FieldBlock', () => {
+      const errorMessage = new FormError('Error message')
+      render(
+        <FieldBlock>
+          <Field.Number error={errorMessage} />
+        </FieldBlock>
+      )
+
+      const input = document.querySelector(
+        '.dnb-forms-field-number__input'
+      )
+      expect(input).toHaveClass('dnb-input__status--error')
     })
 
     it('formats with given thousandSeparator', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -129,6 +129,7 @@ function PhoneNumber(props: Props) {
     info,
     warning,
     error,
+    hasError,
     disabled,
     width = 'large',
     help,
@@ -306,7 +307,7 @@ function PhoneNumber(props: Props) {
             }
             data={dataRef.current}
             value={countryCodeRef.current}
-            status={error ? 'error' : undefined}
+            status={hasError ? 'error' : undefined}
             disabled={disabled}
             on_focus={onFocusHandler}
             on_blur={handleBlur}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -68,6 +68,7 @@ function SelectCountry(props: Props) {
     info,
     warning,
     error,
+    hasError,
     disabled,
     value,
     width = 'large',
@@ -189,6 +190,7 @@ function SelectCountry(props: Props) {
         on_change={handleCountryChange}
         on_type={onTypeHandler}
         stretch
+        status={hasError ? 'error' : undefined}
         show_submit_button
         suffix={
           help ? (

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -3,7 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import SelectCountry, { Props } from '..'
 import { Provider } from '../../../../../shared'
-import { Form, FormError } from '../../..'
+import { Form, FormError, FieldBlock } from '../../..'
 
 describe('Field.SelectCountry', () => {
   it('should render with props', () => {
@@ -267,15 +267,27 @@ describe('Field.SelectCountry', () => {
     expect(selectedItemElement().textContent).toBe('Danmark')
   })
 
-  it('shold display read border on dropdown', () => {
+  it('renders error', () => {
     const errorMessage = new FormError('Error message')
     render(<SelectCountry error={errorMessage} />)
 
-    const input = document.querySelector('.dnb-autocomplete__input')
-    expect(input).toHaveClass('dnb-input__status--error')
-
     const element = document.querySelector('.dnb-form-status')
     expect(element).toHaveTextContent('Error message')
+
+    const input = document.querySelector('.dnb-autocomplete__input')
+    expect(input).toHaveClass('dnb-input__status--error')
+  })
+
+  it('shows error style in FieldBlock', () => {
+    const errorMessage = new FormError('Error message')
+    render(
+      <FieldBlock>
+        <SelectCountry error={errorMessage} />
+      </FieldBlock>
+    )
+
+    const input = document.querySelector('.dnb-autocomplete__input')
+    expect(input).toHaveClass('dnb-input__status--error')
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -3,7 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import SelectCountry, { Props } from '..'
 import { Provider } from '../../../../../shared'
-import { Form } from '../../..'
+import { Form, FormError } from '../../..'
 
 describe('Field.SelectCountry', () => {
   it('should render with props', () => {
@@ -265,6 +265,17 @@ describe('Field.SelectCountry', () => {
 
     expect(inputElement.value).toBe('Danmark')
     expect(selectedItemElement().textContent).toBe('Danmark')
+  })
+
+  it('shold display read border on dropdown', () => {
+    const errorMessage = new FormError('Error message')
+    render(<SelectCountry error={errorMessage} />)
+
+    const input = document.querySelector('.dnb-autocomplete__input')
+    expect(input).toHaveClass('dnb-input__status--error')
+
+    const element = document.querySelector('.dnb-form-status')
+    expect(element).toHaveTextContent('Error message')
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -47,6 +47,7 @@ function Selection(props: Props) {
     info,
     warning,
     error,
+    hasError,
     disabled,
     help,
     emptyValue,
@@ -237,7 +238,7 @@ function Selection(props: Props) {
             portal_class="dnb-forms-field-selection__portal"
             title={placeholder}
             value={String(value ?? '')}
-            status={status && 'error'}
+            status={(hasError || status) && 'error'}
             disabled={disabled}
             data={data}
             suffix={

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -10,6 +10,7 @@ import {
 import userEvent from '@testing-library/user-event'
 import * as DataContext from '../../../DataContext'
 import * as Field from '../..'
+import { FieldBlock } from '../../..'
 
 export async function expectNever(callable: () => unknown): Promise<void> {
   await expect(() => waitFor(callable)).rejects.toEqual(expect.anything())
@@ -221,6 +222,16 @@ describe('Field.String', () => {
         expect(element.className).toContain('dnb-input__status--error')
       })
 
+      it('for basis input in FieldBlock', () => {
+        render(
+          <FieldBlock>
+            <Field.String error={new Error('This is what went wrong')} />
+          </FieldBlock>
+        )
+        const element = document.querySelector('.dnb-input')
+        expect(element.className).toContain('dnb-input__status--error')
+      })
+
       it('for masked input', () => {
         render(
           <Field.String
@@ -232,12 +243,38 @@ describe('Field.String', () => {
         expect(element.className).toContain('dnb-input__status--error')
       })
 
+      it('for masked input in FieldBlock', () => {
+        render(
+          <FieldBlock>
+            <Field.String
+              mask={[/\/d/]}
+              error={new Error('This is what went wrong')}
+            />
+          </FieldBlock>
+        )
+        const element = document.querySelector('.dnb-input-masked')
+        expect(element.className).toContain('dnb-input__status--error')
+      })
+
       it('for multiline input', () => {
         render(
           <Field.String
             multiline
             error={new Error('This is what went wrong')}
           />
+        )
+        const element = document.querySelector('.dnb-textarea')
+        expect(element.className).toContain('dnb-textarea__status--error')
+      })
+
+      it('for multiline in FieldBlock', () => {
+        render(
+          <FieldBlock>
+            <Field.String
+              multiline
+              error={new Error('This is what went wrong')}
+            />
+          </FieldBlock>
         )
         const element = document.querySelector('.dnb-textarea')
         expect(element.className).toContain('dnb-textarea__status--error')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -34,6 +34,7 @@ function Toggle(props: Props) {
     info,
     warning,
     error,
+    hasError,
     handleChange,
   } = useDataValue(props)
 
@@ -83,7 +84,7 @@ function Toggle(props: Props) {
             label={label}
             checked={isOn}
             disabled={disabled}
-            status={error ? 'error' : undefined}
+            status={hasError ? 'error' : undefined}
             on_change={handleCheckboxChange}
             {...pickSpacingProps(props)}
           />
@@ -101,7 +102,7 @@ function Toggle(props: Props) {
             }
             checked={isOn}
             disabled={disabled}
-            status={error ? 'error' : undefined}
+            status={hasError ? 'error' : undefined}
             value={value ? 'true' : 'false'}
             on_change={handleCheckboxChange}
           />
@@ -115,7 +116,7 @@ function Toggle(props: Props) {
               value={{
                 value: isOn ? 'on' : isOff ? 'off' : undefined,
                 onChange: handleToggleChange,
-                status: error ? 'error' : undefined,
+                status: hasError ? 'error' : undefined,
                 disabled,
               }}
             >
@@ -148,7 +149,7 @@ function Toggle(props: Props) {
             }
             checked={isOn}
             disabled={disabled}
-            status={error ? 'error' : undefined}
+            status={hasError ? 'error' : undefined}
             value={value ? 'true' : 'false'}
             on_change={handleCheckboxChange}
           />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
 import Toggle, { Props } from '../Toggle'
+import { FormError, FieldBlock } from '../../..'
 
 describe('Field.Toggle', () => {
   it('should render with props', () => {
@@ -82,6 +83,45 @@ describe('Field.Toggle', () => {
 
         expect(await axeComponent(result)).toHaveNoViolations()
       })
+
+      it('renders error', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <Toggle
+            valueOn="on"
+            valueOff="off"
+            variant="buttons"
+            value="on"
+            error={errorMessage}
+          />
+        )
+
+        const element = document.querySelector('.dnb-form-status')
+        expect(element).toHaveTextContent('Error message')
+
+        const input = document.querySelector('.dnb-toggle-button')
+        expect(input).toHaveClass('dnb-toggle-button__status--error')
+      })
+
+      it('shows error style in FieldBlock', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <FieldBlock>
+            <Toggle
+              valueOn="on"
+              valueOff="off"
+              variant="buttons"
+              value="on"
+              error={errorMessage}
+            />
+          </FieldBlock>
+        )
+
+        const input = document.querySelector('.dnb-toggle-button')
+        expect(input).toHaveClass('dnb-toggle-button__status--error')
+      })
     })
 
     describe('buttons', () => {
@@ -134,6 +174,51 @@ describe('Field.Toggle', () => {
 
         expect(await axeComponent(result)).toHaveNoViolations()
       })
+
+      it('renders error', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <Toggle
+            label="Label"
+            valueOn="on"
+            valueOff="off"
+            variant="buttons"
+            value="on"
+            error={errorMessage}
+          />
+        )
+
+        const element = document.querySelector('.dnb-form-status')
+        expect(element).toHaveTextContent('Error message')
+
+        const [yesElement, noElement]: Array<HTMLButtonElement> =
+          Array.from(document.querySelectorAll('.dnb-toggle-button'))
+        expect(yesElement).toHaveClass('dnb-toggle-button__status--error')
+        expect(noElement).toHaveClass('dnb-toggle-button__status--error')
+      })
+
+      it('shows error style in FieldBlock', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <FieldBlock>
+            <Toggle
+              label="Label"
+              valueOn="on"
+              valueOff="off"
+              variant="buttons"
+              value="on"
+              error={errorMessage}
+            />
+          </FieldBlock>
+        )
+
+        const [yesElement, noElement]: Array<HTMLButtonElement> =
+          Array.from(document.querySelectorAll('.dnb-toggle-button'))
+        expect(yesElement).toHaveClass('dnb-toggle-button__status--error')
+        expect(noElement).toHaveClass('dnb-toggle-button__status--error')
+      })
     })
 
     describe('checkbox-button', () => {
@@ -183,6 +268,47 @@ describe('Field.Toggle', () => {
 
         expect(await axeComponent(result)).toHaveNoViolations()
       })
+
+      it('renders error', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <Toggle
+            label="Label"
+            valueOn="on"
+            valueOff="off"
+            variant="checkbox-button"
+            value="on"
+            error={errorMessage}
+          />
+        )
+
+        const element = document.querySelector('.dnb-form-status')
+        expect(element).toHaveTextContent('Error message')
+
+        const input = document.querySelector('.dnb-toggle-button')
+        expect(input).toHaveClass('dnb-toggle-button__status--error')
+      })
+
+      it('shows error style in FieldBlock', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <FieldBlock>
+            <Toggle
+              label="Label"
+              valueOn="on"
+              valueOff="off"
+              variant="checkbox-button"
+              value="on"
+              error={errorMessage}
+            />
+          </FieldBlock>
+        )
+
+        const input = document.querySelector('.dnb-toggle-button')
+        expect(input).toHaveClass('dnb-toggle-button__status--error')
+      })
     })
 
     describe('checkbox', () => {
@@ -229,6 +355,47 @@ describe('Field.Toggle', () => {
         )
 
         expect(await axeComponent(result)).toHaveNoViolations()
+      })
+
+      it('renders error', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <Toggle
+            label="Label"
+            valueOn="on"
+            valueOff="off"
+            variant="checkbox"
+            value="on"
+            error={errorMessage}
+          />
+        )
+
+        const element = document.querySelector('.dnb-form-status')
+        expect(element).toHaveTextContent('Error message')
+
+        const input = document.querySelector('.dnb-checkbox')
+        expect(input).toHaveClass('dnb-checkbox__status--error')
+      })
+
+      it('shows error style in FieldBlock', () => {
+        const errorMessage = new FormError('Error message')
+
+        render(
+          <FieldBlock>
+            <Toggle
+              label="Label"
+              valueOn="on"
+              valueOff="off"
+              variant="checkbox"
+              value="on"
+              error={errorMessage}
+            />
+          </FieldBlock>
+        )
+
+        const input = document.querySelector('.dnb-checkbox')
+        expect(input).toHaveClass('dnb-checkbox__status--error')
       })
     })
   })


### PR DESCRIPTION
Fixes #2958

The `hasError` prop is used to tell "regular" input components that they have an error