### PR TITLE
fix(Input): should not clear input value with escape key

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/demos.mdx
@@ -68,7 +68,7 @@ Pressing the enter key will trigger a submit.
 
 ### Input with clear button
 
-Pushing the clear button or pressing the ESC key will clear the input.
+Pushing the clear button will clear the input.
 
 <InputExampleClear />
 

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -316,9 +316,6 @@ export default class Input extends React.PureComponent {
     if (event.key === 'Enter') {
       dispatchCustomElementEvent(this, 'on_submit', { value, event })
     }
-    if (isTrue(this.props.clear) && event.key === 'Escape') {
-      this.clearValue(event)
-    }
   }
   clearValue = (event) => {
     const previousValue = this.state.value

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -513,21 +513,6 @@ describe('Input with clear button', () => {
     expect(clearButton).toHaveAttribute('disabled')
   })
 
-  it('should clear the value on escape key press', () => {
-    render(<Input clear={true} value="value" />)
-
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'value'
-    )
-
-    fireEvent.keyDown(document.querySelector('input'), {
-      key: 'Escape',
-      keyCode: 27, // escape
-    })
-
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
-  })
-
   it('should set focus on input when clear button is pressed', () => {
     render(<Input id="input-id" clear={true} value="value" />)
 


### PR DESCRIPTION
When an input is used inside a Dialog/Modal/Drawer, the escape key should only close the modal. Key clear button is still available for keyboard users by tabbing to the clear button.

