### PR TITLE
fix(Field): Refactor Field and Value to use consistent namespace and alias

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Form, DataContext, Field, JSONSchema } from '../../../'
-import { Props as StringFieldProps } from '../../../Field/String/String'
+import { Props as StringFieldProps } from '../../../Field/String'
 import nbNO from '../../../../../shared/locales/nb-NO'
 
 const nb = nbNO['nb-NO'].Forms

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { Checkbox, ToggleButton } from '../../../../components'
 import classnames from 'classnames'
-import Option from '../Option'
+import OptionField from '../Option'
 import FieldBlock from '../../FieldBlock'
 import { useDataValue } from '../../hooks'
 import { FieldProps } from '../../types'
@@ -59,7 +59,8 @@ function ArraySelection(props: Props) {
     () =>
       React.Children.toArray(children)
         .filter(
-          (child) => React.isValidElement(child) && child.type === Option
+          (child) =>
+            React.isValidElement(child) && child.type === OptionField
         )
         .map((option: React.ReactElement) => ({
           title: option.props.title ?? option.props.children,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
-import ArraySelection from '../ArraySelection'
-import Option from '../../Option'
+import { Field, FieldBlock } from '../../..'
 import { FormError } from '../../../types'
-import { FieldBlock } from '../../..'
 
 describe('ArraySelection', () => {
   it('renders correctly', () => {
     render(
-      <ArraySelection>
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection>
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     expect(screen.getByText('Option 1')).toBeInTheDocument()
@@ -21,10 +19,10 @@ describe('ArraySelection', () => {
   it('handles selection correctly', () => {
     const handleChange = jest.fn()
     render(
-      <ArraySelection onChange={handleChange}>
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection onChange={handleChange}>
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     fireEvent.click(screen.getByText('Option 1'))
@@ -40,10 +38,10 @@ describe('ArraySelection', () => {
   it('handles emptyValue correctly', () => {
     const handleChange = jest.fn()
     render(
-      <ArraySelection onChange={handleChange} emptyValue="empty">
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection onChange={handleChange} emptyValue="empty">
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     fireEvent.click(screen.getByText('Option 1'))
@@ -54,10 +52,10 @@ describe('ArraySelection', () => {
   it('displays error message when error prop is provided', () => {
     const errorMessage = new FormError('This is what is wrong...')
     render(
-      <ArraySelection error={errorMessage}>
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection error={errorMessage}>
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     const element = document.querySelector('.dnb-form-status')
@@ -72,10 +70,10 @@ describe('ArraySelection', () => {
   it('applies the correct layout class when layout prop is provided', () => {
     const layout = 'horizontal'
     render(
-      <ArraySelection layout={layout}>
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection layout={layout}>
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     const element = document.querySelector('.dnb-forms-field-block__grid')
@@ -85,10 +83,10 @@ describe('ArraySelection', () => {
   it('applies the correct layout class when optionsLayout prop is provided', () => {
     const layout = 'horizontal'
     render(
-      <ArraySelection optionsLayout={layout}>
-        <Option value="option1">Option 1</Option>
-        <Option value="option2">Option 2</Option>
-      </ArraySelection>
+      <Field.ArraySelection optionsLayout={layout}>
+        <Field.Option value="option1">Option 1</Field.Option>
+        <Field.Option value="option2">Option 2</Field.Option>
+      </Field.ArraySelection>
     )
 
     const element = document.querySelector(
@@ -103,10 +101,10 @@ describe('ArraySelection', () => {
     it('has correct elements when "checkbox" is provided provided', () => {
       const variant = 'checkbox'
       render(
-        <ArraySelection variant={variant}>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection variant={variant}>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -118,10 +116,10 @@ describe('ArraySelection', () => {
 
     it('disables all options when disabled prop is true', () => {
       render(
-        <ArraySelection disabled>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection disabled>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -135,10 +133,10 @@ describe('ArraySelection', () => {
     it('has error class when error prop is provided', () => {
       const errorMessage = new FormError('This is what is wrong...')
       render(
-        <ArraySelection error={errorMessage}>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection error={errorMessage}>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -154,10 +152,10 @@ describe('ArraySelection', () => {
     it('has correct elements when "button" is provided provided', () => {
       const variant = 'button'
       render(
-        <ArraySelection variant={variant}>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection variant={variant}>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -170,10 +168,10 @@ describe('ArraySelection', () => {
     it('has error class when error prop is provided', () => {
       const errorMessage = new FormError('This is what is wrong...')
       render(
-        <ArraySelection variant="button" error={errorMessage}>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection variant="button" error={errorMessage}>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -186,10 +184,10 @@ describe('ArraySelection', () => {
 
     it('disables all options when disabled prop is true', () => {
       render(
-        <ArraySelection variant="button" disabled>
-          <Option value="option1">Option 1</Option>
-          <Option value="option2">Option 2</Option>
-        </ArraySelection>
+        <Field.ArraySelection variant="button" disabled>
+          <Field.Option value="option1">Option 1</Field.Option>
+          <Field.Option value="option2">Option 2</Field.Option>
+        </Field.ArraySelection>
       )
 
       const [option1, option2] = Array.from(
@@ -204,12 +202,12 @@ describe('ArraySelection', () => {
   describe('checkbox', () => {
     it('renders error', () => {
       render(
-        <ArraySelection error={new FormError('Error message')}>
-          <Option value="A" title="Fooo!" />
-          <Option value="B" title="Baar!" />
-          <Option value="C" title="Bazz!" />
-          <Option value="D" title="Quxx!" />
-        </ArraySelection>
+        <Field.ArraySelection error={new FormError('Error message')}>
+          <Field.Option value="A" title="Fooo!" />
+          <Field.Option value="B" title="Baar!" />
+          <Field.Option value="C" title="Bazz!" />
+          <Field.Option value="D" title="Quxx!" />
+        </Field.ArraySelection>
       )
 
       const element = document.querySelector('.dnb-form-status')
@@ -226,12 +224,12 @@ describe('ArraySelection', () => {
     it('shows error style in FieldBlock', () => {
       render(
         <FieldBlock>
-          <ArraySelection error={new FormError('Error message')}>
-            <Option value="A" title="Fooo!" />
-            <Option value="B" title="Baar!" />
-            <Option value="C" title="Bazz!" />
-            <Option value="D" title="Quxx!" />
-          </ArraySelection>
+          <Field.ArraySelection error={new FormError('Error message')}>
+            <Field.Option value="A" title="Fooo!" />
+            <Field.Option value="B" title="Baar!" />
+            <Field.Option value="C" title="Bazz!" />
+            <Field.Option value="D" title="Quxx!" />
+          </Field.ArraySelection>
         </FieldBlock>
       )
 
@@ -247,15 +245,15 @@ describe('ArraySelection', () => {
   describe('button', () => {
     it('renders error', () => {
       render(
-        <ArraySelection
+        <Field.ArraySelection
           variant="button"
           error={new FormError('Error message')}
         >
-          <Option value="A" title="Fooo!" />
-          <Option value="B" title="Baar!" />
-          <Option value="C" title="Bazz!" />
-          <Option value="D" title="Quxx!" />
-        </ArraySelection>
+          <Field.Option value="A" title="Fooo!" />
+          <Field.Option value="B" title="Baar!" />
+          <Field.Option value="C" title="Bazz!" />
+          <Field.Option value="D" title="Quxx!" />
+        </Field.ArraySelection>
       )
 
       const element = document.querySelector('.dnb-form-status')
@@ -278,15 +276,15 @@ describe('ArraySelection', () => {
     it('shows error style in FieldBlock', () => {
       render(
         <FieldBlock>
-          <ArraySelection
+          <Field.ArraySelection
             variant="button"
             error={new FormError('Error message')}
           >
-            <Option value="A" title="Fooo!" />
-            <Option value="B" title="Baar!" />
-            <Option value="C" title="Bazz!" />
-            <Option value="D" title="Quxx!" />
-          </ArraySelection>
+            <Field.Option value="A" title="Fooo!" />
+            <Field.Option value="B" title="Baar!" />
+            <Field.Option value="C" title="Bazz!" />
+            <Field.Option value="D" title="Quxx!" />
+          </Field.ArraySelection>
         </FieldBlock>
       )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useMemo } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringField, { Props as StringFieldProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps & {
+export type Props = StringFieldProps & {
   validate?: boolean
   omitMask?: boolean
 }
@@ -54,7 +54,7 @@ function BankAccountNumber(props: Props) {
     [omitMask]
   )
 
-  const stringComponentProps: Props = {
+  const StringFieldProps: Props = {
     ...props,
     className: 'dnb-forms-field-bank-account-number',
     pattern: props.pattern ?? (validate ? '^[0-9]{11}$' : undefined),
@@ -67,7 +67,7 @@ function BankAccountNumber(props: Props) {
     inputMode: 'numeric',
   }
 
-  return <StringComponent {...stringComponentProps} />
+  return <StringField {...StringFieldProps} />
 }
 
 BankAccountNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import BankAccountNumber, { Props } from '..'
+import { Props } from '..'
+import { Field } from '../../..'
 
 describe('Field.BankAccountNumber', () => {
   it('should render with props', () => {
     const props: Props = {}
 
-    render(<BankAccountNumber {...props} />)
+    render(<Field.BankAccountNumber {...props} />)
 
     const component = document.querySelector(
       '.dnb-forms-field-bank-account-number'
@@ -17,7 +18,7 @@ describe('Field.BankAccountNumber', () => {
   })
 
   it('should have numeric input mode', () => {
-    render(<BankAccountNumber />)
+    render(<Field.BankAccountNumber />)
 
     const input = document.querySelector('.dnb-input__input')
 
@@ -25,7 +26,7 @@ describe('Field.BankAccountNumber', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<BankAccountNumber value="12345678" />)
+    const result = render(<Field.BankAccountNumber value="12345678" />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react'
-import Toggle, { Props as ToggleProps } from '../Toggle'
+import ToggleField, { Props as ToggleFieldProps } from '../Toggle'
 import SharedContext from '../../../../shared/Context'
 
 export type Props = Omit<
-  ToggleProps,
+  ToggleFieldProps,
   'valueOn' | 'valueOff' | 'textOn' | 'textOff'
 > & {
   trueText?: string
@@ -14,7 +14,7 @@ function BooleanComponent(props: Props) {
   const sharedContext = useContext(SharedContext)
   const { trueText, falseText, ...restProps } = props
   return (
-    <Toggle
+    <ToggleField
       {...restProps}
       valueOn={true}
       valueOff={false}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { screen, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as Field from '../../'
+import { Field } from '../../..'
 
 describe('Field.Boolean', () => {
   describe('variant: checkbox', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
@@ -3,9 +3,9 @@ import classnames from 'classnames'
 import { Context } from '../../../../shared'
 import { getCurrencySymbol } from '../../../../components/number-format/NumberUtils'
 import { CURRENCY } from '../../../../shared/defaults'
-import NumberComponent, { Props as NumberProps } from '../Number'
+import NumberField, { Props as NumberFieldProps } from '../Number'
 
-export type Props = NumberProps
+export type Props = NumberFieldProps
 
 function Currency(props: Props) {
   const context = React.useContext(Context)
@@ -18,7 +18,7 @@ function Currency(props: Props) {
   }
 
   return (
-    <NumberComponent
+    <NumberField
       {...preparedProps}
       className={classnames('dnb-forms-field-currency', props.className)}
     />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Currency from '../Currency'
+import { Field } from '../../..'
 import { Provider } from '../../../../../shared'
 
 describe('Field.Currency', () => {
   it('defaults to "kr" and use "NOK" when locale is en-GB', () => {
     const { rerender } = render(
       <Provider>
-        <Currency value={123} />
+        <Field.Currency value={123} />
       </Provider>
     )
 
@@ -16,7 +16,7 @@ describe('Field.Currency', () => {
 
     rerender(
       <Provider locale="en-GB">
-        <Currency value={123} />
+        <Field.Currency value={123} />
       </Provider>
     )
 
@@ -26,7 +26,7 @@ describe('Field.Currency', () => {
   it('placeholder should use correct currency format', () => {
     const { rerender } = render(
       <Provider>
-        <Currency />
+        <Field.Currency />
       </Provider>
     )
 
@@ -36,7 +36,7 @@ describe('Field.Currency', () => {
 
     rerender(
       <Provider locale="en-GB">
-        <Currency />
+        <Field.Currency />
       </Provider>
     )
 
@@ -48,9 +48,9 @@ describe('Field.Currency', () => {
   it('should align input correctly', () => {
     render(
       <>
-        <Currency value={123} align="left" />
-        <Currency value={123} align="center" />
-        <Currency value={123} align="right" />
+        <Field.Currency value={123} align="left" />
+        <Field.Currency value={123} align="center" />
+        <Field.Currency value={123} align="right" />
       </>
     )
 
@@ -61,7 +61,7 @@ describe('Field.Currency', () => {
   })
 
   it('should have decimal input mode', () => {
-    render(<Currency />)
+    render(<Field.Currency />)
 
     const input = document.querySelector('.dnb-input__input')
 
@@ -69,7 +69,7 @@ describe('Field.Currency', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<Currency label="Label" value={123} />)
+    const result = render(<Field.Currency label="Label" value={123} />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
 import { render, waitFor, screen, fireEvent } from '@testing-library/react'
-import Date from '..'
 import userEvent from '@testing-library/user-event'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { FormError, FieldBlock } from '../../..'
+import { Field, FormError, FieldBlock } from '../../..'
 
 describe('Field.Date', () => {
   it('should render with props', () => {
-    render(<Date />)
+    render(<Field.Date />)
   })
 
   it('should show required warning', async () => {
-    render(<Date value="2023-12-07" required />)
+    render(<Field.Date value="2023-12-07" required />)
 
     const datepicker = document.querySelector('.dnb-date-picker')
     const [, , year]: Array<HTMLInputElement> = Array.from(
@@ -53,7 +52,7 @@ describe('Field.Date', () => {
   describe('error handling', () => {
     describe('with validateInitially', () => {
       it('should show error message initially', async () => {
-        render(<Date required validateInitially />)
+        render(<Field.Date required validateInitially />)
         await waitFor(() => {
           expect(screen.getByRole('alert')).toBeInTheDocument()
         })
@@ -64,7 +63,7 @@ describe('Field.Date', () => {
       it('should show error message when blurring without any changes', async () => {
         jest.spyOn(console, 'log').mockImplementationOnce(jest.fn()) // because of the invalid date
         render(
-          <Date
+          <Field.Date
             value="2023-12-0"
             schema={{ type: 'string', minLength: 10 }}
             validateUnchanged
@@ -84,7 +83,7 @@ describe('Field.Date', () => {
   describe('ARIA', () => {
     it('should validate with ARIA rules', async () => {
       const result = render(
-        <Date label="Label" required validateInitially />
+        <Field.Date label="Label" required validateInitially />
       )
 
       expect(await axeComponent(result)).toHaveNoViolations()
@@ -92,7 +91,7 @@ describe('Field.Date', () => {
   })
 
   it('renders error', () => {
-    render(<Date error={new FormError('Error message')} />)
+    render(<Field.Date error={new FormError('Error message')} />)
 
     const element = document.querySelector('.dnb-form-status')
     expect(element).toHaveTextContent('Error message')
@@ -104,7 +103,7 @@ describe('Field.Date', () => {
   it('shows error style in FieldBlock', () => {
     render(
       <FieldBlock>
-        <Date error={new FormError('Error message')} />
+        <Field.Date error={new FormError('Error message')} />
       </FieldBlock>
     )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useMemo } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringField, { Props as StringFieldProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps
+export type Props = StringFieldProps
 
 function Email(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -17,7 +17,7 @@ function Email(props: Props) {
     [tr, props.errorMessages]
   )
 
-  const stringComponentProps: Props = {
+  const StringFieldProps: Props = {
     label: sharedContext?.translation.Forms.emailLabel,
     autoComplete: 'email',
     inputMode: 'email',
@@ -28,7 +28,7 @@ function Email(props: Props) {
     errorMessages,
   }
 
-  return <StringComponent {...stringComponentProps} />
+  return <StringField {...StringFieldProps} />
 }
 
 Email._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Email, { Props } from '..'
-import { Form } from '../../..'
+import { Props } from '..'
+import { Field, Form } from '../../..'
 
 describe('Field.Email', () => {
   it('should render with props', () => {
     const props: Props = {}
-    render(<Email {...props} />)
+    render(<Field.Email {...props} />)
   })
 
   it('should show errors if field is empty on submit', () => {
@@ -16,7 +16,7 @@ describe('Field.Email', () => {
 
     render(
       <Form.Handler onSubmit={onSubmit}>
-        <Email required />
+        <Field.Email required />
       </Form.Handler>
     )
 
@@ -32,7 +32,7 @@ describe('Field.Email', () => {
 
     render(
       <Form.Handler onSubmit={onSubmit}>
-        <Email required path="/email" />
+        <Field.Email required path="/email" />
       </Form.Handler>
     )
 
@@ -59,7 +59,7 @@ describe('Field.Email', () => {
 
     render(
       <Form.Handler onSubmit={onSubmit}>
-        <Email path="/email" />
+        <Field.Email path="/email" />
       </Form.Handler>
     )
 
@@ -80,7 +80,7 @@ describe('Field.Email', () => {
   })
 
   it('should have autocomplete (autofill)', () => {
-    render(<Email />)
+    render(<Field.Email />)
 
     const input = document.querySelector('input')
 
@@ -88,7 +88,7 @@ describe('Field.Email', () => {
   })
 
   it('should have inputmode of email', () => {
-    render(<Email />)
+    render(<Field.Email />)
 
     const input = document.querySelector('input')
 
@@ -96,19 +96,19 @@ describe('Field.Email', () => {
   })
 
   it('should have type="text" to avoid browser input manipulation', () => {
-    const { rerender } = render(<Email />)
+    const { rerender } = render(<Field.Email />)
 
     const input = document.querySelector('input')
 
     expect(input).toHaveAttribute('type', 'text')
 
-    rerender(<Email type="email" />)
+    rerender(<Field.Email type="email" />)
 
     expect(input).toHaveAttribute('type', 'email')
   })
 
   it('should allow a custom pattern', async () => {
-    render(<Email pattern="[A-Z]" required />)
+    render(<Field.Email pattern="[A-Z]" required />)
 
     const input = document.querySelector('input')
 
@@ -124,7 +124,7 @@ describe('Field.Email', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<Email value="me@mail.com" />)
+    const result = render(<Field.Email value="me@mail.com" />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { act, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as Field from '../..'
-import { FormError, FieldBlock } from '../../..'
+import { Field, FormError, FieldBlock } from '../../..'
 
 describe('Field.Expiry', () => {
   beforeEach(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -1,8 +1,9 @@
 import React, { useContext, useMemo } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringField, { Props as StringFieldProps } from '../String'
+
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps & {
+export type Props = StringFieldProps & {
   omitMask?: boolean
   validate?: boolean
 }
@@ -43,7 +44,7 @@ function NationalIdentityNumber(props: Props) {
     [omitMask]
   )
 
-  const stringComponentProps: Props = {
+  const StringFieldProps: Props = {
     ...props,
     pattern:
       props.pattern ??
@@ -57,7 +58,7 @@ function NationalIdentityNumber(props: Props) {
     inputMode: 'numeric',
   }
 
-  return <StringComponent {...stringComponentProps} />
+  return <StringField {...StringFieldProps} />
 }
 
 NationalIdentityNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -1,24 +1,27 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import NationalIdentityNumber, { Props } from '..'
-import { Form, FormError } from '../../..'
+import { Props } from '..'
+import { Field, Form, FormError } from '../../..'
 
 describe('Field.NationalIdentityNumber', () => {
   it('should render with props', () => {
     const props: Props = {}
-    render(<NationalIdentityNumber {...props} />)
+    render(<Field.NationalIdentityNumber {...props} />)
   })
 
   it('should have correct mask', () => {
     const { rerender } = render(
-      <NationalIdentityNumber value="12345678901234567890" />
+      <Field.NationalIdentityNumber value="12345678901234567890" />
     )
 
     const inputElement = document.querySelector('input')
     expect(inputElement.value).toBe('123456 78901')
 
     rerender(
-      <NationalIdentityNumber omitMask value="12345678901234567890" />
+      <Field.NationalIdentityNumber
+        omitMask
+        value="12345678901234567890"
+      />
     )
 
     expect(inputElement.value).toBe('12345678901')
@@ -27,7 +30,7 @@ describe('Field.NationalIdentityNumber', () => {
   it('should validate when required', () => {
     render(
       <Form.Handler>
-        <NationalIdentityNumber required />
+        <Field.NationalIdentityNumber required />
         <Form.SubmitButton />
       </Form.Handler>
     )
@@ -47,12 +50,12 @@ describe('Field.NationalIdentityNumber', () => {
 
   it('should execute validateInitially if required', () => {
     const { rerender } = render(
-      <NationalIdentityNumber required validateInitially />
+      <Field.NationalIdentityNumber required validateInitially />
     )
 
     expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
 
-    rerender(<NationalIdentityNumber validateInitially />)
+    rerender(<Field.NationalIdentityNumber validateInitially />)
 
     expect(
       document.querySelector('.dnb-form-status')
@@ -66,7 +69,7 @@ describe('Field.NationalIdentityNumber', () => {
     })
 
     render(
-      <NationalIdentityNumber
+      <Field.NationalIdentityNumber
         value="123"
         required
         validator={validator}
@@ -88,7 +91,7 @@ describe('Field.NationalIdentityNumber', () => {
     const validator = jest.fn()
 
     render(
-      <NationalIdentityNumber
+      <Field.NationalIdentityNumber
         value="123"
         required
         validator={validator}
@@ -106,7 +109,7 @@ describe('Field.NationalIdentityNumber', () => {
   })
 
   it('should have numeric input mode', () => {
-    render(<NationalIdentityNumber />)
+    render(<Field.NationalIdentityNumber />)
 
     const input = document.querySelector('.dnb-input__input')
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { axeComponent, wait } from '../../../../../core/jest/jestSetup'
 import { screen, render, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as Field from '../../'
-import { FormError, FieldBlock } from '../../..'
+import { Field, FormError, FieldBlock } from '../../..'
 
 describe('Field.Number', () => {
   describe('props', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Option/__tests__/Option.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Option/__tests__/Option.test.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
-import Option, { Props } from '..'
-import Selection from '../../Selection'
+import { Props } from '..'
+import { Field } from '../../..'
 
 describe('Field.Option', () => {
   const props: Props = {}
 
   it('should render with props', () => {
-    render(<Option {...props} />)
+    render(<Field.Option {...props} />)
   })
 
   it('should validate with ARIA rules', async () => {
     const result = render(
-      <Selection>
-        <Option value="foo" title="Foo!" />
-        <Option value="bar" title="Baar!" />
-      </Selection>
+      <Field.Selection>
+        <Field.Option value="foo" title="Foo!" />
+        <Field.Option value="bar" title="Baar!" />
+      </Field.Selection>
     )
 
     expect(await axeComponent(result)).toHaveNoViolations()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useMemo } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringField, { Props as StringFieldProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps & {
+export type Props = StringFieldProps & {
   validate?: boolean
   omitMask?: boolean
 }
@@ -29,7 +29,7 @@ function OrganizationNumber(props: Props) {
     [omitMask]
   )
 
-  const stringComponentProps: Props = {
+  const StringFieldProps: Props = {
     ...props,
     className: 'dnb-forms-field-organization-number',
     pattern: props.pattern ?? (validate ? '^[0-9]{9}$' : undefined),
@@ -42,7 +42,7 @@ function OrganizationNumber(props: Props) {
     inputMode: 'numeric',
   }
 
-  return <StringComponent {...stringComponentProps} />
+  return <StringField {...StringFieldProps} />
 }
 
 OrganizationNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import OrganizationNumber from '../OrganizationNumber'
+import { Field } from '../../..'
 
 describe('Field.OrganizationNumber', () => {
   it('should have Norwegian mask', async () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const element = document.querySelector('input')
     await userEvent.type(element, '123456789')
@@ -14,7 +14,7 @@ describe('Field.OrganizationNumber', () => {
   })
 
   it('should have medium width', () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const element = document.querySelector(
       '.dnb-forms-field-block__contents'
@@ -25,14 +25,14 @@ describe('Field.OrganizationNumber', () => {
   })
 
   it('should have disabled autocomplete', () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const element = document.querySelector('input')
     expect(element.autocomplete).toBe('off')
   })
 
   it('should link for and label', () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const labelElement = document.querySelector('label')
     const inputElement = document.querySelector('input')
@@ -43,14 +43,14 @@ describe('Field.OrganizationNumber', () => {
   })
 
   it('should have default label', () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const element = document.querySelector('label')
     expect(element.textContent).toBe('Organisasjonsnummer')
   })
 
   it('should have numeric input mode', () => {
-    render(<OrganizationNumber />)
+    render(<Field.OrganizationNumber />)
 
     const input = document.querySelector('.dnb-input__input')
 
@@ -58,7 +58,7 @@ describe('Field.OrganizationNumber', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<OrganizationNumber value="12345678" />)
+    const result = render(<Field.OrganizationNumber value="12345678" />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -3,9 +3,9 @@ import { Autocomplete, Flex } from '../../../../components'
 import { InputMaskedProps } from '../../../../components/InputMasked'
 import classnames from 'classnames'
 import countries, { CountryType } from '../../constants/countries'
-import StringComponent, { Props as InputProps } from '../String'
-import { useDataValue } from '../../hooks'
+import StringField, { Props as StringFieldProps } from '../String'
 import FieldBlock from '../../FieldBlock'
+import { useDataValue } from '../../hooks'
 import { FieldHelpProps, FieldProps } from '../../types'
 import { pickSpacingProps } from '../../../../components/flex/utils'
 import SharedContext from '../../../../shared/Context'
@@ -22,7 +22,7 @@ export type Props = FieldHelpProps &
     countryCodePlaceholder?: string
     countryCodeLabel?: string
     numberMask?: InputMaskedProps['mask']
-    pattern?: InputProps['pattern']
+    pattern?: StringFieldProps['pattern']
     width?: 'large' | 'stretch'
     omitCountryCodeField?: boolean
     onCountryCodeChange?: (value: string | undefined) => void
@@ -322,7 +322,7 @@ function PhoneNumber(props: Props) {
           />
         )}
 
-        <StringComponent
+        <StringField
           className={classnames(
             'dnb-forms-field-phone-number__number',
             numberFieldClassName

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -2,13 +2,12 @@ import React from 'react'
 import { wait, axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import PhoneNumber from '..'
 import { Provider } from '../../../../../shared'
-import { Form, JSONSchema } from '../../..'
+import { Field, Form, JSONSchema } from '../../..'
 
 describe('Field.PhoneNumber', () => {
   it('should default to 47', () => {
-    render(<PhoneNumber />)
+    render(<Field.PhoneNumber />)
 
     const codeElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -25,7 +24,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should use nb-NO by default', () => {
-    render(<PhoneNumber />)
+    render(<Field.PhoneNumber />)
 
     const codeElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -42,20 +41,20 @@ describe('Field.PhoneNumber', () => {
 
   it('should support disabled prop', () => {
     const { rerender } = render(
-      <PhoneNumber label="Disabled label" disabled />
+      <Field.PhoneNumber label="Disabled label" disabled />
     )
 
     const labelElement = () => document.querySelector('label')
 
     expect(labelElement()).toHaveAttribute('disabled')
 
-    rerender(<PhoneNumber label="Disabled label" />)
+    rerender(<Field.PhoneNumber label="Disabled label" />)
 
     expect(labelElement()).not.toHaveAttribute('disabled')
   })
 
   it('should only have a mask when +47 is given', async () => {
-    const { rerender } = render(<PhoneNumber value="999999990000" />)
+    const { rerender } = render(<Field.PhoneNumber value="999999990000" />)
 
     const codeElement = () =>
       document.querySelector(
@@ -73,7 +72,7 @@ describe('Field.PhoneNumber', () => {
 
     expect(numberElement().value).toBe('99 99 99 99')
 
-    rerender(<PhoneNumber value="+41 99999999123456" />)
+    rerender(<Field.PhoneNumber value="+41 99999999123456" />)
 
     expect(codeElement().value).toBe('CH (+41)')
     expect(numberElement().value).toBe('999999991234')
@@ -84,13 +83,13 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should only have a placeholder when +47 is given', async () => {
-    const { rerender } = render(<PhoneNumber />)
+    const { rerender } = render(<Field.PhoneNumber />)
 
     expect(
       document.querySelector('.dnb-input__placeholder').textContent
     ).toBe('00 00 00 00')
 
-    rerender(<PhoneNumber value="+41" />)
+    rerender(<Field.PhoneNumber value="+41" />)
 
     expect(
       document.querySelector('.dnb-input__placeholder')
@@ -100,7 +99,7 @@ describe('Field.PhoneNumber', () => {
   it('should return correct value onFocus and onBlur event', async () => {
     const onFocus = jest.fn()
     const onBlur = jest.fn()
-    render(<PhoneNumber onFocus={onFocus} onBlur={onBlur} />)
+    render(<Field.PhoneNumber onFocus={onFocus} onBlur={onBlur} />)
 
     const phoneElement = document.querySelector(
       '.dnb-forms-field-phone-number__number input'
@@ -122,7 +121,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should have selected correct item', async () => {
-    render(<PhoneNumber />)
+    render(<Field.PhoneNumber />)
 
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -152,7 +151,7 @@ describe('Field.PhoneNumber', () => {
       }, [])
 
       return (
-        <PhoneNumber
+        <Field.PhoneNumber
           value={state}
           onFocus={onFocus}
           onCountryCodeChange={onCountryCodeChange}
@@ -221,7 +220,7 @@ describe('Field.PhoneNumber', () => {
     const onCountryCodeChange = jest.fn()
 
     render(
-      <PhoneNumber
+      <Field.PhoneNumber
         onChange={onChange}
         onCountryCodeChange={onCountryCodeChange}
         noAnimation
@@ -291,7 +290,7 @@ describe('Field.PhoneNumber', () => {
 
     render(
       <Form.Handler onChange={onChange}>
-        <PhoneNumber path="/phone" />
+        <Field.PhoneNumber path="/phone" />
       </Form.Handler>
     )
 
@@ -310,7 +309,7 @@ describe('Field.PhoneNumber', () => {
     const onCountryCodeChange = jest.fn()
 
     render(
-      <PhoneNumber
+      <Field.PhoneNumber
         onChange={onChange}
         onCountryCodeChange={onCountryCodeChange}
         value="+47 12"
@@ -371,7 +370,7 @@ describe('Field.PhoneNumber', () => {
     const onCountryCodeChange = jest.fn()
 
     render(
-      <PhoneNumber
+      <Field.PhoneNumber
         onChange={onChange}
         onCountryCodeChange={onCountryCodeChange}
         noAnimation
@@ -412,7 +411,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should support spacing props', () => {
-    render(<PhoneNumber top="2rem" />)
+    render(<Field.PhoneNumber top="2rem" />)
 
     const element = document.querySelector('.dnb-forms-field-phone-number')
     const attributes = Array.from(element.attributes).map(
@@ -432,7 +431,7 @@ describe('Field.PhoneNumber', () => {
   it('should support country code autofill', async () => {
     const onChange = jest.fn()
 
-    render(<PhoneNumber onChange={onChange} />)
+    render(<Field.PhoneNumber onChange={onChange} />)
 
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -465,7 +464,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should require one number', async () => {
-    render(<PhoneNumber required />)
+    render(<Field.PhoneNumber required />)
 
     const phoneElement = document.querySelector(
       '.dnb-forms-field-phone-number__number input'
@@ -487,7 +486,7 @@ describe('Field.PhoneNumber', () => {
   it('should handle "pattern" property', async () => {
     render(
       <Provider locale="en-GB">
-        <PhoneNumber required pattern="^[49]+" />
+        <Field.PhoneNumber required pattern="^[49]+" />
       </Provider>
     )
 
@@ -527,7 +526,7 @@ describe('Field.PhoneNumber', () => {
 
   it('should filter countries list with given filterCountries', () => {
     render(
-      <PhoneNumber
+      <Field.PhoneNumber
         filterCountries={({ regions }) => regions?.includes('Scandinavia')}
       />
     )
@@ -556,7 +555,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should by default sort prioritized countries on top', () => {
-    render(<PhoneNumber />)
+    render(<Field.PhoneNumber />)
 
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -579,7 +578,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should show only Scandinavian countries', () => {
-    render(<PhoneNumber countries="Scandinavia" />)
+    render(<Field.PhoneNumber countries="Scandinavia" />)
 
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -605,7 +604,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should sort prioritized countries on top', () => {
-    render(<PhoneNumber countries="Prioritized" />)
+    render(<Field.PhoneNumber countries="Prioritized" />)
 
     const codeElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-phone-number__country-code input'
@@ -631,7 +630,7 @@ describe('Field.PhoneNumber', () => {
     const onChange = jest.fn()
 
     const { rerender } = render(
-      <PhoneNumber omitCountryCodeField onChange={onChange} />
+      <Field.PhoneNumber omitCountryCodeField onChange={onChange} />
     )
 
     const numberElement = () =>
@@ -652,7 +651,7 @@ describe('Field.PhoneNumber', () => {
     })
 
     rerender(
-      <PhoneNumber
+      <Field.PhoneNumber
         omitCountryCodeField
         value="+47 99999999"
         onChange={onChange}
@@ -685,7 +684,7 @@ describe('Field.PhoneNumber', () => {
   it('should validate when required', () => {
     render(
       <Form.Handler>
-        <PhoneNumber required />
+        <Field.PhoneNumber required />
         <Form.SubmitButton />
       </Form.Handler>
     )
@@ -709,7 +708,7 @@ describe('Field.PhoneNumber', () => {
       pattern: '^\\+47 [49]+',
     }
 
-    render(<PhoneNumber schema={schema} />)
+    render(<Field.PhoneNumber schema={schema} />)
 
     const numberElement = () =>
       document.querySelector(
@@ -732,7 +731,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should not validate initially when required and contry code is provided as a value', () => {
-    render(<PhoneNumber required value="+47" />)
+    render(<Field.PhoneNumber required value="+47" />)
 
     expect(
       document.querySelector('.dnb-form-status')
@@ -740,11 +739,13 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should execute validateInitially if required', () => {
-    const { rerender } = render(<PhoneNumber required validateInitially />)
+    const { rerender } = render(
+      <Field.PhoneNumber required validateInitially />
+    )
 
     expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
 
-    rerender(<PhoneNumber validateInitially />)
+    rerender(<Field.PhoneNumber validateInitially />)
 
     expect(
       document.querySelector('.dnb-form-status')
@@ -752,7 +753,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('phone number input should have tel input mode', () => {
-    render(<PhoneNumber />)
+    render(<Field.PhoneNumber />)
 
     const phoneNumberInput = document.querySelector(
       '.dnb-forms-field-phone-number__number .dnb-input__input'
@@ -764,7 +765,7 @@ describe('Field.PhoneNumber', () => {
   it('should render value from context', () => {
     render(
       <Form.Handler data={{ phoneNumber: '9999' }}>
-        <PhoneNumber path="/phoneNumber" />
+        <Field.PhoneNumber path="/phoneNumber" />
       </Form.Handler>
     )
 
@@ -779,7 +780,7 @@ describe('Field.PhoneNumber', () => {
     it('should change locale', () => {
       const { rerender } = render(
         <Provider>
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -798,7 +799,7 @@ describe('Field.PhoneNumber', () => {
 
       rerender(
         <Provider locale="en-GB">
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -808,7 +809,7 @@ describe('Field.PhoneNumber', () => {
 
       rerender(
         <Provider locale="nb-NO">
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -820,7 +821,7 @@ describe('Field.PhoneNumber', () => {
     it('should show search results based on locale', async () => {
       const { rerender } = render(
         <Provider>
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -845,7 +846,7 @@ describe('Field.PhoneNumber', () => {
 
       rerender(
         <Provider locale="en-GB">
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -857,7 +858,7 @@ describe('Field.PhoneNumber', () => {
 
       rerender(
         <Provider locale="nb-NO">
-          <PhoneNumber />
+          <Field.PhoneNumber />
         </Provider>
       )
 
@@ -870,7 +871,7 @@ describe('Field.PhoneNumber', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<PhoneNumber value="12345678" />)
+    const result = render(<Field.PhoneNumber value="12345678" />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -2,12 +2,12 @@ import React, { useContext } from 'react'
 import classnames from 'classnames'
 import SharedContext from '../../../../shared/Context'
 import FieldBlock, { Props as FieldBlockProps } from '../../FieldBlock'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringField, { Props as StringFieldProps } from '../String'
 import { FieldHelpProps } from '../../types'
 
 export type Props = FieldHelpProps &
   Omit<FieldBlockProps, 'children'> &
-  Record<'postalCode' | 'city', StringComponentProps>
+  Record<'postalCode' | 'city', StringFieldProps>
 
 function PostalCodeAndCity(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -34,7 +34,7 @@ function PostalCodeAndCity(props: Props) {
           'dnb-forms-field-postal-code-and-city__fields'
         )}
       >
-        <StringComponent
+        <StringField
           {...postalCode}
           pattern={postalCode.pattern ?? '^[0-9]{4}$'}
           mask={[/\d/, /\d/, /\d/, /\d/]}
@@ -58,7 +58,7 @@ function PostalCodeAndCity(props: Props) {
           inputClassName="dnb-forms-field-postal-code-and-city__postal-code-input"
           inputMode="numeric"
         />
-        <StringComponent
+        <StringField
           {...city}
           className={classnames(
             'dnb-forms-field-postal-code-and-city__city',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -2,17 +2,18 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import PostalCodeAndCity, { Props } from '..'
+import { Props } from '..'
+import { Field } from '../../..'
 
 const props: Props = { postalCode: {}, city: {} }
 
 describe('Field.PostalCodeAndCity', () => {
   it('should render with props', () => {
-    render(<PostalCodeAndCity {...props} />)
+    render(<Field.PostalCodeAndCity {...props} />)
   })
 
   it('postal code should only allow four numbers', async () => {
-    render(<PostalCodeAndCity {...props} />)
+    render(<Field.PostalCodeAndCity {...props} />)
 
     const postalCodeInput = document.querySelector(
       '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
@@ -26,7 +27,7 @@ describe('Field.PostalCodeAndCity', () => {
   })
 
   it('postal could should have numeric input mode', () => {
-    render(<PostalCodeAndCity {...props} />)
+    render(<Field.PostalCodeAndCity {...props} />)
 
     const postalCodeInput = document.querySelector(
       '.dnb-forms-field-postal-code-and-city__postal-code-input .dnb-input__input'
@@ -36,7 +37,7 @@ describe('Field.PostalCodeAndCity', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<PostalCodeAndCity {...props} />)
+    const result = render(<Field.PostalCodeAndCity {...props} />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import SelectCountry, { Props } from '..'
+import { Props } from '..'
 import { Provider } from '../../../../../shared'
-import { Form, FormError, FieldBlock } from '../../..'
+import { Field, Form, FormError, FieldBlock } from '../../..'
 
 describe('Field.SelectCountry', () => {
   it('should render with props', () => {
     const props: Props = {}
-    render(<SelectCountry {...props} />)
+    render(<Field.SelectCountry {...props} />)
   })
 
   it('should return correct value onChange event', () => {
     const onChange = jest.fn()
 
-    render(<SelectCountry onChange={onChange} />)
+    render(<Field.SelectCountry onChange={onChange} />)
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -59,7 +59,7 @@ describe('Field.SelectCountry', () => {
   it('should select matching country on type change to support autofill', async () => {
     const onChange = jest.fn()
 
-    render(<SelectCountry onChange={onChange} />)
+    render(<Field.SelectCountry onChange={onChange} />)
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -92,7 +92,7 @@ describe('Field.SelectCountry', () => {
 
   it('should filter countries list with given filterCountries', () => {
     render(
-      <SelectCountry
+      <Field.SelectCountry
         filterCountries={({ regions }) => regions?.includes('Scandinavia')}
       />
     )
@@ -120,7 +120,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('should by default sort prioritized countries on top', () => {
-    render(<SelectCountry />)
+    render(<Field.SelectCountry />)
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -143,7 +143,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('should show only Scandinavian countries', () => {
-    render(<SelectCountry countries="Scandinavia" />)
+    render(<Field.SelectCountry countries="Scandinavia" />)
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -164,7 +164,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('should sort prioritized countries on top', () => {
-    render(<SelectCountry countries="Prioritized" />)
+    render(<Field.SelectCountry countries="Prioritized" />)
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -189,7 +189,7 @@ describe('Field.SelectCountry', () => {
   it('should validate when required', () => {
     render(
       <Form.Handler>
-        <SelectCountry required />
+        <Field.SelectCountry required />
         <Form.SubmitButton />
       </Form.Handler>
     )
@@ -209,12 +209,12 @@ describe('Field.SelectCountry', () => {
 
   it('should execute validateInitially if required', () => {
     const { rerender } = render(
-      <SelectCountry required validateInitially />
+      <Field.SelectCountry required validateInitially />
     )
 
     expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
 
-    rerender(<SelectCountry validateInitially />)
+    rerender(<Field.SelectCountry validateInitially />)
 
     expect(
       document.querySelector('.dnb-form-status')
@@ -224,7 +224,7 @@ describe('Field.SelectCountry', () => {
   it('should change locale', async () => {
     const { rerender } = render(
       <Provider>
-        <SelectCountry value="NO" />
+        <Field.SelectCountry value="NO" />
       </Provider>
     )
 
@@ -244,7 +244,7 @@ describe('Field.SelectCountry', () => {
 
     rerender(
       <Provider locale="en-GB">
-        <SelectCountry value="NO" />
+        <Field.SelectCountry value="NO" />
       </Provider>
     )
 
@@ -257,7 +257,7 @@ describe('Field.SelectCountry', () => {
 
     rerender(
       <Provider locale="nb-NO">
-        <SelectCountry value="DK" />
+        <Field.SelectCountry value="DK" />
       </Provider>
     )
 
@@ -269,7 +269,7 @@ describe('Field.SelectCountry', () => {
 
   it('renders error', () => {
     const errorMessage = new FormError('Error message')
-    render(<SelectCountry error={errorMessage} />)
+    render(<Field.SelectCountry error={errorMessage} />)
 
     const element = document.querySelector('.dnb-form-status')
     expect(element).toHaveTextContent('Error message')
@@ -282,7 +282,7 @@ describe('Field.SelectCountry', () => {
     const errorMessage = new FormError('Error message')
     render(
       <FieldBlock>
-        <SelectCountry error={errorMessage} />
+        <Field.SelectCountry error={errorMessage} />
       </FieldBlock>
     )
 
@@ -291,7 +291,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('should validate with ARIA rules', async () => {
-    const result = render(<SelectCountry value="DK" />)
+    const result = render(<Field.SelectCountry value="DK" />)
 
     expect(await axeComponent(result)).toHaveNoViolations()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -8,7 +8,7 @@ import {
 import classnames from 'classnames'
 import { makeUniqueId } from '../../../../shared/component-helper'
 import SharedContext from '../../../../shared/Context'
-import Option from '../Option'
+import OptionField from '../Option'
 import { useDataValue } from '../../hooks'
 import { FormError, FieldProps, FieldHelpProps } from '../../types'
 import { pickSpacingProps } from '../../../../components/flex/utils'
@@ -129,7 +129,8 @@ function Selection(props: Props) {
     () =>
       React.Children.toArray(children)
         .filter(
-          (child) => React.isValidElement(child) && child.type === Option
+          (child) =>
+            React.isValidElement(child) && child.type === OptionField
         )
         .map((option: React.ReactElement) => {
           const {
@@ -193,7 +194,7 @@ function Selection(props: Props) {
 
     case 'dropdown': {
       const optionsData = React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type === Option) {
+        if (React.isValidElement(child) && child.type === OptionField) {
           // Option components
           return child.props.text
             ? {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { screen, render, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as Field from '../../'
+import { Field } from '../../..'
 
 describe('Selection', () => {
   describe('props', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -10,8 +10,7 @@ import {
 import userEvent from '@testing-library/user-event'
 import { Provider } from '../../../../../shared'
 import * as DataContext from '../../../DataContext'
-import * as Field from '../..'
-import { FieldBlock } from '../../..'
+import { Field, FieldBlock } from '../../..'
 
 async function expectNever(callable: () => unknown): Promise<void> {
   await expect(() => waitFor(callable)).rejects.toEqual(expect.anything())

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import Toggle, { Props } from '../Toggle'
-import { FormError, FieldBlock } from '../../..'
+import { Props } from '../Toggle'
+import { Field, FormError, FieldBlock } from '../../..'
 
 describe('Field.Toggle', () => {
   it('should render with props', () => {
     const props: Props = { valueOn: 'checked', valueOff: 'unchecked' }
-    render(<Toggle {...props} />)
+    render(<Field.Toggle {...props} />)
   })
 
   it('should support disabled prop', () => {
     const { rerender } = render(
-      <Toggle
+      <Field.Toggle
         valueOn="checked"
         valueOff="unchecked"
         label="Disabled label"
@@ -25,7 +25,7 @@ describe('Field.Toggle', () => {
     expect(labelElement()).toHaveAttribute('disabled')
 
     rerender(
-      <Toggle
+      <Field.Toggle
         valueOn="checked"
         valueOff="unchecked"
         label="Disabled label"
@@ -41,7 +41,7 @@ describe('Field.Toggle', () => {
         const onChange = jest.fn()
 
         render(
-          <Toggle
+          <Field.Toggle
             valueOn="on"
             valueOff="off"
             variant="button"
@@ -72,7 +72,7 @@ describe('Field.Toggle', () => {
 
       it('should validate with ARIA rules', async () => {
         const result = render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -88,7 +88,7 @@ describe('Field.Toggle', () => {
         const errorMessage = new FormError('Error message')
 
         render(
-          <Toggle
+          <Field.Toggle
             valueOn="on"
             valueOff="off"
             variant="buttons"
@@ -109,7 +109,7 @@ describe('Field.Toggle', () => {
 
         render(
           <FieldBlock>
-            <Toggle
+            <Field.Toggle
               valueOn="on"
               valueOff="off"
               variant="buttons"
@@ -129,7 +129,7 @@ describe('Field.Toggle', () => {
         const onChange = jest.fn()
 
         render(
-          <Toggle
+          <Field.Toggle
             valueOn="on"
             valueOff="off"
             variant="buttons"
@@ -163,7 +163,7 @@ describe('Field.Toggle', () => {
 
       it('should validate with ARIA rules', async () => {
         const result = render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -179,7 +179,7 @@ describe('Field.Toggle', () => {
         const errorMessage = new FormError('Error message')
 
         render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -203,7 +203,7 @@ describe('Field.Toggle', () => {
 
         render(
           <FieldBlock>
-            <Toggle
+            <Field.Toggle
               label="Label"
               valueOn="on"
               valueOff="off"
@@ -226,7 +226,7 @@ describe('Field.Toggle', () => {
         const onChange = jest.fn()
 
         render(
-          <Toggle
+          <Field.Toggle
             valueOn="on"
             valueOff="off"
             variant="checkbox-button"
@@ -257,7 +257,7 @@ describe('Field.Toggle', () => {
 
       it('should validate with ARIA rules', async () => {
         const result = render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -273,7 +273,7 @@ describe('Field.Toggle', () => {
         const errorMessage = new FormError('Error message')
 
         render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -295,7 +295,7 @@ describe('Field.Toggle', () => {
 
         render(
           <FieldBlock>
-            <Toggle
+            <Field.Toggle
               label="Label"
               valueOn="on"
               valueOff="off"
@@ -316,7 +316,7 @@ describe('Field.Toggle', () => {
         const onChange = jest.fn()
 
         render(
-          <Toggle
+          <Field.Toggle
             valueOn="on"
             valueOff="off"
             variant="checkbox"
@@ -345,7 +345,7 @@ describe('Field.Toggle', () => {
 
       it('should validate with ARIA rules', async () => {
         const result = render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -361,7 +361,7 @@ describe('Field.Toggle', () => {
         const errorMessage = new FormError('Error message')
 
         render(
-          <Toggle
+          <Field.Toggle
             label="Label"
             valueOn="on"
             valueOff="off"
@@ -383,7 +383,7 @@ describe('Field.Toggle', () => {
 
         render(
           <FieldBlock>
-            <Toggle
+            <Field.Toggle
               label="Label"
               valueOn="on"
               valueOff="off"

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { Form, Field } from '../../..'
-import type { Props as StringProps } from '../../../Field/String'
+import type { Props as StringFieldProps } from '../../../Field/String'
 import userEvent from '@testing-library/user-event'
 
 describe('Form.Handler', () => {
@@ -195,7 +195,7 @@ describe('Form.Handler', () => {
     const onChange = jest.fn()
     const reset = jest.fn()
 
-    const MockComponent = (props: StringProps) => {
+    const MockComponent = (props: StringFieldProps) => {
       return <Field.String {...props} />
     }
 
@@ -232,7 +232,7 @@ describe('Form.Handler', () => {
     })
     const onChange = jest.fn()
 
-    const MockComponent = (props: StringProps) => {
+    const MockComponent = (props: StringFieldProps) => {
       return <Field.String {...props} />
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as Iterate from '../..'
-import * as Field from '../../../Field'
+import { Field } from '../../..'
 import * as DataContext from '../../../DataContext'
 
 describe('Iterate.Array', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringValue, { Props as StringValueProps } from '../String'
 import {
   format,
   cleanNumber,
 } from '../../../../components/number-format/NumberUtils'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps
+export type Props = StringValueProps
 
 function BankAccountNumber(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -23,7 +23,7 @@ function BankAccountNumber(props: Props) {
         ban: true,
       }).toString(),
   }
-  return <StringComponent {...stringValueProps} />
+  return <StringValue {...stringValueProps} />
 }
 
 BankAccountNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Currency/Currency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Currency/Currency.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import NumberComponent, { Props as NumberComponentProps } from '../Number'
+import NumberValue, { Props as NumberValueProps } from '../Number'
 
-export type Props = NumberComponentProps
+export type Props = NumberValueProps
 
 function Currency(props: Props) {
   const numberProps: Props = {
@@ -10,7 +10,7 @@ function Currency(props: Props) {
     thousandSeparator: props.thousandSeparator ?? ' ',
     suffix: props.suffix ?? ' kr',
   }
-  return <NumberComponent {...numberProps} />
+  return <NumberValue {...numberProps} />
 }
 
 Currency._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringValue, { Props as StringValueProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps
+export type Props = StringValueProps
 
 function DateComponent(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -11,7 +11,7 @@ function DateComponent(props: Props) {
     ...props,
     label: props.label ?? sharedContext?.translation.Forms.dateLabel,
   }
-  return <StringComponent {...stringProps} />
+  return <StringValue {...stringProps} />
 }
 
 DateComponent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Email/Email.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringValue, { Props as StringValueProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 
-export type Props = StringComponentProps
+export type Props = StringValueProps
 
 function Email(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -11,7 +11,7 @@ function Email(props: Props) {
     ...props,
     label: props.label ?? sharedContext?.translation.Forms.emailLabel,
   }
-  return <StringComponent {...stringProps} />
+  return <StringValue {...stringProps} />
 }
 
 Email._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringValue, { Props as StringValueProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 import {
   format,
   cleanNumber,
 } from '../../../../components/number-format/NumberUtils'
 
-export type Props = StringComponentProps
+export type Props = StringValueProps
 
 function NationalIdentityNumber(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -23,7 +23,7 @@ function NationalIdentityNumber(props: Props) {
         nin: true,
       }).toString(),
   }
-  return <StringComponent {...stringValueProps} />
+  return <StringValue {...stringValueProps} />
 }
 
 NationalIdentityNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PhoneNumber/PhoneNumber.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react'
-import StringComponent, { Props as StringComponentProps } from '../String'
+import StringValue, { Props as StringValueProps } from '../String'
 import SharedContext from '../../../../shared/Context'
 import {
   format,
   cleanNumber,
 } from '../../../../components/number-format/NumberUtils'
 
-export type Props = StringComponentProps
+export type Props = StringValueProps
 
 function PhoneNumber(props: Props) {
   const sharedContext = useContext(SharedContext)
@@ -23,7 +23,7 @@ function PhoneNumber(props: Props) {
         phone: true,
       }).toString(),
   }
-  return <StringComponent {...stringValueProps} />
+  return <StringValue {...stringValueProps} />
 }
 
 PhoneNumber._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/String/__tests__/String.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
-import * as Value from '../../'
+import { Value } from '../../..'
 
 describe('Value.String', () => {
   describe('props', () => {


### PR DESCRIPTION
We can't really use `Field.String` inside another Field component, because that would lead to a cyclical dependency. So instead I've used the alias `StringField` where needed. I've also made a clearer distinction between `Value.String` and `Field.String` as that was causing a lot of confusion.