### PR TITLE
chore(Expiry): make Expiry FieldBlock compatible

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/MultiInputMask.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/MultiInputMask.test.tsx
@@ -107,39 +107,39 @@ describe('MultiInputMask', () => {
   })
 
   it('render inputs based on inputs prop', () => {
-    render(<MultiInputMask {...defaultProps} />)
+    render(<MultiInputMask {...defaultProps} id="given-id" />)
 
     const [first, second, third] = Array.from(
       document.querySelectorAll('.dnb-multi-input-mask__input')
     ) as HTMLInputElement[]
 
-    expect(first.id).toMatch(new RegExp(/^day-id-\w+__input/))
+    expect(first.id).toBe('given-id-day')
     expect(first.tagName).toBe('INPUT')
 
-    expect(second.id).toMatch(new RegExp(/^month-id-\w+__input/))
+    expect(second.id).toBe('given-id-month')
     expect(second.tagName).toBe('INPUT')
 
-    expect(third.id).toMatch(new RegExp(/^year-id-\w+__input/))
+    expect(third.id).toBe('given-id-year')
     expect(third.tagName).toBe('INPUT')
   })
 
   it('should apply labels to input inputs', () => {
-    render(<MultiInputMask {...defaultProps} />)
+    render(<MultiInputMask {...defaultProps} id="given-id" />)
 
     const [first, second, third] = Array.from(
       document.querySelectorAll('.dnb-multi-input-mask__input')
     ) as HTMLInputElement[]
 
     expect(first.nextElementSibling).toHaveTextContent('the day')
-    expect(first.labels[0].id).toMatch(new RegExp(/^day-id-\w+__label/))
+    expect(first.labels[0].id).toBe('given-id-day__label')
     expect(first.nextElementSibling.tagName).toBe('LABEL')
 
     expect(second.nextElementSibling).toHaveTextContent('the month')
-    expect(second.labels[0].id).toMatch(new RegExp(/^month-id-\w+__label/))
+    expect(second.labels[0].id).toBe('given-id-month__label')
     expect(second.nextElementSibling.tagName).toBe('LABEL')
 
     expect(third.nextElementSibling).toHaveTextContent('the year')
-    expect(third.labels[0].id).toMatch(new RegExp(/^year-id-\w+__label/))
+    expect(third.labels[0].id).toBe('given-id-year__label')
     expect(third.nextElementSibling.tagName).toBe('LABEL')
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useContext, useMemo, useRef } from 'react'
-import { makeUniqueId } from '../../../../shared/component-helper'
+import React, { useCallback, useContext, useMemo } from 'react'
 import SharedContext from '../../../../shared/Context'
 import { FieldHelpProps, FieldProps } from '../../types'
 import { pickSpacingProps } from '../../../../components/flex/utils'
@@ -43,7 +42,7 @@ function Expiry(props: ExpiryProps) {
   }
 
   const {
-    id: propsId,
+    id,
     className,
     label = translations.expiryLabel,
     error,
@@ -54,7 +53,6 @@ function Expiry(props: ExpiryProps) {
     disabled,
     value = '',
     layout = 'vertical',
-    required,
     ariaAttributes,
     handleFocus,
     handleBlur,
@@ -68,8 +66,6 @@ function Expiry(props: ExpiryProps) {
     year: value?.substring(2, 4) ?? '',
   }
 
-  const idRef = useRef(propsId || makeUniqueId()).current
-
   const status = hasError
     ? 'error'
     : warning
@@ -81,6 +77,9 @@ function Expiry(props: ExpiryProps) {
   return (
     <FieldBlock
       className={classnames('dnb-forms-field-expiry', className)}
+      forId={`${id}-input-month`}
+      label={label}
+      layout={layout}
       info={info}
       warning={warning}
       error={error}
@@ -88,14 +87,11 @@ function Expiry(props: ExpiryProps) {
     >
       <MultiInputMask
         stretch
-        id={`${idRef}__input`}
-        label={label}
-        labelDirection={layout}
+        id={`${id}-input`}
         values={expiry}
         status={status}
         statusState={disabled ? 'disabled' : undefined}
         disabled={disabled}
-        required={required}
         onChange={handleChange}
         onBlur={handleBlur}
         onFocus={handleFocus}


### PR DESCRIPTION
So we can forward `labelDescription` in this PR #3251.

