### PR TITLE
feat(NumberUtils.format): Only return object if returnAria: true

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -30,6 +30,7 @@ export interface formatReturnValue {
 }
 export type formatValue = string | number;
 export type formatReturnType = formatReturnValue | formatValue;
+
 export interface formatOptionParams {
   /** can be "auto" */
   locale?: Locale;
@@ -80,10 +81,15 @@ export interface formatOptionParams {
   /** If an object should be returned, including the "aria" property */
   returnAria?: boolean;
 }
-export const format: (
+
+export function format(
+  value: formatValue,
+  options: formatOptionParams & { returnAria: true }
+): formatReturnValue;
+export function format(
   value: formatValue,
   options?: formatOptionParams
-) => formatReturnType;
+): formatValue;
 
 type cleanNumberOptions = {
   decimalSeparator?: string;


### PR DESCRIPTION
The function `format` only returns an object if the option `returnAria` was passed in as `true`, but TypeScript doesn’t know this.

With this change, we’re making an overload for the function that only returns the object in the right situation. This way, the caller doesn’t need to check the returned value before being able to use it as a string (or number).

The `formatReturnType` type is now unused, but given it's been exported I opted to not remove it as that might be considered a breaking change.

You can consider this more of a suggestion than a request though, I'm not sure what your policy or testing setup is like for type changes :)