### PR TITLE
chore(Breadcrumb): make small screen BreadcrumbMultiple collapse when resizing to medium screen

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -24,7 +24,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import { BreadcrumbMultiple } from './BreadcrumbMultiple'
-import { useMediaQuery } from '../../shared'
+import { useMedia } from '../../shared'
 
 export type BreadcrumbProps = {
   /**
@@ -175,10 +175,7 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
 
   const [isCollapsed, setCollapse] = useState(overrideIsCollapsed)
 
-  const isSmallScreen = useMediaQuery({
-    matchOnSSR: true,
-    when: { max: 'medium' },
-  })
+  const { isLarge } = useMedia()
 
   let currentVariant = variant
   if (!variant) {
@@ -195,10 +192,10 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
 
   // Auto-collapse breadcrumbs if going from small screen to large screen.
   useEffect(() => {
-    if (!isSmallScreen && overrideIsCollapsed !== false) {
+    if (isLarge && overrideIsCollapsed !== false) {
       setCollapse(true)
     }
-  }, [isSmallScreen])
+  }, [isLarge])
 
   validateDOMAttributes(allProps, props)
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -195,7 +195,7 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
 
   // Auto-collapse breadcrumbs if going from small screen to large screen.
   useEffect(() => {
-    if (!isSmallScreen) {
+    if (!isSmallScreen && overrideIsCollapsed !== false) {
       setCollapse(true)
     }
   }, [isSmallScreen])

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -24,6 +24,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import { BreadcrumbMultiple } from './BreadcrumbMultiple'
+import { useMediaQuery } from '../../shared'
 
 export type BreadcrumbProps = {
   /**
@@ -174,6 +175,11 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
 
   const [isCollapsed, setCollapse] = useState(overrideIsCollapsed)
 
+  const isSmallScreen = useMediaQuery({
+    matchOnSSR: true,
+    when: { max: 'medium' },
+  })
+
   let currentVariant = variant
   if (!variant) {
     if (items || data) {
@@ -186,6 +192,13 @@ const Breadcrumb = (localProps: BreadcrumbProps & SpacingProps) => {
   useEffect(() => {
     setCollapse(overrideIsCollapsed)
   }, [overrideIsCollapsed])
+
+  // Auto-collapse breadcrumbs if going from small screen to large screen.
+  useEffect(() => {
+    if (!isSmallScreen) {
+      setCollapse(true)
+    }
+  }, [isSmallScreen])
 
   validateDOMAttributes(allProps, props)
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import Breadcrumb, { BreadcrumbItem, BreadcrumbProps } from '../Breadcrumb'
 import { Provider } from '../../../shared'
 import IconPrimary from '../../icon-primary/IconPrimary'
 import { loadScss, axeComponent } from '../../../core/jest/jestSetup'
 import { BreadcrumbItemProps } from '../BreadcrumbItem'
 import { AnchorAllProps } from '../../Anchor'
+import 'mock-match-media/jest-setup'
+import { setMedia } from 'mock-match-media'
 
 describe('Breadcrumb', () => {
   it('renders without properties', () => {
@@ -269,6 +272,42 @@ describe('Breadcrumb', () => {
       'dnb-breadcrumb--variant-multiple',
       'dnb-space__top--large',
     ])
+  })
+
+  it.only('should automatically collapse breadcrumb-collapse when screen changes to larger than medium', async () => {
+    setMedia({ width: '40em' })
+
+    render(
+      <Breadcrumb
+        data={[
+          { href: '/' },
+          { href: '/page1', text: 'Page 1' },
+          { href: '/page1/page2', text: 'Page 2' },
+        ]}
+      />
+    )
+
+    const toggleButton = () =>
+      document.querySelector('.dnb-breadcrumb__toggle')
+
+    const collapseSection = document.querySelector(
+      '.dnb-breadcrumb__collapse'
+    )
+
+    // Collapsable menu should not be visible before toggle click
+    expect(collapseSection.children.length).toBe(0)
+
+    await userEvent.click(toggleButton())
+
+    // Collapsable should be visible now
+    expect(collapseSection.children.length).toBe(1)
+
+    act(() => {
+      setMedia({ width: '80em' })
+    })
+
+    // Collapsable menu should auto-close when screen goes large
+    expect(collapseSection.children.length).toBe(0)
   })
 
   describe('BreadcrumbItem', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -274,7 +274,7 @@ describe('Breadcrumb', () => {
     ])
   })
 
-  it.only('should automatically collapse breadcrumb-collapse when screen changes to larger than medium', async () => {
+  it('should automatically collapse breadcrumb-collapse when screen changes to larger than medium', async () => {
     setMedia({ width: '40em' })
 
     render(

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -307,7 +307,7 @@ describe('Breadcrumb', () => {
     })
 
     // Collapsable menu should auto-close when screen goes large
-    expect(collapseSection.children.length).toBe(0)
+    expect(collapseSection.children).toHaveLength(0)
   })
 
   describe('BreadcrumbItem', () => {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -295,7 +295,7 @@ describe('Breadcrumb', () => {
     )
 
     // Collapsable menu should not be visible before toggle click
-    expect(collapseSection.children.length).toBe(0)
+    expect(collapseSection.children).toHaveLength(0)
 
     await userEvent.click(toggleButton())
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -300,7 +300,7 @@ describe('Breadcrumb', () => {
     await userEvent.click(toggleButton())
 
     // Collapsable should be visible now
-    expect(collapseSection.children.length).toBe(1)
+    expect(collapseSection.children).toHaveLength(1)
 
     act(() => {
       setMedia({ width: '80em' })


### PR DESCRIPTION
Before:

https://github.com/dnbexperience/eufemia/assets/25927156/4f33a2ee-784f-413f-aa9a-73648998df76


After:

https://github.com/dnbexperience/eufemia/assets/25927156/8cc71bdd-6103-4c2a-abcc-41d3355906c9




No tests at the moment, as testing was made difficult due to all the elements having a width of 0 in the jest-dom

- [x] Add test
- [x] Double check SSR issues

using the `useMediaQuery` to only collapse the `BreadcrumbMultiple` on screen change does not seem to cause hydration issues.