### PR TITLE
feat(InfoCard): add optional dropShadow-prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/Examples.tsx
@@ -104,6 +104,16 @@ export const InfoCardCentered = () => (
   </ComponentBox>
 )
 
+export const InfoCardWithoutDropShadow = () => (
+  <ComponentBox>
+    <InfoCard
+      text="This is a description of some information or a tip that will inform the user of something that will help them."
+      title="Title of your info/tip"
+      dropShadow={false}
+    />
+  </ComponentBox>
+)
+
 export const InfoCardCustomImage = () => (
   <ComponentBox data-visual-test="info-card-custom-image">
     <InfoCard

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/demos.mdx
@@ -13,6 +13,7 @@ import {
   InfoCardCentered,
   InfoCardCustomImage,
   InfoCardCustomImageCentered,
+  InfoCardWithoutDropShadow,
 } from 'Docs/uilib/components/info-card/Examples'
 
 ## Demos
@@ -44,6 +45,10 @@ Each button can be used independently.
 ### InfoCard centered content
 
 <InfoCardCentered />
+
+### InfoCard without drop shadow
+
+<InfoCardWithoutDropShadow />
 
 ### InfoCard custom image
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/properties.mdx
@@ -9,6 +9,7 @@ showTabs: true
 | `text`                                  | _(required)_ The content of the InfoCard can be a string or a react element.                                                       |
 | `title`                                 | _(optional)_ The card title is of type `string`.                                                                                   |
 | `centered`                              | _(optional)_ Centers the content. Defaults to `false`.                                                                             |
+| `dropShadow`                            | _(optional)_ Sets the drop shadow of the info card. Defaults to `true`.                                                            |
 | `className`                             | _(optional)_ Custom className for the component root.                                                                              |
 | `icon`                                  | _(optional)_ Custom icon. Defaults to the `lightbulb` icon.                                                                        |
 | `imgProps`                              | _(optional)_ [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image.  |

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -35,6 +35,11 @@ export interface InfoCardProps {
    */
   centered?: boolean
   /**
+   * Determines whether to display a drop shadow around the card.
+   * Default: true
+   */
+  dropShadow?: boolean
+  /**
    * Replace the default icon with custom icon.
    * Default: Lightbulb (icon)
    */
@@ -102,6 +107,7 @@ export type InfoCardAllProps = InfoCardProps &
 
 export const defaultProps = {
   centered: false,
+  dropShadow: true,
   skeleton: false,
   icon: LightbulbIcon,
 }
@@ -118,6 +124,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
   const {
     alt,
     centered,
+    dropShadow,
     title,
     skeleton,
     className,
@@ -146,6 +153,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
       className={classnames(
         'dnb-info-card',
         centered && 'dnb-info-card--centered',
+        dropShadow && 'dnb-info-card--shadow',
         spacingClasses,
         className
       )}

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -284,7 +284,18 @@ describe('InfoCard', () => {
     expect(Array.from(element.classList)).toEqual([
       'dnb-info-card',
       'dnb-space__top--large',
+      'dnb-info-card--shadow',
     ])
+  })
+
+  it('renders the drop shadow if dropShadow is true', () => {
+    const shadowClassName = 'dnb-info-card--shadow'
+
+    render(<InfoCard dropShadow text="drop-shadow" />)
+
+    expect(document.querySelector('.dnb-info-card').className).toMatch(
+      shadowClassName
+    )
   })
 
   it('should not contain heading element', () => {

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/__snapshots__/InfoCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/__snapshots__/InfoCard.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`InfoCard InfoCard scss has to match style dependencies css 1`] = `
   padding: 1rem;
   overflow: hidden;
   background: var(--color-white);
-  box-shadow: var(--shadow-default);
 }
 .dnb-info-card::after {
   content: "";
@@ -38,6 +37,9 @@ exports[`InfoCard InfoCard scss has to match style dependencies css 1`] = `
   flex-direction: column;
   align-items: center;
   text-align: center;
+}
+.dnb-info-card--shadow {
+  box-shadow: var(--shadow-default);
 }
 .dnb-info-card__content {
   flex-direction: column;

--- a/packages/dnb-eufemia/src/components/info-card/style/dnb-info-card.scss
+++ b/packages/dnb-eufemia/src/components/info-card/style/dnb-info-card.scss
@@ -29,12 +29,14 @@
     border-radius: 0.25rem;
   }
 
-  @include defaultDropShadow();
-
   &--centered {
     flex-direction: column;
     align-items: center;
     text-align: center;
+  }
+
+  &--shadow {
+    @include defaultDropShadow();
   }
 
   &__content {


### PR DESCRIPTION
Added optional `dropShadow`-prop to `InfoCard`-component.

<img width="681" alt="Skjermbilde 2024-02-12 kl  16 24 17" src="https://github.com/dnbexperience/eufemia/assets/21338570/d96b0621-27b4-4fee-ac93-b6f94b94dda6">
