### PR TITLE
chore(Slider): refactor to not include the marker by default (slider extension)

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/Examples.tsx
@@ -9,6 +9,7 @@ import ComponentBox from '../../../../shared/tags/ComponentBox'
 import { format } from '@dnb/eufemia/src/components/number-format/NumberUtils'
 import { Slider, HelpButton, Input, Flex } from '@dnb/eufemia/src'
 import { Provider } from '@dnb/eufemia/src/shared'
+import { SliderMarker } from '@dnb/eufemia/src/components/slider/Slider'
 
 export const SliderExampleDefault = () => (
   <ComponentBox data-visual-test="slider-default">
@@ -185,12 +186,18 @@ export const SliderVerticalWithSteps = () => (
 )
 
 export const SliderExampleMarker = () => (
-  <ComponentBox data-visual-test="slider-marker">
+  <ComponentBox data-visual-test="slider-marker" scope={{ SliderMarker }}>
     <Slider
       min={0}
       max={100}
       value={50}
-      marker={{ value: 20, text: 'Default value' }}
+      extensions={{
+        marker: {
+          instance: SliderMarker,
+          value: 20,
+          text: 'Default value',
+        },
+      }}
       label="Slider with marker"
     />
   </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/demos.mdx
@@ -44,4 +44,10 @@ By default, the thumbs can swap positions. You can change that behavior with `mu
 
 Marks a given point in the Slider with a small marker. If `text` property is provided to the `marker` object, it will be displayed in a tooltip.
 
+You can import the marker like so:
+
+```ts
+import { SliderMarker } from '@dnb/eufemia/components/Slider'
+```
+
 <SliderExampleMarker />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/properties.mdx
@@ -30,5 +30,24 @@ showTabs: true
 | `globalStatusId`                        | _(optional)_ the `status_id` used for the target [GlobalStatus](/uilib/components/global-status).                                                                                                                                                                                                                                                                                  |
 | `suffix`                                | _(optional)_ text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component.                                                                                                                                                                                                                |
 | `skeleton`                              | _(optional)_ if set to `true`, an overlaying skeleton with animation will be shown.                                                                                                                                                                                                                                                                                                |
-| `marker`                                | _(optional)_ shows a small marker at a point given by the marker object's `value` prop. If `text` prop is given, this will be displayed in a tooltip.                                                                                                                                                                                                                              |
+| `extensions`                            | _(optional)_ makes it possible to display overlays with other functionality such as a marker on the slider marking a given value.                                                                                                                                                                                                                                                  |
 | [Space](/uilib/layout/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                                                                                                                                                                                                                                                                              |
+
+## Extensions
+
+A Slider Extension should be an object with the following properties:
+
+```tsx
+import Slider, { SliderMarker } from '@dnb/eufemia/components/Slider'
+
+rende(
+  <Slider
+    extensions={{
+      marker: {
+        instance: SliderMarker,
+        value: 50,
+      },
+    }}
+  />,
+)
+```

--- a/packages/dnb-eufemia/src/components/slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/Slider.tsx
@@ -12,6 +12,9 @@ import type { SliderAllProps } from './types'
 
 export * from './types'
 
+// Export the extensions
+export { default as SliderMarker } from './SliderMarker'
+
 function Slider(localProps: SliderAllProps) {
   return (
     <SliderProvider {...localProps}>

--- a/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
@@ -24,7 +24,6 @@ import {
   SliderTrackBefore,
   SliderTrackAfter,
 } from './SliderTrack'
-import SliderMarker from './SliderMarker'
 import { SliderThumb } from './SliderThumb'
 import { useSliderProps } from './hooks/useSliderProps'
 import { clamp, getFormattedNumber } from './SliderHelpers'
@@ -55,7 +54,7 @@ export function SliderInstance() {
     skeleton,
     disabled,
     className,
-    marker,
+    extensions,
   } = allProps
 
   const mainParams = {
@@ -114,7 +113,13 @@ export function SliderInstance() {
           {showButtons && (isReverse ? addButton : subtractButton)}
 
           <SliderMainTrack>
-            {marker && <SliderMarker />}
+            {extensions &&
+              Object.entries(extensions).map(
+                ([key, { instance, ...options }]) => {
+                  const Element = instance as React.ElementType
+                  return <Element key={key} {...options} />
+                }
+              )}
             <SliderThumb />
             <SliderTrackBefore />
             <SliderTrackAfter />

--- a/packages/dnb-eufemia/src/components/slider/SliderMarker.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderMarker.tsx
@@ -4,11 +4,15 @@ import { useSliderProps } from './hooks/useSliderProps'
 import { clamp, getFormattedNumber } from './SliderHelpers'
 import Tooltip from '../tooltip/Tooltip'
 
-export default function SliderMarker() {
-  const { isReverse, isVertical, allProps } = useSliderProps()
-  const { marker, min, max, numberFormat } = allProps
+type SliderMarkerProps = {
+  value: number
+  text: React.ReactNode
+}
 
-  const { value, text } = marker
+export default function SliderMarker({ value, text }: SliderMarkerProps) {
+  const { isReverse, isVertical, allProps } = useSliderProps()
+  const { min, max, numberFormat } = allProps
+
   const getParams = useCallback(() => {
     const markerId = `slider-marker-${makeUniqueId()}`
     const { number, aria } = getFormattedNumber(value, numberFormat || {})
@@ -33,7 +37,7 @@ export default function SliderMarker() {
     return params
   }, [isReverse, isVertical, max, min, numberFormat, text, value])
 
-  if (!marker || !marker?.value) {
+  if (!value) {
     return null
   }
 

--- a/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
@@ -98,7 +98,7 @@ export function SliderProvider(localProps: SliderAllProps) {
     skeleton,
     max, // eslint-disable-line
     min, // eslint-disable-line
-    marker,
+    extensions, // eslint-disable-line
     disabled,
     className, // eslint-disable-line
     id, // eslint-disable-line

--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react'
 import { axeComponent, loadScss, wait } from '../../../core/jest/jestSetup'
 import { fireEvent, render, act } from '@testing-library/react'
-import Slider from '../Slider'
+import Slider, { SliderMarker } from '../Slider'
 
 import type { SliderAllProps, onChangeEventProps } from '../Slider'
 import { format } from '../../number-format/NumberUtils'
@@ -347,7 +347,10 @@ describe('Slider component', () => {
   describe('Slider with marker', () => {
     it('should render marker in horizontal direction', () => {
       const { rerender } = render(
-        <Slider {...props} marker={{ value: 30 }} />
+        <Slider
+          {...props}
+          extensions={{ marker: { instance: SliderMarker, value: 30 } }}
+        />
       )
 
       const sliderElement = document.querySelector('.dnb-slider')
@@ -365,7 +368,11 @@ describe('Slider component', () => {
 
     it('should render marker in vertical direction', () => {
       const { rerender } = render(
-        <Slider {...props} marker={{ value: 30 }} vertical />
+        <Slider
+          {...props}
+          extensions={{ marker: { instance: SliderMarker, value: 30 } }}
+          vertical
+        />
       )
 
       const sliderElement = document.querySelector('.dnb-slider')
@@ -383,7 +390,10 @@ describe('Slider component', () => {
 
     it('should have html attributes to make it accessible', () => {
       const { rerender } = render(
-        <Slider {...props} marker={{ value: 30 }} />
+        <Slider
+          {...props}
+          extensions={{ marker: { instance: SliderMarker, value: 30 } }}
+        />
       )
 
       const sliderElement = document.querySelector('.dnb-slider')
@@ -394,15 +404,20 @@ describe('Slider component', () => {
       expect(markerElement).toHaveAttribute('aria-label', '30')
       expect(markerElement).toHaveAttribute('tabIndex', '0')
 
-      rerender(<Slider {...props} marker={{ value: 120 }} />)
+      rerender(
+        <Slider
+          {...props}
+          extensions={{ marker: { instance: SliderMarker, value: 120 } }}
+        />
+      )
 
       expect(markerElement).toHaveAttribute('style', 'left: 100%;')
       expect(markerElement).toHaveAttribute('aria-label', '120')
     })
 
     it('shows Tooltip with info', async () => {
-      const marker = { value: 30 }
-      render(<Slider {...props} marker={marker} />)
+      const marker = { instance: SliderMarker, value: 30 }
+      render(<Slider {...props} extensions={{ marker }} />)
 
       const sliderElement = document.querySelector('.dnb-slider')
       const markerElement = sliderElement.querySelector(
@@ -419,8 +434,12 @@ describe('Slider component', () => {
     })
 
     it('shows Tooltip with  text', async () => {
-      const marker = { value: 30, text: 'Here is the text' }
-      render(<Slider {...props} marker={marker} />)
+      const marker = {
+        instance: SliderMarker,
+        value: 30,
+        text: 'Here is the text',
+      }
+      render(<Slider {...props} extensions={{ marker }} />)
 
       const sliderElement = document.querySelector('.dnb-slider')
       const markerElement = sliderElement.querySelector(

--- a/packages/dnb-eufemia/src/components/slider/stories/Slider.stories.tsx
+++ b/packages/dnb-eufemia/src/components/slider/stories/Slider.stories.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled'
 import { Slider, ToggleButton, Input, FormLabel, Flex } from '../../'
 import { format } from '../../number-format/NumberUtils'
 import { Provider } from '../../../shared'
+import SliderMarker from '../SliderMarker'
 
 export default {
   title: 'Eufemia/Components/Slider',
@@ -41,7 +42,12 @@ export function Marker() {
   return (
     <>
       <Slider
-        marker={{ value: 50 }}
+        extensions={{
+          marker: {
+            instance: SliderMarker,
+            value: 50,
+          },
+        }}
         label="Label with some text"
         labelDirection="vertical"
         min={-40}
@@ -52,7 +58,13 @@ export function Marker() {
       />
       <div style={{ height: '20rem' }}>
         <Slider
-          marker={{ value: 50, text: 'Custom text' }}
+          extensions={{
+            marker: {
+              instance: SliderMarker,
+              value: 50,
+              text: 'Custom text',
+            },
+          }}
           label="Label with some text"
           labelDirection="vertical"
           min={-40}

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -20,10 +20,11 @@ export type onChangeEventProps = {
   number?: formatReturnType | null
   event?: Event
 }
-export type MarkerProps = {
-  value: number
-  text?: string
-}
+
+export type SliderExtensions = Record<
+  string,
+  { instance: React.ElementType; [key: string]: unknown }
+>
 
 export type SliderProps = IncludeSnakeCase<{
   /** prepends the Form Label component. If no ID is provided, a random ID is created. */
@@ -72,8 +73,8 @@ export type SliderProps = IncludeSnakeCase<{
   /** the steps the slider takes on changing the value. Defaults to `null`. */
   step?: number
 
-  /** sets a vertical marker on the slider marking a given value. If provided, will show given text in a tooltip  */
-  marker?: MarkerProps
+  /** makes it possible to display overlays with other functionality such as a marker on the slider marking a given value. */
+  extensions: SliderExtensions
 
   /** show the slider vertically. Defaults to `false`. */
   vertical?: boolean


### PR DESCRIPTION
This way, the JavaScript code will not be exposed in app bundles, if they don't use the marker.