### PR TITLE
fix(Field.Boolean): make it possible to reset the value by providing `undefined`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { screen, render, waitFor } from '@testing-library/react'
+import { screen, render, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field } from '../../..'
+import { DataContext, Field, Form } from '../../..'
 
 describe('Field.Boolean', () => {
   describe('variant: checkbox', () => {
@@ -395,6 +395,96 @@ describe('Field.Boolean', () => {
       expect(element.className).toContain(
         'dnb-toggle-button__status--error'
       )
+    })
+
+    it('should change value when path value changes', () => {
+      const { rerender } = render(
+        <DataContext.Provider data={{ isTrue: true }}>
+          <Field.Boolean variant="buttons" path="/isTrue" />
+        </DataContext.Provider>
+      )
+
+      const [yesElement, noElement]: Array<HTMLButtonElement> = Array.from(
+        document.querySelectorAll('.dnb-toggle-button__button')
+      )
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'true')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
+
+      rerender(
+        <DataContext.Provider data={{ isTrue: false }}>
+          <Field.Boolean variant="buttons" path="/isTrue" />
+        </DataContext.Provider>
+      )
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+      expect(noElement).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('should reset both buttons via rerender when undefined was given', () => {
+      const { rerender } = render(
+        <DataContext.Provider data={{ isTrue: true }}>
+          <Field.Boolean variant="buttons" path="/isTrue" />
+        </DataContext.Provider>
+      )
+
+      const [yesElement, noElement]: Array<HTMLButtonElement> = Array.from(
+        document.querySelectorAll('.dnb-toggle-button__button')
+      )
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'true')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
+
+      rerender(
+        <DataContext.Provider data={{ isTrue: undefined }}>
+          <Field.Boolean variant="buttons" path="/isTrue" />
+        </DataContext.Provider>
+      )
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('should reset both buttons via useData update when undefined was given', () => {
+      const MockComponent = () => {
+        const { update } = Form.useData('unique')
+
+        return (
+          <Form.Handler id="unique" data={{}}>
+            <Field.Boolean variant="buttons" path="/isTrue" />
+            <Form.SubmitButton
+              onClick={() => update('/isTrue', () => undefined)}
+            />
+          </Form.Handler>
+        )
+      }
+
+      render(<MockComponent />)
+
+      const resetButton = document.querySelector(
+        '.dnb-forms-submit-button'
+      )
+      const [yesElement, noElement]: Array<HTMLButtonElement> = Array.from(
+        document.querySelectorAll('.dnb-toggle-button__button')
+      )
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
+
+      fireEvent.click(yesElement)
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'true')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
+
+      fireEvent.click(noElement)
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+      expect(noElement).toHaveAttribute('aria-pressed', 'true')
+
+      fireEvent.click(resetButton)
+
+      expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+      expect(noElement).toHaveAttribute('aria-pressed', 'false')
     })
 
     it('should show error when no value is given', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/stories/Boolean.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/stories/Boolean.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import Field, { Form, JSONSchema } from '../../../Forms'
-import { Flex } from '../../../../../components'
+import Field, { Form, JSONSchema, Value } from '../../../Forms'
+import { Button, Flex } from '../../../../../components'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Boolean',
@@ -28,6 +28,33 @@ export function Boolean() {
         />
 
         <Form.SubmitButton />
+      </Flex.Vertical>
+    </Form.Handler>
+  )
+}
+
+export function BooleanReset() {
+  const { update, data } = Form.useData('unique')
+  console.dir('data', data)
+
+  return (
+    <Form.Handler id="unique" data={{}}>
+      <Flex.Vertical>
+        <Field.Boolean
+          variant="buttons"
+          path="/questions/isThisTrue"
+          label="Is this true?"
+        />
+        <Value.Boolean
+          path="/questions/isThisTrue"
+          label="Is it?"
+          showEmpty
+        />
+        <Button
+          onClick={() => update('/questions/isThisTrue', () => undefined)}
+        >
+          Reset
+        </Button>
       </Flex.Vertical>
     </Form.Handler>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -124,7 +124,7 @@ function Toggle(props: Props) {
           <ButtonRow bottom="x-small">
             <ToggleButtonGroupContext.Provider
               value={{
-                value: isOn ? 'on' : isOff ? 'off' : undefined,
+                value: isOn ? 'on' : isOff ? 'off' : null, // use "null" to reset the value
                 onChange: handleToggleChange,
                 status: hasError ? 'error' : undefined,
                 disabled,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -202,6 +202,37 @@ describe('Field.Toggle', () => {
         expect(onChange).toHaveBeenLastCalledWith('on')
       })
 
+      it('should reset both buttons when value is "undefined"', () => {
+        const { rerender } = render(
+          <Field.Toggle
+            valueOn="on"
+            valueOff="off"
+            variant="buttons"
+            value="on"
+          />
+        )
+
+        const [yesElement, noElement]: Array<HTMLButtonElement> =
+          Array.from(
+            document.querySelectorAll('.dnb-toggle-button__button')
+          )
+
+        expect(yesElement).toHaveAttribute('aria-pressed', 'true')
+        expect(noElement).toHaveAttribute('aria-pressed', 'false')
+
+        rerender(
+          <Field.Toggle
+            valueOn="on"
+            valueOff="off"
+            variant="buttons"
+            value={undefined}
+          />
+        )
+
+        expect(yesElement).toHaveAttribute('aria-pressed', 'false')
+        expect(noElement).toHaveAttribute('aria-pressed', 'false')
+      })
+
       describe('ARIA', () => {
         it('should validate with ARIA rules', async () => {
           const result = render(


### PR DESCRIPTION
Fixes #3314

