### PR TITLE
chore(Docs): remove deprecated pxtoem

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
@@ -216,8 +216,6 @@ For those familiar with CSS, we establish typographic rules in the following way
     - margin-**bottom** should be set with **rem**
 
     Use a calculator to calculate the **rem** and **em**.
-    Alternatively, refer to these test pages which show various font sizes embedded in various body font sizes.
-    Here is a good one: http://pxtoem.com/
 
 ## Eufemia Spatial System ≠ A Grid System
 


### PR DESCRIPTION
the previous owner of pxtoem might have sold the domain, as the link as of today takes you to an online casino 🎰 which has nothing to do with px nor em.