### PR TITLE
chore(FieldBlock): remove hover border

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -134,11 +134,4 @@ fieldset.dnb-forms-field-block {
       }
     }
   }
-
-  .dnb-form-label:hover ~ &__contents .dnb-input__shell {
-    @include fakeBorder(
-      var(--input-border-color--hover),
-      var(--input-border-width--focus)
-    );
-  }
 }


### PR DESCRIPTION
This created issues on some fields:
<img width="243" alt="Screenshot 2024-03-02 at 15 01 37" src="https://github.com/dnbexperience/eufemia/assets/1501870/522d5221-08bc-40be-9e35-c58894d412cd">

This was not released, we don't use a fix decorator.