### PR TITLE
fix(Table): fix type error when using array of elements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -795,73 +795,82 @@ export const TableAccordion = () => (
   </ComponentBox>
 )
 
-export const TableAccordionRow = () => (
-  <ComponentBox hideCode data-visual-test="table-accordion-rows">
-    <Table.ScrollView>
-      <Table accordion accordionChevronPlacement="end">
-        <thead>
-          <Tr>
-            <Th>Column A</Th>
-            <Th>Column B</Th>
-            <Th>Column C</Th>
-            <Th>Column D</Th>
-          </Tr>
-        </thead>
+export const TableAccordionRow = () => {
+  return (
+    <ComponentBox hideCode data-visual-test="table-accordion-rows">
+      {() => {
+        const firstRowContent = [
+          {
+            label: 'Expanded 1.1',
+          },
+          {
+            label: 'Expanded 1.2',
+          },
+        ]
+        return (
+          <Table.ScrollView>
+            <Table accordion accordionChevronPlacement="end">
+              <thead>
+                <Tr>
+                  <Th>Column A</Th>
+                  <Th>Column B</Th>
+                  <Th>Column C</Th>
+                  <Th>Column D</Th>
+                </Tr>
+              </thead>
 
-        <tbody>
-          <Tr>
-            <Td>Row 1</Td>
-            <Td>Row 1</Td>
-            <Td>Row 1</Td>
-            <Td>Row 1</Td>
+              <tbody>
+                <Tr>
+                  <Td>Row 1</Td>
+                  <Td>Row 1</Td>
+                  <Td>Row 1</Td>
+                  <Td>Row 1</Td>
 
-            <Tr.AccordionContent>
-              <Td>Expanded 1.1</Td>
-              <Td>Expanded 1.1</Td>
-              <Td>Expanded 1.1</Td>
-              <Td>Expanded 1.1</Td>
-            </Tr.AccordionContent>
+                  {firstRowContent.map(({ label }) => (
+                    <Tr.AccordionContent key={label}>
+                      <Td>{label}</Td>
+                      <Td>{label}</Td>
+                      <Td>{label}</Td>
+                      <Td>{label}</Td>
+                    </Tr.AccordionContent>
+                  ))}
+                </Tr>
 
-            <Tr.AccordionContent>
-              <Td>Expanded 1.2</Td>
-              <Td>Expanded 1.2</Td>
-              <Td>Expanded 1.2</Td>
-              <Td>Expanded 1.2</Td>
-            </Tr.AccordionContent>
-          </Tr>
+                <Tr>
+                  <Td>Row 2</Td>
+                  <Td>Row 2</Td>
+                  <Td>Row 2</Td>
+                  <Td>Row 2</Td>
 
-          <Tr>
-            <Td>Row 2</Td>
-            <Td>Row 2</Td>
-            <Td>Row 2</Td>
-            <Td>Row 2</Td>
+                  <Tr.AccordionContent>
+                    <Td>Expanded 2.1</Td>
+                    <Td>Expanded 2.1</Td>
+                    <Td>Expanded 2.1</Td>
+                    <Td>Expanded 2.1</Td>
+                  </Tr.AccordionContent>
 
-            <Tr.AccordionContent>
-              <Td>Expanded 2.1</Td>
-              <Td>Expanded 2.1</Td>
-              <Td>Expanded 2.1</Td>
-              <Td>Expanded 2.1</Td>
-            </Tr.AccordionContent>
+                  <Tr.AccordionContent>
+                    <Td>Expanded 2.2</Td>
+                    <Td>Expanded 2.2</Td>
+                    <Td>Expanded 2.2</Td>
+                    <Td>Expanded 2.2</Td>
+                  </Tr.AccordionContent>
 
-            <Tr.AccordionContent>
-              <Td>Expanded 2.2</Td>
-              <Td>Expanded 2.2</Td>
-              <Td>Expanded 2.2</Td>
-              <Td>Expanded 2.2</Td>
-            </Tr.AccordionContent>
-
-            <Tr.AccordionContent>
-              <Td>Expanded 2.3</Td>
-              <Td>Expanded 2.3</Td>
-              <Td>Expanded 2.3</Td>
-              <Td>Expanded 2.3</Td>
-            </Tr.AccordionContent>
-          </Tr>
-        </tbody>
-      </Table>
-    </Table.ScrollView>
-  </ComponentBox>
-)
+                  <Tr.AccordionContent>
+                    <Td>Expanded 2.3</Td>
+                    <Td>Expanded 2.3</Td>
+                    <Td>Expanded 2.3</Td>
+                    <Td>Expanded 2.3</Td>
+                  </Tr.AccordionContent>
+                </Tr>
+              </tbody>
+            </Table>
+          </Table.ScrollView>
+        )
+      }}
+    </ComponentBox>
+  )
+}
 
 export const TableSticky = () => {
   const isFullscreen = /data-visual-test|fullscreen/.test(

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -1,16 +1,8 @@
 import React from 'react'
 import classnames from 'classnames'
 import { useTableAccordion } from './TableAccordion'
-import { TableTdProps } from './TableTd'
 import { TableContext } from './TableContext'
 import TableAccordionTr from './TableAccordionTr'
-
-/**
- * Only elements, but still will accept any element, this really only prevents empty or strings
- */
-type ReactNodeTyped<P = any> =
-  | React.ReactElement<P>
-  | Array<ReactNodeTyped<P>>
 
 export type TableTrProps = {
   /**
@@ -66,7 +58,7 @@ export type TableTrProps = {
   /**
    * The content of the component.
    */
-  children: ReactNodeTyped<TableTdProps>
+  children: React.ReactNode
 }
 
 export default function Tr(

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -5,6 +5,13 @@ import { TableTdProps } from './TableTd'
 import { TableContext } from './TableContext'
 import TableAccordionTr from './TableAccordionTr'
 
+/**
+ * Only elements, but still will accept any element, this really only prevents empty or strings
+ */
+type ReactNodeTyped<P = any> =
+  | React.ReactElement<P>
+  | Array<ReactNodeTyped<P>>
+
 export type TableTrProps = {
   /**
    * The variant of the tr
@@ -59,9 +66,7 @@ export type TableTrProps = {
   /**
    * The content of the component.
    */
-  children:
-    | React.ReactElement<TableTdProps>
-    | Array<React.ReactElement<TableTdProps>>
+  children: ReactNodeTyped<TableTdProps>
 }
 
 export default function Tr(


### PR DESCRIPTION
`children` prop should rarely, if ever, be checked using typescript typing. It has limited effect, and is more likely to cause issues than not.