### PR TITLE
feat(forms): implement support for async form submission and autosave feature

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms.mdx
@@ -17,24 +17,23 @@ import FormDiagram2 from 'Docs/uilib/extensions/forms/form-diagram-2.png'
 
 **Table of Contents**
 
-- [Quick start](#quick-start)
 - [Philosophy](#philosophy)
 - [Features](#features)
-- [Examples](#examples)
 - [First steps](#first-steps)
+- [Quick start](#quick-start)
+- [Examples](#examples)
 - [Create your own components](#create-your-own-components)
-
-<QuickStart />
 
 ## Philosophy
 
 Eufemia Forms is:
 
-- A framework for building features
+- A framework for building form features
 - Flexibility by design
 - Data-driven API
 - Standardized data handling
-- Loosely coupled components
+- Loosely coupled components and building blocks
+- Focus on superior user experience, accessibility, and usability
 
 Eufemia Forms is a set of building blocks for form functionality. Components are built on an API with standardized sets of props that make it easier to combine with surrounding data flow, and not least to create your own components that work well together with the ready-made components in Eufemia Forms.
 
@@ -47,13 +46,15 @@ Eufemia Forms consists of reusable components for data input, data display and s
 In summary:
 
 - Ready to use data driven form components.
+- Three shakeable structure. Unused code will not be included in the production bundle.
 - All functionality in all components can be controlled and overridden via props.
-- State management using the declarative [JSON Pointer](/uilib/extensions/forms/getting-started/#what-is-a-json-pointer) directive (i.e `path="/firstName"`).
-- State can be handled outside of the Form.Handler (Provider Context) with the [useData](/uilib/extensions/forms/extended-features/Form/useData) hook.
-- Simple validation (like `minLength` on text fields) as well as advanced and complex [Ajv](https://ajv.js.org/) JSON schema validator (Ajv is like Joi or Yup – check out [some examples](/uilib/extensions/forms/extended-features/#schema-validation)) support on both single fields and the whole data set.
-- Building blocks for [creating custom field components](/uilib/extensions/forms/create-component).
+- Data management using the declarative [JSON Pointer](/uilib/extensions/forms/getting-started/#what-is-a-json-pointer) directive (i.e `path="/firstName"`).
+- State can be handled outside of the [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler) (Provider Context) with the [useData](/uilib/extensions/forms/extended-features/Form/useData) hook.
+- Validation (like `minLength` on text fields) as well as advanced and complex [Ajv](https://ajv.js.org/) JSON schema validator (Ajv is like Joi or Yup – check out [some examples](/uilib/extensions/forms/extended-features/#schema-validation)) support on both single fields and the whole data set.
+- Async form [submission](/uilib/extensions/forms/getting-started/#async-form-behavior) and [validation](/uilib/extensions/forms/getting-started/#async-validation) support.
+- Theming of field sizes with [Form.Appearance](/uilib/extensions/forms/extended-features/Form/Appearance/).
 - Static [value components](/uilib/extensions/forms/extended-features/Value/) for displaying data with proper formatting.
-- Theming of sizes with [Form.Appearance](/uilib/extensions/forms/extended-features/Form/Appearance/).
+- Building blocks for [creating your custom field components](/uilib/extensions/forms/create-component).
 
 ### Basic field usage
 
@@ -83,12 +84,6 @@ In this example, all state data, validation process and error handling are done 
   />
 </div>
 
-## Examples
-
-- [General Demos](/uilib/extensions/forms/general-demos/)
-- [Case Demo 1 (fullscreen)](/uilib/extensions/forms/demo-cases/casedemo1/)
-- [Case Demo 2 (fullscreen)](/uilib/extensions/forms/demo-cases/casedemo2/)
-
 ## First steps
 
 You import the components from with scopes, such as `Form` and `Field`:
@@ -106,11 +101,21 @@ render(
 )
 ```
 
-More details in the [Getting started](/uilib/extensions/forms/getting-started/) section.
+More details in the [getting started](/uilib/extensions/forms/getting-started/) section.
+
+<QuickStart />
+
+More details in the [getting started](/uilib/extensions/forms/getting-started/) section.
+
+## Examples
+
+- [General Demos](/uilib/extensions/forms/general-demos/)
+- [Case Demo 1 (fullscreen)](/uilib/extensions/forms/demo-cases/casedemo1/)
+- [Case Demo 2 (fullscreen)](/uilib/extensions/forms/demo-cases/casedemo2/)
 
 ### Best practices
 
-- [Best practices on Forms](/uilib/extensions/forms/best-practices-on-forms/).
+Read more about [best practices on forms](/uilib/extensions/forms/best-practices-on-forms/).
 
 ## Create your own components
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useDataValue/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useDataValue/info.mdx
@@ -75,9 +75,9 @@ All properties are optional and can be used as needed. These properties can be p
 
 - `required` if true, it will call `validateRequired` for validation.
 - `schema` or `pattern` for JSON schema validation powered by [ajv](https://ajv.js.org/).
-- `validator` your custom validation function. It will run on every keystroke.
+- `validator` your custom validation function. It will run on every keystroke. Can be an async function. Use it together with [debounceAsync](/uilib/helpers/functions/#debounce).
+- `onBlurValidator` your custom validation function. It will run on a `handleBlur()` call. Use it over `validator` for validations with side-effects. Can be an async function.
 - `validateRequired` does allow you to provide a custom logic for how the `required` prop should validate.
-- `onBlurValidator` your custom validation function. It will run on a `handleBlur()` call. Use it over `validator` for validations with side-effects.
 - `validateInitially` in order to show an error without a change and blur event. Used for rare cases.
 - `validateUnchanged` in order to validate without a change and blur event. Used for rare cases.
 - `continuousValidation` in order to validate without a focus event beforehand. Used for rare cases.
@@ -101,7 +101,7 @@ It returns all of the given component properties, in addition to these:
 - `setHasFocus` accepts a boolean as value. When called, it will update the internal logic - for event handling and validation. Will re-render the React Hook and its outer component.
 - `onFocus` event handler to assign to a form element.
 - `onBlur` event handler to assign to a form element.
-- `onChange` event handler to assign to a form element.
+- `onChange` event handler to assign to a form element. When an `async` function is used, it will set the `fieldState` to pending. The corresponding [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) will show an indicator on the field label.
 
 ### Custom validateRequired
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/demo-cases/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/demo-cases/Examples.tsx
@@ -282,7 +282,7 @@ export function PizzaDemo() {
                   <Card stack>
                     <Form.SubHeading>Your address</Form.SubHeading>
 
-                    <FieldBlock label="Address" width="large" composition>
+                    <FieldBlock width="large" composition>
                       <Field.String
                         label="Street"
                         width="stretch"
@@ -298,7 +298,10 @@ export function PizzaDemo() {
                     </FieldBlock>
 
                     <Field.PostalCodeAndCity
-                      postalCode={{ required: true, path: '/postalCode' }}
+                      postalCode={{
+                        required: true,
+                        path: '/postalCode',
+                      }}
                       city={{ required: true, path: '/city' }}
                     />
                   </Card>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features.mdx
@@ -22,15 +22,20 @@ Example using the [Form.Handler](/uilib/extensions/forms/extended-features/Form/
 
 ```jsx
 import { Form, Field, Value } from '@dnb/eufemia/extensions/forms'
-const existingData={
+
+const existingData = {
   email: 'name@email.no'
   date: '2024-01-01'
 }
-function Component() {
-  const { data } = Form.useData('unique')
 
+// The submit handler can be async
+const submitHandler = async (data) => {
+  console.log('Data:', data)
+}
+
+function Component() {
   return (
-    <Form.Handler id="unique" data={existingData} onSubmit={submitHandler}>
+    <Form.Handler data={existingData} onSubmit={submitHandler}>
       <Field.Email path="/email" />
       <Value.Date path="/date" />
       <Form.SubmitButton />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/DataContext/Provider/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/DataContext/Provider/events.mdx
@@ -2,14 +2,12 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { ProviderEvents } from '@dnb/eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs'
+
 ## Events
 
-| Event             | Description                                                                                                                                                                                                |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onChange`        | _(optional)_ Will be called when a value of any input component inside was changed by the user, with the data set (including the changed value) as argument.                                               |
-| `onPathChange`    | _(optional)_ Will be called when a value of any input component inside was changed by the user, with the `path` (JSON Pointer) and new `value` as arguments.                                               |
-| `onSubmit`        | _(optional)_ Will be called when the user submit the form (i.e by clicking a [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton) component inside), with the data set as argument. |
-| `onSubmitRequest` | _(optional)_ Will be called when the user tries to submit, but errors stop the data from being submitted.                                                                                                  |
+<PropertiesTable props={ProviderEvents} />
 
 ### onSubmit parameters
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/DataContext/Provider/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/DataContext/Provider/properties.mdx
@@ -2,16 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { ProviderProperties } from '@dnb/eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs'
+
 ## Properties
 
-| Property            | Type         | Description                                                                                                                                                                                          |
-| ------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `defaultData`       | `object`     | _(required)_ Default source data, only used if no other source is available, and not leading to updates if changed after mount.                                                                      |
-| `data`              | `object`     | _(required)_ Dynamic source data used as both initial data, and updates internal data if changed after mount.                                                                                        |
-| `schema`            | `object`     | _(optional)_ JSON Schema for validation of the data set.                                                                                                                                             |
-| `errorMessages`     | `object`     | _(optional)_ Object containing error messages by either type of JSON Pointer path and type.                                                                                                          |
-| `scrollTopOnSubmit` | `boolean`    | _(optional)_ True for the UI to scroll to the top of the page when data is submitted.                                                                                                                |
-| `sessionStorageId`  | `string`     | _(optional)_ Key for saving active data to session storage and loading it on mount.                                                                                                                  |
-| `ajvInstance`       | `ajv`        | _(optional)_ Provide your own custom Ajv instance. More info in the [Schema validation](/uilib/extensions/forms/extended-features/Form/schema-validation/#custom-ajv-instance-and-keywords) section. |
-| `filterData`        | `function`   | _(optional)_ Filter the internal data context based on your criteria: `(path, value, props) => !props?.disabled`. It will iterate on each data entry.                                                |
-| `children`          | `React.Node` | _(required)_ Contents.                                                                                                                                                                               |
+<PropertiesTable props={ProviderProperties} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/Examples.tsx
@@ -1,13 +1,14 @@
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
 import { Form, Field, FieldBlock } from '@dnb/eufemia/src/extensions/forms'
-import { Card, Flex, P, Section } from '@dnb/eufemia/src'
+import { Button, Card, Flex, P, Section } from '@dnb/eufemia/src'
+import { debounceAsync } from '@dnb/eufemia/src/shared/helpers/debounce'
+import { createRequest } from '../SubmitIndicator/Examples'
 
-export const Default = () => {
+export const AsyncSubmit = () => {
   return (
     <ComponentBox>
       <Form.Handler
-        data={{}}
-        onSubmit={(data) => console.log('onSubmit', data)}
+        onSubmit={async (data) => console.log('onSubmit', data)}
       >
         <Card spacing="medium">
           <Field.Email path="/email" />
@@ -16,6 +17,123 @@ export const Default = () => {
           </Form.ButtonRow>
         </Card>
       </Form.Handler>
+    </ComponentBox>
+  )
+}
+
+export const AsyncSubmitComplete = () => {
+  return (
+    <ComponentBox>
+      <Form.Handler
+        onSubmit={async (data) => {
+          console.log('onSubmit', data)
+
+          // Wait for 2 seconds
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          // e.g. go to new location
+
+          // Optionally, you can return an object with these keys, depending your needs
+          return {
+            info: 'Redirecting to a new location',
+
+            // Force the form to stay in pending state
+            status: 'pending',
+          }
+        }}
+      >
+        <Flex.Stack>
+          <Field.String label="Required field" path="/myField" required />
+          <Form.ButtonRow>
+            <Form.SubmitButton text="Save" />
+          </Form.ButtonRow>
+        </Flex.Stack>
+      </Form.Handler>
+    </ComponentBox>
+  )
+}
+
+export const AsyncChangeAndValidation = () => {
+  return (
+    <ComponentBox scope={{ debounceAsync, createRequest }}>
+      {() => {
+        const validator = debounceAsync(async function secondValidator(
+          value: string,
+        ) {
+          try {
+            const request = createRequest()
+            const wasCanceled = this.addCancelEvent(request.cancel)
+            await request(2000) // Simulate a request
+
+            if (wasCanceled()) {
+              throw new Error('Validation request canceled')
+            }
+          } catch (error) {
+            return error
+          }
+
+          if (value !== 'valid') {
+            return new Error('Custom error with invalid value: ' + value) // Show this message
+          }
+        })
+
+        const cancelRequest = () => {
+          validator.cancel()
+        }
+
+        const onSubmit = async (data) => {
+          console.log('onSubmit', data)
+
+          // Wait for 2 seconds
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          // For demo purposes, we show a message
+          return { info: 'Redirecting to a new location' }
+        }
+
+        const onChangeForm = async (data) => {
+          console.log('onChange', data)
+
+          // Wait for 2 seconds
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          // For demo purposes, we show a message
+          return { warning: 'Warning message' }
+        }
+
+        const onChangeField = async (data) => {
+          console.log('onChange', data)
+
+          // Wait for 2 seconds
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          // For demo purposes, we show a message
+          return { info: 'Info message' }
+        }
+
+        return (
+          <Form.Handler onSubmit={onSubmit} onChange={onChangeForm}>
+            <Flex.Stack>
+              <Field.String
+                label="Required field"
+                path="/myField"
+                required
+                validator={validator}
+                onChange={onChangeField}
+              />
+              <Form.ButtonRow>
+                <Form.SubmitButton text="Save" />
+                <Button
+                  text="Stop async operations"
+                  variant="tertiary"
+                  disabled={false}
+                  onClick={cancelRequest}
+                />
+              </Form.ButtonRow>
+            </Flex.Stack>
+          </Form.Handler>
+        )
+      }}
     </ComponentBox>
   )
 }
@@ -52,20 +170,20 @@ export const Autofill = () => {
         onSubmit={(data) => console.log('onSubmit', data)}
         autoComplete
       >
-        <Form.MainHeading>Delivery address</Form.MainHeading>
+        <Flex.Stack>
+          <Form.MainHeading>Delivery address</Form.MainHeading>
 
-        <Card stack>
-          <Form.SubHeading>Your name</Form.SubHeading>
+          <Card stack>
+            <Form.SubHeading>Your name</Form.SubHeading>
 
-          <Field.String label="First name" path="/firstName" required />
-          <Field.String label="Last name" path="/lastName" required />
-        </Card>
+            <Field.String label="First name" path="/firstName" required />
+            <Field.String label="Last name" path="/lastName" required />
+          </Card>
 
-        <Card stack>
-          <Form.SubHeading>Your address</Form.SubHeading>
+          <Card stack>
+            <Form.SubHeading>Your address</Form.SubHeading>
 
-          <FieldBlock label="Address">
-            <Flex.Horizontal>
+            <FieldBlock width="large" composition>
               <Field.String
                 label="Street"
                 width="stretch"
@@ -78,21 +196,21 @@ export const Autofill = () => {
                 path="/streetNr"
                 required
               />
-            </Flex.Horizontal>
-          </FieldBlock>
+            </FieldBlock>
 
-          <Field.PostalCodeAndCity
-            postalCode={{ required: true, path: '/postalCode' }}
-            city={{ required: true, path: '/city' }}
-          />
-        </Card>
+            <Field.PostalCodeAndCity
+              postalCode={{ required: true, path: '/postalCode' }}
+              city={{ required: true, path: '/city' }}
+            />
+          </Card>
 
-        <Card spacing="medium">
-          <P>More information about this form.</P>
-          <Form.ButtonRow>
-            <Form.SubmitButton />
-          </Form.ButtonRow>
-        </Card>
+          <Card spacing="medium">
+            <P>More information about this form.</P>
+            <Form.ButtonRow>
+              <Form.SubmitButton />
+            </Form.ButtonRow>
+          </Card>
+        </Flex.Stack>
       </Form.Handler>
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/demos.mdx
@@ -8,7 +8,37 @@ import * as Examples from './Examples'
 
 ### In combination with a SubmitButton
 
-<Examples.Default />
+This example uses an async `onSubmit` event handler. It will disable all fields and show an indicator on the [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton/) while the form is pending.
+
+With an async function, you can also handle the response from the server and update the form with the new data.
+
+```ts
+// Async function
+const onSubmit = async (data) => {
+  try {
+    const response = await fetch('https://api.example.com', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+    const data = await response.json()
+    Form.setData('unique', data) // Whatever you want to do with the data
+  } catch (error) {
+    return error // Will display the error message in the form
+  }
+}
+```
+
+<Examples.AsyncSubmit />
+
+### New location after async submit
+
+<Examples.AsyncSubmitComplete />
+
+### Async validation with async onChange
+
+Type "valid" in order to see the validation message.
+
+<Examples.AsyncChangeAndValidation />
 
 ### Filter your data
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/events.mdx
@@ -2,8 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { HandlerEvents } from '@dnb/eufemia/src/extensions/forms/Form/Handler/HandlerDocs'
+
 ## Events
 
-| Property                                                                                                  | Description                             |
-| --------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| All [DataContext.Provider](/uilib/extensions/forms/extended-features/DataContext/Provider/events) events. | _(optional)_ events such as `onSubmit`. |
+<PropertiesTable props={HandlerEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/info.mdx
@@ -2,6 +2,9 @@
 showTabs: true
 ---
 
+import AsyncStateReturnExample from './parts/async-state-return-example.mdx'
+import AsyncChangeExample from './parts/async-change-example.mdx'
+
 ## Description
 
 The `Form.Handler` component provides both the [Form.Element](/uilib/extensions/forms/extended-features/Form/Element) and a HTML form element.
@@ -34,6 +37,12 @@ function Component() {
 ```
 
 More examples can be found in the [Form.useData](/uilib/extensions/forms/extended-features/Form/useData/) docs.
+
+## Async form behavior
+
+<AsyncChangeExample />
+
+<AsyncStateReturnExample />
 
 ## Browser autofill
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/parts/async-change-example.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/parts/async-change-example.mdx
@@ -1,0 +1,24 @@
+You can return parameters from inside the `onChange` event handler. This way you can display more related information, such as an error or an object with these keys:
+
+```ts
+// Async event handler
+const onChange = debounceAsync(async function (data) {
+  try {
+    await makeRequest(data)
+  } catch (error) {
+    return error
+  }
+
+  // Optionally, you can return an object with these keys, depending your needs
+  return {
+    info: 'Info message',
+    warning: 'Warning message',
+
+    // and either an error
+    error: new Error('Error message'),
+
+    // or success (when used for autosave)
+    success: 'saved',
+  } as const
+})
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/parts/async-state-return-example.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/parts/async-state-return-example.mdx
@@ -1,0 +1,40 @@
+In all async operations, you can simply return an error object to display it in the form or influence the form behavior.
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+// Async function
+const onSubmit = async (data) => {
+  try {
+    const response = await fetch('https://api.example.com', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+    const data = await response.json()
+
+    Form.setData('unique', data) // Whatever you want to do with the data
+  } catch (error) {
+    return error // Will display the error message in the form
+  }
+
+  // Optionally, you can return an object with these keys, depending your needs
+  return {
+    info: 'Info message',
+    warning: 'Warning message',
+
+    // Force the form to stay in pending state
+    status: 'pending',
+
+    // and either an error
+    error: new Error('Error message'),
+  } as const
+}
+
+function Component() {
+  return (
+    <Form.Handler id="unique" onSubmit={onSubmit}>
+      ...
+    </Form.Handler>
+  )
+}
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/Handler/properties.mdx
@@ -2,12 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { HandlerProperties } from '@dnb/eufemia/src/extensions/forms/Form/Handler/HandlerDocs'
+
 ## Properties
 
-| Property                                                                                          | Type         | Description                                                                                                                 |
-| ------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `children`                                                                                        | `React.Node` | _(required)_ The content of the form.                                                                                       |
-| `autoComplete`                                                                                    | `boolean`    | _(optional)_ Will set `autoComplete="on"` on all nested [Field.String](/uilib/extensions/forms/base-fields/String/)-fields. |
-| [Space](/uilib/layout/space/properties)                                                           | Various      | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                       |
-| [DataContext.Provider](/uilib/extensions/forms/extended-features/DataContext/Provider/properties) | Various      | _(optional)_ provider properties such as `data` and `onChange`.                                                             |
-| [Form Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attributes)      | Various      | _(optional)_ all supported form element attributes.                                                                         |
+<PropertiesTable props={HandlerProperties} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitButton/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitButton/demos.mdx
@@ -14,6 +14,6 @@ import * as Examples from './Examples'
 
 Example of showing the [SubmitIndicator](/uilib/extensions/forms/extended-features/Form/SubmitIndicator/) with the property `showSubmitIndicator` set to `true`.
 
-When using the submit button inside [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler/) you can use the `enableAsyncBehavior` property to show a loading indicator when the form is submitting.
+When using the submit button inside [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler/) you can use an async `onSubmit` event handler to show a loading indicator when the form is submitting.
 
 <Examples.WithSubmitIndicator />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/Examples.tsx
@@ -2,7 +2,6 @@ import { Button, Card, Flex, FormLabel } from '@dnb/eufemia/src'
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
 import { Field, FieldBlock, Form } from '@dnb/eufemia/src/extensions/forms'
 import { debounceAsync } from '@dnb/eufemia/src/shared/helpers/debounce'
-import { useCallback } from 'react'
 
 export const Default = () => {
   return (
@@ -12,95 +11,75 @@ export const Default = () => {
   )
 }
 
-export const SimpleAsyncBehavior = () => {
+export const AsyncSubmitBehavior = () => {
   return (
-    <ComponentBox>
-      <Form.Handler
-      // enableAsyncBehavior <-- will be supported in another PR
-      >
-        <Card stack>
-          <Field.Email path="/email" />
-          <Form.ButtonRow>
-            <Form.SubmitButton />
-            <Button variant="tertiary">Cancel</Button>
-          </Form.ButtonRow>
-        </Card>
-      </Form.Handler>
-    </ComponentBox>
-  )
-}
-
-export const AdvancedAsyncBehavior = () => {
-  return (
-    <ComponentBox
-      scope={{
-        initialData,
-        firstValidator,
-        secondValidator,
-        thirdValidator,
-        submitHandler,
-        useCancelAsyncOperations,
-      }}
-    >
+    <ComponentBox scope={{ createRequest, debounceAsync }}>
       {() => {
-        const SubmitIndicatorExample = () => {
-          const { cancelHandler } = useCancelAsyncOperations()
+        const delay = debounceAsync(async function () {
+          try {
+            const request = createRequest()
+            await request(1000) // Simulate a request
+          } catch (error) {
+            return error
+          }
+        })
 
-          return (
-            <>
-              <Form.Handler onSubmit={submitHandler} data={initialData}>
-                <Card stack>
-                  <Field.String
-                    label="Field A (onBlurValidator)"
-                    path="/fieldA"
-                    onBlurValidator={firstValidator}
-                  />
-
-                  <FieldBlock width="large" composition>
-                    <Field.String
-                      label="Field B with a long label (onBlurValidator)"
-                      width="medium"
-                      path="/fieldB"
-                      onBlurValidator={secondValidator}
-                    />
-                    <Field.String
-                      label="Field C (validator)"
-                      width="stretch"
-                      path="/fieldC"
-                      validator={thirdValidator}
-                    />
-                  </FieldBlock>
-
-                  <Field.String
-                    label="Field D (required)"
-                    path="/fieldD"
-                    required
-                  />
-                </Card>
-
-                <Form.ButtonRow>
-                  <Form.SubmitButton />
-
-                  <Button
-                    text="Stop async operations"
-                    variant="secondary"
-                    disabled={false}
-                    onClick={cancelHandler}
-                  />
-                </Form.ButtonRow>
-              </Form.Handler>
-            </>
-          )
-        }
-
-        return <SubmitIndicatorExample />
+        return (
+          <Form.Handler onSubmit={delay}>
+            <Card stack>
+              <Field.String path="/myField" label="Short label" />
+              <Form.ButtonRow>
+                <Form.SubmitButton />
+                <Button variant="tertiary">Cancel</Button>
+              </Form.ButtonRow>
+            </Card>
+          </Form.Handler>
+        )
       }}
     </ComponentBox>
   )
 }
 
-const initialData = { fieldA: 'valid', fieldB: 'valid', fieldC: 'valid' }
-const requestTimeoutOffset = 1000
+export const AsyncChangeBehavior = () => {
+  return (
+    <ComponentBox scope={{ createRequest, debounceAsync }}>
+      {() => {
+        const delay = debounceAsync(async function () {
+          try {
+            const request = createRequest()
+            await request(1000) // Simulate a request
+          } catch (error) {
+            return error
+          }
+        })
+
+        return (
+          <Form.Handler onSubmit={delay} onChange={delay}>
+            <Card stack>
+              <Field.String
+                path="/myField1"
+                label="Label (with async validation)"
+                placeholder="Write something ..."
+                validator={delay}
+              />
+              <FieldBlock width="medium">
+                <Field.String
+                  path="/myField2"
+                  width="stretch"
+                  label="This is a long label"
+                />
+              </FieldBlock>
+              <Form.ButtonRow>
+                <Form.SubmitButton />
+                <Button variant="tertiary">Cancel</Button>
+              </Form.ButtonRow>
+            </Card>
+          </Form.Handler>
+        )
+      }}
+    </ComponentBox>
+  )
+}
 
 type CreateRequestReturn = Promise<{ hasError: boolean; cancel?: boolean }>
 
@@ -124,91 +103,6 @@ export const createRequest = () => {
   }
 
   return fn
-}
-
-const firstValidator = debounceAsync(async function firstValidator(
-  value: string,
-) {
-  const start = Date.now()
-
-  const request = createRequest()
-  const wasCanceled = this.addCancelEvent(request.cancel)
-  await request(requestTimeoutOffset * 3) // Simulate a request
-
-  if (wasCanceled()) {
-    return new Error(
-      `Request 1 canceled after ${String(Date.now() - start)}ms`,
-    )
-  }
-
-  if (!wasCanceled() && value !== 'valid') {
-    return new Error('Custom error (A) with invalid value: ' + value) // Show this message
-  }
-})
-
-const secondValidator = debounceAsync(async function secondValidator(
-  value: string,
-) {
-  const start = Date.now()
-
-  const request = createRequest()
-  const wasCanceled = this.addCancelEvent(request.cancel)
-  await request(requestTimeoutOffset * 2) // Simulate a request
-
-  if (wasCanceled()) {
-    return new Error(
-      `Request 2 canceled after ${String(Date.now() - start)}ms`,
-    )
-  }
-
-  if (!wasCanceled() && value !== 'valid') {
-    return new Error('Custom error (B) with invalid value: ' + value) // Show this message
-  }
-})
-
-const thirdValidator = debounceAsync(async function thirdValidator(
-  value: string,
-) {
-  const start = Date.now()
-
-  const request = createRequest()
-  const wasCanceled = this.addCancelEvent(request.cancel)
-  await request(requestTimeoutOffset) // Simulate a request
-
-  if (wasCanceled()) {
-    return new Error(
-      `Request 3 canceled after ${String(Date.now() - start)}ms`,
-    )
-  }
-
-  if (!wasCanceled() && value !== 'valid') {
-    return new Error('Custom error (C) with invalid value: ' + value) // Show this message
-  }
-}, 500)
-
-const submitHandler = debounceAsync(async function submit(data) {
-  const start = Date.now()
-
-  const request = createRequest()
-  const wasCanceled = this.addCancelEvent(request.cancel)
-  await request(requestTimeoutOffset * 2) // Simulate a submit request
-
-  if (wasCanceled()) {
-    return new Error(
-      `Submit canceled after ${String(Date.now() - start)}ms`,
-    )
-  }
-})
-
-function useCancelAsyncOperations() {
-  const cancelHandler = useCallback(() => {
-    firstValidator.cancel()
-    secondValidator.cancel()
-    thirdValidator.cancel()
-    submitHandler.cancel()
-  }, [])
-
-  return { cancelHandler }
 }
 
 export const WithinOtherComponents = () => {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/demos.mdx
@@ -12,16 +12,20 @@ import * as Examples from './Examples'
 
 ### SubmitIndicator in a simple form
 
-<Examples.SimpleAsyncBehavior />
+Press the "Send" button to see the submit indicator.
+
+<Examples.AsyncSubmitBehavior />
+
+### SubmitIndicator with field validation
+
+This example shows a combination of async validation and async change behavior, which could be used for e.g. **autosaving** the field value.
+
+**NB:** if the indicator in the label does not have enough room, it will animate to a new line.
+
+Make a change in the input field.
+
+<Examples.AsyncChangeBehavior />
 
 ### Used in other components
 
 <Examples.WithinOtherComponents />
-
-### SubmitIndicator with field validation
-
-This example contains async validation and async submission.
-
-Note; if the label, like on field B, does not have enough space, it will animate on a new line.
-
-<Examples.AdvancedAsyncBehavior />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/SubmitIndicator/info.mdx
@@ -16,4 +16,4 @@ render(<Form.SubmitIndicator state="pending" />)
 
 ### Integration
 
-The indicator is implemented by default in the [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton/) and [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) label. It will be displayed when the `onSubmit` event is triggered or when `enableAsyncBehavior` is set to true on the [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler/) component. You find some examples down below.
+The indicator is implemented by default in the [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton/) and [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) label. It will be displayed when the `onSubmit` event handler on the [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler/) component is an async function. You can find some examples down below.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/Examples.tsx
@@ -1,6 +1,14 @@
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
 import { Card, P } from '@dnb/eufemia/src'
-import { StepsLayout, Form } from '@dnb/eufemia/src/extensions/forms'
+import {
+  StepsLayout,
+  Form,
+  Field,
+  Value,
+} from '@dnb/eufemia/src/extensions/forms'
+import { debounceAsync } from '@dnb/eufemia/src/shared/helpers/debounce'
+import React from 'react'
+import { createRequest } from '../../Form/SubmitIndicator/Examples'
 
 export const Default = () => {
   return (
@@ -8,75 +16,154 @@ export const Default = () => {
       scope={{ StepsLayout }}
       data-visual-test="steps-layout-card-border"
     >
-      <StepsLayout>
-        <StepsLayout.Step title="Step 1">
-          <Form.MainHeading>Heading</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <StepsLayout.NextButton />
-        </StepsLayout.Step>
-
-        <StepsLayout.Step title="Step 2">
-          <Form.MainHeading>Heading</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <Form.ButtonRow>
-            <StepsLayout.PreviousButton />
+      <Form.Handler
+        data={{
+          firstName: 'John',
+          lastName: 'Doe',
+          streetName: 'Osloveien',
+          streetNr: 12,
+          postalCode: '1234',
+          city: 'Oslo',
+        }}
+      >
+        <StepsLayout>
+          <StepsLayout.Step title="Step 1">
+            <Form.MainHeading>Heading</Form.MainHeading>
+            <Card>
+              <P>Contents</P>
+            </Card>
+            <Card>
+              <P>Contents</P>
+            </Card>
             <StepsLayout.NextButton />
-          </Form.ButtonRow>
-        </StepsLayout.Step>
+          </StepsLayout.Step>
 
-        <StepsLayout.Step title="Summary">
-          <Form.MainHeading>Summary</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <StepsLayout.PreviousButton />
-        </StepsLayout.Step>
-      </StepsLayout>
+          <StepsLayout.Step title="Step 2">
+            <Form.MainHeading>Heading</Form.MainHeading>
+            <Card>
+              <P>Contents</P>
+            </Card>
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Summary">
+            <Form.MainHeading>Summary</Form.MainHeading>
+            <Card stack>
+              <Form.SubHeading>Deliver address</Form.SubHeading>
+
+              <Value.SummaryList layout="grid">
+                <Value.String label="First name" path="/firstName" />
+                <Value.String label="Last name" path="/lastName" />
+
+                <Value.String label="Street" path="/streetName" />
+                <Value.Number label="Nr." path="/streetNr" />
+
+                <Value.String label="Postalc." path="/postalCode" />
+                <Value.String label="City" path="/city" />
+              </Value.SummaryList>
+            </Card>
+            <StepsLayout.PreviousButton />
+          </StepsLayout.Step>
+        </StepsLayout>
+      </Form.Handler>
     </ComponentBox>
   )
 }
 
-export const Drawer = () => {
+export const AsyncStepsLayout = () => {
   return (
-    <ComponentBox scope={{ StepsLayout }}>
-      <StepsLayout variant="drawer">
-        <StepsLayout.Step title="Step 1">
-          <Form.MainHeading>Heading</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <StepsLayout.NextButton />
-        </StepsLayout.Step>
+    <ComponentBox scope={{ StepsLayout, createRequest, debounceAsync }}>
+      {() => {
+        const MyForm = () => {
+          const onStepChange = React.useCallback(async (index, mode) => {
+            console.log('onStepChange', index)
 
-        <StepsLayout.Step title="Step 2">
-          <Form.MainHeading>Heading</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <Form.ButtonRow>
-            <StepsLayout.PreviousButton />
-            <StepsLayout.NextButton />
-          </Form.ButtonRow>
-        </StepsLayout.Step>
+            if (mode === 'next') {
+              try {
+                const request = createRequest()
+                await request(1000) // Simulate a request
+              } catch (error) {
+                return error
+              }
+            }
 
-        <StepsLayout.Step title="Summary">
-          <Form.MainHeading>Summary</Form.MainHeading>
-          <Card>
-            <P>Contents</P>
-          </Card>
-          <StepsLayout.PreviousButton />
-        </StepsLayout.Step>
-      </StepsLayout>
+            // Optional, you can show a FormStatus at the bottom of the form
+            return { info: 'Info message: ' + index }
+          }, [])
+
+          const onSubmit = React.useCallback(async (data) => {
+            console.log('onSubmit', data)
+
+            try {
+              const request = createRequest()
+              await request(1000) // Simulate a request
+            } catch (error) {
+              return error
+            }
+
+            // Optional, you can show a FormStatus at the bottom of the form
+            return { warning: 'Warning message' }
+          }, [])
+
+          const validator = React.useCallback(async (value) => {
+            try {
+              const request = createRequest()
+              await request(1000) // Simulate a request
+            } catch (error) {
+              return error
+            }
+
+            if (value === 'invalid') {
+              return Error('Error message')
+            }
+          }, [])
+
+          const validator1 = debounceAsync(validator)
+          const validator2 = debounceAsync(validator)
+
+          return (
+            <Form.Handler onSubmit={onSubmit}>
+              <StepsLayout onStepChange={onStepChange} variant="drawer">
+                <StepsLayout.Step title="Step 1">
+                  <Card stack>
+                    <Field.String
+                      label="Required field with async validator"
+                      validator={validator1}
+                      path="/field1"
+                      required
+                    />
+                    <Field.String
+                      label="Field with async validator"
+                      validator={validator2}
+                      path="/field2"
+                    />
+                  </Card>
+                  <Form.ButtonRow>
+                    <StepsLayout.PreviousButton />
+                    <StepsLayout.NextButton />
+                  </Form.ButtonRow>
+                </StepsLayout.Step>
+
+                <StepsLayout.Step title="Step 2">
+                  <Form.MainHeading>Heading</Form.MainHeading>
+                  <Card>
+                    <P>Contents of step 2</P>
+                  </Card>
+                  <Form.ButtonRow>
+                    <StepsLayout.PreviousButton />
+                    <Form.SubmitButton />
+                  </Form.ButtonRow>
+                </StepsLayout.Step>
+              </StepsLayout>
+            </Form.Handler>
+          )
+        }
+
+        return <MyForm />
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/demos.mdx
@@ -6,10 +6,10 @@ import * as Examples from './Examples'
 
 ## Demo
 
-### Sidebar variant
+### Basic usage
 
 <Examples.Default />
 
-### Drawer variant
+### Async steps
 
-<Examples.Drawer />
+<Examples.AsyncStepsLayout />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/events.mdx
@@ -2,8 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { StepsLayoutEvents } from '@dnb/eufemia/src/extensions/forms/StepsLayout/StepsLayoutDocs'
+
 ## Events
 
-| Event          | Description                                                                                          |
-| -------------- | ---------------------------------------------------------------------------------------------------- |
-| `onStepChange` | _(optional)_ Will be called when the user navigate to a different step, with step index as argument. |
+<PropertiesTable props={StepsLayoutEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/properties.mdx
@@ -2,15 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { StepsLayoutProperties } from '@dnb/eufemia/src/extensions/forms/StepsLayout/StepsLayoutDocs'
+
 ## Properties
 
-| Property                                | Type         | Description                                                                                                                                                                                    |
-| --------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialActiveIndex`                    | `number`     | _(optional)_ What step should show initially (defaults to 0 for the first one).                                                                                                                |
-| `mode`                                  | `string`     | _(optional)_ How to show the steps. Inherited from [StepIndicator](/uilib/components/step-indicator/properties). Defaults to `strict`.                                                         |
-| `variant`                               | `string`     | _(optional)_ Sets the [StepIndicator](/uilib/components/step-indicator/) to be either `sidebar` or `drawer`. Defaults to `sidebar`.                                                            |
-| `noAnimation`                           | `boolean`    | _(optional)_ Determines if the height animation for step items and the drawer button will run. Inherited from [StepIndicator](/uilib/components/step-indicator/properties) Defaults to `true`. |
-| `sidebarId`                             | `string`     | _(required)_ Sets the id for `<StepIndicator.Sidebar />` Inherited from [StepIndicator](/uilib/components/step-indicator/properties).                                                          |
-| `scrollTopOnStepChange`                 | `boolean`    | _(optional)_ True for the UI to scroll to the top of the page when navigating between steps.                                                                                                   |
-| `children`                              | `React.Node` | _(required)_ Contents ([Step](/uilib/extensions/forms/extended-features/StepsLayout/Step) components).                                                                                         |
-| [Space](/uilib/layout/space/properties) | Various      | _(optional)_ Spacing properties like `top` or `bottom` are supported.                                                                                                                          |
+<PropertiesTable props={StepsLayoutProperties} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/fields.mdx
@@ -50,7 +50,7 @@ On top of these, a number of [feature fields](#feature-fields) have been built t
 
 ### Standardized properties
 
-All input component has a fixed set of props that make it possible to build more complex standardized functionality around them. The most important ones here are `value` and `onChange`. Value expects values in the given data type, so for example `Field.Number` expects a `value` of the type `number`, and will give a type error in Typescript if it e.g. receives a number in a `string`. The callback function submitted to `onChange` will always receive the value of the corresponding type as the first argument.
+All input component has a fixed set of props that make it possible to build more complex standardized functionality around them. The most important ones here are `value` and `onChange` (can be async). Value expects values in the given data type, so for example `Field.Number` expects a `value` of the type `number`, and will give a type error in Typescript if it e.g. receives a number in a `string`. The callback function submitted to `onChange` will always receive the value of the corresponding type as the first argument.
 
 It is deliberate that `onChange` sends out the value from the field, and not the event object that comes from the actual HTML tag into which the user enters data. This is to create a less tight coupling between application code that uses the components, and the internal implementation in the field components. In addition, this makes the surrounding logic simpler by not having to extract, for example, `e.target.value` everywhere.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/general-demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/general-demos.mdx
@@ -10,7 +10,7 @@ breadcrumb:
 
 import * as Examples from './Examples'
 
-# General Demos
+## General Demos
 
 ### Base field components
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -11,6 +11,8 @@ breadcrumb:
 
 import * as Examples from './Examples'
 import QuickStart from './quick-start'
+import AsyncStateReturnExample from './extended-features/Form/Handler/parts/async-state-return-example.mdx'
+import AsyncChangeExample from './extended-features/Form/Handler/parts/async-change-example.mdx'
 
 # Getting started
 
@@ -21,6 +23,7 @@ import QuickStart from './quick-start'
 - [State management](#state-management)
 - [Field components](#field-components)
 - [Value components](#value-components)
+- [Async form behavior](#async-form-behavior)
 - [Validation and error handling](#validation-and-error-handling)
 - [Localization](#localization)
 - [Layout](#layout)
@@ -29,11 +32,11 @@ import QuickStart from './quick-start'
 
 <QuickStart />
 
-The needed styles are included in the Eufemia core package via `dnb-ui-components`.
-
 ### Creating forms
 
-To build an entire form, there are surrounding components such as [Form.Handler](/uilib/extensions/forms/extended-features/Form/Handler) and [StepsLayout](/uilib/extensions/forms/extended-features/StepsLayout) that make data flow and layout easier and save you a lot of extra code, without compromising flexibility.
+To build an entire form, there are surrounding components such as form [Handler](/uilib/extensions/forms/extended-features/Form/Handler) and [StepsLayout](/uilib/extensions/forms/extended-features/StepsLayout) that make data flow and layout easier and save you a lot of extra code, without compromising flexibility.
+
+The needed styles are included in the Eufemia core package via `dnb-ui-components`.
 
 ### State management
 
@@ -82,6 +85,60 @@ In short, field components are interactive components that the user can interact
 ### Value components
 
 Beside the interactive [Field](/uilib/extensions/forms/fields/) components, there are also the static [Value](/uilib/extensions/forms/extended-features/Value/) components. Use these to show summaries or read-only parts of your application with benefits such as linking to source data and standardized formatting based on the type of data to be displayed.
+
+### Async form behavior
+
+This feature allows you to perform asynchronous operations such as fetching data from an API – without additional state management.
+
+You can enable async form submit behavior on the form [Handler](/uilib/extensions/forms/extended-features/Form/Handler) by using:
+
+```tsx
+render(<Form.Handler onSubmit={async () => {}}>...</Form.Handler>)
+```
+
+It will disable all fields and show an indicator on the [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton/) while the **form** is pending ([examples](/uilib/extensions/forms/extended-features/Form/Handler/demos/)).
+
+When using [StepsLayout](/uilib/extensions/forms/extended-features/StepsLayout/) you can use in addition:
+
+```tsx
+render(<StepsLayout onStepChange={async () => {}}>...</StepsLayout>)
+```
+
+It will disable all fields and show an indicator on the [NextButton](/uilib/extensions/forms/extended-features/StepsLayout/NextButton/) while the **step** is pending ([examples](/uilib/extensions/forms/extended-features/StepsLayout/StepsLayout/demos/)).
+
+#### onChange and autosave
+
+You can use an async function for the `onChange` event handler, either on the form [Handler](/uilib/extensions/forms/extended-features/Form/Handler):
+
+```tsx
+render(<Form.Handler onChange={async () => {}}>...</Form.Handler>)
+```
+
+or on every [field](/uilib/extensions/forms/fields/):
+
+```tsx
+render(<Field.PhoneNumber path="/myField" onChange={async () => {}} />)
+```
+
+They can be used in combination as well – including [async validator](/#async-validation) functions.
+
+When the user makes a value change, it will show an indicator on the corresponding field label.
+
+This feature can not only be used for autosave, but for any other real-time async operations.
+
+<AsyncChangeExample />
+
+The `info`, `warning` and `error` messages will be displayed at the bottom of a form or field ([FormStatus](/uilib/components/form-status)), depending where it is used. While the `success` will be displayed on the label of the field that initiated the `onChange` event.
+
+#### Async field validation
+
+A similar indicator behavior will occur when using async functions for field validation, such as `validator` or `onBlurValidation`, your form will exhibit async behavior. This means that the validation needs to be successfully completed before the form can be submitted.
+
+More info about async validation can be found in the [async validation](/#async-validation) section.
+
+#### State handling in async operations
+
+<AsyncStateReturnExample />
 
 ### Validation and error handling
 
@@ -136,29 +193,43 @@ render(<Field.PhoneNumber validator={validator} />)
 
 You can find more info about error messages in the [Error messages](/uilib/extensions/forms/extended-features/Form/error-messages/) docs.
 
-##### Async validator with a Promise
+##### Async validation
 
-Async validation is also supported. The validator function can return a promise that resolves to an error message:
+Async validation is also supported. The validator function can return a promise (async/await) that resolves to an error message.
 
-```tsx
-const validator = (value) => {
-  return new Promise((resolve, reject) => {
-    // Delay the response
-    resolve(new Error('Invalid value')) // Show this message
-  })
-}
-render(<Field.PhoneNumber validator={validator} />)
-```
-
-##### Async validator with async/await
+In this example we use `onBlurValidator` to only validate the field when the user leaves the field:
 
 ```tsx
 const validator = async (value) => {
-  const isInvalid = await makeRequest(value)
-  if (isInvalid) {
-    return new Error('Invalid value') // Show this message
+  try {
+    const isInvalid = await makeRequest(value)
+    if (isInvalid) {
+      return new Error('Invalid value') // Show this message below the field
+    }
+  } catch (error) {
+    return error
   }
 }
+render(<Field.PhoneNumber onBlurValidator={validator} />)
+```
+
+##### Async validator with debounce
+
+While when using async validation on every keystroke, it's a good idea to debounce the validation function to avoid unnecessary requests. This can be done by using the [debounceAsync](/uilib/helpers/functions/#debounce) helper function:
+
+```tsx
+import { debounceAsync } from '@dnb/eufemia/shared/helpers'
+
+const validator = debounceAsync(async function myValidator(value) {
+  try {
+    const isInvalid = await makeRequest(value)
+    if (isInvalid) {
+      return new Error('Invalid value') // Show this message below the field
+    }
+  } catch (error) {
+    return error
+  }
+})
 render(<Field.PhoneNumber validator={validator} />)
 ```
 
@@ -166,7 +237,7 @@ render(<Field.PhoneNumber validator={validator} />)
 
 In short, use the Eufemia [Provider](/uilib/usage/customisation/localization/) to set the locale for your application (forms). This will ensure that the correct language is used for all the fields in your form.
 
-```jsx
+```tsx
 import Provider from '@dnb/eufemia/shared/Provider'
 
 render(
@@ -178,7 +249,7 @@ render(
 
 In addition, you can customize the translations globally:
 
-```jsx
+```tsx
 import Provider from '@dnb/eufemia/shared/Provider'
 
 render(
@@ -200,6 +271,8 @@ When building your application forms, preferably use the following layout compon
 
 - [Flex](/uilib/layout/flex) layout component for easy and consistent application forms.
 - [Card](/uilib/components/card) for the default card outline of forms.
+
+For changing sizes of e.g. input fields, you may have a look at [Form.Appearance](/uilib/extensions/forms/extended-features/Form/Appearance/).
 
 ### Best practices
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/quick-start.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/quick-start.mdx
@@ -4,6 +4,7 @@ Field components can be used directly as they are, for example `Field.Email`:
 
 ```jsx
 import { Field } from '@dnb/eufemia/extensions/forms'
+
 render(<Field.Email />)
 ```
 
@@ -12,6 +13,7 @@ By building an entire form with components from Eufemia and Eufemia Forms, you s
 ```jsx
 import { Card } from '@dnb/eufemia'
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
 render(
   <Form.Handler
     data={existingData}
@@ -41,20 +43,30 @@ render(
 )
 ```
 
-Use the [useData](/uilib/extensions/forms/extended-features/Form/useData/) hook to access or modify your form data outside of the form context within your application:
+### Data handling
+
+You don't need React `useState` to handle your form data.
+
+The form data is handled by the form context and [useData](/uilib/extensions/forms/extended-features/Form/useData/), [getData](/uilib/extensions/forms/extended-features/Form/getData/) and [setData](/uilib/extensions/forms/extended-features/Form/setData/). They lets you access or modify your form data outside of the form context within your application:
 
 ```jsx
 import { Form } from '@dnb/eufemia/extensions/forms'
-function Component() {
-  const { data, update } = Form.useData('unique')
 
-  return (
-    <Form.Handler
-      id="unique"
-      ...
-    >
-      ...
-    </Form.Handler>
-  )
+function MyForm() {
+  return <Form.Handler id="unique">...</Form.Handler>
 }
+
+function OtherComponent() {
+  // Use the data or update one entry at a time
+  const { data, update } = Form.useData('unique')
+}
+
+// Or use the Form.setData method when ever you need to
+Form.setData('unique', { companyName: 'DNB' })
 ```
+
+### Async form handling
+
+It depends on your use case if this feature is needed. But when it is, its ofter a time consuming task to implement. Eufemia Forms has therefor a built-in feature that enables async form behavior.
+
+More details about the async form behavior can be found in the [async form behavior](/uilib/extensions/forms/getting-started/#async-form-behavior) section.

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -3,9 +3,9 @@
  *
  */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 
-import { makeUniqueId, warn } from '../../shared/component-helper'
+import { warn } from '../../shared/component-helper'
 import StepIndicatorSidebar from './StepIndicatorSidebar'
 
 import StepIndicatorModal from './StepIndicatorModal'
@@ -21,6 +21,7 @@ import type {
   StepItemWrapper,
 } from './StepIndicatorItem'
 import { stepIndicatorDefaultProps } from './StepIndicatorProps'
+import useId from '../../shared/helpers/useId'
 
 export type StepIndicatorMode = 'static' | 'strict' | 'loose'
 export type StepIndicatorDataItem = Pick<
@@ -152,13 +153,15 @@ function StepIndicator({
     ...restOfProps,
   }
 
-  const sidebarId = props.sidebar_id || makeUniqueId()
+  const sidebarId = useId(props.sidebar_id)
 
-  if (!props.sidebar_id && props.mode) {
-    warn(
-      'StepIndicator needs an unique "sidebar_id" property, also on the <StepIndicator.Sidebar... />'
-    )
-  }
+  useEffect(() => {
+    if (!props.sidebar_id && props.mode) {
+      warn(
+        'StepIndicator needs an unique "sidebar_id" property, also on the <StepIndicator.Sidebar... />'
+      )
+    }
+  }, [props.mode, props.sidebar_id])
 
   return (
     <StepIndicatorProvider {...props} sidebar_id={sidebarId}>

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 import pointer from 'json-pointer'
 import type { ComponentProps } from '../../types'
-import Context from '../Context'
+import Context, { ContextState } from '../Context'
 
 export type Props = ComponentProps & {
   /** JSON Pointer for where in the source dataset to point at in sub components */
@@ -23,11 +23,11 @@ function At(props: Props) {
 
   const handlePathChange = useMemo(
     () =>
-      contextHandlePathChange
+      (contextHandlePathChange
         ? (changePath, value) => {
             contextHandlePathChange(`${path}${changePath}`, value)
           }
-        : undefined,
+        : undefined) as ContextState['handlePathChange'],
     [contextHandlePathChange, path]
   )
 
@@ -38,11 +38,16 @@ function At(props: Props) {
     return (
       <>
         {data.map((element, i) => {
-          const handlePathChange = contextHandlePathChange
-            ? (changePath, value) => {
-                contextHandlePathChange(`${path}/${i}${changePath}`, value)
-              }
-            : undefined
+          const handlePathChange = (
+            contextHandlePathChange
+              ? (changePath, value) => {
+                  contextHandlePathChange(
+                    `${path}/${i}${changePath}`,
+                    value
+                  )
+                }
+              : undefined
+          ) as ContextState['handlePathChange']
 
           return (
             <Context.Provider

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -3,14 +3,26 @@ import { Ajv, makeAjvInstance } from '../utils/ajv'
 import {
   AllJSONSchemaVersions,
   CustomErrorMessagesWithPaths,
+  SubmitState,
   Path,
+  EventStateObject,
+  EventReturnWithStateObject,
+  Identifier,
 } from '../types'
+import { Props as ProviderProps } from './Provider'
 
 type HandleSubmitProps = {
   formElement?: HTMLFormElement
 }
 
+export type EventListenerCall = {
+  path: Path
+  type: 'onSubmit'
+  callback: () => any
+}
+
 export interface ContextState {
+  id?: Identifier
   hasContext: boolean
   /** The dataset for the form / form steps */
   data: any
@@ -18,53 +30,88 @@ export interface ContextState {
   errors?: Record<string, Error>
   /** Will set autoComplete="on" on each nested Field.String and Field.Number */
   autoComplete?: boolean
-  handlePathChange: (path: Path, value: any) => void
-  updateDataValue: (
+  handlePathChange: (
     path: Path,
-    value: any,
-    props: { disabled: boolean }
-  ) => void
+    value: any
+  ) =>
+    | EventReturnWithStateObject
+    | unknown
+    | Promise<EventReturnWithStateObject | unknown>
+  updateDataValue: (path: Path, value: any) => void
   validateData: () => void
   handleSubmit: (props?: HandleSubmitProps) => any
   scrollToTop: () => void
   // Error status
   showAllErrors: boolean
   setShowAllErrors: (showAllErrors: boolean) => void
+  hasErrors: () => boolean
+  hasFieldState: (state: SubmitState) => boolean
+  checkFieldStateFor: (path: Path, state: SubmitState) => boolean
+  setFieldState: (path: Path, fieldState: SubmitState) => void
   // Mounted fields - Components telling the provider what fields is on screen at any time
   mountedFieldPaths: string[]
   handleMountField: (path: Path) => void
   handleUnMountField: (path: Path) => void
-  setValueWithError: (path: Path, hasError: boolean) => void
+  formState: SubmitState
+  setFormState?: (state: SubmitState) => void
+  handleSubmitCall: ({
+    onSubmit,
+    enableAsyncBehaviour,
+    skipFieldValidation,
+    skipErrorCheck,
+  }: {
+    onSubmit: () =>
+      | EventReturnWithStateObject
+      | void
+      | Promise<EventReturnWithStateObject | void>
+    enableAsyncBehaviour: boolean
+    skipFieldValidation?: boolean
+    skipErrorCheck?: boolean
+  }) => void
+  setFieldEventListener: (
+    path: EventListenerCall['path'],
+    type: EventListenerCall['type'],
+    callback: EventListenerCall['callback']
+  ) => void
   setProps: (path: Path, props: any) => void
-  hasErrors: () => boolean
-  hasFieldError: (path: Path) => boolean
   ajvInstance: Ajv
   contextErrorMessages: CustomErrorMessagesWithPaths
   schema: AllJSONSchemaVersions
+  disabled: boolean
+  submitState: Partial<EventStateObject>
   _isInsideFormElement?: boolean
+  props: ProviderProps<unknown>
 }
 
 export const defaultContextState: ContextState = {
   hasContext: false,
   data: undefined,
   schema: undefined,
+  disabled: undefined,
+  submitState: undefined,
   handlePathChange: () => null,
   updateDataValue: () => null,
   validateData: () => null,
   handleSubmit: () => null,
   scrollToTop: () => null,
   showAllErrors: false,
+  formState: undefined,
+  setFormState: () => null,
+  setFieldEventListener: () => null,
+  handleSubmitCall: () => null,
   setShowAllErrors: () => null,
   mountedFieldPaths: [],
   handleMountField: () => null,
   handleUnMountField: () => null,
   hasErrors: () => false,
-  hasFieldError: () => false,
-  setValueWithError: () => null,
+  hasFieldState: () => false,
+  checkFieldStateFor: () => false,
+  setFieldState: () => null,
   setProps: () => null,
   ajvInstance: makeAjvInstance(),
   contextErrorMessages: undefined,
   _isInsideFormElement: false,
+  props: null,
 }
 
 const Context = React.createContext<ContextState>(defaultContextState)

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1,4 +1,10 @@
-import React, { useRef, useMemo, useCallback, useReducer } from 'react'
+import React, {
+  useRef,
+  useMemo,
+  useCallback,
+  useReducer,
+  useEffect,
+} from 'react'
 import pointer, { JsonObject } from 'json-pointer'
 import { ValidateFunction } from 'ajv/dist/2020'
 import {
@@ -11,12 +17,19 @@ import {
   CustomErrorMessagesWithPaths,
   AllJSONSchemaVersions,
   FieldProps,
+  SubmitState,
   Path,
+  EventStateObject,
+  OnSubmit,
+  OnChange,
+  EventReturnWithStateObject,
 } from '../../types'
+import SharedProvider from '../../../../shared/Provider'
 import useMountEffect from '../../../../shared/helpers/useMountEffect'
 import useUpdateEffect from '../../../../shared/helpers/useUpdateEffect'
+import { isAsync } from '../../../../shared/helpers/isAsync'
 import { useSharedState } from '../../../../shared/helpers/useSharedState'
-import Context, { ContextState } from '../Context'
+import Context, { ContextState, EventListenerCall } from '../Context'
 
 /**
  * Deprecated, as it is supported by all major browsers and Node.js >=v18
@@ -28,8 +41,6 @@ import structuredClone from '@ungap/structured-clone'
 const useLayoutEffect =
   typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
 
-export type UpdateDataValue = (path: Path, data: unknown) => void
-
 export type FilterDataHandler<Data> = (
   data: Data,
   filter: FilterData
@@ -39,18 +50,6 @@ export type FilterData = (
   value: any,
   props: FieldProps
 ) => boolean | undefined
-
-export type OnSubmitReturn = {
-  /** Will remove browser-side stored autocomplete data  */
-  resetForm: () => void
-  /** Will empty the whole internal data set of the form  */
-  clearData: () => void
-}
-
-export type OnSubmit<Data = JsonObject> = (
-  data: Partial<Data>,
-  { resetForm, clearData }: OnSubmitReturn
-) => void
 
 export interface Props<Data extends JsonObject> {
   /**
@@ -82,21 +81,54 @@ export interface Props<Data extends JsonObject> {
    */
   filterData?: FilterData
   /**
-   * Change handler for the whole data set
+   * Change handler for the whole data set.
+   * You can provide an async function to show an indicator on the current label during a field change.
    */
-  onChange?: (data: Data) => void
+  onChange?: OnChange<Data>
   /**
    * Change handler for each value
    */
-  onPathChange?: (path: Path, value: any) => void
+  onPathChange?: (
+    path: Path,
+    value: any
+  ) =>
+    | EventReturnWithStateObject
+    | void
+    | Promise<EventReturnWithStateObject | void>
   /**
-   * Submit called, data was valid (if validation available)
+   * Will emit on a form submit – if validation has passed.
+   * You can provide an async function to shows a submit indicator during submit. All form elements will be disabled during the submit.
    */
   onSubmit?: OnSubmit
   /**
    * Submit was requested, but data was invalid
    */
   onSubmitRequest?: () => void
+  /**
+   * Will be called when the onSubmit is finished and had not errors
+   */
+  onSubmitComplete?: (
+    data: Data,
+    /**
+     * The result of the onSubmit function
+     */
+    result: unknown
+  ) =>
+    | EventReturnWithStateObject
+    | void
+    | Promise<EventReturnWithStateObject | void>
+  /**
+   * Shows an indicator on the current label during a field change.
+   */
+  enableAsyncChangeBehavior?: boolean
+  /**
+   * Minimum time to display the submit indicator.
+   */
+  minimumAsyncBehaviorTime?: number
+  /**
+   * The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission.
+   */
+  asyncBehaviorTimeout?: number
   /**
    * Scroll to top on submit
    */
@@ -110,24 +142,32 @@ export interface Props<Data extends JsonObject> {
 
 const isArrayJsonPointer = /^\/\d+(\/|$)/
 
-export default function Provider<Data extends JsonObject>({
-  id,
-  defaultData,
-  data,
-  schema,
-  onChange,
-  onPathChange,
-  onSubmit,
-  onSubmitRequest,
-  scrollTopOnSubmit,
-  sessionStorageId,
-  ajvInstance,
-  filterData,
-  errorMessages: contextErrorMessages,
-  children,
-  ...rest
-}: Props<Data>) {
+export default function Provider<Data extends JsonObject>(
+  props: Props<Data>
+) {
   const [, forceUpdate] = useReducer(() => ({}), {})
+
+  const {
+    id,
+    defaultData,
+    data,
+    schema,
+    onChange,
+    onPathChange,
+    onSubmit,
+    onSubmitRequest,
+    onSubmitComplete,
+    scrollTopOnSubmit,
+    minimumAsyncBehaviorTime,
+    asyncBehaviorTimeout,
+    sessionStorageId,
+    ajvInstance,
+    filterData,
+    errorMessages: contextErrorMessages,
+    children,
+    ...rest
+  } = props
+
   // Prop error handling
   if (data !== undefined && sessionStorageId !== undefined) {
     console.error(
@@ -137,18 +177,32 @@ export default function Provider<Data extends JsonObject>({
 
   // - Ajv
   const ajvRef = useRef<Ajv>(makeAjvInstance(ajvInstance))
+
   // - Paths
   const mountedFieldPathsRef = useRef<Path[]>([])
+
   // - Errors from provider validation (the whole data set)
-  const errorsRef = useRef<Record<string, FormError> | undefined>()
+  const errorsRef = useRef<Record<Path, FormError> | undefined>()
   const showAllErrorsRef = useRef<boolean>(false)
   const setShowAllErrors = useCallback((showAllErrors: boolean) => {
     showAllErrorsRef.current = showAllErrors
     forceUpdate()
   }, [])
+  const submitStateRef = useRef<Partial<EventStateObject>>({})
+  const setSubmitState = useCallback((state: EventStateObject) => {
+    Object.assign(submitStateRef.current, state)
+    forceUpdate()
+  }, [])
 
-  // - Errors reported by fields, based on their direct validation rules
-  const valuesWithErrorRef = useRef<Path[]>([])
+  // - Progress
+  const formStateRef = useRef<SubmitState>()
+  const setFormState = useCallback((formState: SubmitState) => {
+    formStateRef.current = formState
+    forceUpdate()
+  }, [])
+
+  // - States (e.g. error) reported by fields, based on their direct validation rules
+  const fieldStateRef = useRef<Record<Path, SubmitState>>({})
 
   // - Data
   const initialData = useMemo<Data>(() => {
@@ -192,28 +246,36 @@ export default function Provider<Data extends JsonObject>({
   }, [validateDataNow])
 
   // - Error handling
-  const hasFieldError = useCallback((path: Path) => {
-    return Boolean(
-      errorsRef.current?.[path] !== undefined ||
-        valuesWithErrorRef.current.includes(path)
-    )
-  }, [])
+  const checkFieldStateFor = useCallback(
+    (path: Path, state: SubmitState = 'error') => {
+      return Boolean(
+        (state === 'error' &&
+          errorsRef.current?.[path] instanceof Error) ||
+          fieldStateRef.current[path] === state
+      )
+    },
+    []
+  )
+  const hasFieldState = useCallback(
+    (state: SubmitState) => {
+      return mountedFieldPathsRef.current.some((path) => {
+        return checkFieldStateFor(path, state)
+      })
+    },
+    [checkFieldStateFor]
+  )
   const hasErrors = useCallback(() => {
-    return Boolean(
-      mountedFieldPathsRef.current.find((path) => hasFieldError(path))
-    )
-  }, [hasFieldError])
+    return hasFieldState('error')
+  }, [hasFieldState])
 
   /**
    * Sets the error state for a specific path
    */
-  const setValueWithError = useCallback(
-    (path: Path, withError: boolean) => {
-      if (withError !== valuesWithErrorRef.current.includes(path)) {
-        // The boolean error state for the target value was changed
-        valuesWithErrorRef.current = withError
-          ? addListPath(valuesWithErrorRef.current, path)
-          : removeListPath(valuesWithErrorRef.current, path)
+  const setFieldState = useCallback(
+    (path: Path, fieldState: SubmitState) => {
+      if (fieldState !== fieldStateRef.current[path]) {
+        // The state for the target value was changed
+        fieldStateRef.current[path] = fieldState
         forceUpdate()
       }
     },
@@ -246,23 +308,33 @@ export default function Provider<Data extends JsonObject>({
     },
     [filterData]
   )
-  const fieldPropsRef = useRef<Record<string, FieldProps>>({})
+  const fieldPropsRef = useRef<Record<Path, FieldProps>>({})
   const setProps = useCallback(
     (path: Path, props: Record<string, unknown>) => {
       fieldPropsRef.current[path] = props
     },
     []
   )
+  const hasFieldWithAsyncValidator = useCallback(() => {
+    for (const path in fieldPropsRef.current) {
+      const props = fieldPropsRef.current[path]
+      if (isAsync(props.validator) || isAsync(props.onBlurValidator)) {
+        return true
+      }
+    }
+
+    return false
+  }, [])
 
   // - Shared state
   const sharedData = useSharedState<Data>(id)
   const sharedAttachments = useSharedState<{
     filterDataHandler?: Props<Data>['filterData']
-    hasErrors?: () => boolean
+    hasErrors?: ContextState['hasErrors']
+    setShowAllErrors?: ContextState['setShowAllErrors']
     rerenderUseDataHook?: () => void
   }>(id + '-attachments')
 
-  const updateSharedData = sharedData.update
   const extendSharedData = sharedData.extend
   const extendAttachment = sharedAttachments.extend
   const rerenderUseDataHook = sharedAttachments.data?.rerenderUseDataHook
@@ -345,24 +417,29 @@ export default function Provider<Data extends JsonObject>({
 
   useLayoutEffect(() => {
     if (id) {
-      extendAttachment?.({ filterDataHandler, hasErrors })
+      extendAttachment?.({
+        filterDataHandler,
+        hasErrors,
+        setShowAllErrors,
+      })
       if (filterData) {
         rerenderUseDataHook?.()
       }
     }
   }, [
+    extendAttachment,
     filterData,
     filterDataHandler,
-    rerenderUseDataHook,
     hasErrors,
     id,
-    extendAttachment,
+    rerenderUseDataHook,
+    setShowAllErrors,
   ])
 
   /**
    * Update the data set
    */
-  const updateDataValue: UpdateDataValue = useCallback(
+  const updateDataValue: ContextState['updateDataValue'] = useCallback(
     (path, value) => {
       if (!path) {
         return
@@ -390,7 +467,7 @@ export default function Provider<Data extends JsonObject>({
       }
 
       if (id) {
-        updateSharedData?.(newData)
+        extendSharedData?.(newData)
         if (filterData) {
           rerenderUseDataHook?.()
         }
@@ -410,34 +487,42 @@ export default function Provider<Data extends JsonObject>({
       return newData
     },
     [
-      filterData,
       id,
       sessionStorageId,
+      extendSharedData,
+      filterData,
       rerenderUseDataHook,
-      updateSharedData,
     ]
   )
 
   /**
    * Update the data set on user interaction
    */
-  const handlePathChange: UpdateDataValue = useCallback(
-    (path, value) => {
+  const handlePathChange: ContextState['handlePathChange'] = useCallback(
+    async (path, value) => {
       if (!path) {
-        return
+        return null
       }
 
-      onPathChange?.(path, value)
+      if (isAsync(onPathChange)) {
+        await onPathChange?.(path, value)
+      } else {
+        onPathChange?.(path, value)
+      }
 
       const newData = updateDataValue(path, value)
-
-      onChange?.(newData as Data)
 
       showAllErrorsRef.current = false
 
       validateData()
+
+      if (isAsync(onChange)) {
+        return await onChange(newData as Data)
+      }
+
+      return onChange?.(newData as Data)
     },
-    [onPathChange, updateDataValue, onChange, validateData]
+    [onChange, onPathChange, updateDataValue, validateData]
   )
 
   // - Mounted fields
@@ -466,56 +551,203 @@ export default function Provider<Data extends JsonObject>({
   }, [])
 
   /**
-   * Request to submit the whole form
+   * Shared logic dedicated to submit the whole form
    */
-  const handleSubmit = useCallback<ContextState['handleSubmit']>(
-    ({ formElement = null } = {}) => {
-      if (!hasErrors()) {
-        const resetForm = () => {
-          formElement?.reset?.()
+  const handleSubmitCall = useCallback<ContextState['handleSubmitCall']>(
+    async (args) => {
+      const {
+        onSubmit,
+        enableAsyncBehaviour,
+        skipFieldValidation,
+        skipErrorCheck,
+      } = args
 
-          if (typeof window !== 'undefined') {
-            if (sessionStorageId) {
-              window.sessionStorage.removeItem(sessionStorageId)
+      setSubmitState({ error: undefined })
+
+      const hasError = skipErrorCheck ? false : hasErrors()
+      const asyncBehaviorIsEnabled =
+        !hasError && (enableAsyncBehaviour || hasFieldWithAsyncValidator())
+
+      if (asyncBehaviorIsEnabled) {
+        setFormState('pending')
+      }
+
+      // Just call the submit listeners "once", and not on the retry/recall
+      if (!skipFieldValidation) {
+        for (const {
+          path,
+          type,
+          callback,
+        } of fieldEventListenersRef.current) {
+          if (
+            type === 'onSubmit' &&
+            mountedFieldPathsRef.current.includes(path)
+          ) {
+            // Call all submit listener callbacks (e.g. to validate fields)
+            if (asyncBehaviorIsEnabled) {
+              await callback()
+            } else {
+              callback()
             }
           }
-
-          forceUpdate() // in order to fill "empty fields" again with their internal states
         }
-        const clearData = () => {
-          internalDataRef.current = {}
-          forceUpdate()
+      }
+
+      if (
+        !hasError &&
+        !hasFieldState('pending') &&
+        (skipFieldValidation ? true : !hasFieldState('error'))
+      ) {
+        let result: EventStateObject | unknown
+
+        try {
+          result = await onSubmit()
+
+          if (result instanceof Error) {
+            throw result
+          }
+        } catch (error) {
+          result = { error }
         }
 
-        onSubmit?.(filterDataHandler(internalDataRef.current as Data), {
-          resetForm,
-          clearData,
-        })
+        const state = result as EventStateObject
 
-        if (scrollTopOnSubmit) {
-          scrollToTop()
+        if (asyncBehaviorIsEnabled) {
+          setFormState(state?.error ? 'abort' : 'complete')
+        }
+
+        // Force the state to be set by a custom status
+        if (state?.['status']) {
+          setFormState(state?.['status'])
+        }
+
+        if (state?.error || state?.warning || state?.info) {
+          setSubmitState(state)
         }
       } else {
-        setShowAllErrors(true)
+        if (asyncBehaviorIsEnabled) {
+          window.requestAnimationFrame(() => {
+            setFormState(undefined)
+          })
+        }
+
+        if (!skipFieldValidation) {
+          // Add a event listener to continue the submit after the pending state is resolved
+          onSubmitContinueRef.current = () => {
+            window.requestAnimationFrame(() => {
+              // Do not call the validators again,
+              // because we already did it in the first call
+              // If they are async, we wait for them to finish anyway
+              handleSubmitCall({ ...args, skipFieldValidation: true })
+            })
+          }
+        }
+
         onSubmitRequest?.()
+
+        setShowAllErrors(true)
       }
 
       return internalDataRef.current
     },
     [
+      setSubmitState,
       hasErrors,
-      onSubmit,
-      filterDataHandler,
-      scrollTopOnSubmit,
-      sessionStorageId,
-      scrollToTop,
-      setShowAllErrors,
+      hasFieldWithAsyncValidator,
+      hasFieldState,
+      setFormState,
       onSubmitRequest,
+      setShowAllErrors,
     ]
   )
 
-  // - ajv validator routines
+  /**
+   * Request to submit the whole form
+   */
+  const handleSubmit = useCallback<ContextState['handleSubmit']>(
+    async ({ formElement = null } = {}) => {
+      handleSubmitCall({
+        enableAsyncBehaviour: isAsync(onSubmit),
+        onSubmit: async () => {
+          const args = filterDataHandler(internalDataRef.current as Data)
+          const opts = {
+            resetForm: () => {
+              formElement?.reset?.()
 
+              if (typeof window !== 'undefined') {
+                if (sessionStorageId) {
+                  window.sessionStorage.removeItem(sessionStorageId)
+                }
+              }
+
+              forceUpdate() // in order to fill "empty fields" again with their internal states
+            },
+            clearData: () => {
+              internalDataRef.current = {}
+              forceUpdate()
+            },
+          }
+
+          let result = undefined
+
+          if (isAsync(onSubmit)) {
+            result = await onSubmit(args, opts)
+          } else {
+            result = onSubmit?.(args, opts)
+          }
+
+          const completeResult = await onSubmitComplete?.(args, result)
+          if (completeResult) {
+            result =
+              Object.keys(result).length > 0
+                ? { ...result, ...completeResult }
+                : completeResult
+          }
+
+          if (scrollTopOnSubmit) {
+            scrollToTop()
+          }
+
+          return result
+        },
+      })
+    },
+    [
+      filterDataHandler,
+      handleSubmitCall,
+      onSubmit,
+      onSubmitComplete,
+      scrollToTop,
+      scrollTopOnSubmit,
+      sessionStorageId,
+    ]
+  )
+
+  // Collect listeners to be called during form submit
+  const fieldEventListenersRef = useRef<Array<EventListenerCall>>([])
+  const setFieldEventListener = useCallback(
+    (
+      path: EventListenerCall['path'],
+      type: EventListenerCall['type'],
+      callback: EventListenerCall['callback']
+    ) => {
+      fieldEventListenersRef.current =
+        fieldEventListenersRef.current.filter(({ path: p, type: t }) => {
+          return !(p === path && t === type)
+        })
+      fieldEventListenersRef.current.push({ path, type, callback })
+    },
+    []
+  )
+
+  // Handle unresolved field states during async submit
+  const onSubmitContinueRef = useRef<() => void>(null)
+  if (!hasFieldState('pending')) {
+    onSubmitContinueRef.current?.()
+    onSubmitContinueRef.current = null
+  }
+
+  // - ajv validator routines
   useMountEffect(() => {
     if (schema) {
       ajvValidatorRef.current = ajvRef.current?.compile(schema)
@@ -524,7 +756,6 @@ export default function Provider<Data extends JsonObject>({
     // Validate the initial data
     validateData()
   })
-
   useUpdateEffect(() => {
     if (schema && schema !== cacheRef.current.schema) {
       cacheRef.current.schema = schema
@@ -535,33 +766,59 @@ export default function Provider<Data extends JsonObject>({
     }
   }, [schema, validateData, forceUpdate])
 
+  const { bufferedFormState: formState } = useFormStatusBuffer({
+    formState: formStateRef.current,
+    waitFor: hasFieldState('pending'),
+    minimumAsyncBehaviorTime,
+    asyncBehaviorTimeout,
+  })
+
+  const submitState = submitStateRef.current
+  const disabled = rest?.['disabled'] ?? formState === 'pending'
+
   return (
     <Context.Provider
       value={{
-        hasContext: true,
-        data: internalDataRef.current,
-        ...rest,
+        /** Method */
         handlePathChange,
-        updateDataValue,
-        validateData,
         handleSubmit,
-        scrollToTop,
-        errors: errorsRef.current,
-        showAllErrors: showAllErrorsRef.current,
-        setShowAllErrors,
-        mountedFieldPaths: mountedFieldPathsRef.current,
         handleMountField,
         handleUnMountField,
-        hasErrors,
-        hasFieldError,
-        setValueWithError,
+        handleSubmitCall,
+        setFormState,
+        setShowAllErrors,
+        setFieldEventListener,
+        setFieldState,
         setProps,
-        ajvInstance: ajvRef.current,
+        hasErrors,
+        hasFieldState,
+        checkFieldStateFor,
+        validateData,
+        updateDataValue,
+        scrollToTop,
+
+        /** State handling */
         schema,
+        disabled,
+        formState,
+        submitState,
         contextErrorMessages,
+        hasContext: true,
+        errors: errorsRef.current,
+        showAllErrors: showAllErrorsRef.current,
+        mountedFieldPaths: mountedFieldPathsRef.current,
+        ajvInstance: ajvRef.current,
+
+        /** Additional */
+        id,
+        data: internalDataRef.current,
+        props,
+        ...rest,
       }}
     >
-      {children}
+      <SharedProvider formElement={{ disabled }}>
+        {children}
+      </SharedProvider>
     </Context.Provider>
   )
 }
@@ -574,4 +831,118 @@ function addListPath(paths: PathList, path: Path): PathList {
 
 function removeListPath(paths: PathList, path: Path): PathList {
   return paths.filter((thisPath) => thisPath !== path)
+}
+
+type FormStatusBufferProps = {
+  minimumAsyncBehaviorTime?: Props<unknown>['minimumAsyncBehaviorTime']
+  asyncBehaviorTimeout?: Props<unknown>['asyncBehaviorTimeout']
+  formState: ContextState['formState']
+  waitFor: boolean
+}
+
+function useFormStatusBuffer(props: FormStatusBufferProps) {
+  const {
+    formState,
+    waitFor,
+    minimumAsyncBehaviorTime,
+    asyncBehaviorTimeout,
+  } = props || {}
+
+  const [, forceUpdate] = useReducer(() => ({}), {})
+  const stateRef = useRef<SubmitState>()
+  const nowRef = useRef<number | null>(null)
+  const timeoutRef = useRef<{
+    complete?: NodeJS.Timeout | null
+    reset?: NodeJS.Timeout | null
+    timeout?: NodeJS.Timeout | null
+  }>({})
+
+  const setState = useCallback(
+    (state: SubmitState) => {
+      stateRef.current = state
+      forceUpdate()
+    },
+    [forceUpdate]
+  )
+
+  const clear = useCallback(() => {
+    for (const key in timeoutRef.current) {
+      clearTimeout(timeoutRef.current[key])
+    }
+  }, [])
+
+  const hadCompleteRef = useRef(false)
+
+  useEffect(() => {
+    // This offset is used to calculate the delay,
+    // which ensures that the form state is displayed for at least minimumAsyncBehaviorTime duration.
+    // If the form was 'pending' for less than minimumAsyncBehaviorTime,
+    // the delay will be the remaining time to reach minimumAsyncBehaviorTime.
+    const isTest = process.env.NODE_ENV === 'test'
+    const minimum =
+      minimumAsyncBehaviorTime ??
+      // make it testable
+      (isTest ? 1 : 1000)
+
+    if (stateRef.current && formState === 'error') {
+      clear()
+      setState(undefined)
+      return
+    }
+
+    if (formState === 'abort') {
+      clear()
+      setState('abort')
+
+      timeoutRef.current.reset = setTimeout(() => {
+        nowRef.current = 0
+        setState(undefined)
+      }, minimum)
+      return
+    }
+
+    if (formState === 'complete') {
+      hadCompleteRef.current = true
+    }
+
+    if (formState === 'pending') {
+      clear()
+      nowRef.current = Date.now()
+      hadCompleteRef.current = false
+      setState('pending')
+    } else if (stateRef.current === 'pending') {
+      const offset = Math.max(Date.now() - nowRef.current)
+      const delay = isTest ? minimum : Math.max(minimum - offset, 0)
+
+      if (!waitFor) {
+        timeoutRef.current.complete = setTimeout(() => {
+          if (hadCompleteRef.current) {
+            setState('complete')
+          }
+        }, delay)
+
+        timeoutRef.current.reset = setTimeout(() => {
+          nowRef.current = 0
+          setState(undefined)
+          clear()
+        }, delay + minimum)
+      }
+
+      timeoutRef.current.timeout = setTimeout(() => {
+        nowRef.current = 0
+        setState(undefined)
+      }, asyncBehaviorTimeout ?? 30000)
+    }
+
+    return clear
+  }, [
+    clear,
+    minimumAsyncBehaviorTime,
+    formState,
+    setState,
+    waitFor,
+    asyncBehaviorTimeout,
+  ])
+
+  return { bufferedFormState: stateRef.current }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -1,0 +1,87 @@
+import { PropertiesTableProps } from '../../../../shared/types'
+
+export const ProviderProperties: PropertiesTableProps = {
+  defaultData: {
+    doc: 'Default source data, only used if no other source is available, and not leading to updates if changed after mount.',
+    type: 'object',
+    status: 'required',
+  },
+  data: {
+    doc: 'Dynamic source data used as both initial data, and updates internal data if changed after mount.',
+    type: 'object',
+    status: 'required',
+  },
+  schema: {
+    doc: 'JSON Schema for validation of the data set.',
+    type: 'object',
+    status: 'optional',
+  },
+  errorMessages: {
+    doc: 'Object containing error messages by either type of JSON Pointer path and type.',
+    type: 'object',
+    status: 'optional',
+  },
+  minimumAsyncBehaviorTime: {
+    doc: 'Minimum time to display the submit indicator. Default is 1s.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  asyncBehaviorTimeout: {
+    doc: 'The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission. Default is 30s.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  scrollTopOnSubmit: {
+    doc: 'True for the UI to scroll to the top of the page when data is submitted.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  sessionStorageId: {
+    doc: 'Key for saving active data to session storage and loading it on mount.',
+    type: 'string',
+    status: 'optional',
+  },
+  ajvInstance: {
+    doc: 'Provide your own custom Ajv instance. More info in the <a href="/uilib/extensions/forms/extended-features/Form/schema-validation/#custom-ajv-instance-and-keywords">Schema validation</a> section.',
+    type: 'ajv',
+    status: 'optional',
+  },
+  filterData: {
+    doc: 'Filter the internal data context based on your criteria: `(path, value, props) => !props?.disabled`. It will iterate on each data entry.',
+    type: 'function',
+    status: 'optional',
+  },
+  children: {
+    doc: 'Contents.',
+    type: 'React.Node',
+    status: 'required',
+  },
+}
+
+export const ProviderEvents: PropertiesTableProps = {
+  onChange: {
+    doc: "Will be called when a value of any input component inside was changed by the user, with the data set (including the changed value) as argument. When an async function is provided, it will show an indicator on the current label during a field change. Related props: `minimumAsyncBehaviorTime` and `asyncBehaviorTimeout`. You can return an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const` in addition to { success: 'saved' } indicate the field was saved.",
+    type: 'function',
+    status: 'optional',
+  },
+  onPathChange: {
+    doc: 'Will be called when a value of any input component inside was changed by the user, with the `path` (JSON Pointer) and new `value` as arguments. Can be an async function.',
+    type: 'function',
+    status: 'optional',
+  },
+  onSubmit: {
+    doc: "Will be called when the user submit the form (i.e by clicking a [SubmitButton](/uilib/extensions/forms/extended-features/Form/SubmitButton) component inside), with the data set as argument. When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related props: `minimumAsyncBehaviorTime` and `asyncBehaviorTimeout`. You can return an error or an object with these keys `{ status: 'pending', info: 'Info message', warning: 'Warning message', error: Error('My error') } as const` to be shown in a [FormStatus](/uilib/components/form-status).",
+    type: 'function',
+    status: 'optional',
+  },
+  onSubmitRequest: {
+    doc: 'Will be called when the user tries to submit, but errors stop the data from being submitted.',
+    type: 'function',
+    status: 'optional',
+  },
+  onSubmitComplete: {
+    doc: 'Will be called after onSubmit has finished and had not errors. It supports the same return values as `onSubmit` and will be merged together.',
+    type: 'function',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
@@ -28,7 +28,7 @@ describe('Field.OrganizationNumber', () => {
     render(<Field.OrganizationNumber />)
 
     const element = document.querySelector('input')
-    expect(element.autocomplete).toBe('off')
+    expect(element).not.toHaveAttribute('autocomplete')
   })
 
   it('should link for and label', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -18,12 +18,14 @@ import FieldBlockContext, {
   StateTypes,
   StatusContent,
   FieldBlockContextProps,
+  StateBasis,
 } from './FieldBlockContext'
 import { Space, FormLabel, FormStatus } from '../../../components'
 import { Ul, Li } from '../../../elements'
 import {
   convertJsxToString,
   findElementInChildren,
+  warn,
 } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import useUnmountEffect from '../../../shared/helpers/useUnmountEffect'
@@ -31,9 +33,12 @@ import {
   ComponentProps,
   FieldProps,
   FormError,
+  SubmitState,
   Identifier,
 } from '../types'
 import type { FormLabelAllProps } from '../../../components/FormLabel'
+import SubmitIndicator from '../Form/SubmitIndicator/SubmitIndicator'
+import { createSharedState } from '../../../shared/helpers/useSharedState'
 
 export const states: Array<StateTypes> = ['error', 'info', 'warning']
 
@@ -59,6 +64,8 @@ export type Props = Pick<
   /** Width of contents block, while label etc can be wider if space is available */
   contentWidth?: 'small' | 'medium' | 'large' | 'stretch'
   contentClassName?: string
+  /** To show the SubmitIndicator during async validation */
+  fieldState?: SubmitState
   /** Typography size */
   labelSize?: 'medium' | 'large'
   children: React.ReactNode
@@ -67,6 +74,7 @@ export type Props = Pick<
 function FieldBlock(props: Props) {
   const nestedFieldBlockContext = useContext(FieldBlockContext)
 
+  const sharedData = createSharedState<Props>(props.forId || props.id)
   const {
     className,
     forId,
@@ -78,6 +86,7 @@ function FieldBlock(props: Props) {
     info,
     warning,
     error: errorProp,
+    fieldState,
     disabled,
     width,
     contentWidth,
@@ -85,7 +94,7 @@ function FieldBlock(props: Props) {
     contentClassName,
     children,
     ...rest
-  } = props
+  } = Object.assign({}, sharedData.data, props)
 
   const blockId = useId(props.id)
   const [wasUpdated, forceUpdate] = useReducer(() => ({}), {})
@@ -97,7 +106,7 @@ function FieldBlock(props: Props) {
     return Boolean(errorProp)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const setInternalRecord = useCallback((props) => {
+  const setInternalRecord = useCallback((props: StateBasis) => {
     const { stateId, identifier, type } = props
 
     if (!stateRecordRef.current[identifier]) {
@@ -123,7 +132,7 @@ function FieldBlock(props: Props) {
   }, [])
 
   const setFieldState = useCallback(
-    (props) => {
+    (props: StateBasis) => {
       if (nestedFieldBlockContext) {
         // If this FieldBlock is inside another one, forward the call to the outer one
         nestedFieldBlockContext.setFieldState(props)
@@ -166,30 +175,30 @@ function FieldBlock(props: Props) {
   )
 
   const statusContent = useMemo(() => {
-    if (errorProp) {
+    if (typeof errorProp !== 'undefined') {
       setInternalRecord({
         identifier: blockId,
         showInitially: hasInitiallyErrorProp,
         type: 'error',
-        state: errorProp,
+        content: errorProp,
       })
     }
 
-    if (warning) {
+    if (typeof warning !== 'undefined') {
       setInternalRecord({
         identifier: blockId,
         showInitially: true,
         type: 'warning',
-        state: warning,
+        content: warning,
       })
     }
 
-    if (info) {
+    if (typeof info !== 'undefined') {
       setInternalRecord({
         identifier: blockId,
         showInitially: true,
         type: 'info',
-        state: info,
+        content: info,
       })
     }
 
@@ -221,7 +230,7 @@ function FieldBlock(props: Props) {
           } else {
             acc.push({
               ...cur,
-              state: undefined,
+              content: undefined,
               messages: [
                 {
                   ...cur,
@@ -350,6 +359,10 @@ function FieldBlock(props: Props) {
     disabled,
   }
 
+  if (fieldState && !label) {
+    warn('You have to provide a label to use show an indicator.')
+  }
+
   return (
     <FieldBlockContext.Provider
       value={{
@@ -367,24 +380,20 @@ function FieldBlock(props: Props) {
         {...rest}
       >
         <div className={gridClasses}>
-          {labelDescription ? (
-            <div className="dnb-forms-field-block__label">
-              {label || labelDescription ? (
-                <FormLabel {...labelProps}>
+          <LabelDescription labelDescription={labelDescription}>
+            {(label || labelDescription) && (
+              <FormLabel {...labelProps}>
+                <SubmitIndicator state={fieldState}>
                   {label}
                   {labelDescription && (
                     <span className="dnb-forms-field-block__label-description">
                       {labelDescription}
                     </span>
                   )}
-                </FormLabel>
-              ) : (
-                <>&nbsp;</>
-              )}
-            </div>
-          ) : (
-            label && <FormLabel {...labelProps}>{label}</FormLabel>
-          )}
+                </SubmitIndicator>
+              </FormLabel>
+            )}
+          </LabelDescription>
 
           <div className="dnb-forms-field-block__status">
             <FormStatus {...statusContent?.error} />
@@ -472,13 +481,20 @@ function CombineMessages({
   )
 }
 
-function getMessage(item: Partial<StateWithMessage>): StateMessage {
-  const { state } = item
+function LabelDescription({ labelDescription, children }) {
+  if (!labelDescription) {
+    return children
+  }
+  return <div className="dnb-forms-field-block__label">{children}</div>
+}
 
-  return ((state instanceof Error && state.message) ||
-    (state instanceof FormError && state.message) ||
-    state?.toString() ||
-    state) as StateMessage
+function getMessage(item: Partial<StateWithMessage>): StateMessage {
+  const { content } = item
+
+  return ((content instanceof Error && content.message) ||
+    (content instanceof FormError && content.message) ||
+    content?.toString() ||
+    content) as StateMessage
 }
 
 FieldBlock._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockContext.ts
@@ -11,7 +11,7 @@ export type StateContent =
 export type StateBasis = {
   identifier: Identifier
   type: StateTypes
-  state: StateContent
+  content: StateContent
   stateId?: string
   showInitially?: boolean
   show?: boolean
@@ -39,7 +39,7 @@ export type FieldBlockContextProps = {
     identifier,
     type,
     stateId,
-    state,
+    content,
     showInitially,
     show,
   }: StateBasis) => void

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -10,7 +10,7 @@ import {
   runAnimation,
   simulateAnimationEnd,
 } from '../../../../components/height-animation/__tests__/HeightAnimationUtils'
-import { Field } from '../..'
+import { Field, Form } from '../..'
 
 import nbNO from '../../../../shared/locales/nb-NO'
 const nb = nbNO['nb-NO'].Forms
@@ -444,6 +444,18 @@ describe('FieldBlock', () => {
     })
 
     describe('Composition', () => {
+      it('should not display error messages initially', () => {
+        render(
+          <FieldBlock composition>
+            <Field.String required />
+            <Field.String required />
+          </FieldBlock>
+        )
+
+        const element = document.querySelector('.dnb-form-status')
+        expect(element).toBeNull()
+      })
+
       it('should display both error messages with summary in one status', () => {
         render(
           <FieldBlock composition>
@@ -1093,6 +1105,49 @@ describe('FieldBlock', () => {
 
       expect(status).toHaveAttribute('id', 'unique-form-status--error')
     })
+  })
+
+  it('should warn when formStatus is given, but no label', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation()
+
+    const asyncValidator = async () => {
+      return null
+    }
+
+    const { rerender } = render(
+      <Form.Handler>
+        <Field.String
+          label="Has a label"
+          value="bar"
+          path="/foo"
+          validator={asyncValidator}
+        />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    const buttonElement = document.querySelector('button')
+
+    await userEvent.click(buttonElement)
+
+    expect(log).toHaveBeenCalledTimes(0)
+
+    rerender(
+      <Form.Handler>
+        <Field.String value="bar" path="/foo" validator={asyncValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.click(buttonElement)
+
+    expect(log).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'You have to provide a label to use show an indicator.'
+    )
+
+    log.mockRestore()
   })
 })
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
@@ -31,12 +31,8 @@ export function FieldBlockLabel() {
 export function Composition() {
   return (
     <FieldBlock info="Info at the bottom" width="large" composition>
-      <FieldBlock width="stretch">
-        <Field.String label="Field A with a long label" width="stretch" />
-      </FieldBlock>
-      <FieldBlock width="medium">
-        <Field.String label="Field B" width="stretch" />
-      </FieldBlock>
+      <Field.String label="Field A with a long label" width="stretch" />
+      <Field.String label="Field B" width="medium" />
     </FieldBlock>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/HandlerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/HandlerDocs.ts
@@ -1,0 +1,46 @@
+import { PropertiesTableProps } from '../../../../shared/types'
+import {
+  ProviderEvents,
+  ProviderProperties,
+} from '../../DataContext/Provider/ProviderDocs'
+
+export const HandlerProperties: PropertiesTableProps = {
+  ...ProviderProperties,
+  disabled: {
+    doc: 'Will disable all nested form fields.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  autoComplete: {
+    doc: 'Will set `autoComplete="on"` on all nested [Field.String](/uilib/extensions/forms/base-fields/String/)-fields.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+  '[DataContext.Provider](/uilib/extensions/forms/extended-features/DataContext/Provider/properties)':
+    {
+      doc: 'Provider properties such as `data`.',
+      type: 'Various',
+      status: 'optional',
+    },
+  '[Form Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attributes)':
+    {
+      doc: 'All supported form element attributes.',
+      type: 'string',
+      status: 'optional',
+    },
+}
+
+export const HandlerEvents: PropertiesTableProps = {
+  ...ProviderEvents,
+  '[DataContext.Provider](/uilib/extensions/forms/extended-features/DataContext/Provider/events)':
+    {
+      doc: 'events such as `onSubmit`.',
+      type: 'function',
+      status: 'optional',
+    },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { Form, Field } from '../../..'
 import type { Props as StringFieldProps } from '../../../Field/String'
 import userEvent from '@testing-library/user-event'
+import { wait } from '../../../../../core/jest/jestSetup'
 
 describe('Form.Handler', () => {
   it('should call "onSubmit"', () => {
@@ -366,7 +367,7 @@ describe('Form.Handler', () => {
     expect(screen.queryByRole('alert')).toBeInTheDocument()
   })
 
-  it('should include values from fields in data, without any change', async () => {
+  it('should include values from fields in data, without any change', () => {
     const onSubmit = jest.fn()
 
     render(
@@ -384,5 +385,387 @@ describe('Form.Handler', () => {
       { foo: 'bar', other: 'include this' },
       expect.anything()
     )
+  })
+
+  it('should show error message given in onSubmit', async () => {
+    const onSubmit = jest.fn(() => {
+      throw new Error('Form error')
+    })
+
+    render(
+      <Form.Handler onSubmit={onSubmit} aria-labelledby="custom-id">
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    const buttonElement = document.querySelector('button')
+    fireEvent.click(buttonElement)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toHaveTextContent('Form error')
+    })
+  })
+
+  it('should have error message that is connected with aria-labelledby', async () => {
+    const onSubmit = jest.fn(() => {
+      throw new Error('Form error')
+    })
+
+    render(
+      <Form.Handler onSubmit={onSubmit} aria-labelledby="custom-id">
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    const buttonElement = document.querySelector('button')
+    await userEvent.click(buttonElement)
+
+    const form = screen.getByRole('form')
+    const id = screen.queryByRole('alert').getAttribute('id')
+
+    expect(id).toEqual(expect.stringMatching(/id-.*-form-status/))
+    expect(form).toHaveAttribute(
+      'aria-labelledby',
+      expect.stringMatching(/custom-id/)
+    )
+    expect(form).toHaveAttribute('aria-labelledby')
+    expect(screen.queryByRole('alert')).toHaveTextContent('Form error')
+  })
+
+  describe('async submit', () => {
+    let log: jest.SpyInstance
+    beforeEach(() => {
+      const originalConsoleLog = console.log
+      log = jest.spyOn(console, 'log').mockImplementation((...message) => {
+        if (!message[0].includes('Eufemia')) {
+          originalConsoleLog(...message)
+        }
+      })
+    })
+    afterEach(() => {
+      log.mockRestore()
+    })
+
+    it('should disable form elements during submit indicator when formStatus is pending', () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.String value="Value" />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+      const inputElement = document.querySelector('input')
+
+      fireEvent.click(buttonElement)
+
+      expect(buttonElement).toBeDisabled()
+      expect(inputElement).toBeDisabled()
+    })
+
+    it('should not disable form elements during on async validator handling', async () => {
+      const onSubmit = async () => null
+      const asyncValidator = async () => {
+        return null
+      }
+
+      const { rerender } = render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.String value="Value" onBlurValidator={asyncValidator} />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+      const inputElement = document.querySelector('input')
+
+      await userEvent.type(inputElement, '1')
+      fireEvent.blur(inputElement)
+
+      expect(inputElement).toBeDisabled()
+      expect(buttonElement).not.toBeDisabled()
+
+      rerender(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.String value="Value" validator={asyncValidator} />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      await userEvent.type(inputElement, '2')
+
+      expect(inputElement).not.toBeDisabled()
+      expect(buttonElement).not.toBeDisabled()
+    })
+
+    it('should abort async submit when onSubmit returns error', async () => {
+      const onSubmit = jest.fn(async () => {
+        await wait(1)
+
+        return new Error('Error message')
+      })
+
+      render(
+        <Form.Handler
+          onSubmit={onSubmit}
+          minimumAsyncBehaviorTime={30000} // with a hight wait time, we ensure the Error will abort it
+        >
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+
+      expect(
+        document.querySelector('.dnb-form-submit-indicator--state-pending')
+      ).toBeTruthy()
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        'Error message'
+      )
+
+      expect(
+        document.querySelector('.dnb-form-submit-indicator--state-pending')
+      ).toBeNull()
+    })
+
+    it('should abort async submit onSubmit using asyncBehaviorTimeout', async () => {
+      const onSubmit = jest.fn().mockImplementation(async () => null)
+
+      render(
+        <Form.Handler
+          onSubmit={onSubmit}
+          minimumAsyncBehaviorTime={30000} // with a hight wait time, we ensure the Error will abort it
+          asyncBehaviorTimeout={1}
+        >
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+
+      expect(
+        document.querySelector('.dnb-form-submit-indicator--state-pending')
+      ).toBeTruthy()
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-form-submit-indicator--state-pending'
+          )
+        ).toBeNull()
+      })
+    })
+
+    it('should call onSubmit and onSubmitComplete on async submit call', async () => {
+      const onSubmit = jest.fn()
+      const onSubmitComplete = jest.fn()
+
+      render(
+        <Form.Handler
+          onSubmit={onSubmit}
+          onSubmitComplete={onSubmitComplete}
+        >
+          <Field.String value="bar" path="/foo" />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { foo: 'bar' },
+          {
+            clearData: expect.any(Function),
+            resetForm: expect.any(Function),
+          }
+        )
+
+        expect(onSubmitComplete).toHaveBeenCalledTimes(1)
+        expect(onSubmitComplete).toHaveBeenCalledWith(
+          { foo: 'bar' },
+          undefined
+        )
+      })
+    })
+
+    it('should call onSubmit and onSubmitComplete with async validator', async () => {
+      const onSubmit = jest.fn()
+      const onSubmitComplete = jest.fn()
+
+      const asyncValidator = async () => {
+        return null
+      }
+
+      render(
+        <Form.Handler
+          onSubmit={onSubmit}
+          onSubmitComplete={onSubmitComplete}
+        >
+          <Field.String
+            value="bar"
+            path="/foo"
+            validator={asyncValidator}
+          />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { foo: 'bar' },
+          {
+            clearData: expect.any(Function),
+            resetForm: expect.any(Function),
+          }
+        )
+
+        expect(onSubmitComplete).toHaveBeenCalledTimes(1)
+        expect(onSubmitComplete).toHaveBeenCalledWith(
+          { foo: 'bar' },
+          undefined
+        )
+      })
+    })
+
+    it('should not call async validator when field is not mounted anymore', async () => {
+      const onSubmit = jest.fn()
+      const asyncValidator = jest.fn(async () => {
+        return null
+      })
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.String
+            value="bar"
+            path="/foo"
+            validator={asyncValidator}
+          />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { foo: 'bar' },
+          {
+            clearData: expect.any(Function),
+            resetForm: expect.any(Function),
+          }
+        )
+
+        expect(asyncValidator).toHaveBeenCalledTimes(1)
+        expect(asyncValidator).toHaveBeenCalledWith('bar', {
+          maxLength: expect.any(String),
+          minLength: expect.any(String),
+          pattern: expect.any(String),
+          required: expect.any(String),
+        })
+      })
+    })
+
+    it('should accept custom minimumAsyncBehaviorTimevalue', async () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit} minimumAsyncBehaviorTime={2}>
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+
+      fireEvent.click(buttonElement)
+
+      expect(buttonElement).toBeDisabled()
+
+      await wait(4)
+
+      expect(buttonElement).toBeDisabled()
+
+      await waitFor(() => {
+        expect(buttonElement).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('SubmitIndicator', () => {
+    it('should show SubmitIndicator when formStatus is pending', async () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+      fireEvent.click(buttonElement)
+
+      expect(
+        document.querySelector('.dnb-form-submit-indicator--state-pending')
+      ).toBeTruthy()
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-form-submit-indicator--state-pending'
+          )
+        ).toBeNull()
+      })
+    })
+
+    it('should show SubmitIndicator when onSubmit is async', async () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const buttonElement = document.querySelector('button')
+      fireEvent.click(buttonElement)
+
+      expect(
+        document.querySelector('.dnb-form-submit-indicator--state-pending')
+      ).toBeTruthy()
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-form-submit-indicator--state-pending'
+          )
+        ).toBeNull()
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,0 +1,292 @@
+import React, { useCallback } from 'react'
+import { Field, FieldBlock, Form } from '../../..'
+import { Button, Card } from '../../../../../components'
+import { debounceAsync } from '../../../../../shared/helpers'
+
+export default {
+  title: 'Eufemia/Extensions/Forms/FormHandler',
+}
+
+let requestTimeoutOffset = 1000
+const debug = console.log
+
+type CreateRequestReturn = Promise<{ hasError: boolean; cancel?: boolean }>
+
+export const createRequest = () => {
+  let timeout: NodeJS.Timeout | null
+  let resolvePromise: ((value?: unknown) => void) | undefined
+
+  const fn = (t: number): CreateRequestReturn => {
+    return new Promise((resolve) => {
+      resolvePromise = resolve
+      timeout = setTimeout(() => {
+        resolve({ hasError: false })
+      }, t)
+    })
+  }
+
+  fn.cancel = () => {
+    resolvePromise?.({ hasError: true })
+    clearTimeout(timeout)
+    timeout = null
+  }
+
+  return fn
+}
+
+const firstValidator = debounceAsync(async function firstValidator(
+  value: string
+) {
+  const start = Date.now()
+  debug('Validation request 1', value, start)
+
+  const request = createRequest()
+  const wasCanceled = this.addCancelEvent(request.cancel)
+  await request(requestTimeoutOffset * 3) // Simulate a request
+
+  if (wasCanceled()) {
+    return new Error(
+      `Validation request 1 canceled after ${String(Date.now() - start)}ms`
+    )
+  } else {
+    debug('Validation request 1 done in:', Date.now() - start)
+  }
+
+  if (!wasCanceled() && value !== 'valid') {
+    return new Error('Custom error (A) with invalid value: ' + value) // Show this message
+  }
+})
+
+const secondValidator = debounceAsync(async function secondValidator(
+  value: string
+) {
+  const start = Date.now()
+  debug('Validation request 2', value, start)
+
+  const request = createRequest()
+  const wasCanceled = this.addCancelEvent(request.cancel)
+  await request(requestTimeoutOffset * 1) // Simulate a request
+
+  if (wasCanceled()) {
+    return new Error(
+      `Validation request 2 canceled after ${String(Date.now() - start)}ms`
+    )
+  } else {
+    debug('Validation request 2 done in:', Date.now() - start)
+  }
+
+  if (!wasCanceled() && value !== 'valid') {
+    return new Error('Custom error (B) with invalid value: ' + value) // Show this message
+  }
+})
+
+const thirdValidator = debounceAsync(async function thirdValidator(
+  value: string
+) {
+  const start = Date.now()
+  debug('Validation request 3', value, start)
+
+  const request = createRequest()
+  const wasCanceled = this.addCancelEvent(request.cancel)
+  await request(requestTimeoutOffset * 2) // Simulate a request
+
+  if (wasCanceled()) {
+    return new Error(
+      `Validation request 3 canceled after ${String(Date.now() - start)}ms`
+    )
+  } else {
+    debug('Validation request 3 done in:', Date.now() - start)
+  }
+
+  if (!wasCanceled() && value !== 'valid') {
+    return new Error('Custom error (C) with invalid value: ' + value) // Show this message
+  }
+}, 500)
+
+const submitHandler = debounceAsync(async function submit(data) {
+  const start = Date.now()
+  debug('Submit of data started:', data, start)
+
+  const request = createRequest()
+  const wasCanceled = this.addCancelEvent(request.cancel)
+  await request(requestTimeoutOffset * 2) // Simulate a submit request
+
+  if (wasCanceled()) {
+    debug('Submit of data canceled after', Date.now() - start)
+    return new Error('Submit of data canceled')
+  } else {
+    debug('Submit of data done in:', Date.now() - start)
+  }
+})
+
+const initialData = { fieldA: 'valid', fieldB: 'valid', fieldC: 'valid' }
+
+export function AdvancedForm() {
+  const { cancelHandler } = useCancelAsyncOperations()
+
+  return (
+    <>
+      <Form.Handler onSubmit={submitHandler} data={initialData}>
+        <Form.MainHeading>MainHeading</Form.MainHeading>
+        <Card stack>
+          <Form.SubHeading>SubHeading</Form.SubHeading>
+
+          <Field.String
+            label="Field A (onBlurValidator)"
+            path="/fieldA"
+            onBlurValidator={firstValidator}
+            // validator={firstValidator}
+            // continuousValidation
+            // validateInitially
+            // validateUnchanged
+          />
+
+          <FieldBlock
+            // info="Info at the bottom"
+            width="large"
+            composition
+          >
+            <Field.String
+              label="Field B with a long label (onBlurValidator)"
+              width="medium"
+              path="/fieldB"
+              onBlurValidator={secondValidator}
+            />
+            <Field.String
+              label="Field C (validator)"
+              width="stretch"
+              path="/fieldC"
+              validator={thirdValidator}
+              // validateInitially
+              // required
+            />
+          </FieldBlock>
+
+          <Field.String
+            label="Field D (required)"
+            path="/fieldD"
+            required
+          />
+        </Card>
+
+        <Form.ButtonRow>
+          <Form.SubmitButton />
+          <Button
+            text="Stop async operations"
+            variant="secondary"
+            disabled={false}
+            onClick={cancelHandler}
+          />
+        </Form.ButtonRow>
+      </Form.Handler>
+
+      <Card top>
+        <Options />
+      </Card>
+    </>
+  )
+}
+
+function useCancelAsyncOperations() {
+  const cancelHandler = useCallback(() => {
+    firstValidator.cancel()
+    secondValidator.cancel()
+    thirdValidator.cancel()
+    submitHandler.cancel()
+  }, [])
+
+  return { cancelHandler }
+}
+
+function Options() {
+  const handleSliderChange = useCallback((value) => {
+    requestTimeoutOffset = value
+  }, [])
+
+  return (
+    <Field.Number
+      width="small"
+      label="Request timeout offset (ms)"
+      onChange={handleSliderChange}
+      value={requestTimeoutOffset}
+      minimum={0}
+      maximum={8000}
+      step={500}
+      showStepControls
+    />
+  )
+}
+
+const onSubmit = async function (data) {
+  console.log('onSubmit', data)
+  const request = createRequest()
+
+  await request(1000) // Simulate a request
+
+  // return new Error('My error')
+  return {
+    error: Error('My error'),
+    warning: 'Message',
+    info: 'Info',
+    // status: 'pending',
+  } as const
+}
+
+const onFormChange = debounceAsync(async function (data) {
+  console.log('onFormChange', data)
+  const request = createRequest()
+
+  await request(500) // Simulate a request
+  console.log('onFormChange done')
+
+  // return new Error('My error')
+  return { warning: 'Warning message' }
+}, 500)
+
+const onFieldChange = debounceAsync(async function (value) {
+  console.log('onFieldChange with value', value)
+  const request = createRequest()
+
+  await request(500) // Simulate a request
+  console.log('onFieldChange done', value)
+
+  // return new Error('My error')
+  return { info: value || null, success: 'saved' } as const
+}, 500)
+
+const onSubmitRequest = () => {
+  console.log('onSubmitRequest')
+}
+const onSubmitComplete = (data, result) => {
+  console.log('onSubmitComplete', data, result)
+}
+
+export function SimpleForm() {
+  return (
+    <Form.Handler
+      onSubmit={onSubmit}
+      onChange={onFormChange}
+      onSubmitRequest={onSubmitRequest}
+      onSubmitComplete={onSubmitComplete}
+    >
+      <Card stack>
+        <Field.String
+          value="vali"
+          label="Name"
+          path="/myField1"
+          validator={secondValidator}
+          onBlurValidator={thirdValidator}
+          onChange={onFieldChange}
+        />
+        <Field.String
+          label="This is a long label that will wrap after a certain length"
+          path="/myField2"
+          onChange={onFieldChange}
+        />
+      </Card>
+      <Form.ButtonRow>
+        <Form.SubmitButton />
+      </Form.ButtonRow>
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -17,17 +17,14 @@ export type Props = {
 
 function SubmitButton(props: Props) {
   const sharedContext = useContext(SharedContext)
-  const {
-    className,
-    showIndicator,
-    children = sharedContext?.translation.Forms.contextSubmit,
-    ...rest
-  } = props
-  const {
-    // formState, // will be enabled in a follow-up PR
-    handleSubmit,
-    _isInsideFormElement,
-  } = useContext(DataContext) || {}
+
+  const { className, showIndicator, children, text, ...rest } = props
+
+  const content =
+    text || children || sharedContext?.translation.Forms.contextSubmit
+
+  const { formState, handleSubmit, _isInsideFormElement } =
+    useContext(DataContext) || {}
 
   const onClickHandler = useCallback(() => {
     if (!_isInsideFormElement) {
@@ -42,12 +39,11 @@ function SubmitButton(props: Props) {
       type="submit"
       {...rest}
     >
-      {children}
+      {content}
 
       <SubmitIndicator
         state={
-          showIndicator ? 'pending' : undefined
-          // showIndicator ? 'pending' : formState // will be enabled in a follow-up PR
+          showIndicator ? 'pending' : formState // will be enabled in a follow-up PR
         }
       />
     </Button>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/__tests__/SubmitButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/__tests__/SubmitButton.test.tsx
@@ -197,4 +197,24 @@ describe('Form.SubmitButton', () => {
       'Vennligst vent ...'
     )
   })
+
+  it('should support custom text with submit indicator', () => {
+    const { rerender } = render(<Form.SubmitButton text="Save" />)
+
+    const buttonElement = document.querySelector('button')
+    const indicatorElement = buttonElement.querySelector(
+      '.dnb-form-submit-indicator'
+    )
+
+    expect(indicatorElement).not.toHaveClass(
+      'dnb-form-submit-indicator--state-pending'
+    )
+
+    rerender(<Form.SubmitButton text="Save" showIndicator />)
+
+    expect(buttonElement).toHaveTextContent('Save...')
+    expect(indicatorElement).toHaveClass(
+      'dnb-form-submit-indicator--state-pending'
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/__tests__/SubmitButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/__tests__/SubmitButton.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, render } from '@testing-library/react'
 import { Form, Field } from '../../..'
 import { Provider } from '../../../../../shared'
 
+afterEach(() => {
+  // Reset locale to nb-NO
+  render(<Provider locale="nb-NO">nothing</Provider>)
+})
+
 describe('Form.SubmitButton', () => {
   it('should call "onSubmit" on form element', () => {
     const onSubmit = jest.fn()
@@ -147,7 +152,7 @@ describe('Form.SubmitButton', () => {
     expect(buttonElement.getAttribute('aria-label')).toBe('Aria Label')
   })
 
-  it('should show submit indicator when showIndicator is true', async () => {
+  it('should show submit indicator when showIndicator is true', () => {
     const { rerender } = render(<Form.SubmitButton showIndicator />)
 
     const buttonElement = document.querySelector('button')
@@ -163,5 +168,33 @@ describe('Form.SubmitButton', () => {
     expect(
       document.querySelector('.dnb-form-submit-indicator--state-pending')
     ).toBeNull()
+  })
+
+  it('should contain submit indicator and its aria features', () => {
+    const { rerender } = render(<Form.SubmitButton />)
+
+    const buttonElement = document.querySelector('button')
+    const indicatorElement = buttonElement.querySelector(
+      '.dnb-form-submit-indicator'
+    )
+    const indicatorContentElement = buttonElement.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
+
+    expect(indicatorElement).not.toHaveClass(
+      'dnb-form-submit-indicator--state-pending'
+    )
+
+    rerender(<Form.SubmitButton showIndicator />)
+
+    expect(buttonElement).toHaveTextContent('Send...')
+    expect(indicatorElement).toHaveClass(
+      'dnb-form-submit-indicator--state-pending'
+    )
+    expect(indicatorContentElement).toHaveAttribute('role', 'status')
+    expect(indicatorContentElement).toHaveAttribute(
+      'aria-label',
+      'Vennligst vent ...'
+    )
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/SubmitIndicator.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/SubmitIndicator.tsx
@@ -1,7 +1,8 @@
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import classnames from 'classnames'
-import { Space } from '../../../../components'
+import { Icon, Space, Tooltip } from '../../../../components'
 import type { SpaceProps } from '../../../../components/Space'
+import { check } from '../../../../icons'
 import type { SubmitState } from '../../types'
 import {
   omitSpacingProps,
@@ -12,11 +13,18 @@ import { useLocale } from '../../../../shared'
 export type Props = {
   state: SubmitState
   className?: string
+  successLabel?: string
   children?: React.ReactNode
 } & SpaceProps
 
 function SubmitIndicator(props: Props) {
-  const { className, children, state, ...rest } = props
+  const {
+    className,
+    children,
+    state,
+    successLabel = 'Saved',
+    ...rest
+  } = props
   const tr = useLocale()
   const childrenRef = useRef<HTMLSpanElement>(null)
   const [willWrap, setWillWrap] = useState(false)
@@ -37,15 +45,34 @@ function SubmitIndicator(props: Props) {
     ...pickSpacingProps(rest),
   } as SpaceProps
 
-  const dot = <span>.</span>
-  const dots = (
+  const ariaAttributes =
+    state === 'pending'
+      ? {
+          role: 'status',
+          'aria-busy': true,
+          'aria-label': tr.ProgressIndicator.indicator_label,
+        }
+      : {}
+
+  const dot = <b>.</b>
+  const indicator = (
     <span
-      className="dnb-form-submit-indicator__dots"
-      aria-busy={true}
-      aria-label={tr.ProgressIndicator.indicator_label}
+      className="dnb-form-submit-indicator__content"
+      {...ariaAttributes}
       {...omitSpacingProps(rest)}
     >
-      {state && (
+      {state === 'success' && (
+        <Tooltip
+          targetElement={
+            <span>
+              <Icon icon={check} />
+            </span>
+          }
+        >
+          {successLabel}
+        </Tooltip>
+      )}
+      {state && state !== 'success' && state !== 'abort' && (
         <>
           {dot}
           {dot}
@@ -58,7 +85,7 @@ function SubmitIndicator(props: Props) {
   return (
     <Space {...params} element="span">
       {children && <span ref={childrenRef}>{children}</span>}
-      {dots}
+      {indicator}
     </Space>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/SubmitIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/SubmitIndicatorDocs.ts
@@ -2,12 +2,12 @@ import { PropertiesTableProps } from '../../../../shared/types'
 
 export const SubmitIndicatorProperties: PropertiesTableProps = {
   state: {
-    doc: 'Provide `pending` to make it visible.',
+    doc: 'Provide `pending` to make the dots visible and `success` to show the checkmark icon.',
     type: 'string',
     status: 'required',
   },
   children: {
-    doc: 'If content is provided, the component will try to find out if the indicator needs to be put on a new row or not. This way it will animate the height.',
+    doc: 'If content is provided, the component will try to find out if the indicator needs to be put on a new row or not. This way it will animate the height nicely.',
     type: 'React.Node',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/__tests__/SubmitIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/__tests__/SubmitIndicator.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { Form } from '../../..'
 import locales from '../../../../../shared/locales'
+import { axeComponent } from '../../../../../core/jest/jestSetup'
 
 const nbNO = locales['nb-NO']
 
@@ -46,7 +47,9 @@ describe('Form.SubmitIndicator', () => {
     )
 
     const element = document.querySelector('.dnb-form-submit-indicator')
-    const dots = document.querySelector('.dnb-form-submit-indicator__dots')
+    const dots = document.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
 
     expect(
       Array.from(element.attributes).map((attr) => attr.name)
@@ -54,16 +57,45 @@ describe('Form.SubmitIndicator', () => {
 
     expect(Array.from(dots.attributes).map((attr) => attr.name)).toEqual([
       'class',
+      'role',
       'aria-busy',
       'aria-label',
     ])
     expect(dots).toHaveAttribute('aria-label', 'Custom Label')
   })
 
+  it('should validate with ARIA rules', async () => {
+    const result = render(<Form.SubmitIndicator state="pending" />)
+
+    expect(await axeComponent(result)).toHaveNoViolations()
+  })
+
+  it('should not have role of status when state is not pending', () => {
+    render(<Form.SubmitIndicator state="abort" />)
+
+    const dots = document.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
+
+    expect(dots).not.toHaveAttribute('role', 'status')
+  })
+
+  it('should role of status', () => {
+    render(<Form.SubmitIndicator state="pending" />)
+
+    const dots = document.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
+
+    expect(dots).toHaveAttribute('role', 'status')
+  })
+
   it('should have aria-busy', () => {
     render(<Form.SubmitIndicator state="pending" />)
 
-    const dots = document.querySelector('.dnb-form-submit-indicator__dots')
+    const dots = document.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
 
     expect(dots).toHaveAttribute('aria-busy', 'true')
   })
@@ -71,7 +103,9 @@ describe('Form.SubmitIndicator', () => {
   it('should have default aria-label', () => {
     render(<Form.SubmitIndicator state="pending" />)
 
-    const dots = document.querySelector('.dnb-form-submit-indicator__dots')
+    const dots = document.querySelector(
+      '.dnb-form-submit-indicator__content'
+    )
 
     expect(dots).toHaveAttribute(
       'aria-label',
@@ -90,6 +124,21 @@ describe('Form.SubmitIndicator', () => {
     expect(element).toHaveClass(
       'dnb-form-submit-indicator--state-complete'
     )
+  })
+
+  it('should not add dots when state is "success" or "abort"', () => {
+    const { rerender } = render(<Form.SubmitIndicator state="abort" />)
+
+    const element = document.querySelector('.dnb-form-submit-indicator')
+    expect(element).toHaveTextContent('')
+
+    rerender(<Form.SubmitIndicator state="success" />)
+
+    expect(element).toHaveTextContent('')
+
+    rerender(<Form.SubmitIndicator state="complete" />)
+
+    expect(element).toHaveTextContent('...')
   })
 
   it('should check if a newline is needed', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
@@ -3,19 +3,21 @@
 .dnb-form-submit-indicator {
   display: inline;
 
-  &__dots {
-    font-weight: var(--font-weight-bold);
+  --padding-left: 0.5em;
+
+  &__content {
     font-size: 0;
     line-height: 1em;
 
+    will-change: font-size;
     transition: font-size 800ms var(--easing-default);
 
-    span {
+    b {
       padding-left: 0.125em;
       color: var(--dots-color, currentColor);
 
       &:nth-of-type(1) {
-        padding-left: 0.25em;
+        padding-left: var(--padding-left);
         animation-delay: 50ms;
       }
       &:nth-of-type(2) {
@@ -27,7 +29,7 @@
 
       opacity: 0.2;
 
-      animation-name: submit-indicator-dots;
+      animation-name: submit-indicator-dot;
       animation-iteration-count: infinite;
       animation-duration: 1.3s;
       animation-delay: 200ms; // to get a nicer fade in
@@ -36,29 +38,46 @@
         animation: none;
       }
     }
+  }
 
-    &::before {
-      content: ' '; // To ensure we can "wrap" with "--inline-wrap"
+  &--state-pending &__content {
+    font-size: 1em;
+    font-weight: var(--font-weight-bold);
+  }
+  &--state-success &__content {
+    font-size: 1em;
+    // opacity: 0;
+    // font-size: 0;
+    // white-space: nowrap;
+
+    // animation-name: submit-indicator-success;
+    // animation-duration: 5s;
+
+    .dnb-icon {
+      padding-left: var(--padding-left);
+      color: var(--color-success-green);
+    }
+    .dnb-icon--default {
+      font-size: 1em;
+    }
+
+    &__label {
+      font-size: var(--font-size-small);
+      padding-left: calc(var(--padding-left) * 2);
     }
   }
-
-  &--state-pending &__dots {
-    font-size: 1em;
-  }
-  &--inline-wrap &__dots {
+  &--inline-wrap &__content {
     display: flex;
 
-    i:nth-of-type(1) {
-      padding-left: 0;
-    }
+    --padding-left: 0.25em;
   }
 }
 
-@keyframes submit-indicator-dots {
+@keyframes submit-indicator-dot {
   0% {
     opacity: 0.2;
   }
-  20% {
+  15% {
     opacity: 1;
   }
   50% {
@@ -69,5 +88,30 @@
   }
   100% {
     opacity: 0.2;
+  }
+}
+
+@keyframes submit-indicator-success {
+  0% {
+    opacity: 0.2;
+    font-size: 1em;
+  }
+  20% {
+    opacity: 1;
+    font-size: 1em;
+  }
+  80% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 0.3;
+    font-size: 1em;
+  }
+  90% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+    font-size: 0;
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
@@ -87,7 +87,7 @@ export default function useData<Data>(
       pointer.set(existingData, path, newValue)
 
       // update provider
-      sharedDataRef.current.update(existingData)
+      sharedDataRef.current.extend(existingData)
     },
     []
   )

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayout.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayout.tsx
@@ -1,8 +1,9 @@
-import React, { useContext, useState, useCallback } from 'react'
+import React, { useContext, useCallback, useRef, useReducer } from 'react'
 import classnames from 'classnames'
 import { Space, StepIndicator } from '../../../components'
 import { warn } from '../../../shared/component-helper'
-import { ComponentProps } from '../types'
+import { isAsync } from '../../../shared/helpers/isAsync'
+import useId from '../../../shared/helpers/useId'
 import DataContext from '../DataContext/Context'
 import Step, { Props as StepProps } from './Step'
 import StepsContext from './StepsContext'
@@ -10,14 +11,20 @@ import NextButton from './NextButton'
 import PreviousButton from './PreviousButton'
 import Buttons from './Buttons'
 import Provider from '../DataContext/Provider'
-import useId from '../../../shared/helpers/useId'
+import { ComponentProps, EventReturnWithStateObject } from '../types'
 
 export type Props = ComponentProps & {
   id?: string
   mode?: 'static' | 'strict' | 'loose'
   scrollTopOnStepChange?: boolean
   initialActiveIndex?: number
-  onStepChange?: (index: number) => void
+  onStepChange?: (
+    index: number,
+    mode: 'previous' | 'next'
+  ) =>
+    | EventReturnWithStateObject
+    | void
+    | Promise<EventReturnWithStateObject | void>
   children: React.ReactNode
   variant?: 'sidebar' | 'drawer'
   noAnimation?: boolean
@@ -39,41 +46,105 @@ function StepsLayout(props: Props) {
     ...rest
   } = props
   const dataContext = useContext(DataContext)
-  const { hasContext, hasErrors, setShowAllErrors, scrollToTop } =
-    dataContext
-
-  const [activeIndex, setActiveIndex] =
-    useState<number>(initialActiveIndex)
+  const {
+    hasContext,
+    setFormState,
+    handleSubmitCall,
+    setShowAllErrors,
+    showAllErrors,
+    scrollToTop,
+  } = dataContext
 
   const id = useId(_id)
+  const [, forceUpdate] = useReducer(() => ({}), {})
+  const activeIndexRef = useRef<number>(initialActiveIndex)
+  const errorOnStepRef = useRef<Record<number, boolean>>({})
+
+  // Store the current state of showAllErrors
+  errorOnStepRef.current[activeIndexRef.current] = showAllErrors
+
+  const callOnStepChange = useCallback(
+    async (index: number, mode: 'previous' | 'next') => {
+      if (isAsync(onStepChange)) {
+        return await onStepChange(index, mode)
+      }
+
+      return onStepChange?.(index, mode)
+    },
+    [onStepChange]
+  )
 
   const handlePrevious = useCallback(() => {
-    setActiveIndex((activeIndex) => {
-      onStepChange?.(activeIndex - 1)
-      return activeIndex - 1
-    })
-    if (scrollTopOnStepChange) {
-      scrollToTop()
-    }
-  }, [scrollTopOnStepChange, onStepChange, scrollToTop])
+    handleSubmitCall({
+      skipFieldValidation: true,
+      skipErrorCheck: true,
+      enableAsyncBehaviour: isAsync(onStepChange),
+      onSubmit: async () => {
+        const result = await callOnStepChange(
+          activeIndexRef.current - 1,
+          'previous'
+        )
 
-  const handleNext = useCallback(() => {
-    if (!hasErrors()) {
-      setActiveIndex((activeIndex) => {
-        onStepChange?.(activeIndex + 1)
-        return activeIndex + 1
-      })
-      if (scrollTopOnStepChange) {
-        scrollToTop()
-      }
-    } else {
-      setShowAllErrors(true)
-    }
+        // Hide async indicator
+        setFormState('abort')
+
+        if (!(result instanceof Error)) {
+          activeIndexRef.current = activeIndexRef.current - 1
+          forceUpdate()
+        }
+
+        if (scrollTopOnStepChange) {
+          scrollToTop()
+        }
+
+        return result
+      },
+    })
   }, [
-    hasErrors,
-    scrollTopOnStepChange,
+    callOnStepChange,
+    handleSubmitCall,
     onStepChange,
     scrollToTop,
+    scrollTopOnStepChange,
+    setFormState,
+  ])
+
+  const handleNext = useCallback(() => {
+    handleSubmitCall({
+      enableAsyncBehaviour: isAsync(onStepChange),
+      onSubmit: async () => {
+        const result = await callOnStepChange(
+          activeIndexRef.current + 1,
+          'next'
+        )
+
+        // Hide async indicator
+        setFormState('abort')
+
+        // Set the showAllErrors to the step we got to
+        setShowAllErrors(
+          errorOnStepRef.current[activeIndexRef.current + 1]
+        )
+
+        if (!(result instanceof Error)) {
+          activeIndexRef.current = activeIndexRef.current + 1
+          forceUpdate()
+        }
+
+        if (scrollTopOnStepChange) {
+          scrollToTop()
+        }
+
+        return result
+      },
+    })
+  }, [
+    callOnStepChange,
+    handleSubmitCall,
+    onStepChange,
+    scrollToTop,
+    scrollTopOnStepChange,
+    setFormState,
     setShowAllErrors,
   ])
 
@@ -84,9 +155,17 @@ function StepsLayout(props: Props) {
     return child.props.title ?? 'Title missing'
   }) as string[]
 
-  const handleChange = useCallback(({ current_step }) => {
-    setActiveIndex(current_step)
-  }, [])
+  const handleChange = useCallback(
+    ({ current_step }) => {
+      activeIndexRef.current = current_step
+
+      // Set the showAllErrors to the step we got to
+      setShowAllErrors(errorOnStepRef.current[current_step])
+
+      forceUpdate()
+    },
+    [setShowAllErrors]
+  )
 
   if (!hasContext) {
     warn('You may wrap StepsLayout in Form.Handler')
@@ -100,7 +179,7 @@ function StepsLayout(props: Props) {
   return (
     <StepsContext.Provider
       value={{
-        activeIndex,
+        activeIndex: activeIndexRef.current,
         handlePrevious,
         handleNext,
       }}
@@ -117,7 +196,7 @@ function StepsLayout(props: Props) {
           <StepIndicator.Sidebar sidebar_id={id} />
           <StepIndicator
             bottom
-            current_step={activeIndex}
+            current_step={activeIndexRef.current}
             data={stepIndicatorData}
             mode={mode}
             no_animation={noAnimation}

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayoutDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/StepsLayoutDocs.ts
@@ -1,0 +1,52 @@
+import { PropertiesTableProps } from '../../../shared/types'
+
+export const StepsLayoutProperties: PropertiesTableProps = {
+  initialActiveIndex: {
+    doc: 'What step should show initially (defaults to 0 for the first one).',
+    type: 'number',
+    status: 'optional',
+  },
+  mode: {
+    doc: 'How to show the steps. Inherited from StepIndicator. Defaults to `strict`.',
+    type: 'string',
+    status: 'optional',
+  },
+  variant: {
+    doc: 'Sets the StepIndicator to be either `sidebar` or `drawer`. Defaults to `sidebar`.',
+    type: 'string',
+    status: 'optional',
+  },
+  noAnimation: {
+    doc: 'Determines if the height animation for step items and the drawer button will run. Inherited from StepIndicator. Defaults to `true`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  sidebarId: {
+    doc: 'Sets the id for `<StepIndicator.Sidebar />` Inherited from StepIndicator.',
+    type: 'string',
+    status: 'required',
+  },
+  scrollTopOnStepChange: {
+    doc: 'True for the UI to scroll to the top of the page when navigating between steps.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  children: {
+    doc: 'Contents (Step components).',
+    type: 'React.Node',
+    status: 'required',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const StepsLayoutEvents: PropertiesTableProps = {
+  onStepChange: {
+    doc: 'Will be called when the user navigate to a different step, with step `index` as the first argument and `previous` or `next` (string) as the second argument. When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related Form.Handler props: `minimumAsyncBehaviorTime` and `asyncBehaviorTimeout`.',
+    type: 'function',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/__tests__/StepsLayout.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/__tests__/StepsLayout.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import StepsLayout from '../StepsLayout'
-import { Field } from '../..'
+import { Field, Form } from '../..'
+import userEvent from '@testing-library/user-event'
+
+import nbNO from '../../../../shared/locales/nb-NO'
+const nb = nbNO['nb-NO'].Forms
 
 jest.mock('../../../../shared/component-helper', () => {
   const original = jest.requireActual(
@@ -14,6 +18,19 @@ jest.mock('../../../../shared/component-helper', () => {
 })
 
 describe('StepsLayout', () => {
+  const previousButton = () => {
+    return document.querySelector('.dnb-forms-previous-button')
+  }
+  const nextButton = () => {
+    return document.querySelector('.dnb-forms-next-button')
+  }
+  const submitButton = () => {
+    return document.querySelector('.dnb-forms-submit-button')
+  }
+  const output = () => {
+    return document.querySelector('output')
+  }
+
   it('should have "strict" mode as the default mode', () => {
     render(
       <StepsLayout>
@@ -21,26 +38,26 @@ describe('StepsLayout', () => {
           <StepsLayout.NextButton />
         </StepsLayout.Step>
         <StepsLayout.Step title="Step 2">
-          <StepsLayout.NextButton />
+          <StepsLayout.PreviousButton />
         </StepsLayout.Step>
       </StepsLayout>
     )
 
-    const [first] = Array.from(
+    const [firstStep, secondStep] = Array.from(
       document.querySelectorAll('.dnb-step-indicator__item')
     )
 
-    expect(first.querySelector('button')).toBeInTheDocument()
+    expect(firstStep.querySelector('.dnb-button').tagName).toBe('BUTTON')
+    expect(secondStep.querySelector('.dnb-button').tagName).toBe('SPAN')
   })
 
-  it('should call event listener onStepChange', () => {
-    const onChange = jest.fn()
+  it('should call event listener onStepChange', async () => {
+    const onStepChange = jest.fn()
 
     render(
-      <StepsLayout onStepChange={onChange} mode="loose">
+      <StepsLayout onStepChange={onStepChange} mode="loose">
         <StepsLayout.Step title="Step 1">
           <output>Step 1</output>
-          <StepsLayout.PreviousButton />
           <StepsLayout.NextButton />
         </StepsLayout.Step>
 
@@ -52,40 +69,42 @@ describe('StepsLayout', () => {
       </StepsLayout>
     )
 
-    const [first, second] = Array.from(
+    const [firstStep, secondStep] = Array.from(
       document.querySelectorAll('.dnb-step-indicator__item')
     )
 
-    fireEvent.click(second.querySelector('button'))
-    expect(document.querySelector('output').textContent).toBe('Step 2')
-    expect(onChange).not.toHaveBeenCalledWith(2)
-    expect(onChange).toHaveBeenCalledTimes(0)
+    fireEvent.click(secondStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 2')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
 
-    fireEvent.click(first.querySelector('button'))
-    expect(document.querySelector('output').textContent).toBe('Step 1')
-    expect(onChange).not.toHaveBeenCalledWith(1)
-    expect(onChange).toHaveBeenCalledTimes(0)
+    fireEvent.click(firstStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 1')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
 
-    const nextButton = document.querySelector('.dnb-forms-next-button')
-    fireEvent.click(nextButton)
-    expect(onChange).toHaveBeenCalledWith(1)
-    expect(nextButton).not.toBeInTheDocument()
+    fireEvent.click(nextButton())
+    expect(nextButton()).not.toBeDisabled()
 
-    const previousButton = document.querySelector(
-      '.dnb-forms-previous-button'
-    )
-    fireEvent.click(previousButton)
-    expect(onChange).toHaveBeenCalledWith(1)
-    expect(previousButton).not.toBeInTheDocument()
-    expect(onChange).toHaveBeenCalledTimes(2)
+    await waitFor(() => {
+      expect(onStepChange).toHaveBeenLastCalledWith(1, 'next')
+      expect(previousButton()).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(previousButton())
+    expect(previousButton()).not.toBeDisabled()
+
+    await waitFor(() => {
+      expect(onStepChange).toHaveBeenCalledTimes(2)
+      expect(onStepChange).toHaveBeenLastCalledWith(0, 'previous')
+      expect(previousButton()).not.toBeInTheDocument()
+    })
   })
 
-  it('should scroll to top on step change when scrollTopOnStepChange is true', () => {
+  it('should scroll to top on step change when scrollTopOnStepChange is true', async () => {
     const scrollTo = jest.fn()
     jest.spyOn(window, 'scrollTo').mockImplementation(scrollTo)
 
     render(
-      <StepsLayout mode="loose" scrollTopOnStepChange>
+      <StepsLayout scrollTopOnStepChange>
         <StepsLayout.Step title="Step 1">
           <output>Step 1</output>
           <StepsLayout.PreviousButton />
@@ -100,26 +119,28 @@ describe('StepsLayout', () => {
       </StepsLayout>
     )
 
-    const nextButton = document.querySelector('.dnb-forms-next-button')
-    fireEvent.click(nextButton)
-    expect(scrollTo).toHaveBeenCalledTimes(1)
+    fireEvent.click(nextButton())
 
-    const previousButton = document.querySelector(
-      '.dnb-forms-previous-button'
-    )
-    fireEvent.click(previousButton)
-    expect(scrollTo).toHaveBeenCalledTimes(2)
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledTimes(1)
+    })
 
-    const [first, second] = Array.from(
+    fireEvent.click(previousButton())
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledTimes(2)
+    })
+
+    const [firstStep, secondStep] = Array.from(
       document.querySelectorAll('.dnb-step-indicator__item')
     )
 
-    fireEvent.click(second.querySelector('button'))
-    expect(document.querySelector('output').textContent).toBe('Step 2')
+    fireEvent.click(secondStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 2')
     expect(scrollTo).toHaveBeenCalledTimes(2)
 
-    fireEvent.click(first.querySelector('button'))
-    expect(document.querySelector('output').textContent).toBe('Step 1')
+    fireEvent.click(firstStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 1')
     expect(scrollTo).toHaveBeenCalledTimes(2)
   })
 
@@ -141,23 +162,21 @@ describe('StepsLayout', () => {
       </StepsLayout>
     )
 
-    const nextButton = document.querySelector('.dnb-forms-next-button')
-
-    expect(document.querySelector('output')).toHaveTextContent('Step 1')
+    expect(output()).toHaveTextContent('Step 1')
     expect(screen.queryByRole('alert')).toBeNull()
 
-    fireEvent.click(nextButton)
+    fireEvent.click(nextButton())
 
-    expect(document.querySelector('output')).toHaveTextContent('Step 1')
+    expect(output()).toHaveTextContent('Step 1')
     expect(screen.queryByRole('alert')).toBeInTheDocument()
   })
 
-  it('should show error on navigating back and forth', () => {
+  it('should show error on navigating back and forth', async () => {
     render(
       <StepsLayout>
         <StepsLayout.Step title="Step 1">
           <output>Step 1</output>
-          <Field.String />
+          <Field.String path="/something" />
           <StepsLayout.PreviousButton />
           <StepsLayout.NextButton />
         </StepsLayout.Step>
@@ -177,34 +196,211 @@ describe('StepsLayout', () => {
       </StepsLayout>
     )
 
-    const output = () => document.querySelector('output')
-    const nextButton = () =>
-      document.querySelector('.dnb-forms-next-button')
-    const previousButton = () =>
-      document.querySelector('.dnb-forms-previous-button')
-
     expect(output()).toHaveTextContent('Step 1')
     expect(screen.queryByRole('alert')).toBeNull()
 
     fireEvent.click(nextButton())
 
-    expect(output()).toHaveTextContent('Step 2')
-    expect(screen.queryByRole('alert')).toBeNull()
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
 
     fireEvent.click(nextButton())
 
-    expect(output()).toHaveTextContent('Step 2')
-    expect(screen.queryByRole('alert')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    })
 
     fireEvent.click(previousButton())
 
-    expect(output()).toHaveTextContent('Step 1')
-    expect(screen.queryByRole('alert')).toBeNull()
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
 
     fireEvent.click(nextButton())
 
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    })
+
+    await userEvent.type(document.querySelector('input'), 'foo')
+    fireEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 3')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+  })
+
+  it('should support navigating back and forth with async validators', async () => {
+    const validator = async (value: string) => {
+      if (value !== 'valid') {
+        return new Error('validator-error')
+      }
+    }
+
+    const onBlurValidator = async (value: string) => {
+      if (value !== 'valid') {
+        return new Error('onBlurValidator-error')
+      }
+    }
+
+    render(
+      <StepsLayout>
+        <StepsLayout.Step title="Step 1">
+          <output>Step 1</output>
+          <Field.String
+            path="/foo"
+            required
+            validator={validator}
+            onBlurValidator={onBlurValidator}
+          />
+          <StepsLayout.PreviousButton />
+          <StepsLayout.NextButton />
+        </StepsLayout.Step>
+
+        <StepsLayout.Step title="Step 2">
+          <output>Step 2</output>
+          <Field.String path="/bar" required />
+          <StepsLayout.PreviousButton />
+          <StepsLayout.NextButton />
+        </StepsLayout.Step>
+
+        <StepsLayout.Step title="Step 3">
+          <StepsLayout.PreviousButton />
+        </StepsLayout.Step>
+      </StepsLayout>
+    )
+
+    const input = () => document.querySelector('input')
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    await userEvent.click(nextButton())
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toHaveTextContent(
+      nb.inputErrorRequired
+    )
+
+    await userEvent.type(input(), 'invalid')
+    fireEvent.click(nextButton())
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toHaveTextContent(
+      'validator-error'
+    )
+
+    fireEvent.blur(input())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        'onBlurValidator-error'
+      )
+    })
+
+    fireEvent.change(input(), { target: { value: 'valid' } })
+    await userEvent.click(nextButton())
+
     expect(output()).toHaveTextContent('Step 2')
-    expect(screen.queryByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    await userEvent.click(nextButton())
+
+    expect(output()).toHaveTextContent('Step 2')
+    expect(screen.queryByRole('alert')).toHaveTextContent(
+      nb.inputErrorRequired
+    )
+
+    await userEvent.click(previousButton())
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    await userEvent.type(input(), '{Backspace>8}invalid')
+    fireEvent.click(nextButton())
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toHaveTextContent(
+      'validator-error'
+    )
+
+    fireEvent.blur(input())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        'onBlurValidator-error'
+      )
+    })
+
+    fireEvent.change(input(), { target: { value: 'valid' } })
+    await userEvent.click(nextButton())
+
+    expect(output()).toHaveTextContent('Step 2')
+    expect(screen.queryByRole('alert')).toHaveTextContent(
+      nb.inputErrorRequired
+    )
+  }, 20000)
+
+  it('should show error on navigating back and forth in loose mode', async () => {
+    render(
+      <StepsLayout mode="loose">
+        <StepsLayout.Step title="Step 1">
+          <output>Step 1</output>
+          <Field.String path="/something" />
+          <StepsLayout.NextButton />
+        </StepsLayout.Step>
+
+        <StepsLayout.Step title="Step 2">
+          <output>Step 2</output>
+          <Field.String path="/foo" required />
+          <StepsLayout.NextButton />
+        </StepsLayout.Step>
+      </StepsLayout>
+    )
+
+    const [firstStep, secondStep] = Array.from(
+      document.querySelectorAll('.dnb-step-indicator__item')
+    )
+
+    expect(output()).toHaveTextContent('Step 1')
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    fireEvent.click(secondStep.querySelector('button'))
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    // Show the error message
+    fireEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    })
+
+    fireEvent.click(firstStep.querySelector('button'))
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    fireEvent.click(secondStep.querySelector('button'))
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('Step 2')
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    })
   })
 
   it('should support drawer variant', () => {
@@ -247,5 +443,372 @@ describe('StepsLayout', () => {
 
     expect(stepTrigger()).toBeInTheDocument()
     expect(stepsList()).not.toBeInTheDocument()
+  })
+
+  describe('async step change', () => {
+    it('should handle async onStepChange', async () => {
+      const onStepChange = async () => null
+
+      render(
+        <StepsLayout onStepChange={onStepChange}>
+          <StepsLayout.Step title="Step 1">
+            <output>Step 1</output>
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Step 2">
+            <output>Step 2</output>
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+        </StepsLayout>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(previousButton()).not.toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      fireEvent.click(previousButton())
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should handle async onSubmit', async () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <StepsLayout>
+            <StepsLayout.Step title="Step 1">
+              <output>Step 1</output>
+              <Form.ButtonRow>
+                <StepsLayout.PreviousButton />
+                <StepsLayout.NextButton />
+              </Form.ButtonRow>
+            </StepsLayout.Step>
+
+            <StepsLayout.Step title="Step 2">
+              <output>Step 2</output>
+              <Form.ButtonRow>
+                <StepsLayout.PreviousButton />
+                <Form.SubmitButton />
+              </Form.ButtonRow>
+            </StepsLayout.Step>
+          </StepsLayout>
+        </Form.Handler>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(previousButton()).not.toBeDisabled()
+        expect(submitButton()).not.toBeDisabled()
+      })
+
+      fireEvent.click(previousButton())
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(previousButton()).not.toBeDisabled()
+      expect(submitButton()).not.toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      fireEvent.click(nextButton())
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+      })
+
+      fireEvent.click(submitButton())
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(previousButton()).toBeDisabled()
+      expect(submitButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(previousButton()).not.toBeDisabled()
+        expect(submitButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should handle async validator', async () => {
+      const asyncValidator = async () => null
+
+      render(
+        <StepsLayout>
+          <StepsLayout.Step title="Step 1">
+            <output>Step 1</output>
+            <Field.String value="Value" validator={asyncValidator} />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Step 2">
+            <output>Step 2</output>
+            <Field.String required />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+        </StepsLayout>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(previousButton()).not.toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      fireEvent.click(previousButton())
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(previousButton()).not.toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should handle async validator with error', async () => {
+      const asyncValidator = async (value: string) => {
+        if (value !== 'valid') {
+          return new Error('Error message')
+        }
+      }
+
+      render(
+        <StepsLayout>
+          <StepsLayout.Step title="Step 1">
+            <output>Step 1</output>
+            <Field.String validator={asyncValidator} />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Step 2">
+            <output>Step 2</output>
+            <Field.String required />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+        </StepsLayout>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryAllByRole('alert')).toHaveLength(0)
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(screen.queryAllByRole('alert')).toHaveLength(1)
+        expect(screen.queryByRole('alert')).toHaveTextContent(
+          'Error message'
+        )
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      await userEvent.type(document.querySelector('input'), 'valid')
+
+      fireEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryAllByRole('alert')).toHaveLength(0)
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(screen.queryAllByRole('alert')).toHaveLength(0)
+        expect(previousButton()).not.toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should handle async onBlurValidator', async () => {
+      const onBlurValidator = async () => null
+
+      render(
+        <StepsLayout>
+          <StepsLayout.Step title="Step 1">
+            <output>Step 1</output>
+            <Field.String
+              value="Value"
+              onBlurValidator={onBlurValidator}
+            />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Step 2">
+            <output>Step 2</output>
+            <Field.String required />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+        </StepsLayout>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(previousButton()).not.toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      fireEvent.click(previousButton())
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(previousButton()).not.toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should handle async onBlurValidator with error', async () => {
+      const onBlurValidator = async (value: string) => {
+        if (value !== 'valid') {
+          return new Error('Error message')
+        }
+      }
+
+      render(
+        <StepsLayout>
+          <StepsLayout.Step title="Step 1">
+            <output>Step 1</output>
+            <Field.String onBlurValidator={onBlurValidator} />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+
+          <StepsLayout.Step title="Step 2">
+            <output>Step 2</output>
+            <Field.String required />
+            <Form.ButtonRow>
+              <StepsLayout.PreviousButton />
+              <StepsLayout.NextButton />
+            </Form.ButtonRow>
+          </StepsLayout.Step>
+        </StepsLayout>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryAllByRole('alert')).toHaveLength(0)
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).not.toBeDisabled()
+
+      fireEvent.click(nextButton())
+
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(screen.queryAllByRole('alert')).toHaveLength(1)
+        expect(screen.queryByRole('alert')).toHaveTextContent(
+          'Error message'
+        )
+        expect(previousButton()).toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+
+      await userEvent.type(document.querySelector('input'), 'valid')
+
+      fireEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryAllByRole('alert')).toHaveLength(0)
+      expect(previousButton()).toBeDisabled()
+      expect(nextButton()).toBeDisabled()
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 2')
+        expect(screen.queryAllByRole('alert')).toHaveLength(0)
+        expect(previousButton()).not.toBeDisabled()
+        expect(nextButton()).not.toBeDisabled()
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/stories/StepsLayout.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/stories/StepsLayout.stories.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import StepsLayout from '../StepsLayout'
 import { P } from '../../../../elements'
 import { Card } from '../../../../components'
-import { Form } from '../../Forms'
+import Field, { Form } from '../../Forms'
+import { createRequest } from '../../Form/Handler/stories/FormHandler.stories'
+import { debounceAsync } from '../../../../shared/helpers'
 
 export default {
   title: 'Eufemia/Extensions/Forms/StepsLayout',
@@ -63,5 +65,82 @@ export const StepsLayoutSandbox = () => {
         </StepsLayout.Step>
       </StepsLayout>
     </>
+  )
+}
+
+const validator1 = debounceAsync(async (value) => {
+  console.log('validator1', value)
+  const request = createRequest()
+  await request(300) // Simulate a request
+
+  if (value === 'invalid') {
+    return Error('Error message')
+  }
+})
+const validator2 = debounceAsync(async (value) => {
+  console.log('validator2', value)
+  const request = createRequest()
+  await request(300) // Simulate a request
+
+  if (value === 'invalid') {
+    return Error('Error message')
+  }
+})
+
+export function AsyncStepChange() {
+  const onStepChange = useCallback(async (index, mode) => {
+    console.log('onStepChange', index)
+
+    if (mode === 'next') {
+      const request = createRequest()
+      await request(300) // Simulate a request
+    }
+
+    return { info: 'Info message: ' + index }
+  }, [])
+
+  const onSubmit = useCallback(async (data) => {
+    console.log('onSubmit', data)
+
+    const request = createRequest()
+    await request(300) // Simulate a request
+
+    return { warning: 'Warning message' }
+  }, [])
+
+  return (
+    <Form.Handler onSubmit={onSubmit}>
+      <StepsLayout onStepChange={onStepChange} variant="drawer">
+        <StepsLayout.Step title="Step 1">
+          <Card stack>
+            <Field.String
+              label="Required field with async validator"
+              validator={validator1}
+              path="/field1"
+              required
+            />
+            <Field.String
+              label="Field with async validator"
+              validator={validator2}
+              path="/field2"
+            />
+          </Card>
+          <Form.ButtonRow>
+            <StepsLayout.PreviousButton />
+            <StepsLayout.NextButton />
+          </Form.ButtonRow>
+        </StepsLayout.Step>
+
+        <StepsLayout.Step title="Step 2">
+          <Card stack>
+            <Field.String label="Field 3" path="/field3" required />
+          </Card>
+          <Form.ButtonRow>
+            <StepsLayout.PreviousButton />
+            <Form.SubmitButton />
+          </Form.ButtonRow>
+        </StepsLayout.Step>
+      </StepsLayout>
+    </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/StepsLayout/style/dnb-steps-layout.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/StepsLayout/style/dnb-steps-layout.scss
@@ -17,11 +17,21 @@
   }
 
   &__contents {
-    flex: 1 0 25rem;
+    flex: 1 0 auto;
   }
 
   &__contents .dnb-card {
     --border-color: var(--color-pistachio);
+  }
+
+  // FormStatus as part of the Form.Handler
+  & + .dnb-form-status,
+  & + .dnb-form-status + .dnb-form-status {
+    @include allAbove(small) {
+      &:not([class*='space__left']) {
+        margin-left: var(--spacing-medium);
+      }
+    }
   }
 
   @include allBelow('medium') {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -95,17 +95,17 @@ export const dataValueProperties: PropertiesTableProps = {
 
 export const dataValueEvents: PropertiesTableProps = {
   onChange: {
-    doc: ' Will be called on value changes made by the user, with the new value as argument.',
+    doc: "Will be called on value changes made by the user, with the new value as argument. When an `async` function is used, the corresponding [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) will show an indicator on the field label. You can return `{ success: 'saved' } as const` to show a success symbol, or an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const`.",
     type: 'function',
     status: 'optional',
   },
   onFocus: {
-    doc: ' Will be called when the component gets into focus. Like clicking inside a text input or opening a dropdown. Called with active value as argument.',
+    doc: 'Will be called when the component gets into focus. Like clicking inside a text input or opening a dropdown. Called with active value as argument.',
     type: 'function',
     status: 'optional',
   },
   onBlur: {
-    doc: ' Will be called when the component stop being in focus. Like when going to next field, or closing a dropdown. Called with active value as argument.',
+    doc: 'Will be called when the component stop being in focus. Like when going to next field, or closing a dropdown. Called with active value as argument.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
@@ -46,6 +46,24 @@ describe('isAsync', () => {
     expect(isAsync(IAmAsync)).toBeTruthy()
   })
 
+  it('should not support functions with a promise', () => {
+    expect(
+      isAsync(() => {
+        return new Promise(() => null)
+      })
+    ).toBeFalsy()
+
+    expect(
+      isAsync(function () {
+        return new Promise(() => null)
+      })
+    ).toBeFalsy()
+  })
+
+  it('should return false is no function was given', () => {
+    expect(isAsync(undefined)).toBeFalsy()
+  })
+
   it('should return true if the situation is unclear', () => {
     function IAmSync() {
       return null
@@ -55,9 +73,5 @@ describe('isAsync', () => {
     })
 
     expect(isAsync(IAmSync)).toBeTruthy()
-  })
-
-  it('should return false is no function was given', () => {
-    expect(isAsync(undefined)).toBeFalsy()
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
@@ -12,6 +12,17 @@ describe('isAsync', () => {
     expect(isAsync(IAmAsync)).toBeTruthy()
   })
 
+  it('should return correct result based with jest mock', () => {
+    expect(isAsync(jest.fn(() => null))).toBeFalsy()
+    expect(isAsync(jest.fn(async () => null))).toBeTruthy()
+
+    const IAmSync = jest.fn(() => null)
+    const IAmAsync = jest.fn(async () => null)
+
+    expect(isAsync(IAmSync)).toBeFalsy()
+    expect(isAsync(IAmAsync)).toBeTruthy()
+  })
+
   it('should return correct result based normal functions', () => {
     expect(
       isAsync(function () {

--- a/packages/dnb-eufemia/src/shared/helpers/isAsync.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/isAsync.ts
@@ -5,6 +5,12 @@
  * @returns `true` if the function is asynchronous, `false` otherwise.
  */
 export function isAsync(fn: unknown): boolean {
+  // Support for jest.fn
+  const n = 'getMockImplementation'
+  if (fn?.[n]?.()) {
+    fn = fn[n]()
+  }
+
   const firstCheck = fn instanceof (async () => null).constructor
   const secondCheck = fn?.constructor?.name === 'AsyncFunction'
 

--- a/packages/dnb-eufemia/src/shared/helpers/useSharedState.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/useSharedState.tsx
@@ -39,7 +39,7 @@ export function useSharedState<Data>(
     }
   }, [hasMounted])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (waitForMountedRef.current) {
       forceUpdate()
     }
@@ -155,11 +155,6 @@ export function createSharedState<Data>(
 
     const get = () => sharedStates[id].data
 
-    const extend = (newData: Data) => {
-      sharedStates[id].data = { ...sharedStates[id].data, ...newData }
-      subscribers.forEach((subscriber) => subscriber())
-    }
-
     const set = (newData: Partial<Data>) => {
       sharedStates[id].data = { ...newData }
     }
@@ -169,8 +164,15 @@ export function createSharedState<Data>(
       subscribers.forEach((subscriber) => subscriber())
     }
 
+    const extend = (newData: Data) => {
+      sharedStates[id].data = { ...sharedStates[id].data, ...newData }
+      subscribers.forEach((subscriber) => subscriber())
+    }
+
     const subscribe = (subscriber: Subscriber) => {
-      subscribers.push(subscriber)
+      if (!subscribers.includes(subscriber)) {
+        subscribers.push(subscriber)
+      }
     }
 
     const unsubscribe = (subscriber: Subscriber) => {


### PR DESCRIPTION
This PR adds a couple of new event names for the `Form.Handler`; 

- Such as `onSubmitAsync` and `onChangeAsync` will lets you make "async" operations very easily. It will handle the form state for you (disable all input fields) and show an indicator. 
- When an "async" validator or onBlurValidator are used, it will behave similar as described above (showing an indicator on the corresponding field label).
- When an "async" field `onChange` event handler is used, it will behave similar as described above (showing an indicator on the corresponding field label).

**Feedback wanted:**

- Should we use the suffix `Async` on the onSubmit and onChange events for the `Form.Handler`? 
- Technically, we can check if the given function is async and let the form behave after that.
- We do that with the field `onChange` and the `validator` and `onBlurValidator`, because it would be too messy to have so many extra properties.

**Update**: We are going for only using `async` function as the on/off switch for the async form behavior.

**Additional**

- This is a multi feature PR with several features separated in each commit.
- closes #3333



