### PR TITLE
chore(forms): replace FormError with Error

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/Examples.tsx
@@ -325,7 +325,7 @@ export const Info = () => (
   </ComponentBox>
 )
 
-export const Error = () => (
+export const WithError = () => (
   <ComponentBox hideCode data-visual-test="section-error">
     <Section
       innerSpace={{ top: 'large', bottom: 'large' }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
@@ -50,7 +50,7 @@ Will be default in v11.
 
 ### Variant: error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Variant: warning
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 // Checkbox
 
@@ -112,7 +112,7 @@ export const CheckboxDisabled = () => (
 )
 
 export const CheckboxInfo = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
@@ -127,7 +127,7 @@ export const CheckboxInfo = () => (
 )
 
 export const CheckboxWarning = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
@@ -142,11 +142,11 @@ export const CheckboxWarning = () => (
 )
 
 export const CheckboxError = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
-      error={new FormError('This is what is wrong...')}
+      error={new Error('This is what is wrong...')}
     >
       <Field.Option value="foo" title="Foo!" />
       <Field.Option value="bar" title="Baar!" />
@@ -272,7 +272,7 @@ export const ButtonDisabled = () => (
 )
 
 export const ButtonInfo = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       variant="button"
       label="Label text"
@@ -288,7 +288,7 @@ export const ButtonInfo = () => (
 )
 
 export const ButtonWarning = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       variant="button"
       label="Label text"
@@ -304,12 +304,12 @@ export const ButtonWarning = () => (
 )
 
 export const ButtonError = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.ArraySelection
       variant="button"
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
-      error={new FormError('This is what is wrong...')}
+      error={new Error('This is what is wrong...')}
     >
       <Field.Option value="foo" title="Foo!" />
       <Field.Option value="bar" title="Baar!" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -1,6 +1,6 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Slider, Grid, Flex } from '@dnb/eufemia/src'
-import { Field, Form, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field, Form } from '@dnb/eufemia/src/extensions/forms'
 import React from 'react'
 
 export const Empty = () => {
@@ -193,7 +193,7 @@ export const Info = () => {
 
 export const Warning = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Number
         value={135}
         label="Label text"
@@ -204,14 +204,14 @@ export const Warning = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Number
         value={135}
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )
@@ -285,24 +285,18 @@ export const WithStepControls = () => (
 )
 
 export const WithStepControlsError = () => (
-  <ComponentBox
-    scope={{ FormError }}
-    data-visual-test="number-input-step-controls-error"
-  >
+  <ComponentBox data-visual-test="number-input-step-controls-error">
     <Field.Number
       showStepControls
       maximum={100}
       value={150}
-      error={new FormError('You done messed up, A-a-ron!')}
+      error={new Error('You done messed up, A-a-ron!')}
     />
   </ComponentBox>
 )
 
 export const WithStepControlsDisabled = () => (
-  <ComponentBox
-    scope={{ FormError }}
-    data-visual-test="number-input-step-controls-disabled"
-  >
+  <ComponentBox data-visual-test="number-input-step-controls-disabled">
     <Field.Number showStepControls disabled />
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
@@ -56,7 +56,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/Examples.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Button, Flex } from '@dnb/eufemia/src'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 // Dropdown
 
@@ -150,12 +150,12 @@ export const DropdownDisabled = () => (
 )
 
 export const DropdownError = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.Selection
       value="bar"
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
-      error={new FormError('This is what is wrong...')}
+      error={new Error('This is what is wrong...')}
     >
       <Field.Option value="foo" title="Foo!" />
       <Field.Option value="bar" title="Baar!" />
@@ -362,13 +362,13 @@ export const RadioDisabled = () => (
 )
 
 export const RadioError = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.Selection
       variant="radio"
       value="bar"
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
-      error={new FormError('This is what is wrong...')}
+      error={new Error('This is what is wrong...')}
     >
       <Field.Option value="foo" title="Foo!" />
       <Field.Option value="bar" title="Baar!" />
@@ -447,13 +447,13 @@ export const ButtonDisabled = () => (
 )
 
 export const ButtonError = () => (
-  <ComponentBox scope={{ FormError }}>
+  <ComponentBox>
     <Field.Selection
       variant="button"
       value="bar"
       label="Label text"
       onChange={(value) => console.log('onChange', value)}
-      error={new FormError('This is what is wrong...')}
+      error={new Error('This is what is wrong...')}
     >
       <Field.Option value="foo" title="Foo!" />
       <Field.Option value="bar" title="Baar!" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
@@ -1,6 +1,6 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Flex } from '@dnb/eufemia/src'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -187,7 +187,7 @@ export const Info = () => {
 
 export const Warning = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text"
@@ -198,14 +198,14 @@ export const Warning = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )
@@ -268,14 +268,12 @@ export const ValidatePattern = () => {
 
 export const SynchronousExternalValidator = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text (minimum 4 characters)"
         validator={(value) =>
-          value.length < 4
-            ? new FormError('At least 4 characters')
-            : undefined
+          value.length < 4 ? Error('At least 4 characters') : undefined
         }
         onChange={(value) => console.log('onChange', value)}
       />
@@ -285,7 +283,7 @@ export const SynchronousExternalValidator = () => {
 
 export const AsynchronousExternalValidator = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text (minimum 4 characters)"
@@ -295,7 +293,7 @@ export const AsynchronousExternalValidator = () => {
               () =>
                 resolve(
                   value.length < 5
-                    ? new FormError('At least 5 characters')
+                    ? Error('At least 5 characters')
                     : undefined,
                 ),
               1500,
@@ -310,14 +308,12 @@ export const AsynchronousExternalValidator = () => {
 
 export const SynchronousExternalBlurValidator = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text (minimum 4 characters)"
         onBlurValidator={(value) =>
-          value.length < 4
-            ? new FormError('At least 4 characters')
-            : undefined
+          value.length < 4 ? Error('At least 4 characters') : undefined
         }
         onChange={(value) => console.log('onChange', value)}
       />
@@ -327,7 +323,7 @@ export const SynchronousExternalBlurValidator = () => {
 
 export const AsynchronousExternalBlurValidator = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.String
         value="foo"
         label="Label text (minimum 4 characters)"
@@ -337,7 +333,7 @@ export const AsynchronousExternalBlurValidator = () => {
               () =>
                 resolve(
                   value.length < 5
-                    ? new FormError('At least 5 characters')
+                    ? Error('At least 5 characters')
                     : undefined,
                 ),
               1500,

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
@@ -56,7 +56,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const ValueOn = () => {
   return (
@@ -77,7 +77,7 @@ export const Info = () => {
 
 export const Warning = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Toggle
         valueOn="checked"
         valueOff="unchecked"
@@ -90,16 +90,16 @@ export const Warning = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Toggle
         valueOn="checked"
         valueOff="unchecked"
         variant="checkbox"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/demos.mdx
@@ -32,7 +32,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Value types
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -138,7 +138,7 @@ During validation, the different APIs do have a prioritization order and will st
 
 ### Error handling
 
-Validation and error-handling is tight coupled together. When a validation fails, you may use the error-object to handle and show the failures/statuses:
+Validation and error-handling are tightly coupled together. When a validation fails, you may use the error-object to handle and show the failures/statuses:
 
 ```tsx
 render(

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -138,16 +138,13 @@ During validation, the different APIs do have a prioritization order and will st
 
 ### Error handling
 
-Validation and error-handling is tight coupled together. When a validation fails, you may use the error-object to handle and show the failures/statuses.
-
-To generate the error-object, `FormError` is used. You can use it as well:
+Validation and error-handling is tight coupled together. When a validation fails, you may use the error-object to handle and show the failures/statuses:
 
 ```tsx
-import { FormError } from '@dnb/eufemia/extensions/forms'
 render(
   <Field.String
     label="Label"
-    warning={new FormError("I'm a warning too...")}
+    error={new Error('This is what is wrong...')}
   />,
 )
 ```
@@ -161,6 +158,17 @@ const { error, hasError } = useFieldProps({
     required: 'Show this when "required" fails!',
   },
   ...componentProps,
+})
+```
+
+To re-use existing `errorMessages`, you can use the `FormError` constructor as well:
+
+```ts
+import { FormError } from '@dnb/eufemia/extensions/forms'
+
+// Will show the message from the errorMessages
+new FormError('Internal error message', {
+  validationRule: 'required',
 })
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/error-messages/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/error-messages/info.mdx
@@ -26,7 +26,14 @@ render(<Field.PhoneNumber validator={validator} />)
 
 ### FormError object
 
-Use `new FormError` with a message to display an existing and translated error message.
+You can use the JavaScript `Error` object to display a custom error message:
+
+```tsx
+import { Field } from '@dnb/eufemia/extensions/forms'
+render(<Field.PhoneNumber error={new Error('Custom message')} />)
+```
+
+When it comes to re-using existing translations, you can also use the `FormError` object to display error messages.
 
 The `validationRule` is used to identify the error message to display.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -86,14 +86,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.BankAccountNumber
         value="007"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 import { Provider } from '@dnb/eufemia/src/shared'
 
 export const Empty = () => {
@@ -89,14 +89,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Currency
         value={12345678}
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/demos.mdx
@@ -42,7 +42,7 @@ This field is using `NOK` when `locale` is `en-GB`.
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -73,14 +73,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }} data-visual-test="date-error">
+    <ComponentBox data-visual-test="date-error">
       <Field.Date
         value="2023-01-16"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
@@ -32,7 +32,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -86,14 +86,14 @@ export const InvalidSyntax = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Email
         value="foo@bar.com"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error message
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -52,14 +52,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }} data-visual-test="expiry-error">
+    <ComponentBox data-visual-test="expiry-error">
       <Field.Expiry
         value="0326"
         label="Label text"
         onChange={(expiry) => console.log('onChange', expiry)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/demos.mdx
@@ -44,7 +44,7 @@ import enUS from '@dnb/eufemia/shared/locales/en-US'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -86,14 +86,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.NationalIdentityNumber
         value="007"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )
@@ -114,7 +114,7 @@ export const ValidationRequired = () => {
 
 export const ValidationFunction = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       {() => {
         const fnr = (value: string) =>
           value.length >= 11 ? { status: 'valid' } : { status: 'invalid' }
@@ -122,7 +122,7 @@ export const ValidationFunction = () => {
         const validator = (value, errorMessages) => {
           const result = fnr(value)
           return result.status === 'invalid'
-            ? new FormError(errorMessages.pattern)
+            ? new Error(errorMessages.pattern)
             : undefined
         }
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -86,14 +86,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.OrganizationNumber
         value="007"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Password/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Password/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Placeholder = () => {
   return (
@@ -73,16 +73,16 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.Password
         value="your-birthday"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         onHidePassword={(event) => console.log('onHidePassword', event)}
         onShowPassword={(event) => console.log('onShowPassword', event)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Password/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Password/demos.mdx
@@ -28,7 +28,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -81,17 +81,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox
-      scope={{ FormError }}
-      data-visual-test="phone-number-error"
-    >
+    <ComponentBox data-visual-test="phone-number-error">
       <Field.PhoneNumber
         value="007"
         label="Label text"
         onChange={(...args) => console.log('onChange', ...args)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -107,16 +107,13 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox
-      scope={{ FormError }}
-      data-visual-test="postal-code-and-city-error"
-    >
+    <ComponentBox data-visual-test="postal-code-and-city-error">
       <Field.PostalCodeAndCity
         postalCode={{}}
         city={{}}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -32,7 +32,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, FormError } from '@dnb/eufemia/src/extensions/forms'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -86,14 +86,14 @@ export const Disabled = () => {
   )
 }
 
-export const Error = () => {
+export const WithError = () => {
   return (
-    <ComponentBox scope={{ FormError }}>
+    <ComponentBox>
       <Field.SelectCountry
         value="NO"
         label="Label text"
         onChange={(value, obj) => console.log('onChange', value, obj)}
-        error={new FormError('This is what is wrong...')}
+        error={new Error('This is what is wrong...')}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/demos.mdx
@@ -36,7 +36,7 @@ import * as Examples from './Examples'
 
 ### Error
 
-<Examples.Error />
+<Examples.WithError />
 
 ### Validation - Required
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { Field, FieldBlock } from '../../..'
-import { FormError } from '../../../types'
 
 describe('ArraySelection', () => {
   it('renders correctly', () => {
@@ -50,7 +49,7 @@ describe('ArraySelection', () => {
   })
 
   it('displays error message when error prop is provided', () => {
-    const errorMessage = new FormError('This is what is wrong...')
+    const errorMessage = new Error('This is what is wrong...')
     render(
       <Field.ArraySelection error={errorMessage}>
         <Field.Option value="option1">Option 1</Field.Option>
@@ -129,7 +128,7 @@ describe('ArraySelection', () => {
     })
 
     it('has error class when error prop is provided', () => {
-      const errorMessage = new FormError('This is what is wrong...')
+      const errorMessage = new Error('This is what is wrong...')
       render(
         <Field.ArraySelection error={errorMessage}>
           <Field.Option value="option1">Option 1</Field.Option>
@@ -164,7 +163,7 @@ describe('ArraySelection', () => {
     })
 
     it('has error class when error prop is provided', () => {
-      const errorMessage = new FormError('This is what is wrong...')
+      const errorMessage = new Error('This is what is wrong...')
       render(
         <Field.ArraySelection variant="button" error={errorMessage}>
           <Field.Option value="option1">Option 1</Field.Option>
@@ -200,7 +199,7 @@ describe('ArraySelection', () => {
   describe('checkbox', () => {
     it('renders error', () => {
       render(
-        <Field.ArraySelection error={new FormError('Error message')}>
+        <Field.ArraySelection error={new Error('Error message')}>
           <Field.Option value="A" title="Fooo!" />
           <Field.Option value="B" title="Baar!" />
           <Field.Option value="C" title="Bazz!" />
@@ -222,7 +221,7 @@ describe('ArraySelection', () => {
     it('shows error style in FieldBlock', () => {
       render(
         <FieldBlock>
-          <Field.ArraySelection error={new FormError('Error message')}>
+          <Field.ArraySelection error={new Error('Error message')}>
             <Field.Option value="A" title="Fooo!" />
             <Field.Option value="B" title="Baar!" />
             <Field.Option value="C" title="Bazz!" />
@@ -245,7 +244,7 @@ describe('ArraySelection', () => {
       render(
         <Field.ArraySelection
           variant="button"
-          error={new FormError('Error message')}
+          error={new Error('Error message')}
         >
           <Field.Option value="A" title="Fooo!" />
           <Field.Option value="B" title="Baar!" />
@@ -276,7 +275,7 @@ describe('ArraySelection', () => {
         <FieldBlock>
           <Field.ArraySelection
             variant="button"
-            error={new FormError('Error message')}
+            error={new Error('Error message')}
           >
             <Field.Option value="A" title="Fooo!" />
             <Field.Option value="B" title="Baar!" />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, waitFor, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { Field, FormError, FieldBlock } from '../../..'
+import { Field, FieldBlock } from '../../..'
 
 describe('Field.Date', () => {
   it('should render with props', () => {
@@ -106,7 +106,7 @@ describe('Field.Date', () => {
   })
 
   it('renders error', () => {
-    render(<Field.Date error={new FormError('Error message')} />)
+    render(<Field.Date error={new Error('Error message')} />)
 
     const element = document.querySelector('.dnb-form-status')
     expect(element).toHaveTextContent('Error message')
@@ -118,7 +118,7 @@ describe('Field.Date', () => {
   it('shows error style in FieldBlock', () => {
     render(
       <FieldBlock>
-        <Field.Date error={new FormError('Error message')} />
+        <Field.Date error={new Error('Error message')} />
       </FieldBlock>
     )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { act, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field, FormError, FieldBlock } from '../../..'
+import { Field, FieldBlock } from '../../..'
 
 describe('Field.Expiry', () => {
   beforeEach(() => {
@@ -333,7 +333,7 @@ describe('Field.Expiry', () => {
   })
 
   it('renders error', () => {
-    render(<Field.Expiry error={new FormError('Error message')} />)
+    render(<Field.Expiry error={new Error('Error message')} />)
 
     const element = document.querySelector('.dnb-form-status')
     expect(element).toHaveTextContent('Error message')
@@ -345,7 +345,7 @@ describe('Field.Expiry', () => {
   it('shows error style in FieldBlock', () => {
     render(
       <FieldBlock>
-        <Field.Expiry error={new FormError('Error message')} />
+        <Field.Expiry error={new Error('Error message')} />
       </FieldBlock>
     )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Props } from '..'
-import { Field, Form, FormError } from '../../..'
+import { Field, Form } from '../../..'
 
 describe('Field.NationalIdentityNumber', () => {
   it('should render with props', () => {
@@ -65,7 +65,7 @@ describe('Field.NationalIdentityNumber', () => {
   it('should validate given function', async () => {
     const text = 'Custom Error message'
     const validator = jest.fn((value) => {
-      return value.length < 4 ? new FormError(text) : undefined
+      return value.length < 4 ? new Error(text) : undefined
     })
 
     render(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent, wait } from '../../../../../core/jest/jestSetup'
 import { screen, render, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field, FormError, FieldBlock } from '../../..'
+import { Field, FieldBlock } from '../../..'
 import { Provider } from '../../../../../shared'
 
 describe('Field.Number', () => {
@@ -113,7 +113,7 @@ describe('Field.Number', () => {
     })
 
     it('shows error style in FieldBlock', () => {
-      const errorMessage = new FormError('Error message')
+      const errorMessage = new Error('Error message')
       render(
         <FieldBlock>
           <Field.Number error={errorMessage} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -3,7 +3,7 @@ import { wait, axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from '../../../../../shared'
-import { Field, Form, FormError, JSONSchema } from '../../..'
+import { Field, Form, JSONSchema } from '../../..'
 import locales from '../../../../../shared/locales'
 
 const nbNO = locales['nb-NO']
@@ -562,7 +562,7 @@ describe('Field.PhoneNumber', () => {
 
   it('should handle "validator" property with country code', async () => {
     const validator = jest.fn(() => {
-      return new FormError('some error')
+      return new Error('some error')
     })
 
     render(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -3,7 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Props } from '..'
 import { Provider } from '../../../../../shared'
-import { Field, Form, FormError, FieldBlock } from '../../..'
+import { Field, Form, FieldBlock } from '../../..'
 
 describe('Field.SelectCountry', () => {
   it('should render with props', () => {
@@ -268,7 +268,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('renders error', () => {
-    const errorMessage = new FormError('Error message')
+    const errorMessage = new Error('Error message')
     render(<Field.SelectCountry error={errorMessage} />)
 
     const element = document.querySelector('.dnb-form-status')
@@ -279,7 +279,7 @@ describe('Field.SelectCountry', () => {
   })
 
   it('shows error style in FieldBlock', () => {
-    const errorMessage = new FormError('Error message')
+    const errorMessage = new Error('Error message')
     render(
       <FieldBlock>
         <Field.SelectCountry error={errorMessage} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
@@ -26,13 +26,13 @@ export function Selection() {
         variant="radio"
         layout="horizontal"
         optionsLayout="horizontal"
-        // error={new FormError('This is what is wrong...')}
+        // error={new Error('This is what is wrong...')}
         onChange={(value) => console.log('onChange', value)}
       >
         <Field.Option
           value="foo"
           title="Foo!"
-          // error={new FormError('This is what is wrong...')}
+          // error={new Error('This is what is wrong...')}
         />
         <Field.Option value="bar" title="Baar!" />
       </Field.Selection>
@@ -45,13 +45,13 @@ export function Selection() {
         layout="horizontal"
         optionsLayout="horizontal"
         value="foo"
-        // error={new FormError('This is what is wrong...')}
+        // error={new Error('This is what is wrong...')}
         onChange={(value) => console.log('onChange', value)}
       >
         <Field.Option
           value="foo"
           title="Foo!"
-          // error={new FormError('This is what is wrong...')}
+          // error={new Error('This is what is wrong...')}
         />
         <Field.Option value="bar" title="Baar!" />
       </Field.Selection>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
 import { Props } from '../Toggle'
-import { Field, FormError, FieldBlock } from '../../..'
+import { Field, FieldBlock } from '../../..'
 
 describe('Field.Toggle', () => {
   it('should render with props', () => {
     const props: Props = { valueOn: 'checked', valueOff: 'unchecked' }
     render(<Field.Toggle {...props} />)
+    expect(document.querySelector('input')).toBeInTheDocument()
   })
 
   it('should support disabled prop', () => {
@@ -126,7 +127,7 @@ describe('Field.Toggle', () => {
       })
 
       it('renders error', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <Field.Toggle
@@ -146,7 +147,7 @@ describe('Field.Toggle', () => {
       })
 
       it('shows error style in FieldBlock', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <FieldBlock>
@@ -295,7 +296,7 @@ describe('Field.Toggle', () => {
       })
 
       it('renders error', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <Field.Toggle
@@ -318,7 +319,7 @@ describe('Field.Toggle', () => {
       })
 
       it('shows error style in FieldBlock', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <FieldBlock>
@@ -430,7 +431,7 @@ describe('Field.Toggle', () => {
       })
 
       it('renders error', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <Field.Toggle
@@ -451,7 +452,7 @@ describe('Field.Toggle', () => {
       })
 
       it('shows error style in FieldBlock', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <FieldBlock>
@@ -552,7 +553,7 @@ describe('Field.Toggle', () => {
       })
 
       it('renders error', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <Field.Toggle
@@ -573,7 +574,7 @@ describe('Field.Toggle', () => {
       })
 
       it('shows error style in FieldBlock', () => {
-        const errorMessage = new FormError('Error message')
+        const errorMessage = new Error('Error message')
 
         render(
           <FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import { Input } from '../../../../components'
 import FieldBlock from '../FieldBlock'
-import { FormError } from '../../types'
 import userEvent from '@testing-library/user-event'
 import { useFieldProps } from '../../hooks'
 import {
@@ -373,7 +372,7 @@ describe('FieldBlock', () => {
     }
 
     const { rerender } = render(
-      <FieldBlock error={new FormError('FieldBlock error')}>
+      <FieldBlock error={new Error('FieldBlock error')}>
         <MockComponent />
       </FieldBlock>
     )
@@ -429,9 +428,7 @@ describe('FieldBlock', () => {
     describe('error prop', () => {
       it('should render a FormStatus correctly', () => {
         render(
-          <FieldBlock error={new FormError(blockError)}>
-            content
-          </FieldBlock>
+          <FieldBlock error={new Error(blockError)}>content</FieldBlock>
         )
 
         const element = document.querySelector('.dnb-form-status')
@@ -1002,9 +999,7 @@ describe('FieldBlock', () => {
         const { rerender } = render(<FieldBlock>content</FieldBlock>)
 
         rerender(
-          <FieldBlock error={new FormError(blockError)}>
-            content
-          </FieldBlock>
+          <FieldBlock error={new Error(blockError)}>content</FieldBlock>
         )
 
         const element = document.querySelector('.dnb-form-status')
@@ -1020,9 +1015,7 @@ describe('FieldBlock', () => {
         const { rerender } = render(<FieldBlock>content</FieldBlock>)
 
         rerender(
-          <FieldBlock error={new FormError(blockError)}>
-            content
-          </FieldBlock>
+          <FieldBlock error={new Error(blockError)}>content</FieldBlock>
         )
 
         const element = document.querySelector('.dnb-form-status')
@@ -1048,9 +1041,7 @@ describe('FieldBlock', () => {
         const { rerender } = render(<FieldBlock>content</FieldBlock>)
 
         rerender(
-          <FieldBlock error={new FormError(blockError)}>
-            content
-          </FieldBlock>
+          <FieldBlock error={new Error(blockError)}>content</FieldBlock>
         )
 
         const element = document.querySelector('.dnb-form-status')
@@ -1064,9 +1055,7 @@ describe('FieldBlock', () => {
         const { rerender } = render(<FieldBlock>content</FieldBlock>)
 
         rerender(
-          <FieldBlock error={new FormError(blockError)}>
-            content
-          </FieldBlock>
+          <FieldBlock error={new Error(blockError)}>content</FieldBlock>
         )
 
         const element = document.querySelector('.dnb-form-status')

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2180,7 +2180,7 @@ describe('useFieldProps', () => {
     }
 
     const { rerender } = render(
-      <FieldBlock error={new FormError('Error message')}>
+      <FieldBlock error={new Error('Error message')}>
         <MockComponent />
       </FieldBlock>
     )


### PR DESCRIPTION
Many places we use `FormError` – but there is not any good reason for doing so.