### PR TITLE
fix(Autocomplete): use current value to filter changed data

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
@@ -53,6 +53,26 @@ and if you need to decouple the searchable content from what's displayed, then y
 
 <AutocompleteContentDecoupledExample />
 
+## Re-render data
+
+For performance optimization, you should ensure the `data` array/object is memorized (with `useMemo`, `useState` or `useRef`), so when the Autocomplete re-renders, it does not have to process the internal data unnecessary.
+
+```tsx
+const MyComponent = () => {
+  const data = React.useMemo(() => ['Item 1', 'Item 2'], [])
+  return <Autocomplete data={data} />
+}
+```
+
+Or keep it outside the component:
+
+```tsx
+const data = ['Item 1', 'Item 2']
+const MyComponent = () => {
+  return <Autocomplete data={data} />
+}
+```
+
 ### Numbers
 
 Numbers are often different than a word filter. You can use `search_numbers={true}` to enable a number specialized filtering. See example in the demos.

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -453,6 +453,11 @@ class AutocompleteInstance extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    if (prevProps.data !== this.props.data) {
+      this.setSearchIndex({ overwriteSearchIndex: true }, () => {
+        this.runFilterWithSideEffects(this.state.inputValue)
+      })
+    }
     if (prevProps.value !== this.props.value) {
       this.revalidateSelectedItem()
       this.revalidateInputValue()
@@ -552,7 +557,7 @@ class AutocompleteInstance extends React.PureComponent {
     const { keep_value, keep_selection, keep_value_and_selection } =
       this.props
 
-    if (value && value.length > 0) {
+    if (value?.length > 0) {
       // show the "no_options" message
       if (count === 0) {
         this.showNoOptionsItem()
@@ -1302,7 +1307,7 @@ class AutocompleteInstance extends React.PureComponent {
       return []
     }
 
-    const searchWords = value.split(/\s+/g).filter(Boolean)
+    const searchWords = value?.split(/\s+/g).filter(Boolean) || []
     const wordCond = '^|\\s'
 
     const findSearchWords = (contentChunk) => {
@@ -1310,7 +1315,6 @@ class AutocompleteInstance extends React.PureComponent {
         return []
       }
 
-      // [cc, bb]
       return searchWords
         .map((word, wordIndex) => ({ word, wordIndex }))
         .filter(({ word, wordIndex }) => {


### PR DESCRIPTION
Fixes #3355

There is a big potential downside to our ability to avoid potential performance issues when going forward with the implementation as is.

Because the data prop changes, we need to check if it has changed and update the search index. But not all devs will memorise the given data – and if that is not the case, each re-render will set a new search index, regardless if it has changed or not.

At the moment (late Sunday evening) I can't come up with a smart solution of mitigate that potential downside.

Any suggestions?

And thank you again for the fantastic reproduction and issue description: https://codesandbox.io/p/sandbox/confident-vaughan-ty4tz4?file=%2Fsrc%2FApp.tsx

