### PR TITLE
fix: show error in console when Eufemia CSS and JS versions do not match

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/runCssVersionMismatchWarning.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/runCssVersionMismatchWarning.test.ts
@@ -81,7 +81,12 @@ describe('runCssVersionMismatchWarning', () => {
 
     runCssVersionMismatchWarning()
 
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(0)
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Eufemia CSS and JS version mismatch!',
+      '\nCSS: unknown',
+      '\nJS: 1.0.0'
+    )
 
     window.Eufemia.version = originalJsVersion
   })

--- a/packages/dnb-eufemia/src/shared/helpers/runCssVersionMismatchWarning.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/runCssVersionMismatchWarning.ts
@@ -23,7 +23,7 @@ export function runCssVersionMismatchWarning() {
           window
             .getComputedStyle(document.body)
             .getPropertyValue('--eufemia-version')
-            ?.replace(/["']/g, '') || jsVersion
+            ?.replace(/["']/g, '') || 'unknown'
 
         if (cssVersion !== jsVersion) {
           console.error(
@@ -36,7 +36,7 @@ export function runCssVersionMismatchWarning() {
 
       if (document.readyState === 'complete') {
         window.requestAnimationFrame(runCheck)
-      } else if (typeof window !== 'undefined') {
+      } else {
         window.addEventListener('load', runCheck)
       }
     }


### PR DESCRIPTION
Regarding feature #3371 – this PR will ensure to always show a warning.

