### PR TITLE
feat(forms): add internal field state to `filterData` as a fourth parameter

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/getData/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/getData/Examples.tsx
@@ -29,7 +29,7 @@ export function FilterData() {
   return (
     <ComponentBox>
       {() => {
-        const filterDataHandler = (path, value, props) => {
+        const filterDataHandler = (path, value, props, internal) => {
           if (value === 'foo') {
             return false
           }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/getData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/getData/info.mdx
@@ -50,7 +50,7 @@ const Component = () => {
   )
 }
 
-const filterDataHandler = (path, value, props) => {
+const filterDataHandler = (path, value, props, internal) => {
   if (props.disabled === true) {
     return false
   }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/useData/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/useData/Examples.tsx
@@ -101,7 +101,7 @@ export function FilterData() {
   return (
     <ComponentBox>
       {() => {
-        const filterDataHandler = (path, value, props) => {
+        const filterDataHandler = (path, value, props, internal) => {
           if (value === 'removed') {
             return false
           }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/useData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/extended-features/Form/useData/info.mdx
@@ -140,7 +140,7 @@ The callback function receives the path as the first argument, the value as the 
 It returns the filtered form data.
 
 ```tsx
-const filterDataHandler = (path, value, props) => {
+const filterDataHandler = (path, value, props, internal) => {
   if (props.disabled === true) {
     return false
   }
@@ -156,6 +156,14 @@ const Component = () => {
       <Field.String path="/foo" disabled />
     </Form.Handler>
   )
+}
+```
+
+The `internal` parameter contains `{ error: Error | undefined }` you can utilize if needed.
+
+```tsx
+const filterDataHandler = (path, value, props, internal) => {
+  return !(internal.error instanceof Error)
 }
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -51,7 +51,7 @@ You can filter data by any given criteria. This is done by adding a `filterData`
 The callback function receives the path as the first argument, the value as the second argument, and the related field properties as the third argument. The callback function must return a boolean value or undefined. Return false to exclude an entry.
 
 ```tsx
-const filterDataHandler = (path, value, props) => {
+const filterDataHandler = (path, value, props, internal) => {
   if (props.disabled === true) {
     return false
   }

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -30,7 +30,10 @@ export type FilterDataHandler<Data> = (
 export type FilterData = (
   path: Path,
   value: any,
-  props: FieldProps
+  props: FieldProps,
+  internal: {
+    error: Error | undefined
+  }
 ) => boolean | undefined
 
 export interface ContextState {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -192,7 +192,7 @@ export default function Provider<Data extends JsonObject>(
   }, [])
 
   // - States (e.g. error) reported by fields, based on their direct validation rules
-  const fieldErrorRef = useRef<Record<Path, boolean>>({})
+  const fieldErrorRef = useRef<Record<Path, Error>>({})
   const fieldStateRef = useRef<Record<Path, SubmitState>>({})
 
   // - Data
@@ -243,7 +243,7 @@ export default function Provider<Data extends JsonObject>(
       return Boolean(
         state === 'error'
           ? errorsRef.current?.[path] instanceof Error ||
-              fieldErrorRef.current[path]
+              fieldErrorRef.current[path] instanceof Error
           : fieldStateRef.current[path] === state
       )
     },
@@ -266,7 +266,7 @@ export default function Provider<Data extends JsonObject>(
    */
   const setFieldError = useCallback(
     (path: Path, error: Error | FormError) => {
-      fieldErrorRef.current[path] = Boolean(error)
+      fieldErrorRef.current[path] = error
     },
     []
   )
@@ -297,7 +297,10 @@ export default function Provider<Data extends JsonObject>(
           const result = filter(
             path,
             exists ? pointer.get(data, path) : undefined,
-            props
+            props,
+            {
+              error: fieldErrorRef.current?.[path],
+            }
           )
           if (result === false && exists) {
             pointer.remove(filtered, path)

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -47,7 +47,7 @@ export const ProviderProperties: PropertiesTableProps = {
     status: 'optional',
   },
   filterData: {
-    doc: 'Filter the internal data context based on your criteria: `(path, value, props) => !props?.disabled`. It will iterate on each data entry.',
+    doc: 'Filter the internal data context based on your criteria: `(path, value, props, internal) => !props?.disabled`. It will iterate on each data entry.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -400,12 +400,14 @@ describe('DataContext.Provider', () => {
         1,
         '/foo',
         'Include this value',
+        expect.anything(),
         expect.anything()
       )
       expect(filterDataHandler).toHaveBeenNthCalledWith(
         2,
         '/bar',
         'bar',
+        expect.anything(),
         expect.anything()
       )
 
@@ -438,12 +440,14 @@ describe('DataContext.Provider', () => {
         3,
         '/foo',
         'Skip this value',
+        expect.anything(),
         expect.anything()
       )
       expect(filterDataHandler).toHaveBeenNthCalledWith(
         4,
         '/bar',
         'bar value',
+        expect.anything(),
         expect.anything()
       )
 
@@ -2671,7 +2675,8 @@ describe('DataContext.Provider', () => {
       'foo',
       expect.objectContaining({
         disabled: true,
-      })
+      }),
+      expect.anything()
     )
 
     rerender(
@@ -2697,7 +2702,8 @@ describe('DataContext.Provider', () => {
       'bar',
       expect.objectContaining({
         disabled: false,
-      })
+      }),
+      expect.anything()
     )
   })
 
@@ -3416,7 +3422,8 @@ describe('DataContext.Provider', () => {
         'foo',
         expect.objectContaining({
           disabled: true,
-        })
+        }),
+        expect.anything()
       )
 
       act(() => {
@@ -3452,7 +3459,8 @@ describe('DataContext.Provider', () => {
         'bar',
         expect.objectContaining({
           disabled: false,
-        })
+        }),
+        expect.anything()
       )
 
       rerender(
@@ -3475,7 +3483,8 @@ describe('DataContext.Provider', () => {
         'bar',
         expect.objectContaining({
           disabled: true,
-        })
+        }),
+        expect.anything()
       )
     })
 


### PR DESCRIPTION
This lets a dev also check against the internal error. But other internal states may be more interesting. Bot we at least "document that the possibility".