### PR TITLE
fix(InputMasked): ensure decimal value update does format correctly 

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -117,9 +117,9 @@ export const correctNumberValue = ({
   if (localValue !== null) {
     const localNumberValue = localValue.replace(/[^\d,.-]/g, '')
     const numberValue = value.replace(/[^\d,.-]/g, '')
-    const hasDecimal = numberValue.includes(decimalSymbol)
+    const valueHasDecimal = numberValue.includes(decimalSymbol)
 
-    if (!hasDecimal) {
+    if (!valueHasDecimal) {
       const endsWithDecimal = localNumberValue.endsWith(decimalSymbol)
       const endsWithZeroAndDecimal = localNumberValue.endsWith(
         `${decimalSymbol}0`

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -117,24 +117,27 @@ export const correctNumberValue = ({
   if (localValue !== null) {
     const localNumberValue = localValue.replace(/[^\d,.-]/g, '')
     const numberValue = value.replace(/[^\d,.-]/g, '')
+    const hasDecimal = numberValue.includes(decimalSymbol)
 
-    const endsWithDecimal = localNumberValue.endsWith(decimalSymbol)
-    const endsWithZeroAndDecimal = localNumberValue.endsWith(
-      `${decimalSymbol}0`
-    )
+    if (!hasDecimal) {
+      const endsWithDecimal = localNumberValue.endsWith(decimalSymbol)
+      const endsWithZeroAndDecimal = localNumberValue.endsWith(
+        `${decimalSymbol}0`
+      )
 
-    if (endsWithDecimal) {
-      value = `${value}${decimalSymbol}`
-    } else if (
-      endsWithZeroAndDecimal &&
-      !numberValue.endsWith(`${decimalSymbol}0`)
-    ) {
-      /**
-       * When the users has 20,02, then hits "backspace",
-       * the returned {numberValue} in the onChange event would then be "20",
-       * but we want it to be 20,0
-       */
-      value = `${value}${decimalSymbol}0`
+      if (endsWithDecimal) {
+        value = `${value}${decimalSymbol}`
+      } else if (
+        endsWithZeroAndDecimal &&
+        !numberValue.endsWith(`${decimalSymbol}0`)
+      ) {
+        /**
+         * When the users has 20,02, then hits "backspace",
+         * the returned {numberValue} in the onChange event would then be "20",
+         * but we want it to be 20,0
+         */
+        value = `${value}${decimalSymbol}0`
+      }
     }
 
     /**

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { loadScss, wait } from '../../../core/jest/jestSetup'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import InputMasked, { InputMaskedProps } from '../InputMasked'
 import Provider from '../../../shared/Provider'
@@ -1170,6 +1170,43 @@ describe('InputMasked component as_number', () => {
     )
 
     expect(document.querySelector('input').value).toBe('1 234,9123')
+  })
+
+  it('should correctly update with new value from outside', async () => {
+    const Component = () => {
+      const [value, setValue] = React.useState('')
+      return (
+        <>
+          <label>
+            Native text field
+            <input
+              type="text"
+              value={value}
+              onChange={(e) => setValue(e.currentTarget.value)}
+            />
+          </label>
+          <InputMasked
+            label="Masked text field"
+            value={value}
+            as_number
+            number_mask={{ decimalLimit: 2 }}
+            locale="en-GB"
+          />
+        </>
+      )
+    }
+
+    render(<Component />)
+
+    expect(screen.getByLabelText('Masked text field')).toHaveValue('')
+
+    await userEvent.type(
+      screen.getByLabelText('Native text field'),
+      '1.00'
+    )
+
+    expect(screen.getByLabelText('Native text field')).toHaveValue('1.00')
+    expect(screen.getByLabelText('Masked text field')).toHaveValue('1.00')
   })
 })
 


### PR DESCRIPTION
Adds a testcase showing a problem that happens with decimal handling and values being updated from outside the `InputMasked` component. This can be seen [in this codesandbox](https://codesandbox.io/p/sandbox/shy-grass-tdynr7?file=%2Fsrc%2FApp.tsx%3A25%2C13) - entering "20.00" in the top textbox results in "2000." in the InputMasked field.

@tujoworker then swooped in and fixed the issue by skipping the custom handling of decimals for the local copy of the value if the passed-in value has a decimal separator.

---

Adding the async call to `userEvent.type` seems to break some other unrelated tests - not quite sure what's up with that.

