### PR TITLE
feat(forms): add `transformIn` and `transformOut` to fields for value transformation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Examples.tsx
@@ -501,3 +501,39 @@ export const WithSteps = () => {
     </ComponentBox>
   )
 }
+
+export const Transformers = () => {
+  return (
+    <ComponentBox hideCode>
+      {() => {
+        const MyForm = () => {
+          const transformToUpper = (value) => {
+            return value?.toUpperCase()
+          }
+          const transformToLower = (value) => {
+            return value?.toLowerCase()
+          }
+
+          return (
+            <Form.Handler onChange={console.log}>
+              <Card stack>
+                <Field.String
+                  width="medium"
+                  label="Input value"
+                  placeholder="Type letters"
+                  path="/myField"
+                  transformIn={transformToUpper}
+                  transformOut={transformToLower}
+                />
+
+                <Value.String label="Output value" path="/myField" />
+              </Card>
+            </Form.Handler>
+          )
+        }
+
+        return <MyForm />
+      }}
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -215,4 +215,10 @@ They should return a transformed value: `(value) => value`
 
 - `fromExternal` transforms the given props `value` before any other step gets entered.
 
-- `transformValue` transforms the value given by `handleChange` after `fromInput` and before `updateValue` and `toEvent`. The second parameter returns the current value
+- `transformValue` transforms the value given by `handleChange` after `fromInput` and before `updateValue` and `toEvent`. The second parameter returns the current value.
+
+In addition there are **field value transformers** which should be used outside of the field component (by the field consumer):
+
+- `transformIn` transforms the `value` before its displayed in the field (e.g. input).
+
+- `transformOut` transforms the value before it gets forwarded to the form data object or returned as the onChange value parameter.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/quick-start.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/quick-start.mdx
@@ -1,3 +1,5 @@
+import * as Examples from './Examples'
+
 ## Quick start
 
 Field components can be used directly as they are, for example `Field.Email`:
@@ -93,6 +95,21 @@ Form.setData('unique', { companyName: 'DNB' })
 // ... and the getData method when ever you need to:
 const { data, filterData } = Form.getData('unique')
 ```
+
+### Transforming data
+
+Each field supports transformer functions. So you can transform a value before it is processed to the form data object and vis-a-versa:
+
+```tsx
+<Field.String
+  label="Label"
+  path="/myField"
+  transformIn={transformIn}
+  transformOut={transformOut}
+/>
+```
+
+<Examples.Transformers />
 
 ### Async form handling
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -119,14 +119,15 @@ function StringComponent(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.trim]
   )
+  const transform = props.transformValue
   const transformValue = useCallback(
     (value: string) => {
       if (props.capitalize) {
         value = toCapitalized(String(value || ''))
       }
-      return value
+      return transform?.(value) || value
     },
-    [props.capitalize]
+    [props.capitalize, transform]
   )
 
   const preparedProps: Props = {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -213,6 +213,67 @@ describe('Field.String', () => {
       expect(input).toHaveValue('Æøå')
     })
 
+    it('should transform value with "transformIn" and "transformOut"', async () => {
+      const onChangeProvider = jest.fn()
+      const onChangeField = jest.fn()
+
+      const transformIn = jest.fn((value) => {
+        return value?.toUpperCase()
+      })
+      const transformOut = jest.fn((value) => {
+        return value?.toLowerCase()
+      })
+
+      render(
+        <DataContext.Provider
+          onChange={onChangeProvider}
+          data={{
+            myField: 'xYz',
+          }}
+        >
+          <Field.String
+            path="/myField"
+            transformIn={transformIn}
+            transformOut={transformOut}
+            onChange={onChangeField}
+          />
+        </DataContext.Provider>
+      )
+
+      const input = document.querySelector('input')
+
+      expect(input).toHaveValue('XYZ')
+      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenLastCalledWith('xYz')
+      expect(transformOut).toHaveBeenCalledTimes(0)
+      expect(onChangeProvider).toHaveBeenCalledTimes(0)
+      expect(onChangeField).toHaveBeenCalledTimes(0)
+
+      await userEvent.type(input, '{Backspace>3}aBc')
+
+      expect(input).toHaveValue('ABC')
+      expect(transformIn).toHaveBeenCalledTimes(13)
+      expect(transformIn).toHaveBeenLastCalledWith('abc')
+      expect(transformOut).toHaveBeenCalledTimes(6)
+      expect(transformOut).toHaveBeenLastCalledWith('ABc')
+      expect(onChangeProvider).toHaveBeenCalledTimes(6)
+      expect(onChangeProvider).toHaveBeenLastCalledWith({ myField: 'abc' })
+      expect(onChangeField).toHaveBeenCalledTimes(6)
+      expect(onChangeField).toHaveBeenLastCalledWith('abc')
+
+      await userEvent.type(input, '{Backspace>3}EfG')
+
+      expect(input).toHaveValue('EFG')
+      expect(transformIn).toHaveBeenCalledTimes(25)
+      expect(transformIn).toHaveBeenLastCalledWith('efg')
+      expect(transformOut).toHaveBeenCalledTimes(12)
+      expect(transformOut).toHaveBeenLastCalledWith('EFG')
+      expect(onChangeProvider).toHaveBeenCalledTimes(12)
+      expect(onChangeProvider).toHaveBeenLastCalledWith({ myField: 'efg' })
+      expect(onChangeField).toHaveBeenCalledTimes(12)
+      expect(onChangeField).toHaveBeenLastCalledWith('efg')
+    })
+
     it('should trim whitespaces', async () => {
       const onChange = jest.fn()
       const onBlur = jest.fn()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/stories/String.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/stories/String.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Field } from '../../..'
+import { Field, Form } from '../../..'
 import { Flex } from '../../../../../components'
 
 export default {
@@ -21,5 +21,24 @@ export const String = () => {
       <Field.String label="Label" width="large" />
       <Field.String label="Label" multiline width="large" />
     </Flex.Stack>
+  )
+}
+
+export const Transform = () => {
+  const transformIn = (value) => {
+    return value?.toUpperCase()
+  }
+  const transformOut = (value) => {
+    return value?.toLowerCase()
+  }
+  return (
+    <Form.Handler onChange={console.log}>
+      <Field.String
+        label="Label"
+        path="/myField"
+        transformIn={transformIn}
+        transformOut={transformOut}
+      />
+    </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -81,13 +81,13 @@ export const dataValueProperties: PropertiesTableProps = {
     type: 'function',
     status: 'optional',
   },
-  toInput: {
-    doc: 'Derivate called when the received / active value is sent to the input. Can be used for casting, changing syntax etc.',
+  transformIn: {
+    doc: 'transforms the `value` before its displayed in the field (e.g. input).',
     type: 'function',
     status: 'optional',
   },
-  fromInput: {
-    doc: 'Derivate called when changes is made by the user, to cast or change syntax back to the original (opposite of `toInput`).',
+  transformOut: {
+    doc: 'transforms the value before it gets forwarded to the form data object or returned as the `onChange` value parameter.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -1955,6 +1955,88 @@ describe('useFieldProps', () => {
   })
 
   describe('value manipulation', () => {
+    it('should call "transformIn" and "transformOut"', () => {
+      const transformIn = jest.fn((v) => v - 1)
+      const transformOut = jest.fn((v) => v + 1)
+      const onChange = jest.fn()
+
+      const { result } = renderHook(() =>
+        useFieldProps({
+          value: 1,
+          onChange,
+          transformIn,
+          transformOut,
+        })
+      )
+
+      const { handleChange } = result.current
+
+      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
+      expect(transformOut).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange(2)
+      })
+
+      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenLastCalledWith(3)
+      expect(transformOut).toHaveBeenCalledTimes(1)
+      expect(transformOut).toHaveBeenLastCalledWith(2)
+
+      act(() => {
+        handleChange(4)
+      })
+
+      expect(transformIn).toHaveBeenCalledTimes(3)
+      expect(transformIn).toHaveBeenLastCalledWith(5)
+      expect(transformOut).toHaveBeenCalledTimes(2)
+      expect(transformOut).toHaveBeenLastCalledWith(4)
+    })
+
+    it('should call "transformIn" and "transformOut" after "fromInput" and "toInput"', () => {
+      const transformIn = jest.fn((v) => v - 1)
+      const transformOut = jest.fn((v) => v + 1)
+      const toInput = jest.fn((v) => v - 1)
+      const fromInput = jest.fn((v) => v + 1)
+      const onChange = jest.fn()
+
+      const { result } = renderHook(() =>
+        useFieldProps({
+          value: 1,
+          onChange,
+          transformIn,
+          transformOut,
+          fromInput,
+          toInput,
+        })
+      )
+
+      const { handleChange } = result.current
+
+      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenLastCalledWith(0)
+      expect(transformOut).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange(2)
+      })
+
+      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenLastCalledWith(3)
+      expect(transformOut).toHaveBeenCalledTimes(1)
+      expect(transformOut).toHaveBeenLastCalledWith(3)
+
+      act(() => {
+        handleChange(4)
+      })
+
+      expect(transformIn).toHaveBeenCalledTimes(3)
+      expect(transformIn).toHaveBeenLastCalledWith(5)
+      expect(transformOut).toHaveBeenCalledTimes(2)
+      expect(transformOut).toHaveBeenLastCalledWith(5)
+    })
+
     it('should call "fromInput" and "toInput"', () => {
       const fromInput = jest.fn((v) => v + 1)
       const toInput = jest.fn((v) => v - 1)

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -85,6 +85,8 @@ export default function useFieldProps<
     validateInitially,
     validateUnchanged,
     continuousValidation,
+    transformIn = (value: Value) => value,
+    transformOut = (value: Value) => value,
     toInput = (value: Value) => value,
     fromInput = (value: Value) => value,
     toEvent = (value: Value) => value,
@@ -113,6 +115,8 @@ export default function useFieldProps<
   const tr = useLocale()
 
   const transformers = useRef({
+    transformIn,
+    transformOut,
     toInput,
     fromInput,
     toEvent,
@@ -909,9 +913,8 @@ export default function useFieldProps<
         return
       }
 
-      const transformedValue = transformers.current.transformValue(
-        fromInput,
-        currentValue
+      const transformedValue = transformers.current.transformOut(
+        transformers.current.transformValue(fromInput, currentValue)
       )
 
       // Must be set before validation
@@ -1265,7 +1268,9 @@ export default function useFieldProps<
 
     /** Documented APIs */
     id,
-    value: transformers.current.toInput(valueRef.current),
+    value: transformers.current.transformIn(
+      transformers.current.toInput(valueRef.current)
+    ),
     hasError: hasVisibleError,
     isChanged: changedRef.current,
     htmlAttributes,

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -229,6 +229,8 @@ export interface FieldProps<
   continuousValidation?: boolean
   errorMessages?: ErrorMessages
   // Derivatives
+  transformIn?: (external: Value | unknown) => Value | unknown
+  transformOut?: (internal: Value | unknown) => Value
   toInput?: (external: Value | unknown) => Value | unknown
   fromInput?: (external: Value | unknown) => Value
   toEvent?: (


### PR DESCRIPTION
This new transformer API is a declarative addition that can be used on every field, regardless if the field internals already use one of the other transformers, such as `toInput` and `fromInput`.

These two transformers are meant to be used form the field consumer, and not internally in fields.

```tsx
const transformIn = (value) => {
  return value?.toUpperCase()
}
const transformOut = (value) => {
  return value?.toLowerCase()
}
render(
  <Form.Handler onChange={console.log}>
    <Field.String
       path="/myField"
       transformIn={transformIn}
       transformOut={transformOut}
    />
  </Form.Handler>
)
```