### PR TITLE
fix(OrganizationNumber): add missing full stop for `en-US` error messages

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
@@ -7,8 +7,8 @@ export default {
     ...enGB,
     OrganizationNumber: {
       label: 'Organization number',
-      errorRequired: 'You must enter an organization number',
-      errorPattern: 'This is not a valid organization number',
+      errorRequired: 'You must enter an organization number.',
+      errorPattern: 'This is not a valid organization number.',
     },
   },
 }


### PR DESCRIPTION
Ref this [discussion](https://dnb-it.slack.com/archives/CMXABCHEY/p1709559880531129).

Adding the missing full stops for `OrganizationNumber` `en-US`. The other full stops has thankfully been added in an earlier PR 🔥