### PR TITLE
docs(contribution guide): update title and move sandbox starter

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute.mdx
@@ -117,6 +117,8 @@ Colors, fonts and logo guidelines are set in the DNB Brandbook and the digital v
 
 [Jira Issue Tracking](https://jira.tech.dnb.no/projects/EDS/summary) or [Github Issue Tracking](https://github.com/dnbexperience/eufemia/issues): Where you can report or find new issues
 
+[Codesandbox Template](https://eufemia.dnb.no/issue/): For quickly reproducing issues when reporting bugs.
+
 ### People of Eufemia
 
 We want to thank every [contributor of Eufemia](/design-system/about#please-contribute), without you Eufemia would not be the design system it is today.

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
@@ -30,6 +30,8 @@ The next step is finding an issue to work on. The [/contribute](https://github.c
 
 ## How to report an issue or suggest a new feature
 
+You may use [this "reproduction" starter](!/issue) to reproduce the issue when reporting.
+
 If you discover a **security issue** in the @dnb/eufemia, please report it by sending an
 email to [tobias.hoegh@dnb.no](mailto:tobias.hoegh@dnb.no). This will allow us to assess the risk, and make a fix available before we add a
 bug report to the GitHub repository. Thanks for helping out.

--- a/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
@@ -24,7 +24,7 @@ Many defaults are given by the linting and prettier configurations. But to keep 
 - Use [naming conventions](/contribute/style-guides/naming) when possible.
 - Use best practices for [CSS style structures](/uilib/usage/best-practices/for-styling#structure).
 - Use [nested CSS class selectors](https://medium.com/@andrew_barnes/bem-and-sass-a-perfect-match-5e48d9bc3894) with SASS (SCSS) and [BEM](http://getbem.com/naming/) (Block Element Modifier).
-- Use [React Hooks](https://reactjs.org/docs/hooks-overview.html) over React class components when possible.
+- Use [React Hooks](https://react.dev/reference/react/hooks) over React class components when possible.
 - Use [Typescript](https://www.typescriptlang.org), even most of the components do use PropTypes to generated type definition files only.
 
 ## DNB Code of conduct

--- a/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
@@ -56,7 +56,7 @@ We encourage everyone to participate and are committed to building a community f
 
 Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected characteristics above, including participants with disabilities.
 
-### Reporting Issues
+### Reporting Unacceptable Behavior Guidelines
 
 If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us. All reports will be handled with discretion. In your report please include:
 
@@ -68,8 +68,6 @@ If you experience or witness unacceptable behavior—or have any other concerns�
 After filing a report, a representative will contact you personally. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. A representative will then review the incident, follow up with any additional questions, and make a decision as to how to respond. We will respect confidentiality requests for the purpose of protecting victims of abuse.
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the representative may take any action they deem appropriate, up to and including a permanent ban from our community without warning.
-
-You may use [this "reproduction" starter](!/issue) to reproduce the issue when reporting.
 
 <Section style_type="mint-green" spacing>
   <Button

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/issues.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/issues.mdx
@@ -13,6 +13,8 @@ bug report to the GitHub repository. Thanks for helping out.
 
 When reporting issues or suggesting new features, we would appreciate if you use [GitHub Issues](https://github.com/dnbexperience/eufemia/issues) or our [Jira Kanban board](https://jira.tech.dnb.no/projects/EDS/summary#). Another option is to send a Slack message in [#eufemia-web](https://dnb-it.slack.com/archives/CMXABCHEY).
 
+For reproduction of issues you can use our [codesandbox starter template](https://eufemia.dnb.no/issue/). Including this in your report helps us out a lot.
+
 ## GitHub issues
 
 When reporting issues on GitHub, you need to have a [GitHub account](https://github.com/join).


### PR DESCRIPTION
- Ground rules: Reporting issues title was a bit misleading, changing it and moving the sandbox starter to more relevant place
- Update React docs link to their new docs pages