### PR TITLE
fix(Flex.Container): fix issue where `space` object was ignored in nested `Flex.Containers`

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -190,7 +190,7 @@ function FlexContainer(props: Props) {
 
     return renderWithSpacing(child, {
       key: child?.['key'] || `element-${i}`,
-      space,
+      space: child?.['props']?.space ?? space,
     })
   })
 

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -721,6 +721,35 @@ describe('Flex.Container', () => {
         document.querySelectorAll('[class*="dnb-space__"]')
       ).toHaveLength(3)
     })
+
+    it('should support spacing props for nested Flex.Containers', () => {
+      render(
+        <Flex.Container>
+          <Flex.Vertical
+            id="flex-container-space"
+            space={{
+              bottom: 'xx-large',
+              top: 'xx-large',
+              left: 'xx-large',
+              right: 'xx-large',
+            }}
+          >
+            <Flex.Item>FlexItem 1</Flex.Item>
+            <Flex.Item>FlexItem 2</Flex.Item>
+            <Flex.Item>FlexItem 3</Flex.Item>
+            <Flex.Item>FlexItem 4</Flex.Item>
+          </Flex.Vertical>
+        </Flex.Container>
+      )
+
+      const flexContainer = document.querySelector('#flex-container-space')
+      expect(flexContainer).toHaveClass(
+        'dnb-space__left--xx-large',
+        'dnb-space__right--xx-large',
+        'dnb-space__top--xx-large',
+        'dnb-space__bottom--xx-large'
+      )
+    })
   })
 
   it('should set custom element', () => {


### PR DESCRIPTION
Proposal to fix issue where the space prop was overwritten on `Flex.Container ``children` nested inside another `Flex.Container`.

Not sure if this is the best method to fix this issue 🤔

With this composition: 
<img width="695" alt="Screenshot 2024-04-25 at 10 45 34" src="https://github.com/dnbexperience/eufemia/assets/25927156/679d5aaf-f0bf-4dec-9329-eafc75b0ce0d">

Before:
<img width="243" alt="Screenshot 2024-04-25 at 10 45 11" src="https://github.com/dnbexperience/eufemia/assets/25927156/d13d9928-33fb-4d6d-be36-58a7916768fc">

After:

<img width="406" alt="Screenshot 2024-04-25 at 10 44 46" src="https://github.com/dnbexperience/eufemia/assets/25927156/e8cfdc03-f5a0-454f-bec3-95ffeb19772c">
