### PR TITLE
chore: refactor to internal field boundary

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryContext.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Path } from '../../types'
+
+export interface FieldBoundaryContextState {
+  hasError?: boolean
+  hasErrorAndShowIt?: boolean
+  errorsRef?: React.RefObject<unknown>
+  setFieldError?: (path: Path, error: Error) => void
+}
+
+const FieldBoundaryContext = React.createContext<
+  FieldBoundaryContextState | undefined
+>(undefined)
+
+export default FieldBoundaryContext

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useContext, useRef } from 'react'
+import FieldBoundaryContext, {
+  FieldBoundaryContextState,
+} from './FieldBoundaryContext'
+import DataContext from '../Context'
+import { Path } from '../../types'
+
+export default function FieldBoundaryProvider({ children }) {
+  const { showAllErrors } = useContext(DataContext)
+
+  const errorsRef = useRef<Record<Path, boolean>>({})
+  const hasError = Object.keys(errorsRef.current || {}).length > 0
+  const hasErrorAndShowIt = showAllErrors && hasError
+
+  const setFieldError = useCallback((path: Path, error: Error) => {
+    if (error) {
+      errorsRef.current[path] = !!error
+    } else {
+      delete errorsRef.current?.[path]
+    }
+  }, [])
+
+  const context: FieldBoundaryContextState = {
+    hasError,
+    hasErrorAndShowIt,
+    errorsRef,
+    setFieldError,
+  }
+
+  return (
+    <FieldBoundaryContext.Provider value={context}>
+      {children}
+    </FieldBoundaryContext.Provider>
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
@@ -1,0 +1,107 @@
+import React, { useContext } from 'react'
+import { render } from '@testing-library/react'
+import FieldBoundaryProvider from '../FieldBoundaryProvider'
+import FieldBoundaryContext, {
+  FieldBoundaryContextState,
+} from '../FieldBoundaryContext'
+import Provider from '../../Provider'
+import { Field, Form } from '../../..'
+import userEvent from '@testing-library/user-event'
+
+describe('FieldBoundaryProvider', () => {
+  it('should render children', () => {
+    const { getByText } = render(
+      <FieldBoundaryProvider>content</FieldBoundaryProvider>
+    )
+
+    expect(getByText('content')).toBeInTheDocument()
+  })
+
+  it('should set error in context', async () => {
+    const contextRef: React.MutableRefObject<FieldBoundaryContextState> =
+      React.createRef()
+
+    const ContextConsumer = () => {
+      contextRef.current = useContext(FieldBoundaryContext)
+      return null
+    }
+
+    const { rerender } = render(
+      <Provider>
+        <FieldBoundaryProvider>
+          <ContextConsumer />
+          <Field.String />
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    expect(contextRef.current.hasError).toBe(false)
+    expect(contextRef.current.hasErrorAndShowIt).toBe(false)
+    expect(contextRef.current.errorsRef.current).toMatchObject({})
+
+    rerender(
+      <Provider>
+        <FieldBoundaryProvider>
+          <ContextConsumer />
+          <Field.String required />
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    expect(contextRef.current.hasError).toBe(true)
+    expect(contextRef.current.hasErrorAndShowIt).toBe(false)
+    expect(contextRef.current.errorsRef.current).toMatchObject({
+      'id-r0': true,
+    })
+
+    rerender(
+      <Provider>
+        <FieldBoundaryProvider>
+          <ContextConsumer />
+          <Field.String required />
+          <Form.SubmitButton />
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    await userEvent.click(document.querySelector('button'))
+
+    expect(contextRef.current.hasError).toBe(true)
+    expect(contextRef.current.hasErrorAndShowIt).toBe(true)
+    expect(contextRef.current.errorsRef.current).toMatchObject({
+      'id-r0': true,
+    })
+
+    rerender(
+      <Provider>
+        <FieldBoundaryProvider>
+          <ContextConsumer />
+          <Field.String required value="foo" />
+          <Form.SubmitButton />
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    expect(contextRef.current.hasError).toBe(false)
+    expect(contextRef.current.hasErrorAndShowIt).toBe(false)
+    expect(contextRef.current.errorsRef.current).toMatchObject({})
+
+    rerender(
+      <Provider>
+        <FieldBoundaryProvider>
+          <ContextConsumer />
+          <Field.String required path="/bar" />
+          <Form.SubmitButton />
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    await userEvent.click(document.querySelector('button'))
+
+    expect(contextRef.current.hasError).toBe(true)
+    expect(contextRef.current.hasErrorAndShowIt).toBe(true)
+    expect(contextRef.current.errorsRef.current).toMatchObject({
+      '/bar': true,
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/__tests__/ElementBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/__tests__/ElementBlock.test.tsx
@@ -109,20 +109,20 @@ describe('ElementBlock', () => {
     render(
       <DataContext.Provider
         data={{
-          myList: [''],
+          myList: ['foo'],
         }}
       >
         <Iterate.Array path="/myList">
           {(value, index) => {
             return (
               <Iterate.AnimatedContainer>
-                <Field.String required validateInitially={index === 0} />
+                <Field.String required={index > 0} />
               </Iterate.AnimatedContainer>
             )
           }}
         </Iterate.Array>
 
-        <Iterate.PushButton path="/myList" pushValue="foo" />
+        <Iterate.PushButton path="/myList" pushValue={undefined} />
       </DataContext.Provider>
     )
 
@@ -140,10 +140,10 @@ describe('ElementBlock', () => {
 
     expect(
       elements[0].querySelector('.dnb-form-iterate-block--error')
-    ).toBeTruthy()
+    ).toBeFalsy()
     expect(
       elements[1].querySelector('.dnb-form-iterate-block--error')
-    ).toBeFalsy()
+    ).toBeTruthy()
   })
 
   it('should open delayed when isNew is true', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/IterateElementContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/IterateElementContext.ts
@@ -7,13 +7,11 @@ export interface IterateElementContextState {
   index?: number
   value?: unknown
   isNew?: boolean
-  hasError?: boolean
   path?: Path
   arrayValue?: Array<unknown>
   containerMode?: ContainerMode
   containerRef?: React.RefObject<HTMLDivElement>
   elementRef?: React.RefObject<HTMLDivElement>
-  setFieldError?: (path: Path, error: Error) => void
   switchContainerMode?: (mode: ContainerMode) => void
   handleChange?: (path: Path, value: unknown) => void
   handleRemove?: ({ keepItems }?: { keepItems?: boolean }) => void

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -27,6 +27,7 @@ import useMountEffect from '../../../shared/helpers/useMountEffect'
 import useUnmountEffect from '../../../shared/helpers/useUnmountEffect'
 import FieldBlockContext from '../FieldBlock/FieldBlockContext'
 import IterateElementContext from '../Iterate/IterateElementContext'
+import FieldBoundaryContext from '../DataContext/FieldBoundary/FieldBoundaryContext'
 import useProcessManager from './useProcessManager'
 import {
   createSharedState,
@@ -112,6 +113,7 @@ export default function useFieldProps<
   const dataContext = useContext(DataContext)
   const fieldBlockContext = useContext(FieldBlockContext)
   const iterateElementContext = useContext(IterateElementContext)
+  const fieldBoundaryContext = useContext(FieldBoundaryContext)
   const translation = useTranslation()
 
   const transformers = useRef({
@@ -150,8 +152,8 @@ export default function useFieldProps<
     value: iterateElementValue,
     path: iteratePath,
     handleChange: handleChangeIterateContext,
-    setFieldError: setFieldErrorIterateContext,
   } = iterateElementContext ?? {}
+  const { setFieldError } = fieldBoundaryContext ?? {}
 
   if (path && path.substring(0, 1) !== '/') {
     throw new Error(
@@ -442,7 +444,7 @@ export default function useFieldProps<
 
       // Tell the data context about the error, so it can stop the user from submitting the form until the error has been fixed
       setFieldErrorDataContext?.(identifier, error)
-      setFieldErrorIterateContext?.(identifier, error)
+      setFieldError?.(identifier, error)
 
       // Set the visual states
       setFieldStateDataContext?.(identifier, error ? 'error' : undefined)
@@ -460,7 +462,7 @@ export default function useFieldProps<
       prepareError,
       setFieldErrorDataContext,
       identifier,
-      setFieldErrorIterateContext,
+      setFieldError,
       setFieldStateDataContext,
       setFieldStateFieldBlock,
       stateId,
@@ -1030,7 +1032,8 @@ export default function useFieldProps<
   useUnmountEffect(() => {
     dataContext?.handleUnMountField(identifier)
     setFieldErrorDataContext?.(identifier, undefined)
-    setFieldErrorIterateContext?.(identifier, undefined)
+    setFieldError?.(identifier, undefined)
+    localErrorRef.current = undefined
   })
 
   useUpdateEffect(() => {


### PR DESCRIPTION
This way we can re-use the field boundary logic in other parts.

