### PR TITLE
fix(forms): (TypeScript) ensure `data` type is inherited in onSubmit

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -51,11 +51,11 @@ You can define the TypeScript type structure for your data like so:
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 type MyDataSet = {
-  lastName?: string
+  firstName?: string
 }
 
 const data: MyDataSet = {
-  lastName: 'Nora',
+  firstName: 'Nora',
 }
 
 // Method #1
@@ -64,7 +64,7 @@ function MyForm() {
     <Form.Handler
       data={data}
       onSubmit={(data) => {
-        console.log(data.lastName)
+        console.log(data.firstName)
       }}
     />
   )
@@ -72,7 +72,7 @@ function MyForm() {
 
 // Method #2
 const submitHandler = (data: MyDataSet) => {
-  console.log(data.lastName)
+  console.log(data.firstName)
 }
 function MyForm() {
   return <Form.Handler data={data} onSubmit={submitHandler} />
@@ -81,7 +81,7 @@ function MyForm() {
 // Method #3
 import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
 const submitHandler: OnSubmit<MyDataSet> = (data) => {
-  console.log(data.lastName)
+  console.log(data.firstName)
 }
 function MyForm() {
   return <Form.Handler data={data} onSubmit={submitHandler} />
@@ -111,7 +111,7 @@ You can set `autoComplete` on the `Form.Handler` – each [Field.String](/uilib/
 ```tsx
 <Form.Handler autoComplete={true}>
   <Field.String path="/firstName" />
-  <Field.String path="/lastName" />
+  <Field.String path="/firstName" />
 </Form.Handler>
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -11,6 +11,7 @@ The `Form.Handler` component provides a HTML form element.
 
 ```jsx
 import { Form } from '@dnb/eufemia/extensions/forms'
+
 render(
   <Form.Handler
     data={existingData}
@@ -26,7 +27,8 @@ The form data can be handled outside of the form. This is useful if you want to 
 
 ```jsx
 import { Form } from '@dnb/eufemia/extensions/forms'
-function Component() {
+
+function MyForm() {
   const {
     getValue, // Method to get a single value
     update, // Method to update a single value
@@ -40,6 +42,51 @@ function Component() {
 ```
 
 More examples can be found in the [useData](/uilib/extensions/forms/Form/useData/) hook docs.
+
+### TypeScript support
+
+You can define the TypeScript type structure for your data like so:
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+type MyDataSet = {
+  lastName?: string
+}
+
+const data: MyDataSet = {
+  lastName: 'Nora',
+}
+
+// Method #1
+function MyForm() {
+  return (
+    <Form.Handler
+      data={data}
+      onSubmit={(data) => {
+        console.log(data.lastName)
+      }}
+    />
+  )
+}
+
+// Method #2
+const submitHandler = (data: MyDataSet) => {
+  console.log(data.lastName)
+}
+function MyForm() {
+  return <Form.Handler data={data} onSubmit={submitHandler} />
+}
+
+// Method #3
+import type { OnSubit } from '@dnb/eufemia/extensions/forms'
+const submitHandler: OnSubit<MyDataSet> = (data) => {
+  console.log(data.lastName)
+}
+function MyForm() {
+  return <Form.Handler data={data} onSubmit={submitHandler} />
+}
+```
 
 ## Async `onChange` and `onSubmit` event handlers
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -79,7 +79,7 @@ function MyForm() {
 }
 
 // Method #3
-import type { OnSubit } from '@dnb/eufemia/extensions/forms'
+import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
 const submitHandler: OnSubit<MyDataSet> = (data) => {
   console.log(data.lastName)
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -80,7 +80,7 @@ function MyForm() {
 
 // Method #3
 import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
-const submitHandler: OnSubit<MyDataSet> = (data) => {
+const submitHandler: OnSubmit<MyDataSet> = (data) => {
   console.log(data.lastName)
 }
 function MyForm() {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -60,11 +60,11 @@ export interface Props<Data extends JsonObject> {
   /**
    * Default source data, only used if no other source is available, and not leading to updates if changed after mount
    */
-  defaultData?: Partial<Data>
+  defaultData?: Data
   /**
    * Source data, will be used instead of defaultData, and leading to updates if changed after mount
    */
-  data?: Partial<Data>
+  data?: Data
   /**
    * JSON Schema to validate the data against.
    */
@@ -112,7 +112,7 @@ export interface Props<Data extends JsonObject> {
    * Will emit on a form submit – if validation has passed.
    * You can provide an async function to shows a submit indicator during submit. All form elements will be disabled during the submit.
    */
-  onSubmit?: OnSubmit
+  onSubmit?: OnSubmit<Data>
   /**
    * Submit was requested, but data was invalid
    */
@@ -233,7 +233,7 @@ export default function Provider<Data extends JsonObject>(
     return data ?? defaultData
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Avoid triggering code that should only run initially
   }, [])
-  const internalDataRef = useRef<Partial<Data>>(initialData)
+  const internalDataRef = useRef<Data>(initialData)
 
   // - Validator
   const ajvValidatorRef = useRef<ValidateFunction>()
@@ -782,7 +782,7 @@ export default function Provider<Data extends JsonObject>(
         enableAsyncBehaviour: isAsync(onSubmit),
         onSubmit: async () => {
           // - Mutate the data context
-          const data = internalDataRef.current as Data
+          const data = internalDataRef.current
           const filteredData = filterDataHandler(
             transformOut ? mutateDataHandler(data, transformOut) : data
           )
@@ -799,7 +799,7 @@ export default function Provider<Data extends JsonObject>(
               forceUpdate() // in order to fill "empty fields" again with their internal states
             },
             clearData: () => {
-              internalDataRef.current = {}
+              internalDataRef.current = {} as Data
               if (id) {
                 setSharedData?.({} as Data)
               } else {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -64,7 +64,7 @@ export default function FormHandler<Data extends JsonObject>({
     scrollTopOnSubmit,
     sessionStorageId,
     autoComplete,
-  } as Omit<ProviderProps<Data>, 'children'>
+  }
 
   return (
     <DataContextProvider {...providerProps}>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -864,4 +864,28 @@ describe('Form.Handler', () => {
       })
     })
   })
+
+  it('onSubmit should return the data including the type', () => {
+    let result = null
+
+    render(
+      <Form.Handler
+        defaultData={{ lastName: 'Nora' }}
+        onSubmit={(data) => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          result = data.lastName2
+
+          // Use the correct value
+          result = data.lastName
+        }}
+      >
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+
+    expect(result).toBe('Nora')
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -870,14 +870,14 @@ describe('Form.Handler', () => {
 
     render(
       <Form.Handler
-        defaultData={{ lastName: 'Nora' }}
+        defaultData={{ firstName: 'Nora' }}
         onSubmit={(data) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          result = data.lastName2
+          result = data.firstName2
 
           // Use the correct value
-          result = data.lastName
+          result = data.firstName
         }}
       >
         <Form.SubmitButton />

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -445,7 +445,7 @@ export type OnSubmitParams = {
 }
 
 export type OnSubmit<Data = JsonObject> = (
-  data: Partial<Data>,
+  data: Data,
   { resetForm, clearData }: OnSubmitParams
 ) =>
   | EventReturnWithStateObject


### PR DESCRIPTION
Make this possible (again):
<img width="510" alt="Screenshot 2024-05-07 at 11 58 19" src="https://github.com/dnbexperience/eufemia/assets/1501870/fae82979-f612-44c0-a716-b9495e06f623">

This type test fails when not met:
<img width="315" alt="Screenshot 2024-05-07 at 12 11 42" src="https://github.com/dnbexperience/eufemia/assets/1501870/f0e05312-249a-4862-b89d-39a0e77deaf0">
