### PR TITLE
fix(HeightAnimation): ensure Radio buttons persist their state

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
@@ -181,6 +181,11 @@ export default class HeightAnimation {
 
     const width = this.elem.clientWidth
     const clonedElem = this.elem.cloneNode(true) as HTMLElement
+    const inputs = clonedElem.querySelectorAll('input')
+    inputs.forEach((input) => {
+      input.removeAttribute('name') // because type="radio" will be else effected negatively
+      input.removeAttribute('id') // don't put IDs twice in the DOM
+    })
     this.elem.parentNode?.insertBefore(clonedElem, this.elem.nextSibling)
 
     for (const key in this.firstPaintStyle) {

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
@@ -107,6 +107,75 @@ describe('HeightAnimationInstance', () => {
       expect(removedNodes).toHaveLength(1)
     })
 
+    it('should create a cloned element and remove name and id attributes', async () => {
+      const element = document.createElement('span')
+      const input = document.createElement('input')
+      input.setAttribute('id', 'myId')
+      input.setAttribute('name', 'myName')
+      input.setAttribute('class', 'myClass')
+      element.appendChild(input)
+      document.body.appendChild(element)
+
+      const inst = new HeightAnimationInstance()
+      inst.setElement(element)
+
+      mockHeight(100, element)
+
+      const addedNodes = []
+      const removedNodes = []
+
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList') {
+            if (mutation.removedNodes?.length) {
+              removedNodes.push(mutation.removedNodes)
+            }
+            if (mutation.addedNodes?.length) {
+              addedNodes.push(mutation.addedNodes)
+            }
+          }
+        }
+      })
+
+      observer.observe(document.body, {
+        childList: true,
+      })
+
+      inst.getUnknownHeight()
+
+      await wait(1)
+
+      observer.disconnect()
+
+      expect(addedNodes).toHaveLength(1)
+      expect(removedNodes).toHaveLength(1)
+
+      const addedElement = removedNodes[0][0] as HTMLElement
+      expect(addedElement.querySelector('input')).toHaveAttribute(
+        'class',
+        'myClass'
+      )
+      expect(addedElement.querySelector('input')).not.toHaveAttribute('id')
+      expect(addedElement.querySelector('input')).not.toHaveAttribute(
+        'name'
+      )
+
+      const removedElement = removedNodes[0][0] as HTMLElement
+      expect(removedElement.querySelector('input')).toHaveAttribute(
+        'class',
+        'myClass'
+      )
+      expect(removedElement.querySelector('input')).not.toHaveAttribute(
+        'id'
+      )
+      expect(removedElement.querySelector('input')).not.toHaveAttribute(
+        'name'
+      )
+      expect(removedElement.outerHTML).toMatchInlineSnapshot(
+        `"<span data-height="100" style="visibility: hidden; opacity: 0; height: auto; width: auto; position: absolute;"><input class="myClass"></span>"`
+      )
+    })
+
     it('should create a cloned element with firstPaintStyle styles', async () => {
       const inst = new HeightAnimationInstance()
       inst.setElement(element)


### PR DESCRIPTION
Why it effects radio buttons: The `name` attribute is used to create a "group". But when a new element gets added, that has the same `name`, it conflicts with the existing group, and removes the checked state of the current checked radio button, as there is a second "checked" one.