### PR TITLE
fix(forms): fix wrong TypeScript JSX return type

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -150,7 +150,7 @@ function Visibility({
     )
   }
 
-  return open ? children : null
+  return <>{open ? children : null}</>
 }
 
 Visibility._supportsSpacingProps = 'children'


### PR DESCRIPTION
> 'Form.Visibility' cannot be used as a JSX component.