### PR TITLE
fix(Anchor): add TypeScript (strict) support for react-router-dom Link used as `element`

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -19,8 +19,17 @@ import type { IconIcon } from '../icon/Icon'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import type { DynamicElement, SpacingProps } from '../../shared/types'
 
+// Local type for react-router-dom link with only the necessary props. Done this way to prevent react-router-dom dependency.
+type ReactRouterLink = {
+  to: string | { pathname?: string; search?: string; has?: string }
+}
+
 export type AnchorProps = {
-  element?: DynamicElement<HTMLAnchorElement | AnchorAllProps>
+  element?:
+    | DynamicElement<HTMLAnchorElement | AnchorAllProps>
+    | React.ForwardRefExoticComponent<
+        ReactRouterLink & React.RefAttributes<HTMLAnchorElement>
+      >
   href?: string
   to?: string
   targetBlankTitle?: string

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -20,7 +20,10 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import type { DynamicElement, SpacingProps } from '../../shared/types'
 
 // Local type for react-router-dom link with only the necessary props. Done this way to prevent react-router-dom dependency.
-type ReactRouterLink = {
+type ReactRouterLink = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'href'
+> & {
   to: string | { pathname?: string; search?: string; has?: string }
 }
 

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -393,6 +393,30 @@ describe('Anchor element', () => {
       document.querySelector('.dnb-anchor--icon-left')
     ).toBeInTheDocument()
   })
+
+  it('should support "to" prop type without forwarding to href', () => {
+    render(<Anchor to="/url">text</Anchor>)
+
+    expect(document.querySelector('a')).not.toHaveAttribute('href')
+  })
+
+  it('should support custom Link component with "to" prop', () => {
+    const Link = ({ children, to, ...rest }) => {
+      return (
+        <a {...rest} href={to}>
+          {children}
+        </a>
+      )
+    }
+
+    render(
+      <Anchor to="/url" element={Link}>
+        text
+      </Anchor>
+    )
+
+    expect(document.querySelector('a')).toHaveAttribute('href', '/url')
+  })
 })
 
 describe('Anchor scss', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -9,7 +9,6 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Field } from '../../..'
-import { wait } from '@testing-library/user-event/dist/types/utils'
 
 describe('Selection', () => {
   it('renders selected option', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { screen, render, within, fireEvent } from '@testing-library/react'
+import {
+  screen,
+  render,
+  within,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Field } from '../../..'
+import { wait } from '@testing-library/user-event/dist/types/utils'
 
 describe('Selection', () => {
   it('renders selected option', () => {
@@ -749,8 +756,10 @@ describe('event handlers', () => {
     const selectionButton = screen.getByRole('button')
     await userEvent.click(selectionButton)
 
-    expect(onFocus.mock.calls).toHaveLength(1)
-    expect(onFocus.mock.calls[0][0]).toEqual('bar')
+    await waitFor(() => {
+      expect(onFocus.mock.calls).toHaveLength(1)
+      expect(onFocus.mock.calls[0][0]).toEqual('bar')
+    })
   })
 
   it('calls onBlur when selecting the options so the dropdown closes with selected value as argument', async () => {


### PR DESCRIPTION
before:
<img width="1032" alt="Screenshot 2024-05-15 at 13 43 49" src="https://github.com/dnbexperience/eufemia/assets/25927156/877509e9-b6db-42f2-b387-6f8ba8640fc8">

after:
<img width="585" alt="Screenshot 2024-05-15 at 13 43 21" src="https://github.com/dnbexperience/eufemia/assets/25927156/dfeb453a-11f3-491b-bb67-9b5355373c25">
