### PR TITLE
chore(forms): enhance field props performance

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -379,19 +379,7 @@ export default function Provider<Data extends JsonObject>(
   const fieldPropsRef = useRef<Record<Path, FieldProps>>({})
   const setProps = useCallback(
     (path: Path, props: Record<string, unknown>) => {
-      if (!fieldPropsRef.current[path]) {
-        fieldPropsRef.current[path] = {}
-      }
-      // For async processing, we need to merge the props with the existing props
-      Object.assign(fieldPropsRef.current[path], props)
-
-      // If one of the given props is not in props anymore,
-      // it needs to be removed from the fieldPropsRef
-      for (const key in fieldPropsRef.current[path]) {
-        if (!Object.prototype.hasOwnProperty.call(props, key)) {
-          delete fieldPropsRef.current[path][key]
-        }
-      }
+      fieldPropsRef.current[path] = props
     },
     []
   )

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1015,10 +1015,6 @@ export default function useFieldProps<
 
   useMountEffect(() => {
     dataContext?.handleMountField(identifier)
-
-    // Run this twice, because when remounting, props where removed by the unmount effect
-    setPropsDataContext?.(identifier, props)
-
     validateValue()
   })
   useUnmountEffect(() => {


### PR DESCRIPTION
Since we don't remove props anymore, we don't need to merge and deal with syncing them. This allows us to speed up the performance by not merging them with existing props.

