### PR TITLE
fix(forms): set focus back on existing element after async submission

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1082,6 +1082,7 @@ function useFormStatusBuffer(props: FormStatusBufferProps) {
   }, [])
 
   const hadCompleteRef = useRef(false)
+  const activeElementRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
     // This offset is used to calculate the delay,
@@ -1116,6 +1117,7 @@ function useFormStatusBuffer(props: FormStatusBufferProps) {
     }
 
     if (formState === 'pending' && stateRef.current !== 'pending') {
+      activeElementRef.current = document.activeElement as HTMLElement
       clear()
       nowRef.current = Date.now()
       hadCompleteRef.current = false
@@ -1129,6 +1131,9 @@ function useFormStatusBuffer(props: FormStatusBufferProps) {
           if (hadCompleteRef.current) {
             setState('complete')
           }
+          window.requestAnimationFrame(() => {
+            activeElementRef.current?.focus?.()
+          })
         }, delay)
 
         timeoutRef.current.reset = setTimeout(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -542,6 +542,34 @@ describe('Form.Handler', () => {
       expect(buttonElement).not.toBeDisabled()
     })
 
+    it('should set focus on previously activeElement when submit is completed', async () => {
+      const onSubmit = async () => null
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.String />
+        </Form.Handler>
+      )
+
+      const inputElement = document.querySelector('input')
+
+      await userEvent.type(inputElement, 'something')
+      const activeElement = document.activeElement
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(inputElement).toBeDisabled()
+
+      // Ensure we loose focus
+      inputElement.removeAttribute('disabled')
+      inputElement.blur()
+
+      await waitFor(() => {
+        expect(activeElement).toBe(inputElement)
+        expect(activeElement).toBe(document.activeElement)
+      })
+    })
+
     it('should abort async submit when onSubmit returns error', async () => {
       const onSubmit = jest.fn(async () => {
         await wait(1)


### PR DESCRIPTION
It can be tested in [this example](https://eufemia-git-fix-set-focus-after-submit-eufemia.vercel.app/uilib/extensions/forms/Form/demos/#in-combination-with-a-submitbutton) vs the [existing one](https://eufemia.dnb.no/uilib/extensions/forms/Form/demos/#in-combination-with-a-submitbutton).