### PR TITLE
fix(ArraySelection): make explicit type of value can be undefined

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -14,7 +14,7 @@ interface IOption {
   handleSelect: () => void
 }
 
-export type Props = FieldProps<Array<string | number>> & {
+export type Props = FieldProps<Array<string | number> | undefined> & {
   children?: React.ReactNode
   variant?: 'checkbox' | 'button'
   optionsLayout?: 'horizontal' | 'vertical'


### PR DESCRIPTION
If the project is using "exactOptionalPropertyTypes": true in tsconfig, then this component will not work unless you explicitly say it can be undefined in the type.

I'm not sure how to test this change, since changing the tsconfig flag will break everything else. So I didn't include a test.