### PR TITLE
fix(DrawerList): prevent call attempt for word if not function

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.js
@@ -242,7 +242,11 @@ export const parseContentTitle = (
     if (preferSelectedValue) {
       ret = String(
         convertJsxToString(dataItem.selected_value, separator, (word) => {
-          const nestedChildren = !word.props.children && word?.type?.()
+          const nestedChildren =
+            !word.props.children &&
+            typeof word?.type === 'function' &&
+            word?.type?.()
+
           return nestedChildren?.props?.children ? nestedChildren : word
         })
       )

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.js
@@ -245,7 +245,7 @@ export const parseContentTitle = (
           const nestedChildren =
             !word.props.children &&
             typeof word?.type === 'function' &&
-            word?.type?.()
+            word.type()
 
           return nestedChildren?.props?.children ? nestedChildren : word
         })


### PR DESCRIPTION
Related to https://github.com/dnbexperience/eufemia/pull/3606

It looks like bundled code still tries to call the function based on testing with the previous fix

![image (16)](https://github.com/dnbexperience/eufemia/assets/25927156/357d4148-7ac8-4be2-bad2-83d45c22e0e1)
![image (15)](https://github.com/dnbexperience/eufemia/assets/25927156/667c3514-c9e1-4281-8d6a-0d9183b8615e)
