### PR TITLE
fix(Field.Selection) handle emptying the input field

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -86,7 +86,8 @@ function Selection(props: Props) {
   } = useFieldProps(props)
 
   const handleDropdownChange = useCallback(
-    ({ data: { selectedKey } }) => {
+    ({ data }) => {
+      const selectedKey = data?.selectedKey
       handleChange?.(
         !selectedKey || selectedKey === clearValue
           ? emptyValue


### PR DESCRIPTION
Fixes issue #3623 

This change handles when selectedKey is not present on data object passed in handleDropdownChange.

Before:
https://github.com/dnbexperience/eufemia/assets/16835802/338c0de3-0d6e-4c72-9572-02602a223806

After:
https://github.com/dnbexperience/eufemia/assets/16835802/9be79163-cc50-46b0-8cd2-0230a938d2e6

