### PR TITLE
fix(TableContainer): take full width when inside `Card`

### DIFF
--- a/packages/dnb-eufemia/src/components/table/TableContainer.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableContainer.tsx
@@ -139,7 +139,7 @@ export function TableContainerFoot(
     </div>
   )
 }
-
 TableContainer.Body = TableContainerBody
 TableContainer.Head = TableContainerHead
 TableContainer.Foot = TableContainerFoot
+TableContainer._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -573,6 +573,9 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
 .dnb-modal__content .dnb-table__container .dnb-table__scroll-view {
   overflow: visible;
 }
+.dnb-card .dnb-table__container {
+  width: 100%;
+}
 
 /*
 * Table component

--- a/packages/dnb-eufemia/src/components/table/style/table-container.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-container.scss
@@ -98,4 +98,9 @@
   .dnb-modal__content & .dnb-table__scroll-view {
     overflow: visible;
   }
+
+  // When used in a Card
+  .dnb-card & {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
before:
![Screenshot 2024-05-30 at 10 34 19](https://github.com/dnbexperience/eufemia/assets/25927156/2bebd19c-8190-4c47-873b-ec1431aab83d)


after:
![Screenshot 2024-05-30 at 10 34 05](https://github.com/dnbexperience/eufemia/assets/25927156/1c060be4-c02c-407d-a9eb-7ae33294cab8)
