### PR TITLE
chore(SkipContent): improve failing test

### DIFF
--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -216,11 +216,11 @@ describe('SkipContent.Return', () => {
 
     await waitFor(() => {
       expect(document.activeElement.tagName).toBe('SECTION')
+      expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
+      expect(document.activeElement.classList).toContain(
+        'dnb-skip-content__focus'
+      )
     })
-    expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
-    expect(document.activeElement.classList).toContain(
-      'dnb-skip-content__focus'
-    )
 
     const section = document.querySelector('#unique-id')
 


### PR DESCRIPTION
This is just a first attempt, where I've moved the expect statements inside of the waitForU(seems to be a recurring pattern in SkipContent.text.tsx), not sure if it's fixing anything yet.

## Why do I suggest this change?

I've opened two PRs(https://github.com/dnbexperience/eufemia/pull/3656 & https://github.com/dnbexperience/eufemia/pull/3653), both builds([3656](https://github.com/dnbexperience/eufemia/actions/runs/9380814489/job/25828660556) & [3653](https://github.com/dnbexperience/eufemia/actions/runs/9380686070/job/25828253882)) failing with:

```
FAIL src/components/skip-content/__tests__/SkipContent.test.tsx
  ● SkipContent.Return › should show button and set focus on content element

    expect(element).not.toBeInTheDocument()

    expected document not to contain element, found <button class="dnb-button dnb-button--secondary dnb-button--has-text dnb-button--wrap" type="button"><span aria-hidden="true" class="dnb-button__alignment">‌</span><span class="dnb-button__text dnb-skeleton--show-font">Aria</span></button> instead

      218 |       expect(document.activeElement.tagName).toBe('SECTION')
      219 |     })
    > 220 |     expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
          |                                                      ^
      221 |     expect(document.activeElement.classList).toContain(
      222 |       'dnb-skip-content__focus'
      223 |     )

      at Object.toBeInTheDocument (src/components/skip-content/__tests__/SkipContent.test.tsx:220:54)
```