### PR TITLE
docs: fix heading levels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/consume-styles.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/consume-styles.mdx
@@ -11,7 +11,7 @@ To include the packages `dnb-ui-core`, `ui-theme-basis` and `ui-theme-components
 import '@dnb/eufemia/style'
 ```
 
-# Select a theme
+## Select a theme
 
 The above import is a shorthand for the DNB main theme. It is equivalent to the following import:
 


### PR DESCRIPTION
Fixes the following console warning:

`Can not decrease to heading level 1! Had before 2 - The new level is 2 NB: This warning was triggered by:  #Select a theme`