### PR TITLE
chore: adds color as unique key to tr in ColorTable

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors/ColorTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/colors/ColorTable.tsx
@@ -547,7 +547,7 @@ const getRow = (
   }
 
   return (
-    <tr>
+    <tr key={color}>
       <td>{color}</td>
       <td>{type || 'N/A'}</td>
       <td>{brandName || 'N/A'}</td>


### PR DESCRIPTION
Fixes the following error in the console when running locally, http://localhost:8000/uilib/usage/customisation/colors/

`Warning: Each child in a list should have a unique "key" prop.`

<img width="1782" alt="image" src="https://github.com/dnbexperience/eufemia/assets/1359205/3816657b-cc3e-4715-a046-ba48439298c5">
