### PR TITLE
chore(Component Helpers): improves heading levels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -3,6 +3,8 @@ title: 'Functions'
 order: 3
 ---
 
+# Functions
+
 ## Component helpers
 
 All components have various function helpers, you also can use in projects.


### PR DESCRIPTION
Improves upon the following warning in the console:

`Heading levels can only be changed by factor one! Got: 3 and had before 1 - The new level is 2 NB: This warning was triggered by:  #isTrue`