### PR TITLE
chore(Table): improve heading levels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
@@ -40,13 +40,13 @@ A `small` sized table is only for special circumstances, where a lot of data nee
 
 ### Table with accordion
 
-##### Expand a single container
+#### Expand a single container
 
 The second table uses both a `border` and an `outline`.
 
 <Examples.Accordion />
 
-##### Expand additional rows
+#### Expand additional rows
 
 It's also possible to use accordion to expand the table with more rows.
 


### PR DESCRIPTION
Improves upon the following console warning:

```
Heading levels can only be changed by factor one! Got: 5 and had before 3 - The new level is 4 
NB: This warning was triggered by:  #Expand a single container
```