### PR TITLE
docs(Tabs): improve property docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/properties.mdx
@@ -3,11 +3,18 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import { TabsProperties } from '@dnb/eufemia/src/components/tabs/TabsDocs'
+import {
+  TabsProperties,
+  TabsDataObject,
+} from '@dnb/eufemia/src/components/tabs/TabsDocs'
 
 ## Properties
 
 <PropertiesTable props={TabsProperties} />
+
+## Data object
+
+<PropertiesTable props={TabsDataObject} />
 
 ## Key
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
@@ -44,12 +44,9 @@ export const TabsProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  data: {
-    doc: "defines the data structure to load as a JSON. e.g. `[{title: '...', content: 'Current tab', key: '...', hash: '...'}]`",
-    type: [
-      'string',
-      '{title: string | React.ReactNode, key: string | number, selected?: boolean, disabled?: boolean}',
-    ],
+  '[data](/uilib/components/tabs/properties/#data-object)': {
+    doc: 'defines the data structure to load as an object.',
+    type: 'object',
     status: 'required',
   },
   children: {
@@ -100,6 +97,34 @@ export const TabsProperties: PropertiesTableProps = {
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const TabsDataObject: PropertiesTableProps = {
+  title: {
+    doc: 'The title of the tab.',
+    type: ['string', 'React.ReactNode'],
+    status: 'required',
+  },
+  key: {
+    doc: 'The unique key of the tab.',
+    type: ['string', 'number'],
+    status: 'required',
+  },
+  content: {
+    doc: 'The content of the tab.',
+    type: 'React.ReactNode',
+    status: 'optional',
+  },
+  selected: {
+    doc: 'If set to `true`, the tab will be selected.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  disabled: {
+    doc: 'If set to `true`, the tab will be disabled.',
+    type: 'boolean',
     status: 'optional',
   },
 }


### PR DESCRIPTION
I feel that the [properties docs of tabs](https://eufemia.dnb.no/uilib/components/tabs/properties/#key) is not very readable because of how the `data` property's `type` is formatted.

This is just a suggestion, but instead of changing the values of the type property(as I've done in the PR here) we should probably change the styling or so, to accomplish the same. Perhaps the `PropertiesTable` is the correct place to change? 🤔 

From:

<img width="1792" alt="Screenshot 2024-06-05 at 13 54 05" src="https://github.com/dnbexperience/eufemia/assets/1359205/b1809870-e6e9-4f12-bff4-7bf84bd95101">


To:

<img width="1792" alt="Screenshot 2024-06-05 at 13 53 58" src="https://github.com/dnbexperience/eufemia/assets/1359205/032fd1cf-27d2-4e30-a42f-9a720f4c2200">
