### PR TITLE
chore: adds link to Eufemia's GitHub repository

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -14,7 +14,7 @@
         width: 40vw;
 
         @include allBelow(small) {
-          width: 50vw;
+          width: 45vw;
         }
       }
     }

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -41,6 +41,9 @@
     #toggle-sidebar-menu {
       display: none;
     }
+    #github-button {
+      display: inline-flex;
+    }
 
     /*
     God for a mobile menu instead
@@ -49,6 +52,9 @@
     @include allBelow(medium) {
       #toggle-sidebar-menu {
         display: flex;
+      }
+      #github-button {
+        display: none;
       }
     }
     @include allBelow(small) {

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -25,6 +25,7 @@ import {
   hideSidebarToggleButtonStyle,
 } from './StickyMenuBar.module.scss'
 import { Link } from '../tags/Anchor'
+import GithubLogo from '../../docs/contribute/assets/github-logo.js'
 
 export default function StickyMenuBar({
   hideSidebarToggleButton = false,
@@ -105,6 +106,15 @@ export default function StickyMenuBar({
                 ? 'Hide section content menu'
                 : 'Show section content menu'
             }
+          />
+          <Button
+            id="github-button"
+            href="https://github.com/dnbexperience/eufemia/"
+            size="large"
+            target="_blank"
+            icon={GithubLogo}
+            title="Navigates to Eufemia's GitHub repository"
+            left="x-small"
           />
           <PortalToolsMenu />
         </span>


### PR DESCRIPTION
This is just a suggestion to more easily find the link to Eufemia's GitHub repository.

The GitHub button is available on medium to greater screen widths:

<img width="1350" alt="Screenshot 2024-06-06 at 13 17 03" src="https://github.com/dnbexperience/eufemia/assets/1359205/42ef0862-ca02-44e7-8092-63cb8a287ac2">



The GitHub button is not available on medium to smaller screen widths:

<img width="427" alt="Screenshot 2024-06-06 at 13 17 24" src="https://github.com/dnbexperience/eufemia/assets/1359205/9d6d1964-310e-4045-bee8-24b6743d7522">


Main reason for hiding it on medium to smaller devices is because of the menu button becomes visible at that breakpoint, and also perhaps GitHub link is more attractive to have on larger screens(as I assume people use larger screens than medium when working).
