### PR TITLE
chore(Logo): fix size prop in logo

### DIFF
--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -112,7 +112,7 @@ function Logo(localProps: LogoProps) {
   }, [brand, variant])
 
   /** @deprecated Can remove this in v11 */
-  const height = !isNaN(parseFloat(size)) ? size : heightProp
+  const height = parseFloat(size) > 0 ? size : heightProp
 
   // Alt text for the logo does not need to be translated. DNB alt will be the same in english, and sbanken alt should always be in norwegian
   const altText =

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -85,7 +85,7 @@ function Logo(localProps: LogoProps) {
     ratio, // eslint-disable-line
     width,
     inheritSize,
-    height,
+    height: heightProp,
     brand: brandProp,
     variant,
     color,
@@ -110,6 +110,9 @@ function Logo(localProps: LogoProps) {
 
     return 'dnb'
   }, [brand, variant])
+
+  /** @deprecated Can remove this in v11 */
+  const height = !isNaN(parseFloat(size)) ? size : heightProp
 
   // Alt text for the logo does not need to be translated. DNB alt will be the same in english, and sbanken alt should always be in norwegian
   const altText =

--- a/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
+++ b/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
@@ -19,21 +19,29 @@ describe('Logo component', () => {
 
   it('should set correct class when inheritColor is set', () => {
     render(<Logo inheritColor />)
-    expect(document.querySelector('.dnb-logo').classList).toContain(
+    expect(document.querySelector('.dnb-logo')).toHaveClass(
       'dnb-logo--inherit-color'
     )
   })
 
   it('should set correct class when size="inherit" is set', () => {
     render(<Logo size="inherit" />)
-    expect(document.querySelector('.dnb-logo').classList).toContain(
+    expect(document.querySelector('.dnb-logo')).toHaveClass(
       'dnb-logo--inherit-size'
+    )
+  })
+
+  it('should set height when size is number', () => {
+    render(<Logo size="48" />)
+    expect(document.querySelector('.dnb-logo svg')).toHaveAttribute(
+      'height',
+      '48'
     )
   })
 
   it('should set correct class when inheritSize is true', () => {
     render(<Logo inheritSize />)
-    expect(document.querySelector('.dnb-logo').classList).toContain(
+    expect(document.querySelector('.dnb-logo')).toHaveClass(
       'dnb-logo--inherit-size'
     )
   })
@@ -80,7 +88,7 @@ describe('Logo component', () => {
 
   it('should set custom class', () => {
     render(<Logo className="custom-selector" />)
-    expect(document.querySelector('[role="img"]').classList).toContain(
+    expect(document.querySelector('[role="img"]')).toHaveClass(
       'custom-selector'
     )
   })


### PR DESCRIPTION
The size prop was broken in earlier refactor to ts (#3611). This fix makes it backwards compatible.

