### PR TITLE
chore: improve home button on small devices

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '@dnb/eufemia/src/style/core/utilities.scss';
 
 :global {
@@ -44,12 +45,6 @@
     #github-button {
       display: inline-flex;
     }
-    #toggle-main-menu {
-      display: inline-flex;
-    }
-    #toggle-main-menu-small-screen {
-      display: none;
-    }
 
     /*
     God for a mobile menu instead
@@ -67,8 +62,10 @@
       #toggle-main-menu {
         display: none;
       }
+    }
+    @include allAbove(small, math.div(1, 16)) {
       #toggle-main-menu-small-screen {
-        display: inline-flex;
+        display: none;
       }
     }
   }

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -44,7 +44,12 @@
     #github-button {
       display: inline-flex;
     }
-
+    #toggle-main-menu {
+      display: inline-flex;
+    }
+    #toggle-main-menu-small-screen {
+      display: none;
+    }
     /*
     God for a mobile menu instead
     make sure that Content main "styled.main" gets the same max-width
@@ -58,15 +63,11 @@
       }
     }
     @include allBelow(small) {
-      /* make the button round */
-      .dnb-button:nth-of-type(1) {
-        padding: 0 0.25rem;
-        .dnb-button__text {
-          display: none;
-        }
-        .dnb-button__icon {
-          transform: translateY(0);
-        }
+      #toggle-main-menu {
+        display: none;
+      }
+      #toggle-main-menu-small-screen {
+        display: inline-flex;
       }
     }
   }

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -50,6 +50,7 @@
     #toggle-main-menu-small-screen {
       display: none;
     }
+
     /*
     God for a mobile menu instead
     make sure that Content main "styled.main" gets the same max-width

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -15,6 +15,7 @@ import { SidebarMenuContext } from './SidebarMenuContext'
 import PortalToolsMenu from './PortalToolsMenu'
 import { SearchBarInput } from './SearchBar'
 import { Context } from '@dnb/eufemia/src/shared'
+import { ButtonProps } from '@dnb/eufemia/src/components/Button'
 import { createSkeletonClass } from '@dnb/eufemia/src/components/skeleton/SkeletonHelper'
 import {
   headerStyle,
@@ -61,25 +62,8 @@ export default function StickyMenuBar({
       )}
     >
       <div className={portalHeaderWrapperStyle}>
-        <Button
-          id="toggle-main-menu"
-          variant="primary"
-          text="Home"
-          title="Eufemia main sections"
-          href="/"
-          element={Link}
-          icon="chevron_left"
-          icon_position="left"
-        />
-        <Button
-          id="toggle-main-menu-small-screen"
-          variant="primary"
-          title="Eufemia main sections"
-          href="/"
-          element={Link}
-          icon="chevron_left"
-          icon_position="left"
-        />
+        <HomeButton id="toggle-main-menu" text="Home" />
+        <HomeButton id="toggle-main-menu-small-screen" size="default" />
 
         <span aria-hidden className={centerWrapperStyle}>
           <Icon
@@ -131,6 +115,21 @@ export default function StickyMenuBar({
     </header>
   )
 }
+
+function HomeButton(props: ButtonProps) {
+  return (
+    <Button
+      variant="primary"
+      title="Eufemia main sections"
+      href="/"
+      icon="chevron_left"
+      icon_position="left"
+      element={Link}
+      {...props}
+    />
+  )
+}
+
 StickyMenuBar.propTypes = {
   hideSidebarToggleButton: PropTypes.bool,
   preventBarVisibility: PropTypes.bool,

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -71,6 +71,15 @@ export default function StickyMenuBar({
           icon="chevron_left"
           icon_position="left"
         />
+        <Button
+          id="toggle-main-menu-small-screen"
+          variant="primary"
+          title="Eufemia main sections"
+          href="/"
+          element={Link}
+          icon="chevron_left"
+          icon_position="left"
+        />
 
         <span aria-hidden className={centerWrapperStyle}>
           <Icon


### PR DESCRIPTION
I guess the code/styling in this PR could be made better.
The reason for me going with the current approach(hiding/showing two different home buttons based on screen size) is because of the existing approach(as of today) does not work, because a "icon button with hidden text(display:none) still styles/acts as it is text there, as the node is still rendered".
Resulting in the "strange icon" we see today in the "From example", and this:

<img width="1519" alt="Screenshot 2024-06-06 at 15 01 36" src="https://github.com/dnbexperience/eufemia/assets/1359205/29a5fc30-25f9-4060-938c-df4ffc9b0fa0">


From:
<img width="380" alt="Screenshot 2024-06-06 at 14 37 11" src="https://github.com/dnbexperience/eufemia/assets/1359205/8a347963-ae8b-43c0-a439-227537fabcd3">


To:

<img width="373" alt="image" src="https://github.com/dnbexperience/eufemia/assets/1359205/f385d79a-c135-4bb5-8492-27f404202365">
