### PR TITLE
chore(Logo): rename inherit examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/Examples.tsx
@@ -13,7 +13,7 @@ export const LogoDefaultExample = () => (
   </ComponentBox>
 )
 
-export const LogoAutoSizeExample = () => (
+export const LogoInheritFontSizeExample = () => (
   <ComponentBox data-visual-test="logo-auto-size">
     <span style={{ fontSize: '6rem' }}>
       <Logo />
@@ -21,7 +21,7 @@ export const LogoAutoSizeExample = () => (
   </ComponentBox>
 )
 
-export const LogoInheritSizeExample = () => (
+export const LogoInheritHeightExample = () => (
   <ComponentBox data-visual-test="logo-inherit-size">
     <span style={{ height: '6rem' }}>
       <Logo inheritSize />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
@@ -3,8 +3,8 @@ showTabs: true
 ---
 
 import {
-  LogoAutoSizeExample,
-  LogoInheritSizeExample,
+  LogoInheritFontSizeExample,
+  LogoInheritHeightExample,
   LogoDefaultExample,
   LogoInheritColorExample,
   LogoCompactVariantExample,
@@ -16,13 +16,13 @@ import {
 
 The height will be set based on the inherited `font-size`.
 
-<LogoAutoSizeExample />
+<LogoInheritFontSizeExample />
 
 ### Logo with dynamic height
 
 The height will be set based on the parent, inherited `height`.
 
-<LogoInheritSizeExample />
+<LogoInheritHeightExample />
 
 ### Logo with fixed height
 


### PR DESCRIPTION
Motivation comes from the latest changes done in Logo, where `size="auto"` was removed from the example, etc. 
Hence I feel these "example names" better reflect the actual examples now.