### PR TITLE
fix: add support for ::selection color for Chromium based browsers

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -83,6 +83,7 @@ export default function StickyMenuBar({
             className={classnames(
               sloganStyle,
               createSkeletonClass('font', context.skeleton),
+              'dnb-eufemia-logo',
             )}
           >
             {slogan}

--- a/packages/dnb-eufemia/src/style/themes/theme-sbanken/globals.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-sbanken/globals.scss
@@ -34,7 +34,8 @@
 .dnb-selection ::selection,
 [class^='dnb-']::selection,
 [class^='dnb-'] ::selection {
-  background-color: var(--sb-color-blue-light-2);
-  color: var(--sb-color-black);
+  // Chrome does not support CSS variables in ::selection, so we use a fallback
+  background-color: var(--sb-color-blue-light-2, #bfe3ff);
+  color: var(--sb-color-black, #000);
   text-shadow: none;
 }

--- a/packages/dnb-eufemia/src/style/themes/theme-ui/globals.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-ui/globals.scss
@@ -32,7 +32,8 @@
 .dnb-selection ::selection,
 [class^='dnb-']::selection,
 [class^='dnb-'] ::selection {
-  background-color: var(--color-mint-green);
-  color: var(--color-black);
+  // Chrome does not support CSS variables in ::selection, so we use a fallback
+  background-color: var(--color-mint-green, #a5e1d2);
+  color: var(--color-black, #000);
   text-shadow: none;
 }


### PR DESCRIPTION
Before: 
<img width="272" alt="Screenshot 2024-06-07 at 18 49 59" src="https://github.com/dnbexperience/eufemia/assets/1501870/fc0847d0-d1c0-4c29-9d68-8b9025c411ef">

After:
<img width="253" alt="Screenshot 2024-06-07 at 18 50 34" src="https://github.com/dnbexperience/eufemia/assets/1501870/c546d74d-3e20-46ec-83cd-ab994f02ed72">

Because Chromium does not support CSS custom properties in `::selection`.