### PR TITLE
docs(Tabs): fix the title of Tabs breakout example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/demos.mdx
@@ -48,7 +48,7 @@ Also, this is an example of how to define a different content background color, 
 
 <TabsNoBorder />
 
-### Tabs without breakout bottom border
+### Tabs without breakout
 
 <TabsNoBreakout />
 


### PR DESCRIPTION
Fixed the title of `Tabs` _breakout_ example introduced in #3384.
