### PR TITLE
fix(toCapitalized): remove lookbehind regular expression in order to support iOS Safari <v16 

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -524,14 +524,34 @@ describe('"toKebabCase" should', () => {
 })
 
 describe('"toCapitalized" should', () => {
+  let replaceSpy
+  beforeEach(() => {
+    replaceSpy = jest.spyOn(String.prototype, 'replace')
+  })
+  afterEach(() => {
+    replaceSpy.mockRestore()
+  })
+
   it('capitalize the first letter of every word', () => {
     expect(toCapitalized('first word æøå')).toBe('First Word Æøå')
+  })
+  it('capitalize the first letter of every word even if there is a space', () => {
+    expect(toCapitalized(' first word  æøå')).toBe(' First Word  Æøå')
   })
   it('capitalize the first letter after a dash', () => {
     expect(toCapitalized('first-word')).toBe('First-Word')
   })
   it('capitalize supports non string values', () => {
     expect(toCapitalized(undefined)).toBeUndefined()
+  })
+  it('should not use replace with lookbehind regexp to support older browsers', () => {
+    replaceSpy.mockImplementationOnce(() => 'First Word')
+    expect(String.prototype.replace).toHaveBeenCalledTimes(0)
+    expect(toCapitalized('first word')).toBe('First Word')
+    expect(
+      String(String.prototype.replace.mock.calls?.[0]?.[0])
+    ).not.toContain('?<=')
+    expect(String.prototype.replace).toHaveBeenCalledTimes(0)
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -450,7 +450,13 @@ export function toCapitalized(str) {
   return typeof str === 'string'
     ? str
         .toLowerCase()
-        .replace(/(?<=(^|\s|-))(.)/g, (l) => l.toUpperCase())
+        .split('')
+        .map((char, index, arr) =>
+          index === 0 || arr[index - 1] === ' ' || arr[index - 1] === '-'
+            ? char.toUpperCase()
+            : char
+        )
+        .join('')
     : str
 }
 


### PR DESCRIPTION
The test does fail when using the regexp version:

<img width="490" alt="Screenshot 2024-06-18 at 22 08 08" src="https://github.com/dnbexperience/eufemia/assets/1501870/41be2650-a779-46c4-9934-75eb36c4005d">

Reprod: https://codesandbox.io/p/sandbox/eufemia-js-ios16-issue-gz77wm?file=%2Fsrc%2FApp.js%3A7%2C5
