### PR TITLE
fix(Accordion): add missing bottom border on hover

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -355,6 +355,7 @@ html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover:not([di
   --ui-accordion-after-click-background: var(--color-sea-green);
   --ui-accordion-after-click-border-color: var(--color-sea-green);
   --ui-accordion-after-click-description-color: var(--color-white);
+  z-index: 1;
 }
 .dnb-accordion__header--outlined:active[disabled], html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:active[disabled] {
   cursor: not-allowed;

--- a/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
@@ -85,6 +85,7 @@
         --ui-accordion-background: var(--color-white);
         --ui-accordion-border-color: var(--color-emerald-green);
         --ui-accordion-description-color: var(--color-black-55);
+        // Removes the optional 'inset' property on the box-shadow border, on hover.
         --ui-accordion-border-inset: ;
 
         // state = expanded

--- a/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
@@ -102,6 +102,8 @@
         --ui-accordion-after-click-background: var(--color-sea-green);
         --ui-accordion-after-click-border-color: var(--color-sea-green);
         --ui-accordion-after-click-description-color: var(--color-white);
+
+        z-index: 1;
       }
 
       @include active() {


### PR DESCRIPTION
closes https://github.com/dnbexperience/eufemia/issues/3641

Before:
<img width="346" alt="Screenshot 2024-06-19 at 08 36 35" src="https://github.com/dnbexperience/eufemia/assets/25927156/15e27e6a-5d82-4707-92a8-553eff5355cb">

After:
<img width="349" alt="Screenshot 2024-06-19 at 08 36 17" src="https://github.com/dnbexperience/eufemia/assets/25927156/f82fb154-6416-43e6-b063-4903e6d66cff">
