### PR TITLE
feat(HeightAnimation): add property `compensateForGap`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/events.mdx
@@ -4,9 +4,9 @@ showTabs: true
 
 ## Events
 
-| Events             | Description                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `onOpen`           | _(optional)_ Is called when fully opened or closed. Returns `true` or `false` depending on the state.                              |
-| `onAnimationStart` | _(optional)_ Is called when animation has started.                                                                                 |
-| `onAnimationEnd`   | _(optional)_ Is called when animation is done and the full height is reached.                                                      |
-| `onInit`           | _(optional)_ Is called once before mounting the component (useLayoutEffect). Returns the instance of the internal animation class. |
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { HeightAnimationEvents } from '@dnb/eufemia/src/components/height-animation/HeightAnimationDocs'
+
+## Properties
+
+<PropertiesTable props={HeightAnimationEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/properties.mdx
@@ -2,16 +2,9 @@
 showTabs: true
 ---
 
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { HeightAnimationProperties } from '@dnb/eufemia/src/components/height-animation/HeightAnimationDocs'
+
 ## Properties
 
-| Properties                              | Description                                                                                                       |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `open`                                  | _(optional)_ Set to `true` on second re-render when the view should animate from 0px to auto. Defaults to `true`. |
-| `animate`                               | _(optional)_ Set to `false` to omit the animation. Defaults to `true`.                                            |
-| `keepInDOM`                             | _(optional)_ Set to `true` ensure the nested children content will be kept in the DOM. Defaults to `false`.       |
-| `showOverflow`                          | _(optional)_ Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.                         |
-| `duration`                              | _(optional)_ Custom duration of the animation in milliseconds. Defaults to `400ms`.                               |
-| `delay`                                 | _(optional)_ Custom delay of the animation in milliseconds. Defaults to `0ms`.                                    |
-| `element`                               | _(optional)_ Custom HTML element for the component. Defaults to `div` HTML Element.                               |
-| `innerRef`                              | _(optional)_ Send along a custom React Ref.                                                                       |
-| [Space](/uilib/layout/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                             |
+<PropertiesTable props={HeightAnimationProperties} />

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -61,6 +61,7 @@ function HeightAnimation({
   className,
   innerRef,
   children,
+  compensateForGap,
   onInit = null,
   onOpen = null,
   onAnimationStart = null,
@@ -80,6 +81,7 @@ function HeightAnimation({
     open,
     animate,
     children,
+    compensateForGap,
     onInit,
     onOpen,
     onAnimationStart,
@@ -118,7 +120,11 @@ function HeightAnimation({
       aria-hidden={keepInDOM ? !open : undefined}
       {...rest}
     >
-      {children}
+      {compensateForGap ? (
+        <div className="compensateForGap">{children}</div>
+      ) : (
+        children
+      )}
     </Space>
   )
 }

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -1,0 +1,77 @@
+import { PropertiesTableProps } from '../../shared/types'
+
+export const HeightAnimationProperties: PropertiesTableProps = {
+  open: {
+    doc: 'Set to `true` on second re-render when the view should animate from 0px to auto. Defaults to `true`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  animate: {
+    doc: 'Set to `false` to omit the animation. Defaults to `true`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  keepInDOM: {
+    doc: 'Set to `true` ensure the nested children content will be kept in the DOM. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  compensateForGap: {
+    doc: 'To compensate for CSS gap between the rows so animation not jumps during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
+    type: 'string',
+    status: 'optional',
+  },
+  showOverflow: {
+    doc: 'Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  duration: {
+    doc: 'Custom duration of the animation in milliseconds. Defaults to `400ms`.',
+    type: 'number',
+    status: 'optional',
+  },
+  delay: {
+    doc: 'Custom delay of the animation in milliseconds. Defaults to `0ms`.',
+    type: 'number',
+    status: 'optional',
+  },
+  element: {
+    doc: 'Custom HTML element for the component. Defaults to `div` HTML Element.',
+    type: 'string',
+    status: 'optional',
+  },
+  innerRef: {
+    doc: 'Send along a custom React Ref.',
+    type: 'React.RefObject',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const HeightAnimationEvents: PropertiesTableProps = {
+  onOpen: {
+    doc: 'Is called when fully opened or closed. Returns `true` or `false` depending on the state.',
+    type: 'function',
+    status: 'optional',
+  },
+  onAnimationStart: {
+    doc: 'Is called when animation has started.',
+    type: 'function',
+    status: 'optional',
+  },
+  onAnimationEnd: {
+    doc: 'Is called when animation is done and the full height is reached.',
+    type: 'function',
+    status: 'optional',
+  },
+  onInit: {
+    doc: 'Is called once before mounting the component (useLayoutEffect). Returns the instance of the internal animation class.',
+    type: 'function',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -17,7 +17,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     status: 'optional',
   },
   compensateForGap: {
-    doc: 'To compensate for CSS gap between the rows so animation not jumps during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
+    doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -178,7 +178,7 @@ describe('HeightAnimation', () => {
       expect(inner).toBeInTheDocument()
     })
 
-    it('should marginTop when compensateForGap is given', () => {
+    it('should set marginTop when compensateForGap is given', () => {
       render(
         <div style={{ rowGap: '2rem' }}>
           <HeightAnimation compensateForGap="auto">

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -94,14 +94,14 @@ describe('HeightAnimation', () => {
     expect(onOpen).toHaveBeenCalledTimes(1)
     expect(onOpen).toHaveBeenLastCalledWith(false)
 
-    rerender(<HeightAnimation open />)
+    rerender(<HeightAnimation open onOpen={onOpen} />)
 
     simulateAnimationEnd()
 
     expect(onOpen).toHaveBeenCalledTimes(2)
     expect(onOpen).toHaveBeenLastCalledWith(true)
 
-    rerender(<HeightAnimation open={false} />)
+    rerender(<HeightAnimation open={false} onOpen={onOpen} />)
 
     simulateAnimationEnd()
 
@@ -117,14 +117,18 @@ describe('HeightAnimation', () => {
 
     expect(onAnimationEnd).toHaveBeenCalledTimes(0)
 
-    rerender(<HeightAnimation open={true} />)
+    rerender(
+      <HeightAnimation open={true} onAnimationEnd={onAnimationEnd} />
+    )
 
     simulateAnimationEnd()
 
     expect(onAnimationEnd).toHaveBeenCalledTimes(1)
     expect(onAnimationEnd).toHaveBeenLastCalledWith('opened')
 
-    rerender(<HeightAnimation open={false} />)
+    rerender(
+      <HeightAnimation open={false} onAnimationEnd={onAnimationEnd} />
+    )
 
     simulateAnimationEnd()
 
@@ -143,7 +147,7 @@ describe('HeightAnimation', () => {
       expect.any(HeightAnimationInstance)
     )
 
-    rerender(<HeightAnimation open={true} />)
+    rerender(<HeightAnimation onInit={onInit} open={true} />)
 
     expect(onInit).toHaveBeenCalledTimes(1)
   })
@@ -158,6 +162,37 @@ describe('HeightAnimation', () => {
     runAnimation()
 
     expect(getElement()).toHaveAttribute('style', 'height: auto;')
+  })
+
+  describe('compensateForGap', () => {
+    it('should add wrapper element with compensateForGap class', () => {
+      render(
+        <HeightAnimation compensateForGap="auto">
+          <span className="content">content</span>
+        </HeightAnimation>
+      )
+
+      const inner = document.querySelector(
+        '.dnb-height-animation > .compensateForGap'
+      )
+      expect(inner).toBeInTheDocument()
+    })
+
+    it('should marginTop when compensateForGap is given', () => {
+      render(
+        <div style={{ rowGap: '2rem' }}>
+          <HeightAnimation compensateForGap="auto">
+            <span className="content">content</span>
+          </HeightAnimation>
+        </div>
+      )
+
+      const main = document.querySelector('.dnb-height-animation')
+      expect(main).toHaveStyle('margin-top: calc(2rem * -1);')
+
+      const inner = main.querySelector('.compensateForGap')
+      expect(inner).toHaveStyle('margin-top: 2rem;')
+    })
   })
 
   describe('keepInDOM', () => {

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
@@ -19,7 +19,7 @@ export type useHeightAnimationOptions = {
   animate?: boolean
 
   /**
-   * To compensate for CSS gap between the rows so animation not jumps during the animation.
+   * To compensate for CSS gap between the rows so animation does not jump during the animation.
    * Provide a CSS unit or `var(--row-gap)`.
    */
   compensateForGap?: string | 'auto'


### PR DESCRIPTION
This feature is to make it possible to use `HeightAnimation` as a child inside a container using CSS row-gap, without the "jump" when the HeightAnimation gets display: none when hidden.