### PR TITLE
chore: remove replaceHydrationFunction when testing

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-browser.tsx
+++ b/packages/dnb-design-system-portal/gatsby-browser.tsx
@@ -6,7 +6,6 @@
 import { applyPageFocus } from '@dnb/eufemia/src/shared/helpers'
 import { rootElement, pageElement } from './src/core/PortalProviders'
 import { scrollToHash } from '@dnb/eufemia/src/components/Anchor'
-import ReactDOM from 'react-dom/client'
 
 if (typeof window !== 'undefined') {
   setIsTest(window.location)
@@ -16,17 +15,6 @@ function setIsTest(location) {
   if (location && location.href.includes('data-visual-test')) {
     globalThis.IS_TEST = true
     document.documentElement.setAttribute('data-visual-test', 'true')
-  }
-}
-
-export const replaceHydrateFunction = () => {
-  // Added to solve the following errors, which prevented us from running screenshot tests
-  // https://github.com/gatsbyjs/gatsby/discussions/36232
-  if (globalThis.IS_TEST) {
-    return (element: React.ReactElement, container: HTMLElement) => {
-      const root = ReactDOM.createRoot(container)
-      root.render(element)
-    }
   }
 }
 


### PR DESCRIPTION
Just for debugging builds(screenshot tests), as I want to research(look into) how come the visual tests "fail" while the production build(portal) doesn't fail in the same manner...