### PR TITLE
docs(Field.Number): fix `percent` demo/example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -247,6 +247,7 @@ export const Percentage = () => {
   return (
     <ComponentBox>
       <Field.Number
+        percent
         value={80}
         label="Percentage"
         onChange={(value) => console.log('onChange', value)}


### PR DESCRIPTION
Seems like the `percent` property was forgotten when making the demo/example, in the following commit https://github.com/dnbexperience/eufemia/commit/cb89fa406b837b972677d6764c9ac36dbf7d8a0b