### PR TITLE
feat(Forms): translations EditContainer, ViewContainer, RemoveButton

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/properties.mdx
@@ -3,9 +3,14 @@ showTabs: true
 hideInMenu: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { EditContainerProperties } from '@dnb/eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs'
 
 ## Properties
 
 <PropertiesTable props={EditContainerProperties} />
+
+## Translations
+
+<TranslationsTable localeKey={['SectionEditContainer']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/ViewContainer/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/ViewContainer/properties.mdx
@@ -3,9 +3,14 @@ showTabs: true
 hideInMenu: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { ViewContainerProperties } from '@dnb/eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainerDocs'
 
 ## Properties
 
 <PropertiesTable props={ViewContainerProperties} />
+
+## Translations
+
+<TranslationsTable localeKey={['SectionViewContainer']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/EditContainer/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/EditContainer/properties.mdx
@@ -3,9 +3,14 @@ showTabs: true
 hideInMenu: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { EditContainerProperties } from '@dnb/eufemia/src/extensions/forms/Iterate/EditContainer/EditContainerDocs'
 
 ## Properties
 
 <PropertiesTable props={EditContainerProperties} />
+
+## Translations
+
+<TranslationsTable localeKey={['IterateEditContainer']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/properties.mdx
@@ -3,9 +3,14 @@ showTabs: true
 hideInMenu: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { RemoveButtonProperties } from '@dnb/eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs'
 
 ## Properties
 
 <PropertiesTable props={RemoveButtonProperties} />
+
+## Translations
+
+<TranslationsTable localeKey={['RemoveButton']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/ViewContainer/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/ViewContainer/properties.mdx
@@ -3,9 +3,14 @@ showTabs: true
 hideInMenu: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { ViewContainerProperties } from '@dnb/eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainerDocs'
 
 ## Properties
 
 <PropertiesTable props={ViewContainerProperties} />
+
+## Translations
+
+<TranslationsTable localeKey={['IterateViewContainer']} />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditToolbarTools.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditToolbarTools.tsx
@@ -15,7 +15,7 @@ export default function EditToolbarTools() {
   const { hasVisibleError, hasSubmitError } =
     useContext(FieldBoundaryContext) || {}
 
-  const translation = useTranslation().Section
+  const translation = useTranslation().SectionEditContainer
 
   const [showError, setShowError] = useState(false)
 
@@ -49,7 +49,7 @@ export default function EditToolbarTools() {
           icon_position="left"
           on_click={doneHandler}
         >
-          {translation.done}
+          {translation.doneButton}
         </Button>
 
         <Button
@@ -58,7 +58,7 @@ export default function EditToolbarTools() {
           icon_position="left"
           on_click={cancelHandler}
         >
-          {translation.cancel}
+          {translation.cancelButton}
         </Button>
       </Flex.Horizontal>
     </>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewToolbarTools.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewToolbarTools.tsx
@@ -8,7 +8,7 @@ export default function ViewToolbarTools() {
   const sectionContainerContext = useContext(SectionContainerContext)
   const { switchContainerMode } = sectionContainerContext ?? {}
 
-  const translation = useTranslation().Section
+  const translation = useTranslation().SectionViewContainer
 
   const editHandler = useCallback(() => {
     switchContainerMode?.('edit')
@@ -22,7 +22,7 @@ export default function ViewToolbarTools() {
         icon_position="left"
         on_click={editHandler}
       >
-        {translation.edit}
+        {translation.editButton}
       </Button>
     </Flex.Horizontal>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import ViewContainer from '../ViewContainer'
+import { Form } from '../../../..'
 import nbNO from '../../../../constants/locales/nb-NO'
 import SectionContainerContext from '../../containers/SectionContainerContext'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].SectionViewContainer
 
 describe('ViewContainer', () => {
   it('renders content and without errors', () => {
@@ -83,6 +84,31 @@ describe('ViewContainer', () => {
     const buttons = document.querySelectorAll('button')
 
     expect(buttons).toHaveLength(1)
-    expect(buttons[0]).toHaveTextContent(nb.edit)
+    expect(buttons[0]).toHaveTextContent(nb.editButton)
+  })
+
+  it('supports translations from Form.Handler', () => {
+    const edit = 'custom-translation-edit-button-text'
+
+    render(
+      <Form.Handler
+        translations={{
+          'nb-NO': {
+            'SectionViewContainer.editButton': edit,
+          },
+          'en-GB': {
+            'SectionViewContainer.editButton': edit,
+          },
+        }}
+      >
+        <SectionContainerContext.Provider
+          value={{ containerMode: 'edit' }}
+        >
+          <ViewContainer>content</ViewContainer>
+        </SectionContainerContext.Provider>
+      </Form.Handler>
+    )
+
+    expect(screen.getByText(edit)).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditToolbarTools.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditToolbarTools.tsx
@@ -24,7 +24,7 @@ export default function EditToolbarTools() {
   } = useContext(IterateElementContext) || {}
   const { hasVisibleError } = useContext(FieldBoundaryContext) || {}
 
-  const translation = useTranslation().Section
+  const translation = useTranslation().IterateEditContainer
   const valueBackupRef = useRef<unknown>()
   const wasNew = useWasNew({ isNew, containerMode })
   const [showError, setShowError] = useState(false)
@@ -66,11 +66,11 @@ export default function EditToolbarTools() {
           icon_position="left"
           on_click={doneHandler}
         >
-          {translation.done}
+          {translation.doneButton}
         </Button>
 
         {wasNew ? (
-          <RemoveButton />
+          <RemoveButton text={translation.removeButton} />
         ) : (
           <Button
             variant="tertiary"
@@ -78,7 +78,7 @@ export default function EditToolbarTools() {
             icon_position="left"
             on_click={cancelHandler}
           >
-            {translation.cancel}
+            {translation.cancelButton}
           </Button>
         )}
       </Flex.Horizontal>

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -7,7 +7,7 @@ import { Field, Form, Iterate } from '../../..'
 import userEvent from '@testing-library/user-event'
 import nbNO from '../../../constants/locales/nb-NO'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].IterateEditContainer
 
 describe('EditContainer and ViewContainer', () => {
   it('should switch mode on pressing edit button', async () => {
@@ -185,7 +185,7 @@ describe('EditContainer and ViewContainer', () => {
 
     // Remove the element
     fireEvent.click(removeButton)
-    expect(removeButton).toHaveTextContent(nb.remove)
+    expect(removeButton).toHaveTextContent(nb.removeButton)
 
     await waitFor(() => {
       const elements = document.querySelectorAll(

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditContainer.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { Form } from '../../..'
 import IterateElementContext from '../../IterateElementContext'
 import EditContainer from '../EditContainer'
 import nbNO from '../../../constants/locales/nb-NO'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].IterateEditContainer
 
 describe('EditContainer', () => {
   it('renders content and without errors', () => {
@@ -172,8 +173,8 @@ describe('EditContainer', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(2)
-      expect(buttons[0]).toHaveTextContent(nb.done)
-      expect(buttons[1]).toHaveTextContent(nb.remove)
+      expect(buttons[0]).toHaveTextContent(nb.doneButton)
+      expect(buttons[1]).toHaveTextContent(nb.removeButton)
     })
 
     it('and isNew is not set', () => {
@@ -186,8 +187,70 @@ describe('EditContainer', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(2)
-      expect(buttons[0]).toHaveTextContent(nb.done)
-      expect(buttons[1]).toHaveTextContent(nb.cancel)
+      expect(buttons[0]).toHaveTextContent(nb.doneButton)
+      expect(buttons[1]).toHaveTextContent(nb.cancelButton)
+    })
+
+    it('supports translations removeButton and doneButton from Form.Handler', () => {
+      const remove = 'custom-translation-remove-button-text'
+      const done = 'custom-translation-done-button-text'
+
+      render(
+        <Form.Handler
+          translations={{
+            'nb-NO': {
+              'IterateEditContainer.removeButton': remove,
+              'IterateEditContainer.doneButton': done,
+            },
+            'en-GB': {
+              'IterateEditContainer.removeButton': remove,
+              'IterateEditContainer.doneButton': done,
+            },
+          }}
+        >
+          <IterateElementContext.Provider
+            value={{
+              containerMode: 'edit',
+              isNew: true,
+            }}
+          >
+            <EditContainer>content</EditContainer>
+          </IterateElementContext.Provider>
+        </Form.Handler>
+      )
+
+      expect(screen.getByText(remove)).toBeInTheDocument()
+      expect(screen.getByText(done)).toBeInTheDocument()
+    })
+    it('supports translations cancelButton and doneButton from Form.Handler', () => {
+      const done = 'custom-translation-done-button-text'
+      const cancel = 'custom-translation-cancel-button-text'
+
+      render(
+        <Form.Handler
+          translations={{
+            'nb-NO': {
+              'IterateEditContainer.doneButton': done,
+              'IterateEditContainer.cancelButton': cancel,
+            },
+            'en-GB': {
+              'IterateEditContainer.doneButton': done,
+              'IterateEditContainer.cancelButton': cancel,
+            },
+          }}
+        >
+          <IterateElementContext.Provider
+            value={{
+              containerMode: 'edit',
+            }}
+          >
+            <EditContainer>content</EditContainer>
+          </IterateElementContext.Provider>
+        </Form.Handler>
+      )
+
+      expect(screen.getByText(cancel)).toBeInTheDocument()
+      expect(screen.getByText(done)).toBeInTheDocument()
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditToolbarTools.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditToolbarTools.test.tsx
@@ -6,7 +6,7 @@ import EditToolbarTools from '../EditToolbarTools'
 
 import nbNO from '../../../constants/locales/nb-NO'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].IterateEditContainer
 
 describe('EditToolbarTools', () => {
   it('calls "switchContainerMode" when remove button is clicked', () => {
@@ -87,8 +87,8 @@ describe('EditToolbarTools', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(2)
-      expect(buttons[0]).toHaveTextContent(nb.done)
-      expect(buttons[1]).toHaveTextContent(nb.remove)
+      expect(buttons[0]).toHaveTextContent(nb.doneButton)
+      expect(buttons[1]).toHaveTextContent(nb.removeButton)
     })
 
     it('and isNew is not set', () => {
@@ -103,8 +103,8 @@ describe('EditToolbarTools', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(2)
-      expect(buttons[0]).toHaveTextContent(nb.done)
-      expect(buttons[1]).toHaveTextContent(nb.cancel)
+      expect(buttons[0]).toHaveTextContent(nb.doneButton)
+      expect(buttons[1]).toHaveTextContent(nb.cancelButton)
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
@@ -25,8 +25,8 @@ function RemoveButton(props: Props) {
   const { className, ...restProps } = props
   const { children, text } = useFieldProps(restProps)
   const buttonProps = omitDataValueReadWriteProps(restProps)
-  const translation = useTranslation().Section
-  const textContent = text || children || translation.remove
+  const translation = useTranslation().RemoveButton
+  const textContent = text || children || translation.text
 
   const elementBlockContext = useContext(ElementBlockContext)
   const { handleRemoveBlock } = elementBlockContext ?? {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import IterateElementContext from '../../IterateElementContext'
 import RemoveButton from '../RemoveButton'
 import nbNO from '../../../constants/locales/nb-NO'
+import { Form } from '../../..'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].RemoveButton
 
 describe('RemoveButton', () => {
   const handleRemove = jest.fn()
@@ -57,7 +58,7 @@ describe('RemoveButton', () => {
     render(<RemoveButton />, { wrapper })
 
     const button = document.querySelector('button')
-    expect(button).toHaveTextContent(nb.remove)
+    expect(button).toHaveTextContent(nb.text)
   })
 
   it('should accept "text" prop', () => {
@@ -96,5 +97,27 @@ describe('RemoveButton', () => {
       'data-testid',
       'trash icon'
     )
+  })
+
+  it('supports translations from Form.Handler', () => {
+    const remove = 'custom-translation-remove-button-text'
+
+    render(
+      <Form.Handler
+        translations={{
+          'nb-NO': {
+            'RemoveButton.text': remove,
+          },
+          'en-GB': {
+            'RemoveButton.text': remove,
+          },
+        }}
+      >
+        <RemoveButton />
+      </Form.Handler>,
+      { wrapper }
+    )
+
+    expect(screen.getByText(remove)).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
@@ -5,7 +5,7 @@ import Toolbar from '../Toolbar'
 import nbNO from '../../../constants/locales/nb-NO'
 import RemoveButton from '../../RemoveButton'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].RemoveButton
 
 describe('Toolbar', () => {
   it('supports spacing props', () => {
@@ -69,7 +69,7 @@ describe('Toolbar', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(1)
-      expect(buttons[0]).toHaveTextContent(nb.remove)
+      expect(buttons[0]).toHaveTextContent(nb.text)
     })
 
     it('and isNew is false', () => {
@@ -88,7 +88,7 @@ describe('Toolbar', () => {
       const buttons = document.querySelectorAll('button')
 
       expect(buttons).toHaveLength(1)
-      expect(buttons[0]).toHaveTextContent(nb.remove)
+      expect(buttons[0]).toHaveTextContent(nb.text)
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewToolbarTools.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewToolbarTools.tsx
@@ -9,7 +9,7 @@ export default function ViewToolbarTools() {
   const iterateElementContext = useContext(IterateElementContext)
   const { switchContainerMode } = iterateElementContext ?? {}
 
-  const translation = useTranslation().Section
+  const translation = useTranslation().IterateViewContainer
 
   const editHandler = useCallback(() => {
     switchContainerMode?.('edit')
@@ -23,10 +23,10 @@ export default function ViewToolbarTools() {
         icon_position="left"
         on_click={editHandler}
       >
-        {translation.edit}
+        {translation.editButton}
       </Button>
 
-      <RemoveButton text={translation.remove} />
+      <RemoveButton text={translation.removeButton} />
     </Flex.Horizontal>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/__tests__/ViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/__tests__/ViewContainer.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import IterateElementContext from '../../IterateElementContext'
 import ViewContainer from '../ViewContainer'
+import { Form } from '../../..'
 import nbNO from '../../../constants/locales/nb-NO'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].IterateViewContainer
 
 describe('ViewContainer', () => {
   it('renders content and without errors', () => {
@@ -97,7 +98,34 @@ describe('ViewContainer', () => {
     const buttons = document.querySelectorAll('button')
 
     expect(buttons).toHaveLength(2)
-    expect(buttons[0]).toHaveTextContent(nb.edit)
-    expect(buttons[1]).toHaveTextContent(nb.remove)
+    expect(buttons[0]).toHaveTextContent(nb.editButton)
+    expect(buttons[1]).toHaveTextContent(nb.removeButton)
+  })
+
+  it('supports translations from Form.Handler', () => {
+    const remove = 'custom-translation-remove-button-text'
+    const edit = 'custom-translation-edit-button-text'
+
+    render(
+      <Form.Handler
+        translations={{
+          'nb-NO': {
+            'IterateViewContainer.removeButton': remove,
+            'IterateViewContainer.editButton': edit,
+          },
+          'en-GB': {
+            'IterateViewContainer.removeButton': remove,
+            'IterateViewContainer.editButton': edit,
+          },
+        }}
+      >
+        <IterateElementContext.Provider value={{ containerMode: 'view' }}>
+          <ViewContainer>content</ViewContainer>
+        </IterateElementContext.Provider>
+      </Form.Handler>
+    )
+
+    expect(screen.getByText(remove)).toBeInTheDocument()
+    expect(screen.getByText(edit)).toBeInTheDocument()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/__tests__/ViewToolbarTools.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/__tests__/ViewToolbarTools.test.tsx
@@ -6,7 +6,7 @@ import ViewToolbarTools from '../ViewToolbarTools'
 
 import nbNO from '../../../constants/locales/nb-NO'
 
-const nb = nbNO['nb-NO'].Section
+const nb = nbNO['nb-NO'].IterateViewContainer
 
 describe('ViewToolbarTools', () => {
   it('to have buttons with correct text', () => {
@@ -21,8 +21,8 @@ describe('ViewToolbarTools', () => {
     const buttons = document.querySelectorAll('button')
 
     expect(buttons).toHaveLength(2)
-    expect(buttons[0]).toHaveTextContent(nb.edit)
-    expect(buttons[1]).toHaveTextContent(nb.remove)
+    expect(buttons[0]).toHaveTextContent(nb.editButton)
+    expect(buttons[1]).toHaveTextContent(nb.removeButton)
   })
 
   it('calls "handleRemove" when remove button is clicked', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -20,11 +20,25 @@ export default {
       edit: 'Edit',
       summaryTitle: 'Summary',
     },
-    Section: {
-      remove: 'Remove',
-      done: 'Done',
-      cancel: 'Cancel',
-      edit: 'Edit',
+    RemoveButton: {
+      text: 'Remove',
+    },
+    IterateViewContainer: {
+      removeButton: 'Remove',
+      editButton: 'Edit',
+    },
+    SectionViewContainer: {
+      editButton: 'Edit',
+    },
+    SectionEditContainer: {
+      doneButton: 'Done',
+      cancelButton: 'Cancel',
+      errorInSection: 'Please correct the errors above',
+    },
+    IterateEditContainer: {
+      removeButton: 'Remove',
+      doneButton: 'Done',
+      cancelButton: 'Cancel',
       errorInSection: 'Please correct the errors above',
     },
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -20,11 +20,25 @@ export default {
       edit: 'Endre',
       summaryTitle: 'Oppsummering',
     },
-    Section: {
-      remove: 'Fjern',
-      done: 'Ferdig',
-      cancel: 'Avbryt',
-      edit: 'Endre',
+    RemoveButton: {
+      text: 'Fjern',
+    },
+    IterateViewContainer: {
+      removeButton: 'Fjern',
+      editButton: 'Endre',
+    },
+    SectionViewContainer: {
+      editButton: 'Endre',
+    },
+    SectionEditContainer: {
+      doneButton: 'Ferdig',
+      cancelButton: 'Avbryt',
+      errorInSection: 'Feilene ovenfor må rettes',
+    },
+    IterateEditContainer: {
+      removeButton: 'Fjern',
+      doneButton: 'Ferdig',
+      cancelButton: 'Avbryt',
       errorInSection: 'Feilene ovenfor må rettes',
     },
 


### PR DESCRIPTION
Motivation comes from the following Slack thread: https://dnb-it.slack.com/archives/CMXABCHEY/p1720189333537279

This PR removes the `Section` translation, which was previously used in `Iterate.EditContainer`, `Iterate.ViewContainer`, `Section.EditContainer`, `Section.ViewContainer` and `RemoveButton`. 

`Section` translation has now rather been split into the following separate translations: 
- `IterateEditContainer`
- `IterateViewContainer`
- `SectionEditContainer`
- `SectionViewContainer`
- `RemoveButton`

This PR also adds docs for the translation props of:
- `Iterate.EditContainer`
- `Iterate.ViewContainer`
- `Section.EditContainer`
- `Section.ViewContainer`
- `RemoveButton`

