### PR TITLE
feat(Forms.Wizard): separate translations for buttons

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard.mdx
@@ -10,6 +10,8 @@ tabs:
     key: '/demos'
   - title: Components
     key: '/components'
+  - title: Properties
+    key: '/properties'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/Examples.tsx
@@ -30,39 +30,3 @@ export const Default = () => {
     </ComponentBox>
   )
 }
-
-export const NextButton = () => {
-  return (
-    <ComponentBox>
-      <Wizard.Provider
-        value={{
-          activeIndex: 0,
-          handlePrevious: () => null,
-          handleNext: () => console.log('handleNext'),
-          setActiveIndex: () => null,
-          setFormError: () => null,
-        }}
-      >
-        <Wizard.NextButton />
-      </Wizard.Provider>
-    </ComponentBox>
-  )
-}
-
-export const PreviousButton = () => {
-  return (
-    <ComponentBox>
-      <Wizard.Provider
-        value={{
-          activeIndex: 5,
-          handlePrevious: () => console.log('handlePrevious'),
-          handleNext: () => null,
-          setActiveIndex: () => null,
-          setFormError: () => null,
-        }}
-      >
-        <Wizard.PreviousButton />
-      </Wizard.Provider>
-    </ComponentBox>
-  )
-}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton.mdx
@@ -1,5 +1,8 @@
 ---
-showTabs: false
+title: 'NextButton'
+description: '`Wizard.NextButton` connects to the `Wizard.Context` to move the user to the next step when clicked.'
+hideInMenu: true
+showTabs: true
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
@@ -9,31 +12,17 @@ breadcrumb:
     href: /uilib/extensions/forms/Wizard/Buttons/
   - text: NextButton
     href: /uilib/extensions/forms/Wizard/Buttons/NextButton/
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+  - title: Properties
+    key: '/properties'
 ---
 
-import * as Examples from './Examples'
+import Info from 'Docs/uilib/extensions/forms/Wizard/Buttons/NextButton/info'
+import Demos from 'Docs/uilib/extensions/forms/Wizard/Buttons/NextButton/demos'
 
-# NextButton
-
-## Description
-
-`Wizard.NextButton` connects to the `Wizard.Context` to move the user to the next step when clicked.
-
-```jsx
-import { Form, Wizard } from '@dnb/eufemia/extensions/forms'
-
-render(
-  <Form.Handler>
-    <Wizard.Container>
-      <Wizard.Step title="Step 1">
-        <Wizard.NextButton />
-      </Wizard.Step>
-      <Wizard.Step title="Step 2">next step</Wizard.Step>
-    </Wizard.Container>
-  </Form.Handler>,
-)
-```
-
-## Demo
-
-<Examples.NextButton />
+<Info />
+<Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/Examples.tsx
@@ -1,0 +1,20 @@
+import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
+import { Wizard } from '@dnb/eufemia/src/extensions/forms'
+
+export const Default = () => {
+  return (
+    <ComponentBox>
+      <Wizard.Provider
+        value={{
+          activeIndex: 0,
+          handlePrevious: () => null,
+          handleNext: () => console.log('handleNext'),
+          setActiveIndex: () => null,
+          setFormError: () => null,
+        }}
+      >
+        <Wizard.NextButton />
+      </Wizard.Provider>
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/demos.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import * as Examples from './Examples'
+
+## Demo
+
+<Examples.Default />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/info.mdx
@@ -1,0 +1,22 @@
+---
+showTabs: true
+---
+
+## Description
+
+`Wizard.NextButton` connects to the `Wizard.Context` to move the user to the next step when clicked.
+
+```jsx
+import { Form, Wizard } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Wizard.Container>
+      <Wizard.Step title="Step 1">
+        <Wizard.NextButton />
+      </Wizard.Step>
+      <Wizard.Step title="Step 2">next step</Wizard.Step>
+    </Wizard.Container>
+  </Form.Handler>,
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/NextButton/properties.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+
+## Translations
+
+<TranslationsTable localeKey={['WizardNextButton']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton.mdx
@@ -1,5 +1,8 @@
 ---
-showTabs: false
+title: 'PreviousButton'
+description: '`Wizard.PreviousButton` connects to the `Wizard.Context` to move the user to the previous step when clicked.'
+hideInMenu: true
+showTabs: true
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
@@ -9,31 +12,17 @@ breadcrumb:
     href: /uilib/extensions/forms/Wizard/Buttons/
   - text: PreviousButton
     href: /uilib/extensions/forms/Wizard/Buttons/PreviousButton/
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+  - title: Properties
+    key: '/properties'
 ---
 
-import * as Examples from './Examples'
+import Info from 'Docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/info'
+import Demos from 'Docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/demos'
 
-# PreviousButton
-
-## Description
-
-`Wizard.PreviousButton` connects to the `Wizard.Context` to move the user to the previous step when clicked.
-
-```jsx
-import { Form, Wizard } from '@dnb/eufemia/extensions/forms'
-
-render(
-  <Form.Handler>
-    <Wizard.Container>
-      <Wizard.Step title="Step 1">previous step</Wizard.Step>
-      <Wizard.Step title="Step 2">
-        <Wizard.PreviousButton />
-      </Wizard.Step>
-    </Wizard.Container>
-  </Form.Handler>,
-)
-```
-
-## Demo
-
-<Examples.PreviousButton />
+<Info />
+<Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/Examples.tsx
@@ -1,0 +1,20 @@
+import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
+import { Wizard } from '@dnb/eufemia/src/extensions/forms'
+
+export const Default = () => {
+  return (
+    <ComponentBox>
+      <Wizard.Provider
+        value={{
+          activeIndex: 5,
+          handlePrevious: () => console.log('handlePrevious'),
+          handleNext: () => null,
+          setActiveIndex: () => null,
+          setFormError: () => null,
+        }}
+      >
+        <Wizard.PreviousButton />
+      </Wizard.Provider>
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/demos.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import * as Examples from './Examples'
+
+## Demo
+
+<Examples.Default />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/info.mdx
@@ -1,0 +1,22 @@
+---
+showTabs: true
+---
+
+## Description
+
+`Wizard.PreviousButton` connects to the `Wizard.Context` to move the user to the previous step when clicked.
+
+```jsx
+import { Form, Wizard } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Wizard.Container>
+      <Wizard.Step title="Step 1">previous step</Wizard.Step>
+      <Wizard.Step title="Step 2">
+        <Wizard.PreviousButton />
+      </Wizard.Step>
+    </Wizard.Container>
+  </Form.Handler>,
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Buttons/PreviousButton/properties.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+
+## Translations
+
+<TranslationsTable localeKey={['WizardPreviousButton']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton.mdx
@@ -1,5 +1,8 @@
 ---
-showTabs: false
+title: 'EditButton'
+description: '`Wizard.EditButton` is a button to be placed in a summary step.'
+hideInMenu: true
+showTabs: true
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
@@ -9,37 +12,17 @@ breadcrumb:
     href: /uilib/extensions/forms/Wizard/Step/
   - text: EditButton
     href: /uilib/extensions/forms/Wizard/Step/EditButton/
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+  - title: Properties
+    key: '/properties'
 ---
 
-import * as Examples from './Examples'
+import Info from 'Docs/uilib/extensions/forms/Wizard/Step/EditButton/info'
+import Demos from 'Docs/uilib/extensions/forms/Wizard/Step/EditButton/demos'
 
-# EditButton
-
-## Description
-
-`Wizard.EditButton` is a button to be placed in a summary step.
-
-It provides a `toStep` property that lets you navigate to a specific step.
-
-```jsx
-import { Hr } from '@dnb/eufemia'
-import { Form, Wizard, Value } from '@dnb/eufemia/extensions/forms'
-
-render(
-  <Form.Handler>
-    <Wizard.Layout>
-      <Wizard.Step title="Summary">
-        <Card stack>
-          <Value.Name.First path="/firstName" />
-          <Hr />
-          <Wizard.EditButton toStep={2} />
-        </Card>
-      </Wizard.Step>
-    </Wizard.Layout>
-  </Form.Handler>,
-)
-```
-
-## Demo
-
-<Examples.EditButton />
+<Info />
+<Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/demos.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import * as Examples from './../Examples'
+
+## Demo
+
+<Examples.EditButton />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/info.mdx
@@ -1,0 +1,28 @@
+---
+showTabs: true
+---
+
+## Description
+
+`Wizard.EditButton` is a button to be placed in a summary step.
+
+It provides a `toStep` property that lets you navigate to a specific step.
+
+```jsx
+import { Hr } from '@dnb/eufemia'
+import { Form, Wizard, Value } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Wizard.Layout>
+      <Wizard.Step title="Summary">
+        <Card stack>
+          <Value.Name.First path="/firstName" />
+          <Hr />
+          <Wizard.EditButton toStep={2} />
+        </Card>
+      </Wizard.Step>
+    </Wizard.Layout>
+  </Form.Handler>,
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/EditButton/properties.mdx
@@ -1,0 +1,9 @@
+---
+showTabs: true
+---
+
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+
+## Translations
+
+<TranslationsTable localeKey={['WizardEditButton']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/properties.mdx
@@ -1,0 +1,16 @@
+---
+showTabs: true
+---
+
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+
+## Translations
+
+<TranslationsTable
+  localeKey={[
+    'Step',
+    'WizardEditButton',
+    'WizardPreviousButton',
+    'WizardNextButton',
+  ]}
+/>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/EditButton/EditButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/EditButton/EditButton.tsx
@@ -16,7 +16,7 @@ import {
 export type Props = ComponentProps & ButtonProps & { toStep?: StepIndex }
 
 function EditButton(props: Props) {
-  const translations = useTranslation().Step
+  const translations = useTranslation().WizardEditButton
   const { setActiveIndex } = useStep()
 
   const {
@@ -25,7 +25,7 @@ function EditButton(props: Props) {
     icon_position = 'left',
     icon,
     toStep,
-    children = translations.edit,
+    children = translations.text,
     ...rest
   } = props
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/EditButton/__tests__/EditButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/EditButton/__tests__/EditButton.test.tsx
@@ -8,8 +8,8 @@ import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
 import { Form, Wizard } from '../../..'
 
-const nb = nbNO['nb-NO'].Step
-const en = enGB['en-GB'].Step
+const nb = nbNO['nb-NO'].WizardEditButton
+const en = enGB['en-GB'].WizardEditButton
 
 describe('EditButton', () => {
   it('should have default text', () => {
@@ -17,7 +17,7 @@ describe('EditButton', () => {
 
     const button = document.querySelector('.dnb-forms-edit-button')
 
-    expect(button).toHaveTextContent(nb.edit)
+    expect(button).toHaveTextContent(nb.text)
   })
 
   it('should use en-GB text', () => {
@@ -29,7 +29,7 @@ describe('EditButton', () => {
 
     const button = document.querySelector('.dnb-forms-edit-button')
 
-    expect(button).toHaveTextContent(en.edit)
+    expect(button).toHaveTextContent(en.text)
   })
 
   it('should support custom text', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButton.tsx
@@ -10,13 +10,13 @@ import useTranslation from '../../hooks/useTranslation'
 export type Props = ComponentProps & Omit<ButtonProps, 'variant'>
 
 function NextButton(props: Props) {
-  const translations = useTranslation().Step
+  const translations = useTranslation().WizardNextButton
 
   const {
     className,
     icon_position = 'right',
     icon = 'chevron_right',
-    children = translations.next,
+    children = translations.text,
   } = props
   const { handleNext } = useContext(WizardContext) || {}
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButton.tsx
@@ -10,14 +10,14 @@ import useTranslation from '../../hooks/useTranslation'
 export type Props = ComponentProps & ButtonProps
 
 function PreviousButton(props: Props) {
-  const translations = useTranslation().Step
+  const translations = useTranslation().WizardPreviousButton
 
   const {
     className,
     variant = 'tertiary',
     icon_position = 'left',
     icon = 'chevron_left',
-    children = translations.previous,
+    children = translations.text,
   } = props
   const { activeIndex, handlePrevious } = useContext(WizardContext) || {}
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -15,10 +15,16 @@ export default {
       sendText: 'Send',
     },
     Step: {
-      next: 'Next',
-      previous: 'Back',
-      edit: 'Edit',
       summaryTitle: 'Summary',
+    },
+    WizardEditButton: {
+      text: 'Edit',
+    },
+    WizardPreviousButton: {
+      text: 'Back',
+    },
+    WizardNextButton: {
+      text: 'Next',
     },
     RemoveButton: {
       text: 'Remove',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -15,10 +15,16 @@ export default {
       sendText: 'Send inn',
     },
     Step: {
-      next: 'Neste',
-      previous: 'Tilbake',
-      edit: 'Endre',
       summaryTitle: 'Oppsummering',
+    },
+    WizardEditButton: {
+      text: 'Endre',
+    },
+    WizardPreviousButton: {
+      text: 'Tilbake',
+    },
+    WizardNextButton: {
+      text: 'Neste',
     },
     RemoveButton: {
       text: 'Fjern',


### PR DESCRIPTION
This PR splits the `Step` translation, into the following separate translations:

- `WizardEditButton`
- `WizardPreviousButton`
- `WizardNextButton`

This PR also adds docs for the translation props of:

- `Wizard`
- `Wizard.PreviousButton`
- `Wizard.EditButton`
- `Wizard.Step.EditButton`

I've still kept the `Step` translation with the `summaryTitle`, as it's documented in so many places so there's a high chance changing that might break something for our users.