### PR TITLE
fix(Dropdown): NVDA navigation issue when no items are selected

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -776,6 +776,21 @@ describe('Dropdown component', () => {
     expect(elem.getAttribute('class')).toContain('dnb-dropdown--opened')
   })
 
+  it('should set aria-activedescendant to be of first option, when no items are selected', () => {
+    render(<Dropdown data={['1', '2']} />)
+    open()
+
+    expect(
+      document
+        .querySelectorAll('li.dnb-drawer-list__option')[0]
+        .getAttribute('id')
+    ).toBe(
+      document
+        .querySelector('.dnb-drawer-list__options')
+        .getAttribute('aria-activedescendant')
+    )
+  })
+
   it('has correct length of li elements', () => {
     render(<Dropdown {...props} data={mockData} />)
 

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -261,7 +261,7 @@ class DrawerListInstance extends React.PureComponent {
           !(parseFloat(selected_item) > -1)))
     ) {
       ulParams['aria-activedescendant'] = `option-${id}-${
-        active_item || 0
+        parseFloat(active_item) > -1 ? active_item : 0
       }`
     } else if (
       !isTrue(prevent_selection) &&


### PR DESCRIPTION
I think this fixes it...

So when [there's no items selected](https://github.com/dnbexperience/eufemia/commit/8116f8d1a1844783b34aaa48c3aca0592db452ad#diff-46dbe8d13456e462d06633ec5d300715616d086a119195145ddb53b1219a4fdcR257-R261), meaning `active_item` is `-1` the `aria-activedescendant` [get the `-1` value appended](https://github.com/dnbexperience/eufemia/commit/8116f8d1a1844783b34aaa48c3aca0592db452ad#diff-46dbe8d13456e462d06633ec5d300715616d086a119195145ddb53b1219a4fdcR264)(which it shouldn't).
This results in `aria-activedescendant` value being `option-id-q1yx1378--1` when in reality it should be set to the first item, which should be `option-id-q1yx1378-0`.

So this PR basically handles when `active_item` is `-1`, then we set `aria-activedescendant` value to be first item in the list, `0`, and not `-1`(which it previously did, before this PR).