### PR TITLE
docs(Field.Email): fix link to input docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/properties.mdx
@@ -10,10 +10,10 @@ import { fieldProperties } from '@dnb/eufemia/src/extensions/forms/Field/FieldDo
 
 ### Field-specific props
 
-| Property                                      | Type     | Description                                                                     |
-| --------------------------------------------- | -------- | ------------------------------------------------------------------------------- |
-| `help`                                        | `object` | _(optional)_ Provide a help button. Object consisting of `title` and `content`. |
-| `[Input](/uilib/components/input/properties)` | Various  | _(optional)_ All `Input` properties are supported.                              |
+| Property                                    | Type     | Description                                                                     |
+| ------------------------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `help`                                      | `object` | _(optional)_ Provide a help button. Object consisting of `title` and `content`. |
+| [Input](/uilib/components/input/properties) | Various  | _(optional)_ All `Input` properties are supported.                              |
 
 ### General props
 


### PR DESCRIPTION
Fixes the following "link"([Input](/uilib/components/input/properties)), https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/Email/properties/

<img width="1221" alt="image" src="https://github.com/dnbexperience/eufemia/assets/1359205/aa9c0cb2-9405-4b11-bd5a-dfeb27aadc6e">
