### PR TITLE
chore(Portal): fix Github button size

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -112,7 +112,8 @@ export default function StickyMenuBar({
           <Button
             id="github-button"
             href="https://github.com/dnbexperience/eufemia/"
-            size="large"
+            size="default"
+            icon_size="medium"
             target="_blank"
             icon={GithubLogo}
             title="Navigates to Eufemia's GitHub repository"


### PR DESCRIPTION
The  Github button size was slightly larger than the "more options"-menu button.

Before:
<img width="1435" alt="Skjermbilde 2024-07-16 kl  23 00 39" src="https://github.com/user-attachments/assets/0bbfefc6-b881-4a60-b475-ce5a9ac62996">

After:
<img width="1452" alt="Skjermbilde 2024-07-16 kl  23 00 24" src="https://github.com/user-attachments/assets/29e3c99d-a59d-4cb1-9cff-c32f50ddae3c">
