### PR TITLE
(fix) Can now click on arrow when text is highlighted to expand/collapse

### DIFF
--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -57,7 +57,6 @@
     &.dnb-table__td {
       padding: 0;
     }
-    user-select: none; // prevent selection on double-click
   }
 
   &__tr--clickable &__button {


### PR DESCRIPTION
Fixes #3750

This removes  the previous: `user-select: none; // prevent selection on double-click` . 

If by selection they meant text highlight, then this previous fix i removed only solved double clicking on the arrow only.
