### PR TITLE
docs(Typography): improve font-weights table

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
@@ -13,17 +13,11 @@ For details about what values Typographic elements do use, have a loot at the [F
 
 ## Eufemia has three (3) font-weights
 
-- <span className="dnb-typo-regular">Regular</span> (normal)
-- <span className="dnb-typo-medium">Medium</span> (500)
-- <span className="dnb-typo-bold">Bold</span> (600)
-
-## `font-weight` table
-
-| Type        | Custom Property         |
-| ----------- | ----------------------- |
-| **Regular** | `--font-weight-regular` |
-| **Medium**  | `--font-weight-medium`  |
-| **Bold**    | `--font-weight-bold`    |
+| Type                                                       | Custom Property         | CSS Classname      |
+| ---------------------------------------------------------- | ----------------------- | ------------------ |
+| <span className="dnb-typo-regular">Regular (normal)</span> | `--font-weight-regular` | `dnb-typo-regular` |
+| <span className="dnb-typo-medium">Medium (500)</span>      | `--font-weight-medium`  | `dnb-typo-medium`  |
+| <span className="dnb-typo-bold">Bold (600)</span>          | `--font-weight-bold`    | `dnb-typo-bold`    |
 
 ### How to use the weights (CSS)
 


### PR DESCRIPTION
Before:

<img width="997" alt="Skjermbilde 2024-08-02 kl  21 03 28" src="https://github.com/user-attachments/assets/0c79b88c-eda9-45eb-8540-91758cad89e8">


After:
<img width="1005" alt="Skjermbilde 2024-08-02 kl  21 07 22" src="https://github.com/user-attachments/assets/f6779bd6-4a1a-44e2-8fba-76536b0f1d7a">

