### PR TITLE
fix(Tabs): make sure props data key is used if defined

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.js
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.js
@@ -206,9 +206,9 @@ export default class Tabs extends React.PureComponent {
       ) {
         // tabs data from main prop
         const dataProps =
-          (props.tabs &&
-            Array.isArray(props.tabs) &&
-            props.tabs[reactElemIndex]) ||
+          (props.children &&
+            Array.isArray(props.children) &&
+            props.children[reactElemIndex]) ||
           {}
 
         // props from the "CustomContent" Component

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -628,6 +628,34 @@ describe('A single Tab component', () => {
 
     expect(document.querySelector('.dnb-tabs')).toBeInTheDocument()
   })
+
+  it('should use `key` data prop if defined', () => {
+    render(
+      <Tabs
+        data={[
+          {
+            title: 'First',
+            key: 'first_key',
+          },
+          {
+            title: 'Second',
+            key: 'second_key',
+          },
+          {
+            title: 'Third',
+            key: 'third_key',
+          },
+        ]}
+      />
+    )
+    const [first, second, third] = Array.from(
+      document.querySelectorAll('.dnb-tabs__button')
+    )
+
+    expect(first).toHaveAttribute('data-tab-key', 'first_key')
+    expect(second).toHaveAttribute('data-tab-key', 'second_key')
+    expect(third).toHaveAttribute('data-tab-key', 'third_key')
+  })
 })
 
 describe('Tabs scss', () => {


### PR DESCRIPTION
The custom key given to Tabs data was always set to the tab title, this pr fixes that issue
