### PR TITLE
feat(Form): continuousValidation did not update error state correctly

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
@@ -119,4 +119,43 @@ describe('FieldBoundaryProvider', () => {
       '/bar': true,
     })
   })
+
+  it('should set error in context with continuousValidation', async () => {
+    const contextRef: React.MutableRefObject<FieldBoundaryContextState> =
+      React.createRef()
+
+    const Contexts = ({ children }) => {
+      contextRef.current = useContext(FieldBoundaryContext)
+      return <>{children}</>
+    }
+
+    render(
+      <Provider>
+        <FieldBoundaryProvider>
+          <Contexts>
+            <Field.String required path="/bar" continuousValidation />
+            <Form.SubmitButton />
+          </Contexts>
+        </FieldBoundaryProvider>
+      </Provider>
+    )
+
+    await userEvent.click(document.querySelector('button'))
+
+    expect(contextRef.current.hasError).toBe(true)
+    expect(contextRef.current.hasSubmitError).toBe(true)
+    expect(contextRef.current.hasVisibleError).toBe(true)
+    expect(contextRef.current.errorsRef.current).toMatchObject({
+      '/bar': true,
+    })
+
+    const inputElement = document.querySelector('input')
+    await userEvent.type(inputElement, 'b')
+    await userEvent.click(document.querySelector('button'))
+
+    expect(contextRef.current.hasError).toBe(false)
+    expect(contextRef.current.hasSubmitError).toBe(false)
+    expect(contextRef.current.hasVisibleError).toBe(false)
+    expect(contextRef.current.errorsRef.current).toMatchObject({})
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -356,6 +356,8 @@ export default function useFieldProps<
     showFieldErrorFieldBlock?.(identifier, true)
     if (localErrorRef.current) {
       setHasVisibleErrorDataContext?.(identifier, true)
+    } else {
+      setHasVisibleErrorDataContext?.(identifier, false)
     }
   }, [showFieldErrorFieldBlock, identifier, setHasVisibleErrorDataContext])
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -232,7 +232,7 @@ export default function useFieldProps<
   // Error handling
   // - Should errors received through validation be shown initially. Assume that providing a direct prop to
   // the component means it is supposed to be shown initially.
-  const showErrorRef = useRef<boolean>(
+  const revealErrorRef = useRef<boolean>(
     Boolean(validateInitially || errorProp)
   )
   // - Local errors are errors based on validation instructions received by
@@ -351,8 +351,8 @@ export default function useFieldProps<
     [setFieldStateDataContext, identifier, validateInitially]
   )
 
-  const showError = useCallback(() => {
-    showErrorRef.current = true
+  const revealError = useCallback(() => {
+    revealErrorRef.current = true
     showFieldErrorFieldBlock?.(identifier, true)
     if (localErrorRef.current) {
       setHasVisibleErrorDataContext?.(identifier, true)
@@ -362,7 +362,7 @@ export default function useFieldProps<
   }, [showFieldErrorFieldBlock, identifier, setHasVisibleErrorDataContext])
 
   const hideError = useCallback(() => {
-    showErrorRef.current = false
+    revealErrorRef.current = false
     showFieldErrorFieldBlock?.(identifier, false)
     setHasVisibleErrorDataContext?.(identifier, false)
   }, [setHasVisibleErrorDataContext, identifier, showFieldErrorFieldBlock])
@@ -410,7 +410,7 @@ export default function useFieldProps<
   }, [dataContextError, prepareError])
 
   const error =
-    showErrorRef.current ||
+    revealErrorRef.current ||
     // If the error is a type error, we want to show it even if the field as not been used
     localErrorRef.current?.['validationRule'] === 'type'
       ? errorProp ?? localErrorRef.current ?? contextErrorRef.current
@@ -525,7 +525,7 @@ export default function useFieldProps<
       if (continuousValidation || runAsync) {
         // Because we first need to throw the error to be able to display it, we delay the showError call
         window.requestAnimationFrame(() => {
-          showError()
+          revealError()
           forceUpdate()
         })
       }
@@ -549,7 +549,7 @@ export default function useFieldProps<
     persistErrorState,
     defineAsyncProcess,
     setFieldState,
-    showError,
+    revealError,
   ])
 
   const callOnBlurValidator = useCallback(
@@ -583,10 +583,10 @@ export default function useFieldProps<
         setFieldState(result instanceof Error ? 'error' : 'complete')
       }
 
-      showError()
+      revealError()
       forceUpdate()
     },
-    [persistErrorState, defineAsyncProcess, setFieldState, showError]
+    [persistErrorState, defineAsyncProcess, setFieldState, revealError]
   )
 
   const prioritizeContextSchema = useMemo(() => {
@@ -695,12 +695,12 @@ export default function useFieldProps<
       // When there is a change to the value without there having been any focus callback beforehand, it is likely
       // to believe that the blur callback will not be called either, which would trigger the display of the error.
       // The error is therefore displayed immediately (unless instructed not to with continuousValidation set to false).
-      showError()
+      revealError()
     } else {
       // When changing the value, hide errors to avoid annoying the user before they are finished filling in that value
       hideError()
     }
-  }, [continuousValidation, hideError, showError])
+  }, [continuousValidation, hideError, revealError])
 
   const setHasFocus = useCallback(
     async (hasFocus: boolean, valueOverride?: Value) => {
@@ -735,7 +735,7 @@ export default function useFieldProps<
 
         await runPool(() => {
           // Since the user left the field, show error (if any)
-          showError()
+          revealError()
           forceUpdate()
         })
       }
@@ -746,7 +746,7 @@ export default function useFieldProps<
       onBlur,
       onFocus,
       runPool,
-      showError,
+      revealError,
       validateUnchanged,
     ]
   )
@@ -807,7 +807,7 @@ export default function useFieldProps<
 
     if (typeof result?.error !== 'undefined') {
       persistErrorState('gracefully', result.error)
-      showError()
+      revealError()
     }
     if (typeof result?.warning !== 'undefined') {
       warningRef.current = result.warning
@@ -837,7 +837,7 @@ export default function useFieldProps<
     defineAsyncProcess,
     persistErrorState,
     setFieldState,
-    showError,
+    revealError,
     yieldAsyncProcess,
   ])
 
@@ -1179,11 +1179,11 @@ export default function useFieldProps<
       if (fieldStateRef.current !== 'validating') {
         // If showError on a surrounding data context was changed and set to true, it is because the user clicked next, submit or
         // something else that should lead to showing the user all errors.
-        showError()
+        revealError()
         forceUpdate()
       }
     }
-  }, [showAllErrors, showError])
+  }, [showAllErrors, revealError])
 
   useEffect(() => {
     if (


### PR DESCRIPTION
`FieldBoundaryContext`'s `hasVisibleError` was not updated if attempting to `showError()` and there is none. If there was an error before, then any component that used `hasVisibleError` (only `Iterate.EditContainer` and `Form.Section.EditContainer` at the moment) would still think there was an error visible. 

`showError()` is run at any change whenever `continuousValidation` is used. Some components always use `continuousValidation` like `ArraySelection`.

* `hasVisibleError` is now set to `false` if there is no error when attempting to "showError"
* `showError` renamed to `revealError` to make it more clear that it does not actually mean there is an error.