### PR TITLE
fix(Forms): fallback to use default locale for translations when providing a non-existent locale

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
@@ -181,7 +181,7 @@ describe('ChildrenWithAge', () => {
     )
   })
 
-  it('should display default translations when providing a non-existent locale to Provider', async () => {
+  it('should display default translations when providing a non-existent locale to Form.Handler', () => {
     render(
       <Form.Handler locale="non-existent">
         <ChildrenWithAge />

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
@@ -181,6 +181,18 @@ describe('ChildrenWithAge', () => {
     )
   })
 
+  it('should display default translations when providing a non-existent locale to Provider', async () => {
+    render(
+      <Form.Handler locale="non-existent">
+        <ChildrenWithAge />
+      </Form.Handler>
+    )
+
+    expect(document.querySelector('.dnb-p')).toHaveTextContent(
+      'Antall barn'
+    )
+  })
+
   it('should match snapshot', () => {
     const generateRef = React.createRef<GenerateRef>()
 

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -272,7 +272,8 @@ export function prepareContext<Props>(
   const context = {
     ...props,
     updateTranslation: (locale, newTranslations) => {
-      context.translation = newTranslations[locale]
+      context.translation =
+        newTranslations[locale] || newTranslations[LOCALE]
       context.translations = newTranslations
 
       if (context.locales) {
@@ -309,12 +310,10 @@ function handleLocaleFallbacks(
   locale: InternalLocale | AnyLocale,
   translations: Translations = {}
 ) {
-  if (!translations[locale]) {
-    if (locale === 'en' || String(locale).split('-')[0] === 'en') {
-      return 'en-GB'
-    }
+  if (locale === 'en' || String(locale).split('-')[0] === 'en') {
+    return 'en-GB'
   }
-  return locale
+  return translations[locale] ? locale : LOCALE
 }
 
 // If no provider is given, we use the default context from here

--- a/packages/dnb-eufemia/src/shared/__tests__/Context.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Context.test.tsx
@@ -117,4 +117,22 @@ describe('Context', () => {
     rerender(<HelpButton lang="en-GB">content</HelpButton>)
     expect(screen.queryByLabelText(title_gb)).toBeInTheDocument()
   })
+
+  it('should support fallback "translation" for non-existent locale', () => {
+    let translation = undefined
+
+    render(
+      <Provider locale="non-existent">
+        <Context.Consumer>
+          {(context) => {
+            translation = context.translation
+            return null
+          }}
+        </Context.Consumer>
+      </Provider>
+    )
+
+    expect(translation).not.toBeUndefined()
+    expect(translation.DatePicker.month).toBe('måned')
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/dnbexperience/eufemia/issues/3818

- [x] The actual fix
- [x] A test documenting the error/scenario