### PR TITLE
feat(Field.PhoneNumber, Field.SelectCountry): additional event args for onFocus and onBlur

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
@@ -6,8 +6,12 @@ export const Empty = () => {
   return (
     <ComponentBox>
       <Field.PhoneNumber
-        onFocus={(value) => console.log('onFocus', value)}
-        onBlur={(value) => console.log('onBlur', value)}
+        onFocus={(value, additionalArgs) =>
+          console.log('onFocus', value, additionalArgs)
+        }
+        onBlur={(value, additionalArgs) =>
+          console.log('onBlur', value, additionalArgs)
+        }
         onChange={(value, additionalArgs) =>
           console.log('onChange', value, additionalArgs)
         }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
@@ -22,16 +22,16 @@ import {
 
 The first argument value returned by the event handlers is a string where the country code and phone-number is separated by a space, e.g. `+47 9123457`. If the `omitCountryCodeField` is set to `true`, then only the phone-number will be used, so the argument would be `9123457` without the leading country code.
 
-The `onChange` has an extra second parameter of type `{ countryCode?: string, phoneNumber: string | undefined }`.
+PhoneNumber also has and extra second parameter of type `{ countryCode?: string, phoneNumber: string | undefined }`.
 
-The typing of the `onChange` event callback is as follows:
+The typing of the general event callbacks is as follows:
 
 ```jsx
-onChange: (
-    value: string | undefined, // e.g. "+47 12345678"
-    additionalArgs: {
-        countryCode?: string, // e.g. "+47"
-        phoneNumber: string | undefined // e.g. "12345678"
-    }
+(
+  value: string | undefined, // e.g. "+47 12345678"
+  additionalArgs: {
+      countryCode?: string, // e.g. "+47"
+      phoneNumber: string | undefined // e.g. "12345678"
+  }
 ) => void
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/events.mdx
@@ -22,7 +22,7 @@ import {
 
 The first argument value returned by the event handlers is a string where the country code and phone-number is separated by a space, e.g. `+47 9123457`. If the `omitCountryCodeField` is set to `true`, then only the phone-number will be used, so the argument would be `9123457` without the leading country code.
 
-PhoneNumber also has and extra second parameter of type `{ countryCode?: string, phoneNumber: string | undefined }`.
+PhoneNumber also has an extra second parameter of type `{ countryCode?: string, phoneNumber: string | undefined }`.
 
 The typing of the general event callbacks is as follows:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
@@ -6,6 +6,8 @@ export const Empty = () => {
     <ComponentBox>
       <Field.SelectCountry
         onChange={(value, obj) => console.log('onChange', value, obj)}
+        onBlur={(value, obj) => console.log('onBlur', value, obj)}
+        onFocus={(value, obj) => console.log('onFocus', value, obj)}
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/events.mdx
@@ -3,20 +3,27 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import { fieldEvents } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
+import { selectCountryGeneralEvents } from '@dnb/eufemia/src/extensions/forms/Field/SelectCountry/SelectCountryDocs'
 
 ## Events
 
-<PropertiesTable props={fieldEvents} />
+<PropertiesTable props={selectCountryGeneralEvents} />
 
-### Argument value
+### Details about argument values
 
-The event handlers has two arguments. The first one is a `string` containing the `ISO` of the selected country, e.g. `CH`, and the second argument is an object with the properties `cdc`, `continent`, `i18n` and `iso`. e.g. `{
-  cdc: '41',
-  iso: 'CH',
+The event handlers has two arguments. The first one is a `string` containing the `ISO` of the selected country, e.g. `CH`, and the second argument is an object with the properties `cdc`, `continent`, `i18n` and `iso`.
+
+```jsx
+(
+  value?: string // e.g. "CH"
+  additionalArgs?: {
     i18n: {
-    en: 'Switzerland',
-    nb: 'Sveits'
-  },
-  continent: 'Europe'
-}`
+      en: string, // e.g. "Switzerland"
+      nb: string // e.g. "Sveits"
+    },
+    cdc: string, // e.g. "41"
+    iso: string, // e.g. "CH"
+    continent: string // e.g. "Europe"
+  }
+) => void
+```

--- a/packages/dnb-eufemia/src/extensions/forms/Field/FieldDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/FieldDocs.ts
@@ -28,19 +28,21 @@ export const getFieldEventsWithTypes = (
       }`
     : ''
 
+  const typeString = `(${value}${add}) => void`
+
   return {
     ...fieldEvents,
     onChange: {
       ...fieldEvents.onChange,
-      type: `(${value}${add}) => void`,
+      type: typeString,
     },
     onFocus: {
       ...fieldEvents.onFocus,
-      type: `(${value}) => void`,
+      type: typeString,
     },
     onBlur: {
       ...fieldEvents.onBlur,
-      type: `(${value}) => void`,
+      type: typeString,
     },
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -113,18 +113,30 @@ describe('Field.PhoneNumber', () => {
     )
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith(undefined)
+    expect(onFocus).toHaveBeenLastCalledWith(undefined, {
+      countryCode: '+47',
+      phoneNumber: undefined,
+    })
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith(undefined)
+    expect(onBlur).toHaveBeenLastCalledWith(undefined, {
+      countryCode: '+47',
+      phoneNumber: undefined,
+    })
 
     await userEvent.type(phoneElement, '99999999')
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith('+47 99999999')
+    expect(onFocus).toHaveBeenLastCalledWith('+47 99999999', {
+      countryCode: '+47',
+      phoneNumber: '99999999',
+    })
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith('+47 99999999')
+    expect(onBlur).toHaveBeenLastCalledWith('+47 99999999', {
+      countryCode: '+47',
+      phoneNumber: '99999999',
+    })
   })
 
   it('should have selected correct item', async () => {
@@ -160,7 +172,7 @@ describe('Field.PhoneNumber', () => {
       return (
         <Field.PhoneNumber
           value={state}
-          onFocus={onFocus}
+          onFocus={(value) => onFocus(value)}
           onCountryCodeChange={onCountryCodeChange}
           onChange={(value) => {
             update(value)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -46,6 +46,15 @@ function SelectCountry(props: Props) {
   const translations = useTranslation().SelectCountry
   const lang = sharedContext.locale?.split('-')[0] as CountryLang
 
+  const transformAdditionalArgs = (additionalArgs, value) => {
+    const country = countries.find(({ iso }) => value === iso)
+    if (country?.iso) {
+      return country
+    } else {
+      return additionalArgs
+    }
+  }
+
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
     required: translations.errorRequired,
   })
@@ -56,6 +65,7 @@ function SelectCountry(props: Props) {
   const preparedProps: Props = {
     ...defaultProps,
     ...props,
+    transformAdditionalArgs,
   }
 
   const {
@@ -122,7 +132,7 @@ function SelectCountry(props: Props) {
       const newValue = data?.selectedKey
       const country = countries.find(({ iso }) => newValue === iso)
       if (country?.iso) {
-        handleChange(country.iso, country)
+        handleChange(country.iso)
       }
     },
     [handleChange]
@@ -159,7 +169,7 @@ function SelectCountry(props: Props) {
         )
         if (country?.iso) {
           setHidden()
-          handleChange(country.iso, country)
+          handleChange(country.iso)
         }
       }
     },
@@ -191,6 +201,7 @@ function SelectCountry(props: Props) {
         stretch
         status={hasError ? 'error' : undefined}
         show_submit_button
+        keep_selection
         suffix={
           help ? (
             <HelpButton title={help.title}>{help.content}</HelpButton>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountryDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountryDocs.ts
@@ -1,0 +1,6 @@
+import { getFieldEventsWithTypes } from '../FieldDocs'
+
+export const selectCountryGeneralEvents = getFieldEventsWithTypes(
+  { type: 'string', optional: true },
+  { type: 'object', optional: true }
+)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -14,8 +14,16 @@ describe('Field.SelectCountry', () => {
 
   it('should return correct value onChange event', () => {
     const onChange = jest.fn()
+    const onBlur = jest.fn()
+    const onFocus = jest.fn()
 
-    render(<Field.SelectCountry onChange={onChange} />)
+    render(
+      <Field.SelectCountry
+        onChange={onChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
+      />
+    )
 
     const inputElement: HTMLInputElement = document.querySelector(
       '.dnb-forms-field-select-country input'
@@ -28,19 +36,28 @@ describe('Field.SelectCountry', () => {
     fireEvent.change(inputElement, { target: { value: 'Norge' } })
     fireEvent.click(firstItemElement())
 
-    expect(onChange).toHaveBeenLastCalledWith('NO', {
-      cdc: '47',
-      continent: 'Europe',
-      i18n: {
-        en: 'Norway',
-        nb: 'Norge',
+    const firstEventValues = [
+      'NO',
+      {
+        cdc: '47',
+        continent: 'Europe',
+        i18n: {
+          en: 'Norway',
+          nb: 'Norge',
+        },
+        iso: 'NO',
+        regions: ['Scandinavia', 'Nordic'],
       },
-      iso: 'NO',
-      regions: ['Scandinavia', 'Nordic'],
-    })
+    ]
+    expect(onChange).toHaveBeenLastCalledWith(...firstEventValues)
     expect(inputElement.value).toEqual('Norge')
 
+    fireEvent.blur(inputElement)
     fireEvent.focus(inputElement)
+
+    expect(onFocus).toHaveBeenLastCalledWith(...firstEventValues)
+    expect(onBlur).toHaveBeenLastCalledWith(...firstEventValues)
+
     fireEvent.change(inputElement, { target: { value: 'Dan' } })
     fireEvent.click(firstItemElement())
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -108,6 +108,8 @@ export default function useFieldProps<
     fromInput = (value: Value) => value,
     toEvent = (value: Value) => value,
     transformValue = (value: Value) => value,
+    transformAdditionalArgs = (additionalArgs: AdditionalEventArgs) =>
+      additionalArgs,
     fromExternal = (value: Value) => value,
     validateRequired = (value: Value, { emptyValue, required, error }) => {
       const res =
@@ -134,6 +136,7 @@ export default function useFieldProps<
   const transformers = useRef({
     transformIn,
     transformOut,
+    transformAdditionalArgs,
     toInput,
     fromInput,
     toEvent,
@@ -713,8 +716,14 @@ export default function useFieldProps<
           valueOverride ?? valueRef.current,
           type
         )
-        return typeof additionalArgs !== 'undefined'
-          ? [value, additionalArgs]
+        const transformedAdditionalArgs =
+          transformers.current.transformAdditionalArgs(
+            additionalArgs,
+            value
+          )
+
+        return typeof transformedAdditionalArgs !== 'undefined'
+          ? [value, transformedAdditionalArgs]
           : [value]
       }
 
@@ -1001,8 +1010,14 @@ export default function useFieldProps<
           'onChange'
         )
 
-        return typeof additionalArgs !== 'undefined'
-          ? [value, additionalArgs]
+        const transformedAdditionalArgs =
+          transformers.current.transformAdditionalArgs(
+            additionalArgs,
+            value
+          )
+
+        return typeof transformedAdditionalArgs !== 'undefined'
+          ? [value, transformedAdditionalArgs]
           : [value]
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -701,23 +701,33 @@ export default function useFieldProps<
   }, [continuousValidation, hideError, showError])
 
   const setHasFocus = useCallback(
-    async (hasFocus: boolean, valueOverride?: Value) => {
+    async (
+      hasFocus: boolean,
+      valueOverride?: Value,
+      additionalArgs?: AdditionalEventArgs
+    ) => {
+      const getArgs = (
+        type: Parameters<typeof transformers.current.toEvent>[1]
+      ) => {
+        const value = transformers.current.toEvent(
+          valueOverride ?? valueRef.current,
+          type
+        )
+        return typeof additionalArgs !== 'undefined'
+          ? [value, additionalArgs]
+          : [value]
+      }
+
       if (hasFocus) {
         // Field was put in focus (like when clicking in a text field or opening a dropdown menu)
         hasFocusRef.current = true
-        const value = transformers.current.toEvent(
-          valueOverride ?? valueRef.current,
-          'onFocus'
-        )
-        onFocus?.(value)
+        const args = getArgs('onFocus')
+        onFocus?.apply(this, args)
       } else {
         // Field was removed from focus (like when tabbing out of a text field or closing a dropdown menu)
         hasFocusRef.current = false
-        const value = transformers.current.toEvent(
-          valueOverride ?? valueRef.current,
-          'onBlur'
-        )
-        onBlur?.(value)
+        const args = getArgs('onBlur')
+        onBlur?.apply(this, args)
 
         if (!changedRef.current && !validateUnchanged) {
           // Avoid showing errors when blurring without having changed the value, so tabbing through several
@@ -1375,7 +1385,11 @@ export interface ReturnAdditional<Value> {
   value: Value
   isChanged: boolean
   htmlAttributes: AriaAttributes | DataAttributes
-  setHasFocus: (hasFocus: boolean, valueOverride?: unknown) => void
+  setHasFocus: (
+    hasFocus: boolean,
+    valueOverride?: unknown,
+    additionalArgs?: AdditionalEventArgs
+  ) => void
   handleFocus: () => void
   handleBlur: () => void
   handleChange: (

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -113,8 +113,14 @@ export interface DataValueWriteProps<
   EmptyValue = undefined | unknown,
 > {
   emptyValue?: EmptyValue
-  onFocus?: (value: Value | EmptyValue) => void
-  onBlur?: (value: Value | EmptyValue) => void
+  onFocus?: (
+    value: Value | EmptyValue,
+    additionalArgs?: AdditionalEventArgs
+  ) => void
+  onBlur?: (
+    value: Value | EmptyValue,
+    additionalArgs?: AdditionalEventArgs
+  ) => void
   onChange?: OnChangeValue<Value, EmptyValue>
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -321,6 +321,14 @@ export interface UseFieldProps<
   transformValue?: (value: Value, currentValue?: Value) => Value
 
   /**
+   * Transform additionalArgs or generate it based on value after `toEvent` and before callbacks such as `onChange`, `onFocus` and `onBlur`.
+   */
+  transformAdditionalArgs?: (
+    additionalArgs: AdditionalEventArgs,
+    internal: Value
+  ) => AdditionalEventArgs
+
+  /**
    * Transforms the value before it gets returned as the `value`.
    */
   toInput?: (external: Value | unknown) => Value | unknown


### PR DESCRIPTION
* added two ways to send `additionalArgs` to `onBlur` and `onFocus`:
* method 1: use `setHasFocus()` with new parameter `additionalArgs`, instead of `handleBlur()` and `handleFocus()`
* method 2: use new transformer `transformAdditionalArgs()` that can generate `additionalArgs` from `value`

### Implemented in components:
* added `additionalArgs` to `<Field.PhoneNumber>` `onBlur` and `onFocus` using method 1
* added `additionalArgs` to `<Field.SelectCountry>` `onBlur` and `onFocus` using method 2