### PR TITLE
feat(Field): adds typing for event callbacks

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -19,7 +19,7 @@ import {
   JSONSchema,
   Ajv,
   OnChange,
-  OnChangeValue,
+  DataValueWriteProps,
 } from '../../../'
 import { isCI } from 'repo-utils'
 import { Props as StringFieldProps } from '../../../Field/String'
@@ -32,6 +32,8 @@ import { debounceAsync } from '../../../../../shared/helpers/debounce'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
+
+type OnChangeValue = DataValueWriteProps['onChange']
 
 if (isCI) {
   jest.retryTimes(5) // because of an flaky async validation test

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -13,7 +13,8 @@ import useTranslation from '../../hooks/useTranslation'
 
 type ExpiryValue = MultiInputMaskValue<'month' | 'year'>
 
-export type ExpiryProps = FieldHelpProps & FieldProps<string>
+export type ExpiryProps = FieldHelpProps &
+  FieldProps<string, undefined | ''>
 
 function Expiry(props: ExpiryProps) {
   const {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -11,7 +11,7 @@ import FieldBlock from '../../FieldBlock'
 import { useFieldProps } from '../../hooks'
 import {
   FieldHelpProps,
-  FieldProps,
+  FieldPropsWithExtraValue,
   AllJSONSchemaVersions,
 } from '../../types'
 import { pickSpacingProps } from '../../../../components/flex/utils'
@@ -26,7 +26,11 @@ import useTranslation from '../../hooks/useTranslation'
 import { DrawerListDataObject } from '../../../../fragments/DrawerList'
 
 export type Props = FieldHelpProps &
-  FieldProps<string, undefined | string> & {
+  FieldPropsWithExtraValue<
+    string,
+    { country: string; phone: string },
+    undefined | string
+  > & {
     countryCodeFieldClassName?: string
     numberFieldClassName?: string
     countryCodePlaceholder?: string

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -9,7 +9,11 @@ import countries, {
   type CountryLang,
 } from '../../constants/countries'
 import { useFieldProps } from '../../hooks'
-import { FieldBlockWidth, FieldHelpProps, FieldProps } from '../../types'
+import {
+  FieldBlockWidth,
+  FieldHelpProps,
+  FieldPropsWithExtraValue,
+} from '../../types'
 import FieldBlock from '../../FieldBlock'
 import useErrorMessage from '../../hooks/useErrorMessage'
 import useTranslation from '../../hooks/useTranslation'
@@ -21,7 +25,7 @@ export type CountryFilterSet =
   | 'Prioritized'
 
 export type Props = FieldHelpProps &
-  FieldProps<string, undefined | string> & {
+  FieldPropsWithExtraValue<string, CountryType, undefined | string> & {
     countries?: CountryFilterSet
 
     // Styling
@@ -46,7 +50,7 @@ function SelectCountry(props: Props) {
   const translations = useTranslation().SelectCountry
   const lang = sharedContext.locale?.split('-')[0] as CountryLang
 
-  const transformAdditionalArgs = (additionalArgs, value) => {
+  const transformAdditionalArgs = (additionalArgs: CountryType, value) => {
     const country = countries.find(({ iso }) => value === iso)
     if (country?.iso) {
       return country

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -25,7 +25,7 @@ import SummaryListContext from '../../Value/SummaryList/SummaryListContext'
 import ValueBlockContext from '../../ValueBlock/ValueBlockContext'
 import FieldBoundaryProvider from '../../DataContext/FieldBoundary/FieldBoundaryProvider'
 
-import type { ContainerMode, ElementChild, Props, Value } from './types'
+import type { ContainerMode, ElementChild, Props } from './types'
 import type { Identifier, Path } from '../../types'
 
 /**
@@ -87,7 +87,7 @@ function ArrayComponent(props: Props) {
     handleChange,
     onChange,
     children,
-  } = useFieldProps<Value, Props>(preparedProps)
+  } = useFieldProps(preparedProps)
 
   const idsRef = useRef<Array<Identifier>>([])
   const isNewRef = useRef<Record<string, boolean>>({})

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
@@ -8,16 +8,17 @@ export type ElementChild =
   | ((value: any, index: number) => React.ReactNode)
 export type Props = Omit<
   FlexContainerProps,
-  'children' | 'width' | 'defaultValue'
-> & {
-  children: ElementChild | Array<ElementChild>
-  value?: UseFieldProps<Value, undefined | Value>['value']
-  path?: Path
-  countPath?: Path
-  countPathLimit?: number
-  countPathTransform?: (params: { value: any; index: number }) => any
-  withoutFlex?: boolean
-  emptyValue?: UseFieldProps<Value, undefined | Value>['emptyValue']
-  placeholder?: React.ReactNode
-  onChange?: UseFieldProps<Value, undefined | Value>['onChange']
-}
+  keyof Omit<React.HTMLAttributes<HTMLDivElement>, 'className'>
+> &
+  Pick<
+    UseFieldProps<Value, undefined | Value>,
+    'value' | 'emptyValue' | 'onChange'
+  > & {
+    children: ElementChild | Array<ElementChild>
+    path?: Path
+    countPath?: Path
+    countPathLimit?: number
+    countPathTransform?: (params: { value: any; index: number }) => any
+    withoutFlex?: boolean
+    placeholder?: React.ReactNode
+  }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -13,7 +13,7 @@ import { errorChanged } from '../utils'
 import { ajvErrorsToOneFormError } from '../utils/ajv'
 import {
   FormError,
-  FieldPropsBase,
+  FieldPropsGeneric,
   AdditionalEventArgs,
   SubmitState,
   EventReturnWithStateObjectAndSuccess,
@@ -72,7 +72,7 @@ export type DataAttributes = {
 // useEffect depend on them (like the external `value`)
 
 export default function useFieldProps<Value, EmptyValue, Props>(
-  localeProps: Props & FieldPropsBase<Value, EmptyValue>,
+  localeProps: Props & FieldPropsGeneric<Value, EmptyValue>,
   { executeOnChangeRegardlessOfError = false } = {}
 ): typeof localeProps & ReturnAdditional<Value> {
   const { extend } = useContext(FieldPropsContext)

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -13,7 +13,7 @@ import { errorChanged } from '../utils'
 import { ajvErrorsToOneFormError } from '../utils/ajv'
 import {
   FormError,
-  FieldProps,
+  FieldPropsBase,
   AdditionalEventArgs,
   SubmitState,
   EventReturnWithStateObjectAndSuccess,
@@ -71,15 +71,12 @@ export type DataAttributes = {
 // Many variables are kept in refs to avoid triggering unnecessary update loops because updates using
 // useEffect depend on them (like the external `value`)
 
-export default function useFieldProps<
-  Value = unknown,
-  Props extends FieldProps<Value> = FieldProps<Value>,
->(
-  localeProps: Props,
+export default function useFieldProps<Value, EmptyValue, Props>(
+  localeProps: Props & FieldPropsBase<Value, EmptyValue>,
   { executeOnChangeRegardlessOfError = false } = {}
-): Props & FieldProps<Value> & ReturnAdditional<Value> {
+): typeof localeProps & ReturnAdditional<Value> {
   const { extend } = useContext(FieldPropsContext)
-  const props = extend<Props>(localeProps)
+  const props = extend(localeProps)
 
   const {
     path: pathProp,
@@ -111,10 +108,10 @@ export default function useFieldProps<
     transformAdditionalArgs = (additionalArgs: AdditionalEventArgs) =>
       additionalArgs,
     fromExternal = (value: Value) => value,
-    validateRequired = (value: Value, { emptyValue, required, error }) => {
+    validateRequired = (value, { emptyValue, required, error }) => {
       const res =
         required &&
-        (value === emptyValue ||
+        ((value as any) === emptyValue ||
           (typeof emptyValue === 'undefined' && value === ''))
           ? error
           : undefined
@@ -970,7 +967,7 @@ export default function useFieldProps<
 
   const handleChange = useCallback(
     async (
-      argFromInput: Value,
+      argFromInput: Value | unknown,
       additionalArgs: AdditionalEventArgs = undefined
     ) => {
       const currentValue = valueRef.current
@@ -1408,7 +1405,7 @@ export interface ReturnAdditional<Value> {
   handleFocus: () => void
   handleBlur: () => void
   handleChange: (
-    value: Value,
+    value: Value | unknown,
     additionalArgs?: AdditionalEventArgs
   ) => void
   updateValue: (value: Value) => void

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -108,20 +108,24 @@ export function omitDataValueReadProps<Props extends DataValueReadProps>(
   )
 }
 
+type EventArgs<
+  Value,
+  ExtraValue extends AdditionalEventArgs,
+> = ExtraValue extends undefined
+  ? [value: Value]
+  : [value: Value, additionalArgs?: ExtraValue]
+
 export interface DataValueWriteProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
+  ExtraValue extends AdditionalEventArgs = AdditionalEventArgs,
 > {
   emptyValue?: EmptyValue
-  onFocus?: (
-    value: Value | EmptyValue,
-    additionalArgs?: AdditionalEventArgs
-  ) => void
-  onBlur?: (
-    value: Value | EmptyValue,
-    additionalArgs?: AdditionalEventArgs
-  ) => void
-  onChange?: OnChangeValue<Value, EmptyValue>
+  onFocus?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
+  onBlur?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
+  onChange?: (
+    ...args: EventArgs<Value | EmptyValue, ExtraValue>
+  ) => OnChangeReturnType
 }
 
 const dataValueWriteProps = ['emptyValue', 'onFocus', 'onBlur', 'onChange']
@@ -357,11 +361,32 @@ export interface UseFieldProps<
   valueType?: string | number | boolean | Array<string | number | boolean>
 }
 
-export type FieldProps<
+export type FieldPropsBase<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
 > = UseFieldProps<Value, EmptyValue, ErrorMessages> & FieldBlockProps
+
+export type FieldProps<
+  Value = unknown,
+  EmptyValue = undefined | unknown,
+  ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
+> = Omit<
+  FieldPropsBase<Value, EmptyValue, ErrorMessages>,
+  keyof DataValueWriteProps
+> &
+  DataValueWriteProps<Value, EmptyValue, undefined>
+
+export type FieldPropsWithExtraValue<
+  Value = unknown,
+  ExtraValue extends AdditionalEventArgs = AdditionalEventArgs,
+  EmptyValue = undefined | unknown,
+  ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
+> = Omit<
+  FieldPropsBase<Value, EmptyValue, ErrorMessages>,
+  keyof DataValueWriteProps
+> &
+  DataValueWriteProps<Value, EmptyValue, ExtraValue>
 
 export interface FieldHelpProps {
   help?: {
@@ -503,20 +528,9 @@ export type OnCommit<Data = JsonObject> = (
   | void
   | Promise<EventReturnWithStateObject | void>
 
-export type OnChange<Data = unknown> = (
-  data: Data
-) =>
-  | EventReturnWithStateObjectAndSuccess
-  | void
-  | Promise<EventReturnWithStateObjectAndSuccess | void>
+export type OnChange<Data = unknown> = (data: Data) => OnChangeReturnType
 
-export type OnChangeValue<
-  Value = unknown,
-  EmptyValue = undefined | unknown,
-> = (
-  value: Value | EmptyValue,
-  additionalArgs?: AdditionalEventArgs
-) =>
+type OnChangeReturnType =
   | EventReturnWithStateObjectAndSuccess
   | void
   | Promise<EventReturnWithStateObjectAndSuccess | void>

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -118,7 +118,7 @@ type EventArgs<
 export interface DataValueWriteProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
-  ExtraValue extends AdditionalEventArgs = AdditionalEventArgs,
+  ExtraValue extends AdditionalEventArgs = undefined,
 > {
   emptyValue?: EmptyValue
   onFocus?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
@@ -361,21 +361,21 @@ export interface UseFieldProps<
   valueType?: string | number | boolean | Array<string | number | boolean>
 }
 
-export type FieldPropsBase<
+export type FieldProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
 > = UseFieldProps<Value, EmptyValue, ErrorMessages> & FieldBlockProps
 
-export type FieldProps<
+export type FieldPropsGeneric<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
 > = Omit<
-  FieldPropsBase<Value, EmptyValue, ErrorMessages>,
+  FieldProps<Value, EmptyValue, ErrorMessages>,
   keyof DataValueWriteProps
 > &
-  DataValueWriteProps<Value, EmptyValue, undefined>
+  DataValueWriteProps<Value, EmptyValue, AdditionalEventArgs>
 
 export type FieldPropsWithExtraValue<
   Value = unknown,
@@ -383,7 +383,7 @@ export type FieldPropsWithExtraValue<
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
 > = Omit<
-  FieldPropsBase<Value, EmptyValue, ErrorMessages>,
+  FieldProps<Value, EmptyValue, ErrorMessages>,
   keyof DataValueWriteProps
 > &
   DataValueWriteProps<Value, EmptyValue, ExtraValue>


### PR DESCRIPTION
* Added the type `FieldPropsWithExtraValue` if we need to type events with two arguments.
* The type `FieldProps` will now type events like `onChange`, `onBlur` and `onFocus` with only one argument.
* Added the type `FieldPropsGeneric` that makes no assumptions on whether events have one or two parameters
* `Field.PhoneNumber` and `Field.SelectCountry` now types their second event arguments.

Other fixes:
* fixed `Field.Expiry` missing type for empty value causing useless event type
* fixed `Iterate.Array` having types for non existing props