### PR TITLE
fix(forms): ensure correct spacing between `Iterate.Array` items

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/style/dnb-iterate.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/style/dnb-iterate.scss
@@ -5,7 +5,7 @@
     outline: none; // for JavaSCript focus
   }
 
-  & > &__element:has(> &-block) {
+  & > &__element:has(> .dnb-forms-section-block) {
     // To make Animation not jump, we add "margin-bottom" in the inner element
     margin-top: 0;
   }


### PR DESCRIPTION
**Before:** 
<img width="557" alt="Screenshot 2024-08-19 at 10 14 48" src="https://github.com/user-attachments/assets/77bbd774-9668-4545-b532-b40edc90eb7e">

**After:**
<img width="565" alt="Screenshot 2024-08-19 at 10 14 27" src="https://github.com/user-attachments/assets/9baac8d1-6ac3-4724-98ab-7309db889c3a">


