### PR TITLE
chore(PostalCodeAndCity): fix iterate over array example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -151,7 +151,7 @@ export const LongLabel = () => {
 
 export const IterateArray = () => {
   return (
-    <ComponentBox>
+    <ComponentBox scope={{ Iterate }}>
       <Iterate.Array
         value={[
           {


### PR DESCRIPTION
Fixes the following error:
`ReferenceError: Iterate is not defined`

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/362671d5-e1a0-4c0e-ad18-fd05315bf409">

