### PR TITLE
chore(TypeScript): set lib version from 2018 to `es2022` to support newer JavaScript APIs

### DIFF
--- a/packages/dnb-design-system-portal/tsconfig.json
+++ b/packages/dnb-design-system-portal/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2022", "dom"],
     "types": ["node", "jest"],
     "outDir": "./out",
     "rootDir": ".",

--- a/packages/dnb-eufemia/tsconfig.definitions.json
+++ b/packages/dnb-eufemia/tsconfig.definitions.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "jsx": "react-jsx",
+    "lib": ["es2022", "dom"],
     "skipLibCheck": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/packages/dnb-eufemia/tsconfig.json
+++ b/packages/dnb-eufemia/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2022", "dom"],
     "types": ["node", "jest"],
     "outDir": "./build",
     "rootDir": ".",


### PR DESCRIPTION
In this PR #3854 we need the support of [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which is supported with es2022.
I'm unsure about the relation to this PR #3860 as of now.