### PR TITLE
docs(Selection): value should be string when variant is radio or button

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/properties.mdx
@@ -14,7 +14,4 @@ import { SelectionProperties } from '@dnb/eufemia/src/extensions/forms/Field/Sel
 
 ### General props
 
-<PropertiesTable
-  props={fieldProperties}
-  valueType={['number', 'string']}
-/>
+<PropertiesTable props={fieldProperties} omit={['value']} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
@@ -6,6 +6,11 @@ export const SelectionProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  value: {
+    doc: 'Defines the `value`. When using variant `radio` or `button`, value has to be a `string`.',
+    type: ['number', 'string'],
+    status: 'optional',
+  },
   optionsLayout: {
     doc: 'Layout for the list of options. Can be `horizontal` or `vertical`.',
     type: 'string',


### PR DESCRIPTION
Motivation:
The [value property of Field.Selection](https://eufemia.dnb.no/uilib/extensions/forms/base-fields/Selection/properties/) states the type is string and number, however when using variant radio or button with a value of type number it breaks.

Reason it breaks, is because the value property of [RadioButton](https://eufemia.dnb.no/uilib/components/radio/properties/) and [ToggleButton](https://eufemia.dnb.no/uilib/components/toggle-button/properties/) states it only supports string. 

Any better ways to fix/improve on this, rather than just adding a description to the docs? 🤔 