### PR TITLE
fix(Forms): enhance `Field.Email` validation pattern

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
@@ -18,7 +18,17 @@ function Email(props: Props) {
     autoComplete: 'email',
     inputMode: 'email',
     pattern:
-      "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$",
+      `^(?!.*\\.\\.)(?!.*--)(?!.*\\.-)(?!.*-\\.)` + // No consecutive dots, hyphens, or dot-hyphen sequences
+      `[a-zA-Z0-9]+([._%+-]?[a-zA-Z0-9]+)*@` + // Local part: letters, numbers, dots, etc.
+      `(?:` +
+      `([a-zA-Z0-9]+([.-]?[a-zA-Z0-9]+)*\\.[a-zA-Z]{2,})` + // Domain part: standard domain names
+      `|` +
+      `\\[(?:` +
+      `(?:\\d{1,3}\\.){3}\\d{1,3}` + // Allow IPv4 address (no validation)
+      `|` +
+      `IPv6:[0-9a-fA-F:]+` + // Allow IPv6 address (no validation)
+      `)\\]` +
+      `)$`,
     trim: true,
     ...props,
     errorMessages,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
@@ -4,6 +4,9 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Props } from '..'
 import { Field, Form } from '../../..'
+import nbNO from '../../../constants/locales/nb-NO'
+
+const nb = nbNO['nb-NO']
 
 describe('Field.Email', () => {
   it('should render with props', () => {
@@ -126,6 +129,76 @@ describe('Field.Email', () => {
     fireEvent.blur(input)
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  describe('should validate the correctness of email addresses', () => {
+    const validNames = [
+      'simple@example.com',
+      'user.name+tag@example.co.uk',
+      'user-name@example.org',
+      'user_name@sub.domain.com',
+      'user.name@domain.io',
+      'user%email@example.com',
+      'user.name@example.travel',
+      'user123@example.info',
+      'user@example123.com',
+      'firstname.lastname@example.co',
+
+      // IP address literal
+      'user@[192.168.1.1]',
+      'user@[255.255.255.255]',
+      'user@[0.0.0.0]',
+      'user@[10.0.0.1]',
+      'user@[172.16.254.1]',
+
+      // IPv6 address literal
+      'user@[IPv6:2001:db8::1]',
+      'admin@[IPv6:2607:fe80::1ff:fe23:4567:890a]',
+      'info@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+      'contact@[IPv6:2001:db8:1234:5678:9abc:def0:1234:5678]',
+      'support@[IPv6:2001:db8:85a3:0000:0000:8a2e:0370:7334]',
+      'user@[IPv6:::1]',
+      'user@[IPv6:2001:db8:ff00:42:8329]',
+      'user@[IPv6:2001:db8:abcd:1234::]',
+      'service@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+      'test@[IPv6:2001:db8:1234::abcd]',
+    ]
+
+    const invalidNames = [
+      'user..name@example.com', // Consecutive dots in local part
+      'user.name.@example.com', // Dot at the end of the local part
+      '.username@example.com', // Dot at the beginning of the local part
+      'user.@example.com', // Dot before @
+      'user@.example.com', // Dot at the beginning of the domain
+      'user@sub_domain.com', // Underscore in domain part
+      'user@domain.com-', // Hyphen at the end of domain
+      'user@domain..com', // Consecutive dots in the domain
+      'user@domain.c', // TLD too short
+      'user@-domain.com', // Hyphen at the start of the domain
+
+      // The regex we have does not take such invalid addresses into account
+      // 'user@[256.100.50.25]', // Invalid IPv4, 256 is out of range
+      // 'user@[192.168.1.300]', // Invalid IPv4, 300 is out of range
+      // 'user@[192.168.1.1.1]', // Invalid IPv4, too many octets
+      // 'user@[192.168.1]', // Invalid IPv4, too few octets
+      // 'user@[abc.def.ghi.jkl]', // Invalid IPv4, non-numeric characters
+      // 'user@[300.168.1.1]', // Invalid IPv4 address
+      // 'user@[192.168.1.256]', // Invalid IPv4 address
+      // 'user@[IPv6:2001::85a3::8a2e]', // Invalid IPv6 address
+    ]
+
+    it.each(validNames)('Valid email: %s', (email) => {
+      render(<Field.Email validateInitially value={email} />)
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it.each(invalidNames)('Invalid email: %s', (email) => {
+      render(<Field.Email validateInitially value={email} />)
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        nb.Email.errorPattern
+      )
+    })
   })
 
   describe('ARIA', () => {


### PR DESCRIPTION
See the tests for more details about what we now allow. In short, its not possible to have the perfect validation. Here is an [article about the challenge](https://www.abstractapi.com/guides/email-validation/email-address-pattern-validation). 
The Regex gets way larger when we try to validate IPv4 and especially IPv6. But I think we don't need a perfect validation for these, as these are exceptions anyways.