### PR TITLE
feat(Forms): add function support for the `prefix` or `suffix` props in `Field.Number`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -49,6 +49,27 @@ export const LabelAndValue = () => {
   )
 }
 
+export const PrefixAndSuffix = () => {
+  return (
+    <ComponentBox>
+      <Flex.Stack>
+        <Field.Number
+          value={1234}
+          label="With prefix"
+          prefix="prefix "
+          onChange={(value) => console.log('onChange', value)}
+        />
+        <Field.Number
+          value={1}
+          label="With suffix (function)"
+          suffix={(value) => (value === 1 ? ' year' : ' years')}
+          onChange={(value) => console.log('onChange', value)}
+        />
+      </Flex.Stack>
+    </ComponentBox>
+  )
+}
+
 export const Alignment = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
@@ -22,6 +22,12 @@ import * as Examples from './Examples'
 
 <Examples.LabelAndValue />
 
+### Prefix and suffix
+
+You can also use a function as a prefix or suffix.
+
+<Examples.PrefixAndSuffix />
+
 ### Alignment
 
 <Examples.Alignment />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -44,8 +44,8 @@ export type Props = FieldHelpProps &
     decimalLimit?: number
     allowNegative?: boolean
     disallowLeadingZeroes?: boolean
-    prefix?: string
-    suffix?: string
+    prefix?: string | ((value: number) => string)
+    suffix?: string | ((value: number) => string)
     // Validation
     minimum?: number // aka greater than or equal to
     maximum?: number // aka less than or equal to
@@ -77,8 +77,8 @@ function NumberComponent(props: Props) {
     decimalLimit = 12,
     allowNegative = true,
     disallowLeadingZeroes = false,
-    prefix,
-    suffix,
+    prefix: prefixProp,
+    suffix: suffixProp,
     showStepControls,
   } = props
 
@@ -126,52 +126,6 @@ function NumberComponent(props: Props) {
     },
     [props.emptyValue]
   )
-
-  const maskProps: Partial<InputMaskedProps> = useMemo(() => {
-    const mask_options = {
-      prefix,
-      suffix,
-      decimalLimit,
-      allowNegative,
-      disallowLeadingZeroes,
-    }
-
-    if (currency) {
-      return {
-        as_currency: currency,
-        mask_options,
-        currency_mask: {
-          currencyDisplay,
-        },
-      }
-    }
-
-    if (percent) {
-      return {
-        as_percent: percent,
-        mask_options,
-      }
-    }
-
-    // Custom mask based on props
-    return {
-      as_number: true,
-      mask,
-      number_mask: {
-        ...mask_options,
-      },
-    }
-  }, [
-    currency,
-    currencyDisplay,
-    decimalLimit,
-    mask,
-    percent,
-    prefix,
-    suffix,
-    allowNegative,
-    disallowLeadingZeroes,
-  ])
 
   const preparedProps: Props = {
     valueType: 'number',
@@ -332,6 +286,57 @@ function NumberComponent(props: Props) {
       String(value - step)
     ),
   }
+
+  const prefix =
+    typeof prefixProp === 'function' ? prefixProp(value) : prefixProp
+  const suffix =
+    typeof suffixProp === 'function' ? suffixProp(value) : suffixProp
+
+  const maskProps: Partial<InputMaskedProps> = useMemo(() => {
+    const mask_options = {
+      prefix,
+      suffix,
+      decimalLimit,
+      allowNegative,
+      disallowLeadingZeroes,
+    }
+
+    if (currency) {
+      return {
+        as_currency: currency,
+        mask_options,
+        currency_mask: {
+          currencyDisplay,
+        },
+      }
+    }
+
+    if (percent) {
+      return {
+        as_percent: percent,
+        mask_options,
+      }
+    }
+
+    // Custom mask based on props
+    return {
+      as_number: true,
+      mask,
+      number_mask: {
+        ...mask_options,
+      },
+    }
+  }, [
+    currency,
+    currencyDisplay,
+    decimalLimit,
+    mask,
+    percent,
+    prefix,
+    suffix,
+    allowNegative,
+    disallowLeadingZeroes,
+  ])
 
   const ariaParams = showStepControls && {
     role: 'spinbutton',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -220,6 +220,30 @@ describe('Field.Number', () => {
           '12 345 suffix'
         )
       })
+
+      it('formats with prefix as a function', () => {
+        const prefix = jest.fn(() => {
+          return 'prefix '
+        })
+        render(<Field.Number value={12345} currency prefix={prefix} />)
+        expect(document.querySelector('input')).toHaveValue(
+          'prefix 12 345 kr'
+        )
+        expect(prefix).toHaveBeenCalledTimes(1)
+        expect(prefix).toHaveBeenCalledWith(12345)
+      })
+
+      it('formats with suffix as a function', () => {
+        const suffix = jest.fn(() => {
+          return ' suffix'
+        })
+        render(<Field.Number value={12345} suffix={suffix} />)
+        expect(document.querySelector('input')).toHaveValue(
+          '12 345 suffix'
+        )
+        expect(suffix).toHaveBeenCalledTimes(1)
+        expect(suffix).toHaveBeenCalledWith(12345)
+      })
     })
 
     describe('decimalLimit', () => {


### PR DESCRIPTION
Quick example:

```tsx
<Field.Number
  value={1}
  label="With suffix (function)"
  suffix={(value) => (value === 1 ? ' year' : ' years')}
/>
```