### PR TITLE
fix(Forms): warn on value prop usage on fields inside iterate with itemPath

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -1086,7 +1086,7 @@ describe('Iterate.Array', () => {
 
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
-        'Using value="bar" prop inside iterate is not supported yet'
+        'Using value="bar" prop inside Iterate is not supported yet'
       )
 
       log.mockRestore()

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -1105,7 +1105,7 @@ describe('Iterate.Array', () => {
 
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
-        'Using defaultValue="bar" prop inside iterate is not supported yet'
+        'Using defaultValue="bar" prop inside Iterate is not supported yet'
       )
 
       log.mockRestore()

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -1071,4 +1071,44 @@ describe('Iterate.Array', () => {
       expect(container.querySelector('.dnb-flex-container')).toBeNull()
     })
   })
+
+  describe('value and defaultValue', () => {
+    it('should warn when "value" prop is used', () => {
+      const log = jest.spyOn(console, 'log').mockImplementation()
+
+      render(
+        <Form.Handler data={['foo']}>
+          <Iterate.Array path="/">
+            <Field.String itemPath="/" value="bar" />
+          </Iterate.Array>
+        </Form.Handler>
+      )
+
+      expect(log).toHaveBeenCalledWith(
+        expect.any(String),
+        'Using value="bar" prop inside iterate is not supported yet'
+      )
+
+      log.mockRestore()
+    })
+
+    it('should warn when "defaultValue" prop is used', () => {
+      const log = jest.spyOn(console, 'log').mockImplementation()
+
+      render(
+        <Form.Handler data={['foo']}>
+          <Iterate.Array path="/">
+            <Field.String itemPath="/" defaultValue="bar" />
+          </Iterate.Array>
+        </Form.Handler>
+      )
+
+      expect(log).toHaveBeenCalledWith(
+        expect.any(String),
+        'Using defaultValue="bar" prop inside iterate is not supported yet'
+      )
+
+      log.mockRestore()
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1148,7 +1148,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   useEffect(() => {
     if (itemPath && valueProp !== undefined) {
       warn(
-        `Using value="${valueProp}" prop inside iterate is not supported yet`
+        `Using value="${valueProp}" prop inside Iterate is not supported yet`
       )
     }
     if (itemPath && defaultValue !== undefined) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -22,7 +22,7 @@ import {
 import { Context as DataContext, ContextState } from '../DataContext'
 import { clearedData } from '../DataContext/Provider/Provider'
 import FieldPropsContext from '../Form/FieldProps/FieldPropsContext'
-import { combineDescribedBy } from '../../../shared/component-helper'
+import { combineDescribedBy, warn } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import useUpdateEffect from '../../../shared/helpers/useUpdateEffect'
 import useMountEffect from '../../../shared/helpers/useMountEffect'
@@ -1144,6 +1144,19 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     prepareError,
     validateInitially,
   ])
+
+  useEffect(() => {
+    if (itemPath && valueProp !== undefined) {
+      warn(
+        `Using value="${valueProp}" prop inside iterate is not supported yet`
+      )
+    }
+    if (itemPath && defaultValue !== undefined) {
+      warn(
+        `Using defaultValue="${defaultValue}" prop inside iterate is not supported yet`
+      )
+    }
+  }, [defaultValue, itemPath, valueProp])
 
   useEffect(() => {
     if (hasPath) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1153,7 +1153,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     }
     if (itemPath && defaultValue !== undefined) {
       warn(
-        `Using defaultValue="${defaultValue}" prop inside iterate is not supported yet`
+        `Using defaultValue="${defaultValue}" prop inside Iterate is not supported yet`
       )
     }
   }, [defaultValue, itemPath, valueProp])


### PR DESCRIPTION
Move out the warning from PR #3877 in regards of this issue #3882