### PR TITLE
fix(Flex): enhance handling of React fragments

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { Fragment, useCallback } from 'react'
 import classnames from 'classnames'
 import Space, { SpaceProps } from '../space/Space'
 import { Hr } from '../../elements'
@@ -105,8 +105,7 @@ function FlexContainer(props: Props) {
   } = props
 
   const spacing = spacingProp ?? gap ?? 'small'
-
-  const childrenArray = wrapChildren(props, children)
+  const childrenArray = replaceRootFragment(wrapChildren(props, children))
   const hasHeading = childrenArray.some((child, i) => {
     const previousChild = childrenArray?.[i - 1]
     return (
@@ -270,6 +269,17 @@ function wrapChildren(props: Props, children: React.ReactNode) {
 
     return child
   })
+}
+
+function replaceRootFragment(children) {
+  const firstChild = children[0]
+  if (
+    React.Children.count(children) === 1 &&
+    firstChild?.type === Fragment
+  ) {
+    return React.Children.toArray(firstChild?.props?.children)
+  }
+  return children
 }
 
 FlexContainer._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -5,7 +5,9 @@ import { setMedia, matchMedia } from 'mock-match-media'
 import Flex from '../Flex'
 import { createSpacingClasses } from '../../space/SpacingUtils'
 import { SpaceProps } from '../../Space'
+import { Form } from '../../../extensions/forms'
 import H1 from '../../../elements/H1'
+import P from '../../../elements/P'
 
 describe('Flex.Container', () => {
   it('should forward HTML attributes', () => {
@@ -720,6 +722,183 @@ describe('Flex.Container', () => {
       expect(
         document.querySelectorAll('[class*="dnb-space__"]')
       ).toHaveLength(3)
+    })
+
+    it('should handle nested fragments like _supportsSpacingProps=children', () => {
+      const { rerender, Wrapper, TestComponent } = getMocks()
+
+      Wrapper._supportsSpacingProps = 'children'
+
+      rerender(
+        <Flex.Vertical>
+          <>
+            <>
+              Content A<p>Content B</p>
+            </>
+            <>
+              <TestComponent top="large" />
+            </>
+          </>
+        </Flex.Vertical>
+      )
+
+      const container = document.querySelector('.dnb-flex-container')
+      expect(container).toMatchInlineSnapshot(`
+        <div
+          class="dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space"
+        >
+          <div
+            class="dnb-space dnb-space__top--zero dnb-space__bottom--zero"
+          >
+            Content A
+          </div>
+          <div
+            class="dnb-space dnb-space__top--zero dnb-space__bottom--zero"
+          >
+            <p>
+              Content B
+            </p>
+          </div>
+          <div
+            class="dnb-space__top--large dnb-space__bottom--zero test-item"
+          >
+            content
+          </div>
+        </div>
+      `)
+
+      expect(
+        document.querySelectorAll('.dnb-flex-container')
+      ).toHaveLength(1)
+      expect(
+        document.querySelectorAll('[class*="dnb-space__"]')
+      ).toHaveLength(3)
+    })
+
+    it('should handle Form.Visibility', () => {
+      const { rerender, Wrapper } = getMocks()
+
+      Wrapper._supportsSpacingProps = 'children'
+
+      rerender(
+        <Form.Handler
+          id="unique-id"
+          data={{
+            visible: false,
+          }}
+        >
+          <Flex.Vertical>
+            <Form.SubHeading>Heading</Form.SubHeading>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible', hasValue: true }}
+            >
+              <P>text</P>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible', hasValue: true }}
+            >
+              <P>text</P>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible', hasValue: true }}
+            >
+              <P>text</P>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible', hasValue: true }}
+            >
+              <P>text</P>
+            </Form.Visibility>
+          </Flex.Vertical>
+        </Form.Handler>
+      )
+
+      const container = document.querySelector('.dnb-flex-container')
+      expect(container).toMatchInlineSnapshot(`
+        <div
+          class="dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space"
+        >
+          <h3
+            class="dnb-heading dnb-h--medium dnb-forms-sub-heading dnb-space__top--zero dnb-space__bottom--zero"
+          >
+            Heading
+          </h3>
+        </div>
+      `)
+
+      expect(
+        document.querySelectorAll('.dnb-flex-container')
+      ).toHaveLength(1)
+      expect(
+        document.querySelectorAll('[class*="dnb-space__"]')
+      ).toHaveLength(1)
+    })
+
+    it('should handle Form.Visibility nested in fragments', () => {
+      const { rerender, Wrapper } = getMocks()
+
+      Wrapper._supportsSpacingProps = 'children'
+
+      rerender(
+        <Form.Handler
+          id="unique-id"
+          data={{
+            visible: false,
+          }}
+        >
+          <Flex.Vertical>
+            <Form.SubHeading>Heading</Form.SubHeading>
+            <>
+              <>
+                <Form.Visibility
+                  visibleWhen={{ path: '/visible', hasValue: true }}
+                >
+                  <P>text</P>
+                </Form.Visibility>
+                <Form.Visibility
+                  visibleWhen={{ path: '/visible', hasValue: true }}
+                >
+                  <P>text</P>
+                </Form.Visibility>
+              </>
+              <Form.Visibility
+                visibleWhen={{ path: '/visible', hasValue: true }}
+              >
+                <P>text</P>
+              </Form.Visibility>
+            </>
+            <>
+              <>
+                <Form.Visibility
+                  visibleWhen={{ path: '/visible', hasValue: true }}
+                >
+                  <P>text</P>
+                </Form.Visibility>
+              </>
+            </>
+          </Flex.Vertical>
+        </Form.Handler>
+      )
+
+      const container = document.querySelector('.dnb-flex-container')
+      expect(container).toMatchInlineSnapshot(`
+        <div
+          class="dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space"
+        >
+          <h3
+            class="dnb-heading dnb-h--medium dnb-forms-sub-heading dnb-space__top--zero dnb-space__bottom--zero"
+          >
+            Heading
+          </h3>
+        </div>
+      `)
+
+      expect(
+        document.querySelectorAll('.dnb-flex-container')
+      ).toHaveLength(1)
+      expect(
+        document.querySelectorAll('[class*="dnb-space__"]')
+      ).toHaveLength(1)
     })
   })
 

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -702,7 +702,7 @@ describe('Flex.Container', () => {
             Content A 
           </div>
           <div
-            class="dnb-space dnb-space__top--zero dnb-space__bottom--zero"
+            class="dnb-space dnb-space__top--small dnb-space__bottom--zero"
           >
             <p>
               Content B

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -128,6 +128,8 @@ export function renderWithSpacing(
 function wrapWithSpace({ element, spaceProps, variant = null }) {
   return variant ?? getSpaceVariant(element) === true ? (
     React.cloneElement(element as React.ReactElement, spaceProps)
+  ) : getSpaceVariant(element) === 'children' ? (
+    renderWithSpacing(element, spaceProps)
   ) : (
     <Space {...spaceProps}>{element}</Space>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import { Field, Form } from '../../..'
-import { Flex, Section } from '../../../../../components'
+import { Flex, Section, Card } from '../../../../../components'
+import { P } from '../../../../../elements'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Visibility',
@@ -171,6 +172,180 @@ export const KeepInDOM = () => {
         </Form.Visibility>
         <span>bottom</span>
       </Flex.Stack>
+    </Form.Handler>
+  )
+}
+
+export const wrappingVisibilityInFragmentAllVisible = () => {
+  return (
+    <Form.Handler
+      id={'wrappingVisibilityInFragmentAllVisible'}
+      data={{
+        visible: true,
+      }}
+    >
+      <Card stack>
+        <Form.SubHeading>Test heading</Form.SubHeading>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export const wrappingVisibilityInFragmentAllHidden = () => {
+  return (
+    <Form.Handler
+      id={'wrappingVisibilityInFragmentAllHidden'}
+      data={{
+        visible: false,
+      }}
+    >
+      <Card stack>
+        <Form.SubHeading>Test heading</Form.SubHeading>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export const wrappingVisibilityInFragments2Hidden = () => {
+  return (
+    <Form.Handler
+      id={'wrappingVisibilityInFragments2Hidden'}
+      data={{
+        visible1: true,
+        visible2: false,
+        visible3: true,
+        visible4: false,
+        visible5: true,
+      }}
+    >
+      <Card stack>
+        <Form.SubHeading>Test heading</Form.SubHeading>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible1', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible2', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible3', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible4', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible5', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export const wrappingVisibilityInFragments3Hidden = () => {
+  return (
+    <Form.Handler
+      id={'wrappingVisibilityInFragments3Hidden'}
+      data={{
+        visible1: false,
+        visible2: true,
+        visible3: false,
+        visible4: true,
+        visible5: false,
+      }}
+    >
+      <Card stack>
+        <Form.SubHeading>Test heading</Form.SubHeading>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible1', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible2', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible3', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible4', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible5', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+      </Card>
     </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import { Field, Form } from '../../..'
 import { Flex, Section, Card } from '../../../../../components'
-import { P } from '../../../../../elements'
+import { P, Ul, Li } from '../../../../../elements'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Visibility',
@@ -341,6 +341,129 @@ export const wrappingVisibilityInFragments3Hidden = () => {
           </Form.Visibility>
           <Form.Visibility
             visibleWhen={{ path: '/visible5', hasValue: true }}
+          >
+            <P>text</P>
+          </Form.Visibility>
+        </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export const wrappingVisibilityInFragment = () => {
+  return (
+    <Form.Handler
+      id={'wrappingVisibilityInFragment'}
+      data={{
+        visible: false,
+        visible2: false,
+        visible3: true,
+        visible4: false,
+        visible5: false,
+      }}
+    >
+      <Card stack>
+        <>
+          <Form.SubHeading>Test heading</Form.SubHeading>
+          <>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible', hasValue: true }}
+            >
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <Ul>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+              </Ul>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible2', hasValue: true }}
+            >
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <Ul>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+              </Ul>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible3', hasValue: true }}
+            >
+              <P>Text</P>
+              <P>Text</P>
+              <Ul>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+              </Ul>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible4', hasValue: true }}
+            >
+              <P>Text</P>
+
+              <Ul>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+              </Ul>
+            </Form.Visibility>
+            <Form.Visibility
+              visibleWhen={{ path: '/visible5', hasValue: true }}
+            >
+              <P>Text</P>
+              <P>Text</P>
+              <P>Text</P>
+              <Ul>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+                <Li>Li</Li>
+              </Ul>
+            </Form.Visibility>
+          </>
+          <Field.Boolean
+            variant="buttons"
+            path="/testPath"
+            defaultValue={false}
+            label="Yes no question"
+          />
+          <P>Text that should appear underneath</P>
+        </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export const wrappingSingleVisibilityInRootFragment = () => {
+  return (
+    <Form.Handler
+      id="test"
+      data={{
+        visible1: false,
+      }}
+    >
+      <Card stack>
+        <>
+          <Form.Visibility
+            visibleWhen={{ path: '/visible1', hasValue: true }}
           >
             <P>text</P>
           </Form.Visibility>


### PR DESCRIPTION
Motivation comes from [this Slack thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1725282736084299).

This PR basically ignores fragments in the Container, so it removes the fragment and returns its children instead.

Here's two failing CSBs, to display what the error/problem is/was:

- [Fragment as root in Card](https://codesandbox.io/p/sandbox/hidden-dew-335rcs?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd)
- [Fragment nested/inside Card](https://codesandbox.io/p/sandbox/strange-northcutt-nrdvwj?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd)

Here's the same CSBs using the fix of this PR:

- [Fragment as root in Card](https://codesandbox.io/p/sandbox/quizzical-lamport-cnj4kh?file=%2Fsrc%2FApp.tsx&workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd)
- [Fragment nested/inside Card](https://codesandbox.io/p/sandbox/romantic-mendel-zc5z5v?file=%2Fsrc%2FApp.tsx&workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd)