### PR TITLE
fix(Forms): provide `connectWithPath` in the change validator and onBlurValidator

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
@@ -24,6 +24,20 @@ const validator = (value) => {
 render(<Field.PhoneNumber validator={validator} />)
 ```
 
+## Reuse existing error messages in a validator function
+
+You can reuse existing error messages in a validator function. The types of error messages available depend on the field type.
+
+For example, you can reuse the `required` error message in a validator function:
+
+```tsx
+const validator = (value, { errorMessages }) => {
+  // Your validation logic
+  return new Error(errorMessages.required)
+}
+render(<Field.String validator={validator} />)
+```
+
 ### FormError object
 
 You can use the JavaScript `Error` object to display a custom error message:

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -141,7 +141,7 @@ export const ValidationFunction = () => {
         const fnr = (value: string) =>
           value.length >= 11 ? { status: 'valid' } : { status: 'invalid' }
 
-        const validator = (value, errorMessages) => {
+        const validator = (value, { errorMessages }) => {
           const result = fnr(value)
           return result.status === 'invalid'
             ? new Error(errorMessages.pattern)

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -355,25 +355,25 @@ const schema = {
 The `onBlurValidator` and `validator` properties accepts a function that takes the current value of the field as an argument and returns an error message if the value is invalid:
 
 ```tsx
-const validator = (value) => {
+const onChangeValidator = (value) => {
   const isInvalid = new RegExp('Your RegExp').test(value)
   if (isInvalid) {
     return new Error('Invalid value message')
   }
 }
-render(<Field.PhoneNumber validator={validator} />)
+render(<Field.PhoneNumber validator={onChangeValidator} />)
 ```
 
 You can find more info about error messages in the [Error messages](/uilib/extensions/forms/Form/error-messages/) docs.
 
 ##### Connect with another field
 
-You can also use the `connectWithPath` function to connect the validator to another field. This allows you to rerender the validator function once the value of the connected field changes:
+You can also use the `connectWithPath` function to connect the validator to another field. This allows you to rerun the validator function once the value of the connected field changes:
 
 ```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
 
-const validator = (value, { connectWithPath }) => {
+const onChangeValidator = (value, { connectWithPath }) => {
   const { getValue } = connectWithPath('/myReference')
   const amount = getValue()
   if (amount >= value) {
@@ -388,21 +388,19 @@ render(
     <Field.Number
       path="/withValidator"
       defaultValue={2}
-      validator={validator} // NB: You may use "onBlurValidator" depending on use case.
-
-      //
+      validator={onChangeValidator} // NB: You may use "onBlurValidator" depending on use case.
     />
   </Form.Handler>,
 )
 ```
 
-By default, the validator function will only run when the "/withValidator" field is changed (and blurred). When the error message is shown, it will update the error message with the new value of the "/myReference" field.
+By default, the validator function will only run when the "/withValidator" field is changed. When the error message is shown, it will update the message with the new value of the "/myReference" field.
 
-You can also change this behaviour by using the following props:
+You can also change this behavior by using the following props:
 
-- `validateInitially` Will run the validator initially.
-- `continuousValidation` Will run the validator on every change, including when the connected field changes.
-- `validateUnchanged` Is a combination of `validateInitially` and `continuousValidation`.
+- `validateInitially` will run the validation initially.
+- `continuousValidation` will run the validation on every change, including when the connected field changes.
+- `validateUnchanged` will validate without any changes made by the user, including when the connected field changes.
 
 ##### Async validation
 
@@ -411,7 +409,7 @@ Async validation is also supported. The validator function can return a promise 
 In this example we use `onBlurValidator` to only validate the field when the user leaves the field:
 
 ```tsx
-const validator = async (value) => {
+const onChangeValidator = async (value) => {
   try {
     const isInvalid = await makeRequest(value)
     if (isInvalid) {
@@ -421,7 +419,7 @@ const validator = async (value) => {
     return error
   }
 }
-render(<Field.PhoneNumber onBlurValidator={validator} />)
+render(<Field.PhoneNumber onBlurValidator={onChangeValidator} />)
 ```
 
 ##### Async validator with debounce
@@ -431,7 +429,7 @@ While when using async validation on every keystroke, it's a good idea to deboun
 ```tsx
 import { debounceAsync } from '@dnb/eufemia/shared/helpers'
 
-const validator = debounceAsync(async function myValidator(value) {
+const onChangeValidator = debounceAsync(async function myValidator(value) {
   try {
     const isInvalid = await makeRequest(value)
     if (isInvalid) {
@@ -441,7 +439,7 @@ const validator = debounceAsync(async function myValidator(value) {
     return error
   }
 })
-render(<Field.PhoneNumber validator={validator} />)
+render(<Field.PhoneNumber validator={onChangeValidator} />)
 ```
 
 ### Localization and translation

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -350,9 +350,9 @@ const schema = {
 <Field.PhoneNumber schema={schema} />
 ```
 
-#### validator
+#### onBlurValidator and validator
 
-The `validator` (including `onBlurValidator`) property is a function that takes the current value of the field as an argument and returns an error message if the value is invalid:
+The `onBlurValidator` and `validator` properties accepts a function that takes the current value of the field as an argument and returns an error message if the value is invalid:
 
 ```tsx
 const validator = (value) => {
@@ -365,6 +365,44 @@ render(<Field.PhoneNumber validator={validator} />)
 ```
 
 You can find more info about error messages in the [Error messages](/uilib/extensions/forms/Form/error-messages/) docs.
+
+##### Connect with another field
+
+You can also use the `connectWithPath` function to connect the validator to another field. This allows you to rerender the validator function once the value of the connected field changes:
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const validator = (value, { connectWithPath }) => {
+  const { getValue } = connectWithPath('/myReference')
+  const amount = getValue()
+  if (amount >= value) {
+    return new Error(`The amount should be greater than ${amount}`)
+  }
+}
+
+render(
+  <Form.Handler>
+    <Field.Number path="/myReference" defaultValue={2} />
+
+    <Field.Number
+      path="/withValidator"
+      defaultValue={2}
+      validator={validator} // NB: You may use "onBlurValidator" depending on use case.
+
+      //
+    />
+  </Form.Handler>,
+)
+```
+
+By default, the validator function will only run when the "/withValidator" field is changed (and blurred). When the error message is shown, it will update the error message with the new value of the "/myReference" field.
+
+You can also change this behaviour by using the following props:
+
+- `validateInitially` Will run the validator initially.
+- `continuousValidation` Will run the validator on every change, including when the connected field changes.
+- `validateUnchanged` Is a combination of `validateInitially` and `continuousValidation`.
 
 ##### Async validation
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -21,8 +21,8 @@ type HandleSubmitProps = {
 
 export type EventListenerCall = {
   path?: Path
-  type?: 'onSubmit'
-  callback: () => void
+  type?: 'onSubmit' | 'onPathChange'
+  callback: (params?: { value: unknown }) => void | Promise<void | Error>
 }
 
 export type FilterDataHandler<Data> = (
@@ -66,6 +66,7 @@ export interface ContextState {
   hasContext: boolean
   /** The dataset for the form / form wizard */
   data: any
+  internalDataRef?: React.MutableRefObject<any>
   /** Should the form validate data before submitting? */
   errors?: Record<string, Error>
   /** Will set autoComplete="on" on each nested Field.String and Field.Number */

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -749,6 +749,12 @@ export default function Provider<Data extends JsonObject>(
         } else {
           onPathChange?.(path, value)
         }
+
+        for (const itm of fieldEventListenersRef.current) {
+          if (itm.type === 'onPathChange' && itm.path === path) {
+            itm.callback({ value })
+          }
+        }
       },
       [onPathChange, updateDataValue]
     )
@@ -1182,6 +1188,7 @@ export default function Provider<Data extends JsonObject>(
         /** Additional */
         id,
         data: internalDataRef.current,
+        internalDataRef,
         props,
         ...rest,
       }}

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -752,7 +752,12 @@ export default function Provider<Data extends JsonObject>(
 
         for (const itm of fieldEventListenersRef.current) {
           if (itm.type === 'onPathChange' && itm.path === path) {
-            itm.callback({ value })
+            const { callback } = itm
+            if (isAsync(callback)) {
+              await callback({ value })
+            } else {
+              callback({ value })
+            }
           }
         }
       },
@@ -876,11 +881,8 @@ export default function Provider<Data extends JsonObject>(
 
       // Just call the submit listeners "once", and not on the retry/recall
       if (!skipFieldValidation) {
-        for (const {
-          path,
-          type,
-          callback,
-        } of fieldEventListenersRef.current) {
+        for (const item of fieldEventListenersRef.current) {
+          const { path, type, callback } = item
           if (
             type === 'onSubmit' &&
             mountedFieldPathsRef.current.includes(path)
@@ -1079,9 +1081,11 @@ export default function Provider<Data extends JsonObject>(
       callback: EventListenerCall['callback']
     ) => {
       fieldEventListenersRef.current =
-        fieldEventListenersRef.current.filter(({ path: p, type: t }) => {
-          return !(p === path && t === type)
-        })
+        fieldEventListenersRef.current.filter(
+          ({ path: p, type: t, callback: c }) => {
+            return !(p === path && t === type && c === callback)
+          }
+        )
       fieldEventListenersRef.current.push({ path, type, callback })
     },
     []

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -11,14 +11,15 @@ export type Props = StringFieldProps & {
 }
 
 function NationalIdentityNumber(props: Props) {
-  const translations = useTranslation().NationalIdentityNumber
-  const errorMessage = translations.errorRequired
-
   const { validate = true, omitMask } = props
 
+  const translations = useTranslation().NationalIdentityNumber
+  const { label, errorRequired, errorFnr, errorDnr } = translations
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
-    required: errorMessage,
-    pattern: errorMessage,
+    required: errorRequired,
+    pattern: errorRequired,
+    errorFnr,
+    errorDnr,
   })
 
   const mask = useMemo(
@@ -49,11 +50,11 @@ function NationalIdentityNumber(props: Props) {
         new RegExp(validationPattern).test(value) &&
         fnr(value).status === 'invalid'
       ) {
-        return Error(translations.errorFnr)
+        return Error(errorFnr)
       }
       return undefined
     },
-    [translations.errorFnr]
+    [errorFnr]
   )
 
   const dnrValidator = useCallback(
@@ -63,11 +64,11 @@ function NationalIdentityNumber(props: Props) {
         new RegExp(validationPattern).test(value) &&
         dnr(value).status === 'invalid'
       ) {
-        return Error(translations.errorDnr)
+        return Error(errorDnr)
       }
       return undefined
     },
-    [translations.errorDnr]
+    [errorDnr]
   )
 
   const dnrAndFnrValidator = useCallback(
@@ -85,7 +86,7 @@ function NationalIdentityNumber(props: Props) {
         : validate && !props.validator
         ? validationPattern
         : undefined,
-    label: props.label ?? translations.label,
+    label: props.label ?? label,
     errorMessages,
     mask,
     width: props.width ?? 'medium',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -105,12 +105,19 @@ describe('Field.NationalIdentityNumber', () => {
     )
 
     expect(validator).toHaveBeenCalledTimes(1)
-    expect(validator).toHaveBeenCalledWith('123', {
-      maxLength: expect.stringContaining('{maxLength}'),
-      minLength: expect.stringContaining('{minLength}'),
-      pattern: expect.stringContaining('11'),
-      required: expect.stringContaining('11'),
-    })
+    expect(validator).toHaveBeenCalledWith(
+      '123',
+      expect.objectContaining({
+        errorMessages: expect.objectContaining({
+          maxLength: expect.stringContaining('{maxLength}'),
+          minLength: expect.stringContaining('{minLength}'),
+          pattern: expect.stringContaining('11'),
+          required: expect.stringContaining('11'),
+          errorDnr: expect.stringContaining('d-nummer'),
+          errorFnr: expect.stringContaining('fødselsnummer'),
+        }),
+      })
+    )
   })
 
   it('should have numeric input mode', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/stories/Number.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/stories/Number.stories.tsx
@@ -1,4 +1,5 @@
-import { Field } from '../../..'
+import { useCallback } from 'react'
+import { Field, Form, UseFieldProps } from '../../..'
 import { Flex } from '../../../../../components'
 
 export default {
@@ -40,5 +41,48 @@ export const Number = () => {
       />
       <Field.Number showStepControls width="stretch" value={1} />
     </Flex.Stack>
+  )
+}
+
+export const WithFreshValidator = () => {
+  const validator: UseFieldProps<number>['validator'] = useCallback(
+    (num, { connectWithPath }) => {
+      const { getValue } = connectWithPath('/refValue')
+      const amount = getValue()
+      // console.log('amount', amount, amount >= num)
+      if (amount >= num) {
+        return new Error(`The amount should be greater than ${amount}`)
+      }
+      if (num === undefined) {
+        return new Error(`No amount was given`)
+      }
+    },
+    []
+  )
+
+  return (
+    <Form.Handler
+      defaultData={{ refValue: 2 }}
+      onSubmit={() => {
+        console.log('onSubmit 🍏')
+      }}
+    >
+      <Flex.Stack>
+        <Field.Number label="Ref" path="/refValue" />
+
+        <Field.Number
+          label="Num"
+          // onBlurValidator={validator}
+          validator={validator}
+          defaultValue={2}
+          // validateInitially
+          // continuousValidation
+          // validateUnchanged
+          path="/myNumberWithValidator"
+        />
+
+        <Form.SubmitButton />
+      </Flex.Stack>
+    </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -649,10 +649,15 @@ describe('Field.PhoneNumber', () => {
     )
 
     expect(validator).toHaveBeenCalledTimes(1)
-    expect(validator).toHaveBeenCalledWith('+41 9999', {
-      pattern: enGB.PhoneNumber.errorRequired,
-      required: enGB.PhoneNumber.errorRequired,
-    })
+    expect(validator).toHaveBeenCalledWith(
+      '+41 9999',
+      expect.objectContaining({
+        errorMessages: expect.objectContaining({
+          pattern: enGB.PhoneNumber.errorRequired,
+          required: enGB.PhoneNumber.errorRequired,
+        }),
+      })
+    )
 
     await waitFor(() => {
       expect(document.querySelector('[role="alert"]')).toBeInTheDocument()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
@@ -47,24 +47,24 @@ function SliderComponent(props: Props) {
   const dataContextRef = useRef<ContextState>()
   dataContextRef.current = useContext<ContextState>(DataContext)
 
-  const { getValue } = useDataValue()
+  const { getSourceValue } = useDataValue()
   const getValues = useCallback(
     (source: SliderValue | Path | Array<Path>) => {
       if (Array.isArray(source)) {
-        return source.map((s) => getValue(s) || 0)
+        return source.map((s) => getSourceValue(s) || 0)
       }
 
-      return getValue(source) || 0
+      return getSourceValue(source) || 0
     },
-    [getValue]
+    [getSourceValue]
   )
 
   const value = getValues(props.paths ?? props.path ?? props.value)
   const preparedProps = {
     ...props,
-    step: getValue(props.step),
-    min: getValue(props.min),
-    max: getValue(props.max),
+    step: getSourceValue(props.step),
+    min: getSourceValue(props.min),
+    max: getSourceValue(props.max),
   }
 
   const {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -810,7 +810,6 @@ describe('Form.Handler', () => {
       )
 
       const buttonElement = document.querySelector('button')
-
       fireEvent.click(buttonElement)
 
       await waitFor(() => {
@@ -823,15 +822,20 @@ describe('Form.Handler', () => {
             filterData: expect.any(Function),
           }
         )
-
-        expect(asyncValidator).toHaveBeenCalledTimes(1)
-        expect(asyncValidator).toHaveBeenCalledWith('bar', {
-          maxLength: expect.any(String),
-          minLength: expect.any(String),
-          pattern: expect.any(String),
-          required: expect.any(String),
-        })
       })
+
+      expect(asyncValidator).toHaveBeenCalledTimes(1)
+      expect(asyncValidator).toHaveBeenCalledWith(
+        'bar',
+        expect.objectContaining({
+          errorMessages: expect.objectContaining({
+            maxLength: expect.any(String),
+            minLength: expect.any(String),
+            pattern: expect.any(String),
+            required: expect.any(String),
+          }),
+        })
+      )
     })
 
     it('should accept custom minimumAsyncBehaviorTimevalue', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -43,7 +43,7 @@ function ArrayComponent(props: Props) {
   const summaryListContext = useContext(SummaryListContext)
   const valueBlockContext = useContext(ValueBlockContext)
 
-  const { getValue } = useDataValue()
+  const { getValueByPath } = useDataValue()
   const preparedProps = useMemo(() => {
     const {
       path,
@@ -53,8 +53,8 @@ function ArrayComponent(props: Props) {
     } = props
 
     if (countPath) {
-      const arrayValue = getValue(path)
-      let countValue = parseFloat(getValue(countPath))
+      const arrayValue = getValueByPath(path)
+      let countValue = parseFloat(getValueByPath(countPath))
       if (!(countValue >= 0)) {
         countValue = 0
       }
@@ -76,7 +76,7 @@ function ArrayComponent(props: Props) {
     }
 
     return props
-  }, [getValue, props])
+  }, [getValueByPath, props])
 
   const {
     path,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -72,22 +72,22 @@ export const dataValueProperties: PropertiesTableProps = {
     status: 'optional',
   },
   validator: {
-    doc: 'Custom validator function that will be called for every change done by the user. Can be asynchronous or synchronous.',
+    doc: 'Custom validator function that is triggered on every change done by the user. The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath }.',
     type: 'function',
     status: 'optional',
   },
   onBlurValidator: {
-    doc: 'Custom validator function that will be called when the user leaves the field (blurring a text input, closing a dropdown etc). Can be asynchronous or synchronous.',
+    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath }.',
     type: 'function',
     status: 'optional',
   },
   transformIn: {
-    doc: 'transforms the `value` before its displayed in the field (e.g. input).',
+    doc: 'Transforms the `value` before its displayed in the field (e.g. input).',
     type: 'function',
     status: 'optional',
   },
   transformOut: {
-    doc: 'transforms the value before it gets forwarded to the form data object or returned as the `onChange` value parameter.',
+    doc: 'Transforms the value before it gets forwarded to the form data object or returned as the `onChange` value parameter.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useDataValue.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useDataValue.test.tsx
@@ -56,7 +56,9 @@ describe('useDataValue', () => {
         ),
       })
 
-      expect(result.current.getValue('/example/path')).toBe('Test Value')
+      expect(result.current.getSourceValue('/example/path')).toBe(
+        'Test Value'
+      )
     })
 
     it('should return the whole data set when the path is one level like "/"', () => {
@@ -69,7 +71,7 @@ describe('useDataValue', () => {
         ),
       })
 
-      expect(result.current.getValue('/')).toEqual({
+      expect(result.current.getSourceValue('/')).toEqual({
         example: { path: 'Test Value' },
       })
     })
@@ -77,7 +79,9 @@ describe('useDataValue', () => {
     it('should return the given value when source is not a path', () => {
       const { result } = renderHook(() => useDataValue())
 
-      expect(result.current.getValue('Test Value')).toBe('Test Value')
+      expect(result.current.getSourceValue('Test Value')).toBe(
+        'Test Value'
+      )
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2731,7 +2731,7 @@ describe('useFieldProps', () => {
     expect(result.current.error).toBeInstanceOf(Error)
   })
 
-  describe('validator and onBlurValidator', () => {
+  describe('validator', () => {
     describe('connectWithPath', () => {
       const validatorFn: UseFieldProps<number>['validator'] = (
         num,
@@ -2744,40 +2744,165 @@ describe('useFieldProps', () => {
         }
       }
 
-      describe('validator', () => {
-        it('should show validator error on form submit', async () => {
-          const validator = jest.fn(validatorFn)
+      it('should show validator error on form submit', async () => {
+        const validator = jest.fn(validatorFn)
 
-          render(
-            <Form.Handler>
-              <Field.Number path="/refValue" defaultValue={2} />
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
 
-              <Field.Number
-                path="/myNumberWithValidator"
-                defaultValue={2}
-                validator={validator}
-              />
-            </Form.Handler>
-          )
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              validator={validator}
+            />
+          </Form.Handler>
+        )
 
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
-          fireEvent.submit(document.querySelector('form'))
+        fireEvent.submit(document.querySelector('form'))
 
+        await waitFor(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
           expect(screen.queryByRole('alert')).toHaveTextContent(
             'The amount should be greater than 2'
           )
-          expect(validator).toHaveBeenCalledTimes(1)
-          expect(validator).toHaveBeenLastCalledWith(
-            2,
-            expect.objectContaining({
-              connectWithPath: expect.any(Function),
-            })
+        })
+        expect(validator).toHaveBeenCalledTimes(1)
+        expect(validator).toHaveBeenLastCalledWith(
+          2,
+          expect.objectContaining({
+            connectWithPath: expect.any(Function),
+          })
+        )
+      })
+
+      it('should update error message on input change', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              validator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Show error message
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
           )
         })
 
-        it('should update error message on input change', async () => {
+        // Make a change to the ref input
+        await userEvent.type(inputWithRefValue, '2')
+
+        expect(screen.queryByRole('alert')).toHaveTextContent(
+          'The amount should be greater than 22'
+        )
+      })
+
+      it('should hide error message when validation is successful', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              validator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Show error message
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+        })
+
+        await userEvent.type(inputWithRefValue, '{Backspace}')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(validator).toHaveBeenCalledTimes(2)
+        expect(validator).toHaveBeenLastCalledWith(
+          2,
+          expect.objectContaining({
+            connectWithPath: expect.any(Function),
+          })
+        )
+      })
+
+      it('should keep error message hidden after validation is successful and another input change', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              validator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Show error message
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+        })
+
+        await userEvent.type(inputWithRefValue, '{Backspace}')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(validator).toHaveBeenCalledTimes(2)
+
+        await userEvent.type(inputWithRefValue, '2')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      })
+
+      describe('validateInitially', () => {
+        it('should show error message initially', async () => {
           const validator = jest.fn(validatorFn)
 
           render(
@@ -2788,6 +2913,31 @@ describe('useFieldProps', () => {
                 path="/myNumberWithValidator"
                 defaultValue={2}
                 validator={validator}
+                validateInitially
+              />
+            </Form.Handler>
+          )
+
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 2'
+            )
+          })
+        })
+
+        it('should not show error message after it was hidden while typing', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+                validateInitially
               />
             </Form.Handler>
           )
@@ -2796,66 +2946,25 @@ describe('useFieldProps', () => {
             document.querySelectorAll('input')
           )
 
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-          // Show error message
-          fireEvent.submit(document.querySelector('form'))
-
-          expect(screen.queryByRole('alert')).toBeInTheDocument()
-          expect(screen.queryByRole('alert')).toHaveTextContent(
-            'The amount should be greater than 2'
-          )
-
-          // Make a change to the ref input
-          await userEvent.type(inputWithRefValue, '2')
-
-          expect(screen.queryByRole('alert')).toHaveTextContent(
-            'The amount should be greater than 22'
-          )
-        })
-
-        it('should hide error message when validation is successful', async () => {
-          const validator = jest.fn(validatorFn)
-
-          render(
-            <Form.Handler>
-              <Field.Number path="/refValue" defaultValue={2} />
-
-              <Field.Number
-                path="/myNumberWithValidator"
-                defaultValue={2}
-                validator={validator}
-              />
-            </Form.Handler>
-          )
-
-          const [inputWithRefValue] = Array.from(
-            document.querySelectorAll('input')
-          )
-
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-          // Show error message
-          fireEvent.submit(document.querySelector('form'))
-
-          expect(screen.queryByRole('alert')).toBeInTheDocument()
-          expect(screen.queryByRole('alert')).toHaveTextContent(
-            'The amount should be greater than 2'
-          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 2'
+            )
+          })
 
           await userEvent.type(inputWithRefValue, '{Backspace}')
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-          expect(validator).toHaveBeenCalledTimes(2)
-          expect(validator).toHaveBeenLastCalledWith(
-            2,
-            expect.objectContaining({
-              connectWithPath: expect.any(Function),
-            })
-          )
-        })
 
-        it('should keep error message hidden after validation is successful and another input change', async () => {
+          await userEvent.type(inputWithRefValue, '3')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+      })
+
+      describe('validateUnchanged', () => {
+        it('should show error message initially', async () => {
           const validator = jest.fn(validatorFn)
 
           render(
@@ -2866,6 +2975,31 @@ describe('useFieldProps', () => {
                 path="/myNumberWithValidator"
                 defaultValue={2}
                 validator={validator}
+                validateUnchanged
+              />
+            </Form.Handler>
+          )
+
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 2'
+            )
+          })
+        })
+
+        it('should hide and show error message while typing', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+                validateUnchanged
               />
             </Form.Handler>
           )
@@ -2874,227 +3008,30 @@ describe('useFieldProps', () => {
             document.querySelectorAll('input')
           )
 
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-          // Show error message
-          fireEvent.submit(document.querySelector('form'))
-
-          expect(screen.queryByRole('alert')).toBeInTheDocument()
-          expect(screen.queryByRole('alert')).toHaveTextContent(
-            'The amount should be greater than 2'
-          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 2'
+            )
+          })
 
           await userEvent.type(inputWithRefValue, '{Backspace}')
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-          expect(validator).toHaveBeenCalledTimes(2)
 
-          await userEvent.type(inputWithRefValue, '2')
+          await userEvent.type(inputWithRefValue, '3')
 
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-        })
-
-        describe('validateInitially', () => {
-          it('should show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  validateInitially
-                />
-              </Form.Handler>
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 3'
             )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-          })
-
-          it('should not show error message after it was hidden while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  validateInitially
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-        })
-
-        describe('validateUnchanged', () => {
-          it('should show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  validateUnchanged
-                />
-              </Form.Handler>
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-          })
-
-          it('should hide and show error message while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  validateUnchanged
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 3'
-              )
-            })
-          })
-        })
-
-        describe('continuousValidation', () => {
-          it('should show not show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  continuousValidation
-                />
-              </Form.Handler>
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-
-          it('should hide and show error message while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  validator={validator}
-                  continuousValidation
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            // Show error message
-            fireEvent.submit(document.querySelector('form'))
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 3'
-              )
-            })
           })
         })
       })
 
-      describe('onBlurValidator', () => {
-        it('should show validator error on form submit', async () => {
+      describe('continuousValidation', () => {
+        it('should show not show error message initially', async () => {
           const validator = jest.fn(validatorFn)
 
           render(
@@ -3104,13 +3041,36 @@ describe('useFieldProps', () => {
               <Field.Number
                 path="/myNumberWithValidator"
                 defaultValue={2}
-                onBlurValidator={validator}
+                validator={validator}
+                continuousValidation
               />
             </Form.Handler>
           )
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
 
+        it('should hide and show error message while typing', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+                continuousValidation
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          // Show error message
           fireEvent.submit(document.querySelector('form'))
 
           await waitFor(() => {
@@ -3120,56 +3080,243 @@ describe('useFieldProps', () => {
             )
           })
 
-          expect(validator).toHaveBeenCalledTimes(1)
-          expect(validator).toHaveBeenLastCalledWith(
-            2,
-            expect.objectContaining({
-              connectWithPath: expect.any(Function),
-            })
-          )
-        })
-
-        it('should update error message on input change', async () => {
-          const validator = jest.fn(validatorFn)
-
-          render(
-            <Form.Handler>
-              <Field.Number path="/refValue" defaultValue={12} />
-
-              <Field.Number
-                path="/myNumberWithValidator"
-                defaultValue={1}
-                onBlurValidator={validator}
-              />
-            </Form.Handler>
-          )
-
-          const [inputWithRefValue, inputWithValidator] = Array.from(
-            document.querySelectorAll('input')
-          )
+          await userEvent.type(inputWithRefValue, '{Backspace}')
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
-          // Make a change to the input with the validator
-          await userEvent.type(inputWithValidator, '2')
-          fireEvent.blur(inputWithValidator)
+          await userEvent.type(inputWithRefValue, '3')
 
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              'The amount should be greater than 12'
+              'The amount should be greater than 3'
             )
           })
+        })
+      })
+    })
+  })
 
-          // Make a change to the ref input
+  describe('onBlurValidator', () => {
+    describe('connectWithPath', () => {
+      const validatorFn: UseFieldProps<number>['validator'] = (
+        num,
+        { connectWithPath }
+      ) => {
+        const amount = connectWithPath('/refValue').getValue()
+
+        if (amount >= num) {
+          return new Error(`The amount should be greater than ${amount}`)
+        }
+      }
+
+      it('should show validator error on form submit', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              onBlurValidator={validator}
+            />
+          </Form.Handler>
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+        })
+
+        expect(validator).toHaveBeenCalledTimes(1)
+        expect(validator).toHaveBeenLastCalledWith(
+          2,
+          expect.objectContaining({
+            connectWithPath: expect.any(Function),
+          })
+        )
+      })
+
+      it('should update error message on input change', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={12} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={1}
+              onBlurValidator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue, inputWithValidator] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Make a change to the input with the validator
+        await userEvent.type(inputWithValidator, '2')
+        fireEvent.blur(inputWithValidator)
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 12'
+          )
+        })
+
+        // Make a change to the ref input
+        await userEvent.type(inputWithRefValue, '3')
+
+        expect(screen.queryByRole('alert')).toHaveTextContent(
+          'The amount should be greater than 123'
+        )
+      })
+
+      it('should hide error message when validation is successful', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              onBlurValidator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Show error message
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+
+        await userEvent.type(inputWithRefValue, '{Backspace}')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(validator).toHaveBeenCalledTimes(2)
+        expect(validator).toHaveBeenLastCalledWith(
+          2,
+          expect.objectContaining({
+            connectWithPath: expect.any(Function),
+          })
+        )
+      })
+
+      it('should keep error message hidden during ref input change', async () => {
+        const validator = jest.fn(validatorFn)
+
+        render(
+          <Form.Handler>
+            <Field.Number path="/refValue" defaultValue={2} />
+
+            <Field.Number
+              path="/myNumberWithValidator"
+              defaultValue={2}
+              onBlurValidator={validator}
+            />
+          </Form.Handler>
+        )
+
+        const [inputWithRefValue] = Array.from(
+          document.querySelectorAll('input')
+        )
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+        // Show error message
+        fireEvent.submit(document.querySelector('form'))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+
+        await userEvent.type(inputWithRefValue, '{Backspace}')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(validator).toHaveBeenCalledTimes(2)
+
+        await userEvent.type(inputWithRefValue, '2')
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      })
+
+      describe('validateInitially', () => {
+        it('should not show error message initially', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+                validateInitially
+              />
+            </Form.Handler>
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+
+        it('should not show error message while typing', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+                validateInitially
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          await userEvent.type(inputWithRefValue, '{Backspace}')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
           await userEvent.type(inputWithRefValue, '3')
 
-          expect(screen.queryByRole('alert')).toHaveTextContent(
-            'The amount should be greater than 123'
-          )
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
         })
+      })
 
-        it('should hide error message when validation is successful', async () => {
+      describe('validateUnchanged', () => {
+        it('should not show error message initially', async () => {
           const validator = jest.fn(validatorFn)
 
           render(
@@ -3180,34 +3327,15 @@ describe('useFieldProps', () => {
                 path="/myNumberWithValidator"
                 defaultValue={2}
                 onBlurValidator={validator}
+                validateUnchanged
               />
             </Form.Handler>
           )
 
-          const [inputWithRefValue] = Array.from(
-            document.querySelectorAll('input')
-          )
-
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-          // Show error message
-          fireEvent.submit(document.querySelector('form'))
-
-          expect(screen.queryByRole('alert')).toBeInTheDocument()
-
-          await userEvent.type(inputWithRefValue, '{Backspace}')
-
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-          expect(validator).toHaveBeenCalledTimes(2)
-          expect(validator).toHaveBeenLastCalledWith(
-            2,
-            expect.objectContaining({
-              connectWithPath: expect.any(Function),
-            })
-          )
         })
 
-        it('should keep error message hidden during ref input change', async () => {
+        it('should not show error message while typing', async () => {
           const validator = jest.fn(validatorFn)
 
           render(
@@ -3218,6 +3346,7 @@ describe('useFieldProps', () => {
                 path="/myNumberWithValidator"
                 defaultValue={2}
                 onBlurValidator={validator}
+                validateUnchanged
               />
             </Form.Handler>
           )
@@ -3228,200 +3357,36 @@ describe('useFieldProps', () => {
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
-          // Show error message
-          fireEvent.submit(document.querySelector('form'))
-
-          expect(screen.queryByRole('alert')).toBeInTheDocument()
-
           await userEvent.type(inputWithRefValue, '{Backspace}')
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-          expect(validator).toHaveBeenCalledTimes(2)
 
-          await userEvent.type(inputWithRefValue, '2')
+          await userEvent.type(inputWithRefValue, '3')
+
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          })
+        })
+      })
+
+      describe('continuousValidation', () => {
+        it('should show not show error message initially', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+                continuousValidation
+              />
+            </Form.Handler>
+          )
 
           expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-        })
-
-        describe('validateInitially', () => {
-          it('should not show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  validateInitially
-                />
-              </Form.Handler>
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-
-          it('should not show error message while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  validateInitially
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-          })
-        })
-
-        describe('validateUnchanged', () => {
-          it('should not show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  validateUnchanged
-                />
-              </Form.Handler>
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-
-          it('should not show error message while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  validateUnchanged
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-        })
-
-        describe('continuousValidation', () => {
-          it('should show not show error message initially', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  continuousValidation
-                />
-              </Form.Handler>
-            )
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-            })
-          })
-
-          it('should hide and show error message while typing', async () => {
-            const validator = jest.fn(validatorFn)
-
-            render(
-              <Form.Handler>
-                <Field.Number path="/refValue" defaultValue={2} />
-
-                <Field.Number
-                  path="/myNumberWithValidator"
-                  defaultValue={2}
-                  onBlurValidator={validator}
-                  continuousValidation
-                />
-              </Form.Handler>
-            )
-
-            const [inputWithRefValue] = Array.from(
-              document.querySelectorAll('input')
-            )
-
-            // Show error message
-            fireEvent.submit(document.querySelector('form'))
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 2'
-              )
-            })
-
-            await userEvent.type(inputWithRefValue, '{Backspace}')
-
-            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-            await userEvent.type(inputWithRefValue, '3')
-
-            await waitFor(() => {
-              expect(screen.queryByRole('alert')).toBeInTheDocument()
-              expect(screen.queryByRole('alert')).toHaveTextContent(
-                'The amount should be greater than 3'
-              )
-            })
-          })
         })
       })
     })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -1,14 +1,23 @@
 import React from 'react'
-import { act, render, renderHook, waitFor } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  waitFor,
+  screen,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import useFieldProps from '../useFieldProps'
 import { Provider } from '../../DataContext'
-import {
+import Field, {
   FieldBlock,
   Form,
   FormError,
   JSONSchema,
   OnChange,
   SubmitState,
+  UseFieldProps,
 } from '../../Forms'
 import { wait } from '../../../../core/jest/jestSetup'
 import { useSharedState } from '../../../../shared/helpers/useSharedState'
@@ -2720,5 +2729,701 @@ describe('useFieldProps', () => {
       expect.anything()
     )
     expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  describe('validator and onBlurValidator', () => {
+    describe('connectWithPath', () => {
+      const validatorFn: UseFieldProps<number>['validator'] = (
+        num,
+        { connectWithPath }
+      ) => {
+        const amount = connectWithPath('/refValue').getValue()
+
+        if (amount >= num) {
+          return new Error(`The amount should be greater than ${amount}`)
+        }
+      }
+
+      describe('validator', () => {
+        it('should show validator error on form submit', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+              />
+            </Form.Handler>
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(validator).toHaveBeenLastCalledWith(
+            2,
+            expect.objectContaining({
+              connectWithPath: expect.any(Function),
+            })
+          )
+        })
+
+        it('should update error message on input change', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Show error message
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+
+          // Make a change to the ref input
+          await userEvent.type(inputWithRefValue, '2')
+
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 22'
+          )
+        })
+
+        it('should hide error message when validation is successful', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Show error message
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+
+          await userEvent.type(inputWithRefValue, '{Backspace}')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(2)
+          expect(validator).toHaveBeenLastCalledWith(
+            2,
+            expect.objectContaining({
+              connectWithPath: expect.any(Function),
+            })
+          )
+        })
+
+        it('should keep error message hidden after validation is successful and another input change', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                validator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Show error message
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 2'
+          )
+
+          await userEvent.type(inputWithRefValue, '{Backspace}')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(2)
+
+          await userEvent.type(inputWithRefValue, '2')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+
+        describe('validateInitially', () => {
+          it('should show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  validateInitially
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+          })
+
+          it('should not show error message after it was hidden while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  validateInitially
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+        })
+
+        describe('validateUnchanged', () => {
+          it('should show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  validateUnchanged
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+          })
+
+          it('should hide and show error message while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  validateUnchanged
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 3'
+              )
+            })
+          })
+        })
+
+        describe('continuousValidation', () => {
+          it('should show not show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  continuousValidation
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+
+          it('should hide and show error message while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  validator={validator}
+                  continuousValidation
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            // Show error message
+            fireEvent.submit(document.querySelector('form'))
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 3'
+              )
+            })
+          })
+        })
+      })
+
+      describe('onBlurValidator', () => {
+        it('should show validator error on form submit', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+              />
+            </Form.Handler>
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          fireEvent.submit(document.querySelector('form'))
+
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 2'
+            )
+          })
+
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(validator).toHaveBeenLastCalledWith(
+            2,
+            expect.objectContaining({
+              connectWithPath: expect.any(Function),
+            })
+          )
+        })
+
+        it('should update error message on input change', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={12} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={1}
+                onBlurValidator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue, inputWithValidator] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Make a change to the input with the validator
+          await userEvent.type(inputWithValidator, '2')
+          fireEvent.blur(inputWithValidator)
+
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              'The amount should be greater than 12'
+            )
+          })
+
+          // Make a change to the ref input
+          await userEvent.type(inputWithRefValue, '3')
+
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'The amount should be greater than 123'
+          )
+        })
+
+        it('should hide error message when validation is successful', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Show error message
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+
+          await userEvent.type(inputWithRefValue, '{Backspace}')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(2)
+          expect(validator).toHaveBeenLastCalledWith(
+            2,
+            expect.objectContaining({
+              connectWithPath: expect.any(Function),
+            })
+          )
+        })
+
+        it('should keep error message hidden during ref input change', async () => {
+          const validator = jest.fn(validatorFn)
+
+          render(
+            <Form.Handler>
+              <Field.Number path="/refValue" defaultValue={2} />
+
+              <Field.Number
+                path="/myNumberWithValidator"
+                defaultValue={2}
+                onBlurValidator={validator}
+              />
+            </Form.Handler>
+          )
+
+          const [inputWithRefValue] = Array.from(
+            document.querySelectorAll('input')
+          )
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+          // Show error message
+          fireEvent.submit(document.querySelector('form'))
+
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+
+          await userEvent.type(inputWithRefValue, '{Backspace}')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(2)
+
+          await userEvent.type(inputWithRefValue, '2')
+
+          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+
+        describe('validateInitially', () => {
+          it('should not show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  validateInitially
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+
+          it('should not show error message while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  validateInitially
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          })
+        })
+
+        describe('validateUnchanged', () => {
+          it('should not show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  validateUnchanged
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+
+          it('should not show error message while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  validateUnchanged
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+        })
+
+        describe('continuousValidation', () => {
+          it('should show not show error message initially', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  continuousValidation
+                />
+              </Form.Handler>
+            )
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+          })
+
+          it('should hide and show error message while typing', async () => {
+            const validator = jest.fn(validatorFn)
+
+            render(
+              <Form.Handler>
+                <Field.Number path="/refValue" defaultValue={2} />
+
+                <Field.Number
+                  path="/myNumberWithValidator"
+                  defaultValue={2}
+                  onBlurValidator={validator}
+                  continuousValidation
+                />
+              </Form.Handler>
+            )
+
+            const [inputWithRefValue] = Array.from(
+              document.querySelectorAll('input')
+            )
+
+            // Show error message
+            fireEvent.submit(document.querySelector('form'))
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 2'
+              )
+            })
+
+            await userEvent.type(inputWithRefValue, '{Backspace}')
+
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+            await userEvent.type(inputWithRefValue, '3')
+
+            await waitFor(() => {
+              expect(screen.queryByRole('alert')).toBeInTheDocument()
+              expect(screen.queryByRole('alert')).toHaveTextContent(
+                'The amount should be greater than 3'
+              )
+            })
+          })
+        })
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -9,6 +9,8 @@ export type Props<Value> = {
   value?: Value
 }
 
+export type GetValueByPath<Value = unknown> = <T = Value>(path: Path) => T
+
 export default function useDataValue<Value>({
   path: pathProp,
   value,
@@ -19,11 +21,12 @@ export default function useDataValue<Value>({
   const { makePath, makeIteratePath } = usePath()
 
   const get = useCallback((selector: Path) => {
+    const data = dataContextRef.current?.internalDataRef?.current
     if (selector === '/') {
-      return dataContextRef.current?.data
+      return data
     }
-    return pointer.has(dataContextRef.current?.data, selector)
-      ? pointer.get(dataContextRef.current.data, selector)
+    return pointer.has(data, selector)
+      ? pointer.get(data, selector)
       : undefined
   }, [])
 
@@ -70,7 +73,7 @@ export default function useDataValue<Value>({
     [getValueByPath, moveValueToPath]
   )
 
-  const getValue = useCallback(
+  const getSourceValue = useCallback(
     (source: Path | Value) => {
       if (typeof source === 'string' && isPath(source)) {
         return getValueByPath(source)
@@ -82,11 +85,11 @@ export default function useDataValue<Value>({
   )
 
   if (pathProp) {
-    value = getValue(pathProp)
+    value = getSourceValue(pathProp)
   }
 
   return {
-    getValue,
+    getSourceValue,
     getValueByPath,
     getValueByIteratePath,
     moveValueToPath,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -122,7 +122,16 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     },
   } = props
 
-  const [, forceUpdate] = useReducer(() => ({}), {})
+  const [salt, forceUpdate] = useReducer(() => ({}), {})
+  const isInternalRerenderRef = useRef(undefined)
+  useMemo(() => {
+    /**
+     * This is currently not used, but we keep it here for future use.
+     * It lets you check for isInternalRerenderRef.current !== undefined
+     * inside a useUpdateEffect or useEffect to know if the component is rerendering from inside or outside.
+     */
+    isInternalRerenderRef.current = salt
+  }, [salt])
   const { startProcess } = useProcessManager()
   const id = useId(props.id)
   const dataContext = useContext(DataContext)
@@ -153,7 +162,6 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     setFieldError: setFieldErrorDataContext,
     setFieldProps: setPropsDataContext,
     setHasVisibleError: setHasVisibleErrorDataContext,
-    setFieldEventListener: setFieldEventListenerDataContext,
     handleMountField,
     handleUnMountField,
     setFieldEventListener,
@@ -198,8 +206,8 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   // Hold an internal copy of the input value in case the input component is used uncontrolled,
   // and to handle errors in Eufemia on components that does not take updated callback functions into account.
   const valueRef = useRef<Value>(externalValue)
-  const changedRef = useRef<boolean>(false)
-  const hasFocusRef = useRef<boolean>(false)
+  const changedRef = useRef<boolean>()
+  const hasFocusRef = useRef<boolean>()
 
   const required = useMemo(() => {
     if (requiredProp) {
@@ -255,9 +263,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     dataContextError
   )
 
-  const validatorRef = useRef(validator)
+  const onChangeValidatorRef = useRef(validator)
   useUpdateEffect(() => {
-    validatorRef.current = validator
+    onChangeValidatorRef.current = validator
   }, [validator])
   const onBlurValidatorRef = useRef(onBlurValidator)
   useUpdateEffect(() => {
@@ -358,20 +366,20 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   )
 
   const revealError = useCallback(() => {
-    revealErrorRef.current = true
-    showFieldErrorFieldBlock?.(identifier, true)
-    if (localErrorRef.current) {
-      setHasVisibleErrorDataContext?.(identifier, true)
-    } else {
-      setHasVisibleErrorDataContext?.(identifier, false)
+    if (!revealErrorRef.current) {
+      revealErrorRef.current = true
+      showFieldErrorFieldBlock?.(identifier, true)
+      setHasVisibleErrorDataContext?.(identifier, !!localErrorRef.current)
     }
-  }, [showFieldErrorFieldBlock, identifier, setHasVisibleErrorDataContext])
+  }, [identifier, setHasVisibleErrorDataContext, showFieldErrorFieldBlock])
 
   const hideError = useCallback(() => {
-    revealErrorRef.current = false
-    showFieldErrorFieldBlock?.(identifier, false)
-    setHasVisibleErrorDataContext?.(identifier, false)
-  }, [setHasVisibleErrorDataContext, identifier, showFieldErrorFieldBlock])
+    if (revealErrorRef.current) {
+      revealErrorRef.current = false
+      showFieldErrorFieldBlock?.(identifier, false)
+      setHasVisibleErrorDataContext?.(identifier, false)
+    }
+  }, [identifier, setHasVisibleErrorDataContext, showFieldErrorFieldBlock])
 
   /**
    * Prepare error from validation logic with correct error messages based on props
@@ -430,39 +438,23 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     )
   }, [errorProp])
 
-  const { getValueByPath } = useDataValue()
-  const connectWithPathRef = useRef<
-    ValidatorAdditionalArgs<Value>['connectWithPath']
-  >((path) => {
-    setFieldEventListenerDataContext(path, 'onPathChange', async () => {
-      let result = undefined
-
-      if (
-        localErrorRef.current ||
-        changedRef.current ||
-        validateUnchanged ||
-        continuousValidation
-      ) {
-        if (validatorRef.current) {
-          result = await callValidator()
-        }
-
-        if (onBlurValidatorRef.current) {
-          result = await callOnBlurValidator()
-        }
-
-        if (!result) {
-          changedRef.current = false
-          hideError()
-          clearErrorState()
-        }
+  const connectWithPathListenerRef = useRef(async () => {
+    if (
+      localErrorRef.current ||
+      validateUnchanged ||
+      continuousValidation
+    ) {
+      if (onChangeValidatorRef.current) {
+        runOnChangeValidator()
       }
-    })
+    }
 
-    return {
-      getValue: () => getValueByPath(path),
+    if (localErrorRef.current && onBlurValidatorRef.current) {
+      runOnBlurValidator()
     }
   })
+
+  const { getValueByPath } = useDataValue()
   const additionalArgs = useMemo(() => {
     const errorMessages = {
       ...contextErrorMessages,
@@ -473,11 +465,22 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       ...errorMessages,
 
       errorMessages,
-      connectWithPath: connectWithPathRef.current,
+      connectWithPath: (path) => {
+        setFieldEventListener?.(
+          path,
+          'onPathChange',
+          connectWithPathListenerRef.current
+        )
+
+        return {
+          getValue: () => getValueByPath(path),
+        }
+      },
     }
 
     return args
-  }, [contextErrorMessages])
+  }, [contextErrorMessages, getValueByPath, setFieldEventListener])
+
   const callValidatorFnSync = useCallback(
     (
       validator: Validator<Value>,
@@ -493,6 +496,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     },
     [additionalArgs]
   )
+
   const callValidatorFnAsync = useCallback(
     async (
       validator: Validator<Value>,
@@ -577,85 +581,148 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     hasLocalErrorRef.current = false
   }, [persistErrorState])
 
-  const callValidator = useCallback(async () => {
-    if (typeof validatorRef.current !== 'function') {
+  const validatorCacheRef = useRef({
+    onChangeValidator: null,
+    onBlurValidator: null,
+  })
+
+  const revealOnChangeValidatorResult = useCallback(
+    ({ result, unchangedValue }) => {
+      const runAsync = isAsync(onChangeValidatorRef.current)
+
+      // Don't show the error if the value has changed in the meantime
+      if (unchangedValue) {
+        persistErrorState('gracefully', result as Error)
+
+        if (
+          (validateInitially && !changedRef.current) ||
+          validateUnchanged ||
+          continuousValidation ||
+          runAsync // Because its a better UX to show the error when the validation is async/delayed
+        ) {
+          // Because we first need to throw the error to be able to display it, we delay the showError call
+          window.requestAnimationFrame(() => {
+            revealError()
+            forceUpdate()
+          })
+        }
+      }
+
+      if (runAsync) {
+        defineAsyncProcess(undefined)
+
+        if (unchangedValue) {
+          setFieldState(result instanceof Error ? 'error' : 'complete')
+        } else {
+          setFieldState('pending')
+        }
+      }
+    },
+    [
+      continuousValidation,
+      defineAsyncProcess,
+      persistErrorState,
+      revealError,
+      setFieldState,
+      validateInitially,
+      validateUnchanged,
+    ]
+  )
+
+  const callOnChangeValidator = useCallback(async () => {
+    if (typeof onChangeValidatorRef.current !== 'function') {
+      return {}
+    }
+
+    const tmpValue = valueRef.current
+
+    let result = isAsync(onChangeValidatorRef.current)
+      ? await callValidatorFnAsync(onChangeValidatorRef.current)
+      : callValidatorFnSync(onChangeValidatorRef.current)
+    if (result instanceof Promise) {
+      result = await result
+    }
+
+    const unchangedValue = tmpValue === valueRef.current
+    return { result, unchangedValue }
+  }, [callValidatorFnAsync, callValidatorFnSync])
+
+  const startOnChangeValidatorValidation = useCallback(async () => {
+    if (typeof onChangeValidatorRef.current !== 'function') {
       return
     }
 
-    const runAsync = isAsync(validatorRef.current)
-
-    if (runAsync) {
+    if (isAsync(onChangeValidatorRef.current)) {
       defineAsyncProcess('validator')
       setFieldState('validating')
       hideError()
     }
 
+    // Ideally, we should rather call "callOnChangeValidator", but sadly it's not possible,
+    // because the we get an additional delay due to the async nature, which is too much.
     const tmpValue = valueRef.current
-    let result = isAsync(validatorRef.current)
-      ? await callValidatorFnAsync(validatorRef.current)
-      : callValidatorFnSync(validatorRef.current)
+    let result = isAsync(onChangeValidatorRef.current)
+      ? await callValidatorFnAsync(onChangeValidatorRef.current)
+      : callValidatorFnSync(onChangeValidatorRef.current)
     if (result instanceof Promise) {
       result = await result
     }
     const unchangedValue = tmpValue === valueRef.current
 
-    // Don't show the error if the value has changed in the meantime
-    if (unchangedValue) {
-      persistErrorState('gracefully', result as Error)
+    revealOnChangeValidatorResult({ result, unchangedValue })
 
-      // Because its a better UX to show the error when the validation is async/delayed
-      if (continuousValidation || validateUnchanged || runAsync) {
-        // Because we first need to throw the error to be able to display it, we delay the showError call
-        window.requestAnimationFrame(() => {
-          revealError()
-          forceUpdate()
-        })
-      }
-    }
-
-    if (runAsync) {
-      defineAsyncProcess(undefined)
-
-      if (unchangedValue) {
-        setFieldState(result instanceof Error ? 'error' : 'complete')
-      } else {
-        setFieldState('pending')
-      }
-    }
-
-    return result
+    return { result }
   }, [
     callValidatorFnAsync,
     callValidatorFnSync,
     defineAsyncProcess,
-    setFieldState,
     hideError,
-    persistErrorState,
-    continuousValidation,
-    validateUnchanged,
-    revealError,
+    revealOnChangeValidatorResult,
+    setFieldState,
+  ])
+
+  const runOnChangeValidator = useCallback(async () => {
+    if (!onChangeValidatorRef.current) {
+      return // stop here
+    }
+
+    const { result, unchangedValue } = await callOnChangeValidator()
+
+    if (
+      String(result) !==
+      String(validatorCacheRef.current.onChangeValidator)
+    ) {
+      if (result) {
+        revealOnChangeValidatorResult({ result, unchangedValue })
+      } else {
+        hideError()
+        clearErrorState()
+      }
+    }
+
+    validatorCacheRef.current.onChangeValidator = result || null
+  }, [
+    callOnChangeValidator,
+    clearErrorState,
+    hideError,
+    revealOnChangeValidatorResult,
   ])
 
   const callOnBlurValidator = useCallback(
-    async ({ valueOverride = null } = {}) => {
+    async ({
+      overrideValue = null,
+    }: {
+      overrideValue?: Value
+    } = {}) => {
       if (typeof onBlurValidatorRef.current !== 'function') {
-        return
+        return {}
       }
-      // External blur validators makes it possible to validate values but not on every character change in case of
-      // expensive validation calling external services etc.
 
       // Since the validator can return either a synchronous result or an asynchronous
       const value = transformers.current.toEvent(
-        valueOverride ?? valueRef.current,
+        overrideValue ?? valueRef.current,
         'onBlurValidator'
       )
-
-      const runAsync = isAsync(onBlurValidatorRef.current)
-
-      if (runAsync) {
-        defineAsyncProcess('onBlurValidator')
-        setFieldState('validating')
-      }
 
       let result = isAsync(onBlurValidatorRef.current)
         ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
@@ -664,27 +731,78 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         result = await result
       }
 
+      return { result }
+    },
+    [callValidatorFnAsync, callValidatorFnSync]
+  )
+
+  const revealOnBlurValidatorResult = useCallback(
+    ({ result }) => {
       persistErrorState('gracefully', result as Error)
 
-      if (runAsync) {
+      if (isAsync(onBlurValidatorRef.current)) {
         defineAsyncProcess(undefined)
         setFieldState(result instanceof Error ? 'error' : 'complete')
       }
 
       revealError()
-      forceUpdate()
+    },
+    [defineAsyncProcess, persistErrorState, revealError, setFieldState]
+  )
 
-      return result
+  const startOnBlurValidatorProcess = useCallback(
+    async ({
+      overrideValue = null,
+    }: {
+      overrideValue?: Value
+    } = {}) => {
+      if (typeof onBlurValidatorRef.current !== 'function') {
+        return
+      }
+
+      if (isAsync(onBlurValidatorRef.current)) {
+        defineAsyncProcess('onBlurValidator')
+        setFieldState('validating')
+      }
+
+      const { result } = await callOnBlurValidator({ overrideValue })
+      revealOnBlurValidatorResult({ result })
     },
     [
-      callValidatorFnAsync,
-      callValidatorFnSync,
-      persistErrorState,
-      revealError,
+      callOnBlurValidator,
       defineAsyncProcess,
+      revealOnBlurValidatorResult,
       setFieldState,
     ]
   )
+
+  const runOnBlurValidator = useCallback(async () => {
+    if (!onBlurValidatorRef.current) {
+      return // stop here
+    }
+
+    const { result } = await callOnBlurValidator()
+
+    if (
+      String(result) !==
+        String(validatorCacheRef.current.onBlurValidator) &&
+      revealErrorRef.current
+    ) {
+      if (result) {
+        revealOnBlurValidatorResult({ result })
+      } else {
+        hideError()
+        clearErrorState()
+      }
+    }
+
+    validatorCacheRef.current.onBlurValidator = result || null
+  }, [
+    callOnBlurValidator,
+    clearErrorState,
+    hideError,
+    revealOnBlurValidatorResult,
+  ])
 
   const prioritizeContextSchema = useMemo(() => {
     if (errorPrioritization) {
@@ -748,10 +866,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
       // Validate by provided derivative validator
       if (
-        validatorRef.current &&
+        onChangeValidatorRef.current &&
         (changedRef.current || validateInitially || validateUnchanged)
       ) {
-        const result = await callValidator()
+        const { result } = await startOnChangeValidatorValidation()
 
         if (result instanceof Error) {
           throw result
@@ -781,7 +899,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     prioritizeContextSchema,
     validateInitially,
     validateUnchanged,
-    callValidator,
+    startOnChangeValidatorValidation,
     persistErrorState,
   ])
 
@@ -803,14 +921,14 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const setHasFocus = useCallback(
     async (
       hasFocus: boolean,
-      valueOverride?: Value,
+      overrideValue?: Value,
       additionalArgs?: AdditionalEventArgs
     ) => {
       const getArgs = (
         type: Parameters<typeof transformers.current.toEvent>[1]
       ) => {
         const value = transformers.current.toEvent(
-          valueOverride ?? valueRef.current,
+          overrideValue ?? valueRef.current,
           type
         )
         const transformedAdditionalArgs =
@@ -843,7 +961,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
         addToPool(
           'onBlurValidator',
-          async () => await callOnBlurValidator({ valueOverride }),
+          async () => await startOnBlurValidatorProcess({ overrideValue }),
           isAsync(onBlurValidatorRef.current)
         )
 
@@ -860,7 +978,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       validateUnchanged,
       addToPool,
       runPool,
-      callOnBlurValidator,
+      startOnBlurValidatorProcess,
       revealError,
     ]
   )
@@ -1040,7 +1158,11 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         handlePathChangeUnvalidatedDataContext(identifier, newValue)
       }
 
-      addToPool('validator', validateValue, isAsync(validatorRef.current))
+      addToPool(
+        'validator',
+        validateValue,
+        isAsync(onChangeValidatorRef.current)
+      )
 
       addToPool(
         'onChangeContext',
@@ -1345,7 +1467,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   useEffect(() => {
     if (
       dataContext.formState === 'pending' &&
-      (validatorRef.current || onBlurValidatorRef.current)
+      (onChangeValidatorRef.current || onBlurValidatorRef.current)
     ) {
       hideError()
       forceUpdate()
@@ -1357,15 +1479,26 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       return // stop here
     }
 
-    addToPool('validator', callValidator, isAsync(validatorRef.current))
+    addToPool(
+      'validator',
+      startOnChangeValidatorValidation,
+      isAsync(onChangeValidatorRef.current)
+    )
+
     addToPool(
       'onBlurValidator',
-      callOnBlurValidator,
+      startOnBlurValidatorProcess,
       isAsync(onBlurValidatorRef.current)
     )
 
     await runPool()
-  }, [addToPool, callOnBlurValidator, callValidator, hasError, runPool])
+  }, [
+    addToPool,
+    startOnBlurValidatorProcess,
+    hasError,
+    runPool,
+    startOnChangeValidatorValidation,
+  ])
 
   // Validate/call validator functions during submit of the form
   useEffect(() => {
@@ -1496,6 +1629,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const sharedData = useSharedState('field-block-props-' + id)
   sharedData.set(fieldBlockProps)
 
+  useEffect(() => {
+    isInternalRerenderRef.current = undefined
+  })
+
   return {
     ...props,
     ...fieldBlockProps,
@@ -1512,7 +1649,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       transformers.current.toInput(valueRef.current)
     ),
     hasError: hasVisibleError,
-    isChanged: changedRef.current,
+    isChanged: Boolean(changedRef.current),
     props,
     htmlAttributes,
     setHasFocus,
@@ -1534,7 +1671,7 @@ export interface ReturnAdditional<Value> {
   htmlAttributes: AriaAttributes | DataAttributes
   setHasFocus: (
     hasFocus: boolean,
-    valueOverride?: unknown,
+    overrideValue?: Value,
     additionalArgs?: AdditionalEventArgs
   ) => void
   handleFocus: () => void

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -23,20 +23,27 @@ export { JSONSchemaType }
 
 type ValidationRule = 'type' | 'pattern' | 'required' | string
 type MessageValues = Record<string, string>
+export type ValidatorReturnSync = Error | undefined | void
+export type ValidatorReturnAsync =
+  | ValidatorReturnSync
+  | Promise<ValidatorReturnSync>
 export type Validator<Value, ErrorMessages = DefaultErrorMessages> = (
   value: Value,
   additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
-) =>
-  | Error
-  | undefined
-  | void
-  | Promise<Error | undefined | void>
-  | Array<Validator<Value>>
+) => ValidatorReturnAsync
 export type ValidatorAdditionalArgs<
   Value,
   ErrorMessages = DefaultErrorMessages,
 > = {
+  /**
+   * Returns the error messages from the { errorMessages } object.
+   */
   errorMessages: ErrorMessages
+
+  /**
+   * Connects the validator to another field.
+   * This allows you to rerun the validator function once the value of the connected field changes.
+   */
   connectWithPath: (path: Path) => { getValue: () => Value }
 } & {
   /** @deprecated use the error messages from the { errorMessages } object instead. */

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -23,12 +23,26 @@ export { JSONSchemaType }
 
 type ValidationRule = 'type' | 'pattern' | 'required' | string
 type MessageValues = Record<string, string>
+export type Validator<Value, ErrorMessages = DefaultErrorMessages> = (
+  value: Value,
+  additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
+) =>
+  | Error
+  | undefined
+  | void
+  | Promise<Error | undefined | void>
+  | Array<Validator<Value>>
 export type ValidatorAdditionalArgs<
   Value,
   ErrorMessages = DefaultErrorMessages,
 > = {
   errorMessages: ErrorMessages
   connectWithPath: (path: Path) => { getValue: () => Value }
+} & {
+  /** @deprecated use the error messages from the { errorMessages } object instead. */
+  pattern: string
+  /** @deprecated use the error messages from the { errorMessages } object instead. */
+  required: string
 }
 
 interface IFormErrorOptions {
@@ -272,14 +286,8 @@ export interface UseFieldProps<
   // - Validation
   required?: boolean
   schema?: AllJSONSchemaVersions<Value>
-  validator?: (
-    value: Value,
-    additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
-  ) => Error | undefined | void | Promise<Error | undefined | void>
-  onBlurValidator?: (
-    value: Value,
-    additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
-  ) => Error | undefined | void | Promise<Error | undefined | void>
+  validator?: Validator<Value>
+  onBlurValidator?: Validator<Value>
   validateRequired?: (
     internal: Value,
     {

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -23,6 +23,13 @@ export { JSONSchemaType }
 
 type ValidationRule = 'type' | 'pattern' | 'required' | string
 type MessageValues = Record<string, string>
+export type ValidatorAdditionalArgs<
+  Value,
+  ErrorMessages = DefaultErrorMessages,
+> = {
+  errorMessages: ErrorMessages
+  connectWithPath: (path: Path) => { getValue: () => Value }
+}
 
 interface IFormErrorOptions {
   validationRule?: ValidationRule
@@ -266,11 +273,12 @@ export interface UseFieldProps<
   required?: boolean
   schema?: AllJSONSchemaVersions<Value>
   validator?: (
-    value: Value | EmptyValue,
-    errorMessages?: ErrorMessages
+    value: Value,
+    additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
   ) => Error | undefined | void | Promise<Error | undefined | void>
   onBlurValidator?: (
-    value: Value | EmptyValue
+    value: Value,
+    additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
   ) => Error | undefined | void | Promise<Error | undefined | void>
   validateRequired?: (
     internal: Value,


### PR DESCRIPTION
This feature allows a validator for a field to connect to another data path. Changes to the data path value will be reflected in a rerender of the validator. But only if the validator is actually in use. This can be controlled with field properties, such as `validateUnchanged` etc.

**Good to know:** Why do validators not rerender on every data change? Because field A should not emit the validator of field B. It can be used for various cases, such as backend requests.

But with the new feature called `connectWithPath` you as a dev get the possibility to control this in a fine granted way.

Quick examples:

```tsx
import { Form, Field } from '@dnb/eufemia/extensions/forms'

const validator = (value, { connectWithPath }) => {
  const { getValue } = connectWithPath('/myReference')
  const amount = getValue()
  if (amount >= value) {
    return new Error(`The amount should be greater than ${amount}`)
  }
}

render(
  <Form.Handler>
    <Field.Number path="/myReference" defaultValue={2} />

    <Field.Number
      path="/withValidator"
      defaultValue={2}
      validator={validator} // NB: You may use "onBlurValidator" depending on use case.

      //
    />
  </Form.Handler>,
)
```