### PR TITLE
fix(LabelDescription): nothing was returned

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -519,7 +519,10 @@ function CombineMessages({
 
 function LabelDescription({ labelDescription, children }) {
   if (!labelDescription) {
-    return children
+    if (children) {
+      return children
+    }
+    return null
   }
   return <div className="dnb-forms-field-block__label">{children}</div>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -519,10 +519,7 @@ function CombineMessages({
 
 function LabelDescription({ labelDescription, children }) {
   if (!labelDescription) {
-    if (children) {
-      return children
-    }
-    return null
+    return children ?? null
   }
   return <div className="dnb-forms-field-block__label">{children}</div>
 }


### PR DESCRIPTION
Motivation from [this Slack thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1725367722056839).

Importing/using `<Field.SelectCountry />` and/or `<Field.PhoneNumber />` from `import { Field } from '@dnb/eufemia/extensions/forms'` with eufemia 10.46.0 and react 17.0.2 results in the following error: `LabelDescription(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.`, see [CSB](https://codesandbox.io/p/sandbox/new-cookies-82klmm?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd)

Here's the [same CSB with the fix in this PR](https://codesandbox.io/p/sandbox/elegant-http-2kc6y5?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd).
