### PR TITLE
docs(useTheme): updates docs to match TS type definitions

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -12,7 +12,7 @@ The Theme component is a helper component that lets you create nested theming so
 import { Theme, useTheme } from '@dnb/eufemia/shared'
 
 const Component = () => {
-  const { name } = useTheme()
+  const themeName = useTheme()?.name
   return 'My Component'
 }
 
@@ -58,7 +58,8 @@ In order to change or map CSS properties, you can make use of the `propMapping` 
 import { Theme, useTheme } from '@dnb/eufemia/shared'
 
 const Component = () => {
-  const { name, propMapping } = useTheme()
+  const theme = useTheme()
+  const { name, propMapping } = theme || {}
   return 'My Component'
 }
 
@@ -136,7 +137,8 @@ import { Theme, useTheme } from '@dnb/eufemia/shared'
 
 const Component = () => {
   // Result: { name: 'sbanken', isUi: false, isSbanken: true, isEiendom: false }
-  const { name, isUi, isSbanken, isEiendom } = useTheme()
+  const theme = useTheme()
+  const { name, isUi, isSbanken, isEiendom } = theme || {}
   return null
 }
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -261,7 +261,7 @@ function ListItem({
   subheadings,
   hideInMenu,
 }: ListItemProps) {
-  const { name: currentTheme } = useTheme()
+  const currentTheme = useTheme()?.name
   const { closeMenu } = useContext(SidebarMenuContext)
   const { skeleton } = useContext(Context)
   const ref = useRef(null)


### PR DESCRIPTION
Motivation from this [Slack thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1725533657841919).

The follow code:

```
  const { isSbanken } = useTheme()
  console.log(isSbanken)
```

Results in this error message:

`Property 'isSbanken' does not exist on type 'UseThemeReturn'.typescript(2339)`

[CSB displaying the error.](https://codesandbox.io/p/sandbox/silent-star-67jztx)

This is because of the type definition introduced in this PR https://github.com/dnbexperience/eufemia/pull/3861/files

This PR types just the `object`, and not `object | null`(which it was), since all fields in JavaScript (and in TypeScript) can have the value null or undefined? So by just typing the `object`, it could also be `null` instead of the `object`?

Here's a [CSB with the fix](https://codesandbox.io/p/sandbox/cocky-rumple-5hdk2m?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd).