### PR TITLE
chore(Forms): Behaviour => Behavior

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -98,7 +98,7 @@ export interface ContextState {
   addOnChangeHandler?: (callback: OnChange) => void
   handleSubmitCall: ({
     onSubmit,
-    enableAsyncBehaviour,
+    enableAsyncBehavior,
     skipFieldValidation,
     skipErrorCheck,
   }: {
@@ -106,7 +106,7 @@ export interface ContextState {
       | EventReturnWithStateObject
       | void
       | Promise<EventReturnWithStateObject | void>
-    enableAsyncBehaviour: boolean
+    enableAsyncBehavior: boolean
     skipFieldValidation?: boolean
     skipErrorCheck?: boolean
   }) => void

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -850,7 +850,7 @@ export default function Provider<Data extends JsonObject>(
     async (args) => {
       const {
         onSubmit,
-        enableAsyncBehaviour,
+        enableAsyncBehavior,
         skipFieldValidation,
         skipErrorCheck,
       } = args
@@ -860,9 +860,9 @@ export default function Provider<Data extends JsonObject>(
       const asyncBehaviorIsEnabled =
         (skipErrorCheck
           ? true
-          : // Don't enable async behaviour if we have errors, but when we have a pending state
+          : // Don't enable async behavior if we have errors, but when we have a pending state
             !hasErrors() || hasFieldState('pending')) &&
-        (enableAsyncBehaviour || hasFieldWithAsyncValidator())
+        (enableAsyncBehavior || hasFieldWithAsyncValidator())
 
       if (asyncBehaviorIsEnabled) {
         setFormState('pending')
@@ -990,7 +990,7 @@ export default function Provider<Data extends JsonObject>(
   const handleSubmit = useCallback<ContextState['handleSubmit']>(
     async ({ formElement = null } = {}) => {
       handleSubmitCall({
-        enableAsyncBehaviour: isAsync(onSubmit),
+        enableAsyncBehavior: isAsync(onSubmit),
         onSubmit: async () => {
           if (handleSubmitListeners()) {
             return // stop here

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -544,7 +544,7 @@ describe('Field.String', () => {
 
   describe('error handling', () => {
     describe('json schema', () => {
-      describe('default behaviour', () => {
+      describe('default behavior', () => {
         it('should not show error message initially', () => {
           render(
             <Field.String

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -179,7 +179,7 @@ function WizardContainer(props: Props) {
       handleSubmitCall({
         skipErrorCheck,
         skipFieldValidation: skipErrorCheck,
-        enableAsyncBehaviour: isAsync(onStepChange),
+        enableAsyncBehavior: isAsync(onStepChange),
         onSubmit: async () => {
           if (!skipStepChangeCallFromHook) {
             sharedStateRef.current?.data?.onStepChange?.(index, mode)


### PR DESCRIPTION
"Behaviour" is the British English spelling.
"Behavior" is the American English spelling.

Our code is written in en-us English, while the translation English is en-gb.

There are a couple more. One in the Accordion component (`expandBehaviour`) as a property. But this I think we should keep, as it needs to be deprecated. Feel free to make another PR 🙏 