### PR TITLE
feat(Forms): make it possible to reuse and extend internal validators

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -93,7 +93,7 @@ All properties are optional and can be used as needed. These properties can be p
 
 - `exportValidators` object with your validators you want to export. More info down below.
 
-For more advanced use cases, you can export your custom Field validators with `exportValidators`. They are then available (as `validators`) to be used in the validator.
+For more advanced use cases, you can export your custom Field validators with `exportValidators`. They are then available (as `validators` in object of the second validator parameter) to be used in the validator.
 
 When an array is returned from the validator, it will be used to only call these validators.
 If no array is returned, the internal validator will be called in addition.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -89,6 +89,38 @@ All properties are optional and can be used as needed. These properties can be p
 - `validateUnchanged` in order to validate without a change and blur event. Used for rare cases.
 - `continuousValidation` in order to validate without a focus event beforehand. Used for rare cases.
 
+**Validators**
+
+- `exportValidators` object with your validators you want to export. More info down below.
+
+For more advanced use cases, you can export your curstom Field validators with `exportValidators`. They are then available (as `validators`) to be used in the validator.
+
+When an array is returned from the validator, it will be used to only call these validators.
+If no array is returned, the internal validator will be called in addition.
+
+```tsx
+const MyField = (props) => {
+  const myInternalValidator = useCallback(() => {
+    if (value === 'fail now') {
+      return new Error('Internal validation error')
+    }
+  }, [])
+  return (
+    <Field.String exportValidators={{ myInternalValidator }} {...props} />
+  )
+}
+
+const myValidator = (value, { validators: { myInternalValidator } }) => {
+  if (value === 'fail') {
+    return new Error('My error')
+  }
+
+  return [myInternalValidator] // optional
+}
+
+render(<MyField onBlurValidator={myValidator} />)
+```
+
 **Error**
 
 - `error` object like `FormError` that includes the string to display or an object with the key `validationRule`. More info down below.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -93,7 +93,7 @@ All properties are optional and can be used as needed. These properties can be p
 
 - `exportValidators` object with your validators you want to export. More info down below.
 
-For more advanced use cases, you can export your curstom Field validators with `exportValidators`. They are then available (as `validators`) to be used in the validator.
+For more advanced use cases, you can export your custom Field validators with `exportValidators`. They are then available (as `validators`) to be used in the validator.
 
 When an array is returned from the validator, it will be used to only call these validators.
 If no array is returned, the internal validator will be called in addition.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -78,7 +78,7 @@ All properties are optional and can be used as needed. These properties can be p
 - `path` the JSON pointer that defines the entry name/key in the data structure.
 - `itemPath` similar to `path`, but is used when run inside the [Iterate](/uilib/extensions/forms/Iterate/) context.
 
-**Validation**
+#### Validation
 
 - `required` if true, it will call `validateRequired` for validation.
 - `schema` or `pattern` for JSON schema validation powered by [ajv](https://ajv.js.org/).
@@ -89,7 +89,7 @@ All properties are optional and can be used as needed. These properties can be p
 - `validateUnchanged` in order to validate without a change and blur event. Used for rare cases.
 - `continuousValidation` in order to validate without a focus event beforehand. Used for rare cases.
 
-**Validators**
+#### Validators
 
 - `exportValidators` object with your validators you want to export. More info down below.
 
@@ -121,7 +121,7 @@ const myValidator = (value, { validators: { myInternalValidator } }) => {
 render(<MyField onBlurValidator={myValidator} />)
 ```
 
-**Error**
+#### Error
 
 - `error` object like `FormError` that includes the string to display or an object with the key `validationRule`. More info down below.
 - `errorMessages` object with your custom messages, where each key represents a `validationRule`. More info down below.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -95,7 +95,7 @@ All properties are optional and can be used as needed. These properties can be p
 
 For more advanced use cases, you can export your custom Field validators with `exportValidators`. They are then available (as `validators` in object of the second validator parameter) to be used in the validator.
 
-When an array is returned from the validator, it will be used to only call these validators.
+When an array is returned from the validator, it will be used to only call these validators (in the order they are returned).
 If no array is returned, the internal validator will be called in addition.
 
 ```tsx

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -72,12 +72,12 @@ export const dataValueProperties: PropertiesTableProps = {
     status: 'optional',
   },
   validator: {
-    doc: 'Custom validator function that is triggered on every change done by the user. The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath }.',
+    doc: 'Custom validator function that is triggered on every change done by the user. The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
     type: 'function',
     status: 'optional',
   },
   onBlurValidator: {
-    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath }.',
+    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -3367,7 +3367,7 @@ describe('useFieldProps', () => {
 
         await userEvent.type(
           document.querySelector('input'),
-          '{Backspace}bar' // remove one letter from foo, so the foo validator should return undefined
+          '{Backspace}bar' // remove one letter from bar, so the bar validator should return undefined
         )
         await waitFor(() => {
           // Here we should not see the bar validator called

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -3857,7 +3857,7 @@ describe('useFieldProps', () => {
 
         await userEvent.type(
           input,
-          '{Backspace}bar' // remove one letter from foo, so the foo validator should return undefined
+          '{Backspace}bar' // remove one letter from bar, so the bar validator should return undefined
         )
         fireEvent.blur(input)
         await waitFor(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -40,9 +40,21 @@ export type ValidatorAdditionalArgs<
   Value,
   ErrorMessages = DefaultErrorMessages,
 > = {
+  /**
+   * Returns the error messages from the { errorMessages } object.
+   */
   errorMessages: ErrorMessages
-  validators: Record<string, Validator<Value>>
+
+  /**
+   * Connects the validator to another field.
+   * This allows you to rerun the validator function once the value of the connected field changes.
+   */
   connectWithPath: (path: Path) => { getValue: () => Value }
+
+  /**
+   * Returns the validators from the { exportValidators } object.
+   */
+  validators: Record<string, Validator<Value>>
 } & {
   /** @deprecated use the error messages from the { errorMessages } object instead. */
   pattern: string

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -23,27 +23,25 @@ export { JSONSchemaType }
 
 type ValidationRule = 'type' | 'pattern' | 'required' | string
 type MessageValues = Record<string, string>
-export type ValidatorReturnSync = Error | undefined | void
-export type ValidatorReturnAsync =
-  | ValidatorReturnSync
-  | Promise<ValidatorReturnSync>
+export type ValidatorReturnSync<Value> =
+  | Error
+  | undefined
+  | void
+  | Array<Validator<Value>>
+
+export type ValidatorReturnAsync<Value> =
+  | ValidatorReturnSync<Value>
+  | Promise<ValidatorReturnSync<Value>>
 export type Validator<Value, ErrorMessages = DefaultErrorMessages> = (
   value: Value,
   additionalArgs?: ValidatorAdditionalArgs<Value, ErrorMessages>
-) => ValidatorReturnAsync
+) => ValidatorReturnAsync<Value>
 export type ValidatorAdditionalArgs<
   Value,
   ErrorMessages = DefaultErrorMessages,
 > = {
-  /**
-   * Returns the error messages from the { errorMessages } object.
-   */
   errorMessages: ErrorMessages
-
-  /**
-   * Connects the validator to another field.
-   * This allows you to rerun the validator function once the value of the connected field changes.
-   */
+  validators: Record<string, Validator<Value>>
   connectWithPath: (path: Path) => { getValue: () => Value }
 } & {
   /** @deprecated use the error messages from the { errorMessages } object instead. */
@@ -295,6 +293,7 @@ export interface UseFieldProps<
   schema?: AllJSONSchemaVersions<Value>
   validator?: Validator<Value>
   onBlurValidator?: Validator<Value>
+  exportValidators?: Record<string, Validator<Value>>
   validateRequired?: (
     internal: Value,
     {


### PR DESCRIPTION
Quick example: 

```tsx
const MyField = (props) => {
  const myInternalValidator = useCallback(() => {
    if (value === 'fail now') {
      return new Error('Internal validation error')
    }
  }, [])
  return (
    <Field.String exportValidators={{ myInternalValidator }} {...props} />
  )
}

const myValidator = (value, { validators: { myInternalValidator } }) => {
  if (value === 'fail') {
    return new Error('My error')
  }

  return [myInternalValidator] // optional
}

render(<MyField onBlurValidator={myValidator} />)
```