### PR TITLE
chore(Forms): add demos to showcase exclusive to Field.Currency and Field.Number

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -49,6 +49,22 @@ export const LabelAndValue = () => {
   )
 }
 
+export const ExclusiveMinMax = () => {
+  return (
+    <ComponentBox>
+      <Field.Number
+        value={1000}
+        label="Label text"
+        allowNegative={false}
+        required
+        exclusiveMinimum={900}
+        exclusiveMaximum={1000}
+        validateInitially
+      />
+    </ComponentBox>
+  )
+}
+
 export const PrefixAndSuffix = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
@@ -22,6 +22,10 @@ import * as Examples from './Examples'
 
 <Examples.LabelAndValue />
 
+### Exclusive minimum and exclusive maximum
+
+<Examples.ExclusiveMinMax />
+
 ### Prefix and suffix
 
 You can also use a function as a prefix or suffix.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
@@ -48,6 +48,22 @@ export const LabelAndValue = () => {
   )
 }
 
+export const ExclusiveMinMax = () => {
+  return (
+    <ComponentBox>
+      <Field.Number
+        value={1000}
+        label="Label text"
+        allowNegative={false}
+        required
+        exclusiveMinimum={900}
+        exclusiveMaximum={1000}
+        validateInitially
+      />
+    </ComponentBox>
+  )
+}
+
 export const WithHelp = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/demos.mdx
@@ -22,6 +22,10 @@ import * as Examples from './Examples'
 
 <Examples.LabelAndValue />
 
+### Exclusive minimum and exclusive maximum
+
+<Examples.ExclusiveMinMax />
+
 ### With step controls
 
 <Examples.WithStepControls />


### PR DESCRIPTION
The motivation is that these two fields are very often used, and I saw a dev using the `onChange` event for throwing an error, instead of using the `valdiator` prop.