### PR TITLE
chore: removes faulty description of Toolbar example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Toolbar/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Toolbar/demos.mdx
@@ -7,6 +7,4 @@ import * as Examples from './Examples'
 
 ## Demos
 
-Using the [Iterate.Count](/uilib/extensions/forms/Iterate/Count) component to count the array length.
-
 <Examples.Default />


### PR DESCRIPTION
There's no Iterate.Count used in the example, hence we can remove the faulty text/info stating it.