### PR TITLE
fix: removes outdated countries based on ISO 3166-1 alpha-2

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
@@ -1447,15 +1447,6 @@ const countries: Array<CountryType> = [
   },
   {
     i18n: {
-      en: 'Netherlands Antilles',
-      nb: 'Nederlandske Antiller',
-    },
-    cdc: '599',
-    iso: 'AN',
-    continent: 'North America',
-  },
-  {
-    i18n: {
       en: 'New Caledonia',
       nb: 'Ny-Caledonia',
     },
@@ -1985,15 +1976,6 @@ const countries: Array<CountryType> = [
     cdc: '47',
     iso: 'SJ',
     continent: 'Europe',
-  },
-  {
-    i18n: {
-      en: 'Swaziland',
-      nb: 'Swaziland',
-    },
-    cdc: '268',
-    iso: 'SZ',
-    continent: 'Africa',
   },
   {
     i18n: {


### PR DESCRIPTION
- Removes Netherlands Antilles. See wiki section and first row for reasoning: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Transitional_reservations
- Removes duplicate SZ entry. See note in entry for SZ: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements 
- Fixes code for Martinique (MQ)