### PR TITLE
fix(Forms): rename "Hviterussland" to "Belarus"

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
@@ -210,7 +210,7 @@ const countries: Array<CountryType> = [
   {
     i18n: {
       en: 'Belarus',
-      nb: 'Hviterussland',
+      nb: 'Belarus',
     },
     cdc: '375',
     iso: 'BY',


### PR DESCRIPTION
Ever since May 2022, the Norwegian Ministry of Foreign Affairs has decided to use the name "Belarus" for Belarus [(source)](https://www.regjeringen.no/no/aktuelt/hviterussland-blir-til-belarus/id2916338/). Unless DNB has made a executive decision to keep the name "Hviterussland", I say we should change it.