### PR TITLE
chore: rename 'Macedonia' to 'North Macedonia'

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
@@ -1213,15 +1213,6 @@ const countries: Array<CountryType> = [
   },
   {
     i18n: {
-      en: 'Macedonia',
-      nb: 'Makedonia',
-    },
-    cdc: '389',
-    iso: 'MK',
-    continent: 'Europe',
-  },
-  {
-    i18n: {
       en: 'Madagascar',
       nb: 'Madagaskar',
     },
@@ -1516,6 +1507,15 @@ const countries: Array<CountryType> = [
     cdc: '850',
     iso: 'KP',
     continent: 'Asia',
+  },
+  {
+    i18n: {
+      en: 'North Macedonia',
+      nb: 'Nord-Makedonia',
+    },
+    cdc: '389',
+    iso: 'MK',
+    continent: 'Europe',
   },
   {
     i18n: {


### PR DESCRIPTION
North Macedonia got its new name starting February 12 2019 [(source)](https://en.wikipedia.org/wiki/Macedonia_naming_dispute).