### PR TITLE
fix(HeightAnimation): enhance adjusting the height to 0

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
@@ -61,6 +61,24 @@ describe('HeightAnimationInstance', () => {
     expect(inst.getHeight()).toBe(100)
   })
 
+  it('getHeight with 0 should return 0', () => {
+    const inst = new HeightAnimationInstance()
+    inst.setElement(element)
+
+    mockHeight(0, element)
+
+    expect(inst.getHeight()).toBe(0)
+  })
+
+  it('getHeight with unknown value should return "null"', () => {
+    const inst = new HeightAnimationInstance()
+    inst.setElement(element)
+
+    mockHeight(undefined, element)
+
+    expect(inst.getHeight()).toBe(null)
+  })
+
   describe('getUnknownHeight', () => {
     it('should return proper height', () => {
       const inst = new HeightAnimationInstance()


### PR DESCRIPTION
When animating/adjusting the height for some value to 0, it did not. Also animating/adjusting from 0 to a a certain value did not work properly.

From value to 0, first the issue and then with the fix:

https://github.com/user-attachments/assets/316d7288-2a2d-4792-90e1-3d41313602a0


https://github.com/user-attachments/assets/93dc3198-0ffd-4eb3-b5de-b7e6f0d6ac76

From 0 to value, first the issue and then with the fix:

https://github.com/user-attachments/assets/ddd21697-60a8-4555-af5d-a1d3a8b6ebc0


https://github.com/user-attachments/assets/cd97dbca-8a1d-46d1-8fd8-16f7cea85b5a



