### PR TITLE
fix(PushContainer): Add missing variant type

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
@@ -17,7 +17,7 @@ import { ContainerMode } from './types'
 
 export type ArrayItemAreaProps = {
   /**
-   * Defines the variant of the ViewContainer or EditContainer. Can be `outline`.
+   * Defines the variant of the ViewContainer, EditContainer or PushContainer. Can be `outline` or `basic`.
    * Defaults to `outline`.
    */
   variant?: 'outline' | 'basic'

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -13,6 +13,7 @@ import { SpacingProps } from '../../../../shared/types'
 import { useSwitchContainerMode } from '../hooks'
 import Toolbar from '../Toolbar'
 import { useTranslation } from '../../hooks'
+import { ArrayItemAreaProps } from '../Array/ArrayItemArea'
 
 export type Props = {
   /**
@@ -52,7 +53,7 @@ export type Props = {
   children: React.ReactNode
 }
 
-export type AllProps = Props & SpacingProps
+export type AllProps = Props & SpacingProps & ArrayItemAreaProps
 
 function PushContainer(props: AllProps) {
   const {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
@@ -21,6 +21,11 @@ export const PushContainerProperties: PropertiesTableProps = {
     type: 'function',
     status: 'optional',
   },
+  variant: {
+    doc: 'Defines the variant of the container. Can be `outline` or `basic`. Defaults to `outline`.',
+    type: 'string',
+    status: 'optional',
+  },
   toolbar: {
     doc: 'A custom toolbar to be shown below the container.',
     type: 'React.Node',


### PR DESCRIPTION
`PushContainer` can use the prop `variant` to change between outline or no outline surrounding the contents.
The prop has not been exposed in the prop type, and using it will result in a typescript error even though it functionally works.