### PR TITLE
feat(Forms): add `preventChangeValidator` to each field

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -390,7 +390,7 @@ export const InitialOpen = () => {
                   label="Land du er statsborger i"
                   itemPath="/"
                   required
-                  preventInputValidator={(value, { connectWithPath }) => {
+                  preventChangeValidator={(value, { connectWithPath }) => {
                     const { getValue } = connectWithPath('/countries')
                     if ((getValue() || []).includes(value)) {
                       return new Error(

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -390,6 +390,14 @@ export const InitialOpen = () => {
                   label="Land du er statsborger i"
                   itemPath="/"
                   required
+                  preventInputValidator={(value, { connectWithPath }) => {
+                    const { getValue } = connectWithPath('/countries')
+                    if ((getValue() || []).includes(value)) {
+                      return new Error(
+                        'You can not have the same country twice',
+                      )
+                    }
+                  }}
                 />
               </Iterate.EditContainer>
             </Iterate.Array>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -149,7 +149,7 @@ describe('Field.SelectCountry', () => {
         <Field.SelectCountry
           noAnimation
           onChange={onChange}
-          preventInputValidator={(value, { connectWithPath }) => {
+          preventChangeValidator={(value, { connectWithPath }) => {
             const { getValue } = connectWithPath('/countries')
             const countries = getValue()
             if (countries.includes(value)) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -86,7 +86,7 @@ export const dataValueProperties: PropertiesTableProps = {
     type: 'function',
     status: 'optional',
   },
-  preventInputValidator: {
+  preventChangeValidator: {
     doc: 'Custom validator function (synchronous) that is triggered when the user makes a change to a field (e.g. making a change to a dropdown). When the function returns an error, the field will not store the new value in the data context or call the onChange event. The given error will be shown.  The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
     type: 'function',
     status: 'optional',

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -87,7 +87,7 @@ export const dataValueProperties: PropertiesTableProps = {
     status: 'optional',
   },
   preventChangeValidator: {
-    doc: 'Custom validator function (synchronous) that is triggered when the user makes a change to a field (e.g. making a change to a dropdown). When the function returns an error, the field will not store the new value in the data context or call the onChange event. The given error will be shown.  The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
+    doc: 'Custom validator function (synchronous) that is triggered when the user makes a change to a field (e.g. making a change to a dropdown). When the function returns an error, the field will not store the new value in the data context or call the onChange event. The given error will be shown. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueDocs.ts
@@ -82,7 +82,12 @@ export const dataValueProperties: PropertiesTableProps = {
     status: 'optional',
   },
   onBlurValidator: {
-    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
+    doc: 'Custom validator function that is triggered when the user leaves a field (e.g. blurring a text input or making a change to a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
+    type: 'function',
+    status: 'optional',
+  },
+  preventInputValidator: {
+    doc: 'Custom validator function (synchronous) that is triggered when the user makes a change to a field (e.g. making a change to a dropdown). When the function returns an error, the field will not store the new value in the data context or call the onChange event. The given error will be shown.  The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -835,10 +835,10 @@ describe('useFieldProps', () => {
       log.mockRestore()
     })
 
-    it('should not update value when preventInputValidator returns error', async () => {
-      const preventInputValidator = jest.fn((value) => {
+    it('should not update value when preventChangeValidator returns error', async () => {
+      const preventChangeValidator = jest.fn((value) => {
         if (value === 'invalid') {
-          return new Error('throw-preventInputValidator')
+          return new Error('throw-preventChangeValidator')
         }
       })
 
@@ -846,7 +846,7 @@ describe('useFieldProps', () => {
       const { result } = renderHook(useFieldProps, {
         initialProps: {
           defaultValue,
-          preventInputValidator,
+          preventChangeValidator,
         },
       })
 
@@ -866,7 +866,7 @@ describe('useFieldProps', () => {
       expect(result.current.value).toBe('bar')
       expect(result.current.error).toBeInstanceOf(Error)
       expect(result.current.error.message).toBe(
-        'throw-preventInputValidator'
+        'throw-preventChangeValidator'
       )
 
       act(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -835,6 +835,48 @@ describe('useFieldProps', () => {
       log.mockRestore()
     })
 
+    it('should not update value when preventInputValidator returns error', async () => {
+      const preventInputValidator = jest.fn((value) => {
+        if (value === 'invalid') {
+          return new Error('throw-preventInputValidator')
+        }
+      })
+
+      const defaultValue = 'foo'
+      const { result } = renderHook(useFieldProps, {
+        initialProps: {
+          defaultValue,
+          preventInputValidator,
+        },
+      })
+
+      const { handleChange } = result.current
+
+      act(() => {
+        handleChange('bar')
+      })
+
+      expect(result.current.value).toBe('bar')
+      expect(result.current.error).toBeUndefined()
+
+      act(() => {
+        handleChange('invalid')
+      })
+
+      expect(result.current.value).toBe('bar')
+      expect(result.current.error).toBeInstanceOf(Error)
+      expect(result.current.error.message).toBe(
+        'throw-preventInputValidator'
+      )
+
+      act(() => {
+        handleChange('baz')
+      })
+
+      expect(result.current.value).toBe('baz')
+      expect(result.current.error).toBeUndefined()
+    })
+
     it('should have correct validation order', async () => {
       const schema: JSONSchema = {
         type: 'string',

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -97,7 +97,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     onChange,
     onBlurValidator,
     validator,
-    preventInputValidator,
+    preventChangeValidator,
     exportValidators,
     schema,
     validateInitially,
@@ -273,10 +273,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   useUpdateEffect(() => {
     onBlurValidatorRef.current = onBlurValidator
   }, [onBlurValidator])
-  const preventInputValidatorRef = useRef(preventInputValidator)
+  const preventChangeValidatorRef = useRef(preventChangeValidator)
   useUpdateEffect(() => {
-    preventInputValidatorRef.current = preventInputValidator
-  }, [preventInputValidator])
+    preventChangeValidatorRef.current = preventChangeValidator
+  }, [preventChangeValidator])
 
   const schemaValidatorRef = useRef<ValidateFunction>(
     schema ? dataContext.ajvInstance?.compile(schema) : undefined
@@ -1294,9 +1294,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         transformers.current.transformValue(fromInput, currentValue)
       )
 
-      if (preventInputValidatorRef.current) {
+      if (preventChangeValidatorRef.current) {
         const result = callValidatorFnSync(
-          preventInputValidatorRef.current,
+          preventChangeValidatorRef.current,
           transformedValue
         )
         if (result instanceof Error) {

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -309,6 +309,7 @@ export interface UseFieldProps<
   schema?: AllJSONSchemaVersions<Value>
   validator?: Validator<Value>
   onBlurValidator?: Validator<Value>
+  preventInputValidator?: Validator<Value>
   exportValidators?: Record<string, Validator<Value>>
   validateRequired?: (
     internal: Value,

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -309,7 +309,7 @@ export interface UseFieldProps<
   schema?: AllJSONSchemaVersions<Value>
   validator?: Validator<Value>
   onBlurValidator?: Validator<Value>
-  preventInputValidator?: Validator<Value>
+  preventChangeValidator?: Validator<Value>
   exportValidators?: Record<string, Validator<Value>>
   validateRequired?: (
     internal: Value,


### PR DESCRIPTION
Should we even call it "Validator"? It acts very similar and has the same API. But it does also a little more, as it actually prevents the "new value" to be a part of the data set. Something which is not possible with our other validators. But on the other side, it also shows an error. So it "validates" the field. Any thoughts?

Quick example:

```tsx
<Field.SelectCountry
  label="Land du er statsborger i"
  required
  preventChangeValidator={(value, { connectWithPath }) => {
    const { getValue } = connectWithPath('/countries')
    if ((getValue() || []).includes(value)) {
      return new Error(
        'You can not have the same country twice',
      )
    }
  }}
/>
```