### PR TITLE
feat(Forms): add `{nextItemNo}` support to Iterate.PushContainer open button

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
@@ -17,13 +17,13 @@ You can place it below the [Array](/uilib/extensions/forms/Iterate/Array/) compo
 import { Iterate, Field } from '@dnb/eufemia/extensions/forms'
 
 render(
-  <>
-    <Iterate.Array>...</Iterate.Array>
+  <Form.Handler>
+    <Iterate.Array path="/myList">...</Iterate.Array>
 
-    <Iterate.PushContainer title="New item title">
+    <Iterate.PushContainer path="/myList" title="New item title">
       <Field.Name.Last itemPath="/name" />
     </Iterate.PushContainer>
-  </>,
+  </Form.Handler>,
 )
 ```
 
@@ -41,10 +41,11 @@ The button will be shown instead of the content provided by the children when th
 import { Iterate, Field } from '@dnb/eufemia/extensions/forms'
 
 render(
-  <>
-    <Iterate.Array>...</Iterate.Array>
+  <Form.Handler>
+    <Iterate.Array path="/myList">...</Iterate.Array>
 
     <Iterate.PushContainer
+      path="/myList"
       title="New item title"
       openButton={
         <Iterate.PushContainer.OpenButton text="Add another item" />
@@ -53,8 +54,33 @@ render(
     >
       Will be hidden based on the showOpenButtonWhen function
     </Iterate.PushContainer>
-  </>,
+  </Form.Handler>,
 )
 ```
 
 The `Iterate.PushContainer.OpenButton` accepts the same props as the [Button](/uilib/components/button/) component.
+
+## Show the next item number in the open button
+
+You can use the `{nextItemNr}` variable in the `text` or `children` property to display the next item number.
+
+```tsx
+import { Iterate, Field, Value } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Iterate.Array path="/myList">...</Iterate.Array>
+
+    <Iterate.PushContainer
+      path="/myList"
+      title="New item title"
+      openButton={
+        <Iterate.PushContainer.OpenButton text="Add no. {nextItemNr}" />
+      }
+      showOpenButtonWhen={(list) => list.length > 0}
+    >
+      <Field.Name.Last itemPath="/name" />
+    </Iterate.PushContainer>
+  </Form.Handler>,
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
@@ -62,7 +62,7 @@ The `Iterate.PushContainer.OpenButton` accepts the same props as the [Button](/u
 
 ## Show the next item number in the open button
 
-You can use the `{nextItemNr}` variable in the `text` or `children` property to display the next item number.
+You can use the `{nextItemNo}` variable in the `text` or `children` property to display the next item number.
 
 ```tsx
 import { Iterate, Field, Value } from '@dnb/eufemia/extensions/forms'
@@ -75,7 +75,7 @@ render(
       path="/myList"
       title="New item title"
       openButton={
-        <Iterate.PushContainer.OpenButton text="Add no. {nextItemNr}" />
+        <Iterate.PushContainer.OpenButton text="Add no. {nextItemNo}" />
       }
       showOpenButtonWhen={(list) => list.length > 0}
     >

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/OpenButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/OpenButton.tsx
@@ -21,9 +21,9 @@ function OpenButton(props: Props) {
     if (children || text) {
       const str = convertJsxToString(children || text)
 
-      if (str.includes('{nextItemNr}')) {
-        const nextItemNr = (entries?.length || 0) + 1
-        return str.replace('{nextItemNr}', String(nextItemNr))
+      if (str.includes('{nextItemNo}')) {
+        const nextItemNo = (entries?.length || 0) + 1
+        return str.replace('{nextItemNo}', String(nextItemNo))
       }
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/OpenButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/OpenButton.tsx
@@ -1,18 +1,34 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import classnames from 'classnames'
 import Button, { ButtonProps } from '../../../../components/Button'
 import { add } from '../../../../icons'
 import IterateItemContext from '../IterateItemContext'
+import PushContainerContext from './PushContainerContext'
+import { convertJsxToString } from '../../../../shared/component-helper'
 
 type Props = ButtonProps
 
 function OpenButton(props: Props) {
-  const { className, children, ...restProps } = props
+  const { className, text, children, ...restProps } = props
   const { switchContainerMode } = useContext(IterateItemContext) || {}
+  const { entries } = useContext(PushContainerContext) || {}
 
   const handleClick = useCallback(() => {
     switchContainerMode?.('edit')
   }, [switchContainerMode])
+
+  const content = useMemo(() => {
+    if (children || text) {
+      const str = convertJsxToString(children || text)
+
+      if (str.includes('{nextItemNr}')) {
+        const nextItemNr = (entries?.length || 0) + 1
+        return str.replace('{nextItemNr}', String(nextItemNr))
+      }
+    }
+
+    return children || text
+  }, [entries?.length, children, text])
 
   return (
     <Button
@@ -23,7 +39,7 @@ function OpenButton(props: Props) {
       on_click={handleClick}
       {...restProps}
     >
-      {children}
+      {content}
     </Button>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -525,7 +525,7 @@ describe('PushContainer', () => {
     log.mockRestore()
   })
 
-  it('should support {nextItemNr}', async () => {
+  it('should support {nextItemNo}', async () => {
     render(
       <Form.Handler data={{ myList: undefined }}>
         <Iterate.Array path="/myList">
@@ -536,7 +536,7 @@ describe('PushContainer', () => {
         <Iterate.PushContainer
           path="/myList"
           openButton={
-            <Iterate.PushContainer.OpenButton text="Add no. {nextItemNr}" />
+            <Iterate.PushContainer.OpenButton text="Add no. {nextItemNo}" />
           }
           showOpenButtonWhen={(list) => list.length >= 0}
         >

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -141,11 +141,7 @@ describe('PushContainer', () => {
   it('should render children with initial data value as an object', () => {
     render(
       <Form.Handler>
-        <Iterate.PushContainer
-          path="/entries"
-          data={{ name: 'Tony' }}
-          openButton={<Iterate.PushContainer.OpenButton />}
-        >
+        <Iterate.PushContainer path="/entries" data={{ name: 'Tony' }}>
           <Field.String itemPath="/name" />
         </Iterate.PushContainer>
       </Form.Handler>
@@ -527,5 +523,40 @@ describe('PushContainer', () => {
     )
 
     log.mockRestore()
+  })
+
+  it('should support {nextItemNr}', async () => {
+    render(
+      <Form.Handler data={{ myList: undefined }}>
+        <Iterate.Array path="/myList">
+          <Iterate.ViewContainer>View Content</Iterate.ViewContainer>
+          <Iterate.EditContainer>Edit Content</Iterate.EditContainer>
+        </Iterate.Array>
+
+        <Iterate.PushContainer
+          path="/myList"
+          openButton={
+            <Iterate.PushContainer.OpenButton text="Add no. {nextItemNr}" />
+          }
+          showOpenButtonWhen={(list) => list.length >= 0}
+        >
+          <Field.String itemPath="/name" />
+        </Iterate.PushContainer>
+      </Form.Handler>
+    )
+
+    const openButton = document.querySelector(
+      '.dnb-forms-iterate-open-button'
+    )
+    const doneButton = document.querySelector('button')
+
+    expect(openButton).toHaveTextContent('Add no. 1')
+
+    await userEvent.click(doneButton)
+    expect(openButton).toHaveTextContent('Add no. 2')
+
+    const removeButton = document.querySelectorAll('button')[1]
+    await userEvent.click(removeButton)
+    expect(openButton).toHaveTextContent('Add no. 1')
   })
 })


### PR DESCRIPTION
Quick example:

```tsx
<Form.Handler>
  <Iterate.Array path="/myList">...</Iterate.Array>

  <Iterate.PushContainer
    path="/myList"
    title="New item title"
    openButton={
      <Iterate.PushContainer.OpenButton text="Add no. {nextItemNo}" />
    }
    showOpenButtonWhen={(list) => list.length > 0}
  >
    <Field.Name.Last itemPath="/name" />
  </Iterate.PushContainer>
</Form.Handler>
```