### PR TITLE
fix(Forms): remove unwanted Iterate.EditContainer error confirmation when using required on Form.Handler

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -72,13 +72,14 @@ function ArrayComponent(props: Props) {
         }
 
         return {
+          required: false,
           ...props,
           value: newValue,
         }
       }
     }
 
-    return props
+    return { required: false, ...props }
   }, [getValueByPath, props])
 
   const {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/DoneButton.tsx
@@ -16,7 +16,6 @@ export default function DoneButton(props: Props) {
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
     useContext(FieldBoundaryContext) || {}
   const { commitHandleRef } = useContext(PushContainerContext) || {}
-  useContext(FieldBoundaryContext) || {}
   const { setShowError } = useContext(ToolbarContext) || {}
 
   const { doneButton } = useTranslation().IterateEditContainer

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -150,6 +150,52 @@ describe('EditContainer and ViewContainer', () => {
     expect(containerMode).toBe('edit')
   })
 
+  it('should not show error if every field is required via Form.Handler required', async () => {
+    let containerMode = null
+
+    const ContextConsumer = () => {
+      const context = React.useContext(IterateItemContext)
+      containerMode = context.containerMode
+
+      return null
+    }
+
+    render(
+      <Form.Handler required defaultData={{ myList: ['foo'] }}>
+        <Iterate.Array path="/myList">
+          <Iterate.ViewContainer>ViewContainer</Iterate.ViewContainer>
+          <Iterate.EditContainer>EditContainer</Iterate.EditContainer>
+          <ContextConsumer />
+        </Iterate.Array>
+      </Form.Handler>
+    )
+
+    const [editButton, removeButton, doneButton, cancelButton] =
+      Array.from(document.querySelectorAll('button'))
+
+    expect(containerMode).toBe('view')
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+
+    expect(editButton).toHaveTextContent(tr.viewContainer.editButton)
+    expect(removeButton).toHaveTextContent(tr.viewContainer.removeButton)
+    expect(doneButton).toHaveTextContent(tr.editContainer.doneButton)
+    expect(cancelButton).toHaveTextContent(tr.editContainer.cancelButton)
+
+    await userEvent.click(editButton)
+    expect(containerMode).toBe('edit')
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(doneButton)
+    expect(containerMode).toBe('view')
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+  })
+
   describe('focus management', () => {
     it('should not set focus when container opens initially in edit mode', async () => {
       let containerMode = null

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 import { Button } from '../../../../components'
 import { ButtonProps } from '../../../../components/Button'
 import IterateItemContext from '../IterateItemContext'
-import { useFieldProps, useTranslation } from '../../hooks'
+import { useTranslation } from '../../hooks'
 import ArrayItemAreaContext from '../Array/ArrayItemAreaContext'
 import {
   DataValueReadWriteComponentProps,
@@ -22,8 +22,7 @@ function RemoveButton(props: Props) {
     throw new Error('RemoveButton must be inside an Iterate.Array')
   }
 
-  const { className, ...restProps } = props
-  const { children, text } = useFieldProps(restProps)
+  const { text, children, className, ...restProps } = props
   const buttonProps = omitDataValueReadWriteProps(restProps)
   const translation = useTranslation().RemoveButton
   const textContent = text || children || translation.text

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
@@ -688,6 +688,7 @@ describe('Tools.ListAllProps', () => {
           },
           "countPath": "/count",
           "path": "/items",
+          "required": false,
           "value": [
             {
               "item": 0,

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/__snapshots__/ChildrenWithAge.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/__snapshots__/ChildrenWithAge.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`ChildrenWithAge should match snapshot 1`] = `
     "countPath": "/countChildren",
     "countPathLimit": 20,
     "path": "/children",
-    "required": true,
+    "required": false,
     "translations": {
       "en-GB": {
         "ChildrenWithAge": {


### PR DESCRIPTION
When `required` was set on the Form.Handler, this code;

```tsx
<Form.Handler required>
  <Iterate.Array path="/myList">
    <Iterate.ViewContainer>ViewContainer</Iterate.ViewContainer>
    <Iterate.EditContainer>EditContainer</Iterate.EditContainer>
  </Iterate.Array>
  <Iterate.PushButton path="/myList" pushValue={{}} />
</Form.Handler>
```

did result in this;

<img width="318" alt="Screenshot 2024-09-15 at 20 20 06" src="https://github.com/user-attachments/assets/f9d872e3-7fa4-4c5e-8ceb-d27a921406fe">

... when pressing the done button.

This happened because the remove button did use the hook `useFieldProps` which is meant to be used by fields. So it suddenly did validate as required.