### PR TITLE
fix(Forms): enhance container boundary error handling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -376,7 +376,7 @@ export const InitialOpen = () => {
         <Flex.Stack>
           <Form.MainHeading>Statsborgerskap</Form.MainHeading>
 
-          <Card align="stretch">
+          <Card stack>
             <Iterate.Array path="/countries" defaultValue={[null]}>
               <Iterate.ViewContainer toolbarVariant="minimumOneItem">
                 <Value.SelectCountry

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -120,7 +120,7 @@ export interface ContextState {
     type: EventListenerCall['type'],
     callback: EventListenerCall['callback']
   ) => void
-  setHasVisibleError?: (path: Path, hasError: boolean) => void
+  setVisibleError?: (path: Path, hasError: boolean) => void
   setFieldProps?: (path: Path, props: unknown) => void
   setValueProps?: (path: Path, props: unknown) => void
   setHandleSubmit?: (callback: HandleSubmitCallback) => void

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryContext.ts
@@ -39,6 +39,11 @@ export interface FieldBoundaryContextState {
    * To set the local error state.
    */
   setFieldError?: (path: Path, error: Error) => void
+
+  /**
+   * To set the local visible error state.
+   */
+  setVisibleError?: (path: Path, hasError: boolean) => void
 }
 
 const FieldBoundaryContext = React.createContext<

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
@@ -14,7 +14,7 @@ export type Props = {
 export default function FieldBoundaryProvider(props: Props) {
   const { showErrors = false, onPathError = null, children } = props
   const [, forceUpdate] = useReducer(() => ({}), {})
-  const { showAllErrors, hasVisibleError } = useContext(DataContext)
+  const { showAllErrors } = useContext(DataContext)
 
   const onPathErrorRef = useRef(onPathError)
   onPathErrorRef.current = onPathError
@@ -34,6 +34,16 @@ export default function FieldBoundaryProvider(props: Props) {
     onPathErrorRef.current?.(path, error)
   }, [])
 
+  const hasVisibleErrorRef = useRef<Record<Path, boolean>>({})
+  const setVisibleError = useCallback((path: Path, hasError: boolean) => {
+    if (hasError) {
+      hasVisibleErrorRef.current[path] = hasError
+    } else {
+      delete hasVisibleErrorRef.current[path]
+    }
+    forceUpdate()
+  }, [])
+
   const setShowBoundaryErrors: FieldBoundaryContextState['setShowBoundaryErrors'] =
     useCallback((showBoundaryErrors) => {
       showBoundaryErrorsRef.current = showBoundaryErrors
@@ -43,11 +53,12 @@ export default function FieldBoundaryProvider(props: Props) {
   const context: FieldBoundaryContextState = {
     hasError,
     hasSubmitError,
-    hasVisibleError,
+    hasVisibleError: Object.keys(hasVisibleErrorRef.current).length > 0,
     errorsRef,
     showBoundaryErrors: showBoundaryErrorsRef.current,
     setShowBoundaryErrors,
     setFieldError,
+    setVisibleError,
   }
 
   return (

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
@@ -77,6 +77,7 @@ describe('FieldBoundaryProvider', () => {
       hasVisibleError: true,
       showBoundaryErrors: false,
       setFieldError: expect.any(Function),
+      setVisibleError: expect.any(Function),
       setShowBoundaryErrors: expect.any(Function),
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -239,17 +239,14 @@ export default function Provider<Data extends JsonObject>(
     showAllErrorsRef.current = showAllErrors
     forceUpdate()
   }, [])
-  const setHasVisibleError = useCallback(
-    (path: Path, hasError: boolean) => {
-      if (hasError) {
-        hasVisibleErrorRef.current[path] = hasError
-      } else {
-        delete hasVisibleErrorRef.current[path]
-      }
-      forceUpdate() // Will rerender the whole form initially
-    },
-    []
-  )
+  const setVisibleError = useCallback((path: Path, hasError: boolean) => {
+    if (hasError) {
+      hasVisibleErrorRef.current[path] = hasError
+    } else {
+      delete hasVisibleErrorRef.current[path]
+    }
+    forceUpdate() // Will rerender the whole form initially
+  }, [])
   const submitStateRef = useRef<Partial<EventStateObject>>({})
   const setSubmitState = useCallback((state: EventStateObject) => {
     Object.assign(submitStateRef.current, state)
@@ -1158,7 +1155,7 @@ export default function Provider<Data extends JsonObject>(
         setFormState,
         setSubmitState,
         setShowAllErrors,
-        setHasVisibleError,
+        setVisibleError,
         setFieldEventListener,
         setFieldState,
         setFieldError,

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
@@ -120,7 +120,7 @@ export const ViewAndEditContainer = () => {
         <Flex.Vertical>
           <Form.MainHeading>Accounts</Form.MainHeading>
 
-          <Card align="stretch">
+          <Card stack>
             <Iterate.Array path="/accounts">
               <MyViewItem />
               <MyEditItem />

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -162,7 +162,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     setFieldState: setFieldStateDataContext,
     setFieldError: setFieldErrorDataContext,
     setFieldProps: setPropsDataContext,
-    setHasVisibleError: setHasVisibleErrorDataContext,
+    setVisibleError: setVisibleErrorDataContext,
     setMountedFieldState: setMountedFieldStateDataContext,
     setFieldEventListener,
     errors: dataContextErrors,
@@ -181,7 +181,11 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const { handleChange: handleChangeIterateContext } =
     iterateItemContext || {}
   const { path: sectionPath, errorPrioritization } = sectionContext || {}
-  const { setFieldError, showBoundaryErrors } = fieldBoundaryContext || {}
+  const {
+    setFieldError: setFieldErrorBoundary,
+    setVisibleError: setVisibleErrorBoundary,
+    showBoundaryErrors,
+  } = fieldBoundaryContext || {}
 
   const hasPath = Boolean(pathProp)
   const { path, identifier, makeIteratePath } = usePath({
@@ -375,11 +379,13 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     if (!revealErrorRef.current) {
       revealErrorRef.current = true
       showFieldErrorFieldBlock?.(identifier, true)
-      setHasVisibleErrorDataContext?.(identifier, !!localErrorRef.current)
+      setVisibleErrorBoundary?.(identifier, !!localErrorRef.current)
+      setVisibleErrorDataContext?.(identifier, !!localErrorRef.current)
     }
   }, [
     identifier,
-    setHasVisibleErrorDataContext,
+    setVisibleErrorDataContext,
+    setVisibleErrorBoundary,
     showFieldErrorFieldBlock,
     validateInitially,
   ])
@@ -388,9 +394,15 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     if (revealErrorRef.current) {
       revealErrorRef.current = undefined
       showFieldErrorFieldBlock?.(identifier, false)
-      setHasVisibleErrorDataContext?.(identifier, false)
+      setVisibleErrorBoundary?.(identifier, false)
+      setVisibleErrorDataContext?.(identifier, false)
     }
-  }, [identifier, setHasVisibleErrorDataContext, showFieldErrorFieldBlock])
+  }, [
+    identifier,
+    setVisibleErrorBoundary,
+    setVisibleErrorDataContext,
+    showFieldErrorFieldBlock,
+  ])
 
   /**
    * Prepare error from validation logic with correct error messages based on props
@@ -611,7 +623,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
       // Tell the data context about the error, so it can stop the user from submitting the form until the error has been fixed
       setFieldErrorDataContext?.(identifier, error)
-      setFieldError?.(identifier, error)
+      setFieldErrorBoundary?.(identifier, error)
 
       // Set the visual states
       setFieldStateDataContext?.(identifier, error ? 'error' : undefined)
@@ -629,7 +641,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       prepareError,
       setFieldErrorDataContext,
       identifier,
-      setFieldError,
+      setFieldErrorBoundary,
       setFieldStateDataContext,
       setFieldStateFieldBlock,
       stateId,
@@ -1403,12 +1415,12 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         isMounted: false,
       })
       setFieldErrorDataContext?.(identifier, undefined)
-      setFieldError?.(identifier, undefined)
+      setFieldErrorBoundary?.(identifier, undefined)
       localErrorRef.current = undefined
     }
   }, [
     identifier,
-    setFieldError,
+    setFieldErrorBoundary,
     setFieldErrorDataContext,
     setMountedFieldStateDataContext,
   ])


### PR DESCRIPTION
This PR adds the "visible error" logic to the field boundary. 

Before it just inherited it from the global data context, which could lead in worst case to error disturbance, similar to what [happened here](https://github.com/dnbexperience/eufemia/pull/3938).