### PR TITLE
fix(Forms): enhance Field props pre-render routine in Wizard steps

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -20,7 +20,6 @@ import FieldBlockContext, {
   FieldBlockContextProps,
   StateBasis,
 } from './FieldBlockContext'
-import DataContext from '../DataContext/Context'
 import IterateElementContext from '../Iterate/IterateItemContext'
 import { Space, FormLabel, FormStatus } from '../../../components'
 import { Ul, Li } from '../../../elements'
@@ -83,7 +82,6 @@ export type Props = Pick<
 } & React.HTMLAttributes<HTMLDivElement>
 
 function FieldBlock(props: Props) {
-  const dataContext = useContext(DataContext)
   const nestedFieldBlockContext = useContext(FieldBlockContext)
 
   const sharedData = createSharedState<Props>(
@@ -423,10 +421,6 @@ function FieldBlock(props: Props) {
     space: { top: 0, bottom: 'x-small' },
     size: labelSize,
     disabled,
-  }
-
-  if (dataContext?.prerenderFieldProps) {
-    return null
   }
 
   if (fieldState && typeof label === 'undefined') {

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -11,7 +11,6 @@ import { Dd, Dl, Dt, Span } from '../../../elements'
 import { FormLabel } from '../../../components'
 import SummaryListContext from '../Value/SummaryList/SummaryListContext'
 import ValueBlockContext from './ValueBlockContext'
-import DataContext from '../DataContext/Context'
 import { ValueProps } from '../types'
 import { pickSpacingProps } from '../../../components/flex/utils'
 import IterateElementContext from '../Iterate/IterateItemContext'
@@ -37,7 +36,6 @@ export type Props = Omit<ValueProps<unknown>, 'value'> & {
 function ValueBlock(props: Props) {
   const summaryListContext = useContext(SummaryListContext)
   const valueBlockContext = useContext(ValueBlockContext)
-  const dataContext = useContext(DataContext)
   const iterateItemContext = useContext(IterateElementContext)
   const { index: iterateIndex } = iterateItemContext ?? {}
 
@@ -70,10 +68,9 @@ function ValueBlock(props: Props) {
   useNotInSummaryList(valueBlockContext?.composition ? null : ref, label)
 
   if (
-    ((children === undefined || children === null || children === false) &&
-      !showEmpty &&
-      !placeholder) ||
-    dataContext?.prerenderFieldProps
+    (children === undefined || children === null || children === false) &&
+    !showEmpty &&
+    !placeholder
   ) {
     return null
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -284,7 +284,7 @@ function WizardContainer(props: Props) {
 
   const titlesRef = useRef({})
   const updateTitlesRef = useRef<() => void>()
-  const prerenderFieldPropsRef = useRef<
+  const prerenderFieldsRef = useRef<
     Record<string, () => React.ReactElement>
   >({})
 
@@ -301,7 +301,7 @@ function WizardContainer(props: Props) {
       activeIndexRef,
       totalStepsRef,
       prerenderFieldProps,
-      prerenderFieldPropsRef,
+      prerenderFieldsRef,
       check,
       setActiveIndex,
       handlePrevious,
@@ -365,7 +365,7 @@ function WizardContainer(props: Props) {
 
       {prerenderFieldProps && (
         <PrerenderFieldPropsOfOtherSteps
-          prerenderFieldPropsRef={prerenderFieldPropsRef}
+          prerenderFieldsRef={prerenderFieldsRef}
         />
       )}
     </WizardContext.Provider>
@@ -412,7 +412,7 @@ function IterateOverSteps({ children }) {
     activeIndexRef,
     totalStepsRef,
     prerenderFieldProps,
-    prerenderFieldPropsRef,
+    prerenderFieldsRef,
   } = useContext(WizardContext)
 
   titlesRef.current = {}
@@ -459,10 +459,10 @@ function IterateOverSteps({ children }) {
           prerenderFieldProps &&
           typeof document !== 'undefined' &&
           index !== activeIndexRef.current &&
-          typeof prerenderFieldPropsRef.current['step-' + index] ===
+          typeof prerenderFieldsRef.current['step-' + index] ===
             'undefined'
         ) {
-          prerenderFieldPropsRef.current['step-' + index] = () =>
+          prerenderFieldsRef.current['step-' + index] = () =>
             clone({
               key,
               index,
@@ -494,9 +494,9 @@ function IterateOverSteps({ children }) {
 }
 
 function PrerenderFieldPropsOfOtherSteps({
-  prerenderFieldPropsRef,
+  prerenderFieldsRef,
 }: {
-  prerenderFieldPropsRef: WizardContextState['prerenderFieldPropsRef']
+  prerenderFieldsRef: WizardContextState['prerenderFieldsRef']
 }) {
   const hasRenderedRef = useRef(true)
   if (!hasRenderedRef.current) {
@@ -508,7 +508,7 @@ function PrerenderFieldPropsOfOtherSteps({
     <WizardPortal>
       <PrerenderFieldPropsProvider>
         <iframe title="Wizard Prerender" hidden>
-          {Object.values(prerenderFieldPropsRef.current).map((Fn, i) => (
+          {Object.values(prerenderFieldsRef.current).map((Fn, i) => (
             <Fn key={i} />
           ))}
         </iframe>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -1821,11 +1821,7 @@ describe('Wizard.Container', () => {
 
             <Wizard.Step title="Step 3">
               <Field.String path="/fooStep3" />
-              <Field.String
-                path="/barStep3"
-                // excludeFromFilterData
-                data-exclude-field
-              />
+              <Field.String path="/barStep3" data-exclude-field />
               <Wizard.Buttons />
             </Wizard.Step>
           </Wizard.Container>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
@@ -27,7 +27,7 @@ export interface WizardContextState {
   updateTitlesRef?: React.MutableRefObject<() => void>
   activeIndexRef?: React.MutableRefObject<StepIndex>
   totalStepsRef?: React.MutableRefObject<number>
-  prerenderFieldPropsRef?: React.MutableRefObject<
+  prerenderFieldsRef?: React.MutableRefObject<
     Record<string, () => React.ReactElement>
   >
   prerenderFieldProps?: boolean

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import React, {
   useRef,
   useEffect,
@@ -168,6 +169,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     errors: dataContextErrors,
     showAllErrors,
     contextErrorMessages,
+    prerenderFieldProps,
   } = dataContext || {}
   const onChangeContext = dataContext?.props?.onChange
 
@@ -193,6 +195,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     path: pathProp,
     itemPath,
   })
+
+  // Put props into the surrounding data context as early as possible
+  setPropsDataContext?.(identifier, props)
 
   const defaultValueRef = useRef(defaultValue)
   const externalValue =
@@ -1401,7 +1406,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const handleBlur = useCallback(() => setHasFocus(false), [setHasFocus])
 
   // Put props into the surrounding data context as early as possible
-  setPropsDataContext?.(identifier, props)
+  // setPropsDataContext?.(identifier, props)
 
   useEffect(() => {
     // Mount procedure.
@@ -1555,6 +1560,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     validateDataDataContext,
     valueProp,
   ])
+
+  if (prerenderFieldProps) {
+    return {} as typeof props & ReturnAdditional<Value>
+  }
 
   useEffect(() => {
     if (showAllErrors || showBoundaryErrors) {


### PR DESCRIPTION
This PR should not change anything, expect it will enhance performance, as we bail out as early as possible during the Wizard step "props per-render" phase. This saves us unnecessary code and imperative solutions in further features.

It may be a bit controversial to break out early in a React hook and silence the `react-hooks/rules-of-hooks` error. But on the other side, we do not re-render when this call happens. We just run it once, so it should not have any negative side-effects.