### PR TITLE
chore: minor spelling improvement witch -> any

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/info.mdx
@@ -50,7 +50,7 @@ By default it has no validation. But you can enable it by giving a `required`, `
 
 ### Norwegian mobile numbers
 
-E.g. the following pattern will strictly match Norwegian mobile numbers, which are defined as having a "+47" country code, followed by a number starting with 4 or 9, and exactly 7 more digits. If the country code is set to any other two-digit code, the pattern will match witch 6 digits after the country code.
+E.g. the following pattern will strictly match Norwegian mobile numbers, which are defined as having a "+47" country code, followed by a number starting with 4 or 9, and exactly 7 more digits. If the country code is set to any other two-digit code, the pattern will match any 6 digits after the country code.
 
 ```jsx
 <Field.PhoneNumber pattern="((?=\+47)^\+47 [49]\d{7}$)|((?!\+47)^\+\d{2} \d{6})" />


### PR DESCRIPTION
This is a witch, we don't like witches 🧙‍♀️ 
![image](https://github.com/user-attachments/assets/987b4488-1c45-4cc9-ba41-5c528078c10d)


Not sure if the sentence I updated makes sense seen up against the [regex](https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/PhoneNumber/#norwegian-mobile-numbers) it should describe.