### PR TITLE
chore: split out ChildrenWithAge into its own docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
@@ -1,7 +1,15 @@
 ---
 title: 'ChildrenWithAge'
+description: '`ChildrenWithAge` is a block for displaying children with age.'
 hideInMenu: true
-showTabs: false
+showTabs: true
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+  - title: Properties
+    key: '/properties'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
@@ -10,45 +18,8 @@ breadcrumb:
   - text: ChildrenWithAge
 ---
 
-import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import { ChildrenWithAgeProperties } from '@dnb/eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs'
-import * as Examples from './Examples'
+import Info from 'Docs/uilib/extensions/forms/blocks/ChildrenWithAge/info'
+import Demos from 'Docs/uilib/extensions/forms/blocks/ChildrenWithAge/demos'
 
-# ChildrenWithAge
-
-`ChildrenWithAge` is a block for displaying children with age. Check out the [source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge) for more information.
-
-## Usage
-
-```tsx
-import { ChildrenWithAge } from '@dnb/eufemia/extensions/forms/blocks'
-render(<ChildrenWithAge />)
-```
-
-## In Wizard
-
-All features are enabled in this example.
-
-<Examples.ChildrenWithAgeWizard />
-
-## Basic
-
-<Examples.ChildrenWithAge />
-
-## With `joint-responsibility` question
-
-<Examples.ChildrenWithAge
-  enableAdditionalQuestions={['joint-responsibility']}
-/>
-
-## With `daycare` question
-
-<Examples.ChildrenWithAge enableAdditionalQuestions={['daycare']} />
-
-## Properties
-
-<PropertiesTable props={ChildrenWithAgeProperties} />
-
-<VisibleWhenVisualTest>
-  <Examples.ChildrenWithAgePrefilledYes />
-</VisibleWhenVisualTest>
+<Info />
+<Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from 'react'
-import ComponentBox from '../../../../../shared/tags/ComponentBox'
+import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Flex, HelpButton, Lead, Section } from '@dnb/eufemia/src'
 import {
   Field,

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/demos.mdx
@@ -1,0 +1,31 @@
+---
+showTabs: true
+---
+
+import * as Examples from './Examples'
+
+## Demos
+
+### In Wizard
+
+All features are enabled in this example.
+
+<Examples.ChildrenWithAgeWizard />
+
+### Basic
+
+<Examples.ChildrenWithAge />
+
+### With `joint-responsibility` question
+
+<Examples.ChildrenWithAge
+  enableAdditionalQuestions={['joint-responsibility']}
+/>
+
+### With `daycare` question
+
+<Examples.ChildrenWithAge enableAdditionalQuestions={['daycare']} />
+
+<VisibleWhenVisualTest>
+  <Examples.ChildrenWithAgePrefilledYes />
+</VisibleWhenVisualTest>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/info.mdx
@@ -1,0 +1,12 @@
+---
+showTabs: true
+---
+
+## Description
+
+`ChildrenWithAge` is a block for displaying children with age. Check out the [source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge) for more information.
+
+```tsx
+import { ChildrenWithAge } from '@dnb/eufemia/extensions/forms/blocks'
+render(<ChildrenWithAge />)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/properties.mdx
@@ -2,9 +2,15 @@
 showTabs: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { ChildrenWithAgeProperties } from '@dnb/eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs'
+import { translations } from '@dnb/eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeTranslations'
 
 ## Properties
 
 <PropertiesTable props={ChildrenWithAgeProperties} />
+
+## Translations
+
+<TranslationsTable source={translations} localeKey="ChildrenWithAge" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/properties.mdx
@@ -1,0 +1,10 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { ChildrenWithAgeProperties } from '@dnb/eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs'
+
+## Properties
+
+<PropertiesTable props={ChildrenWithAgeProperties} />

--- a/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
@@ -4,6 +4,7 @@ import { extendDeep, warn } from '@dnb/eufemia/src/shared/component-helper'
 import globalTranslations from '@dnb/eufemia/src/shared/locales'
 import formsTranslations from '@dnb/eufemia/src/extensions/forms/constants/locales'
 import { FormattedCode } from './PropertiesTable'
+import { Translation } from '@dnb/eufemia/src/shared/Context'
 
 const StyledTable = styled(Table)`
   td {
@@ -11,17 +12,17 @@ const StyledTable = styled(Table)`
   }
 `
 
-const allTranslations = extendDeep(
-  {},
-  globalTranslations,
-  formsTranslations,
-)
-
 export default function TranslationsTable({
   localeKey,
+  source = null,
 }: {
   localeKey?: string | Array<string>
+  source?: Record<string, Translation>
 }) {
+  if (!source) {
+    source = extendDeep({}, globalTranslations, formsTranslations)
+  }
+
   const entries = {}
   const allowList = {}
   const localeKeys = (
@@ -37,7 +38,7 @@ export default function TranslationsTable({
     return key
   })
 
-  function addToEntries(key, translation, locale, localeKey) {
+  const addToEntries = (key, translation, locale, localeKey) => {
     key = `${localeKey}.${key}`
     if (allowList[localeKey] && !allowList[localeKey].includes(key)) {
       return
@@ -47,7 +48,7 @@ export default function TranslationsTable({
     })
   }
 
-  Object.entries(allTranslations).forEach(([locale, translations]) => {
+  Object.entries(source).forEach(([locale, translations]) => {
     localeKeys.forEach((localeKey) => {
       const translationsObj = translations[localeKey]
       if (!translationsObj) {
@@ -69,7 +70,7 @@ export default function TranslationsTable({
     })
   })
 
-  const locales = Object.keys(allTranslations)
+  const locales = Object.keys(source)
   const tableRows = Object.entries(entries).map(([key, values]) => {
     return (
       <Tr key={key}>

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.screenshot.test.ts
@@ -11,7 +11,7 @@ import {
 describe.each(['ui', 'sbanken'])('ChildrenWithAge for %s', (themeName) => {
   setupPageScreenshot({
     themeName,
-    url: '/uilib/extensions/forms/blocks/ChildrenWithAge',
+    url: '/uilib/extensions/forms/blocks/ChildrenWithAge/demos',
   })
 
   it('have to match when answering yes to all options', async () => {
@@ -24,7 +24,7 @@ describe.each(['ui', 'sbanken'])('ChildrenWithAge for %s', (themeName) => {
 
 describe('ChildrenWithAge', () => {
   setupPageScreenshot({
-    url: '/uilib/extensions/forms/blocks/ChildrenWithAge',
+    url: '/uilib/extensions/forms/blocks/ChildrenWithAge/demos',
     pageViewport: {
       width: 480, // 30rem
     },


### PR DESCRIPTION
TODO before merging: 

- [x] Check if there's any links that's now outdated(as I've made own Pages for info, demos, properties). 
- [x] Display the translations for this block? Not sure if that's easy, as the translations is sort of "on the side" in the file `ChildrenWithAgeTranslations.ts`, and it’s structured a bit differently than other translations. 