### PR TITLE
docs: fix markdown link to text counter component

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
@@ -17,7 +17,7 @@ You may consider to use [InputMasked](/uilib/components/input-masked/) for forma
 
 ### Accessibility
 
-Please avoid using the `maxlength` attribute when possible, as it may lower good accessibility. You can instead, use the [TextCounter][/uilib/components/fragments/text-counter/] component.
+Please avoid using the `maxlength` attribute when possible, as it may lower good accessibility. You can instead, use the [TextCounter](/uilib/components/fragments/text-counter/) component.
 
 But you may also consider to use a multiline input with a `characterCounter`:
 


### PR DESCRIPTION
Fixes this incorrect markdown link on the [input component page](https://eufemia.dnb.no/uilib/components/input/#accessibility):

![CleanShot 2024-09-18 at 15 30 08](https://github.com/user-attachments/assets/a5953091-3656-4d81-86d7-799ce78ac96d)
