### PR TITLE
fix(Forms): ensure `defaultValue` works in React.StrictMode

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -82,6 +82,27 @@ describe('useFieldProps', () => {
       })
     })
 
+    it('should support ReactStrict mode', () => {
+      const defaultValue = 'include this'
+
+      const { result } = renderHook(
+        () => useFieldProps({ path: '/foo', defaultValue }),
+        {
+          wrapper: ({ children }) => {
+            return (
+              <React.StrictMode>
+                <Provider>{children}</Provider>
+              </React.StrictMode>
+            )
+          },
+        }
+      )
+
+      expect(result.current.dataContext.data).toEqual({
+        foo: defaultValue,
+      })
+    })
+
     it('given "defaultValue" should not take precedence over data context value', () => {
       const givenValue = 'given value'
       const defaultValue = 'include this'
@@ -90,7 +111,9 @@ describe('useFieldProps', () => {
         () => useFieldProps({ path: '/foo', defaultValue }),
         {
           wrapper: (props) => (
-            <Provider data={{ foo: givenValue }} {...props} />
+            <React.StrictMode>
+              <Provider data={{ foo: givenValue }} {...props} />
+            </React.StrictMode>
           ),
         }
       )

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -27,6 +27,7 @@ import FieldPropsContext from '../Form/FieldProps/FieldPropsContext'
 import { combineDescribedBy, warn } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import useUpdateEffect from '../../../shared/helpers/useUpdateEffect'
+import useMountEffect from '../../../shared/helpers/useMountEffect'
 import FieldBlockContext from '../FieldBlock/FieldBlockContext'
 import IterateElementContext from '../Iterate/IterateItemContext'
 import SectionContext from '../Form/Section/SectionContext'
@@ -200,6 +201,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   })
 
   const defaultValueRef = useRef(defaultValue)
+  useMountEffect(() => {
+    // To support ReactStrict mode, we also need to add it from inside a useEffect
+    defaultValueRef.current = defaultValue
+  })
   const externalValue =
     useExternalValue<Value>({
       path,


### PR DESCRIPTION
This can be experienced e.g. in the ChildrenWithAge block rendered in React.StrictMode. Then non of the default values are selected.

<img width="284" alt="Screenshot 2024-09-18 at 22 02 08" src="https://github.com/user-attachments/assets/dc26c179-49c9-44de-8803-8c0c254d09e3">

