### PR TITLE
fix(Forms): enhance reset routine of ChildrenWithAge block

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/demos.mdx
@@ -44,7 +44,7 @@ This example is only for demo purpose and will NOT redirect to a new location. I
 
 <Examples.AsyncSubmitComplete />
 
-### Visible data
+### Reduce your data to visible fields
 
 You can use the `reduceToVisibleFields` function to get only the data of visible (mounted) fields.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
@@ -14,7 +14,11 @@ import { useData } from '@dnb/eufemia/src/extensions/forms/Form'
 
 export const ChildrenWithAge = (props) => {
   return (
-    <Form.Handler>
+    <Form.Handler
+      onSubmit={(data, { reduceToVisibleFields }) => {
+        console.log(reduceToVisibleFields(data))
+      }}
+    >
       <WithToolbar>
         <Flex.Stack>
           <Blocks.ChildrenWithAge
@@ -40,7 +44,11 @@ export const ChildrenWithAgeWizard = (props) => {
         const MyForm = () => {
           const { summaryTitle } = Form.useLocale().Step
           return (
-            <Form.Handler>
+            <Form.Handler
+              onSubmit={(data, { reduceToVisibleFields }) => {
+                console.log(reduceToVisibleFields(data))
+              }}
+            >
               <Wizard.Container>
                 <Wizard.Step title="Step 1">
                   <Blocks.ChildrenWithAge {...props} />
@@ -50,7 +58,6 @@ export const ChildrenWithAgeWizard = (props) => {
                 <Wizard.Step title={summaryTitle}>
                   <Blocks.ChildrenWithAge
                     mode="summary"
-                    showEmpty
                     toWizardStep={0}
                     {...props}
                   />
@@ -177,6 +184,9 @@ export const ChildrenWithAgePrefilledYes = () => {
           usesDaycare: true,
           countChildren: 2,
           children: [{}, {}],
+        }}
+        onSubmit={(data, { reduceToVisibleFields }) => {
+          console.log(reduceToVisibleFields(data))
         }}
       >
         <Flex.Stack>

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
@@ -28,6 +28,7 @@ function NumberValue(props: Props) {
     inline,
     showEmpty,
     className,
+    path, // eslint-disable-line
     ...rest
   } = useValueProps(props)
   const numberFormatProps = convertCamelCaseProps(omitSpacingProps(rest))

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/__tests__/Number.test.tsx
@@ -184,6 +184,20 @@ describe('Value.Number', () => {
     ).toBe('-12 345.68 Swedish kronor')
   })
 
+  it('should forward HTML attributes', () => {
+    render(
+      <Value.Number path="/myValue" data-testid="testid" value={123} />
+    )
+
+    const element = document.querySelector('.dnb-number-format')
+    const attributes = Array.from(element.attributes).map(
+      (attr) => attr.name
+    )
+
+    expect(attributes).toEqual(['lang', 'class', 'data-testid', 'role'])
+    expect(element).toHaveAttribute('data-testid', 'testid')
+  })
+
   describe('inheritLabel', () => {
     it('renders label from field with same path', () => {
       render(

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAge.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAge.tsx
@@ -22,9 +22,9 @@ export type Props = SectionProps & {
 
 export default function ChildrenWithAge({
   mode,
-  showEmpty,
   enableAdditionalQuestions,
   toWizardStep,
+  showEmpty,
   ...props
 }: Props) {
   const spacingProps = pickSpacingProps<Props>(props)
@@ -32,13 +32,13 @@ export default function ChildrenWithAge({
   return (
     <Form.Section translations={translations} required {...restProps}>
       {mode === 'summary' ? (
-        <Summary
-          showEmpty={showEmpty}
+        <SummaryContainer
           toWizardStep={toWizardStep}
+          showEmpty={showEmpty}
           spacingProps={spacingProps}
         />
       ) : (
-        <EditContent
+        <EditContainer
           enableAdditionalQuestions={enableAdditionalQuestions}
           spacingProps={spacingProps}
         />
@@ -47,14 +47,13 @@ export default function ChildrenWithAge({
   )
 }
 
-function EditContent({
+function EditContainer({
   spacingProps,
   enableAdditionalQuestions,
 }: Props & {
   spacingProps?: SpacingProps
 }) {
   const tr = Form.useTranslation<Translation>()
-  const { update } = Form.useData()
 
   return (
     <Card stack {...spacingProps}>
@@ -67,11 +66,6 @@ function EditContent({
         defaultValue={false}
         errorMessages={{
           required: tr.ChildrenWithAge.hasChildren.required,
-        }}
-        onChange={(value) => {
-          if (value === false) {
-            update('/countChildren', 0)
-          }
         }}
       />
 
@@ -115,10 +109,10 @@ function EditContent({
         />
 
         <Iterate.Array
+          path="/children"
           countPath="/countChildren"
           countPathTransform={transformAgeItem}
           countPathLimit={20}
-          path="/children"
         >
           <Field.Composition
             label={tr.ChildrenWithAge.childrenAge.fieldLabel}
@@ -158,7 +152,7 @@ function EditContent({
   )
 }
 
-function Summary({
+function SummaryContainer({
   spacingProps,
   toWizardStep,
   showEmpty,
@@ -166,6 +160,9 @@ function Summary({
   spacingProps?: SpacingProps
 }) {
   const tr = Form.useTranslation<Translation>()
+
+  const { getValue } = Form.useData()
+  const hasNoChildren = getValue('/hasChildren') === false
 
   return (
     <Form.Visibility visible={showEmpty} pathTrue="/hasChildren" animate>
@@ -179,9 +176,13 @@ function Summary({
             defaultValue={0}
             suffix={tr.ChildrenWithAge.countChildren.suffix}
             maximum={20}
+            transformIn={(value) => (hasNoChildren ? 0 : value)}
           />
 
-          <Iterate.Array path="/children">
+          <Iterate.Array
+            path="/children"
+            limit={hasNoChildren ? 0 : undefined}
+          >
             <Value.Composition
               label={tr.ChildrenWithAge.childrenAge.fieldLabel}
               gap={false}

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
@@ -6,11 +6,6 @@ export const ChildrenWithAgeProperties: PropertiesTableProps = {
     type: 'number',
     status: 'optional',
   },
-  showEmpty: {
-    doc: 'Show the `Value.*` version when there are no children. Defaults to `false`.',
-    type: 'boolean',
-    status: 'optional',
-  },
   enableAdditionalQuestions: {
     doc: '[`joint-responsibility`, `daycare`]',
     type: 'array',
@@ -19,6 +14,11 @@ export const ChildrenWithAgeProperties: PropertiesTableProps = {
   toWizardStep: {
     doc: 'If defined, a `Wizard.EditButton` will be shown.',
     type: 'number',
+    status: 'optional',
+  },
+  showEmpty: {
+    doc: 'Show the `Value.*` version when there are no children. Defaults to `false`.',
+    type: 'boolean',
     status: 'optional',
   },
   '[Space](/uilib/layout/space/properties)': {

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/stories/ChildrenWithAge.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/stories/ChildrenWithAge.stories.tsx
@@ -30,6 +30,10 @@ export function Basic() {
       // onChange={(data) => {
       //   console.log('onChange', data.children.length)
       // }}
+      onSubmit={(data, { reduceToVisibleFields }) => {
+        console.log('Raw', data)
+        console.log('Reduced', reduceToVisibleFields(data))
+      }}
       translations={myTranslations}
     >
       <Flex.Stack>
@@ -40,6 +44,7 @@ export function Basic() {
         <ChildrenWithAge
           mode="summary"
           enableAdditionalQuestions={['daycare', 'joint-responsibility']}
+          showEmpty
         />
         <Form.SubmitButton />
       </Flex.Stack>
@@ -64,6 +69,10 @@ export function InsideWizard() {
             age: undefined,
           },
         ],
+      }}
+      onSubmit={(data, { reduceToVisibleFields }) => {
+        console.log('Raw', data)
+        console.log('Reduced', reduceToVisibleFields(data))
       }}
     >
       <Wizard.Container initialActiveIndex={0}>


### PR DESCRIPTION
Instead of resetting the amount of children, this PR removes it, so the default value applies when switching back again. 