### PR TITLE
fix(Forms): add support for `transformIn` and `transformOut` to Field.SelectCountry

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
@@ -24,3 +24,39 @@ const MyComponent = () => {
   const { getCountryNameByIso } = Value.SelectCountry.useCountry('NO')
 }
 ```
+
+### TransformIn and TransformOut
+
+You can use the `transformIn` and `transformOut` to transform the value before it gets displayed in the field and before it gets sent to the form. The second parameter is the country object. You may have a look at the demo below to see how it works.
+
+```tsx
+const transformOut = (value, country) => {
+  if (value) {
+    return `${country.name} (${value})`
+  }
+}
+const transformIn = (value) => {
+  return String(value).match(/\((.*)\)/)?.[1]
+}
+```
+
+### onFocus, onBlur, onChange
+
+These events have an additional parameter with the country object.
+
+```tsx
+const onFocus = (value, country) => {}
+```
+
+## The country object
+
+```ts
+{
+  cdc: '47',
+  iso: 'NO',
+  name: 'Norge',
+  i18n: { en: 'Norway', nb: 'Norge' },
+  regions: ['Scandinavia', 'Nordic'],
+  continent: 'Europe',
+}
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/Examples.tsx
@@ -1,5 +1,11 @@
+import { Card } from '@dnb/eufemia/src'
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field } from '@dnb/eufemia/src/extensions/forms'
+import {
+  Field,
+  Form,
+  Tools,
+  Value,
+} from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -111,6 +117,49 @@ export const ValidationRequired = () => {
         validateInitially
         validateUnchanged
       />
+    </ComponentBox>
+  )
+}
+
+export function TransformInAndOut() {
+  return (
+    <ComponentBox scope={{ Tools }}>
+      {() => {
+        const transformOut = (value, country) => {
+          if (value) {
+            return country
+          }
+        }
+        const transformIn = (country) => {
+          return country?.iso
+        }
+
+        const MyForm = () => {
+          return (
+            <Form.Handler onSubmit={console.log}>
+              <Card stack>
+                <Field.SelectCountry
+                  path="/country"
+                  transformIn={transformIn}
+                  transformOut={transformOut}
+                  defaultValue="NO"
+                />
+
+                <Value.SelectCountry
+                  path="/country"
+                  transformIn={transformIn}
+                  placeholder="(Select a country)"
+                  showEmpty
+                />
+
+                <Tools.Log />
+              </Card>
+              <Form.SubmitButton />
+            </Form.Handler>
+          )
+        }
+        return <MyForm />
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/demos.mdx
@@ -41,3 +41,7 @@ import * as Examples from './Examples'
 ### Validation - Required
 
 <Examples.ValidationRequired />
+
+### TransformIn and TransformOut
+
+<Examples.TransformInAndOut />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -3,7 +3,8 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Props } from '..'
 import { Provider } from '../../../../../shared'
-import { Field, Form, FieldBlock } from '../../..'
+import { Field, Form, FieldBlock, Value } from '../../..'
+import userEvent from '@testing-library/user-event'
 
 describe('Field.SelectCountry', () => {
   it('should render with props', () => {
@@ -30,7 +31,7 @@ describe('Field.SelectCountry', () => {
     )
     const firstItemElement = () =>
       document.querySelectorAll('li.dnb-drawer-list__option')[0]
-    expect(inputElement.value).toEqual('')
+    expect(inputElement).toHaveValue('')
 
     fireEvent.focus(inputElement)
     fireEvent.change(inputElement, { target: { value: 'Norge' } })
@@ -47,10 +48,11 @@ describe('Field.SelectCountry', () => {
         },
         iso: 'NO',
         regions: ['Scandinavia', 'Nordic'],
+        name: 'Norge',
       },
     ]
     expect(onChange).toHaveBeenLastCalledWith(...firstEventValues)
-    expect(inputElement.value).toEqual('Norge')
+    expect(inputElement).toHaveValue('Norge')
 
     fireEvent.blur(inputElement)
     fireEvent.focus(inputElement)
@@ -70,8 +72,9 @@ describe('Field.SelectCountry', () => {
       },
       iso: 'DK',
       regions: ['Scandinavia', 'Nordic'],
+      name: 'Danmark',
     })
-    expect(inputElement.value).toEqual('Danmark')
+    expect(inputElement).toHaveValue('Danmark')
   })
 
   it('should select matching country on type change to support autofill', async () => {
@@ -95,7 +98,7 @@ describe('Field.SelectCountry', () => {
       nativeEvent: undefined,
     })
 
-    expect(inputElement.value).toEqual('Sverige')
+    expect(inputElement).toHaveValue('Sverige')
     expect(liElements()).toHaveLength(2)
     expect(selectedItemElement().textContent).toBe('Sverige')
     expect(onChange).toHaveBeenCalledTimes(1)
@@ -105,6 +108,7 @@ describe('Field.SelectCountry', () => {
       i18n: { en: 'Sweden', nb: 'Sverige' },
       iso: 'SE',
       regions: ['Scandinavia', 'Nordic'],
+      name: 'Sverige',
     })
   })
 
@@ -320,6 +324,123 @@ describe('Field.SelectCountry', () => {
 
     const input = document.querySelector('.dnb-autocomplete__input')
     expect(input).toHaveClass('dnb-input__status--error')
+  })
+
+  it('should support "transformIn" and "transformOut"', async () => {
+    const transformOut = jest.fn((value, country) => {
+      if (value) {
+        return `${country.name} (${value})`
+      }
+    })
+    const transformIn = jest.fn((value) => {
+      return String(value).match(/\((.*)\)/)?.[1]
+    })
+    const valueTransformIn = jest.fn((value) => {
+      return String(value).match(/\((.*)\)/)?.[1]
+    })
+
+    const onSubmit = jest.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.SelectCountry
+          path="/country"
+          transformIn={transformIn}
+          transformOut={transformOut}
+          defaultValue="NO"
+        />
+
+        <Value.SelectCountry
+          path="/country"
+          transformIn={valueTransformIn}
+        />
+
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    const NO = {
+      cdc: '47',
+      continent: 'Europe',
+      i18n: { en: 'Norway', nb: 'Norge' },
+      iso: 'NO',
+      name: 'Norge',
+      regions: ['Scandinavia', 'Nordic'],
+    }
+
+    const CH = {
+      cdc: '41',
+      continent: 'Europe',
+      i18n: { en: 'Switzerland', nb: 'Sveits' },
+      iso: 'CH',
+      name: 'Sveits',
+    }
+
+    expect(transformOut).toHaveBeenCalledTimes(1)
+    expect(transformIn).toHaveBeenCalledTimes(3)
+    expect(valueTransformIn).toHaveBeenCalledTimes(2)
+
+    const firstItemElement = () =>
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+
+    const form = document.querySelector('form')
+    const input = document.querySelector('input')
+    const value = document.querySelector('.dnb-forms-value-block__content')
+
+    fireEvent.submit(form)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      { country: 'Norge (NO)' },
+      expect.anything()
+    )
+
+    expect(transformOut).toHaveBeenCalledTimes(1)
+    expect(transformIn).toHaveBeenCalledTimes(4)
+    expect(valueTransformIn).toHaveBeenCalledTimes(3)
+
+    expect(input).toHaveValue('Norge')
+    expect(value).toHaveTextContent('Norge')
+
+    await userEvent.type(input, '{Backspace>10}Sveits')
+    await waitFor(() => {
+      expect(firstItemElement()).toBeInTheDocument()
+    })
+    await userEvent.click(firstItemElement())
+
+    expect(input).toHaveValue('Sveits')
+    expect(value).toHaveTextContent('Sveits')
+
+    expect(transformOut).toHaveBeenCalledTimes(2)
+    expect(transformIn).toHaveBeenCalledTimes(6)
+    expect(valueTransformIn).toHaveBeenCalledTimes(4)
+
+    fireEvent.submit(form)
+    expect(onSubmit).toHaveBeenCalledTimes(2)
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      { country: 'Sveits (CH)' },
+      expect.anything()
+    )
+
+    expect(transformOut).toHaveBeenCalledTimes(2)
+    expect(transformIn).toHaveBeenCalledTimes(7)
+    expect(valueTransformIn).toHaveBeenCalledTimes(5)
+
+    expect(transformOut).toHaveBeenNthCalledWith(1, 'NO', NO)
+    expect(transformOut).toHaveBeenNthCalledWith(2, 'CH', CH)
+
+    expect(transformIn).toHaveBeenNthCalledWith(1, 'NO')
+    expect(transformIn).toHaveBeenNthCalledWith(2, 'NO')
+    expect(transformIn).toHaveBeenNthCalledWith(3, 'Norge (NO)')
+    expect(transformIn).toHaveBeenNthCalledWith(4, 'Norge (NO)')
+    expect(transformIn).toHaveBeenNthCalledWith(5, 'Norge (NO)')
+    expect(transformIn).toHaveBeenNthCalledWith(6, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(7, 'Sveits (CH)')
+
+    expect(valueTransformIn).toHaveBeenNthCalledWith(1, undefined)
+    expect(valueTransformIn).toHaveBeenNthCalledWith(2, 'Norge (NO)')
+    expect(valueTransformIn).toHaveBeenNthCalledWith(3, 'Norge (NO)')
+    expect(valueTransformIn).toHaveBeenNthCalledWith(4, 'Sveits (CH)')
+    expect(valueTransformIn).toHaveBeenNthCalledWith(5, 'Sveits (CH)')
   })
 
   describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/stories/SelectCountry.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/stories/SelectCountry.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import { Field } from '../../..'
+import { Field, Form, Tools, Value } from '../../..'
+import { Flex } from '../../../../../components'
+import { CountryType } from '../../../constants/countries'
 
 export default {
   title: 'Eufemia/Extensions/Forms/SelectCountry',
@@ -19,5 +21,39 @@ export function SelectCountry() {
         update(value)
       }}
     />
+  )
+}
+
+const transformOut = (value, country: CountryType) => {
+  if (value) {
+    return `${country.name} (${value})`
+  }
+}
+const transformIn = (value) => {
+  return String(value).match(/\((.*)\)/)?.[1]
+}
+
+export function Transform() {
+  return (
+    <Form.Handler onSubmit={console.log}>
+      <Flex.Stack>
+        <Field.SelectCountry
+          path="/country"
+          transformIn={transformIn}
+          transformOut={transformOut}
+          defaultValue="NO"
+        />
+
+        <Value.SelectCountry
+          path="/country"
+          transformIn={transformIn}
+          showEmpty
+        />
+
+        <Tools.Log />
+
+        <Form.SubmitButton />
+      </Flex.Stack>
+    </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
@@ -14,7 +14,7 @@ function Log(props: SectionProps) {
       {...props}
     >
       <pre>
-        {JSON.stringify(data)}
+        {JSON.stringify(data, null, 2)}
         {' ' /* Ensure one line of spacing */}
       </pre>
     </Section>

--- a/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts
@@ -24,6 +24,7 @@ export type CountryType = {
     | 'South America'
     | 'None'
   regions?: Array<'Scandinavia' | 'Nordic'>
+  name?: string
 }
 
 export type CountryLang = keyof CountryType['i18n']


### PR DESCRIPTION
Based on PR #3974

Here is a [demo](https://eufemia-git-fix-select-country-transform-eufemia.vercel.app/uilib/extensions/forms/feature-fields/SelectCountry/#transformin-and-transformout).