### PR TITLE
feat(Forms): implement TypeScript version of `json-pointer`

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -113,7 +113,6 @@
     "classnames": "2.3.1",
     "core-js": "3.26.1",
     "date-fns": "2.25.0",
-    "json-pointer": "0.6.2",
     "keycode": "2.2.1",
     "prop-types": "15.7.2",
     "what-input": "5.2.10"

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import type { ComponentProps } from '../../types'
 import Context, { ContextState } from '../Context'
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useContext,
 } from 'react'
-import pointer, { JsonObject } from 'json-pointer'
+import pointer, { JsonObject } from '../../utils/json-pointer'
 import { ValidateFunction } from 'ajv/dist/2020'
 import {
   Ajv,
@@ -585,7 +585,7 @@ export default function Provider<Data extends JsonObject>(
   }, [])
 
   // - Shared state
-  const sharedData = useSharedState<Data>(id)
+  const sharedData = useSharedState<Data & { clearForm?: () => void }>(id)
   const sharedAttachments = useSharedState<{
     visibleDataHandler?: VisibleDataHandler<Data>
     filterDataHandler?: FilterDataHandler<Data>
@@ -623,7 +623,8 @@ export default function Provider<Data extends JsonObject>(
       initialData &&
       sharedData.data &&
       cacheRef.current.shared === sharedData.data &&
-      internalDataRef.current === initialData
+      internalDataRef.current === initialData &&
+      typeof internalDataRef.current === 'object'
     ) {
       return {
         ...internalDataRef.current,
@@ -647,7 +648,8 @@ export default function Provider<Data extends JsonObject>(
       id &&
       sharedData.data &&
       cacheRef.current.shared !== sharedData.data &&
-      sharedData.data !== internalDataRef.current
+      sharedData.data !== internalDataRef.current &&
+      typeof internalDataRef.current === 'object'
     ) {
       cacheRef.current.shared = sharedData.data
 
@@ -1348,8 +1350,8 @@ export default function Provider<Data extends JsonObject>(
 }
 
 type FormStatusBufferProps = {
-  minimumAsyncBehaviorTime?: Props<unknown>['minimumAsyncBehaviorTime']
-  asyncSubmitTimeout?: Props<unknown>['asyncSubmitTimeout']
+  minimumAsyncBehaviorTime?: Props<JsonObject>['minimumAsyncBehaviorTime']
+  asyncSubmitTimeout?: Props<JsonObject>['asyncSubmitTimeout']
   formState: ContextState['formState']
   waitFor: boolean
   onTimeout: () => void

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -567,7 +567,7 @@ describe('DataContext.Provider', () => {
         })
 
         let filteredData = undefined
-        const onSubmit: OnSubmit = jest.fn((data, { filterData }) => {
+        const onSubmit = jest.fn((data, { filterData }) => {
           return (filteredData = filterData(filterDataHandler))
         })
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/stories/Provider.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/stories/Provider.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Field, Form, JSONSchema } from '../../..'
 import { Flex } from '../../../../../components'
 import Provider from '../Provider'
+import type { FilterData } from '../../Context'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Provider',
@@ -92,13 +93,13 @@ export function Validation() {
 
 const id = 'form-with-disabled'
 
-const filterDataHandler = ({ props }) => {
+const filterDataHandler: FilterData = ({ props }) => {
   if (props.disabled === true) {
     return false
   }
 }
 
-export const FilterData = () => {
+export const FilterDataStory = () => {
   const { hasErrors } = Form.useValidation(id)
   const { data, filterData } = Form.useData(id, {
     disabled: true,
@@ -109,8 +110,8 @@ export const FilterData = () => {
   return (
     <Form.Handler
       id={id}
-      onSubmit={(data) => {
-        console.log('onSubmit', filterDataHandler(data))
+      onSubmit={(data, { filterData }) => {
+        console.log('onSubmit', filterData(filterDataHandler))
       }}
     >
       <Flex.Stack>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/useDependencePaths.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/useDependencePaths.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useMemo, useRef } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import DataContext from '../../DataContext/Context'
 import { Props } from './Indeterminate'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { JsonObject } from 'json-pointer'
+import { JsonObject } from '../../utils/json-pointer'
 import DataContextProvider, {
   Props as ProviderProps,
 } from '../../DataContext/Provider'

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -6,7 +6,7 @@ import React, {
   useReducer,
   useRef,
 } from 'react'
-import pointer, { JsonObject } from 'json-pointer'
+import pointer, { JsonObject } from '../../utils/json-pointer'
 import { extendDeep } from '../../../../shared/component-helper'
 import { isAsync } from '../../../../shared/helpers/isAsync'
 import useDataValue from '../../hooks/useDataValue'
@@ -39,7 +39,10 @@ export type IsolationProviderProps<Data> = {
    * It will receive the data from the isolated context and the data from the outer context.
    * You can use this to transform the data before it is committed.
    */
-  transformOnCommit?: (isolatedData: Data, handlerData: Data) => Data
+  transformOnCommit?: (
+    isolatedData: JsonObject,
+    handlerData: JsonObject
+  ) => unknown
   /**
    * Used internally by the Form.Isolation component
    */
@@ -165,7 +168,7 @@ function IsolationProvider<Data extends JsonObject>(
           : dataOuter
 
       localDataRef.current = mountedData
-      let isolatedData = structuredClone(mountedData) as Data
+      let isolatedData = structuredClone(mountedData)
 
       if (typeof transformOnCommitProp === 'function') {
         isolatedData = transformOnCommitProp(isolatedData, outerData)

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
@@ -15,6 +15,7 @@ import type {
   FieldProps,
   OnChange,
 } from '../../types'
+import type { JsonObject } from '../../utils/json-pointer'
 
 export type OverwritePropsDefaults = {
   [key: Path]: (FieldProps & FieldBlockProps) | OverwritePropsDefaults
@@ -55,7 +56,7 @@ export type SectionProps<overwriteProps = OverwritePropsDefaults> = {
    */
   errorPrioritization?: SectionContextState['errorPrioritization']
 } & Pick<
-  DataContextProps<unknown>,
+  DataContextProps<JsonObject>,
   'data' | 'defaultData' | 'onChange' | 'translations'
 >
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useRef } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import DataContext from '../../DataContext/Context'
 import usePath from '../../hooks/usePath'
 import { Path } from '../../types'

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/getData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/getData.tsx
@@ -1,4 +1,4 @@
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import {
   SharedStateId,
   createSharedState,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
@@ -5,7 +5,7 @@ import {
   useReducer,
   useRef,
 } from 'react'
-import pointer from 'json-pointer'
+import pointer, { JsonObject } from '../../utils/json-pointer'
 import {
   SharedStateId,
   useSharedState,
@@ -37,7 +37,7 @@ type UseDataReturnUpdate<Data> = <P extends Path>(
 
 export type UseDataReturnGetValue<Data> = <P extends Path>(
   path: P
-) => PathType<Data, P>
+) => PathType<Data, P> | unknown
 
 export type UseDataReturnFilterData<Data> = (
   filterDataHandler: FilterData,
@@ -70,7 +70,7 @@ type SharedAttachment<Data> = {
  * @param {Data} initialData - The initial data value (optional).
  * @returns {UseDataReturn<Data>} An object containing the data and data management functions.
  */
-export default function useData<Data>(
+export default function useData<Data = JsonObject>(
   id: SharedStateId = undefined,
   initialData: Data = undefined
 ): UseDataReturn<Data> {
@@ -122,8 +122,8 @@ export default function useData<Data>(
   const update = useCallback<UseDataReturnUpdate<Data>>(
     (path, value = undefined) => {
       const existingData = structuredClone(
-        sharedDataRef.current.data || ({} as Data)
-      )
+        sharedDataRef.current.data || {}
+      ) as Data & JsonObject
       const existingValue = pointer.has(existingData, path)
         ? pointer.get(existingData, path)
         : undefined
@@ -150,8 +150,8 @@ export default function useData<Data>(
   const remove = useCallback<UseDataReturn<Data>['remove']>(
     (path) => {
       const existingData = structuredClone(
-        sharedDataRef.current.data || ({} as Data)
-      )
+        sharedDataRef.current.data || {}
+      ) as Data & JsonObject
 
       if (pointer.has(existingData, path)) {
         // Remove existing data

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -7,7 +7,7 @@ import React, {
   useContext,
 } from 'react'
 import classnames from 'classnames'
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import { useFieldProps } from '../../hooks'
 import { makeUniqueId } from '../../../../shared/component-helper'
 import { Flex, FormStatus, HeightAnimation } from '../../../../components'

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/Count.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/Count.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../../utils/json-pointer'
 import { Identifier, Path } from '../../types'
 import { useData, getData } from '../../Form'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/GenerateSchema.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/GenerateSchema.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useRef } from 'react'
-import pointer, { JsonObject } from 'json-pointer'
+import pointer, { JsonObject } from '../utils/json-pointer'
 import DataContext, { FilterData } from '../DataContext/Context'
 import { JSONSchema } from '../types'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/ListAllProps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/ListAllProps.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, useCallback, useContext, useRef } from 'react'
-import pointer, { JsonObject } from 'json-pointer'
+import pointer, { JsonObject } from '../utils/json-pointer'
 import DataContext, { FilterData } from '../DataContext/Context'
 
 export type ListAllPropsReturn = {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useDataValue.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useRef } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../utils/json-pointer'
 import { Path } from '../types'
 import DataContext, { ContextState } from '../DataContext/Context'
 import usePath from './usePath'
@@ -48,14 +48,14 @@ export default function useDataValue<Value>({
     [get, makeIteratePath]
   )
 
-  const moveValueToPath = useCallback(<T>(path: Path, value: unknown) => {
+  const moveValueToPath = useCallback(<T>(path: Path, value: T): T => {
     if (path !== '/' && isPath(path)) {
-      const obj = {} as T
+      const obj = {}
       pointer.set(obj, path, value)
-      return obj
+      return obj as T
     }
 
-    return value as T
+    return value
   }, [])
 
   const getData = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useExternalValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useExternalValue.ts
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../utils/json-pointer'
 import { FieldProps, Path } from '../types'
 import DataContext from '../DataContext/Context'
 import IterateElementContext from '../Iterate/IterateItemContext'

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -7,7 +7,7 @@ import React, {
   useReducer,
   AriaAttributes,
 } from 'react'
-import pointer from 'json-pointer'
+import pointer from '../utils/json-pointer'
 import { ValidateFunction } from 'ajv/dist/2020'
 import { errorChanged } from '../utils'
 import { ajvErrorsToOneFormError } from '../utils/ajv'
@@ -247,7 +247,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
           ? pointer.get(schema, schemaPath)
           : schema
 
-        requiredList.push(schemaPart?.required)
+        requiredList.push(schemaPart?.['required'])
       }
 
       if (sectionPath) {
@@ -1632,7 +1632,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         if (hasValue) {
           const sharedValue = pointer.get(sharedState.data, identifier)
           if (sharedValue) {
-            value = sharedValue
+            value = sharedValue as Value
           }
         }
       }

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -1,7 +1,7 @@
 import type { SpacingProps } from '../../components/space/types'
 import type { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema'
 import type { JSONSchemaType } from 'ajv/dist/2020'
-import { JsonObject } from 'json-pointer'
+import { JsonObject } from './utils/json-pointer'
 import { AriaAttributes } from 'react'
 import { FilterData, VisibleDataOptions } from './DataContext'
 
@@ -601,7 +601,7 @@ export type OnCommit<Data = JsonObject> = (
   | void
   | Promise<EventReturnWithStateObject | void>
 
-export type OnChange<Data = unknown> = (
+export type OnChange<Data = JsonObject> = (
   data: Data,
   additionalArgs: Pick<OnSubmitParams, 'filterData'>
 ) => OnChangeReturnType

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
@@ -1,6 +1,6 @@
 import ajvInstance, { ErrorObject } from 'ajv/dist/2020'
 import ajvErrors from 'ajv-errors'
-import pointer from 'json-pointer'
+import pointer, { JsonObject } from './json-pointer'
 import { FormError, Path } from '../types'
 import type Ajv from 'ajv/dist/2020'
 
@@ -156,7 +156,7 @@ export function ajvErrorsToOneFormError(
  */
 export const ajvErrorsToFormErrors = (
   errors?: ErrorObject[] | null,
-  data?: Record<Path, unknown>
+  data?: JsonObject
 ): Record<string, FormError> => {
   return (errors ?? []).reduce((errors, ajvError) => {
     const path = getInstancePath(ajvError)

--- a/packages/dnb-eufemia/src/extensions/forms/utils/index.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './errors'
+export * from './json-pointer'
 export { default as TestElement } from './TestElement/TestElement'

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer.ts
@@ -1,0 +1,5 @@
+export * from './json-pointer/json-pointer'
+
+// For TypeScript compatibility we import and export it this way
+import * as _default from './json-pointer/export'
+export { _default as default }

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
@@ -1,0 +1,359 @@
+import pointer, {
+  compile,
+  dict,
+  get,
+  has,
+  parse,
+  remove,
+  set,
+  walk,
+  PointerPath,
+} from '../../json-pointer'
+
+describe('json-pointer', () => {
+  let rfcExample, rfcValues, rfcParsed
+
+  function resetExamples() {
+    rfcExample = {
+      foo: ['bar', 'baz'],
+      bar: { baz: 10 },
+      '': 0,
+      'a/b': 1,
+      'c%d': 2,
+      'e^f': 3,
+      'g|h': 4,
+      'i\\j': 5,
+      'k"l': 6,
+      ' ': 7,
+      'm~n': 8,
+    }
+
+    rfcValues = {
+      '': rfcExample,
+      '/foo': rfcExample.foo,
+      '/foo/0': 'bar',
+      '/bar': rfcExample.bar,
+      '/bar/baz': 10,
+      '/': 0,
+      '/a~1b': 1,
+      '/c%d': 2,
+      '/e^f': 3,
+      '/g|h': 4,
+      '/i\\j': 5,
+      '/k"l': 6,
+      '/ ': 7,
+      '/m~0n': 8,
+    }
+
+    rfcParsed = {
+      '': { tokens: [], value: rfcExample },
+      '/foo': { tokens: ['foo'], value: rfcExample.foo },
+      '/foo/0': { tokens: ['foo', '0'], value: 'bar' },
+      '/bar': { tokens: ['bar'], value: rfcExample.bar },
+      '/bar/baz': { tokens: ['bar', 'baz'], value: 10 },
+      '/': { tokens: [''], value: 0 },
+      '/a~1b': { tokens: ['a/b'], value: 1 },
+      '/c%d': { tokens: ['c%d'], value: 2 },
+      '/e^f': { tokens: ['e^f'], value: 3 },
+      '/g|h': { tokens: ['g|h'], value: 4 },
+      '/i\\j': { tokens: ['i\\j'], value: 5 },
+      '/k"l': { tokens: ['k"l'], value: 6 },
+      '/ ': { tokens: [' '], value: 7 },
+      '/m~0n': { tokens: ['m~n'], value: 8 },
+    }
+  }
+
+  resetExamples()
+  beforeEach(resetExamples)
+
+  describe('get', () => {
+    it('should work for root element', () => {
+      const obj = {}
+      expect(get(obj, '')).toBe(obj)
+    })
+
+    Object.keys(rfcValues).forEach(function (p) {
+      it('should work for "' + p + '"', () => {
+        const expectedValue = rfcValues[p]
+        expect(get(rfcExample, p)).toBe(expectedValue)
+      })
+    })
+
+    Object.keys(rfcParsed).forEach(function (p) {
+      const tokens = [...rfcParsed[p].tokens]
+      it('should work for ' + JSON.stringify(tokens), function () {
+        const expectedValue = rfcParsed[p].value
+        expect(get(rfcExample, tokens)).toBe(expectedValue)
+      })
+    })
+
+    it('should work for with inherited properties', () => {
+      function O() {
+        // empty
+      }
+      O.prototype.x = 10
+      expect(get(new O(), '/x')).toBe(10)
+      expect(get(Object.create({ x: 10 }), '/x')).toBe(10)
+    })
+  })
+
+  describe('set', () => {
+    it('should throw when try to set the root object', () => {
+      const obj = {} as PointerPath
+      expect(() => set(pointer, obj, '')).toThrow(Error)
+    })
+
+    it('should set a value on an object with pointer', () => {
+      const obj = {
+        existing: 'bla',
+      }
+
+      set(obj, '/new-value/bla', 'expected')
+      expect(obj['new-value'].bla).toBe('expected')
+    })
+
+    it('should set a value on an object with tokens', () => {
+      const obj = {
+        existing: 'bla',
+      }
+
+      set(obj, ['new-value', 'bla'], 'expected')
+      expect(obj['new-value'].bla).toBe('expected')
+    })
+
+    it('should work on first level with pointer', () => {
+      const obj = {
+        existing: 'bla',
+      }
+
+      set(obj, '/first-level', 'expected')
+      expect(obj['first-level']).toBe('expected')
+    })
+
+    it('should work on first level with tokens', () => {
+      const obj = {
+        existing: 'bla',
+      }
+
+      set(obj, ['first-level'], 'expected')
+      expect(obj['first-level']).toBe('expected')
+    })
+
+    it('should create arrays for numeric reference tokens and objects for other tokens', () => {
+      const obj = []
+      set(obj, '/0/test/0', 'expected')
+      expect(Array.isArray(obj)).toBe(true)
+      expect(Array.isArray(obj[0])).toBe(false)
+      expect(Array.isArray(obj[0].test)).toBe(true)
+    })
+
+    it('should create arrays for numeric reference tokens and objects for other tokens when tokens are passed', () => {
+      const obj = []
+      set(obj, ['0', 'test', '0'], 'expected')
+      expect(Array.isArray(obj)).toBe(true)
+      expect(Array.isArray(obj[0])).toBe(false)
+      expect(Array.isArray(obj[0].test)).toBe(true)
+    })
+
+    it('should create arrays for - and reference the (nonexistent) member after the last array element.', () => {
+      const obj: Array<string & { test?: string }> = ['foo']
+      set(obj, '/-/test/-', 'expected')
+      expect(Array.isArray(obj)).toBe(true)
+      expect(obj).toHaveLength(2)
+      expect(Array.isArray(obj[1].test)).toBe(true)
+      expect(obj[1].test).toHaveLength(1)
+      expect(obj[1].test[0]).toBe('expected')
+    })
+
+    it('should create arrays for - and reference the (nonexistent) member after the last array element when tokens are passed.', () => {
+      const obj: Array<string & { test?: string }> = ['foo']
+      set(obj, ['-', 'test', '-'], 'expected')
+      expect(Array.isArray(obj)).toBe(true)
+      expect(obj).toHaveLength(2)
+      expect(Array.isArray(obj[1].test)).toBe(true)
+      expect(obj[1].test).toHaveLength(1)
+      expect(obj[1].test[0]).toBe('expected')
+    })
+  })
+
+  describe('remove', () => {
+    Object.keys(rfcValues).forEach(function (p) {
+      if (p === '' || p === '/foo/0') return
+
+      it('should work for "' + p + '"', () => {
+        remove(rfcExample, p)
+        expect(() => get(pointer, rfcExample)).toThrow(Error)
+      })
+    })
+
+    it('should work for "/foo/0"', () => {
+      const p = '/foo/0'
+      remove(rfcExample, p)
+      expect(get(rfcExample, p)).toBe('baz')
+    })
+
+    it('should work for "/foo/1"', () => {
+      const p = '/foo/1'
+      remove(rfcExample, p)
+      expect(() => get(pointer, rfcExample)).toThrow(Error)
+    })
+
+    Object.keys(rfcParsed).forEach(function (p) {
+      if (p === '' || p === '/foo/0') return
+
+      it(
+        'should work for ' + JSON.stringify(rfcParsed[p].tokens),
+        function () {
+          remove(rfcExample, [...rfcParsed[p].tokens])
+          expect(() => get(rfcExample, [...rfcParsed[p].tokens])).toThrow(
+            Error
+          )
+        }
+      )
+    })
+
+    it('should work for ["foo","0"]', () => {
+      const p = ['foo', '0']
+      remove(rfcExample, p)
+      expect(get(rfcExample, p)).toBe('baz')
+    })
+
+    it('should work for ["foo","1"]', () => {
+      const p = ['foo', '1']
+      remove(rfcExample, p)
+      expect(() => get(pointer, rfcExample)).toThrow(Error)
+    })
+  })
+
+  describe('dict', () => {
+    it('should return a dictionary (pointer -> value)', () => {
+      const obj = {
+          bla: {
+            test: 'expected',
+          },
+          abc: 'bla',
+        },
+        dictResult = dict(obj)
+
+      expect(dictResult['/bla/test']).toBe('expected')
+      expect(dictResult['/abc']).toBe('bla')
+    })
+
+    it('should work with arrays', () => {
+      const obj = {
+          users: [{ name: 'example 1' }, { name: 'example 2' }],
+        },
+        dictResult = dict(obj),
+        pointers = Object.keys(dictResult)
+
+      expect(pointers).toHaveLength(2)
+      expect(pointers[0]).toBe('/users/0/name')
+      expect(pointers[1]).toBe('/users/1/name')
+    })
+
+    it('should work with other arrays', () => {
+      const obj = {
+          bla: {
+            bli: [4, 5, 6],
+          },
+        },
+        dictResult = dict(obj)
+      expect(dictResult['/bla/bli/0']).toBe(4)
+      expect(dictResult['/bla/bli/1']).toBe(5)
+      expect(dictResult['/bla/bli/2']).toBe(6)
+    })
+  })
+
+  describe('has', () => {
+    it('should return true when the pointer exists', () => {
+      const obj = {
+        bla: {
+          test: 'expected',
+        },
+        foo: [['hello']],
+        abc: 'bla',
+      }
+      expect(has(obj, '/bla')).toBe(true)
+      expect(has(obj, '/abc')).toBe(true)
+      expect(has(obj, '/foo/0/0')).toBe(true)
+      expect(has(obj, '/bla/test')).toBe(true)
+    })
+
+    it('should return true when the tokens point to value', () => {
+      const obj = {
+        bla: {
+          test: 'expected',
+        },
+        foo: [['hello']],
+        abc: 'bla',
+      }
+      expect(has(obj, ['bla'])).toBe(true)
+      expect(has(obj, ['abc'])).toBe(true)
+      expect(has(obj, ['foo', '0', '0'])).toBe(true)
+      expect(has(obj, ['bla', 'test'])).toBe(true)
+    })
+
+    it('should return false when the pointer does not exist', () => {
+      const obj = {
+        bla: {
+          test: 'expected',
+        },
+        abc: 'bla',
+      }
+      expect(has(obj, '/not-existing')).toBe(false)
+      expect(has(obj, '/not-existing/bla')).toBe(false)
+      expect(has(obj, '/test/1/bla')).toBe(false)
+      expect(has(obj, '/bla/test1')).toBe(false)
+    })
+
+    it('should return false when the tokens do not point to value', () => {
+      const obj = {
+        bla: {
+          test: 'expected',
+        },
+        abc: 'bla',
+      }
+      expect(has(obj, ['not-existing'])).toBe(false)
+      expect(has(obj, ['not-existing', 'bla'])).toBe(false)
+      expect(has(obj, ['test', '1', 'bla'])).toBe(false)
+      expect(has(obj, ['bla', 'test1'])).toBe(false)
+    })
+  })
+
+  describe('walk', () => {
+    it('should iterate over an object', () => {
+      walk({ bla: { test: 'expected' } }, function (value, pointer) {
+        expect(pointer).toBe('/bla/test')
+        expect(value).toBe('expected')
+      })
+    })
+  })
+
+  describe('parse', () => {
+    it('should work with top level path', () => {
+      expect(parse('/bla')[0]).toBe('bla')
+      expect(parse('/bla')).toHaveLength(1)
+    })
+
+    it('should convert a pointer to an array of reference tokens', () => {
+      expect(parse('/hello~0bla/test~1bla')[0]).toBe('hello~bla')
+      expect(parse('/hello~0bla/test~1bla')[1]).toBe('test/bla')
+    })
+  })
+
+  describe('compile', () => {
+    it('should build a json pointer from an array of reference tokens', () => {
+      expect(compile(['hello~bla', 'test/bla'])).toBe(
+        '/hello~0bla/test~1bla'
+      )
+    })
+  })
+
+  describe('parse and then #compile pointer', () => {
+    Object.keys(rfcValues).forEach(function (p) {
+      it('should equal for "' + p + '"', () => {
+        expect(compile(parse(p))).toBe(p)
+      })
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
@@ -72,14 +72,14 @@ describe('json-pointer', () => {
       expect(get(obj, '')).toBe(obj)
     })
 
-    Object.keys(rfcValues).forEach(function (p) {
+    Object.keys(rfcValues).forEach((p) => {
       it('should work for "' + p + '"', () => {
         const expectedValue = rfcValues[p]
         expect(get(rfcExample, p)).toBe(expectedValue)
       })
     })
 
-    Object.keys(rfcParsed).forEach(function (p) {
+    Object.keys(rfcParsed).forEach((p) => {
       const tokens = [...rfcParsed[p].tokens]
       it('should work for ' + JSON.stringify(tokens), function () {
         const expectedValue = rfcParsed[p].value
@@ -177,7 +177,7 @@ describe('json-pointer', () => {
   })
 
   describe('remove', () => {
-    Object.keys(rfcValues).forEach(function (p) {
+    Object.keys(rfcValues).forEach((p) => {
       if (p === '' || p === '/foo/0') return
 
       it('should work for "' + p + '"', () => {
@@ -198,7 +198,7 @@ describe('json-pointer', () => {
       expect(() => get(pointer, rfcExample)).toThrow(Error)
     })
 
-    Object.keys(rfcParsed).forEach(function (p) {
+    Object.keys(rfcParsed).forEach((p) => {
       if (p === '' || p === '/foo/0') return
 
       it(
@@ -350,9 +350,11 @@ describe('json-pointer', () => {
   })
 
   describe('parse and then #compile pointer', () => {
-    Object.keys(rfcValues).forEach(function (p) {
+    Object.keys(rfcValues).forEach((p) => {
       it('should equal for "' + p + '"', () => {
-        expect(compile(parse(p))).toBe(p)
+        expect(
+          compile(parse(p) as Extract<PointerPath, Array<string>>)
+        ).toBe(p)
       })
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/export.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/export.ts
@@ -1,0 +1,1 @@
+export * from './json-pointer'

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -1,0 +1,197 @@
+export type PointerPath = string | Array<string>
+export type JsonValue = any
+export type JsonObject = any
+
+/**
+ * Lookup a json pointer in an object
+ */
+export function get<T = JsonObject>(
+  obj: JsonObject | T,
+  pointer: PointerPath
+) {
+  const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
+
+  for (let i = 0; i < refTokens.length; ++i) {
+    const tok = refTokens[i]
+    if (!(typeof obj == 'object' && tok in obj)) {
+      throw new Error('Invalid reference token: ' + tok)
+    }
+    obj = obj[tok] as T
+  }
+
+  return obj as T
+}
+
+/**
+ * Sets a value on an object
+ */
+export function set(
+  obj: JsonObject,
+  pointer: PointerPath,
+  value: JsonValue
+) {
+  const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
+  let nextTok = refTokens[0]
+
+  if (refTokens.length === 0) {
+    throw Error('Can not set the root object')
+  }
+
+  for (let i = 0; i < refTokens.length - 1; ++i) {
+    let tok = refTokens[i]
+    if (typeof tok !== 'string' && typeof tok !== 'number') {
+      tok = String(tok)
+    }
+    if (
+      tok === '__proto__' ||
+      tok === 'constructor' ||
+      tok === 'prototype'
+    ) {
+      continue
+    }
+    if (tok === '-' && Array.isArray(obj)) {
+      tok = obj.length
+    }
+    nextTok = refTokens[i + 1]
+
+    if (!(tok in obj)) {
+      if (nextTok.match(/^(\d+|-)$/)) {
+        obj[tok] = []
+      } else {
+        obj[tok] = {}
+      }
+    }
+    obj = obj[tok] as JsonObject
+  }
+
+  if (nextTok === '-' && Array.isArray(obj)) {
+    nextTok = obj.length
+  }
+
+  obj[nextTok] = value
+}
+
+/**
+ * Removes an attribute
+ */
+export function remove(obj: JsonObject, pointer: PointerPath) {
+  const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
+  const finalToken = refTokens[refTokens.length - 1]
+  if (finalToken === undefined) {
+    throw new Error('Invalid JSON pointer for remove: "' + pointer + '"')
+  }
+
+  const parent = get(obj, refTokens.slice(0, -1))
+  if (Array.isArray(parent)) {
+    const index = +finalToken
+    if (finalToken === '' && isNaN(index)) {
+      throw new Error('Invalid array index: "' + finalToken + '"')
+    }
+
+    Array.prototype.splice.call(parent, index, 1)
+  } else {
+    delete parent[finalToken]
+  }
+}
+
+/**
+ * Returns a (pointer -> value) dictionary for an object
+ */
+export function dict(obj: JsonObject, descend = null) {
+  const results = {}
+  walk(
+    obj,
+    function (value, pointer: string) {
+      results[pointer] = value
+    },
+    descend
+  )
+  return results
+}
+
+/**
+ * Iterates over an object
+ */
+export function walk(obj: JsonObject, iterator, descend = null) {
+  const refTokens = []
+
+  descend =
+    descend ||
+    function (value) {
+      const type = Object.prototype.toString.call(value)
+      return type === '[object Object]' || type === '[object Array]'
+    }
+
+  function next(cur) {
+    if (Array.isArray(cur)) {
+      cur = cur.reduce((acc, cur, i) => {
+        acc[i] = cur
+        return acc
+      }, {})
+    }
+
+    Object.keys(cur).forEach((key) => {
+      refTokens.push(String(key))
+      if (descend(cur[key])) {
+        next(cur[key])
+      } else {
+        iterator(cur[key], compile(refTokens))
+      }
+      refTokens.pop()
+    })
+  }
+
+  next(obj)
+}
+
+/**
+ * Tests if an object has a value for a json pointer
+ */
+export function has<T = JsonObject>(
+  obj: JsonObject | T,
+  pointer: PointerPath
+) {
+  try {
+    get<T>(obj, pointer)
+  } catch (e) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Escapes a reference token
+ */
+export function escape(str) {
+  return str.toString().replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+/**
+ * Unescape a reference token
+ */
+export function unescape(str) {
+  return str.replace(/~1/g, '/').replace(/~0/g, '~')
+}
+
+/**
+ * Converts a json pointer into a array of reference tokens
+ */
+export function parse(pointer) {
+  if (pointer === '') {
+    return []
+  }
+  if (pointer.charAt(0) !== '/') {
+    throw new Error('Invalid JSON pointer: ' + pointer)
+  }
+  return pointer.substring(1).split(/\//).map(unescape)
+}
+
+/**
+ * Builds a json pointer from a array of reference tokens
+ */
+export function compile(refTokens) {
+  if (refTokens.length === 0) {
+    return ''
+  }
+  return '/' + refTokens.map(escape).join('/')
+}

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export type PointerPath = string | Array<string>
 export type JsonValue = any
 export type JsonObject = any
@@ -5,10 +7,7 @@ export type JsonObject = any
 /**
  * Lookup a json pointer in an object
  */
-export function get<T = JsonObject>(
-  obj: JsonObject | T,
-  pointer: PointerPath
-) {
+export function get<T = JsonObject>(obj: T, pointer: PointerPath) {
   const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
 
   for (let i = 0; i < refTokens.length; ++i) {
@@ -25,12 +24,14 @@ export function get<T = JsonObject>(
 /**
  * Sets a value on an object
  */
-export function set(
-  obj: JsonObject,
+export function set<T = JsonObject>(
+  obj: T,
   pointer: PointerPath,
   value: JsonValue
 ) {
-  const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
+  const refTokens = (
+    Array.isArray(pointer) ? pointer : parse(pointer)
+  ) as Array<number | string>
   let nextTok = refTokens[0]
 
   if (refTokens.length === 0) {
@@ -52,16 +53,16 @@ export function set(
     if (tok === '-' && Array.isArray(obj)) {
       tok = obj.length
     }
-    nextTok = refTokens[i + 1]
+    nextTok = refTokens[i + 1] as string
 
-    if (!(tok in obj)) {
+    if (!(tok in (obj as JsonObject))) {
       if (nextTok.match(/^(\d+|-)$/)) {
         obj[tok] = []
       } else {
         obj[tok] = {}
       }
     }
-    obj = obj[tok] as JsonObject
+    obj = obj[tok] as T
   }
 
   if (nextTok === '-' && Array.isArray(obj)) {
@@ -74,7 +75,7 @@ export function set(
 /**
  * Removes an attribute
  */
-export function remove(obj: JsonObject, pointer: PointerPath) {
+export function remove<T = JsonObject>(obj: T, pointer: PointerPath) {
   const refTokens = Array.isArray(pointer) ? pointer : parse(pointer)
   const finalToken = refTokens[refTokens.length - 1]
   if (finalToken === undefined) {
@@ -97,7 +98,7 @@ export function remove(obj: JsonObject, pointer: PointerPath) {
 /**
  * Returns a (pointer -> value) dictionary for an object
  */
-export function dict(obj: JsonObject, descend = null) {
+export function dict<T = JsonObject>(obj: T, descend = null) {
   const results = {}
   walk(
     obj,
@@ -112,7 +113,7 @@ export function dict(obj: JsonObject, descend = null) {
 /**
  * Iterates over an object
  */
-export function walk(obj: JsonObject, iterator, descend = null) {
+export function walk<T = JsonObject>(obj: T, iterator, descend = null) {
   const refTokens = []
 
   descend =
@@ -147,10 +148,7 @@ export function walk(obj: JsonObject, iterator, descend = null) {
 /**
  * Tests if an object has a value for a json pointer
  */
-export function has<T = JsonObject>(
-  obj: JsonObject | T,
-  pointer: PointerPath
-) {
+export function has<T = JsonObject>(obj: T, pointer: PointerPath) {
   try {
     get<T>(obj, pointer)
   } catch (e) {
@@ -162,21 +160,21 @@ export function has<T = JsonObject>(
 /**
  * Escapes a reference token
  */
-export function escape(str) {
+export function escape(str: string) {
   return str.toString().replace(/~/g, '~0').replace(/\//g, '~1')
 }
 
 /**
  * Unescape a reference token
  */
-export function unescape(str) {
+export function unescape(str: string) {
   return str.replace(/~1/g, '/').replace(/~0/g, '~')
 }
 
 /**
  * Converts a json pointer into a array of reference tokens
  */
-export function parse(pointer) {
+export function parse(pointer: Extract<PointerPath, string>): PointerPath {
   if (pointer === '') {
     return []
   }
@@ -189,7 +187,7 @@ export function parse(pointer) {
 /**
  * Builds a json pointer from a array of reference tokens
  */
-export function compile(refTokens) {
+export function compile(refTokens: Extract<PointerPath, Array<string>>) {
   if (refTokens.length === 0) {
     return ''
   }

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -7,7 +7,7 @@ import { createContext } from 'react'
 import { LOCALE, CURRENCY, CURRENCY_DISPLAY } from './defaults'
 import defaultLocales from './locales'
 import { extendDeep } from './component-helper'
-import pointer from 'json-pointer'
+import pointer from '../extensions/forms/utils/json-pointer'
 
 // All TypeScript based Eufemia elements
 import type { ScrollViewProps } from '../fragments/scroll-view/ScrollView'
@@ -228,10 +228,10 @@ export type TranslationFlat = Record<
 
 export type TranslationFlatToObject<T> = T extends Record<string, unknown>
   ? {
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line
       [K in keyof T as K extends `${infer First}.${infer Rest}`
         ? First
-        : // eslint-disable-next-line no-unused-vars
+        : // eslint-disable-next-line
           K]: K extends `${infer First}.${infer Rest}`
         ? TranslationFlatToObject<Record<Rest, T[K]>>
         : T[K]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,7 +3508,6 @@ __metadata:
     jest-playwright-preset: "npm:3.0.1"
     jest-raw-loader: "npm:1.0.1"
     jest-tobetype: "npm:1.2.3"
-    json-pointer: "npm:0.6.2"
     keycode: "npm:2.2.1"
     lint-staged: "npm:11.2.6"
     lockfile-lint: "npm:4.6.2"
@@ -16668,13 +16667,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreach@npm:^2.0.4":
-  version: 2.0.6
-  resolution: "foreach@npm:2.0.6"
-  checksum: 93b0e65b3f03d9f696418d45f589d0135268b97bf71b4c2628687ce77ce49c20abd60f3c1b23052306b4e789435683a467a7828beac486d2ea17ba8b80933d38
-  languageName: node
-  linkType: hard
-
 "foreground-child@npm:^2.0.0":
   version: 2.0.0
   resolution: "foreground-child@npm:2.0.0"
@@ -21908,15 +21900,6 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 5f3a99009ed5f2a5a67d06e2f298cc97bc86d462034173308156f15b43a6e850be8511dc204b9b94566305da2947f7d90289657237d210351a39059ff9d666cf
-  languageName: node
-  linkType: hard
-
-"json-pointer@npm:0.6.2":
-  version: 0.6.2
-  resolution: "json-pointer@npm:0.6.2"
-  dependencies:
-    foreach: "npm:^2.0.4"
-  checksum: 1d8fc507008cf28815ad398baa7a6d62a73cce2d5ca7859097bb56043b3b6889e393bf5285db9674ddcdb8bc10551146cf8048d3d6430d55ce922105813661e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I believe this is the right step for now because the dependency we’re using is written in CJS and doesn't treeshake unused parts. Since we rely on this pointer in the default Eufemia Context, reducing its footprint is my main motivation.

By using the native `foreach` method and the export approach in this PR, we can ship smaller bundle (maybe 20%). In the future, we may consider submitting a PR to the original dependency to address this issue directly.

PR no. 4000