### PR TITLE
fix(Forms): `Form.useData` should not throw error when used in Wizard

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { renderHook, act, render, fireEvent } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
-import { Field, Form, Wizard, Iterate } from '../../..'
+import { Field, Form, Wizard } from '../../..'
 import Provider from '../../../DataContext/Provider'
 import useData from '../useData'
 import { FilterData } from '../../../DataContext/Context'
@@ -34,27 +34,21 @@ describe('Form.useData', () => {
   })
 
   it('should not throw when used within a Form.Handler and Wizard without id', () => {
-    const log = jest.spyOn(console, 'error').mockImplementation()
-
-    const CountCountries = () => {
-      const { count } = Iterate.useCount()
-      return (
-        <Iterate.Array path="/countries">
-          {() => `{itemNo} of ' ${count('/countries')}`}
-        </Iterate.Array>
-      )
+    const MockComponent = () => {
+      Form.useData()
+      return null
     }
 
     const renderComponent = () => {
       render(
-        <Form.Handler data={{ countries: [] }}>
+        <Form.Handler>
           <Wizard.Container>
             <Wizard.Step title="Step 1">
-              <CountCountries />
+              <MockComponent />
             </Wizard.Step>
 
             <Wizard.Step title="Step 2">
-              <CountCountries />
+              <MockComponent />
             </Wizard.Step>
           </Wizard.Container>
         </Form.Handler>
@@ -64,8 +58,32 @@ describe('Form.useData', () => {
     expect(renderComponent).not.toThrow(
       'useData needs to run inside DataContext (Form.Handler) or have a valid id'
     )
+  })
 
-    log.mockRestore()
+  it('should work inside Wizard when prerender (step 2', () => {
+    let collectData = null
+
+    const MockComponent = () => {
+      const { data } = Form.useData()
+      collectData = data
+      return null
+    }
+
+    render(
+      <Form.Handler data={{ foo: 'bar' }}>
+        <Wizard.Container>
+          <Wizard.Step title="Step 1">
+            <MockComponent />
+          </Wizard.Step>
+
+          <Wizard.Step title="Step 2">
+            <MockComponent />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
+    )
+
+    expect(collectData).toEqual({ foo: 'bar' })
   })
 
   it('should return "getValue" method that lets you get a single path value', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { renderHook, act, render, fireEvent } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
-import { Field, Form } from '../../..'
+import { Field, Form, Wizard, Iterate } from '../../..'
 import Provider from '../../../DataContext/Provider'
 import useData from '../useData'
 import { FilterData } from '../../../DataContext/Context'
@@ -27,6 +27,41 @@ describe('Form.useData', () => {
     }
 
     expect(renderComponent).toThrow(
+      'useData needs to run inside DataContext (Form.Handler) or have a valid id'
+    )
+
+    log.mockRestore()
+  })
+
+  it('should not throw when used within a Form.Handler and Wizard without id', () => {
+    const log = jest.spyOn(console, 'error').mockImplementation()
+
+    const CountCountries = () => {
+      const { count } = Iterate.useCount()
+      return (
+        <Iterate.Array path="/countries">
+          {() => `{itemNo} of ' ${count('/countries')}`}
+        </Iterate.Array>
+      )
+    }
+
+    const renderComponent = () => {
+      render(
+        <Form.Handler data={{ countries: [] }}>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <CountCountries />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <CountCountries />
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    expect(renderComponent).not.toThrow(
       'useData needs to run inside DataContext (Form.Handler) or have a valid id'
     )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
@@ -92,23 +92,21 @@ export default function useData<Data>(
   )
 
   // If no id is provided, use the context data
-  const context = useContext(DataContext)
+  const dataContext = useContext(DataContext)
   if (!id) {
-    if (!context?.hasContext) {
+    if (!dataContext.hasContext) {
       throw new Error(
         'useData needs to run inside DataContext (Form.Handler) or have a valid id'
       )
     }
 
-    if (context) {
-      sharedDataRef.current.data = context.data
-      sharedAttachmentsRef.current.data.filterDataHandler =
-        context.filterDataHandler
-    }
+    sharedDataRef.current.data = dataContext.data
+    sharedAttachmentsRef.current.data.filterDataHandler =
+      dataContext.filterDataHandler
   }
 
-  const updateDataValue = context?.updateDataValue
-  const setData = context?.setData
+  const updateDataValue = dataContext?.updateDataValue
+  const setData = dataContext?.setData
 
   const set = useCallback(
     (newData: Data) => {
@@ -181,9 +179,9 @@ export default function useData<Data>(
         )
       }
 
-      return context?.visibleDataHandler?.(data, options)
+      return dataContext?.visibleDataHandler?.(data, options)
     },
-    [context, id]
+    [dataContext, id]
   )
 
   const filterData = useCallback<UseDataReturn<Data>['filterData']>(
@@ -195,9 +193,9 @@ export default function useData<Data>(
         )
       }
 
-      return context?.filterDataHandler?.(data, filter)
+      return dataContext?.filterDataHandler?.(data, filter)
     },
-    [context, id]
+    [dataContext, id]
   )
 
   const getValue = useCallback<UseDataReturn<Data>['getValue']>((path) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Field, Form, Iterate, Value } from '../..'
+import { Field, Form, Iterate, Value, Wizard } from '../..'
 import { Card, Flex, Section } from '../../../../components'
 
 export default {
@@ -256,3 +256,27 @@ export const WithArrayValidator = () => {
     </Form.Handler>
   )
 }
+
+const CountCountries = () => {
+  const { count } = Iterate.useCount()
+
+  return (
+    <Iterate.Array path="/countries">
+      {() => `{itemNo} of ' ${count('/countries')}`}
+    </Iterate.Array>
+  )
+}
+
+export const useCount = () => (
+  <Form.Handler data={{ countries: [] }}>
+    <Wizard.Container>
+      <Wizard.Step title="Step 1">
+        <CountCountries />
+      </Wizard.Step>
+
+      <Wizard.Step title="Step 2">
+        <CountCountries />
+      </Wizard.Step>
+    </Wizard.Container>
+  </Form.Handler>
+)

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -536,6 +536,7 @@ function PrerenderFieldPropsProvider({ children }) {
         setFieldProps,
         updateDataValue,
         prerenderFieldProps: true,
+        hasContext: true,
       }}
     >
       <WizardContext.Provider value={{ prerenderFieldProps: true }}>


### PR DESCRIPTION
As reported here https://dnb-it.slack.com/archives/C07JEJVSHJR/p1727258016481019

TODO:
- [x] The actual fix...