### PR TITLE
chore: fixes Space's properties tab

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
@@ -7,7 +7,7 @@ tabs:
   - title: Info
     key: /space/info
   - title: Demos
-    key: /space/demos
+    key: /demos
   - title: Properties
     key: /space/properties
 hideTabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
@@ -9,7 +9,7 @@ tabs:
   - title: Demos
     key: /demos
   - title: Properties
-    key: /space/properties
+    key: /properties
 hideTabs:
   - title: Events
 breadcrumb:

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
@@ -3,6 +3,13 @@ title: 'Space'
 description: 'The Space component provides margins within the provided spacing patterns.'
 showTabs: true
 theme: 'sbanken'
+tabs:
+  - title: Info
+    key: /space/info
+  - title: Demos
+    key: /space/demos
+  - title: Properties
+    key: /space/properties
 hideTabs:
   - title: Events
 breadcrumb:

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
@@ -5,7 +5,7 @@ showTabs: true
 theme: 'sbanken'
 tabs:
   - title: Info
-    key: /space/info
+    key: /info
   - title: Demos
     key: /demos
   - title: Properties


### PR DESCRIPTION
properties tab doesn't display when visiting https://eufemia-git-main-eufemia.vercel.app/uilib/layout/space/
But it does show when visiting https://eufemia-git-main-eufemia.vercel.app/uilib/layout/space/demos/

Should be able to see the tab when visiting both urls.

Seems to work now, see the deploy preview:
https://eufemia-git-chore-fixes-properties-tab-which-ran-c6430a-eufemia.vercel.app/uilib/layout/space/
https://eufemia-git-chore-fixes-properties-tab-which-ran-c6430a-eufemia.vercel.app/uilib/layout/space/demos