### PR TITLE
docs(Value.Currency): improve documented properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Currency/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Currency/properties.mdx
@@ -3,17 +3,10 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import {
-  CurrencyValueProperties,
-  CurrencyValueHighlightedProperties,
-} from '@dnb/eufemia/src/extensions/forms/Value/Currency/CurrencyDocs'
+import { CurrencyValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/Currency/CurrencyDocs'
 import { ValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/ValueDocs'
 
 ## Value-specific properties
-
-<PropertiesTable props={CurrencyValueHighlightedProperties} />
-
-## Properties
 
 <PropertiesTable props={CurrencyValueProperties} />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Currency/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Currency/properties.mdx
@@ -3,16 +3,21 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import { CurrencyValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/Currency/CurrencyDocs'
+import {
+  CurrencyValueProperties,
+  CurrencyValueHighlightedProperties,
+} from '@dnb/eufemia/src/extensions/forms/Value/Currency/CurrencyDocs'
 import { ValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/ValueDocs'
+
+## Value-specific properties
+
+<PropertiesTable props={CurrencyValueHighlightedProperties} />
 
 ## Properties
 
-### Value-specific properties
-
 <PropertiesTable props={CurrencyValueProperties} />
 
-### General properties
+## General properties
 
 <PropertiesTable
   props={ValueProperties}

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
@@ -7,11 +7,6 @@ export const NumberFormatProperties: PropertiesTableProps = {
     type: 'number',
     status: 'required',
   },
-  srLabel: {
-    doc: 'Will add a visually hidden label, to give screen reader users the missing context to easier understand what the number represents.',
-    type: 'string',
-    status: 'optional',
-  },
   locale: {
     doc: 'Use a [2 Letter Language Code](https://www.sitepoint.com/iso-2-letter-language-codes/) or an extended code such as `nb-NO`. Use `auto` to detect the locale from the browser (`navigator.language`). Defaults to the Norwegian locale: `nb-NO`.',
     type: 'string',
@@ -20,11 +15,6 @@ export const NumberFormatProperties: PropertiesTableProps = {
   compact: {
     doc: 'Shortens any number or currency including an abbreviation. You can combine `compact` with `currency`. It gives you zero decimal by default `decimals={0}`. Use either `short` or `long`. Defaults to `short` if `true` is given.',
     type: ['boolean', 'string'],
-    status: 'optional',
-  },
-  clean: {
-    doc: 'If set to `true` a dirty string will be parsed to extract the number (`prefix -123.45 suffix` would result in e.g. `kr -123,45`).',
-    type: 'boolean',
     status: 'optional',
   },
   currency: {
@@ -92,6 +82,11 @@ export const NumberFormatProperties: PropertiesTableProps = {
     type: 'React.Node',
     status: 'optional',
   },
+  srLabel: {
+    doc: 'Will add a visually hidden label, to give screen reader users the missing context to easier understand what the number represents.',
+    type: 'string',
+    status: 'optional',
+  },
   selectall: {
     doc: 'Use `false` to disable the auto select all on the first click. Defaults to `true`.',
     type: 'boolean',
@@ -109,6 +104,11 @@ export const NumberFormatProperties: PropertiesTableProps = {
   },
   clean_copy_value: {
     doc: 'If set to `true` the copy&paste value will be provided without e.g. a currency sign or a percent sign. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  clean: {
+    doc: 'If set to `true` a dirty string will be parsed to extract the number (`prefix -123.45 suffix` would result in e.g. `kr -123,45`).',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Currency/CurrencyDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Currency/CurrencyDocs.tsx
@@ -1,19 +1,17 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 import { NumberProperties } from '../Number/NumberDocs'
 
-const currency: PropertiesTableProps = {
-  currency: {
-    doc: 'Currency code (ISO 4217) or `true` to use the default `NOK`, which use two decimals by default. Defaults to value `NOK`.',
-    type: ['string', 'boolean'],
-    status: 'optional',
-  },
-}
-
 export const CurrencyValueProperties: PropertiesTableProps = {
+  value: NumberProperties.value,
+  currency: NumberProperties.currency,
+  currencyDisplay: NumberProperties.currencyDisplay,
+  currencyPosition: NumberProperties.currencyPosition,
   ...NumberProperties,
-  ...currency,
-}
-
-export const CurrencyValueHighlightedProperties: PropertiesTableProps = {
-  ...currency,
+  ban: undefined,
+  nin: undefined,
+  org: undefined,
+  percent: undefined,
+  phone: undefined,
+  link: undefined,
+  omitRounding: undefined,
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Currency/CurrencyDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Currency/CurrencyDocs.tsx
@@ -1,11 +1,19 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 import { NumberProperties } from '../Number/NumberDocs'
 
-export const CurrencyValueProperties: PropertiesTableProps = {
-  ...NumberProperties,
+const currency: PropertiesTableProps = {
   currency: {
     doc: 'Currency code (ISO 4217) or `true` to use the default `NOK`, which use two decimals by default. Defaults to value `NOK`.',
     type: ['string', 'boolean'],
     status: 'optional',
   },
+}
+
+export const CurrencyValueProperties: PropertiesTableProps = {
+  ...NumberProperties,
+  ...currency,
+}
+
+export const CurrencyValueHighlightedProperties: PropertiesTableProps = {
+  ...currency,
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/NumberDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/NumberDocs.tsx
@@ -2,7 +2,7 @@ import { PropertiesTableProps } from '../../../../shared/types'
 import { NumberFormatPropertiesCamelCase } from '../../../../components/number-format/NumberFormatDocs'
 
 export const NumberProperties: PropertiesTableProps = {
-  ...NumberFormatPropertiesCamelCase,
+  value: NumberFormatPropertiesCamelCase.value,
   minimum: {
     doc: 'Defines the minimum value of the rendered number. Defaults to `Number.MIN_SAFE_INTEGER`.',
     type: 'number',
@@ -13,4 +13,5 @@ export const NumberProperties: PropertiesTableProps = {
     type: 'number',
     status: 'optional',
   },
+  ...NumberFormatPropertiesCamelCase,
 }


### PR DESCRIPTION
Follow-up to https://github.com/dnbexperience/eufemia/pull/4008#discussion_r1776864819

As of now docs looks like the following([deploy preview](https://eufemia-dnb-design-system-portal.vercel.app/uilib/extensions/forms/Value/Currency/properties/) of release [v10.51](https://github.com/dnbexperience/eufemia/pull/4012)):

This PR will change it to be looking like this([deploy preview](https://eufemia-git-docs-improve-value-currency-docs-eufemia.vercel.app/uilib/extensions/forms/Value/Currency/properties/) this PR).

TODO:

- [x] Decide which props we want to display under [Value-specific properties](https://eufemia-git-docs-improve-value-currency-docs-eufemia.vercel.app/uilib/extensions/forms/Value/Currency/properties/#value-specific-properties)
