### PR TITLE
fix(Form.UseData): getValue returns any instead of unknown

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
@@ -37,7 +37,7 @@ type UseDataReturnUpdate<Data> = <P extends Path>(
 
 export type UseDataReturnGetValue<Data> = <P extends Path>(
   path: P
-) => PathType<Data, P> | unknown
+) => PathType<Data, P> | any
 
 export type UseDataReturnFilterData<Data> = (
   filterDataHandler: FilterData,


### PR DESCRIPTION
Not sure if it was intentionally done or not, but in PR https://github.com/dnbexperience/eufemia/pull/4000.
https://github.com/dnbexperience/eufemia/pull/4000/files#diff-140a134e6c50d8779c0d649217f3bf668c632db66fdb1d8e41f1405b330ecaa1R40

By using `unknown` makes it so that all consumers will have to type their expected value, like `getValue('/a') as string` to prevent a TS error. Of course it could potentially be "fixed" on consumer side to reduce the "strictness" or so. Just fixing this now, and then we can have a discussion about this after the vacation break.