### PR TITLE
fix(Field.Selection): prevent `radio` re-render onClick to enable keyboard navigation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -342,7 +342,7 @@ function renderRadioItems({
     return (
       <Component
         id={optionsCount === 1 ? id : undefined}
-        key={`option-${i}-${value}`}
+        key={`option-${i}-${id}`}
         label={variant === 'radio' ? label : undefined}
         text={variant === 'button' ? label : undefined}
         value={String(value ?? '')}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -342,6 +342,54 @@ describe('variants', () => {
       )
     })
 
+    it('should support keyboard navigation to select an option', async () => {
+      render(
+        <Field.Selection variant="radio" value="bar">
+          <Field.Option value="foo">Foo</Field.Option>
+          <Field.Option value="bar">Bar</Field.Option>
+          <Field.Option value="baz">Baz</Field.Option>
+        </Field.Selection>
+      )
+
+      const radioButtons = screen.queryAllByRole('radio')
+
+      expect(radioButtons.length).toEqual(3)
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+
+      await userEvent.tab()
+      await userEvent.keyboard('{arrowdown}')
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).toBeChecked()
+
+      await userEvent.keyboard('{arrowdown}')
+      expect(radioButtons[0]).toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+
+      await userEvent.keyboard('{arrowdown}')
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+
+      await userEvent.keyboard('{arrowup}')
+      expect(radioButtons[0]).toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+
+      await userEvent.keyboard('{arrowup}')
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).toBeChecked()
+
+      await userEvent.keyboard('{arrowup}')
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+    })
+
     describe('ARIA', () => {
       it('should validate with ARIA rules', async () => {
         const result = render(


### PR DESCRIPTION
closes [this issue](https://github.com/dnbexperience/eufemia/issues/3840)

Before:

https://github.com/user-attachments/assets/4629c16f-111e-47a5-85d2-3e6ed66fb003


After:

https://github.com/user-attachments/assets/f7419a58-a0ea-4430-9eb9-461c7298968e

