### PR TITLE
feat(Forms): add `isValid` to Form.Visibility for showing content based on the validation of a field

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/Examples.tsx
@@ -310,3 +310,25 @@ export function InheritVisibility() {
     </ComponentBox>
   )
 }
+
+export function VisibilityOnValidation() {
+  return (
+    <ComponentBox>
+      <Form.Handler>
+        <Card stack>
+          <Field.Name.First path="/foo" required />
+
+          <Form.Visibility
+            visibleWhen={{
+              path: '/foo',
+              hasValidated: true,
+            }}
+            animate
+          >
+            <Value.Name.First path="/foo" />
+          </Form.Visibility>
+        </Card>
+      </Form.Handler>
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/Examples.tsx
@@ -321,7 +321,7 @@ export function VisibilityOnValidation() {
           <Form.Visibility
             visibleWhen={{
               path: '/foo',
-              hasValidated: true,
+              isValid: true,
             }}
             animate
           >

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/demos.mdx
@@ -56,3 +56,11 @@ In this example we filter out all fields that have the `data-exclude-field` attr
 ### Inherit visibility
 
 <Examples.InheritVisibility />
+
+### Visibility on validation
+
+When using `hasValidated`, the visibility will only change when the field has no errors and has lost focus (blurred).
+
+This prevents visibility changes during user interactions like typing.
+
+<Examples.VisibilityOnValidation />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/demos.mdx
@@ -57,10 +57,6 @@ In this example we filter out all fields that have the `data-exclude-field` attr
 
 <Examples.InheritVisibility />
 
-### Visibility on validation
-
-When using `hasValidated`, the visibility will only change when the field has no errors and has lost focus (blurred).
-
-This prevents visibility changes during user interactions like typing.
+### Show children when field has no errors (validation)
 
 <Examples.VisibilityOnValidation />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
@@ -47,7 +47,7 @@ render(
 
 ### Validation driven visibility
 
-You can conditionally display children based on field validation by using the `visibleWhen` property with `hasValidated: true`:
+You can conditionally display children based on field validation by using the `visibleWhen` property with `isValid: true`:
 
 ```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
@@ -58,7 +58,7 @@ render(
     <Form.Visibility
       visibleWhen={{
         path: '/myField',
-        hasValidated: true,
+        isValid: true,
       }}
     >
       show me when the validation succeeds

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
@@ -4,19 +4,70 @@ showTabs: true
 
 ## Description
 
-The `Form.Visibility` component makes it possible to show or hide components on the screen based on the state of data. It can either be fed with the values directly via properties, or it can read data from a surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler) and show or hide components based on the data it points to.
+The `Form.Visibility` component allows you to conditionally show or hide components based on the state of data or field validation. You can either provide the values directly via properties or let it read data from a surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler). This enables dynamic visibility control based on the paths it points to.
+
+### Data driven visibility
+
+There are several properties you can use to control visibility, such as `pathDefined`, `pathTruthy`, `pathTrue` etc.
 
 ```tsx
-import { Form } from '@dnb/eufemia/extensions/forms'
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
 render(
   <>
     <Field.Boolean path="/myState" />
     <Form.Visibility pathTrue="/myState">
-      show me when the state value is true
+      show me when the data value is true
     </Form.Visibility>
   </>,
 )
 ```
+
+#### Dynamic value driven visibility
+
+You can also use the `visibleWhen` property to conditionally show the children based on the data value of the path.
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <>
+    <Field.Boolean path="/myState" />
+    <Form.Visibility
+      visibleWhen={{
+        path: '/myState',
+        hasValue: (value) => value === true,
+      }}
+    >
+      show me when the data value is true
+    </Form.Visibility>
+  </>,
+)
+```
+
+### Validation driven visibility
+
+You can conditionally display children based on field validation by using the `visibleWhen` property with `hasValidated: true`:
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <>
+    <Field.Boolean path="/myField" />
+    <Form.Visibility
+      visibleWhen={{
+        path: '/myField',
+        hasValidated: true,
+      }}
+    >
+      show me when the validation succeeds
+    </Form.Visibility>
+  </>,
+)
+```
+
+To prevent visibility changes during user interactions like typing, it shows the children first when the field both has no errors and has lost focus (blurred). You can use the `continuousValidation: true` property to immediately show the children when the field has no errors.
 
 ## Accessibility
 
@@ -32,7 +83,7 @@ render(
   <>
     <Field.Boolean path="/myState" />
     <Form.Visibility pathTrue="/myState" animate>
-      show me when the state value is true
+      show me when the data value is true
     </Form.Visibility>
   </>,
 )
@@ -48,7 +99,7 @@ render(
   <>
     <Field.Boolean path="/myState" />
     <Form.Visibility pathTrue="/myState" keepInDOM>
-      show me when the state value is true
+      show me when the data value is true
     </Form.Visibility>
   </>,
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/info.mdx
@@ -8,7 +8,7 @@ The `Form.Visibility` component allows you to conditionally show or hide compone
 
 ### Data driven visibility
 
-There are several properties you can use to control visibility, such as `pathDefined`, `pathTruthy`, `pathTrue` etc.
+There are several [properties](/uilib/extensions/forms/Form/Visibility/properties/) you can use to control visibility, such as `pathDefined`, `pathTruthy`, `pathTrue` etc.
 
 ```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -18,17 +18,21 @@ import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
 
 **Table of Contents**
 
-- [Quick start](#quick-start)
+- [Getting started](#getting-started)
   - [Creating forms](#creating-forms)
   - [State management](#state-management)
     - [What is a JSON Pointer?](#what-is-a-json-pointer)
     - [Data handling](#data-handling)
+    - [Visible data](#visible-data)
     - [Filter data](#filter-data)
       - [Filter data during submit](#filter-data-during-submit)
     - [Transforming data](#transforming-data)
+      - [Complex objects in the data context](#complex-objects-in-the-data-context)
   - [Async form handling](#async-form-handling)
   - [Field components](#field-components)
   - [Value components](#value-components)
+    - [Inherit visibility from fields](#inherit-visibility-from-fields)
+  - [Conditionally display content](#conditionally-display-content)
   - [Async form behavior](#async-form-behavior)
     - [onChange and autosave](#onchange-and-autosave)
     - [Async field validation](#async-field-validation)
@@ -37,7 +41,8 @@ import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
     - [required](#required)
     - [pattern](#pattern)
     - [schema](#schema)
-    - [validator](#validator)
+    - [onBlurValidator and validator](#onblurvalidator-and-validator)
+      - [Connect with another field](#connect-with-another-field)
       - [Async validation](#async-validation)
       - [Async validator with debounce](#async-validator-with-debounce)
   - [Localization and translation](#localization-and-translation)
@@ -46,7 +51,7 @@ import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
     - [Use the shared Provider to customize translations](#use-the-shared-provider-to-customize-translations)
   - [Layout](#layout)
   - [Best practices](#best-practices)
-- [Create your own component](#create-your-own-component)
+  - [Create your own component](#create-your-own-component)
 
 <QuickStart />
 
@@ -318,6 +323,23 @@ User entered data will always be stored internally in the data context, even if 
 `Value.*` components will render the value regardless of the visibility of the field.
 
 You can use the `inheritVisibility` property on the [Value.\*](/uilib/extensions/forms/Value/) components to inherit the visibility from the field with the same path.
+
+### Conditionally display content
+
+You can conditionally display content using the [Form.Visibility](/uilib/extensions/forms/Form/Visibility/) component. This allows you to show or hide its children based on the validation (A.) or the value (B.) of another path (data entry).
+
+```tsx
+<Form.Visibility
+  animate
+  visibleWhen={{
+    path: '/myField',
+    hasValue: (value) => value === 'foo', // A. Value based
+    isValid: true, // B. Validation based
+  }}
+>
+  <Field.String path="/myField" />
+</Form.Visibility>
+```
 
 ### Async form behavior
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -20,6 +20,7 @@ export type MountState = {
   isPreMounted?: boolean
   isMounted?: boolean
   isVisible?: boolean
+  isFocused?: boolean
   wasStepChange?: boolean
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -16,12 +16,21 @@ import VisibilityContext from './VisibilityContext'
 export type VisibleWhen =
   | {
       path: Path
-      hasValue: unknown
+      hasValue: unknown | ((value: unknown) => boolean)
     }
   | {
       itemPath: Path
-      hasValue: unknown
+      hasValue: unknown | ((value: unknown) => boolean)
     }
+  | {
+      path: Path
+      hasValidated: boolean
+    }
+  | {
+      itemPath: Path
+      hasValidated: boolean
+    }
+
   /**
    * @deprecated Will be removed in v11!
    */

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -24,12 +24,12 @@ export type VisibleWhen =
     }
   | {
       path: Path
-      hasValidated: boolean
+      isValid: boolean
       continuousValidation?: boolean
     }
   | {
       itemPath: Path
-      hasValidated: boolean
+      isValid: boolean
       continuousValidation?: boolean
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -25,10 +25,12 @@ export type VisibleWhen =
   | {
       path: Path
       hasValidated: boolean
+      continuousValidation?: boolean
     }
   | {
       itemPath: Path
       hasValidated: boolean
+      continuousValidation?: boolean
     }
 
   /**

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -1,6 +1,16 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 
 export const VisibilityProperties: PropertiesTableProps = {
+  visibleWhen: {
+    doc: 'Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the excepted value in order to show children. The first parameter is the value of the path. You can also use `hasValidated` instead of `hasValue` to only show the children when the field has no errors and has lost focus (blurred).',
+    type: 'object',
+    status: 'optional',
+  },
+  visibleWhenNot: {
+    doc: 'Same as `visibleWhen`, but with inverted logic.',
+    type: 'object',
+    status: 'optional',
+  },
   pathDefined: {
     doc: 'Given data context path must be defined to show children.',
     type: 'string',
@@ -29,16 +39,6 @@ export const VisibilityProperties: PropertiesTableProps = {
   pathFalse: {
     doc: 'Given data context path must be false to show children.',
     type: 'string',
-    status: 'optional',
-  },
-  visibleWhen: {
-    doc: 'Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the excepted value in order to show children. The first parameter is the value of the path.',
-    type: 'object',
-    status: 'optional',
-  },
-  visibleWhenNot: {
-    doc: 'Same as `visibleWhen`, but with inverted logic.',
-    type: 'object',
     status: 'optional',
   },
   inferData: {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -2,7 +2,7 @@ import { PropertiesTableProps } from '../../../../shared/types'
 
 export const VisibilityProperties: PropertiesTableProps = {
   visibleWhen: {
-    doc: 'Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the excepted value in order to show children. The first parameter is the value of the path. You can also use `hasValidated` instead of `hasValue` to only show the children when the field has no errors and has lost focus (blurred).',
+    doc: 'Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the excepted value in order to show children. The first parameter is the value of the path. You can also use `isValid` instead of `hasValue` to only show the children when the field has no errors and has lost focus (blurred). You can change that behavior by using the `continuousValidation` property.',
     type: 'object',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FilterData, Provider } from '../../../DataContext'
 import Visibility from '../Visibility'
+import useVisibility from '../useVisibility'
 import { Field, Form, Iterate } from '../../..'
 import { Flex } from '../../../../../components'
 import { P } from '../../../../../elements'
@@ -942,6 +943,96 @@ describe('Visibility', () => {
       )
 
       expect(screen.getByText('Child')).toBeInTheDocument()
+    })
+  })
+
+  describe('visibleWhen with "isValid"', () => {
+    it('should return only false when field path is non existent', () => {
+      const collectResult = []
+
+      const MockComponent = () => {
+        const result = useVisibility().check({
+          visibleWhen: {
+            path: '/non-existent-path',
+            isValid: true,
+          },
+        })
+        collectResult.push(result)
+        return null
+      }
+
+      render(
+        <Provider>
+          <MockComponent />
+        </Provider>
+      )
+
+      expect(collectResult).toEqual([false])
+    })
+
+    it('should return only false on first render', () => {
+      const collectResult = []
+
+      const MockComponent = () => {
+        const result = useVisibility().check({
+          visibleWhen: {
+            path: '/myPath',
+            isValid: true,
+          },
+        })
+        collectResult.push(result)
+        return null
+      }
+
+      render(
+        <Provider>
+          <Field.Number path="/myPath" required minimum={2} />
+          <MockComponent />
+        </Provider>
+      )
+
+      expect(collectResult).toEqual([false, false, false])
+
+      fireEvent.focus(document.querySelector('input'))
+      fireEvent.change(document.querySelector('input'), {
+        target: { value: '2' },
+      })
+      expect(collectResult).toEqual([false, false, false, false])
+
+      fireEvent.blur(document.querySelector('input'))
+      expect(collectResult).toEqual([false, false, false, false, true])
+    })
+
+    it('should support fields without focus and blur events', async () => {
+      const collectResult = []
+
+      const MockComponent = () => {
+        const result = useVisibility().check({
+          visibleWhen: {
+            path: '/myPath',
+            isValid: true,
+          },
+        })
+        collectResult.push(result)
+        return null
+      }
+
+      render(
+        <Provider>
+          <Field.Boolean path="/myPath" required />
+          <MockComponent />
+        </Provider>
+      )
+
+      expect(collectResult).toEqual([false, false, false])
+
+      await userEvent.click(document.querySelector('input'))
+      expect(collectResult).toEqual([false, false, false, true])
+
+      // Should have no effect
+      fireEvent.focus(document.querySelector('input'))
+      fireEvent.blur(document.querySelector('input'))
+      expect(collectResult).toEqual([false, false, false, true])
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { renderHook } from '@testing-library/react'
+import { fireEvent, renderHook } from '@testing-library/react'
 import { Provider } from '../../../DataContext'
 import useVisibility from '../useVisibility'
+import { Field } from '../../..'
 
 describe('useVisibility', () => {
   describe('visibility', () => {
@@ -121,7 +122,7 @@ describe('useVisibility', () => {
     })
 
     it('does not render children when target path is not truthy', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ isFalsy: null }}>{children}</Provider>
         ),
@@ -134,7 +135,7 @@ describe('useVisibility', () => {
     })
 
     it('does not render children when target path is not defined', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ isFalse: false }}>{children}</Provider>
         ),
@@ -164,7 +165,7 @@ describe('useVisibility', () => {
     })
 
     it('renders children when target path is not defined', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ isFalse: false }}>{children}</Provider>
         ),
@@ -177,7 +178,7 @@ describe('useVisibility', () => {
     })
 
     it('does not render children when target path is not falsy', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ isTruthy: 'value' }}>{children}</Provider>
         ),
@@ -210,7 +211,7 @@ describe('useVisibility', () => {
     })
 
     it('should not render children when hasValue does not match', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ myPath: 'foo' }}>{children}</Provider>
         ),
@@ -226,7 +227,7 @@ describe('useVisibility', () => {
     })
 
     it('should not render children when path does not match', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ myPath: 'foo' }}>{children}</Provider>
         ),
@@ -266,7 +267,7 @@ describe('useVisibility', () => {
     it('should not render children when withValue does not match', () => {
       const log = jest.spyOn(console, 'warn').mockImplementation()
 
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ myPath: 'foo' }}>{children}</Provider>
         ),
@@ -281,6 +282,105 @@ describe('useVisibility', () => {
       ).toBe(false)
 
       log.mockRestore()
+    })
+
+    describe('hasValidated', () => {
+      it('should return false when path is not existing', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => <Provider>{children}</Provider>,
+        })
+
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/something',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+      })
+
+      it('should return false when path did validate', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" required minimum={2} />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+      })
+
+      it('should return false children when path did validate, but is not blurred', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+      })
+
+      it('should return true when path did validate after blur', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" required minimum={2} />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+
+        fireEvent.change(document.querySelector('input'), {
+          target: { value: '2' },
+        })
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+
+        fireEvent.blur(document.querySelector('input'))
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+      })
     })
   })
 
@@ -304,7 +404,7 @@ describe('useVisibility', () => {
     })
 
     it('should not render children when hasValue does not match', () => {
-      const { result } = renderHook(() => useVisibility(), {
+      const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
           <Provider data={{ myPath: 'foo' }}>{children}</Provider>
         ),
@@ -317,6 +417,105 @@ describe('useVisibility', () => {
           },
         })
       ).toBe(true)
+    })
+
+    describe('hasValidated', () => {
+      it('should return true when path is not existing', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => <Provider>{children}</Provider>,
+        })
+
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/something',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+      })
+
+      it('should return true when path did validate', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" required minimum={2} />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+      })
+
+      it('should return true children when path did validate, but is not blurred', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+      })
+
+      it('should return false when path did validate after blur', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" required minimum={2} />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+
+        fireEvent.change(document.querySelector('input'), {
+          target: { value: '2' },
+        })
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+
+        fireEvent.blur(document.querySelector('input'))
+        expect(
+          result.current.check({
+            visibleWhenNot: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(false)
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -382,6 +382,51 @@ describe('useVisibility', () => {
           })
         ).toBe(true)
       })
+
+      it('should return true immediately when "continuousValidation" is true', () => {
+        const { result } = renderHook(useVisibility, {
+          wrapper: ({ children }) => (
+            <Provider>
+              <Field.Number path="/myPath" required minimum={2} />
+              {children}
+            </Provider>
+          ),
+        })
+
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+              continuousValidation: true,
+            },
+          })
+        ).toBe(false)
+
+        fireEvent.focus(document.querySelector('input'))
+        fireEvent.change(document.querySelector('input'), {
+          target: { value: '2' },
+        })
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+              continuousValidation: true,
+            },
+          })
+        ).toBe(true)
+
+        fireEvent.blur(document.querySelector('input'))
+        expect(
+          result.current.check({
+            visibleWhen: {
+              path: '/myPath',
+              hasValidated: true,
+            },
+          })
+        ).toBe(true)
+      })
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -284,7 +284,7 @@ describe('useVisibility', () => {
       log.mockRestore()
     })
 
-    describe('hasValidated', () => {
+    describe('isValid', () => {
       it('should return false when path is not existing', () => {
         const { result } = renderHook(useVisibility, {
           wrapper: ({ children }) => <Provider>{children}</Provider>,
@@ -294,7 +294,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/something',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)
@@ -314,7 +314,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)
@@ -334,7 +334,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -354,7 +354,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)
@@ -367,7 +367,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)
@@ -377,7 +377,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -397,7 +397,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
               continuousValidation: true,
             },
           })
@@ -411,7 +411,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
               continuousValidation: true,
             },
           })
@@ -422,7 +422,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhen: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -465,7 +465,7 @@ describe('useVisibility', () => {
       ).toBe(true)
     })
 
-    describe('hasValidated', () => {
+    describe('isValid', () => {
       it('should return true when path is not existing', () => {
         const { result } = renderHook(useVisibility, {
           wrapper: ({ children }) => <Provider>{children}</Provider>,
@@ -475,7 +475,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/something',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -495,7 +495,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -515,7 +515,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)
@@ -535,7 +535,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -548,7 +548,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(true)
@@ -558,7 +558,7 @@ describe('useVisibility', () => {
           result.current.check({
             visibleWhenNot: {
               path: '/myPath',
-              hasValidated: true,
+              isValid: true,
             },
           })
         ).toBe(false)

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -320,7 +320,7 @@ describe('useVisibility', () => {
         ).toBe(false)
       })
 
-      it('should return false children when path did validate, but is not blurred', () => {
+      it('should return true children when path did validate initially', () => {
         const { result } = renderHook(useVisibility, {
           wrapper: ({ children }) => (
             <Provider>
@@ -337,7 +337,7 @@ describe('useVisibility', () => {
               hasValidated: true,
             },
           })
-        ).toBe(false)
+        ).toBe(true)
       })
 
       it('should return true when path did validate after blur', () => {
@@ -359,6 +359,7 @@ describe('useVisibility', () => {
           })
         ).toBe(false)
 
+        fireEvent.focus(document.querySelector('input'))
         fireEvent.change(document.querySelector('input'), {
           target: { value: '2' },
         })
@@ -455,7 +456,7 @@ describe('useVisibility', () => {
         ).toBe(true)
       })
 
-      it('should return true children when path did validate, but is not blurred', () => {
+      it('should return false children when path did validate initially', () => {
         const { result } = renderHook(useVisibility, {
           wrapper: ({ children }) => (
             <Provider>
@@ -472,7 +473,7 @@ describe('useVisibility', () => {
               hasValidated: true,
             },
           })
-        ).toBe(true)
+        ).toBe(false)
       })
 
       it('should return false when path did validate after blur', () => {
@@ -494,6 +495,7 @@ describe('useVisibility', () => {
           })
         ).toBe(true)
 
+        fireEvent.focus(document.querySelector('input'))
         fireEvent.change(document.querySelector('input'), {
           target: { value: '2' },
         })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Field, Form } from '../../..'
+import { Field, Form, Value } from '../../..'
 import { Flex, Section, Card } from '../../../../../components'
 import { P, Ul, Li } from '../../../../../elements'
 
@@ -469,6 +469,26 @@ export const wrappingSingleVisibilityInRootFragment = () => {
             <P>text</P>
           </Form.Visibility>
         </>
+      </Card>
+    </Form.Handler>
+  )
+}
+
+export function VisibilityOnValidation() {
+  return (
+    <Form.Handler>
+      <Card stack>
+        <Field.Name.First path="/foo" required />
+
+        <Form.Visibility
+          visibleWhen={{
+            path: '/foo',
+            hasValidated: true,
+          }}
+          animate
+        >
+          <Value.Name.First path="/foo" />
+        </Form.Visibility>
       </Card>
     </Form.Handler>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/stories/Visibility.stories.tsx
@@ -483,7 +483,7 @@ export function VisibilityOnValidation() {
         <Form.Visibility
           visibleWhen={{
             path: '/foo',
-            hasValidated: true,
+            isValid: true,
           }}
           animate
         >

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -57,7 +57,7 @@ export default function useVisibility(props?: Partial<Props>) {
             ? makeIteratePath(visibleWhen.itemPath)
             : makePath(visibleWhen.path)
 
-        if ('hasValidated' in visibleWhen) {
+        if ('isValid' in visibleWhen) {
           const item = mountedFieldsRef.current[path]
           if (!item || item.isMounted !== true) {
             return visibleWhenNot ? true : false

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -8,7 +8,12 @@ import { Props } from './Visibility'
 export type { Props }
 
 export default function useVisibility(props?: Partial<Props>) {
-  const { filterDataHandler, data: originalData } = useContext(DataContext)
+  const {
+    hasFieldError,
+    filterDataHandler,
+    mountedFieldsRef,
+    data: originalData,
+  } = useContext(DataContext)
 
   const { makePath, makeIteratePath } = usePath()
 
@@ -51,33 +56,46 @@ export default function useVisibility(props?: Partial<Props>) {
           'itemPath' in visibleWhen
             ? makeIteratePath(visibleWhen.itemPath)
             : makePath(visibleWhen.path)
-        const hasPath = pointer.has(data, path)
 
-        if (hasPath) {
-          const value = pointer.get(data, path)
-
-          if (visibleWhen?.['withValue']) {
-            console.warn(
-              'VisibleWhen: "withValue" is deprecated, use "hasValue" instead'
-            )
+        if ('hasValidated' in visibleWhen) {
+          const item = mountedFieldsRef.current[path]
+          if (!item || item.isMounted === false) {
+            return visibleWhenNot ? true : false
           }
-
-          const hasValue =
-            visibleWhen?.['hasValue'] ?? visibleWhen?.['withValue']
           const result =
-            typeof hasValue === 'function'
-              ? hasValue(value) === false
-              : hasValue !== value
+            item.isFocused === false && hasFieldError(path) === false
+          return visibleWhenNot ? !result : result
+        }
 
-          if (visibleWhenNot) {
-            if (!result) {
+        if ('hasValue' in visibleWhen || 'withValue' in visibleWhen) {
+          const hasPath = pointer.has(data, path)
+
+          if (hasPath) {
+            const value = pointer.get(data, path)
+
+            if (visibleWhen?.['withValue']) {
+              console.warn(
+                'VisibleWhen: "withValue" is deprecated, use "hasValue" instead'
+              )
+            }
+
+            const hasValue =
+              visibleWhen?.['hasValue'] ?? visibleWhen?.['withValue']
+            const result =
+              typeof hasValue === 'function'
+                ? hasValue(value) === false
+                : hasValue !== value
+
+            if (visibleWhenNot) {
+              if (!result) {
+                return false
+              }
+            } else if (result) {
               return false
             }
-          } else if (result) {
+          } else {
             return false
           }
-        } else {
-          return false
         }
       }
 
@@ -120,7 +138,13 @@ export default function useVisibility(props?: Partial<Props>) {
 
       return true
     },
-    [filterDataHandler, originalData, makePath, makeIteratePath]
+    [
+      filterDataHandler,
+      originalData,
+      makePath,
+      makeIteratePath,
+      hasFieldError,
+    ]
   )
 
   return { check }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -63,7 +63,7 @@ export default function useVisibility(props?: Partial<Props>) {
             return visibleWhenNot ? true : false
           }
           const result =
-            item.isFocused === false && hasFieldError(path) === false
+            item.isFocused !== true && hasFieldError(path) === false
           return visibleWhenNot ? !result : result
         }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -59,11 +59,13 @@ export default function useVisibility(props?: Partial<Props>) {
 
         if ('hasValidated' in visibleWhen) {
           const item = mountedFieldsRef.current[path]
-          if (!item || item.isMounted === false) {
+          if (!item || item.isMounted !== true) {
             return visibleWhenNot ? true : false
           }
           const result =
-            item.isFocused !== true && hasFieldError(path) === false
+            (visibleWhen.continuousValidation
+              ? true
+              : item.isFocused !== true) && hasFieldError(path) === false
           return visibleWhenNot ? !result : result
         }
 
@@ -143,6 +145,7 @@ export default function useVisibility(props?: Partial<Props>) {
       originalData,
       makePath,
       makeIteratePath,
+      mountedFieldsRef,
       hasFieldError,
     ]
   )

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1085,10 +1085,16 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         // Field was put in focus (like when clicking in a text field or opening a dropdown menu)
         hasFocusRef.current = true
         onFocus?.apply(this, args)
+        setMountedFieldStateDataContext(identifier, {
+          isFocused: true,
+        })
       } else {
         // Field was removed from focus (like when tabbing out of a text field or closing a dropdown menu)
         hasFocusRef.current = false
         onBlur?.apply(this, args)
+        setMountedFieldStateDataContext(identifier, {
+          isFocused: false,
+        })
 
         if (!changedRef.current && !validateUnchanged) {
           // Avoid showing errors when blurring without having changed the value, so tabbing through several
@@ -1112,6 +1118,8 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     [
       getEventArgs,
       onFocus,
+      setMountedFieldStateDataContext,
+      identifier,
       onBlur,
       validateUnchanged,
       addToPool,


### PR DESCRIPTION
As of now, the Visibility does only react on data content, but not on validation.
This PR is an attempt to add support for showing something based on the validation result by another field:

```tsx
<Form.Visibility
  visibleWhen={{
    path: '/foo',
    isValid: true,
  }}
>
  <Value.Name.First path="/foo" />
</Form.Visibility>
```


Here is [a demo](https://eufemia-git-feat-visibility-validate-eufemia.vercel.app/uilib/extensions/forms/Form/Visibility/#show-children-when-field-has-no-errors-validation).

## Why first act on the blur event?


To avoid hiding/showing its content during e.g. typing, it will wait until the field has blurred.

E.g. the name field does validate negatively when a space is added after a name. During typing are we going then from false to true to false several times.

<img width="321" alt="Screenshot 2024-10-01 at 10 32 22" src="https://github.com/user-attachments/assets/2232bb1e-6845-404c-aa96-7fd3a65a32ae">



This blur behavior could for sure be omitted with a property such as `continuously: true` (a little bit like `continuousValidation`).
