### PR TITLE
fix(Forms): support validation when using object based `transformOut` and `transformIn` on fields

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
@@ -1,6 +1,11 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Flex } from '@dnb/eufemia/src'
-import { Field } from '@dnb/eufemia/src/extensions/forms'
+import { Card, Flex } from '@dnb/eufemia/src'
+import {
+  Field,
+  Form,
+  Tools,
+  Value,
+} from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -408,6 +413,50 @@ export const MultipleWithHelp = () => {
         multiline
         onChange={(value) => console.log('onChange', value)}
       />
+    </ComponentBox>
+  )
+}
+
+export function TransformInAndOut() {
+  return (
+    <ComponentBox scope={{ Tools }}>
+      {() => {
+        const transformOut = (value) => {
+          return { value, foo: 'bar' }
+        }
+        const transformIn = (data) => {
+          return data?.value
+        }
+
+        const MyForm = () => {
+          return (
+            <Form.Handler onSubmit={console.log}>
+              <Card stack>
+                <Field.String
+                  label="String field"
+                  path="/myValue"
+                  transformIn={transformIn}
+                  transformOut={transformOut}
+                  defaultValue="Default value"
+                />
+
+                <Value.String
+                  label="String value"
+                  path="/myValue"
+                  transformIn={transformIn}
+                  placeholder="(placeholder)"
+                  showEmpty
+                />
+
+                <Form.SubHeading>Data Context</Form.SubHeading>
+                <Tools.Log />
+              </Card>
+              <Form.SubmitButton />
+            </Form.Handler>
+          )
+        }
+        return <MyForm />
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
@@ -106,6 +106,10 @@ import * as Examples from './Examples'
 
 <Examples.MultipleWithHelp />
 
+### TransformIn and TransformOut
+
+<Examples.TransformInAndOut />
+
 ### Widths
 
 <Examples.Widths />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -379,8 +379,6 @@ describe('Field.SelectCountry', () => {
           path="/country"
           transformIn={valueTransformIn}
         />
-
-        <Form.SubmitButton />
       </Form.Handler>
     )
 
@@ -402,7 +400,7 @@ describe('Field.SelectCountry', () => {
     }
 
     expect(transformOut).toHaveBeenCalledTimes(1)
-    expect(transformIn).toHaveBeenCalledTimes(3)
+    expect(transformIn).toHaveBeenCalledTimes(4)
     expect(valueTransformIn).toHaveBeenCalledTimes(2)
 
     const firstItemElement = () =>
@@ -420,7 +418,7 @@ describe('Field.SelectCountry', () => {
     )
 
     expect(transformOut).toHaveBeenCalledTimes(1)
-    expect(transformIn).toHaveBeenCalledTimes(4)
+    expect(transformIn).toHaveBeenCalledTimes(5)
     expect(valueTransformIn).toHaveBeenCalledTimes(3)
 
     expect(input).toHaveValue('Norge')
@@ -435,8 +433,8 @@ describe('Field.SelectCountry', () => {
     expect(input).toHaveValue('Sveits')
     expect(value).toHaveTextContent('Sveits')
 
-    expect(transformOut).toHaveBeenCalledTimes(2)
-    expect(transformIn).toHaveBeenCalledTimes(6)
+    expect(transformOut).toHaveBeenCalledTimes(4)
+    expect(transformIn).toHaveBeenCalledTimes(8)
     expect(valueTransformIn).toHaveBeenCalledTimes(4)
 
     fireEvent.submit(form)
@@ -446,20 +444,24 @@ describe('Field.SelectCountry', () => {
       expect.anything()
     )
 
-    expect(transformOut).toHaveBeenCalledTimes(2)
-    expect(transformIn).toHaveBeenCalledTimes(7)
+    expect(transformOut).toHaveBeenCalledTimes(4)
+    expect(transformIn).toHaveBeenCalledTimes(9)
     expect(valueTransformIn).toHaveBeenCalledTimes(5)
 
     expect(transformOut).toHaveBeenNthCalledWith(1, 'NO', NO)
-    expect(transformOut).toHaveBeenNthCalledWith(2, 'CH', CH)
+    expect(transformOut).toHaveBeenNthCalledWith(2, 'NO', NO)
+    expect(transformOut).toHaveBeenNthCalledWith(3, 'CH', CH)
+    expect(transformOut).toHaveBeenNthCalledWith(4, 'CH', CH)
 
-    expect(transformIn).toHaveBeenNthCalledWith(1, 'NO')
-    expect(transformIn).toHaveBeenNthCalledWith(2, 'NO')
+    expect(transformIn).toHaveBeenNthCalledWith(1, undefined)
+    expect(transformIn).toHaveBeenNthCalledWith(2, undefined)
     expect(transformIn).toHaveBeenNthCalledWith(3, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(4, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(5, 'Norge (NO)')
-    expect(transformIn).toHaveBeenNthCalledWith(6, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(6, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(7, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(8, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(9, 'Sveits (CH)')
 
     expect(valueTransformIn).toHaveBeenNthCalledWith(1, undefined)
     expect(valueTransformIn).toHaveBeenNthCalledWith(2, 'Norge (NO)')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/stories/String.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/stories/String.stories.tsx
@@ -42,3 +42,29 @@ export const Transform = () => {
     </Form.Handler>
   )
 }
+
+export function TransformObject() {
+  const defaultData = {
+    myLabel: { value: 'Some value', test: 'test' },
+  }
+
+  return (
+    <Form.Handler
+      defaultData={defaultData}
+      onSubmit={(data) => console.log('onSubmit', data)}
+      onChange={(data) => console.log('onChange', data)}
+    >
+      <Field.Name.First
+        path="/myLabel"
+        transformOut={(value) => {
+          return { value, test: 'test' }
+        }}
+        transformIn={(data: typeof defaultData.myLabel) => {
+          return data?.value
+        }}
+      />
+
+      <Form.SubmitButton top />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2227,18 +2227,20 @@ describe('useFieldProps', () => {
       })
 
       expect(transformIn).toHaveBeenCalledTimes(2)
-      expect(transformIn).toHaveBeenLastCalledWith(3)
-      expect(transformOut).toHaveBeenCalledTimes(1)
-      expect(transformOut).toHaveBeenLastCalledWith(2, undefined)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
+      expect(transformOut).toHaveBeenCalledTimes(2)
+      expect(transformOut).toHaveBeenNthCalledWith(1, 2, expect.anything())
+      expect(transformOut).toHaveBeenNthCalledWith(2, 2, undefined)
 
       act(() => {
         handleChange(4)
       })
 
       expect(transformIn).toHaveBeenCalledTimes(3)
-      expect(transformIn).toHaveBeenLastCalledWith(5)
-      expect(transformOut).toHaveBeenCalledTimes(2)
-      expect(transformOut).toHaveBeenLastCalledWith(4, undefined)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
+      expect(transformOut).toHaveBeenCalledTimes(4)
+      expect(transformOut).toHaveBeenNthCalledWith(3, 4, expect.anything())
+      expect(transformOut).toHaveBeenNthCalledWith(4, 4, undefined)
     })
 
     it('should call "transformOut" initially when path is given', () => {
@@ -2321,7 +2323,7 @@ describe('useFieldProps', () => {
       const { handleChange } = result.current
 
       expect(transformIn).toHaveBeenCalledTimes(1)
-      expect(transformIn).toHaveBeenLastCalledWith(0)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(0)
 
       act(() => {
@@ -2329,18 +2331,20 @@ describe('useFieldProps', () => {
       })
 
       expect(transformIn).toHaveBeenCalledTimes(2)
-      expect(transformIn).toHaveBeenLastCalledWith(3)
-      expect(transformOut).toHaveBeenCalledTimes(1)
-      expect(transformOut).toHaveBeenLastCalledWith(3, undefined)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
+      expect(transformOut).toHaveBeenCalledTimes(2)
+      expect(transformOut).toHaveBeenNthCalledWith(1, 3, expect.anything())
+      expect(transformOut).toHaveBeenNthCalledWith(2, 3, undefined)
 
       act(() => {
         handleChange(4)
       })
 
       expect(transformIn).toHaveBeenCalledTimes(3)
-      expect(transformIn).toHaveBeenLastCalledWith(5)
-      expect(transformOut).toHaveBeenCalledTimes(2)
-      expect(transformOut).toHaveBeenLastCalledWith(5, undefined)
+      expect(transformIn).toHaveBeenLastCalledWith(1)
+      expect(transformOut).toHaveBeenCalledTimes(4)
+      expect(transformOut).toHaveBeenNthCalledWith(3, 5, expect.anything())
+      expect(transformOut).toHaveBeenNthCalledWith(4, 5, undefined)
     })
 
     it('should call "fromInput" and "toInput"', () => {
@@ -2566,28 +2570,44 @@ describe('useFieldProps', () => {
         handleBlur()
       })
 
-      expect(result.current.value).toBe(3)
+      expect(result.current.value).toBe(2)
       expect(result.current.dataContext.data).toEqual({
         myPath: 3,
       })
-      expect(transformOut).toHaveBeenCalledTimes(2)
-      expect(transformOut).toHaveBeenLastCalledWith(2, {
+      expect(transformOut).toHaveBeenCalledTimes(5)
+      expect(transformOut).toHaveBeenNthCalledWith(1, 1, {
+        value: 1,
+        foo: 'bar',
+      })
+      expect(transformOut).toHaveBeenNthCalledWith(2, 1, {
+        value: 1,
+        foo: 'bar',
+      })
+      expect(transformOut).toHaveBeenNthCalledWith(3, 2, {
+        value: 2,
+        foo: 'bar',
+      })
+      expect(transformOut).toHaveBeenNthCalledWith(4, 2, {
+        value: 2,
+        foo: 'bar',
+      })
+      expect(transformOut).toHaveBeenNthCalledWith(5, 2, {
         value: 2,
         foo: 'bar',
       })
       expect(onFocus).toHaveBeenCalledTimes(1)
-      expect(onFocus).toHaveBeenLastCalledWith(1, {
+      expect(onFocus).toHaveBeenLastCalledWith(2, {
         value: 1,
         foo: 'bar',
       })
       expect(onBlur).toHaveBeenCalledTimes(1)
       expect(onBlur).toHaveBeenLastCalledWith(3, {
-        value: 3,
+        value: 2,
         foo: 'bar',
       })
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(onChange).toHaveBeenLastCalledWith(3, {
-        value: 3,
+        value: 2,
         foo: 'bar',
       })
 
@@ -2597,28 +2617,28 @@ describe('useFieldProps', () => {
         handleBlur()
       })
 
-      expect(result.current.value).toBe(5)
+      expect(result.current.value).toBe(4)
       expect(result.current.dataContext.data).toEqual({
         myPath: 5,
       })
-      expect(transformOut).toHaveBeenCalledTimes(3)
+      expect(transformOut).toHaveBeenCalledTimes(9)
       expect(transformOut).toHaveBeenLastCalledWith(4, {
         value: 4,
         foo: 'bar',
       })
       expect(onFocus).toHaveBeenCalledTimes(2)
       expect(onFocus).toHaveBeenLastCalledWith(3, {
-        value: 3,
+        value: 2,
         foo: 'bar',
       })
       expect(onBlur).toHaveBeenCalledTimes(2)
       expect(onBlur).toHaveBeenLastCalledWith(5, {
-        value: 5,
+        value: 4,
         foo: 'bar',
       })
       expect(onChange).toHaveBeenCalledTimes(2)
       expect(onChange).toHaveBeenLastCalledWith(5, {
-        value: 5,
+        value: 4,
         foo: 'bar',
       })
     })

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -350,16 +350,13 @@ export interface UseFieldProps<
    * Transforms the `value` before its displayed in the field (e.g. input).
    * Public API. Should not be used internally.
    */
-  transformIn?: (external: Value | unknown) => Value | unknown
+  transformIn?: (external: unknown) => Value
 
   /**
    * Transforms the value before it gets forwarded to the form data object or returned as the onChange value parameter.
    * Public API. Should not be used internally.
    */
-  transformOut?: (
-    internal: Value | unknown,
-    additionalArgs?: unknown
-  ) => Value
+  transformOut?: (internal: Value, additionalArgs?: unknown) => unknown
 
   /**
    * Transforms the value given by `handleChange` after `fromInput` and before `updateValue` and `toEvent`. The second parameter returns the current value.

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
@@ -185,7 +185,9 @@ function ajvErrorsTransformation(
 ) {
   if (ajvError.keyword === 'type') {
     const value =
-      data && typeof data === 'object' ? pointer.get(data, path) : data
+      data && typeof data === 'object' && path
+        ? pointer.get(data, path)
+        : data
 
     // Remove the error if the value is empty
     if (value === '' || value === null) {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -178,7 +178,7 @@ export function parse(pointer: Extract<PointerPath, string>): PointerPath {
   if (pointer === '') {
     return []
   }
-  if (pointer.charAt(0) !== '/') {
+  if (pointer?.charAt(0) !== '/') {
     throw new Error('Invalid JSON pointer: ' + pointer)
   }
   return pointer.substring(1).split(/\//).map(unescape)


### PR DESCRIPTION
Fixes #3997

Until now, the "out" transformed value was used inside useFidldProps. But when transforming out to an object, validation can not be performed anymore. So this PR transforms the object "in" again internally, so validation can be performed. 