### PR TITLE
feat(Forms): add `createMinimumAgeValidator` to Field.NationalIdentityNumber make a customizable `adultValidator`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -1,4 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
+import { createAboveAgeValidator } from '@dnb/eufemia/src/extensions/forms/Field/NationalIdentityNumber'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
@@ -191,10 +192,11 @@ export const ValidationExtendValidator = () => {
 
 export const ValidationExtendValidatorAdult = () => {
   return (
-    <ComponentBox>
+    <ComponentBox scope={{ createAboveAgeValidator }}>
       {() => {
+        const adultValidator = createAboveAgeValidator(18)
         const myAdultValidator = (value, { validators }) => {
-          const { adultValidator, dnrAndFnrValidator } = validators
+          const { dnrAndFnrValidator } = validators
 
           return [dnrAndFnrValidator, adultValidator]
         }
@@ -214,10 +216,11 @@ export const ValidationExtendValidatorAdult = () => {
 
 export const ValidationFnrAdult = () => {
   return (
-    <ComponentBox>
+    <ComponentBox scope={{ createAboveAgeValidator }}>
       {() => {
+        const adultValidator = createAboveAgeValidator(18)
         const myFnrAdultValidator = (value, { validators }) => {
-          const { adultValidator, fnrValidator } = validators
+          const { fnrValidator } = validators
 
           return [fnrValidator, adultValidator]
         }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -211,3 +211,26 @@ export const ValidationExtendValidatorAdult = () => {
     </ComponentBox>
   )
 }
+
+export const ValidationFnrAdult = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const myFnrAdultValidator = (value, { validators }) => {
+          const { adultValidator, fnrValidator } = validators
+
+          return [fnrValidator, adultValidator]
+        }
+
+        return (
+          <Field.NationalIdentityNumber
+            required
+            value="49100651997"
+            onBlurValidator={myFnrAdultValidator}
+            validateInitially
+          />
+        )
+      }}
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { createAgeValidator } from '@dnb/eufemia/src/extensions/forms/Field/NationalIdentityNumber'
+import { createMinimumAgeValidator } from '@dnb/eufemia/src/extensions/forms/Field/NationalIdentityNumber'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
@@ -192,9 +192,9 @@ export const ValidationExtendValidator = () => {
 
 export const ValidationExtendValidatorAdult = () => {
   return (
-    <ComponentBox scope={{ createAgeValidator }}>
+    <ComponentBox scope={{ createMinimumAgeValidator }}>
       {() => {
-        const adultValidator = createAgeValidator(18)
+        const adultValidator = createMinimumAgeValidator(18)
         const myAdultValidator = (value, { validators }) => {
           const { dnrAndFnrValidator } = validators
 
@@ -216,9 +216,9 @@ export const ValidationExtendValidatorAdult = () => {
 
 export const ValidationFnrAdult = () => {
   return (
-    <ComponentBox scope={{ createAgeValidator }}>
+    <ComponentBox scope={{ createMinimumAgeValidator }}>
       {() => {
-        const adultValidator = createAgeValidator(18)
+        const adultValidator = createMinimumAgeValidator(18)
         const myFnrAdultValidator = (value, { validators }) => {
           const { fnrValidator } = validators
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { createAboveAgeValidator } from '@dnb/eufemia/src/extensions/forms/Field/NationalIdentityNumber'
+import { createAgeValidator } from '@dnb/eufemia/src/extensions/forms/Field/NationalIdentityNumber'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
@@ -192,9 +192,9 @@ export const ValidationExtendValidator = () => {
 
 export const ValidationExtendValidatorAdult = () => {
   return (
-    <ComponentBox scope={{ createAboveAgeValidator }}>
+    <ComponentBox scope={{ createAgeValidator }}>
       {() => {
-        const adultValidator = createAboveAgeValidator(18)
+        const adultValidator = createAgeValidator(18)
         const myAdultValidator = (value, { validators }) => {
           const { dnrAndFnrValidator } = validators
 
@@ -216,9 +216,9 @@ export const ValidationExtendValidatorAdult = () => {
 
 export const ValidationFnrAdult = () => {
   return (
-    <ComponentBox scope={{ createAboveAgeValidator }}>
+    <ComponentBox scope={{ createAgeValidator }}>
       {() => {
-        const adultValidator = createAboveAgeValidator(18)
+        const adultValidator = createAgeValidator(18)
         const myFnrAdultValidator = (value, { validators }) => {
           const { fnrValidator } = validators
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -188,3 +188,26 @@ export const ValidationExtendValidator = () => {
     </ComponentBox>
   )
 }
+
+export const ValidationExtendValidatorAdult = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const myAdultValidator = (value, { validators }) => {
+          const { adultValidator, dnrAndFnrValidator } = validators
+
+          return [dnrAndFnrValidator, adultValidator]
+        }
+
+        return (
+          <Field.NationalIdentityNumber
+            required
+            value="56052459244"
+            onBlurValidator={myAdultValidator}
+            validateInitially
+          />
+        )
+      }}
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
@@ -66,13 +66,13 @@ You can provide your own validation function, either to `validator` or `onBlurVa
 
 ### Extend validation with custom validation function
 
-You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, `dnrAndFnrValidator`, and `adultValidator`) with your own validation function.
+You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, `dnrAndFnrValidator`, and make your own age validator by using the `createMinimumAgeValidator` function) with your own validation function.
 
 <Examples.ValidationExtendValidator />
 
 ### Extend validation with adult validator
 
-You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, and `dnrAndFnrValidator`) with the `adultValidator`.
+You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, and `dnrAndFnrValidator`) with your own age validator, by using the `createMinimumAgeValidator` function.
 
 <Examples.ValidationExtendValidatorAdult />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
@@ -75,3 +75,7 @@ You can [extend the existing validations](/uilib/extensions/forms/create-compone
 You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, and `dnrAndFnrValidator`) with the `adultValidator`.
 
 <Examples.ValidationExtendValidatorAdult />
+
+### Validate only national identity numbers(fnr) above 18 years old
+
+<Examples.ValidationFnrAdult />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
@@ -54,18 +54,24 @@ Below is an example of the error message displayed when there's an invalid Norwe
 
 It validates [D numbers](https://www.skatteetaten.no/en/person/national-registry/identitetsnummer/d-nummer/) using the [fnrvalidator](https://github.com/navikt/fnrvalidator).
 
-Below is an example of the error message displayed when there's an invalid D number:
+Below is an example of the error message displayed when there's an invalid D number(a D number has its first number in the identification number increased by 4):
 
 <Examples.ValidationDnr />
 
 ### Validation function
 
-You can provide your own validation function.
+You can provide your own validation function, either to `validator` or `onBlurValidator`.
 
 <Examples.ValidationFunction />
 
 ### Extend validation with custom validation function
 
-You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, and `dnrAndFnrValidator`) with your own validation function.
+You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, `dnrAndFnrValidator`, and `adultValidator`) with your own validation function.
 
 <Examples.ValidationExtendValidator />
+
+### Extend validation with adult validator
+
+You can [extend the existing validations](/uilib/extensions/forms/create-component/useFieldProps/info/#validators)(`dnrValidator`, `fnrValidator`, and `dnrAndFnrValidator`) with the `adultValidator`.
+
+<Examples.ValidationExtendValidatorAdult />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -37,7 +37,7 @@ You need to import the `createMinimumAgeValidator` function from the `Field.Nati
 import { createMinimumAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
 
 // Create a validator that validates if the value is above 18 years old
-const above18Validator = createMinimumAgeValidator(18)
+const above18YearsValidator = createMinimumAgeValidator(18)
 ```
 
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -21,11 +21,12 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
 
 `Field.NationalIdentityNumber` expose the following validators through its `validator` and `onBlurValidator` property:
 
-- `dnrValidator`: validates a d number.
+- `dnrValidator`: validates a D number.
 - `fnrValidator`: validates a national identity number (fødselsnummer).
 - `dnrAndFnrValidator`:
-  - validates the identification number as a d number when first digit is 4 or greater (because a d number has its first number increased by 4).
+  - validates the identification number as a D number when first digit is 4 or greater (because a D number has its first number increased by 4).
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
+- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older.
 
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -28,6 +28,17 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
 - `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 9 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next three digits are individual numbers. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
+You can create your own `adultValidator` by using the `createAboveAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
+
+You need to import the `createAboveAgeValidator` function from the `Field.NationalIdentityNumber` component:
+
+```tsx
+import { createAboveAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
+
+// Create a validator that validates if the value is above 18 years old
+const above18Validator = createAboveAgeValidator(18)
+```
+
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.
 
 ## Translations

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -26,7 +26,7 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
 - `dnrAndFnrValidator`:
   - validates the identification number as a D number when first digit is 4 or greater (because a D number has its first number increased by 4).
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
-- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older.
+- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 9 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next three digits are individual numbers. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -28,7 +28,7 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
 
 You can create your own age validator by using the `createMinimumAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
-It validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next digit represents the century.
+It validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of the identification number to validate. The first 6 digits representing the birth of date, and the next digit represents the century.
 As it only use the 7 first digits, it does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
 You need to import the `createMinimumAgeValidator` function from the `Field.NationalIdentityNumber` component:

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -26,17 +26,18 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
 - `dnrAndFnrValidator`:
   - validates the identification number as a D number when first digit is 4 or greater (because a D number has its first number increased by 4).
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
-- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next digit represents the century. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
-You can create your own `adultValidator` by using the `createAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
+You can create your own age validator by using the `createMinimumAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
+It validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next digit represents the century.
+As it only use the 7 first digits, it does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
-You need to import the `createAgeValidator` function from the `Field.NationalIdentityNumber` component:
+You need to import the `createMinimumAgeValidator` function from the `Field.NationalIdentityNumber` component:
 
 ```tsx
-import { createAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
+import { createMinimumAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
 
 // Create a validator that validates if the value is above 18 years old
-const above18Validator = createAgeValidator(18)
+const above18Validator = createMinimumAgeValidator(18)
 ```
 
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -26,7 +26,7 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
 - `dnrAndFnrValidator`:
   - validates the identification number as a D number when first digit is 4 or greater (because a D number has its first number increased by 4).
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
-- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 9 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next three digits are individual numbers. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
+- `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next digit represents the century. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
 You can create your own `adultValidator` by using the `createAboveAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties.mdx
@@ -28,15 +28,15 @@ import { NationalIdentityNumberProperties } from '@dnb/eufemia/src/extensions/fo
   - validates the identification number as a national identity number (fødselsnummer) when first digit is 3 or less.
 - `adultValidator`: validates if the identification number has a date of birth that is 18 years or older. It uses only the 7 first digits of an identification number to validate, first 6 digits representing the birth of date, and the next digit represents the century. It does not validate the identification number, therefore it's quite common to use this validator together with one of the validators above (`dnrValidator`, `fnrValidator` or `dnrAndFnrValidator`) to validate the identification number as well.
 
-You can create your own `adultValidator` by using the `createAboveAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
+You can create your own `adultValidator` by using the `createAgeValidator` function. It takes an age as a parameter and returns a validator function. The validator function takes a value and returns an error message if the value is not above the given age.
 
-You need to import the `createAboveAgeValidator` function from the `Field.NationalIdentityNumber` component:
+You need to import the `createAgeValidator` function from the `Field.NationalIdentityNumber` component:
 
 ```tsx
-import { createAboveAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
+import { createAgeValidator } from '@dnb/eufemia/extensions/forms/Field/NationalIdentityNumber'
 
 // Create a validator that validates if the value is above 18 years old
-const above18Validator = createAboveAgeValidator(18)
+const above18Validator = createAgeValidator(18)
 ```
 
 See the following [example](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/#extend-validation-with-custom-validation-function) on how to extend validation using the exposed validators.

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -150,7 +150,7 @@ export function getBirthDateByFnrOrDnr(value: string) {
   return new Date(Number.parseInt(year), month - 1, day)
 }
 
-export function createAboveAgeValidator(age: number) {
+export function createAgeValidator(age: number) {
   return (value: string) => {
     if (typeof value !== 'string') {
       return // stop here

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -152,7 +152,7 @@ export function getBirthDateByFnrOrDnr(value: string) {
 
 export function createAboveAgeValidator(age: number) {
   return (value: string) => {
-    if (typeof value !== 'string' || value.length < 9) {
+    if (typeof value !== 'string' || value.length < 7) {
       return
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -133,9 +133,9 @@ export function getBirthDateByFnrOrDnr(value: string) {
   }
 
   const yearPart = value.substring(4, 6)
-  const individualNumber = Number.parseInt(value.substring(6, 9))
+  const centuryNumber = Number.parseInt(value.substring(6, 7))
 
-  const isBornIn20XX = individualNumber >= 500 && individualNumber <= 999
+  const isBornIn20XX = centuryNumber >= 5
   const year = isBornIn20XX ? `20${yearPart}` : `19${yearPart}`
   const month = Number.parseInt(value.substring(2, 4))
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -152,17 +152,21 @@ export function getBirthDateByFnrOrDnr(value: string) {
 
 export function createAboveAgeValidator(age: number) {
   return (value: string) => {
-    if (typeof value !== 'string' || value.length < 7) {
-      return
+    if (typeof value !== 'string') {
+      return // stop here
     }
 
-    const date = getBirthDateByFnrOrDnr(value)
-    if (getAgeByBirthDate(date) < age) {
-      return new FormError('NationalIdentityNumber.errorBelowAge', {
-        validationRule: 'errorBelowAge', // "validationRule" Will be removed in future PR
-        messageValues: { age: String(age) },
-      })
+    if (value.length > 6) {
+      const date = getBirthDateByFnrOrDnr(value)
+      if (getAgeByBirthDate(date) >= age) {
+        return // stop here
+      }
     }
+
+    return new FormError('NationalIdentityNumber.errorBelowAge', {
+      validationRule: 'errorBelowAge', // "validationRule" Will be removed in future PR
+      messageValues: { age: String(age) },
+    })
   }
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -150,7 +150,7 @@ export function getBirthDateByFnrOrDnr(value: string) {
   return new Date(Number.parseInt(year), month - 1, day)
 }
 
-export function createAgeValidator(age: number) {
+export function createMinimumAgeValidator(age: number) {
   return (value: string) => {
     if (typeof value !== 'string') {
       return // stop here

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -14,14 +14,14 @@ export type Props = Omit<StringFieldProps, 'onBlurValidator'> & {
 
 function NationalIdentityNumber(props: Props) {
   const translations = useTranslation().NationalIdentityNumber
-  const { label, errorRequired, errorFnr, errorDnr, errorBelowAge } =
+  const { label, errorRequired, errorFnr, errorDnr, errorAgeValidator } =
     translations
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
     required: errorRequired,
     pattern: errorFnr,
     errorFnr,
     errorDnr,
-    errorBelowAge,
+    errorAgeValidator,
   })
 
   const fnrValidator = useCallback(
@@ -163,8 +163,8 @@ export function createAgeValidator(age: number) {
       }
     }
 
-    return new FormError('NationalIdentityNumber.errorBelowAge', {
-      validationRule: 'errorBelowAge', // "validationRule" Will be removed in future PR
+    return new FormError('NationalIdentityNumber.errorAgeValidator', {
+      validationRule: 'errorAgeValidator', // "validationRule" Will be removed in future PR
       messageValues: { age: String(age) },
     })
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -26,8 +26,11 @@ function NationalIdentityNumber(props: Props) {
 
   const fnrValidator = useCallback(
     (value: string) => {
-      // We don't want to validate if the value is undefined
-      if (value !== undefined && fnr(value).status === 'invalid') {
+      if (
+        value !== undefined &&
+        (Number.parseInt(value.substring(0, 1)) > 3 ||
+          fnr(value).status === 'invalid')
+      ) {
         return Error(errorFnr)
       }
     },
@@ -36,8 +39,11 @@ function NationalIdentityNumber(props: Props) {
 
   const dnrValidator = useCallback(
     (value: string) => {
-      // We don't want to validate if the value is undefined
-      if (value !== undefined && dnr(value).status === 'invalid') {
+      if (
+        value !== undefined &&
+        (Number.parseInt(value.substring(0, 1)) < 4 ||
+          dnr(value).status === 'invalid')
+      ) {
         return Error(errorDnr)
       }
     },
@@ -58,7 +64,9 @@ function NationalIdentityNumber(props: Props) {
 
   const adultValidator = useCallback(
     (value: string) => {
-      // We don't want to validate if the value is undefined
+      // if (value !== undefined && value.length < 9) {
+      //   return Error(errorAdultPattern)
+      // }
       if (value !== undefined && !is18YearsOrOlder(value)) {
         return Error(errorAdult)
       }
@@ -142,7 +150,9 @@ function is18YearsOrOlder(value: string) {
   const year = isBornIn20XX ? `20${yearPart}` : `19${yearPart}`
   const month = Number.parseInt(value.substring(2, 4))
 
-  const isDnr = dnr(value).status === 'valid'
+  const differentiatorValue =
+    value.length > 0 ? Number.parseInt(value.substring(0, 1)) : undefined
+  const isDnr = differentiatorValue && differentiatorValue > 3
 
   const day = isDnr
     ? Number.parseInt(value.substring(0, 2)) - 40

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -14,14 +14,19 @@ export type Props = Omit<StringFieldProps, 'onBlurValidator'> & {
 
 function NationalIdentityNumber(props: Props) {
   const translations = useTranslation().NationalIdentityNumber
-  const { label, errorRequired, errorFnr, errorDnr, errorAgeValidator } =
-    translations
+  const {
+    label,
+    errorRequired,
+    errorFnr,
+    errorDnr,
+    errorMinimumAgeValidator,
+  } = translations
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
     required: errorRequired,
     pattern: errorFnr,
     errorFnr,
     errorDnr,
-    errorAgeValidator,
+    errorMinimumAgeValidator,
   })
 
   const fnrValidator = useCallback(
@@ -163,10 +168,13 @@ export function createMinimumAgeValidator(age: number) {
       }
     }
 
-    return new FormError('NationalIdentityNumber.errorAgeValidator', {
-      validationRule: 'errorAgeValidator', // "validationRule" Will be removed in future PR
-      messageValues: { age: String(age) },
-    })
+    return new FormError(
+      'NationalIdentityNumber.errorMinimumAgeValidator',
+      {
+        validationRule: 'errorMinimumAgeValidator', // "validationRule" Will be removed in future PR
+        messageValues: { age: String(age) },
+      }
+    )
   }
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 import { render, waitFor, screen } from '@testing-library/react'
 import { Field, Validator } from '../../..'
+import { createAboveAgeValidator } from '../NationalIdentityNumber'
 
 import nbNO from '../../../constants/locales/nb-NO'
 
 const nb = nbNO['nb-NO']
 
 describe('Field.NationalIdentityNumber with adultValidator', () => {
+  const errorBelowAge = nb.NationalIdentityNumber.errorBelowAge.replace(
+    '{age}',
+    '18'
+  )
+  const adultValidator = createAboveAgeValidator(18)
   const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
     string
   > = (value, { validators }) => {
-    const { adultValidator, dnrAndFnrValidator } = validators
+    const { dnrAndFnrValidator } = validators
 
     return [dnrAndFnrValidator, adultValidator]
   }
@@ -19,7 +25,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     value,
     { validators }
   ) => {
-    const { adultValidator, dnrValidator } = validators
+    const { dnrValidator } = validators
 
     return [dnrValidator, adultValidator]
   }
@@ -28,14 +34,12 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     value,
     { validators }
   ) => {
-    const { adultValidator, fnrValidator } = validators
+    const { fnrValidator } = validators
 
     return [fnrValidator, adultValidator]
   }
 
-  const myAdultValidator: Validator<string> = (value, { validators }) => {
-    const { adultValidator } = validators
-
+  const myAdultValidator: Validator<string> = () => {
     return [adultValidator]
   }
 
@@ -56,20 +60,18 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     })
   })
 
-  it('should display error when validateInitially and value', async () => {
+  it.skip('should display error when value is invalid', async () => {
     render(
       <Field.NationalIdentityNumber
         onBlurValidator={myAdultValidator}
         validateInitially
-        value="123"
+        value="123" // outputs the age of 105 years, which is valid
       />
     )
 
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
-      expect(screen.queryByRole('alert')).toHaveTextContent(
-        nb.NationalIdentityNumber.errorAdult
-      )
+      expect(screen.queryByRole('alert')).toHaveTextContent(errorBelowAge)
     })
   })
 
@@ -213,7 +215,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -251,7 +253,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -291,7 +293,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -373,7 +375,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -455,7 +457,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -513,7 +515,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -574,7 +576,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }
@@ -632,7 +634,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              nb.NationalIdentityNumber.errorAdult
+              errorBelowAge
             )
           })
         }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -1,0 +1,408 @@
+import React from 'react'
+import { render, waitFor, screen } from '@testing-library/react'
+import { Field, Validator } from '../../..'
+
+import nbNO from '../../../constants/locales/nb-NO'
+
+const nb = nbNO['nb-NO']
+
+describe('Field.NationalIdentityNumber with adultValidator', () => {
+  const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
+    string
+  > = (value, { validators }) => {
+    const { adultValidator, dnrAndFnrValidator } = validators
+
+    return [dnrAndFnrValidator, adultValidator]
+  }
+
+  const myAdultValidator: Validator<string> = (value, { validators }) => {
+    const { adultValidator } = validators
+
+    return [adultValidator]
+  }
+
+  it('should display error if required and validateInitially', async () => {
+    render(
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        required
+        validateInitially
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        nb.NationalIdentityNumber.errorRequired
+      )
+    })
+  })
+
+  it('should display error when validateInitially and value', async () => {
+    render(
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        validateInitially
+        value="123"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        nb.NationalIdentityNumber.errorAdult
+      )
+    })
+  })
+
+  it('should not display error when validateInitially and no value', async () => {
+    render(
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        validateInitially
+      />
+    )
+
+    await expect(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    }).neverToResolve()
+  })
+
+  describe('should validate if identity numbers is adult(18 years and older)', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-10-09').getTime())
+    const fnr0YearsOld = [
+      '10072476609',
+      '29082499936',
+      '03022450718',
+      '11032455001',
+      '30082489912',
+    ]
+
+    const fnr17YearsOld = [
+      '31050752669',
+      '10040752779',
+      '28050772596',
+      '25060798446',
+      '07100782566',
+      '08100787300',
+    ]
+
+    const fnrUnder18YearsOld = [...fnr0YearsOld, ...fnr17YearsOld]
+
+    const fnr18Years = [
+      '09100654021',
+      '09100696336',
+      '24040664900',
+      '26020682328',
+      '07070663990',
+      '11030699302',
+      '31010699021',
+      '49100651997',
+    ]
+    const fnr99Years = [
+      '14102535759',
+      '20042528022',
+      '14082523414',
+      '01022537632',
+      '01022504416',
+    ]
+    const fnr18YearsOldTo99 = [
+      '25047441741',
+      '06118836551',
+      '19042648291',
+      '18053526132',
+      '29075642618',
+    ]
+    const fnr99To120YearsOld = [
+      '22041330302',
+      '02061234694',
+      '23020704845',
+      '28021741177',
+      '10121933999',
+    ]
+    const fnr18YearsOldAndOlder = [
+      ...fnr18Years,
+      ...fnr99Years,
+      ...fnr18YearsOldTo99,
+      ...fnr99To120YearsOld,
+    ]
+
+    const dnrUnder18YearsOld = [
+      '42011660597',
+      '44011957371',
+      '45010886213',
+      '60050972871',
+      '65052062378',
+      '70121275293',
+      '71072354979',
+      '43072496079',
+      '44052351836',
+      '56052459244',
+      '59082354829',
+      '63032486179',
+      '48100754692',
+    ]
+    const dnr18YearsOldAndOlder = [
+      '49100651997',
+      '49100697466',
+      '41070663889',
+      '42020653633',
+      '41012413597',
+      '41062421922',
+      '41080422588',
+      '44081020024',
+      '71081924796',
+      '60067139081',
+      '60075812380',
+    ]
+
+    const validIds = [...fnr18YearsOldAndOlder, ...dnr18YearsOldAndOlder]
+
+    const invalidIds = [...fnrUnder18YearsOld, ...dnrUnder18YearsOld]
+
+    const invalidDnums = ['69020112345', '690']
+    const invalidFnrs = ['29020112345', '290']
+
+    describe('when provided as the only validator validation function', () => {
+      it.each(validIds)(
+        'Identity number is 18 years or older : %s',
+        async (validId) => {
+          render(
+            <Field.NationalIdentityNumber
+              validator={myAdultValidator}
+              onBlurValidator={false}
+              validateInitially
+              value={validId}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(invalidIds)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidId) => {
+          render(
+            <Field.NationalIdentityNumber
+              validator={myAdultValidator}
+              onBlurValidator={false}
+              validateInitially
+              value={invalidId}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+    })
+
+    describe('when provided as the only onBlurValidation validation function', () => {
+      it.each(validIds)(
+        'Identity number is 18 years or older : %s',
+        async (validId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={myAdultValidator}
+              validateInitially
+              value={validId}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(invalidIds)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={myAdultValidator}
+              validateInitially
+              value={invalidId}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+    })
+
+    describe('when extending the dnrAndFnrValidator as validator', () => {
+      it.each(validIds)(
+        'Identity number is 18 years or older : %s',
+        async (validId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrAndFnrValidatorWithAdultValidator}
+              validateInitially
+              value={validId}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(invalidIds)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrAndFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidId}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each(invalidDnums)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrAndFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidDnum}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorDnr
+            )
+          })
+        }
+      )
+
+      it.each(invalidFnrs)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrAndFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidFnr}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorFnr
+            )
+          })
+        }
+      )
+    })
+
+    describe('when extending the dnrAndFnrValidator as onBlurValidator', () => {
+      it.each(validIds)(
+        'Identity number is 18 years or older : %s',
+        async (validId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={
+                extendingDnrAndFnrValidatorWithAdultValidator
+              }
+              validateInitially
+              value={validId}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(invalidIds)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidId) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={
+                extendingDnrAndFnrValidatorWithAdultValidator
+              }
+              validateInitially
+              value={invalidId}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each(invalidDnums)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={
+                extendingDnrAndFnrValidatorWithAdultValidator
+              }
+              validateInitially
+              value={invalidDnum}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorDnr
+            )
+          })
+        }
+      )
+
+      it.each(invalidFnrs)(
+        'Invalid identity number is not 18 years or older: %s',
+        async (invalidFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={
+                extendingDnrAndFnrValidatorWithAdultValidator
+              }
+              validateInitially
+              value={invalidFnr}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorFnr
+            )
+          })
+        }
+      )
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -15,6 +15,24 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     return [dnrAndFnrValidator, adultValidator]
   }
 
+  const extendingDnrValidatorWithAdultValidator: Validator<string> = (
+    value,
+    { validators }
+  ) => {
+    const { adultValidator, dnrValidator } = validators
+
+    return [dnrValidator, adultValidator]
+  }
+
+  const extendingFnrValidatorWithAdultValidator: Validator<string> = (
+    value,
+    { validators }
+  ) => {
+    const { adultValidator, fnrValidator } = validators
+
+    return [fnrValidator, adultValidator]
+  }
+
   const myAdultValidator: Validator<string> = (value, { validators }) => {
     const { adultValidator } = validators
 
@@ -97,7 +115,6 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
       '07070663990',
       '11030699302',
       '31010699021',
-      '49100651997',
     ]
     const fnr99Years = [
       '14102535759',
@@ -403,6 +420,244 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           })
         }
       )
+    })
+
+    describe('when extending the dnrValidator as validator', () => {
+      it.each(dnr18YearsOldAndOlder)(
+        'D number is 18 years or older : %s',
+        async (validDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrValidatorWithAdultValidator}
+              validateInitially
+              value={validDnum}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(dnrUnder18YearsOld)(
+        'D number is not 18 years or older: %s',
+        async (invalidDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidDnum}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each([...invalidDnums, ...invalidFnrs, ...fnr18YearsOldAndOlder])(
+        'Invalid d number: %s',
+        async (invalidDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingDnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidDnum}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorDnr
+            )
+          })
+        }
+      )
+    })
+
+    describe('when extending the dnrValidator as onBlurValidator', () => {
+      it.each(dnr18YearsOldAndOlder)(
+        'D number is 18 years or older : %s',
+        async (validDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={extendingDnrValidatorWithAdultValidator}
+              validateInitially
+              value={validDnum}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(dnrUnder18YearsOld)(
+        'D number is not 18 years or older: %s',
+        async (invalidDnum) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={extendingDnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidDnum}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each([
+        ...invalidDnums,
+        ...invalidFnrs,
+        ...fnr18YearsOldAndOlder,
+        ...fnrUnder18YearsOld,
+      ])('Invalid d number: %s', async (invalidDnum) => {
+        render(
+          <Field.NationalIdentityNumber
+            onBlurValidator={extendingDnrValidatorWithAdultValidator}
+            validateInitially
+            value={invalidDnum}
+          />
+        )
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            nb.NationalIdentityNumber.errorDnr
+          )
+        })
+      })
+    })
+
+    describe('when extending the fnrValidator as validator', () => {
+      it.each(fnr18YearsOldAndOlder)(
+        'Identity number(fnr) is 18 years or older : %s',
+        async (validFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingFnrValidatorWithAdultValidator}
+              validateInitially
+              value={validFnr}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(fnrUnder18YearsOld)(
+        'Identity number(fnr) is not 18 years or older: %s',
+        async (invalidFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidFnr}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each([...invalidFnrs, ...invalidDnums, ...dnr18YearsOldAndOlder])(
+        'Invalid identity number(fnr): %s',
+        async (invalidFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={false}
+              validator={extendingFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidFnr}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorFnr
+            )
+          })
+        }
+      )
+    })
+
+    describe('when extending the fnrValidator as onBlurValidator', () => {
+      it.each(fnr18YearsOldAndOlder)(
+        'Identity number(fnr) is 18 years or older : %s',
+        async (validFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={extendingFnrValidatorWithAdultValidator}
+              validateInitially
+              value={validFnr}
+            />
+          )
+
+          await expect(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+          }).neverToResolve()
+        }
+      )
+
+      it.each(fnrUnder18YearsOld)(
+        'Identity number(fnr) is not 18 years or older: %s',
+        async (invalidFnr) => {
+          render(
+            <Field.NationalIdentityNumber
+              onBlurValidator={extendingFnrValidatorWithAdultValidator}
+              validateInitially
+              value={invalidFnr}
+            />
+          )
+          await waitFor(() => {
+            expect(screen.queryByRole('alert')).toBeInTheDocument()
+            expect(screen.queryByRole('alert')).toHaveTextContent(
+              nb.NationalIdentityNumber.errorAdult
+            )
+          })
+        }
+      )
+
+      it.each([
+        ...invalidFnrs,
+        ...invalidDnums,
+        ...dnr18YearsOldAndOlder,
+        ...dnrUnder18YearsOld,
+      ])('Invalid identity number(fnr): %s', async (invalidFnr) => {
+        render(
+          <Field.NationalIdentityNumber
+            onBlurValidator={extendingFnrValidatorWithAdultValidator}
+            validateInitially
+            value={invalidFnr}
+          />
+        )
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            nb.NationalIdentityNumber.errorFnr
+          )
+        })
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -60,12 +60,12 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     })
   })
 
-  it.skip('should display error when value is invalid', async () => {
+  it('should display error when value is invalid', async () => {
     render(
       <Field.NationalIdentityNumber
         onBlurValidator={myAdultValidator}
         validateInitially
-        value="123" // outputs the age of 105 years, which is valid
+        value="123"
       />
     )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -8,8 +8,11 @@ import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('Field.NationalIdentityNumber with adultValidator', () => {
-  const errorAgeValidator =
-    nb.NationalIdentityNumber.errorAgeValidator.replace('{age}', '18')
+  const errorMinimumAgeValidator =
+    nb.NationalIdentityNumber.errorMinimumAgeValidator.replace(
+      '{age}',
+      '18'
+    )
   const adultValidator = createMinimumAgeValidator(18)
   const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
     string
@@ -70,7 +73,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert')).toHaveTextContent(
-        errorAgeValidator
+        errorMinimumAgeValidator
       )
     })
   })
@@ -215,7 +218,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -253,7 +256,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -293,7 +296,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -375,7 +378,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -457,7 +460,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -515,7 +518,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -576,7 +579,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }
@@ -634,7 +637,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorAgeValidator
+              errorMinimumAgeValidator
             )
           })
         }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, waitFor, screen } from '@testing-library/react'
 import { Field, Validator } from '../../..'
-import { createAgeValidator } from '../NationalIdentityNumber'
+import { createMinimumAgeValidator } from '../NationalIdentityNumber'
 
 import nbNO from '../../../constants/locales/nb-NO'
 
@@ -10,7 +10,7 @@ const nb = nbNO['nb-NO']
 describe('Field.NationalIdentityNumber with adultValidator', () => {
   const errorAgeValidator =
     nb.NationalIdentityNumber.errorAgeValidator.replace('{age}', '18')
-  const adultValidator = createAgeValidator(18)
+  const adultValidator = createMinimumAgeValidator(18)
   const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
     string
   > = (value, { validators }) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, waitFor, screen } from '@testing-library/react'
 import { Field, Validator } from '../../..'
-import { createAboveAgeValidator } from '../NationalIdentityNumber'
+import { createAgeValidator } from '../NationalIdentityNumber'
 
 import nbNO from '../../../constants/locales/nb-NO'
 
@@ -12,7 +12,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
     '{age}',
     '18'
   )
-  const adultValidator = createAboveAgeValidator(18)
+  const adultValidator = createAgeValidator(18)
   const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
     string
   > = (value, { validators }) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumberAdultValidator.test.tsx
@@ -8,10 +8,8 @@ import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('Field.NationalIdentityNumber with adultValidator', () => {
-  const errorBelowAge = nb.NationalIdentityNumber.errorBelowAge.replace(
-    '{age}',
-    '18'
-  )
+  const errorAgeValidator =
+    nb.NationalIdentityNumber.errorAgeValidator.replace('{age}', '18')
   const adultValidator = createAgeValidator(18)
   const extendingDnrAndFnrValidatorWithAdultValidator: Validator<
     string
@@ -71,7 +69,9 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
 
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
-      expect(screen.queryByRole('alert')).toHaveTextContent(errorBelowAge)
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        errorAgeValidator
+      )
     })
   })
 
@@ -215,7 +215,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -253,7 +253,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -293,7 +293,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -375,7 +375,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -457,7 +457,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -515,7 +515,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -576,7 +576,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }
@@ -634,7 +634,7 @@ describe('Field.NationalIdentityNumber with adultValidator', () => {
           await waitFor(() => {
             expect(screen.queryByRole('alert')).toBeInTheDocument()
             expect(screen.queryByRole('alert')).toHaveTextContent(
-              errorBelowAge
+              errorAgeValidator
             )
           })
         }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Field, Validator } from '../../..'
 import { Wrapper } from 'storybook-utils/helpers'
-import { createAgeValidator } from '../NationalIdentityNumber'
+import { createMinimumAgeValidator } from '../NationalIdentityNumber'
 
 export default {
   title: 'Eufemia/Extensions/Forms/NationalIdentityNumber',
@@ -11,7 +11,7 @@ const simpleValidator = (value) => {
   return value?.length < 4 ? Error('At least 4 characters') : undefined
 }
 
-const adultValidator = createAgeValidator(18)
+const adultValidator = createMinimumAgeValidator(18)
 
 const myAdultValidator: Validator<string> = () => {
   return [adultValidator]

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Field, Validator } from '../../..'
 import { Wrapper } from 'storybook-utils/helpers'
+import { createAboveAgeValidator } from '../NationalIdentityNumber'
 
 export default {
   title: 'Eufemia/Extensions/Forms/NationalIdentityNumber',
@@ -10,13 +11,9 @@ const simpleValidator = (value) => {
   return value?.length < 4 ? Error('At least 4 characters') : undefined
 }
 
-// const alwaysErrorValidator = (value) => {
-//   return Error('Always Error Validator')
-// }
+const adultValidator = createAboveAgeValidator(18)
 
-const myAdultValidator: Validator<string> = (value, { validators }) => {
-  const { adultValidator } = validators
-
+const myAdultValidator: Validator<string> = () => {
   return [adultValidator]
 }
 
@@ -24,7 +21,7 @@ const myAdultFnrDnrValidator: Validator<string> = (
   value,
   { validators }
 ) => {
-  const { adultValidator, dnrAndFnrValidator } = validators
+  const { dnrAndFnrValidator } = validators
 
   return [dnrAndFnrValidator, adultValidator]
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
@@ -1,16 +1,761 @@
 import React from 'react'
-import { Field } from '../../..'
+import { Field, Validator } from '../../..'
+import { Wrapper } from 'storybook-utils/helpers'
 
 export default {
   title: 'Eufemia/Extensions/Forms/NationalIdentityNumber',
 }
 
-export function NationalIdentityNumber() {
+const simpleValidator = (value) => {
+  return value?.length < 4 ? Error('At least 4 characters') : undefined
+}
+
+// const alwaysErrorValidator = (value) => {
+//   return Error('Always Error Validator')
+// }
+
+const myAdultValidator: Validator<string> = (value, { validators }) => {
+  const { adultValidator } = validators
+
+  return [adultValidator]
+}
+
+const myAdultFnrDnrValidator: Validator<string> = (
+  value,
+  { validators }
+) => {
+  const { adultValidator, dnrAndFnrValidator } = validators
+
+  return [dnrAndFnrValidator, adultValidator]
+}
+
+const myFnrValidator: Validator<string> = (value, { validators }) => {
+  const { fnrValidator } = validators
+
+  return [fnrValidator]
+}
+
+const myDnrValidator: Validator<string> = (value, { validators }) => {
+  const { dnrValidator } = validators
+
+  return [dnrValidator]
+}
+
+const myFnrAndDnrValidator: Validator<string> = (
+  value,
+  { validators }
+) => {
+  const { dnrAndFnrValidator } = validators
+
+  return [dnrAndFnrValidator]
+}
+
+export function ValidatorsUndefinedFalse() {
   return (
-    <>
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        validator={undefined}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validator={undefined}
+        onBlurValidator={false}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        validator={undefined}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={undefined}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={undefined}
+        onBlurValidator={false}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={undefined}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function NationalIdentityNumberDefault() {
+  return (
+    <Wrapper>
       <Field.NationalIdentityNumber />
-      <Field.NationalIdentityNumber value="123" />
       <Field.NationalIdentityNumber value="12345678901" />
-    </>
+      <Field.NationalIdentityNumber value="42345678901" />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber validateInitially />
+      <Field.NationalIdentityNumber
+        validateInitially
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function NationalIdentityNumberAndDNumberOnBlurValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        onBlurValidator={myFnrAndDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myFnrAndDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myFnrAndDnrValidator}
+        value="42345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrAndDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrAndDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrAndDnrValidator}
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function NationalIdentityNumberOnBlurValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber onBlurValidator={myFnrValidator} />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myFnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myFnrValidator}
+        value="42345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myFnrValidator}
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function NationalIdentityNumberValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myFnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myFnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myFnrValidator}
+        value="42345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myFnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myFnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myFnrValidator}
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function DNumberOnBlurValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber onBlurValidator={myDnrValidator} />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myDnrValidator}
+        value="42345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myDnrValidator}
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function DNumberValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myDnrValidator}
+        value="42345678901"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myDnrValidator}
+        value="42345678901"
+      />
+    </Wrapper>
+  )
+}
+
+export function AdultOnBlurValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber onBlurValidator={myAdultValidator} />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultValidator}
+        value="44011957371"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultValidator}
+        value="44011957371"
+      />
+    </Wrapper>
+  )
+}
+
+export function AdultValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="44011957371"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="123"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={false}
+        validator={myAdultValidator}
+        value="44011957371"
+      />
+    </Wrapper>
+  )
+}
+
+export function AdultOnBlurValidatorAndDefaultValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultFnrDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="44011957371"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultFnrDnrValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={myAdultFnrDnrValidator}
+        value="44011957371"
+      />
+    </Wrapper>
+  )
+}
+
+export function AdultValidatorAndDefaultValidator() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="44011957371"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={myAdultFnrDnrValidator}
+        onBlurValidator={false}
+        value="44011957371"
+      />
+    </Wrapper>
+  )
+}
+
+export function CustomValidatorFunction() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="44011957371"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="29082499936"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="44011957371"
+      />
+    </Wrapper>
+  )
+}
+
+export function CustomOnBlurValidatorFunction() {
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber onBlurValidator={simpleValidator} />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="123"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="123"
+      />
+    </Wrapper>
+  )
+}
+
+export function CustomValidatorFunctionReturnArray() {
+  const validatorX = (value) => {
+    return value?.length < 4 ? Error('At least 4 characters') : undefined
+  }
+
+  const simpleValidator = () => {
+    return [validatorX]
+  }
+
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="123"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        validator={simpleValidator}
+        onBlurValidator={false}
+        value="123"
+      />
+    </Wrapper>
+  )
+}
+
+export function CustomOnBlurValidatorFunctionReturnArray() {
+  const validatorX = (value) => {
+    return value?.length < 4 ? Error('At least 4 characters') : undefined
+  }
+
+  const simpleValidator = () => {
+    return [validatorX]
+  }
+
+  return (
+    <Wrapper>
+      <Field.NationalIdentityNumber onBlurValidator={simpleValidator} />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        onBlurValidator={simpleValidator}
+        value="123"
+      />
+      <h2>Validate Initially:</h2>
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="12345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="42345678901"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="321"
+      />
+      <Field.NationalIdentityNumber
+        validateInitially
+        onBlurValidator={simpleValidator}
+        value="123"
+      />
+    </Wrapper>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/stories/NationalIdentityNumber.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Field, Validator } from '../../..'
 import { Wrapper } from 'storybook-utils/helpers'
-import { createAboveAgeValidator } from '../NationalIdentityNumber'
+import { createAgeValidator } from '../NationalIdentityNumber'
 
 export default {
   title: 'Eufemia/Extensions/Forms/NationalIdentityNumber',
@@ -11,7 +11,7 @@ const simpleValidator = (value) => {
   return value?.length < 4 ? Error('At least 4 characters') : undefined
 }
 
-const adultValidator = createAboveAgeValidator(18)
+const adultValidator = createAgeValidator(18)
 
 const myAdultValidator: Validator<string> = () => {
   return [adultValidator]

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -120,6 +120,7 @@ export default {
       errorRequired: 'You must enter a national identity number.',
       errorFnr: 'Invalid national identity number.',
       errorDnr: 'Invalid D number.',
+      errorAdult: 'Must be atleast 18 years of age.',
     },
     OrganizationNumber: {
       label: 'Organisation number',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -120,7 +120,7 @@ export default {
       errorRequired: 'You must enter a national identity number.',
       errorFnr: 'Invalid national identity number.',
       errorDnr: 'Invalid D number.',
-      errorAgeValidator: 'Must be at least {age} years of age.',
+      errorMinimumAgeValidator: 'Must be at least {age} years of age.',
     },
     OrganizationNumber: {
       label: 'Organisation number',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -120,7 +120,7 @@ export default {
       errorRequired: 'You must enter a national identity number.',
       errorFnr: 'Invalid national identity number.',
       errorDnr: 'Invalid D number.',
-      errorAdult: 'Must be atleast 18 years of age.',
+      errorBelowAge: 'Must be at least {age} years of age.',
     },
     OrganizationNumber: {
       label: 'Organisation number',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -120,7 +120,7 @@ export default {
       errorRequired: 'You must enter a national identity number.',
       errorFnr: 'Invalid national identity number.',
       errorDnr: 'Invalid D number.',
-      errorBelowAge: 'Must be at least {age} years of age.',
+      errorAgeValidator: 'Must be at least {age} years of age.',
     },
     OrganizationNumber: {
       label: 'Organisation number',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -118,6 +118,7 @@ export default {
       errorRequired: 'Du må fylle inn et fødselsnummer.',
       errorFnr: 'Ugyldig fødselsnummer.',
       errorDnr: 'Ugyldig d-nummer.',
+      errorAdult: 'Må være minst 18 år.',
     },
     OrganizationNumber: {
       label: 'Organisasjonsnummer',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -118,7 +118,7 @@ export default {
       errorRequired: 'Du må fylle inn et fødselsnummer.',
       errorFnr: 'Ugyldig fødselsnummer.',
       errorDnr: 'Ugyldig d-nummer.',
-      errorAdult: 'Må være minst 18 år.',
+      errorBelowAge: 'Må være minst {age} år.',
     },
     OrganizationNumber: {
       label: 'Organisasjonsnummer',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -118,7 +118,7 @@ export default {
       errorRequired: 'Du må fylle inn et fødselsnummer.',
       errorFnr: 'Ugyldig fødselsnummer.',
       errorDnr: 'Ugyldig d-nummer.',
-      errorAgeValidator: 'Må være minst {age} år.',
+      errorMinimumAgeValidator: 'Må være minst {age} år.',
     },
     OrganizationNumber: {
       label: 'Organisasjonsnummer',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -118,7 +118,7 @@ export default {
       errorRequired: 'Du må fylle inn et fødselsnummer.',
       errorFnr: 'Ugyldig fødselsnummer.',
       errorDnr: 'Ugyldig d-nummer.',
-      errorBelowAge: 'Må være minst {age} år.',
+      errorAgeValidator: 'Må være minst {age} år.',
     },
     OrganizationNumber: {
       label: 'Organisasjonsnummer',


### PR DESCRIPTION
PR adds `createAgeValidator`.

Give the feature a test in this [CSB(outdated](https://codesandbox.io/p/sandbox/xenodochial-ardinghelli-ph6w2k?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd) or in the [new CSB](https://codesandbox.io/p/sandbox/pensive-heisenberg-kcj484?workspaceId=9eb653cb-4406-4b8f-bc96-714927cc7fcd), or in the [pr preview](https://eufemia-git-feat-is-adult-validator-eufemia.vercel.app/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos/#extend-validation-with-adult-validator).


To dos:
- [x] Have a discussion on how we should export the validator(in terms of tree shaking).
- [x] Improve tests.
- [x] Add docs about it.



