### PR TITLE
chore: adds beta badge to blocks in menu

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Blocks'
 order: 20
+status: 'beta'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/


### PR DESCRIPTION
Reason why it feels beta to me, is because it's so many frequent changes to the design and layout of the only existing block we have, ChildrenWithAge. They even have a new design now, that we'll have to implement, so just want to mark it as beta for now.