### PR TITLE
fix(Forms): ensure `onBlurValidator` gets called when `validateInitially` is true

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -663,10 +663,10 @@ describe('Field.String', () => {
       render(<Field.String value="abc" onChange={onChange} />)
       const input = document.querySelector('input')
       await userEvent.type(input, 'def')
-      expect(onChange.mock.calls).toHaveLength(3)
-      expect(onChange.mock.calls[0][0]).toEqual('abcd')
-      expect(onChange.mock.calls[1][0]).toEqual('abcde')
-      expect(onChange.mock.calls[2][0]).toEqual('abcdef')
+      expect(onChange).toHaveBeenCalledTimes(3)
+      expect(onChange).toHaveBeenNthCalledWith(1, 'abcd')
+      expect(onChange).toHaveBeenNthCalledWith(2, 'abcde')
+      expect(onChange).toHaveBeenNthCalledWith(3, 'abcdef')
     })
 
     it('calls onFocus with current value', () => {
@@ -676,8 +676,8 @@ describe('Field.String', () => {
       act(() => {
         input.focus()
       })
-      expect(onFocus.mock.calls).toHaveLength(1)
-      expect(onFocus.mock.calls[0][0]).toEqual('blah')
+      expect(onFocus).toHaveBeenCalledTimes(1)
+      expect(onFocus).toHaveBeenNthCalledWith(1, 'blah')
     })
 
     it('calls onBlur with current value', async () => {
@@ -687,12 +687,12 @@ describe('Field.String', () => {
       input.focus()
       fireEvent.blur(input)
       await wait(0)
-      expect(onBlur.mock.calls).toHaveLength(1)
-      expect(onBlur.mock.calls[0][0]).toEqual('song2')
+      expect(onBlur).toHaveBeenCalledTimes(1)
+      expect(onBlur).toHaveBeenNthCalledWith(1, 'song2')
       await userEvent.type(input, '345')
       fireEvent.blur(input)
-      expect(onBlur.mock.calls).toHaveLength(2)
-      expect(onBlur.mock.calls[1][0]).toEqual('song2345')
+      expect(onBlur).toHaveBeenCalledTimes(2)
+      expect(onBlur).toHaveBeenNthCalledWith(2, 'song2345')
     })
   })
 
@@ -881,8 +881,12 @@ describe('Field.String', () => {
         )
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(1)
-          expect((validator.mock.calls[0] as unknown[])[0]).toEqual('abc')
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(validator).toHaveBeenNthCalledWith(
+            1,
+            'abc',
+            expect.anything()
+          )
           expect(
             screen.getByText('I think this is wrong')
           ).toBeInTheDocument()
@@ -893,13 +897,21 @@ describe('Field.String', () => {
         fireEvent.blur(input)
 
         await waitFor(() => {
-          expect(validator.mock.calls).toHaveLength(4)
-          expect((validator.mock.calls[1] as unknown[])[0]).toEqual('abcd')
-          expect((validator.mock.calls[2] as unknown[])[0]).toEqual(
-            'abcde'
+          expect(validator).toHaveBeenCalledTimes(4)
+          expect(validator).toHaveBeenNthCalledWith(
+            2,
+            'abcd',
+            expect.anything()
           )
-          expect((validator.mock.calls[3] as unknown[])[0]).toEqual(
-            'abcdef'
+          expect(validator).toHaveBeenNthCalledWith(
+            3,
+            'abcde',
+            expect.anything()
+          )
+          expect(validator).toHaveBeenNthCalledWith(
+            4,
+            'abcdef',
+            expect.anything()
           )
           expect(
             screen.getByText('I think this is wrong')
@@ -935,8 +947,12 @@ describe('Field.String', () => {
         )
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(1)
-          expect((validator.mock.calls[0] as unknown[])[0]).toEqual('abc')
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(validator).toHaveBeenNthCalledWith(
+            1,
+            'abc',
+            expect.anything()
+          )
           expect(
             screen.getByText('Whats left when nothing is right?')
           ).toBeInTheDocument()
@@ -949,10 +965,22 @@ describe('Field.String', () => {
           fireEvent.blur(input)
         })
 
-        expect(validator.mock.calls).toHaveLength(4)
-        expect((validator.mock.calls[1] as unknown[])[0]).toEqual('abcd')
-        expect((validator.mock.calls[2] as unknown[])[0]).toEqual('abcde')
-        expect((validator.mock.calls[3] as unknown[])[0]).toEqual('abcdef')
+        expect(validator).toHaveBeenCalledTimes(4)
+        expect(validator).toHaveBeenNthCalledWith(
+          2,
+          'abcd',
+          expect.anything()
+        )
+        expect(validator).toHaveBeenNthCalledWith(
+          3,
+          'abcde',
+          expect.anything()
+        )
+        expect(validator).toHaveBeenNthCalledWith(
+          4,
+          'abcdef',
+          expect.anything()
+        )
         expect(
           screen.getByText('Whats left when nothing is right?')
         ).toBeInTheDocument()
@@ -988,8 +1016,8 @@ describe('Field.String', () => {
 
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(0)
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
         })
         const input = document.querySelector('input')
         await userEvent.type(input, 'def')
@@ -997,9 +1025,16 @@ describe('Field.String', () => {
 
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(1)
-          expect((validator.mock.calls[0] as unknown[])[0]).toEqual(
-            'abcdef'
+          expect(validator).toHaveBeenCalledTimes(2)
+          expect(validator).toHaveBeenNthCalledWith(
+            1,
+            'abc',
+            expect.anything()
+          )
+          expect(validator).toHaveBeenNthCalledWith(
+            2,
+            'abcdef',
+            expect.anything()
           )
 
           expect(
@@ -1040,8 +1075,8 @@ describe('Field.String', () => {
 
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(0)
-          expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+          expect(validator).toHaveBeenCalledTimes(1)
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
         })
         const input = document.querySelector('input')
         await userEvent.type(input, 'def')
@@ -1049,9 +1084,16 @@ describe('Field.String', () => {
 
         await waitFor(() => {
           // Wait for since external validators are processed asynchronously
-          expect(validator.mock.calls).toHaveLength(1)
-          expect((validator.mock.calls[0] as unknown[])[0]).toEqual(
-            'abcdef'
+          expect(validator).toHaveBeenCalledTimes(2)
+          expect(validator).toHaveBeenNthCalledWith(
+            1,
+            'abc',
+            expect.anything()
+          )
+          expect(validator).toHaveBeenNthCalledWith(
+            2,
+            'abcdef',
+            expect.anything()
           )
 
           expect(
@@ -1153,29 +1195,36 @@ describe('Field.String', () => {
       await userEvent.type(input, 'O!')
 
       await waitFor(() => {
-        expect(inputOnChange.mock.calls).toHaveLength(2)
-        expect(inputOnChange.mock.calls[0][0]).toEqual('FOOO')
-        expect(inputOnChange.mock.calls[1][0]).toEqual('FOOO!')
+        expect(inputOnChange).toHaveBeenNthCalledWith(1, 'FOOO')
+        expect(inputOnChange).toHaveBeenNthCalledWith(2, 'FOOO!')
 
-        expect(dataContextOnChange.mock.calls).toHaveLength(2)
-        expect(dataContextOnChange.mock.calls[0][0]).toEqual({
-          foo: 'FOOO',
-          bar: 'BAAAR',
-        })
-        expect(dataContextOnChange.mock.calls[1][0]).toEqual({
-          foo: 'FOOO!',
-          bar: 'BAAAR',
-        })
+        expect(dataContextOnChange).toHaveBeenNthCalledWith(
+          1,
+          {
+            foo: 'FOOO',
+            bar: 'BAAAR',
+          },
+          expect.anything()
+        )
+        expect(dataContextOnChange).toHaveBeenNthCalledWith(
+          2,
+          {
+            foo: 'FOOO!',
+            bar: 'BAAAR',
+          },
+          expect.anything()
+        )
 
-        expect(dataContextOnPathChange.mock.calls).toHaveLength(2)
-        expect(dataContextOnPathChange.mock.calls[0]).toEqual([
+        expect(dataContextOnPathChange).toHaveBeenNthCalledWith(
+          1,
           '/foo',
-          'FOOO',
-        ])
-        expect(dataContextOnPathChange.mock.calls[1]).toEqual([
+          'FOOO'
+        )
+        expect(dataContextOnPathChange).toHaveBeenNthCalledWith(
+          2,
           '/foo',
-          'FOOO!',
-        ])
+          'FOOO!'
+        )
       })
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2968,6 +2968,46 @@ describe('useFieldProps', () => {
   })
 
   describe('validator', () => {
+    describe('validateInitially', () => {
+      it('should show error message initially', async () => {
+        const validator = jest.fn(() => {
+          return new Error('My Error')
+        })
+
+        render(
+          <Form.Handler>
+            <Field.Number validator={validator} validateInitially />
+          </Form.Handler>
+        )
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+        expect(validator).toHaveBeenCalledTimes(1)
+      })
+
+      it('should show error message initially when validator is async', async () => {
+        const validator = jest.fn(async () => {
+          return new Error('My Error')
+        })
+
+        render(
+          <Form.Handler>
+            <Field.Number
+              label="Label"
+              validator={validator}
+              validateInitially
+            />
+          </Form.Handler>
+        )
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+        expect(validator).toHaveBeenCalledTimes(1)
+      })
+    })
+
     describe('connectWithPath', () => {
       const validatorFn: UseFieldProps<number>['validator'] = (
         num,
@@ -3773,6 +3813,36 @@ describe('useFieldProps', () => {
         expect(internalValidators).toHaveBeenCalledTimes(0)
       })
 
+      it('should show error when validateInitially is set to true', async () => {
+        const exportedValidator = jest.fn(() => {
+          return Error('Error message')
+        })
+
+        const myValidator = jest.fn((value, { validators }) => {
+          const { exportedValidator } = validators
+          return [exportedValidator]
+        })
+
+        const MockComponent = (props) => {
+          return (
+            <Field.String
+              label="Label"
+              validator={props.validator}
+              exportValidators={{ exportedValidator }}
+              validateInitially
+            />
+          )
+        }
+
+        render(<MockComponent validator={myValidator} />)
+
+        await waitFor(() => {
+          expect(
+            document.querySelector('.dnb-form-status')
+          ).toBeInTheDocument()
+        })
+      })
+
       it('should call internal validates when they are not returned in the publicValidator', async () => {
         let internalValidators, barValidator, bazValidator
 
@@ -3866,6 +3936,49 @@ describe('useFieldProps', () => {
   })
 
   describe('onBlurValidator', () => {
+    describe('validateInitially', () => {
+      it('should show error message initially', async () => {
+        const onBlurValidator = jest.fn(() => {
+          return new Error('My Error')
+        })
+
+        render(
+          <Form.Handler>
+            <Field.Number
+              onBlurValidator={onBlurValidator}
+              validateInitially
+            />
+          </Form.Handler>
+        )
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      it('should show error message initially when validator is async', async () => {
+        const onBlurValidator = jest.fn(async () => {
+          return new Error('My Error')
+        })
+
+        render(
+          <Form.Handler>
+            <Field.Number
+              label="Label"
+              onBlurValidator={onBlurValidator}
+              validateInitially
+            />
+          </Form.Handler>
+        )
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        })
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+    })
+
     describe('connectWithPath', () => {
       const validatorFn: UseFieldProps<number>['validator'] = (
         num,
@@ -4260,6 +4373,35 @@ describe('useFieldProps', () => {
         expect(barValidator).toHaveBeenCalledTimes(0)
         expect(bazValidator).toHaveBeenCalledTimes(2)
         expect(internalValidators).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    it('should show error when validateInitially is set to true', async () => {
+      const exportedValidator = jest.fn(() => {
+        return Error('Error message')
+      })
+
+      const myValidator = jest.fn((value, { validators }) => {
+        const { exportedValidator } = validators
+        return [exportedValidator]
+      })
+
+      const MockComponent = (props) => {
+        return (
+          <Field.String
+            onBlurValidator={props.onBlurValidator}
+            exportValidators={{ exportedValidator }}
+            validateInitially
+          />
+        )
+      }
+
+      render(<MockComponent onBlurValidator={myValidator} />)
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
       })
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1027,6 +1027,19 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         }
       }
 
+      // Only for when "validateInitially" is set to true
+      if (
+        onBlurValidatorRef.current &&
+        validateInitially &&
+        !changedRef.current
+      ) {
+        const { result } = await callOnBlurValidator()
+
+        if (result instanceof Error) {
+          throw result
+        }
+      }
+
       if (isProcessActive()) {
         clearErrorState()
       }
@@ -1051,6 +1064,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     validateInitially,
     validateUnchanged,
     startOnChangeValidatorValidation,
+    callOnBlurValidator,
     persistErrorState,
   ])
 


### PR DESCRIPTION
- Relies on #4068
- Fixes #4066

At least hope it will fix it. 

**NB:** When using this code:

```tsx
<Field.OrganizationNumber
  onBlurValidator={myValidator}
  validateInitially
/>
```

it will not show the error. This is simply because internally we check if there is a value/pattern that matches. And only if it matches, the validator will run.

Therefore this particular field needs a `value` or `defaultValue` to run a validator, not matter if it is an `onBlurValidator` or not.

```tsx
<Field.OrganizationNumber
  onBlurValidator={myValidator}
  validateInitially
  defaultValue="123 331 231"
/>
```

