### PR TITLE
chore(Field.OrganizationNumber): fixes error when validateInitially

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -60,6 +60,8 @@ function OrganizationNumber(props: Props) {
  * www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/
  */
 function isValidOrgNumber(digits: string) {
+  if (digits === undefined) return false
+
   let checkDigit = 2
   let sum = 0
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
@@ -60,6 +60,23 @@ describe('Field.OrganizationNumber', () => {
     expect(input).toHaveAttribute('inputmode', 'numeric')
   })
 
+  it('should execute validateInitially if required', async () => {
+    const { rerender } = render(
+      <Field.OrganizationNumber required validateInitially />
+    )
+
+    expect(screen.queryByRole('alert')).toBeInTheDocument()
+
+    rerender(<Field.OrganizationNumber validateInitially />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).toHaveTextContent(
+        nb.OrganizationNumber.errorPattern
+      )
+    })
+  })
+
   it('should validate organization number based on the internal pattern', () => {
     render(
       <Form.Handler>


### PR DESCRIPTION
Fixes the following error message( Cannot read properties of undefined (reading 'length')), when using validateInitially like so:

`<Field.OrganizationNumber validateInitially />`
