### PR TITLE
feat(Forms): remove internal pattern from `Field.OrganizationNumber` in favor of the internal validator

### DIFF
--- a/packages/dnb-eufemia/jest.d.ts
+++ b/packages/dnb-eufemia/jest.d.ts
@@ -1,5 +1,6 @@
 declare namespace jest {
   interface Matchers<R> {
     toBeType(received: string, expected?: string): R;
+    neverToResolve(): Promise<R>;
   }
 }

--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -7,6 +7,7 @@ import { axe, toHaveNoViolations } from 'jest-axe'
 import fs from 'fs-extra'
 import path from 'path'
 import sass from 'sass'
+import { waitFor } from '@testing-library/react'
 import { toBeType } from 'jest-tobetype'
 
 export { axe, toHaveNoViolations }
@@ -136,6 +137,25 @@ export const axeComponent = async (...components) => {
     typeof components[1] === 'object' ? components[1] : null
   )
 }
+
+expect.extend({
+  async neverToResolve(callable) {
+    try {
+      await waitFor(callable)
+      return {
+        pass: false,
+        message: () => 'Expected the function to reject, but it resolved.',
+      }
+    } catch (error) {
+      // If it rejects, the test passes
+      return {
+        pass: true,
+        message: () =>
+          'Expected the function to resolve, but it correctly rejected.',
+      }
+    }
+  },
+})
 
 // For Yarn v3 we need this fix in order to make jest-axe work properly
 // https://github.com/nickcolley/jest-axe/issues/147

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -39,7 +39,6 @@ function OrganizationNumber(props: Props) {
   const StringFieldProps: Props = {
     ...props,
     className: 'dnb-forms-field-organization-number',
-    pattern: props.pattern ?? (validate ? '^[0-9]{9}$' : undefined),
     label: props.label ?? label,
     errorMessages,
     mask,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -15,10 +15,6 @@ import enGB from '../../../../../shared/locales/en-GB'
 
 const gb = enGB['en-GB']
 
-async function expectNever(callable: () => unknown): Promise<void> {
-  await expect(() => waitFor(callable)).rejects.toEqual(expect.anything())
-}
-
 const syncValidatorReturningUndefined = () => undefined
 
 const syncValidatorReturningError = () =>
@@ -928,10 +924,9 @@ describe('Field.String', () => {
             validateInitially
           />
         )
-        await expectNever(() => {
-          // Can't just waitFor and expect not to be in the document, it would approve the first render before the error might appear async.
+        await expect(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
-        })
+        }).neverToResolve()
       })
     })
 
@@ -996,10 +991,9 @@ describe('Field.String', () => {
           />
         )
 
-        await expectNever(() => {
-          // Can't just waitFor and expect not to be in the document, it would approve the first render before the error might appear async.
+        await expect(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
-        })
+        }).neverToResolve()
       })
     })
 
@@ -1055,10 +1049,9 @@ describe('Field.String', () => {
         const input = document.querySelector('input')
         await userEvent.type(input, 'd')
         fireEvent.blur(input)
-        await expectNever(() => {
-          // Can't just waitFor and expect not to be in the document, it would approve the first render before the error might appear async.
+        await expect(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
-        })
+        }).neverToResolve()
       })
     })
 
@@ -1114,10 +1107,9 @@ describe('Field.String', () => {
         const input = document.querySelector('input')
         await userEvent.type(input, 'd')
         fireEvent.blur(input)
-        await expectNever(() => {
-          // Can't just waitFor and expect not to be in the document, it would approve the first render before the error might appear async.
+        await expect(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
-        })
+        }).neverToResolve()
       })
     })
 


### PR DESCRIPTION
Fixes #4073

The reason for the outcome in the issue is that the internal pattern is prioritized over the custom validator. But we probably don't need the pattern. So this PR removes is.

Also, I think when first utilizing the `expectNever`, we rather should add a Jest matcher.