### PR TITLE
feat(Forms): add support for `id` for when using dynamic steps with `activeWhen`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/Examples.tsx
@@ -11,9 +11,14 @@ export const DynamicSteps = () => {
   return (
     <ComponentBox>
       <Form.Handler defaultData={{ activeSteps: 'group-1' }}>
-        <Wizard.Container>
+        <Wizard.Container
+          onStepChange={(index, mode, args) => {
+            console.log('onStepChange', index, mode, args.id)
+          }}
+        >
           <Wizard.Step
             title="Step A"
+            id="step-a"
             activeWhen={{ path: '/activeSteps', hasValue: 'group-1' }}
           >
             <Form.MainHeading>Step A</Form.MainHeading>
@@ -22,6 +27,7 @@ export const DynamicSteps = () => {
 
           <Wizard.Step
             title="Step B"
+            id="step-b"
             activeWhen={{ path: '/activeSteps', hasValue: 'group-1' }}
           >
             <Form.MainHeading>Step B</Form.MainHeading>
@@ -30,6 +36,7 @@ export const DynamicSteps = () => {
 
           <Wizard.Step
             title="Step C"
+            id="step-c"
             activeWhen={{
               path: '/activeSteps',
               hasValue: (value: string) =>
@@ -42,6 +49,7 @@ export const DynamicSteps = () => {
 
           <Wizard.Step
             title="Step D"
+            id="step-d"
             activeWhen={{ path: '/activeSteps', hasValue: 'group-2' }}
           >
             <Form.MainHeading>Step D</Form.MainHeading>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Step/info.mdx
@@ -45,3 +45,29 @@ In order to navigate back to another step, you can use the [EditButton](/uilib/e
 ## Events
 
 If you need an event to be triggered when the user changes the active step, you can use the `onStepChange` in the [Wizard.Container](/uilib/extensions/forms/Wizard/Container/).
+
+## Dynamic steps support
+
+You can use the `Wizard.Step` component to create dynamic steps. The `active` and `activeWhen` properties allow you to show or hide a step based on specific conditions.
+
+If a step is replaced by another step, the `onStepChange` event will trigger with `stepListModified` as the second argument. The current step index might remain the same. However, if the total number of steps becomes less than the current step, the index will adjust to the last step.
+
+To keep track of the current step, you can provide each step with an `id` property. This `id` can then be used to identify the current step and will be returned as part of an object in the `onStepChange` event.
+
+```tsx
+<Wizard.Container
+  onStepChange={(index, mode, args) => {
+    const { id, previousIndex, preventNavigation } = args
+  }}
+>
+  <Wizard.Step
+    title="Step 1"
+    id="step-1"
+    activeWhen={{ path: '/myPath', hasValue: '...' }}
+  >
+    content
+  </Wizard.Step>
+</Wizard.Container>
+```
+
+In the demo section, you will find an example demonstrating how to use the `Wizard.Step` component with `activeWhen`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/info.mdx
@@ -26,7 +26,7 @@ render(
 
 ## Dynamic steps support
 
-You can use the `Wizard.Step` component to create dynamic steps. The `active` and `activeWhen` properties can be used to enable or disable a step based on the current data. Here is a [demo of a dynamic step](/uilib/extensions/forms/Wizard/Step/).
+You can use the `Wizard.Step` component to create dynamic steps. The `active` and `activeWhen` properties allow you to show or hide a step based on specific conditions. You find an [example](/uilib/extensions/forms/Wizard/Step/#dynamic-steps) in the demo section.
 
 ## Summary step
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Buttons/Buttons.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Buttons/Buttons.tsx
@@ -12,9 +12,9 @@ export type Props = ComponentProps & {
 
 function Buttons(props: Props) {
   const { className } = props
-  const { activeIndex, titlesRef } = useContext(WizardContext) || {}
+  const { activeIndex, stepsRef } = useContext(WizardContext) || {}
 
-  const totalSteps = Object.keys(titlesRef?.current || {}).length || 0
+  const totalSteps = Object.keys(stepsRef?.current || {}).length || 0
   const showPreviousButton = activeIndex > 0
   const showNextButton = activeIndex < totalSteps - 1
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
@@ -50,7 +50,7 @@ export const WizardContainerProperties: PropertiesTableProps = {
 
 export const WizardContainerEvents: PropertiesTableProps = {
   onStepChange: {
-    doc: 'Will be called when the user navigate to a different step, with step `index` as the first argument and `previous` or `next` (string) as the second argument, and an options object containing `preventNavigation` function as the third parameter. When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related Form.Handler props: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`.',
+    doc: 'Will be called when the user navigate to a different step, with step `index` (number) as the first argument and a string with `previous` or `next` (or `stepListModified` when a step gets replaced) as the second argument, and an object containing `previousIndex`, `id` (if set on the Wizard.Step), `preventNavigation` function as the third parameter. \n\nWhen an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related Form.Handler props: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -64,20 +64,19 @@ describe('Wizard.Container', () => {
     expect(secondStep.querySelector('.dnb-button').tagName).toBe('SPAN')
   })
 
-  it('should call event listener onStepChange', async () => {
+  it('should call event listener "onStepChange"', async () => {
     const onStepChange = jest.fn()
 
     render(
       <Wizard.Container onStepChange={onStepChange} mode="loose">
         <Wizard.Step title="Step 1">
           <output>Step 1</output>
-          <Wizard.NextButton />
+          <Wizard.Buttons />
         </Wizard.Step>
 
         <Wizard.Step title="Step 2">
           <output>Step 2</output>
-          <Wizard.PreviousButton />
-          <Wizard.NextButton />
+          <Wizard.Buttons />
         </Wizard.Step>
       </Wizard.Container>
     )
@@ -96,7 +95,6 @@ describe('Wizard.Container', () => {
     )
 
     await userEvent.click(firstStep.querySelector('.dnb-button'))
-    await wait(1000)
     expect(output()).toHaveTextContent('Step 1')
     expect(onStepChange).toHaveBeenCalledTimes(2)
     expect(onStepChange).toHaveBeenLastCalledWith(
@@ -106,7 +104,6 @@ describe('Wizard.Container', () => {
     )
 
     await userEvent.click(nextButton())
-    expect(nextButton()).not.toBeDisabled()
 
     expect(onStepChange).toHaveBeenCalledTimes(3)
     expect(onStepChange).toHaveBeenLastCalledWith(
@@ -117,7 +114,6 @@ describe('Wizard.Container', () => {
 
     // Use fireEvent to trigger the event fast
     fireEvent.click(previousButton())
-    expect(previousButton()).not.toBeDisabled()
 
     await waitFor(() => {
       expect(previousButton()).toBeNull()
@@ -128,6 +124,97 @@ describe('Wizard.Container', () => {
         expect.anything()
       )
       expect(previousButton()).not.toBeInTheDocument()
+    })
+  })
+
+  it('should have previousIndex in "onStepChange" when navigating back and forth', async () => {
+    const onStepChange = jest.fn()
+
+    render(
+      <Wizard.Container onStepChange={onStepChange} mode="loose">
+        <Wizard.Step title="Step 1">
+          <output>Step 1</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+
+        <Wizard.Step title="Step 2">
+          <output>Step 2</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      </Wizard.Container>
+    )
+
+    await userEvent.click(nextButton())
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 0,
+    })
+
+    await userEvent.click(previousButton())
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(onStepChange).toHaveBeenLastCalledWith(0, 'previous', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 1,
+    })
+
+    await userEvent.click(nextButton())
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
+    expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 0,
+    })
+  })
+
+  it('should provide id prop in "onStepChange"', async () => {
+    const onStepChange = jest.fn()
+
+    render(
+      <Wizard.Container onStepChange={onStepChange} mode="loose">
+        <Wizard.Step title="Step 1" id="step-1">
+          <output>Step 1</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+
+        <Wizard.Step title="Step 2" id="step-2">
+          <output>Step 2</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      </Wizard.Container>
+    )
+
+    const [firstStep, secondStep] = Array.from(
+      document.querySelectorAll('.dnb-step-indicator__item')
+    )
+
+    await userEvent.click(secondStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 2')
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+      id: 'step-2',
+      previousIndex: 0,
+      preventNavigation: expect.any(Function),
+    })
+
+    await userEvent.click(firstStep.querySelector('.dnb-button'))
+    expect(output()).toHaveTextContent('Step 1')
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(onStepChange).toHaveBeenLastCalledWith(0, 'previous', {
+      id: 'step-1',
+      previousIndex: 1,
+      preventNavigation: expect.any(Function),
+    })
+
+    await userEvent.click(nextButton())
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
+    expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+      id: 'step-2',
+      previousIndex: 0,
+      preventNavigation: expect.any(Function),
     })
   })
 
@@ -832,6 +919,10 @@ describe('Wizard.Container', () => {
         </Form.Handler>
       )
 
+      const [groupOne, groupTwo] = Array.from(
+        document.querySelectorAll('.dnb-toggle-button button')
+      )
+
       expect(output()).toHaveTextContent('Step 2')
       expect(
         document.querySelector('.dnb-step-indicator')
@@ -842,9 +933,7 @@ describe('Wizard.Container', () => {
       expect(previousButton()).toBeNull()
       expect(nextButton()).toBeNull()
 
-      await userEvent.click(
-        document.querySelectorAll('.dnb-toggle-button button')[0]
-      )
+      await userEvent.click(groupOne)
 
       expect(output()).toHaveTextContent('Step 1')
       expect(
@@ -856,9 +945,7 @@ describe('Wizard.Container', () => {
       expect(previousButton()).toBeNull()
       expect(nextButton()).toBeInTheDocument()
 
-      await userEvent.click(
-        document.querySelectorAll('.dnb-toggle-button button')[1]
-      )
+      await userEvent.click(groupTwo)
 
       expect(output()).toHaveTextContent('Step 2')
       expect(
@@ -883,6 +970,155 @@ describe('Wizard.Container', () => {
       ).toHaveLength(0)
       expect(previousButton()).toBeNull()
       expect(nextButton()).toBeNull()
+    })
+
+    it('should provide "id" prop and "same" mode in "onStepChange"', async () => {
+      const onStepChange = jest.fn(async () => null)
+
+      render(
+        <Form.Handler defaultData={{ enabledStep: 'group-2' }}>
+          <Field.Selection path="/enabledStep" variant="button">
+            <Field.Option value="group-1" title="1" />
+            <Field.Option value="group-2" title="2" />
+          </Field.Selection>
+
+          <Wizard.Container mode="loose" onStepChange={onStepChange}>
+            <Wizard.Step
+              title="Step 1"
+              id="step-1"
+              activeWhen={{ path: '/enabledStep', hasValue: 'group-1' }}
+            >
+              <output>Step 1</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+
+            <Wizard.Step
+              title="Step 2"
+              id="step-2"
+              activeWhen={{ path: '/enabledStep', hasValue: 'group-2' }}
+            >
+              <output>Step 2</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+
+            <Wizard.Step
+              title="Step 3"
+              id="step-3"
+              activeWhen={{ path: '/enabledStep', hasValue: 'group-1' }}
+            >
+              <output>Step 3</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(onStepChange).toHaveBeenCalledTimes(0)
+
+      const [groupOne, groupTwo] = Array.from(
+        document.querySelectorAll('.dnb-toggle-button button')
+      )
+
+      await userEvent.click(groupOne)
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(onStepChange).toHaveBeenCalledTimes(1)
+      expect(onStepChange).toHaveBeenLastCalledWith(
+        0,
+        'stepListModified',
+        {
+          id: 'step-1',
+          previousIndex: 0,
+          preventNavigation: expect.any(Function),
+        }
+      )
+
+      await userEvent.click(groupTwo)
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(onStepChange).toHaveBeenCalledTimes(2)
+      expect(onStepChange).toHaveBeenLastCalledWith(
+        0,
+        'stepListModified',
+        {
+          id: 'step-2',
+          previousIndex: 0,
+          preventNavigation: expect.any(Function),
+        }
+      )
+
+      await userEvent.click(groupOne)
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(onStepChange).toHaveBeenCalledTimes(3)
+      expect(onStepChange).toHaveBeenLastCalledWith(
+        0,
+        'stepListModified',
+        {
+          id: 'step-1',
+          previousIndex: 0,
+          preventNavigation: expect.any(Function),
+        }
+      )
+
+      await userEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 3')
+      expect(onStepChange).toHaveBeenCalledTimes(4)
+      expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+        id: 'step-3',
+        previousIndex: 0,
+        preventNavigation: expect.any(Function),
+      })
+
+      await userEvent.click(groupTwo)
+
+      expect(output()).toHaveTextContent('Step 2')
+      expect(onStepChange).toHaveBeenCalledTimes(5)
+      expect(onStepChange).toHaveBeenLastCalledWith(
+        0,
+        'stepListModified',
+        {
+          id: 'step-2',
+          previousIndex: 0,
+          preventNavigation: expect.any(Function),
+        }
+      )
+
+      await userEvent.click(groupOne)
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(onStepChange).toHaveBeenCalledTimes(6)
+      expect(onStepChange).toHaveBeenLastCalledWith(
+        0,
+        'stepListModified',
+        {
+          id: 'step-1',
+          previousIndex: 0,
+          preventNavigation: expect.any(Function),
+        }
+      )
+
+      await userEvent.click(nextButton())
+
+      expect(output()).toHaveTextContent('Step 3')
+      expect(onStepChange).toHaveBeenCalledTimes(7)
+      expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+        id: 'step-3',
+        previousIndex: 0,
+        preventNavigation: expect.any(Function),
+      })
+
+      await userEvent.click(previousButton())
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(onStepChange).toHaveBeenCalledTimes(8)
+      expect(onStepChange).toHaveBeenLastCalledWith(0, 'previous', {
+        id: 'step-1',
+        previousIndex: 1,
+        preventNavigation: expect.any(Function),
+      })
     })
   })
 
@@ -930,7 +1166,7 @@ describe('Wizard.Container', () => {
   })
 
   describe('async step change', () => {
-    it('should handle async onStepChange', async () => {
+    it('should disable and enable buttons', async () => {
       const onStepChange = async () => null
 
       render(
@@ -979,6 +1215,55 @@ describe('Wizard.Container', () => {
         expect(output()).toHaveTextContent('Step 1')
         expect(previousButton()).toBeDisabled()
         expect(nextButton()).not.toBeDisabled()
+      })
+    })
+
+    it('should provide id prop in "onStepChange"', async () => {
+      const onStepChange = jest.fn(async () => null)
+
+      render(
+        <Wizard.Container onStepChange={onStepChange} mode="loose">
+          <Wizard.Step title="Step 1" id="step-1">
+            <output>Step 1</output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+
+          <Wizard.Step title="Step 2" id="step-2">
+            <output>Step 2</output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+        </Wizard.Container>
+      )
+
+      const [firstStep, secondStep] = Array.from(
+        document.querySelectorAll('.dnb-step-indicator__item')
+      )
+
+      await userEvent.click(secondStep.querySelector('.dnb-button'))
+      expect(output()).toHaveTextContent('Step 2')
+      expect(onStepChange).toHaveBeenCalledTimes(1)
+      expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+        id: 'step-2',
+        previousIndex: 0,
+        preventNavigation: expect.any(Function),
+      })
+
+      await userEvent.click(firstStep.querySelector('.dnb-button'))
+      expect(output()).toHaveTextContent('Step 1')
+      expect(onStepChange).toHaveBeenCalledTimes(2)
+      expect(onStepChange).toHaveBeenLastCalledWith(0, 'previous', {
+        id: 'step-1',
+        previousIndex: 1,
+        preventNavigation: expect.any(Function),
+      })
+
+      await userEvent.click(nextButton())
+
+      expect(onStepChange).toHaveBeenCalledTimes(3)
+      expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+        id: 'step-2',
+        previousIndex: 0,
+        preventNavigation: expect.any(Function),
       })
     })
 
@@ -1691,6 +1976,7 @@ describe('Wizard.Container', () => {
     expect(output()).toHaveTextContent('Step 1')
     expect(onStepChange).toHaveBeenCalledTimes(1)
     expect(onStepChange).toHaveBeenLastCalledWith(1, 'next', {
+      previousIndex: 0,
       preventNavigation: expect.any(Function),
     })
   })
@@ -1779,7 +2065,6 @@ describe('Wizard.Container', () => {
         fooStep3: undefined,
       })
 
-      await wait(10)
       await userEvent.type(document.querySelector('input'), ' changed')
 
       expect(onChange).toHaveBeenCalledTimes(8)

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
@@ -2,16 +2,22 @@ import React from 'react'
 import { EventReturnWithStateObject } from '../../types'
 import { VisibleWhen } from '../../Form/Visibility'
 
+export type OnStepsChangeMode = 'previous' | 'next' | 'stepListModified'
 export type OnStepChange = (
   index: StepIndex,
-  mode: 'previous' | 'next',
-  options: { preventNavigation: (shouldPrevent?: boolean) => void }
+  mode: OnStepsChangeMode,
+  options: {
+    id?: string
+    previousIndex: StepIndex
+    preventNavigation: (shouldPrevent?: boolean) => void
+  }
 ) =>
   | EventReturnWithStateObject
   | void
   | Promise<EventReturnWithStateObject | void>
 
 export type StepIndex = number
+export type Steps = Record<string, { title: string; id: string }>
 export type SetActiveIndexOptions = {
   skipStepChangeCall?: boolean
   skipStepChangeCallBeforeMounted?: boolean
@@ -23,7 +29,7 @@ export interface WizardContextState {
   totalSteps?: number
   activeIndex?: StepIndex
   stepElementRef?: React.MutableRefObject<HTMLElement>
-  titlesRef?: React.MutableRefObject<Record<string, string>>
+  stepsRef?: React.MutableRefObject<Steps>
   updateTitlesRef?: React.MutableRefObject<() => void>
   activeIndexRef?: React.MutableRefObject<StepIndex>
   totalStepsRef?: React.MutableRefObject<number>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
@@ -59,15 +59,15 @@ function Step(props: Props): JSX.Element {
     children,
     ...restProps
   } = props
-  const { check, activeIndex, titlesRef, stepElementRef } =
+  const { check, activeIndex, stepsRef, stepElementRef } =
     useContext(WizardContext) || {}
 
   const ariaLabel = useMemo(() => {
     return (
-      (!prerenderFieldProps && titlesRef?.current?.[index]) ??
+      (!prerenderFieldProps && stepsRef?.current?.[index]) ??
       convertJsxToString(title)
     )
-  }, [index, prerenderFieldProps, title, titlesRef])
+  }, [index, prerenderFieldProps, title, stepsRef])
 
   const currentElementRef = useRef<HTMLElement>()
   useLayoutEffect(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.tsx
@@ -41,19 +41,19 @@ export default function useStep(
   }
 
   const value = data || context
-  const { titlesRef } = value || {}
+  const { stepsRef } = value || {}
   const setTotalSteps = useCallback(() => {
-    const totalSteps = Object.keys(titlesRef?.current || {}).length || 0
+    const totalSteps = Object.keys(stepsRef?.current || {}).length || 0
     if (value.totalSteps !== totalSteps) {
       value.totalSteps = totalSteps
     }
-  }, [titlesRef, value])
+  }, [stepsRef, value])
   if (data) {
     setTotalSteps()
   }
   useLayoutEffect(() => {
     setTotalSteps()
-  }, [setTotalSteps, titlesRef, value])
+  }, [setTotalSteps, stepsRef, value])
 
   return value
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/stories/Wizard.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/stories/Wizard.stories.tsx
@@ -41,122 +41,70 @@ export const Basic = () => {
   )
 }
 
-const Step1 = () => {
-  const { data } = Form.useData<typeof initialData>()
-  return (
-    <Wizard.Step
-      title="Step 1"
-      active={data?.step1}
-      activeWhen={{
-        path: '/enabledStep',
-        hasValue: (value) => {
-          return value === '1' || value === undefined
-        },
-      }}
-    >
-      <Form.MainHeading>Heading Step 1</Form.MainHeading>
-
-      <Field.Boolean
-        bottom
-        label="Toggle step 2"
-        variant="buttons"
-        path="/step2"
-        // help={{
-        //   title: 'Help is available',
-        //   content:
-        //     'Helping others, without expecting anything in return is what true self-worth is all about.',
-        // }}
-      />
-
-      <Card stack>
-        <P>Contents</P>
-        <P>Contents</P>
-      </Card>
-      <Card stack>
-        <P>Contents</P>
-        <P>Contents</P>
-      </Card>
-      <Wizard.Buttons />
-    </Wizard.Step>
-  )
-}
-const Step2 = () => {
-  const { data } = Form.useData<typeof initialData>()
-  return (
-    <Wizard.Step
-      title="Step 2"
-      active={data?.step2}
-      activeWhen={{ path: '/enabledStep', hasValue: '2' }}
-    >
-      <Form.MainHeading>Heading Step 2</Form.MainHeading>
-      <Card stack>
-        <P>Contents</P>
-        <P>Contents</P>
-      </Card>
-      <Wizard.Buttons />
-    </Wizard.Step>
-  )
-}
-const Step3 = () => {
-  const { data } = Form.useData<typeof initialData>()
-  const { summaryTitle } = Form.useLocale().Step
-
-  return (
-    <Wizard.Step
-      title={summaryTitle}
-      active={data?.step3}
-      activeWhen={{ path: '/enabledStep', hasValue: '3' }}
-    >
-      <Form.MainHeading>Summary</Form.MainHeading>
-      <Card stack>
-        <P>Contents</P>
-        <P>Contents</P>
-        <P>Contents</P>
-      </Card>
-      <Wizard.Buttons />
-    </Wizard.Step>
-  )
-}
-
-const initialData = {
-  step1: true,
-  step2: true,
-  step3: true,
-}
-
-export const WizardDynamicSteps = () => {
-  return (
-    <Form.Handler id="my-wizard" defaultData={initialData}>
-      <Wizard.Container mode="loose">
-        <Step1 />
-        <Step2 />
-        <Step3 />
-        {/* {data?.step1 && <Step1 />}
-          {data?.step2 && <Step2 />}
-          {data?.step3 && <Step3 />} */}
-      </Wizard.Container>
-    </Form.Handler>
-  )
-}
-
 export const WizardDynamicStepsActiveWhen = () => {
   return (
-    <Form.Handler>
-      <Field.Selection
-        path="/enabledStep"
-        variant="button"
-        onChange={(value) => console.log('onChange', value)}
+    <Form.Handler defaultData={{ activeSteps: 'group-1' }}>
+      <Wizard.Container
+        onStepChange={(index, mode, args) => {
+          console.log(
+            'onStepChange',
+            index,
+            mode,
+            args.id,
+            args.previousIndex
+          )
+        }}
       >
-        <Field.Option value="1" title="1" />
-        <Field.Option value="2" title="2" />
-        <Field.Option value="3" title="3" />
-      </Field.Selection>
+        <Wizard.Step
+          title="Step A"
+          activeWhen={{ path: '/activeSteps', hasValue: 'group-1' }}
+          id="step-a"
+        >
+          <Form.MainHeading>Step A</Form.MainHeading>
+          <Wizard.Buttons />
+        </Wizard.Step>
 
-      <Wizard.Container mode="loose">
-        <Step1 />
-        <Step2 />
-        <Step3 />
+        <Wizard.Step
+          title="Step B"
+          activeWhen={{ path: '/activeSteps', hasValue: 'group-1' }}
+          id="step-b"
+        >
+          <Form.MainHeading>Step B</Form.MainHeading>
+          <Wizard.Buttons />
+        </Wizard.Step>
+
+        <Wizard.Step
+          title="Step C"
+          activeWhen={{
+            path: '/activeSteps',
+            hasValue: (value: string) =>
+              ['group-1', 'group-2'].includes(value),
+          }}
+          id="step-c"
+        >
+          <Form.MainHeading>Step C</Form.MainHeading>
+          <Wizard.Buttons />
+        </Wizard.Step>
+
+        <Wizard.Step
+          title="Step D"
+          activeWhen={{ path: '/activeSteps', hasValue: 'group-2' }}
+          id="step-d"
+        >
+          <Form.MainHeading>Step D</Form.MainHeading>
+          <Wizard.Buttons />
+        </Wizard.Step>
       </Wizard.Container>
+
+      <Field.Selection
+        path="/activeSteps"
+        variant="button"
+        optionsLayout="horizontal"
+        top
+      >
+        <Field.Option value="group-1" title="Group 1" />
+        <Field.Option value="group-2" title="Group 2" />
+      </Field.Selection>
     </Form.Handler>
   )
 }


### PR DESCRIPTION
Quick example:

```tsx
<Wizard.Container
  onStepChange={(index, mode, args) => {
    console.log('onStepChange', index, mode, args.id) // 👈 here we get the "id"
  }}
>
  <Wizard.Step
    title="Step A"
    id="step-a" // 👈 here we add an "id"
    activeWhen={{ path: '/activeSteps', hasValue: 'group-1' }}
  >
    content
  </Wizard.Step>
<Wizard.Container
```