### PR TITLE
feat(Forms): remove internal pattern from `Field.NationalIdentityNumber` in favor of the internal validator

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -42,7 +42,6 @@ function NationalIdentityNumber(props: Props) {
           ],
     [omitMask]
   )
-  const validationPattern = '^[0-9]{11}$'
 
   const fnrValidator = useCallback(
     (value: string) => {
@@ -66,9 +65,9 @@ function NationalIdentityNumber(props: Props) {
 
   const dnrAndFnrValidator = useCallback(
     (value: string) => {
-      const validationPattern = '^[4-9].*' // 1st num is increased by 4. i.e, if 01.01.1985, D number would be 410185.
+      const dnrValidationPattern = '^[4-9].*' // 1st num is increased by 4. i.e, if 01.01.1985, D number would be 410185.
 
-      if (new RegExp(validationPattern).test(value)) {
+      if (new RegExp(dnrValidationPattern).test(value)) {
         return dnrValidator(value)
       }
       return fnrValidator(value)
@@ -78,12 +77,6 @@ function NationalIdentityNumber(props: Props) {
 
   const StringFieldProps: Props = {
     ...props,
-    pattern:
-      validate && props.pattern
-        ? props.pattern
-        : validate && !props.validator
-        ? validationPattern
-        : undefined,
     label: props.label ?? label,
     errorMessages,
     mask,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -59,15 +59,6 @@ describe('Field.NationalIdentityNumber', () => {
     )
   })
 
-  it('should show "errorRequired" error message when "pattern" not matches', async () => {
-    render(<Field.NationalIdentityNumber validateInitially value="123" />)
-
-    expect(screen.queryByRole('alert')).toBeInTheDocument()
-    expect(screen.queryByRole('alert')).toHaveTextContent(
-      nb.NationalIdentityNumber.errorRequired
-    )
-  })
-
   it('should validate internal validator', async () => {
     const { rerender } = render(
       <Field.NationalIdentityNumber
@@ -98,6 +89,49 @@ describe('Field.NationalIdentityNumber', () => {
         nb.NationalIdentityNumber.errorDnr
       )
     })
+  })
+
+  it('should support custom pattern', async () => {
+    render(
+      <Form.Handler>
+        <Field.NationalIdentityNumber
+          validateInitially
+          value="58081633086" // valid, but not in the pattern
+          pattern="^6"
+        />
+      </Form.Handler>
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('alert').textContent).toBe(
+        nb.NationalIdentityNumber.errorRequired
+      )
+    })
+  })
+
+  it('should support custom pattern without validator', async () => {
+    const dummyValidator = jest.fn()
+
+    render(
+      <Form.Handler>
+        <Field.NationalIdentityNumber
+          validateInitially
+          value="6"
+          pattern="^6"
+          onBlurValidator={() => {
+            return [dummyValidator]
+          }}
+        />
+      </Form.Handler>
+    )
+
+    await expect(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    }).neverToResolve()
+
+    expect(dummyValidator).toHaveBeenCalledTimes(1)
+    expect(dummyValidator).toHaveBeenCalledWith('6', expect.anything())
   })
 
   it('should validate given function', async () => {
@@ -213,7 +247,7 @@ describe('Field.NationalIdentityNumber', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert')).toHaveTextContent(
-        nb.NationalIdentityNumber.errorRequired
+        nb.NationalIdentityNumber.errorFnr
       )
     })
   })
@@ -224,22 +258,6 @@ describe('Field.NationalIdentityNumber', () => {
     await expect(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
     }).neverToResolve()
-  })
-
-  it('should not validate custom pattern when validate false', async () => {
-    const invalidPattern = '1234'
-    render(
-      <Field.NationalIdentityNumber
-        pattern="[A-Z]"
-        value={invalidPattern}
-        validateInitially
-        validate={false}
-      />
-    )
-
-    fireEvent.blur(document.querySelector('input'))
-
-    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('should not validate dnum when validate false', async () => {


### PR DESCRIPTION
As done in https://github.com/dnbexperience/eufemia/pull/4092 as well.

I think these components is easier to understand only using validators and not patterns as well.

Since we don't use the pattern, the error message is a bit simplified(only using the error message from the validators):


Previously:
<img width="565" alt="Screenshot 2024-10-09 at 15 03 09" src="https://github.com/user-attachments/assets/00aaa038-dca3-4894-9833-fd48b4063971">

Now:
<img width="434" alt="Screenshot 2024-10-09 at 15 04 11" src="https://github.com/user-attachments/assets/d528efdf-a4dd-4dd5-afe9-9499ae662d27">
