### PR TITLE
feat(Forms): add `onBeforeStepChange` event handler with the current index

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
@@ -50,7 +50,12 @@ export const WizardContainerProperties: PropertiesTableProps = {
 
 export const WizardContainerEvents: PropertiesTableProps = {
   onStepChange: {
-    doc: 'Will be called when the user navigate to a different step, with step `index` (number) as the first argument and a string with `previous` or `next` (or `stepListModified` when a step gets replaced) as the second argument, and an object containing `previousIndex`, `id` (if set on the Wizard.Step), `preventNavigation` function as the third parameter. \n\nWhen an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related Form.Handler props: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`.',
+    doc: 'Will be called when the user navigate to a different step, with step `index` as the first argument and `previous` or `next` (string) as the second argument, and an options object containing `preventNavigation` function as the third parameter. When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for minimum 1 second. Related Form.Handler props: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`.',
+    type: 'function',
+    status: 'optional',
+  },
+  onBeforeStepChange: {
+    doc: 'Same as `onStepChange`, but will be called with the current step index.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -127,6 +127,51 @@ describe('Wizard.Container', () => {
     })
   })
 
+  it('should provide current index in "onBeforeStepChange" when navigating back and forth', async () => {
+    const onBeforeStepChange = jest.fn()
+
+    render(
+      <Wizard.Container
+        onBeforeStepChange={onBeforeStepChange}
+        mode="loose"
+      >
+        <Wizard.Step title="Step 1">
+          <output>Step 1</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+
+        <Wizard.Step title="Step 2">
+          <output>Step 2</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      </Wizard.Container>
+    )
+
+    await userEvent.click(nextButton())
+
+    expect(onBeforeStepChange).toHaveBeenCalledTimes(1)
+    expect(onBeforeStepChange).toHaveBeenLastCalledWith(0, 'next', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 0,
+    })
+
+    await userEvent.click(previousButton())
+
+    expect(onBeforeStepChange).toHaveBeenCalledTimes(2)
+    expect(onBeforeStepChange).toHaveBeenLastCalledWith(1, 'previous', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 1,
+    })
+
+    await userEvent.click(nextButton())
+
+    expect(onBeforeStepChange).toHaveBeenCalledTimes(3)
+    expect(onBeforeStepChange).toHaveBeenLastCalledWith(0, 'next', {
+      preventNavigation: expect.any(Function),
+      previousIndex: 0,
+    })
+  })
+
   it('should have previousIndex in "onStepChange" when navigating back and forth', async () => {
     const onStepChange = jest.fn()
 


### PR DESCRIPTION
This PR is based on #4093

It makes it possible to get the current step index, during navigation, including the current step `id`. 

If there are any better event name recommendations, let me know.