### PR TITLE
chore(Field.NationalIdentityNumber): updates required translation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -17,7 +17,7 @@ function NationalIdentityNumber(props: Props) {
   const { label, errorRequired, errorFnr, errorDnr } = translations
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
     required: errorRequired,
-    pattern: errorRequired,
+    pattern: errorFnr,
     errorFnr,
     errorDnr,
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -105,7 +105,7 @@ describe('Field.NationalIdentityNumber', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert').textContent).toBe(
-        nb.NationalIdentityNumber.errorRequired
+        nb.NationalIdentityNumber.errorFnr
       )
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -178,7 +178,7 @@ describe('Field.NationalIdentityNumber', () => {
         errorMessages: expect.objectContaining({
           maxLength: expect.stringContaining('{maxLength}'),
           minLength: expect.stringContaining('{minLength}'),
-          pattern: expect.stringContaining('11'),
+          pattern: expect.stringContaining('fødselsnummer'),
           required: expect.stringContaining('fødselsnummer'),
           errorDnr: expect.stringContaining('d-nummer'),
           errorFnr: expect.stringContaining('fødselsnummer'),

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -179,7 +179,7 @@ describe('Field.NationalIdentityNumber', () => {
           maxLength: expect.stringContaining('{maxLength}'),
           minLength: expect.stringContaining('{minLength}'),
           pattern: expect.stringContaining('11'),
-          required: expect.stringContaining('11'),
+          required: expect.stringContaining('fødselsnummer'),
           errorDnr: expect.stringContaining('d-nummer'),
           errorFnr: expect.stringContaining('fødselsnummer'),
         }),

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -117,8 +117,7 @@ export default {
     },
     NationalIdentityNumber: {
       label: 'National identity number (11 digits)',
-      errorRequired:
-        'Invalid national identity number. Enter a valid 11-digit number.',
+      errorRequired: 'You must enter a national identity number.',
       errorFnr: 'Invalid national identity number.',
       errorDnr: 'Invalid D number.',
     },

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -115,8 +115,7 @@ export default {
     },
     NationalIdentityNumber: {
       label: 'Fødselsnummer (11 siffer)',
-      errorRequired:
-        'Ugyldig fødselsnummer. Skriv inn et gyldig fødselsnummer med 11 siffer.',
+      errorRequired: 'Du må fylle inn et fødselsnummer.',
       errorFnr: 'Ugyldig fødselsnummer.',
       errorDnr: 'Ugyldig d-nummer.',
     },


### PR DESCRIPTION
I think this required translation(`Du må fylle inn et fødselsnummer.`) is more in line with the required translation of organization number(`Du må fylle inn et organisasjonsnummer.`)