### PR TITLE
chore(Field.OrganizationNumber): changes translation from errorPattern to errorOrgNo

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -10,13 +10,14 @@ export type Props = StringFieldProps & {
 
 function OrganizationNumber(props: Props) {
   const translations = useTranslation().OrganizationNumber
-  const { errorPattern, errorRequired, label } = translations
+  const { errorOrgNo, errorRequired, label } = translations
 
   const { validate = true, omitMask } = props
 
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
     required: errorRequired,
-    pattern: errorPattern,
+    pattern: errorOrgNo,
+    errorOrgNo,
   })
 
   const mask = useMemo(
@@ -30,10 +31,10 @@ function OrganizationNumber(props: Props) {
   const organizationNumberValidator = useCallback(
     (value: string) => {
       if (value !== undefined && !isValidOrgNumber(value)) {
-        return Error(errorPattern)
+        return Error(errorOrgNo)
       }
     },
-    [errorPattern]
+    [errorOrgNo]
   )
 
   const StringFieldProps: Props = {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
@@ -112,7 +112,7 @@ describe('Field.OrganizationNumber', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert')).toHaveTextContent(
-        nb.OrganizationNumber.errorPattern
+        nb.OrganizationNumber.errorOrgNo
       )
     })
   })
@@ -139,7 +139,7 @@ describe('Field.OrganizationNumber', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert').textContent).toBe(
-        nb.OrganizationNumber.errorPattern
+        nb.OrganizationNumber.errorOrgNo
       )
     })
   })
@@ -178,7 +178,7 @@ describe('Field.OrganizationNumber', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeInTheDocument()
       expect(screen.queryByRole('alert').textContent).toBe(
-        nb.OrganizationNumber.errorPattern
+        nb.OrganizationNumber.errorOrgNo
       )
     })
   })
@@ -343,7 +343,7 @@ describe('Field.OrganizationNumber', () => {
         await waitFor(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
           expect(screen.queryByRole('alert')).toHaveTextContent(
-            nb.OrganizationNumber.errorPattern
+            nb.OrganizationNumber.errorOrgNo
           )
         })
       }
@@ -442,7 +442,7 @@ describe('Field.OrganizationNumber', () => {
         await waitFor(() => {
           expect(screen.queryByRole('alert')).toBeInTheDocument()
           expect(screen.queryByRole('alert')).toHaveTextContent(
-            nb.OrganizationNumber.errorPattern
+            nb.OrganizationNumber.errorOrgNo
           )
         })
       }

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -125,7 +125,7 @@ export default {
     OrganizationNumber: {
       label: 'Organisation number',
       errorRequired: 'You must enter an organisation number.',
-      errorPattern: 'This is not a valid organisation number.',
+      errorOrgNo: 'This is not a valid organisation number.',
     },
     BankAccountNumber: {
       label: 'Bank account',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
@@ -8,7 +8,7 @@ export default {
     OrganizationNumber: {
       label: 'Organization number',
       errorRequired: 'You must enter an organization number.',
-      errorPattern: 'This is not a valid organization number.',
+      errorOrgNo: 'This is not a valid organization number.',
     },
   },
 }

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -123,7 +123,7 @@ export default {
     OrganizationNumber: {
       label: 'Organisasjonsnummer',
       errorRequired: 'Du må fylle inn et organisasjonsnummer.',
-      errorPattern: 'Dette er ikke et gyldig organisasjonsnummer.',
+      errorOrgNo: 'Dette er ikke et gyldig organisasjonsnummer.',
     },
     BankAccountNumber: {
       label: 'Bankkonto',


### PR DESCRIPTION
I think this makes more sense for the component, as we don't use pattern internally by default, but we do support validator by default