### PR TITLE
feat(Forms): add `bubbleValidation` to Form.Isolation and Iterate.PushContainer to prevent the form from being submitted when there are fields with errors

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
@@ -65,6 +65,23 @@ function MyForm() {
 render(<MyForm />)
 ```
 
+## Prevent the form from being submitted
+
+To prevent the [Form.Handler](/uilib/extensions/forms/Form/Handler/) from being submitted when there are fields with errors inside the Isolation, you can use the `bubbleValidation` property.
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Form.Isolation bubbleValidation>
+      <Field.String label="Required field" path="/isolated" required />
+      <Form.Isolation.CommitButton />
+    </Form.Isolation>
+  </Form.Handler>,
+)
+```
+
 ## Schema support
 
 You can also use a `schema` to define the properties of the nested fields:

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/info.mdx
@@ -33,6 +33,24 @@ render(
 )
 ```
 
+## Prevent the form from being submitted
+
+To prevent the [Form.Handler](/uilib/extensions/forms/Form/Handler/) from being submitted when there are fields with errors inside the PushContainer, you can use the `bubbleValidation` property.
+
+```tsx
+import { Form, Field, Iterate } from '@dnb/eufemia/extensions/forms'
+
+render(
+  <Form.Handler>
+    <Iterate.Array path="/myList">...</Iterate.Array>
+
+    <Iterate.PushContainer path="/myList" bubbleValidation>
+      <Field.Name.Last itemPath="/name" required />
+    </Iterate.PushContainer>
+  </Form.Handler>,
+)
+```
+
 ## Show a button to create a new item
 
 By default, it keeps the form open after a new item has been created. You can change this behavior by using the `openButton` and `showOpenButtonWhen` properties.

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -165,6 +165,7 @@ export interface ContextState {
     Map<SnapshotName, Map<Path, unknown>>
   >
   formElementRef?: React.MutableRefObject<HTMLFormElement>
+  fieldErrorRef?: React.MutableRefObject<Record<Path, Error>>
   showAllErrors: boolean
   hasVisibleError: boolean
   formState: SubmitState

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1332,13 +1332,14 @@ export default function Provider<Data extends JsonObject>(
     mountedFieldsRef,
     snapshotsRef,
     formElementRef,
+    isEmptyDataRef,
+    fieldErrorRef,
     ajvInstance: ajvRef.current,
 
     /** Additional */
     id,
     data: internalDataRef.current,
     internalDataRef,
-    isEmptyDataRef,
     props,
     ...rest,
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationDocs.ts
@@ -20,6 +20,11 @@ export const IsolationProperties: PropertiesTableProps = {
     type: 'React.Ref',
     status: 'optional',
   },
+  bubbleValidation: {
+    doc: 'Prevent the form from being submitted when there are fields with errors inside the Form.Isolation.',
+    type: 'boolean',
+    status: 'optional',
+  },
   ...ProviderProperties,
   minimumAsyncBehaviorTime: undefined,
   asyncSubmitTimeout: undefined,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -1643,4 +1643,49 @@ describe('Form.Isolation', () => {
     expect(synced).toHaveValue('inside changed')
     expect(regular).toHaveValue('regular')
   })
+
+  describe('bubbleValidation', () => {
+    it('should prevent the form from submitting as long as there are errors', async () => {
+      const onSubmitRequest = jest.fn()
+      const onSubmit = jest.fn()
+      const onCommit = jest.fn()
+
+      render(
+        <Form.Handler
+          onSubmitRequest={onSubmitRequest}
+          onSubmit={onSubmit}
+        >
+          <Form.Isolation onCommit={onCommit} bubbleValidation>
+            <Field.String label="Isolated" path="/isolated" required />
+            <Form.Isolation.CommitButton />
+          </Form.Isolation>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const form = document.querySelector('form')
+      const commitButton = document.querySelector('button')
+
+      await userEvent.click(commitButton)
+      fireEvent.submit(form)
+
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.Field.errorRequired
+      )
+
+      expect(onSubmit).toHaveBeenCalledTimes(0)
+      expect(onSubmitRequest).toHaveBeenCalledTimes(1)
+      expect(onCommit).toHaveBeenCalledTimes(0)
+
+      await userEvent.type(input, 'Tony')
+      fireEvent.submit(form)
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmitRequest).toHaveBeenCalledTimes(1)
+      expect(onCommit).toHaveBeenCalledTimes(0)
+
+      await userEvent.click(commitButton)
+      expect(onCommit).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -54,6 +54,11 @@ export type Props = {
   isolatedData?: Record<string, unknown>
 
   /**
+   * Prevent the form from being submitted when there are fields with errors inside the PushContainer.
+   */
+  bubbleValidation?: boolean
+
+  /**
    * A custom toolbar to be shown below the container.
    */
   toolbar?: React.ReactNode
@@ -76,6 +81,7 @@ function PushContainer(props: AllProps) {
     data: dataProp,
     defaultData: defaultDataProp,
     isolatedData,
+    bubbleValidation,
     path,
     title,
     children,
@@ -145,6 +151,7 @@ function PushContainer(props: AllProps) {
       data={data}
       defaultData={defaultData}
       emptyData={emptyData}
+      bubbleValidation={bubbleValidation}
       commitHandleRef={commitHandleRef}
       transformOnCommit={({ pushContainerItems }) => {
         return moveValueToPath(path, [...entries, ...pushContainerItems])

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
@@ -27,6 +27,11 @@ export const PushContainerProperties: PropertiesTableProps = {
     type: 'object',
     status: 'optional',
   },
+  bubbleValidation: {
+    doc: 'Prevent the form from being submitted when there are fields with errors inside the PushContainer.',
+    type: 'boolean',
+    status: 'optional',
+  },
   openButton: {
     doc: 'The button to open container.',
     type: 'React.Node',


### PR DESCRIPTION
Partially solves #4072