### PR TITLE
chore(Field.NationalIdentityNumber): disable default onBlurValidator using `false`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -85,7 +85,7 @@ function NationalIdentityNumber(props: Props) {
   )
 
   const onBlurValidatorToUse =
-    onBlurValidator == false ? undefined : onBlurValidator
+    onBlurValidator === false ? undefined : onBlurValidator
 
   const StringFieldProps: StringFieldProps = {
     ...props,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -1,18 +1,18 @@
 import React, { useCallback, useMemo } from 'react'
 import StringField, { Props as StringFieldProps } from '../String'
 import { dnr, fnr } from '@navikt/fnrvalidator'
+import { Validator } from '../../types'
 
 import useErrorMessage from '../../hooks/useErrorMessage'
 import useTranslation from '../../hooks/useTranslation'
 
-export type Props = StringFieldProps & {
+export type Props = Omit<StringFieldProps, 'onBlurValidator'> & {
   omitMask?: boolean
   validate?: boolean
+  onBlurValidator?: Validator<string> | false
 }
 
 function NationalIdentityNumber(props: Props) {
-  const { validate = true, omitMask } = props
-
   const translations = useTranslation().NationalIdentityNumber
   const { label, errorRequired, errorFnr, errorDnr } = translations
   const errorMessages = useErrorMessage(props.path, props.errorMessages, {
@@ -21,27 +21,6 @@ function NationalIdentityNumber(props: Props) {
     errorFnr,
     errorDnr,
   })
-
-  const mask = useMemo(
-    () =>
-      omitMask
-        ? Array(11).fill(/\d/)
-        : [
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            ' ',
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-          ],
-    [omitMask]
-  )
 
   const fnrValidator = useCallback(
     (value: string) => {
@@ -75,18 +54,53 @@ function NationalIdentityNumber(props: Props) {
     [dnrValidator, fnrValidator]
   )
 
-  const StringFieldProps: Props = {
+  const {
+    validate = true,
+    omitMask,
+    onBlurValidator = dnrAndFnrValidator,
+    validator,
+    width,
+    label: labelProp,
+  } = props
+
+  const mask = useMemo(
+    () =>
+      omitMask
+        ? Array(11).fill(/\d/)
+        : [
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            ' ',
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+            /\d/,
+          ],
+    [omitMask]
+  )
+
+  const onBlurValidatorToUse =
+    onBlurValidator == false ? undefined : onBlurValidator
+
+  const StringFieldProps: StringFieldProps = {
     ...props,
-    label: props.label ?? label,
+    label: labelProp ?? label,
     errorMessages,
     mask,
-    width: props.width ?? 'medium',
+    width: width ?? 'medium',
     inputMode: 'numeric',
-    validator: validate ? props.validator : undefined,
-    onBlurValidator: validate
-      ? props.onBlurValidator || dnrAndFnrValidator
-      : undefined,
-    exportValidators: { dnrValidator, fnrValidator, dnrAndFnrValidator },
+    validator: validate ? validator : undefined,
+    onBlurValidator: validate ? onBlurValidatorToUse : undefined,
+    exportValidators: {
+      dnrValidator,
+      fnrValidator,
+      dnrAndFnrValidator,
+    },
   }
 
   return <StringField {...StringFieldProps} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumberDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumberDocs.tsx
@@ -12,7 +12,7 @@ export const NationalIdentityNumberProperties: PropertiesTableProps = {
     status: 'optional',
   },
   onBlurValidator: {
-    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }. Defaults to validation of the identification number(national identity numbers and D numbers), using `dnrAndFnrValidator`.',
+    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }. Defaults to validation of the identification number(national identity numbers and D numbers), using `dnrAndFnrValidator`. Can be disabled using `false`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -260,6 +260,23 @@ describe('Field.NationalIdentityNumber', () => {
     }).neverToResolve()
   })
 
+  it('should not validate when onBlurValidator is false', async () => {
+    const invalidFnr = '29020112345'
+    render(
+      <Field.NationalIdentityNumber
+        value={invalidFnr}
+        validateInitially
+        onBlurValidator={false}
+      />
+    )
+
+    fireEvent.blur(document.querySelector('input'))
+
+    await expect(() => {
+      expect(screen.queryByRole('alert')).toBeInTheDocument()
+    }).neverToResolve()
+  })
+
   it('should not validate dnum when validate false', async () => {
     const invalidDnum = '69020112345'
     render(


### PR DESCRIPTION
Let's say if user wants to use validator instead of onBlurValidator, then he should be able to disable the default `onBlurValidator`.