### PR TITLE
fix(Forms): Fix use of unpolyfilled structuredClone in useData hook

### DIFF
--- a/packages/dnb-eufemia/.eslintrc
+++ b/packages/dnb-eufemia/.eslintrc
@@ -143,6 +143,13 @@
               }
             ]
           }
+        ],
+        "no-restricted-globals": [
+          "error",
+          {
+            "name": "structuredClone",
+            "message": "Import `structuredClone` from '@ungap/structured-clone' instead."
+          }
         ]
       }
     },

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useData.tsx
@@ -18,6 +18,12 @@ import DataContext, {
 } from '../../DataContext/Context'
 import { SharedAttachments } from '../../DataContext/Provider'
 
+/**
+ * Deprecated, as it is supported by all major browsers and Node.js >=v18
+ * So its a question of time, when we will remove this polyfill
+ */
+import structuredClone from '@ungap/structured-clone'
+
 type PathImpl<T, P extends string> = P extends `${infer Key}/${infer Rest}`
   ? Key extends keyof T
     ? Rest extends ''


### PR DESCRIPTION
We had a spot that was using `window.structuredClone` instead of the polyfill from `@ungap/structured-clone` that is used everywhere else.

Fixed that spot, and added a rule to eslint to make sure we don't forget in the future.

Note that I don't make any judgement on whether we should be using this or not here, just enforcing consistency.

With this linting rule in place:

![CleanShot 2024-10-10 at 14 30 28](https://github.com/user-attachments/assets/a1956341-5d2e-45c8-a59d-cc1db935668f)
