### PR TITLE
feat(Forms): add `country` prop to Field.PostalCodeAndCity to support other countries than Norway

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Field, Iterate } from '@dnb/eufemia/src/extensions/forms'
+import { Field, Form, Iterate } from '@dnb/eufemia/src/extensions/forms'
 
 export const Empty = () => {
   return (
@@ -169,6 +169,17 @@ export const IterateArray = () => {
           city={{ itemPath: '/city' }}
         />
       </Iterate.Array>
+    </ComponentBox>
+  )
+}
+
+export const SettingCountryBasedOnPath = () => {
+  return (
+    <ComponentBox>
+      <Form.Handler>
+        <Field.SelectCountry path="/myCountry" defaultValue="NO" />
+        <Field.PostalCodeAndCity country="/myCountry" />
+      </Form.Handler>
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@dnb/eufemia/src'
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Field, Form, Iterate } from '@dnb/eufemia/src/extensions/forms'
 
@@ -177,12 +178,10 @@ export const SettingCountryBasedOnPath = () => {
   return (
     <ComponentBox>
       <Form.Handler>
-        <Field.SelectCountry
-          path="/myCountry"
-          defaultValue="NO"
-          bottom="medium"
-        />
-        <Field.PostalCodeAndCity country="/myCountry" />
+        <Card stack>
+          <Field.SelectCountry path="/myCountry" defaultValue="NO" />
+          <Field.PostalCodeAndCity country="/myCountry" />
+        </Card>
       </Form.Handler>
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -177,7 +177,11 @@ export const SettingCountryBasedOnPath = () => {
   return (
     <ComponentBox>
       <Form.Handler>
-        <Field.SelectCountry path="/myCountry" defaultValue="NO" />
+        <Field.SelectCountry
+          path="/myCountry"
+          defaultValue="NO"
+          bottom="medium"
+        />
         <Field.PostalCodeAndCity country="/myCountry" />
       </Form.Handler>
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -192,7 +192,7 @@ export const NonNorwegianPostalCode = () => {
   return (
     <ComponentBox>
       <Field.PostalCodeAndCity
-        country="de"
+        country="DE"
         postalCode={{
           pattern: '^[0-9]{5}$',
           mask: [/\\d/, /\\d/, /\\d/, /\\d/, /\\d/],

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -172,3 +172,20 @@ export const IterateArray = () => {
     </ComponentBox>
   )
 }
+
+export const NonNorwegianPostalCode = () => {
+  return (
+    <ComponentBox>
+      <Field.PostalCodeAndCity
+        country="de"
+        postalCode={{
+          pattern: '^[0-9]{5}$',
+          mask: [/\\d/, /\\d/, /\\d/, /\\d/, /\\d/],
+          placeholder: '00000',
+          width: 'medium',
+        }}
+        city={{ pattern: '^[a-zA-ZäöüÄÖÜß -]+$', width: 'stretch' }}
+      />
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -196,7 +196,7 @@ export const NonNorwegianPostalCode = () => {
           pattern: '^[0-9]{5}$',
           mask: [/\\d/, /\\d/, /\\d/, /\\d/, /\\d/],
           placeholder: '00000',
-          width: 'medium',
+          width: '5.4rem',
         }}
         city={{ pattern: '^[a-zA-ZäöüÄÖÜß -]+$', width: 'stretch' }}
       />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -46,7 +46,7 @@ By using the `itemPath` property, you can iterate over an array and use the `pos
 
 ### Non-Norwegian Postal Codes
 
-If you want to allow for a postal code that is not Norwegain, just set the `country` property to the desired country and add your own custom validation.
+If you want to allow for a postal code that is not Norwegian, just set the `country` property to the desired country and add your own custom validation.
 
 <Examples.NonNorwegianPostalCode />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -44,6 +44,12 @@ By using the `itemPath` property, you can iterate over an array and use the `pos
 
 <Examples.ValidationRequired />
 
+### Non Norwegain Postal Codes
+
+If you want to allow for a postal code that is not Norwegain, just set the `country` property to the desired country and add your own custom validation.
+
+<Examples.NonNorwegianPostalCode />
+
 <VisibleWhenVisualTest>
   <Examples.LongLabel />
 </VisibleWhenVisualTest>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -52,7 +52,8 @@ The `country` property supports a field path as value. This allows you to set th
 
 ### Non-Norwegian Postal Codes
 
-If you want to allow for a postal code that is not Norwegian, just set the `country` property to the desired country and add your own custom validation.
+If you want to allow for a postal code that is not Norwegian, just set the `country` property to the desired country, and add your own custom validation.
+NB: As of today, setting `country` property to anything other than `NO` will only remove the default norwegian postal code pattern, and not actually set the postal code pattern for the value provided to the `country` property. This functionality will hopefully be implemented in the future.
 
 <Examples.NonNorwegianPostalCode />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -53,7 +53,8 @@ The `country` property supports a field path as value. This allows you to set th
 ### Non-Norwegian Postal Codes
 
 If you want to allow for a postal code that is not Norwegian, just set the `country` property to the desired country, and add your own custom validation.
-NB: As of today, setting `country` property to anything other than `NO` will only remove the default norwegian postal code pattern, and not actually set the postal code pattern for the value provided to the `country` property. This functionality will hopefully be implemented in the future.
+
+NB: As of today, setting `country` property to anything other than `NO` will only remove the default norwegian postal code pattern, mask, and placeholder, but not actually set the postal code pattern, mask, and placeholder for the value provided to the `country` property. This functionality will hopefully be implemented in the future.
 
 <Examples.NonNorwegianPostalCode />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -44,7 +44,7 @@ By using the `itemPath` property, you can iterate over an array and use the `pos
 
 <Examples.ValidationRequired />
 
-### Non Norwegain Postal Codes
+### Non-Norwegian Postal Codes
 
 If you want to allow for a postal code that is not Norwegain, just set the `country` property to the desired country and add your own custom validation.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -44,6 +44,12 @@ By using the `itemPath` property, you can iterate over an array and use the `pos
 
 <Examples.ValidationRequired />
 
+### Path Based Country
+
+The `country` prop supports a field path as value. This allows you to set the `country` based on the value of another field.
+
+<Examples.SettingCountryBasedOnPath />
+
 ### Non-Norwegian Postal Codes
 
 If you want to allow for a postal code that is not Norwegian, just set the `country` property to the desired country and add your own custom validation.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/demos.mdx
@@ -46,7 +46,7 @@ By using the `itemPath` property, you can iterate over an array and use the `pos
 
 ### Path Based Country
 
-The `country` prop supports a field path as value. This allows you to set the `country` based on the value of another field.
+The `country` property supports a field path as value. This allows you to set the `country` based on the value of another field.
 
 <Examples.SettingCountryBasedOnPath />
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -61,21 +61,12 @@ function PostalCodeAndCity(props: Props) {
 
   const postalCodeValidationProps = useMemo(() => {
     return {
-      mask: postalCodeMask
-        ? postalCodeMask
-        : isNorway
-        ? [/\d/, /\d/, /\d/, /\d/]
-        : undefined,
-      pattern: postalCodePattern
-        ? postalCodePattern
-        : isNorway
-        ? '^[0-9]{4}$'
-        : undefined,
-      placeholder: postalCodePlaceHolder
-        ? postalCodePlaceHolder
-        : isNorway
-        ? '0000'
-        : undefined,
+      mask:
+        postalCodeMask ??
+        (isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined),
+      pattern: postalCodePattern ?? (isNorway ? '^[0-9]{4}$' : undefined),
+      placeholder:
+        postalCodePlaceHolder ?? (isNorway ? '0000' : undefined),
     }
   }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -37,7 +37,6 @@ function PostalCodeAndCity(props: Props) {
   const isNorway = useMemo(() => countryValue === 'no', [countryValue])
 
   const postalCodeValidationProps = useMemo(() => {
-    console.log('Recalc')
     return {
       mask:
         postalCode.mask ?? isNorway

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -14,7 +14,7 @@ export type Props = FieldHelpProps &
      * Defines which country the postal code and city is for.
      * Setting it to anything other than `no` will remove the default norwegian postal code pattern.
      * You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.
-     * Default: `no`
+     * Default: `NO`
      */
     // Add type for all country codes?
     country?: Path | string

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -3,8 +3,9 @@ import classnames from 'classnames'
 import { Props as FieldBlockProps } from '../../FieldBlock'
 import StringField, { Props as StringFieldProps } from '../String'
 import CompositionField from '../Composition'
-import { FieldHelpProps } from '../../types'
+import { FieldHelpProps, Path } from '../../types'
 import useTranslation from '../../hooks/useTranslation'
+import useDataValue from '../../hooks/useDataValue'
 
 export type Props = FieldHelpProps &
   Omit<FieldBlockProps, 'children'> &
@@ -14,23 +15,29 @@ export type Props = FieldHelpProps &
      * Setting it to anything other than `no` will remove the default norwegian postal code pattern.
      * Default: `no`
      */
-    country?: string
+    // Add type for all country codes?
+    country?: Path | 'no' | string
   }
 
 function PostalCodeAndCity(props: Props) {
   const translations = useTranslation()
+  const { getSourceValue } = useDataValue()
 
   const {
     postalCode = {},
     city = {},
     help,
     width = 'large',
-    country = 'no', // default to Norway
+    country = 'no',
     ...fieldBlockProps
   } = props
 
+  const countryValue = getSourceValue(country)
+
+  const isNorway = useMemo(() => countryValue === 'no', [countryValue])
+
   const postalCodeValidationProps = useMemo(() => {
-    const isNorway = country === 'no'
+    console.log('Recalc')
     return {
       mask:
         postalCode.mask ?? isNorway
@@ -43,7 +50,7 @@ function PostalCodeAndCity(props: Props) {
     postalCode.pattern,
     postalCode.placeholder,
     postalCode.mask,
-    country,
+    isNorway,
   ])
 
   return (
@@ -87,8 +94,7 @@ function PostalCodeAndCity(props: Props) {
           pattern: translations.City.errorPattern,
           ...city.errorMessages,
         }}
-        // Propably have to update this pattern to allow for more characters like Û, Ô, Ñ, etc.
-        pattern={'^[A-Za-zÆØÅæøå -]+$'}
+        pattern={city.pattern ?? '^[A-Za-zÆØÅæøå -]+$'}
         trim
         width="stretch"
         autoComplete="address-level2"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -50,9 +50,9 @@ function PostalCodeAndCity(props: Props) {
   } = city
 
   const {
-    mask: postalCodeMask = isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined,
-    pattern: postalCodePattern = isNorway ? '^[0-9]{4}$' : undefined,
-    placeholder: postalCodePlaceHolder = isNorway ? '0000' : undefined,
+    mask: postalCodeMask,
+    pattern: postalCodePattern,
+    placeholder: postalCodePlaceHolder,
     className: postalCodeClassName,
     label: postalCodeLabel,
     width: postalCodeWidth,
@@ -61,9 +61,10 @@ function PostalCodeAndCity(props: Props) {
 
   const postalCodeValidationProps = useMemo(() => {
     return {
-      mask: postalCodeMask,
-      pattern: postalCodePattern,
-      placeholder: postalCodePlaceHolder,
+      mask:
+        postalCodeMask ?? isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined,
+      pattern: postalCodePattern ?? isNorway ? '^[0-9]{4}$' : undefined,
+      placeholder: postalCodePlaceHolder ?? isNorway ? '0000' : undefined,
     }
   }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -13,6 +13,7 @@ export type Props = FieldHelpProps &
     /**
      * Defines which country the postal code and city is for.
      * Setting it to anything other than `no` will remove the default norwegian postal code pattern.
+     * You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.
      * Default: `no`
      */
     // Add type for all country codes?

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -61,13 +61,25 @@ function PostalCodeAndCity(props: Props) {
 
   const postalCodeValidationProps = useMemo(() => {
     return {
-      mask:
-        postalCodeMask ?? isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined,
-      pattern: postalCodePattern ?? isNorway ? '^[0-9]{4}$' : undefined,
-      placeholder: postalCodePlaceHolder ?? isNorway ? '0000' : undefined,
+      mask: postalCodeMask
+        ? postalCodeMask
+        : isNorway
+        ? [/\d/, /\d/, /\d/, /\d/]
+        : undefined,
+      pattern: postalCodePattern
+        ? postalCodePattern
+        : isNorway
+        ? '^[0-9]{4}$'
+        : undefined,
+      placeholder: postalCodePlaceHolder
+        ? postalCodePlaceHolder
+        : isNorway
+        ? '0000'
+        : undefined,
     }
   }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
 
+  console.log('postalCodeValidationProps', postalCodeValidationProps)
   return (
     <CompositionField
       className={classnames(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -17,7 +17,7 @@ export type Props = FieldHelpProps &
      * Default: `no`
      */
     // Add type for all country codes?
-    country?: Path | 'no' | string
+    country?: Path | string
   }
 
 function PostalCodeAndCity(props: Props) {
@@ -39,12 +39,21 @@ function PostalCodeAndCity(props: Props) {
 
   const postalCodeValidationProps = useMemo(() => {
     return {
-      mask:
-        postalCode.mask ?? isNorway
-          ? [/\d/, /\d/, /\d/, /\d/]
-          : postalCode.mask,
-      pattern: postalCode.pattern ?? isNorway ? '^[0-9]{4}$' : '',
-      placeholder: postalCode.placeholder ?? isNorway ? '0000' : '',
+      mask: postalCode?.mask
+        ? postalCode.mask
+        : isNorway
+        ? [/\d/, /\d/, /\d/, /\d/]
+        : postalCode.mask,
+      pattern: postalCode.pattern
+        ? postalCode?.pattern
+        : isNorway
+        ? '^[0-9]{4}$'
+        : '',
+      placeholder: postalCode?.placeholder
+        ? postalCode.placeholder
+        : isNorway
+        ? '0000'
+        : '',
     }
   }, [
     postalCode.pattern,
@@ -96,7 +105,7 @@ function PostalCodeAndCity(props: Props) {
         }}
         pattern={city.pattern ?? '^[A-Za-zÆØÅæøå -]+$'}
         trim
-        width="stretch"
+        width={city.width ?? 'stretch'}
         autoComplete="address-level2"
         help={help}
       />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -41,30 +41,31 @@ function PostalCodeAndCity(props: Props) {
     [countryValue]
   )
 
+  const {
+    pattern: cityPattern,
+    className: cityClassName,
+    label: cityLabel,
+    width: cityWidth,
+    errorMessages: cityErrorMessages,
+  } = city
+
+  const {
+    mask: postalCodeMask = isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined,
+    pattern: postalCodePattern = isNorway ? '^[0-9]{4}$' : undefined,
+    placeholder: postalCodePlaceHolder = isNorway ? '0000' : undefined,
+    className: postalCodeClassName,
+    label: postalCodeLabel,
+    width: postalCodeWidth,
+    errorMessages: postalCodeErrorMessages,
+  } = postalCode
+
   const postalCodeValidationProps = useMemo(() => {
     return {
-      mask: postalCode?.mask
-        ? postalCode.mask
-        : isNorway
-        ? [/\d/, /\d/, /\d/, /\d/]
-        : undefined,
-      pattern: postalCode.pattern
-        ? postalCode?.pattern
-        : isNorway
-        ? '^[0-9]{4}$'
-        : undefined,
-      placeholder: postalCode?.placeholder
-        ? postalCode.placeholder
-        : isNorway
-        ? '0000'
-        : undefined,
+      mask: postalCodeMask,
+      pattern: postalCodePattern,
+      placeholder: postalCodePlaceHolder,
     }
-  }, [
-    postalCode.pattern,
-    postalCode.placeholder,
-    postalCode.mask,
-    isNorway,
-  ])
+  }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
 
   return (
     <CompositionField
@@ -81,16 +82,16 @@ function PostalCodeAndCity(props: Props) {
         mask={postalCodeValidationProps.mask}
         className={classnames(
           'dnb-forms-field-postal-code-and-city__postal-code',
-          postalCode.className
+          postalCodeClassName
         )}
-        label={postalCode.label ?? translations.PostalCode.label}
+        label={postalCodeLabel ?? translations.PostalCode.label}
         errorMessages={{
           required: translations.PostalCode.errorRequired,
           pattern: translations.PostalCode.errorPattern,
-          ...postalCode.errorMessages,
+          ...postalCodeErrorMessages,
         }}
         placeholder={postalCodeValidationProps.placeholder}
-        width={postalCode.width ?? false}
+        width={postalCodeWidth ?? false}
         inputClassName="dnb-forms-field-postal-code-and-city__postal-code-input"
         inputMode="numeric"
         autoComplete="postal-code"
@@ -99,17 +100,17 @@ function PostalCodeAndCity(props: Props) {
         {...city}
         className={classnames(
           'dnb-forms-field-postal-code-and-city__city',
-          city.className
+          cityClassName
         )}
-        label={city.label ?? translations.City.label}
+        label={cityLabel ?? translations.City.label}
         errorMessages={{
           required: translations.City.errorRequired,
           pattern: translations.City.errorPattern,
-          ...city.errorMessages,
+          ...cityErrorMessages,
         }}
-        pattern={city.pattern ?? '^[A-Za-zÆØÅæøå -]+$'}
+        pattern={cityPattern ?? '^[A-Za-zÆØÅæøå -]+$'}
         trim
-        width={city.width ?? 'stretch'}
+        width={cityWidth ?? 'stretch'}
         autoComplete="address-level2"
         help={help}
       />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import classnames from 'classnames'
 import { Props as FieldBlockProps } from '../../FieldBlock'
 import StringField, { Props as StringFieldProps } from '../String'
@@ -34,13 +34,6 @@ function PostalCodeAndCity(props: Props) {
     ...fieldBlockProps
   } = props
 
-  const countryValue = getSourceValue(country)
-
-  const isNorway = useMemo(
-    () => countryValue === defaultCountry,
-    [countryValue]
-  )
-
   const {
     pattern: cityPattern,
     className: cityClassName,
@@ -49,19 +42,28 @@ function PostalCodeAndCity(props: Props) {
     errorMessages: cityErrorMessages,
   } = city
 
-  const handleNorwegianDefaults = useCallback(
+  const countryValue = getSourceValue(country)
+  const handleDefaults = useCallback(
     (postalCode: StringFieldProps) => {
-      const props = { ...postalCode }
+      const props: StringFieldProps = {}
 
-      if (isNorway) {
-        props.mask = postalCode.mask ?? [/\d/, /\d/, /\d/, /\d/]
-        props.pattern = postalCode.pattern ?? '^[0-9]{4}$'
-        props.placeholder = postalCode.placeholder ?? '0000'
+      switch (countryValue) {
+        case defaultCountry:
+        case 'DK':
+        case 'CH': {
+          props.mask = [/\d/, /\d/, /\d/, /\d/]
+          props.pattern = '^[0-9]{4}$'
+          props.placeholder = '0000'
+          break
+        }
+        default:
+          props.width = '8rem'
+          break
       }
 
-      return props
+      return { ...props, ...postalCode }
     },
-    [isNorway]
+    [countryValue]
   )
 
   const {
@@ -72,7 +74,7 @@ function PostalCodeAndCity(props: Props) {
     label: postalCodeLabel,
     width: postalCodeWidth,
     errorMessages: postalCodeErrorMessages,
-  } = handleNorwegianDefaults(postalCode)
+  } = handleDefaults(postalCode)
 
   const postalCodeValidationProps = {
     mask: postalCodeMask,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -43,7 +43,7 @@ function PostalCodeAndCity(props: Props) {
         ? postalCode.mask
         : isNorway
         ? [/\d/, /\d/, /\d/, /\d/]
-        : postalCode.mask,
+        : '',
       pattern: postalCode.pattern
         ? postalCode?.pattern
         : isNorway

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -79,7 +79,6 @@ function PostalCodeAndCity(props: Props) {
     }
   }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
 
-  console.log('postalCodeValidationProps', postalCodeValidationProps)
   return (
     <CompositionField
       className={classnames(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -9,6 +9,11 @@ import useTranslation from '../../hooks/useTranslation'
 export type Props = FieldHelpProps &
   Omit<FieldBlockProps, 'children'> &
   Partial<Record<'postalCode' | 'city', StringFieldProps>> & {
+    /**
+     * Defines which country the postal code and city is for.
+     * Setting it to anything other than `no` will remove the default norwegian postal code pattern.
+     * Default: `no`
+     */
     country?: string
   }
 
@@ -24,7 +29,22 @@ function PostalCodeAndCity(props: Props) {
     ...fieldBlockProps
   } = props
 
-  const isNorway = useMemo(() => country === 'no', [country])
+  const postalCodeValidationProps = useMemo(() => {
+    const isNorway = country === 'no'
+    return {
+      mask:
+        postalCode.mask ?? isNorway
+          ? [/\d/, /\d/, /\d/, /\d/]
+          : postalCode.mask,
+      pattern: postalCode.pattern ?? isNorway ? '^[0-9]{4}$' : '',
+      placeholder: postalCode.placeholder ?? isNorway ? '0000' : '',
+    }
+  }, [
+    postalCode.pattern,
+    postalCode.placeholder,
+    postalCode.mask,
+    country,
+  ])
 
   return (
     <CompositionField
@@ -37,8 +57,8 @@ function PostalCodeAndCity(props: Props) {
     >
       <StringField
         {...postalCode}
-        pattern={postalCode.pattern ?? isNorway ? '^[0-9]{4}$' : ''}
-        mask={isNorway ? [/\d/, /\d/, /\d/, /\d/] : postalCode.mask}
+        pattern={postalCodeValidationProps.pattern}
+        mask={postalCodeValidationProps.mask}
         className={classnames(
           'dnb-forms-field-postal-code-and-city__postal-code',
           postalCode.className
@@ -49,8 +69,8 @@ function PostalCodeAndCity(props: Props) {
           pattern: translations.PostalCode.errorPattern,
           ...postalCode.errorMessages,
         }}
-        placeholder={postalCode.placeholder ?? isNorway ? '0000' : ''}
-        width={isNorway ? false : postalCode.width ?? 'small'}
+        placeholder={postalCodeValidationProps.placeholder}
+        width={postalCode.width ?? false}
         inputClassName="dnb-forms-field-postal-code-and-city__postal-code-input"
         inputMode="numeric"
         autoComplete="postal-code"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -43,17 +43,17 @@ function PostalCodeAndCity(props: Props) {
         ? postalCode.mask
         : isNorway
         ? [/\d/, /\d/, /\d/, /\d/]
-        : '',
+        : undefined,
       pattern: postalCode.pattern
         ? postalCode?.pattern
         : isNorway
         ? '^[0-9]{4}$'
-        : '',
+        : undefined,
       placeholder: postalCode?.placeholder
         ? postalCode.placeholder
         : isNorway
         ? '0000'
-        : '',
+        : undefined,
     }
   }, [
     postalCode.pattern,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -6,6 +6,7 @@ import CompositionField from '../Composition'
 import { FieldHelpProps, Path } from '../../types'
 import useTranslation from '../../hooks/useTranslation'
 import useDataValue from '../../hooks/useDataValue'
+import { COUNTRY as defaultCountry } from '../../../../shared/defaults'
 
 export type Props = FieldHelpProps &
   Omit<FieldBlockProps, 'children'> &
@@ -29,13 +30,16 @@ function PostalCodeAndCity(props: Props) {
     city = {},
     help,
     width = 'large',
-    country = 'no',
+    country = defaultCountry,
     ...fieldBlockProps
   } = props
 
   const countryValue = getSourceValue(country)
 
-  const isNorway = useMemo(() => countryValue === 'no', [countryValue])
+  const isNorway = useMemo(
+    () => countryValue === defaultCountry,
+    [countryValue]
+  )
 
   const postalCodeValidationProps = useMemo(() => {
     return {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import classnames from 'classnames'
 import { Props as FieldBlockProps } from '../../FieldBlock'
 import StringField, { Props as StringFieldProps } from '../String'
@@ -49,6 +49,21 @@ function PostalCodeAndCity(props: Props) {
     errorMessages: cityErrorMessages,
   } = city
 
+  const handleNorwegianDefaults = useCallback(
+    (postalCode: StringFieldProps) => {
+      const props = { ...postalCode }
+
+      if (isNorway) {
+        props.mask = postalCode.mask ?? [/\d/, /\d/, /\d/, /\d/]
+        props.pattern = postalCode.pattern ?? '^[0-9]{4}$'
+        props.placeholder = postalCode.placeholder ?? '0000'
+      }
+
+      return props
+    },
+    [isNorway]
+  )
+
   const {
     mask: postalCodeMask,
     pattern: postalCodePattern,
@@ -57,18 +72,13 @@ function PostalCodeAndCity(props: Props) {
     label: postalCodeLabel,
     width: postalCodeWidth,
     errorMessages: postalCodeErrorMessages,
-  } = postalCode
+  } = handleNorwegianDefaults(postalCode)
 
-  const postalCodeValidationProps = useMemo(() => {
-    return {
-      mask:
-        postalCodeMask ??
-        (isNorway ? [/\d/, /\d/, /\d/, /\d/] : undefined),
-      pattern: postalCodePattern ?? (isNorway ? '^[0-9]{4}$' : undefined),
-      placeholder:
-        postalCodePlaceHolder ?? (isNorway ? '0000' : undefined),
-    }
-  }, [postalCodePattern, postalCodePlaceHolder, postalCodeMask, isNorway])
+  const postalCodeValidationProps = {
+    mask: postalCodeMask,
+    pattern: postalCodePattern,
+    placeholder: postalCodePlaceHolder,
+  }
 
   return (
     <CompositionField
@@ -81,8 +91,7 @@ function PostalCodeAndCity(props: Props) {
     >
       <StringField
         {...postalCode}
-        pattern={postalCodeValidationProps.pattern}
-        mask={postalCodeValidationProps.mask}
+        {...postalCodeValidationProps}
         className={classnames(
           'dnb-forms-field-postal-code-and-city__postal-code',
           postalCodeClassName
@@ -93,7 +102,6 @@ function PostalCodeAndCity(props: Props) {
           pattern: translations.PostalCode.errorPattern,
           ...postalCodeErrorMessages,
         }}
-        placeholder={postalCodeValidationProps.placeholder}
         width={postalCodeWidth ?? false}
         inputClassName="dnb-forms-field-postal-code-and-city__postal-code-input"
         inputMode="numeric"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -3,10 +3,10 @@ import { PropertiesTableProps } from '../../../../shared/types'
 export const PostalCodeAndCityProperties: PropertiesTableProps = {
   country: {
     doc:
-      'Defines which country the postal code and city is for.' +
+      'Defines which country the postal code and city is for, based on the ISO 3166-1 alpha-2 format.' +
       'Setting it to anything other than `no` will remove the default norwegian postal code pattern.' +
       'You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.' +
-      'Defaults to `no`',
+      'Defaults to `NO`',
     type: ['Path', 'string'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -7,7 +7,7 @@ export const PostalCodeAndCityProperties: PropertiesTableProps = {
       'Setting it to anything other than `no` will remove the default norwegian postal code pattern.' +
       'You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.' +
       'Defaults to `no`',
-    type: ['Path', 'no', 'string'],
+    type: ['Path', 'string'],
     status: 'optional',
   },
   postalCode: {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -1,6 +1,15 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 
 export const PostalCodeAndCityProperties: PropertiesTableProps = {
+  country: {
+    doc:
+      'Defines which country the postal code and city is for.' +
+      'Setting it to anything other than `no` will remove the default norwegian postal code pattern.' +
+      'You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.' +
+      'Defaults to `no`',
+    type: ['Path', 'no', 'string'],
+    status: 'optional',
+  },
   postalCode: {
     doc: 'Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postcode.',
     type: 'object',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -3,9 +3,9 @@ import { PropertiesTableProps } from '../../../../shared/types'
 export const PostalCodeAndCityProperties: PropertiesTableProps = {
   country: {
     doc:
-      'Defines which country the postal code and city is for, based on the ISO 3166-1 alpha-2 format.' +
-      'Setting it to anything other than `no` will remove the default norwegian postal code pattern.' +
-      'You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`.' +
+      'Defines which country the postal code and city is for, based on the ISO 3166-1 alpha-2 format i.e. `NO`, `DE` etc. ' +
+      'Setting it to anything other than `NO` will remove the default norwegian postal code pattern. ' +
+      'You can also use the value of another field to define the country, by using a path value i.e. `/myCountryPath`. ' +
       'Defaults to `NO`',
     type: ['Path', 'string'],
     status: 'optional',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -213,7 +213,7 @@ describe('Field.PostalCodeAndCity', () => {
 
   it('should be able to use a path to set the country value', async () => {
     const { rerender } = render(
-      <Form.Handler data={{ country: 'de' }}>
+      <Form.Handler data={{ country: 'DE' }}>
         <Field.PostalCodeAndCity country="/country" />
       </Form.Handler>
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -164,7 +164,7 @@ describe('Field.PostalCodeAndCity', () => {
     expect(city2).toHaveValue('Bergen')
   })
 
-  it('should not use Norwegian postal code validation rules of `country` is set to something other than `no`', async () => {
+  it('should not use Norwegian postal code validation rules if `country` is set to something other than `NO`', async () => {
     render(<Field.PostalCodeAndCity country="DE" />)
 
     const postalCodeInput = document.querySelector(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -171,7 +171,6 @@ describe('Field.PostalCodeAndCity', () => {
       '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
     ) as HTMLInputElement
 
-
     expect(postalCodeInput).not.toHaveAttribute('placeholder')
 
     await userEvent.type(postalCodeInput, '123456')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -10,8 +10,8 @@ const nb = nbNO['nb-NO']
 describe('Field.PostalCodeAndCity', () => {
   it('should render with props', () => {
     render(<Field.PostalCodeAndCity />)
-    expect(screen.getByLabelText('Postnr.')).toBeInTheDocument()
-    expect(screen.getByLabelText('Sted')).toBeInTheDocument()
+    expect(screen.getByLabelText(nb.PostalCode.label)).toBeInTheDocument()
+    expect(screen.getByLabelText(nb.City.label)).toBeInTheDocument()
   })
 
   it('postal code should only allow four numbers', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -171,7 +171,6 @@ describe('Field.PostalCodeAndCity', () => {
       '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
     ) as HTMLInputElement
 
-    console.log(postalCodeInput.placeholder)
 
     expect(postalCodeInput).not.toHaveAttribute('placeholder')
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -181,7 +181,7 @@ describe('Field.PostalCodeAndCity', () => {
   it('should support custom postal code validation', async () => {
     render(
       <Field.PostalCodeAndCity
-        country="de"
+        country="DE"
         postalCode={{
           pattern: '^[0-9]{5}$',
           mask: [/\d/, /\d/, /\d/, /\d/, /\d/],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -227,7 +227,7 @@ describe('Field.PostalCodeAndCity', () => {
     expect(postalCodeDe).not.toHaveAttribute('aria-placeholder')
 
     rerender(
-      <Form.Handler data={{ country: 'no' }}>
+      <Form.Handler data={{ country: 'NO' }}>
         <Field.PostalCodeAndCity country="/country" />
       </Form.Handler>
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -201,7 +201,7 @@ describe('Field.PostalCodeAndCity', () => {
       document.querySelectorAll('input')
     )
 
-    expect(postalCode).toHaveAttribute('placeholder', '00000')
+    expect(postalCode).toHaveAttribute('aria-placeholder', '00000')
     await userEvent.type(postalCode, 'abcs123456')
 
     expect(postalCode).toHaveValue('12345')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -233,7 +233,6 @@ describe('Field.PostalCodeAndCity', () => {
       </Form.Handler>
     )
 
-    // TODO: Figure out why previous input is still in the DOM
     const postalCodeNo = document.querySelector(
       '.dnb-forms-field-postal-code-and-city input'
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -165,7 +165,7 @@ describe('Field.PostalCodeAndCity', () => {
   })
 
   it('should not use Norwegian postal code validation rules of `country` is set to something other than `no`', async () => {
-    render(<Field.PostalCodeAndCity country="de" />)
+    render(<Field.PostalCodeAndCity country="DE" />)
 
     const postalCodeInput = document.querySelector(
       '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field, Iterate } from '../../..'
+import { Field, Form, Iterate } from '../../..'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -162,6 +162,85 @@ describe('Field.PostalCodeAndCity', () => {
     expect(city1).toHaveValue('Oslo')
     expect(code2).toHaveValue('0789')
     expect(city2).toHaveValue('Bergen')
+  })
+
+  it('should not use Norwegian postal code validation rules of `country` is set to something other than `no`', async () => {
+    render(<Field.PostalCodeAndCity country="de" />)
+
+    const postalCodeInput = document.querySelector(
+      '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
+    ) as HTMLInputElement
+
+    console.log(postalCodeInput.placeholder)
+
+    expect(postalCodeInput).not.toHaveAttribute('placeholder')
+
+    await userEvent.type(postalCodeInput, '123456')
+
+    expect(postalCodeInput).toHaveValue('123456')
+  })
+
+  it('should support custom postal code validation', async () => {
+    render(
+      <Field.PostalCodeAndCity
+        country="de"
+        postalCode={{
+          pattern: '^[0-9]{5}$',
+          mask: [/\d/, /\d/, /\d/, /\d/, /\d/],
+          placeholder: '00000',
+          validateInitially: true,
+        }}
+        city={{
+          validateInitially: true,
+          pattern: '^[a-zA-ZäöüÄÖÜß -]+$',
+        }}
+      />
+    )
+
+    const [postalCode, city] = Array.from(
+      document.querySelectorAll('input')
+    )
+
+    expect(postalCode).toHaveAttribute('placeholder', '00000')
+    await userEvent.type(postalCode, 'abcs123456')
+
+    expect(postalCode).toHaveValue('12345')
+
+    await userEvent.type(city, 'München')
+
+    expect(city).toHaveValue('München')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('should be able to use a path to set the country value', async () => {
+    const { rerender } = render(
+      <Form.Handler data={{ country: 'de' }}>
+        <Field.PostalCodeAndCity country="/country" />
+      </Form.Handler>
+    )
+
+    const postalCodeDe = document.querySelector(
+      '.dnb-forms-field-postal-code-and-city input'
+    )
+
+    await userEvent.type(postalCodeDe, '123456')
+    expect(postalCodeDe).toHaveValue('123456')
+    expect(postalCodeDe).not.toHaveAttribute('aria-placeholder')
+
+    rerender(
+      <Form.Handler data={{ country: 'no' }}>
+        <Field.PostalCodeAndCity country="/country" />
+      </Form.Handler>
+    )
+
+    // TODO: Figure out why previous input is still in the DOM
+    const postalCodeNo = document.querySelector(
+      '.dnb-forms-field-postal-code-and-city input'
+    )
+
+    await userEvent.type(postalCodeNo, '{Backspace>4}987654')
+    expect(postalCodeNo).toHaveValue('9876')
+    expect(postalCodeNo).toHaveAttribute('aria-placeholder', '0000')
   })
 
   describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
@@ -30,7 +30,7 @@ export function PostalCodeAndCityCountryCodeSelection() {
       <Form.Handler>
         <Field.Selection path="/country" defaultValue="no" variant="radio">
           <Field.Option value="NO" label="Norway" />
-          <Field.Option value="de" label="Germany" />
+          <Field.Option value="DE" label="Germany" />
         </Field.Selection>
         <Field.PostalCodeAndCity
           country="/country"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
@@ -1,4 +1,4 @@
-import { Field } from '../../..'
+import { Field, Form, Value } from '../../..'
 
 export default {
   title: 'Eufemia/Extensions/Forms/PostalCodeAndCity',
@@ -21,5 +21,27 @@ export const PostalCodeAndCity = () => {
         )
       }
     />
+  )
+}
+
+export function PostalCodeAndCityCountryCodeSelection() {
+  return (
+    <>
+      <Form.Handler>
+        <Field.Selection path="/country" defaultValue="no" variant="radio">
+          <Field.Option value="no" label="Norway" />
+          <Field.Option value="de" label="Germany" />
+        </Field.Selection>
+        <Field.PostalCodeAndCity
+          country="/country"
+          postalCode={{ path: '/postalCode' }}
+          city={{ path: '/city' }}
+        />
+        <Value.PostalCodeAndCity
+          postalCode={{ path: '/postalCode' }}
+          city={{ path: '/city' }}
+        />
+      </Form.Handler>
+    </>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
@@ -28,7 +28,7 @@ export function PostalCodeAndCityCountryCodeSelection() {
   return (
     <>
       <Form.Handler>
-        <Field.Selection path="/country" defaultValue="no" variant="radio">
+        <Field.Selection path="/country" defaultValue="NO" variant="radio">
           <Field.Option value="NO" label="Norway" />
           <Field.Option value="DE" label="Germany" />
         </Field.Selection>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/stories/PostalCodeAndCity.stories.tsx
@@ -29,7 +29,7 @@ export function PostalCodeAndCityCountryCodeSelection() {
     <>
       <Form.Handler>
         <Field.Selection path="/country" defaultValue="no" variant="radio">
-          <Field.Option value="no" label="Norway" />
+          <Field.Option value="NO" label="Norway" />
           <Field.Option value="de" label="Germany" />
         </Field.Selection>
         <Field.PostalCodeAndCity

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -34,15 +34,7 @@ function PostalCodeAndCity(props: Props) {
 }
 
 function usePostalCodeAndCityValue(props: Props) {
-  let value = props.value ?? undefined
-
-  const valueProps = useValueProps(props)
-
-  if (valueProps.value) {
-    value = valueProps.value
-  }
-
-  return value
+  return useValueProps(props).value ?? props.value
 }
 
 PostalCodeAndCity._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -9,25 +9,18 @@ export type Props = StringValueProps &
 function PostalCodeAndCity(props: Props) {
   const translations = useTranslation().PostalCodeAndCity
 
-  const city = props?.city || {}
-  const postalCode = props?.postalCode || {}
-
-  const cityProps = useValueProps(city)
-  if (cityProps.value) {
-    city.value = cityProps.value
-  }
-
-  const postalCodeProps = useValueProps(postalCode)
-  if (postalCodeProps.value) {
-    postalCode.value = postalCodeProps.value
-  }
+  const cityValue = usePostalCodeAndCityValue(props?.city || {})
+  const postalCodeValue = usePostalCodeAndCityValue(
+    props?.postalCode || {}
+  )
 
   const value =
     props.value ??
-    ((postalCode || city
-      ? [postalCode?.value, city?.value].filter(Boolean).join(' ')
+    ((postalCodeValue || cityValue
+      ? [postalCodeValue, cityValue].filter(Boolean).join(' ')
       : undefined) ||
       undefined)
+
   const label =
     props.label ?? (props.inline ? undefined : translations.label)
 
@@ -38,6 +31,18 @@ function PostalCodeAndCity(props: Props) {
   }
 
   return <StringValue {...stringValueProps} />
+}
+
+function usePostalCodeAndCityValue(props: Props) {
+  let value = props.value ?? undefined
+
+  const valueProps = useValueProps(props)
+
+  if (valueProps.value) {
+    value = valueProps.value
+  }
+
+  return value
 }
 
 PostalCodeAndCity._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -9,10 +9,9 @@ export type Props = StringValueProps &
 function PostalCodeAndCity(props: Props) {
   const translations = useTranslation().PostalCodeAndCity
 
-  const cityValue = usePostalCodeAndCityValue(props?.city || {})
-  const postalCodeValue = usePostalCodeAndCityValue(
-    props?.postalCode || {}
-  )
+  const cityValue = useValueProps(props?.city || {}).value ?? props.value
+  const postalCodeValue =
+    useValueProps(props?.postalCode || {}).value ?? props.value
 
   const value =
     props.value ??
@@ -31,10 +30,6 @@ function PostalCodeAndCity(props: Props) {
   }
 
   return <StringValue {...stringValueProps} />
-}
-
-function usePostalCodeAndCityValue(props: Props) {
-  return useValueProps(props).value ?? props.value
 }
 
 PostalCodeAndCity._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/shared/defaults.ts
+++ b/packages/dnb-eufemia/src/shared/defaults.ts
@@ -6,3 +6,4 @@
 export const LOCALE = 'nb-NO'
 export const CURRENCY = 'NOK'
 export const CURRENCY_DISPLAY = 'code' // code, name, symbol, narrowSymbol
+export const COUNTRY = 'NO' // ISO 3166-1 alpha-2


### PR DESCRIPTION
- [x] Add example
- [x] Document props
- [x] Add tests
- [x] Add path support for `country` prop
- [x] Figure out wonky behavior in new tests 🤔
- [x] Fix `mask` type error
- [x] Add demo for path based country values
- [x] Update Postal Code input width in example
