### PR TITLE
fix(Forms): don't call internal `exportValidators` when they not are exported as an array

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -3874,7 +3874,7 @@ describe('useFieldProps', () => {
         }).neverToResolve()
       })
 
-      it('should not call internal validates when they are not returned in the publicValidator', async () => {
+      it('should not call internal validators when they are not returned in the publicValidator', async () => {
         let internalValidators, barValidator, bazValidator
 
         const MockComponent = (props) => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -3372,7 +3372,7 @@ describe('useFieldProps', () => {
       })
     })
 
-    describe('exportValidators', () => {
+    describe('validators given as an array', () => {
       it('should call all validators returned as an array', async () => {
         const fooValidator = jest.fn((value) => {
           if (value.includes('foo')) {
@@ -3470,7 +3470,9 @@ describe('useFieldProps', () => {
         expect(fooValidator).toHaveBeenCalledTimes(5)
         expect(barValidator).toHaveBeenCalledTimes(4)
       })
+    })
 
+    describe('exportValidators', () => {
       it('should call exported validators from mock component', async () => {
         let internalValidators, fooValidator, barValidator, bazValidator
 
@@ -3589,13 +3591,13 @@ describe('useFieldProps', () => {
         await userEvent.type(input, '123')
         fireEvent.blur(input)
 
-        expect(onBlurValidator).toHaveBeenCalledTimes(2)
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
         expect(document.querySelector('.dnb-form-status')).toBeNull()
 
         await userEvent.type(input, '4')
         fireEvent.blur(input)
 
-        expect(onBlurValidator).toHaveBeenCalledTimes(3)
+        expect(onBlurValidator).toHaveBeenCalledTimes(2)
         await waitFor(() => {
           expect(
             document.querySelector('.dnb-form-status')
@@ -3843,7 +3845,36 @@ describe('useFieldProps', () => {
         })
       })
 
-      it('should call internal validates when they are not returned in the publicValidator', async () => {
+      it('should not run exported internal validators when a validator is given', async () => {
+        const exportedValidator = jest.fn(() => {
+          return undefined
+        })
+
+        const myValidator = jest.fn(() => {
+          return undefined
+        })
+
+        const MockComponent = (props) => {
+          return (
+            <Field.String
+              label="Label"
+              validator={props.validator}
+              exportValidators={{ exportedValidator }}
+              validateInitially
+            />
+          )
+        }
+
+        render(<MockComponent validator={myValidator} />)
+
+        await expect(() => {
+          expect(
+            document.querySelector('.dnb-form-status')
+          ).toBeInTheDocument()
+        }).neverToResolve()
+      })
+
+      it('should not call internal validates when they are not returned in the publicValidator', async () => {
         let internalValidators, barValidator, bazValidator
 
         const MockComponent = (props) => {
@@ -3911,12 +3942,12 @@ describe('useFieldProps', () => {
           document.querySelector('input'),
           '{Backspace}bar'
         )
-        await waitFor(() => {
-          expect(screen.queryByRole('alert')).toHaveTextContent('bar')
-        })
+        await expect(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        }).neverToResolve()
         expect(publicValidator).toHaveBeenCalledTimes(5)
-        expect(barValidator).toHaveBeenCalledTimes(4)
-        expect(bazValidator).toHaveBeenCalledTimes(3)
+        expect(barValidator).toHaveBeenCalledTimes(0)
+        expect(bazValidator).toHaveBeenCalledTimes(0)
         expect(internalValidators).toHaveBeenCalledTimes(0)
 
         await userEvent.type(
@@ -3924,12 +3955,12 @@ describe('useFieldProps', () => {
           '{Backspace}baz'
         )
 
-        await waitFor(() => {
-          expect(screen.queryByRole('alert')).toHaveTextContent('baz')
-        })
+        await expect(() => {
+          expect(screen.queryByRole('alert')).toBeInTheDocument()
+        }).neverToResolve()
         expect(publicValidator).toHaveBeenCalledTimes(9)
-        expect(barValidator).toHaveBeenCalledTimes(8)
-        expect(bazValidator).toHaveBeenCalledTimes(7)
+        expect(barValidator).toHaveBeenCalledTimes(0)
+        expect(bazValidator).toHaveBeenCalledTimes(0)
         expect(internalValidators).toHaveBeenCalledTimes(0)
       })
     })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -533,24 +533,6 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
     return args
   }, [contextErrorMessages, getValueByPath, setFieldEventListener])
-  const extendWithExportedValidators = useCallback(
-    (
-      validator: Validator<Value>,
-      result: ReturnType<Validator<Value>>
-    ) => {
-      if (
-        exportValidatorsRef.current &&
-        !result &&
-        (validator === onChangeValidatorRef.current ||
-          validator === onBlurValidatorRef.current)
-      ) {
-        return Object.values(exportValidatorsRef.current)
-      }
-
-      return result
-    },
-    []
-  )
 
   const callStackRef = useRef<Array<Validator<Value>>>([])
   const hasBeenCalledRef = useCallback((validator: Validator<Value>) => {
@@ -568,10 +550,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         return
       }
 
-      const result = extendWithExportedValidators(
-        validator,
-        await validator(value, additionalArgs)
-      )
+      const result = await validator(value, additionalArgs)
 
       if (Array.isArray(result)) {
         for (const validator of result) {
@@ -589,7 +568,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         return result
       }
     },
-    [additionalArgs, extendWithExportedValidators, hasBeenCalledRef]
+    [additionalArgs, hasBeenCalledRef]
   )
 
   const callValidatorFnSync = useCallback(
@@ -601,10 +580,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         return // stop here
       }
 
-      const result = extendWithExportedValidators(
-        validator,
-        validator(value, additionalArgs)
-      )
+      const result = validator(value, additionalArgs)
 
       if (Array.isArray(result)) {
         const hasAsyncValidator = result.some((validator) =>
@@ -633,12 +609,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         return result
       }
     },
-    [
-      additionalArgs,
-      callValidatorFnAsync,
-      extendWithExportedValidators,
-      hasBeenCalledRef,
-    ]
+    [additionalArgs, callValidatorFnAsync, hasBeenCalledRef]
   )
 
   /**


### PR DESCRIPTION
Fixes #4106