### PR TITLE
fix(Forms): ensure Field.SelectCountry has a fallback locale (nb-NO)

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useMemo, useRef } from 'react'
 import classnames from 'classnames'
 import SharedContext from '../../../../shared/Context'
+import { LOCALE } from '../../../../shared/defaults'
 import { Autocomplete, HelpButton } from '../../../../components'
 import { pickSpacingProps } from '../../../../components/flex/utils'
 import countries, {
@@ -51,7 +52,9 @@ export type Props = FieldHelpProps &
 function SelectCountry(props: Props) {
   const sharedContext = useContext(SharedContext)
   const translations = useTranslation().SelectCountry
-  const lang = sharedContext.locale?.split('-')[0] as CountryLang
+  const lang = (sharedContext.locale || LOCALE).split(
+    '-'
+  )[0] as CountryLang
 
   const getCountryObjectByIso = useCallback(
     (value: CountryType['iso']) => {
@@ -291,7 +294,7 @@ export function getCountryData({
         }
       }
 
-      return a[lang].localeCompare(b[lang])
+      return String(a[lang])?.localeCompare?.(b[lang])
     })
     .map((country) => makeObject(country, lang))
 }


### PR DESCRIPTION
- Link for [more info](https://dnb-it.slack.com/archives/CMXABCHEY/p1728383158013599).
- Link to a [CSB](https://codesandbox.io/p/sandbox/selectcountry-locale-issue-cj7d3k?file=/src/App.tsx:11,1&workspaceId=9ef62a18-9e27-4ef9-bc06-7cacaacfab66) that uses React v17, but sadly it does not crash there.


![image](https://github.com/user-attachments/assets/49428bf1-cd1b-4d4f-b281-459dee697f29)
