### PR TITLE
feat(Forms): add `Form.useTranslation` hook

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation.mdx
@@ -1,0 +1,23 @@
+---
+title: 'useTranslation'
+description: '`Form.useTranslation` is a hook that returns the translations for the current locale.'
+showTabs: true
+tabs:
+  - title: Info
+    key: '/info'
+  - title: Demos
+    key: '/demos'
+breadcrumb:
+  - text: Forms
+    href: /uilib/extensions/forms/
+  - text: Form
+    href: /uilib/extensions/forms/Form/
+  - text: Form.useTranslation
+    href: /uilib/extensions/forms/Form/useTranslation/
+---
+
+import Info from 'Docs/uilib/extensions/forms/Form/useTranslation/info'
+import Demos from 'Docs/uilib/extensions/forms/Form/useTranslation/demos'
+
+<Info />
+<Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/Examples.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import React from 'react'
+import ComponentBox from '../../../../../../shared/tags/ComponentBox'
+import { Form } from '@dnb/eufemia/src/extensions/forms'
+
+export const CustomTranslations = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const MyField = () => {
+          const { Custom, formatMessage } = Form.useTranslation()
+
+          const myTranslation = formatMessage(Custom.translation, {
+            myKey: 'value!',
+          })
+          console.log('Custom', myTranslation)
+
+          return <>{myTranslation}</>
+        }
+
+        const MyForm = () => {
+          return (
+            <Form.Handler
+              locale="en-GB"
+              translations={{
+                'en-GB': {
+                  Custom: { translation: 'My translation with a {myKey}' },
+                },
+              }}
+            >
+              <MyField />
+            </Form.Handler>
+          )
+        }
+
+        return <MyForm />
+      }}
+    </ComponentBox>
+  )
+}
+
+export const GetTranslation = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const MyField = () => {
+          const { formatMessage } = Form.useTranslation()
+
+          const myTranslation = formatMessage('Custom.translation', {
+            myKey: 'value!',
+          })
+          const errorRequired = formatMessage('Field.errorRequired')
+          console.log(errorRequired)
+
+          return <>{myTranslation}</>
+        }
+
+        const MyForm = () => {
+          return (
+            <Form.Handler
+              locale="en-GB"
+              translations={{
+                'en-GB': {
+                  Custom: { translation: 'My translation with a {myKey}' },
+                },
+              }}
+            >
+              <MyField />
+            </Form.Handler>
+          )
+        }
+
+        return <MyForm />
+      }}
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/demos.mdx
@@ -1,0 +1,15 @@
+---
+showTabs: true
+---
+
+import * as Examples from './Examples'
+
+## Demos
+
+### Custom translations example
+
+<Examples.CustomTranslations />
+
+### Get translations with a key
+
+<Examples.GetTranslation />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -48,7 +48,7 @@ render(
 
 ## Custom translations
 
-You can also extend the translations with your custom translations.
+You can also extend the translations with your own custom translations.
 
 ```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -1,0 +1,155 @@
+---
+showTabs: true
+---
+
+## Description
+
+The `Form.useTranslation` is a hook that returns the translations for the current locale.
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+function MyComponent() {
+  const { Field } = Form.useTranslation()
+  const { errorRequired } = Field
+
+  return <>MyComponent</>
+}
+
+render(
+  <Form.Handler locale="en-GB">
+    <MyComponent />
+  </Form.Handler>,
+)
+```
+
+## Additional utilities
+
+In addition to all internal translations, you also get;
+
+- `formatMessage` - a function you can use to get a specific translation based on a key (flattened object with dot-notation).
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+function MyComponent() {
+  const { formatMessage } = Form.useTranslation()
+  const errorRequired = formatMessage('Field.errorRequired')
+
+  return <>MyComponent</>
+}
+
+render(
+  <Form.Handler locale="en-GB">
+    <MyComponent />
+  </Form.Handler>,
+)
+```
+
+## Custom translations
+
+You can also extend the translations with your custom translations.
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+const myTranslations = {
+  'nb-NO': { myString: 'Min egendefinerte streng' },
+  'en-GB': {
+    // Cascaded translations
+    Nested: {
+      stringWithArgs: 'My custom string with an argument: {myKey}',
+    },
+
+    // Flat translations
+    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+  },
+}
+
+const MyComponent = () => {
+  const t = Form.useTranslation<typeof myTranslations>()
+
+  // Internal translations
+  const existingString = t.Field.errorRequired
+
+  // Your translations
+  const myString = t.myString
+
+  // Use the "formatMessage" function to handle strings with arguments
+  const myStringWithArgsA = t.formatMessage(t.Nested.stringWithArgs, {
+    myKey: 'myValue',
+  })
+  // You can also get the string with a key (dot-notation)
+  const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
+    myKey: 'myValue',
+  })
+
+  return <>MyComponent</>
+}
+
+render(
+  <Form.Handler translations={myTranslations}>
+    <MyComponent />
+  </Form.Handler>,
+)
+```
+
+## Using the `<Translation />`
+
+Instead of using the hook, you can also, use the `<Translation />` component to consume your translations:
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+import { Translation, TranslationProps } from '@dnb/eufemia/shared'
+
+const myTranslations = {
+  'nb-NO': { 'custom.string': 'Min egendefinerte streng' },
+  'en-GB': { 'custom.string': 'My custom string' },
+}
+
+// For TypeScript support
+type Tr<T> = TranslationProps<T[keyof T]>
+const Tr = (props: Tr<typeof myTranslations>) => <Translation {...props} />
+
+render(
+  <Form.Handler translations={myTranslations}>
+    <Form.MainHeading>
+      <Translation id="custom.string" />
+    </Form.MainHeading>
+
+    <Form.SubHeading>
+      <Tr id={(t) => t.custom.string} />
+    </Form.SubHeading>
+  </Form.Handler>,
+)
+```
+
+## Use the shared Provider to customize translations
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import { Provider, Translation } from '@dnb/eufemia/shared'
+
+const myTranslations = {
+  'nb-NO': {
+    'PhoneNumber.label': 'Egendefinert',
+    'custom.string': 'Min egendefinerte streng',
+  },
+  'en-GB': {
+    'PhoneNumber.label': 'Custom',
+    'custom.string': 'My custom string',
+  },
+}
+
+render(
+  <Provider translations={myTranslations}>
+    <Heading>
+      <Translation id="custom.string" />
+    </Heading>
+
+    <Form.Handler>
+      <Field.PhoneNumber />
+    </Form.Handler>
+  </Provider>,
+)
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
@@ -163,7 +163,7 @@ You can also use a [FieldBlock](/uilib/extensions/forms/create-component/FieldBl
 
 ## Localization and translations
 
-You can use the `Form.useTranslation` hook to use existing translations or extend it with your custom field localization:
+You can use the [Form.useTranslation](/uilib/extensions/forms/Form/useTranslation/) hook to use existing translations or extend it with your custom field localization:
 
 ```tsx
 import {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -581,7 +581,7 @@ function MyForm() {
 
 #### Customize translations
 
-You can customize the internal translations in a flat structure:
+You can customize the internal translations in a flat structure (dot-notation):
 
 ```tsx
 {
@@ -605,7 +605,7 @@ You can customize the translations in a form by using the `translations` propert
 
 Alternatively, you can use the global Eufemia [Provider](/uilib/usage/customisation/localization/) (example further down).
 
-You can find all available strings/keys in the properties tab of each field component. You can have a look at the [PhoneNumber field](!/uilib/extensions/forms/feature-fields/PhoneNumber/properties/#translations).
+You can find all available strings and keys in the properties tab of each field or value component. For example, check out the [PhoneNumber field properties](#!/uilib/extensions/forms/feature-fields/PhoneNumber/properties/#translations).
 
 ```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
@@ -622,20 +622,45 @@ render(
 )
 ```
 
-You can consume them with the `useTranslation` hook:
+##### Consume the translations
+
+You can consume both the internal or your own translations with the [Form.useTranslation](/uilib/extensions/forms/Form/useTranslation/) hook:
 
 ```tsx
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
-import { useTranslation } from '@dnb/eufemia/shared'
+import { Form } from '@dnb/eufemia/extensions/forms'
 
 const myTranslations = {
-  'nb-NO': { 'custom.string': 'Min egendefinerte streng' },
-  'en-GB': { 'custom.string': 'My custom string' },
+  'nb-NO': { myString: 'Min egendefinerte streng' },
+  'en-GB': {
+    // Cascaded translations
+    Nested: {
+      stringWithArgs: 'My custom string with an argument: {myKey}',
+    },
+
+    // Flat translations
+    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+  },
 }
 
 const MyComponent = () => {
-  const t = useTranslation<typeof myTranslations>()
-  return t.custom.string
+  const t = Form.useTranslation<typeof myTranslations>()
+
+  // Internal translations
+  const existingString = t.Field.errorRequired
+
+  // Your translations
+  const myString = t.myString
+
+  // Use the "formatMessage" function to handle strings with arguments
+  const myStringWithArgsA = t.formatMessage(t.Nested.stringWithArgs, {
+    myKey: 'myValue',
+  })
+  // You can also get the string with a key (dot-notation)
+  const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
+    myKey: 'myValue',
+  })
+
+  return <>MyComponent</>
 }
 
 render(
@@ -645,67 +670,9 @@ render(
 )
 ```
 
-Or customize them with the `<Translation />` component:
-
-```tsx
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
-import { Translation, TranslationProps } from '@dnb/eufemia/shared'
-
-const myTranslations = {
-  'nb-NO': { 'custom.string': 'Min egendefinerte streng' },
-  'en-GB': { 'custom.string': 'My custom string' },
-}
-
-// For TypeScript support
-type Tr<T> = TranslationProps<T[keyof T]>
-const Tr = (props: Tr<typeof myTranslations>) => <Translation {...props} />
-
-render(
-  <Form.Handler translations={myTranslations}>
-    <Form.MainHeading>
-      <Translation id="custom.string" />
-    </Form.MainHeading>
-
-    <Form.SubHeading>
-      <Tr id={(t) => t.custom.string} />
-    </Form.SubHeading>
-  </Form.Handler>,
-)
-```
-
 Here is a [demo](/uilib/extensions/forms/Form/Handler/demos/#locale-and-translations) of how to use the translations in a form.
 
 When creating [your own field](/uilib/extensions/forms/create-component/#localization-and-translations), you can use the `Form.useTranslation` hook to localize your field.
-
-#### Use the shared Provider to customize translations
-
-```tsx
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
-import { Provider, Translation } from '@dnb/eufemia/shared'
-
-const myTranslations = {
-  'nb-NO': {
-    'PhoneNumber.label': 'Egendefinert',
-    'custom.string': 'Min egendefinerte streng',
-  },
-  'en-GB': {
-    'PhoneNumber.label': 'Custom',
-    'custom.string': 'My custom string',
-  },
-}
-
-render(
-  <Provider translations={myTranslations}>
-    <Heading>
-      <Translation id="custom.string" />
-    </Heading>
-
-    <Form.Handler>
-      <Field.PhoneNumber />
-    </Form.Handler>
-  </Provider>,
-)
-```
 
 ### Layout
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -105,29 +105,29 @@ render(
 
 ## Provide your own translations
 
+You can provide your own translations by using the shared [Provider](/uilib/usage/customisation/provider). Translation strings with several levels of depth can be given as a flat object with dot-notation, or as a nested object (cascaded).
+
 ```tsx
-import Provider, { Locales } from '@dnb/eufemia/shared/Provider'
+import Provider from '@dnb/eufemia/shared/Provider'
 
-const customTranslation = {
-  'en-GB': {
-    // Extend the translation as an object
-    myString: 'Custom string',
-    myGroup: {
-      subString: 'Second string',
-      stringWithArgument: 'String with {myArg}',
-    },
-
-    // Or as a flat object (dot-notated keys)
-    'myGroup.subString': 'Second string',
-    'myGroup.stringWithArgument': 'String with {myArg}',
+const nbNO = { myString: 'Min egendefinerte streng' }
+const enGB = {
+  // Cascaded translations
+  Nested: {
+    stringWithArgs: 'My custom string with an argument: {myKey}',
   },
+
+  // Flat translations
+  'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
 }
 
-type CustomLocales = keyof typeof customTranslation
-type CustomTranslation = (typeof customTranslation)[CustomLocales]
+const myTranslations = {
+  'nb-NO': nbNO,
+  'en-GB': enGB,
+}
 
 render(
-  <Provider translations={customTranslation} locale="en-GB">
+  <Provider translations={myTranslations} locale="en-GB">
     <MyApp>
       <MyComponent />
     </MyApp>
@@ -142,30 +142,47 @@ You can use the `useTranslation` hook to get the strings from the shared context
 ```tsx
 import { useTranslation } from '@dnb/eufemia/shared'
 
-function MyComponent() {
-  const { Dropdown, myString, myGroup, formatMessage } =
-    useTranslation<CustomTranslation>()
-  return (
-    <>
-      <P>{Dropdown.title}</P>
+const myTranslations = {
+  'nb-NO': { myString: 'Min egendefinerte streng' },
+  'en-GB': {
+    // Cascaded translations
+    Nested: {
+      stringWithArgs: 'My custom string with an argument: {myKey}',
+    },
 
-      <P>{myString}</P>
-      <P>{myGroup.subString}</P>
-
-      <P>
-        {formatMessage(myGroup.stringWithArgument, {
-          myArg: 'dynamic-value',
-        })}
-      </P>
-
-      <P>
-        {formatMessage('myGroup.stringWithArgument', {
-          myArg: 'dynamic-value',
-        })}
-      </P>
-    </>
-  )
+    // Flat translations
+    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+  },
 }
+
+const MyComponent = () => {
+  const t = useTranslation<typeof myTranslations>()
+
+  // Internal translations
+  const existingString = t.Dropdown.title
+
+  // Your translations
+  const myString = t.myString
+
+  // Use the "formatMessage" function to handle strings with arguments
+  const myStringWithArgsA = t.formatMessage(t.Nested.stringWithArgs, {
+    myKey: 'myValue',
+  })
+  // You can also get the string with a key (dot-notation)
+  const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
+    myKey: 'myValue',
+  })
+
+  return <>MyComponent</>
+}
+
+render(
+  <Provider translations={myTranslations} locale="en-GB">
+    <MyApp>
+      <MyComponent />
+    </MyApp>
+  </Provider>,
+)
 ```
 
 **Good to know:** You can consume the strings with a dot-notated key, directly from
@@ -173,6 +190,28 @@ the `formatMessage` function:
 
 ```tsx
 formatMessage('myGroup.subString')
+```
+
+## TypeScript support
+
+```tsx
+import Provider, { Locales } from '@dnb/eufemia/shared/Provider'
+
+const nbNO = {
+  myString: 'Min egendefinerte streng',
+}
+const enGB = {
+  myString: 'My custom string',
+} satisfies typeof nbNO // Ensure the types are compatible
+
+const myTranslations = {
+  'nb-NO': nbNO,
+  'en-GB': enGB,
+}
+
+// Infer the type of the translations
+type MyLocales = keyof typeof myTranslations
+type MyTranslation = (typeof myTranslations)[MyLocales]
 ```
 
 ## How to combine with other tools
@@ -324,10 +363,10 @@ And add the file, like so:
 
 ```jsx
 import Provider from '@dnb/eufemia/shared/Provider'
-import customTranslation from './locales/sv-SE'
+import myTranslations from './locales/sv-SE'
 
 render(
-  <Provider translations={customTranslation}>
+  <Provider translations={myTranslations}>
     <MyApp>Eufemia components</MyApp>
   </Provider>,
 )
@@ -339,13 +378,13 @@ or add/update the locales during runtime:
 import Provider from '@dnb/eufemia/shared/Provider'
 import Context from '@dnb/eufemia/shared/Context'
 
-import customTranslation from './locales/sv-SE'
+import myTranslations from './locales/sv-SE'
 
 const ChangeLocale = () => {
   const { update, locale } = React.useContext(Context)
 
   // Add new locales
-  update({ locales: customTranslation, locale: 'sv-SE' })
+  update({ locales: myTranslations, locale: 'sv-SE' })
 
   return locale
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -103,6 +103,78 @@ render(
 )
 ```
 
+## Provide your own translations
+
+```tsx
+import Provider, { Locales } from '@dnb/eufemia/shared/Provider'
+
+const customTranslation = {
+  'en-GB': {
+    // Extend the translation as an object
+    myString: 'Custom string',
+    myGroup: {
+      subString: 'Second string',
+      stringWithArgument: 'String with {myArg}',
+    },
+
+    // Or as a flat object (dot-notated keys)
+    'myGroup.subString': 'Second string',
+    'myGroup.stringWithArgument': 'String with {myArg}',
+  },
+}
+
+type CustomLocales = keyof typeof customTranslation
+type CustomTranslation = (typeof customTranslation)[CustomLocales]
+
+render(
+  <Provider translations={customTranslation} locale="en-GB">
+    <MyApp>
+      <MyComponent />
+    </MyApp>
+  </Provider>,
+)
+```
+
+## Consume translations in your components
+
+You can use the `useTranslation` hook to get the strings from the shared context. The hook returns an object with the strings and a `formatMessage` function you can use to get the translated strings with arguments.
+
+```tsx
+import { useTranslation } from '@dnb/eufemia/shared'
+
+function MyComponent() {
+  const { Dropdown, myString, myGroup, formatMessage } =
+    useTranslation<CustomTranslation>()
+  return (
+    <>
+      <P>{Dropdown.title}</P>
+
+      <P>{myString}</P>
+      <P>{myGroup.subString}</P>
+
+      <P>
+        {formatMessage(myGroup.stringWithArgument, {
+          myArg: 'dynamic-value',
+        })}
+      </P>
+
+      <P>
+        {formatMessage('myGroup.stringWithArgument', {
+          myArg: 'dynamic-value',
+        })}
+      </P>
+    </>
+  )
+}
+```
+
+**Good to know:** You can consume the strings with a dot-notated key, directly from
+the `formatMessage` function:
+
+```tsx
+formatMessage('myGroup.subString')
+```
+
 ## How to combine with other tools
 
 You can easily combine the locales support it with other translation tools, like `react-intl`.
@@ -134,63 +206,7 @@ render(
 )
 ```
 
-## How to use your own translation strings
-
-You have even the option to extend the strings with your own and use it as an internationalization tool replacement for e.g. `react-intl`.
-
-## Get the strings from Context
-
-It is possible to use the Eufemia shared Provider for your own project / App localization.
-
-```tsx
-import Provider, { Locales } from '@dnb/eufemia/shared/Provider'
-
-const customTranslation = {
-  // extend the translation
-  'en-GB': {
-    myString: 'Custom string',
-    myGroup: {
-      subString: 'Second string',
-      stringWithArgument: 'String with {myArg}',
-    },
-  },
-}
-
-type CustomLocales = keyof typeof customTranslation
-type CustomTranslation = (typeof customTranslation)[CustomLocales]
-
-render(
-  <Provider translations={customTranslation} locale="en-GB">
-    <MyApp>
-      <MyComponent />
-    </MyApp>
-  </Provider>,
-)
-```
-
-... and consume the strings in your components:
-
-```tsx
-import { useTranslation } from '@dnb/eufemia/shared'
-
-function MyComponent() {
-  const { myString, myGroup, formatMessage } =
-    useTranslation<CustomTranslation>()
-  return (
-    <>
-      <P>{myString}</P>
-      <P>{myGroup.subString}</P>
-      <P>
-        {formatMessage('myGroup.stringWithArgument', {
-          myArg: 'dynamic-value',
-        })}
-      </P>
-    </>
-  )
-}
-```
-
-### Cascaded string ids support
+### Cascaded object (flat object, dot-notated keys) support
 
 1. Lets say you have your translation files as JSON object/files `en.json`:
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react'
-import { renderHook } from '@testing-library/react'
+import { render, renderHook } from '@testing-library/react'
 import useTranslation from '../useTranslation'
 import Provider from '../../../../shared/Provider'
 
@@ -97,5 +97,140 @@ describe('Form.useTranslation', () => {
     expect(resultGB.current.Email).not.toMatchObject(
       extendedLocale['nb-NO'].Email
     )
+  })
+
+  describe('formatMessage', () => {
+    const myTranslations = {
+      'nb-NO': {
+        Custom: {
+          translation: 'My translation with a {myKey}',
+        },
+      },
+      'en-GB': {
+        Custom: {
+          translation: 'My translation with a {myKey}',
+        },
+      },
+    }
+    type Translation = (typeof myTranslations)[keyof typeof myTranslations]
+
+    it('should return translation', () => {
+      const { result } = renderHook(useTranslation)
+
+      expect(result.current.formatMessage('Field.errorRequired')).toBe(
+        forms_nbNO['nb-NO'].Field.errorRequired
+      )
+    })
+
+    it('should return translation for given locale', () => {
+      const { result } = renderHook(useTranslation, {
+        wrapper: ({ children }) => (
+          <Provider locale="en-GB">{children}</Provider>
+        ),
+      })
+
+      expect(result.current.formatMessage('Field.errorRequired')).toBe(
+        forms_enGB['en-GB'].Field.errorRequired
+      )
+    })
+
+    it('should return translation when switching locale', () => {
+      const MockComponent = () => {
+        const { formatMessage } = useTranslation()
+        return <>{formatMessage('Field.errorRequired')}</>
+      }
+
+      const { rerender } = render(
+        <Provider locale="nb-NO">
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        forms_nbNO['nb-NO'].Field.errorRequired
+      )
+
+      rerender(
+        <Provider locale="en-GB">
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        forms_enGB['en-GB'].Field.errorRequired
+      )
+    })
+
+    it('should support custom translation when switching locale', () => {
+      const MockComponent = () => {
+        const { formatMessage } = useTranslation<Translation>()
+        return (
+          <>
+            {formatMessage('Custom.translation', {
+              myKey: 'value!',
+            })}
+          </>
+        )
+      }
+
+      const { rerender } = render(
+        <Provider locale="nb-NO" translations={myTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        myTranslations['nb-NO'].Custom.translation.replace(
+          '{myKey}',
+          'value!'
+        )
+      )
+
+      rerender(
+        <Provider locale="en-GB" translations={myTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        myTranslations['en-GB'].Custom.translation.replace(
+          '{myKey}',
+          'value!'
+        )
+      )
+    })
+
+    it('should support custom translation object when switching locale', () => {
+      const MockComponent = () => {
+        const { formatMessage, Custom } = useTranslation<Translation>()
+        return (
+          <>
+            {formatMessage(Custom.translation, {
+              myKey: 'value!',
+            })}
+          </>
+        )
+      }
+
+      const { rerender } = render(
+        <Provider locale="nb-NO" translations={myTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        myTranslations['nb-NO'].Custom.translation.replace(
+          '{myKey}',
+          'value!'
+        )
+      )
+
+      rerender(
+        <Provider locale="en-GB" translations={myTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        myTranslations['en-GB'].Custom.translation.replace(
+          '{myKey}',
+          'value!'
+        )
+      )
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useContext } from 'react'
-import SharedContext from '../../../shared/Context'
-import { combineWithExternalTranslations } from '../../../shared/useTranslation'
+import SharedContext, {
+  TranslationObjectToFlat,
+} from '../../../shared/Context'
+import {
+  combineWithExternalTranslations,
+  FormatMessage,
+} from '../../../shared/useTranslation'
 import { extendDeep } from '../../../shared/component-helper'
 import { DeepPartial } from '../../../shared/types'
 import { LOCALE } from '../../../shared/defaults'
@@ -15,6 +20,8 @@ export type FormsTranslationValues =
 export type FormsTranslation = DeepPartial<
   FormsTranslationDefaultLocales[FormsTranslationLocale]
 >
+export type FormsTranslationFlat =
+  TranslationObjectToFlat<FormsTranslation>
 
 type CustomLocales = Partial<
   Record<FormsTranslationLocale, FormsTranslation>
@@ -40,6 +47,6 @@ export default function useTranslation<T = FormsTranslation>(
       translation,
       messages,
       locale,
-    }) as T
+    }) as T & FormatMessage
   }, [globalTranslation, locale, messages])
 }

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -197,15 +197,11 @@ export type InternalLocale =
   | Locale
   // more strict type definitions than string breaks applications using React Intl.
   | AnyLocale
-export type ComponentTranslationsName = keyof ContextComponents | string
-export type ComponentTranslation = string
 export type Translations =
   | Partial<Record<InternalLocale, Translation | TranslationFlat>>
   | Partial<Record<InternalLocale, FormsTranslation>>
 export type TranslationDefaultLocales = typeof defaultLocales
 export type TranslationLocale = keyof TranslationDefaultLocales
-export type TranslationKeys =
-  keyof TranslationDefaultLocales[TranslationLocale]
 export type TranslationValues =
   TranslationDefaultLocales[TranslationLocale]
 export type TranslationCustomLocales = Record<
@@ -221,9 +217,8 @@ export type Translation = DeepPartial<TranslationValues>
 /**
  * E.g. "HelpButton.title"
  */
-export type TranslationFlat = Record<
-  ComponentTranslationsName,
-  TranslationKeys | ComponentTranslation
+export type TranslationFlat = Partial<
+  Record<TranslationObjectToFlat<TranslationValues>, string>
 >
 
 export type TranslationFlatToObject<T> = T extends Record<string, unknown>
@@ -237,6 +232,12 @@ export type TranslationFlatToObject<T> = T extends Record<string, unknown>
         : T[K]
     }
   : T
+
+export type TranslationObjectToFlat<T, Prefix extends string = ''> = {
+  [K in keyof T]: T[K] extends Record<string, unknown>
+    ? TranslationObjectToFlat<T[K], `${Prefix}${K & string}.`>
+    : `${Prefix}${K & string}`
+}[keyof T]
 
 export function prepareContext<Props>(
   props: ContextProps = {}

--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -38,24 +38,26 @@ export default function useTranslation<T = Translation>(
   }, [locale, messages, args, translation])
 }
 
-export type combineWithExternalTranslationsArgs = {
+export type CombineWithExternalTranslationsArgs = {
   translation: Translation
   messages?: TranslationCustomLocales
   locale?: InternalLocale
 }
-export type combineWithExternalTranslationsReturn = Translation &
-  TranslationCustomLocales & {
-    formatMessage: typeof formatMessage
-  }
+export type FormatMessage = {
+  formatMessage: typeof formatMessage
+}
+export type CombineWithExternalTranslationsReturn = Translation &
+  TranslationCustomLocales &
+  FormatMessage
 
 export function combineWithExternalTranslations({
   translation,
   messages,
   locale,
-}: combineWithExternalTranslationsArgs): combineWithExternalTranslationsReturn {
+}: CombineWithExternalTranslationsArgs): CombineWithExternalTranslationsReturn {
   let combined = {
     ...translation,
-  } as combineWithExternalTranslationsReturn
+  } as CombineWithExternalTranslationsReturn
 
   if (messages) {
     if (Object.keys(defaultLocales).some((locale) => messages[locale])) {
@@ -81,27 +83,35 @@ export function combineWithExternalTranslations({
 
 export function formatMessage(
   id: TranslationId | TranslationIdAsFunction,
-  args: TranslationArguments,
-  messages: TranslationCustomLocales
+  args?: TranslationArguments,
+  messages?: TranslationCustomLocales
 ) {
   let str = undefined
 
-  if (typeof id === 'function') {
-    str = id(messages)
-  } else if (messages[id]) {
-    str = messages[id]
-  } else if (id?.includes?.('.')) {
-    const keys = id.split('.')
-    for (const key of keys) {
-      if (messages[key]) {
-        messages = messages[key]
-      } else {
-        break
+  if (typeof id === 'string') {
+    let found = false
+    if (messages[id]) {
+      str = messages[id]
+      found = true
+    } else if (id?.includes?.('.')) {
+      const keys = id.split('.')
+      for (const key of keys) {
+        if (messages[key]) {
+          messages = messages[key]
+        } else {
+          break
+        }
+      }
+      if (typeof messages === 'string') {
+        str = messages
+        found = true
       }
     }
-    if (typeof messages === 'string') {
-      str = messages
+    if (!found && typeof id === 'string') {
+      str = id
     }
+  } else if (typeof id === 'function') {
+    str = id(messages)
   }
 
   if (str) {


### PR DESCRIPTION
This PR relies on #4121 as of now.

This lets form components consume the internal translations as well as extending the translations with your own strings: 

```tsx
import { Form } from '@dnb/eufemia/extensions/forms'

const myTranslations = {
  'en-GB': {
    Custom: {
      translation: 'My translation with a {myKey}',
    },
  },
}

function MyComponent() {
  const { Custom, formatMessage } = Form.useTranslation<myTranslations>()

  // Use it directly
  const str1 = formatMessage(Custom.translation, {
    myKey: 'value!',
  })

  // Or use it with a key
  const str2 = formatMessage('Field.errorRequired', {
    myKey: 'value!',
  })

  return <>MyComponent</>
}

<Form.Handler locale="en-GB" translations={myTranslations}>
  <MyComponent />
</Form.Handler>
```