### PR TITLE
feat: add `renderMessage` to useTranslation hook for line-break support

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -28,13 +28,13 @@ render(
 In addition to all internal translations, you also get;
 
 - `formatMessage` - a function you can use to get a specific translation based on a key (flattened object with dot-notation).
-- `renderWithFormatting` - a function you can use to render a string with line-breaks. It converts `{br}` to a JSX line-break.
+- `renderMessage` - a function you can use to render a string with line-breaks. It converts `{br}` to a JSX line-break.
 
 ```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 function MyComponent() {
-  const { formatMessage, renderWithFormatting } = Form.useTranslation()
+  const { formatMessage, renderMessage } = Form.useTranslation()
   const errorRequired = formatMessage('Field.errorRequired')
 
   return <>MyComponent</>
@@ -87,7 +87,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderMessage(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -28,12 +28,13 @@ render(
 In addition to all internal translations, you also get;
 
 - `formatMessage` - a function you can use to get a specific translation based on a key (flattened object with dot-notation).
+- `renderWithLinebreaks` - a function you can use to render a string with line-breaks. It converts `{br}` to a JSX line-break.
 
 ```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 function MyComponent() {
-  const { formatMessage } = Form.useTranslation()
+  const { formatMessage, renderWithLinebreaks } = Form.useTranslation()
   const errorRequired = formatMessage('Field.errorRequired')
 
   return <>MyComponent</>
@@ -62,7 +63,8 @@ const myTranslations = {
     },
 
     // Flat translations
-    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+    'Nested.stringWithLinebreaks':
+      'My custom string with a {br}line-break',
   },
 }
 
@@ -83,6 +85,9 @@ const MyComponent = () => {
   const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
     myKey: 'myValue',
   })
+
+  // Render line-breaks
+  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -28,13 +28,13 @@ render(
 In addition to all internal translations, you also get;
 
 - `formatMessage` - a function you can use to get a specific translation based on a key (flattened object with dot-notation).
-- `renderWithLinebreaks` - a function you can use to render a string with line-breaks. It converts `{br}` to a JSX line-break.
+- `renderWithFormatting` - a function you can use to render a string with line-breaks. It converts `{br}` to a JSX line-break.
 
 ```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 function MyComponent() {
-  const { formatMessage, renderWithLinebreaks } = Form.useTranslation()
+  const { formatMessage, renderWithFormatting } = Form.useTranslation()
   const errorRequired = formatMessage('Field.errorRequired')
 
   return <>MyComponent</>
@@ -87,7 +87,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -662,7 +662,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -638,7 +638,8 @@ const myTranslations = {
     },
 
     // Flat translations
-    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+    'Nested.stringWithLinebreaks':
+      'My custom string with a {br}line-break',
   },
 }
 
@@ -659,6 +660,9 @@ const MyComponent = () => {
   const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
     myKey: 'myValue',
   })
+
+  // Render line-breaks
+  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -662,7 +662,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderMessage(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -175,7 +175,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -151,7 +151,8 @@ const myTranslations = {
     },
 
     // Flat translations
-    'Nested.stringWithArgs': 'My custom string with an argument: {myKey}',
+    'Nested.stringWithLinebreaks':
+      'My custom string with a {br}line-break',
   },
 }
 
@@ -172,6 +173,9 @@ const MyComponent = () => {
   const myStringWithArgsB = t.formatMessage('Nested.stringWithArgs', {
     myKey: 'myValue',
   })
+
+  // Render line-breaks
+  const jsxOutput = t.renderWithLinebreaks(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -175,7 +175,7 @@ const MyComponent = () => {
   })
 
   // Render line-breaks
-  const jsxOutput = t.renderWithFormatting(t.Nested.stringWithLinebreaks)
+  const jsxOutput = t.renderMessage(t.Nested.stringWithLinebreaks)
 
   return <>MyComponent</>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -24,6 +24,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
+    nb['renderWithLinebreaks'] = expect.any(Function)
 
     expect(result.current).toEqual(nb)
   })
@@ -38,6 +39,7 @@ describe('Form.useTranslation', () => {
     const gb = {}
     extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
     gb['formatMessage'] = expect.any(Function)
+    gb['renderWithLinebreaks'] = expect.any(Function)
 
     expect(resultGB.current).toEqual(gb)
 
@@ -50,6 +52,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
+    nb['renderWithLinebreaks'] = expect.any(Function)
 
     expect(resultNO.current).toEqual(nb)
   })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -24,7 +24,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
-    nb['renderWithFormatting'] = expect.any(Function)
+    nb['renderMessage'] = expect.any(Function)
 
     expect(result.current).toEqual(nb)
   })
@@ -39,7 +39,7 @@ describe('Form.useTranslation', () => {
     const gb = {}
     extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
     gb['formatMessage'] = expect.any(Function)
-    gb['renderWithFormatting'] = expect.any(Function)
+    gb['renderMessage'] = expect.any(Function)
 
     expect(resultGB.current).toEqual(gb)
 
@@ -52,7 +52,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
-    nb['renderWithFormatting'] = expect.any(Function)
+    nb['renderMessage'] = expect.any(Function)
 
     expect(resultNO.current).toEqual(nb)
   })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -24,7 +24,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
-    nb['renderWithLinebreaks'] = expect.any(Function)
+    nb['renderWithFormatting'] = expect.any(Function)
 
     expect(result.current).toEqual(nb)
   })
@@ -39,7 +39,7 @@ describe('Form.useTranslation', () => {
     const gb = {}
     extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
     gb['formatMessage'] = expect.any(Function)
-    gb['renderWithLinebreaks'] = expect.any(Function)
+    gb['renderWithFormatting'] = expect.any(Function)
 
     expect(resultGB.current).toEqual(gb)
 
@@ -52,7 +52,7 @@ describe('Form.useTranslation', () => {
     const nb = {}
     extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
     nb['formatMessage'] = expect.any(Function)
-    nb['renderWithLinebreaks'] = expect.any(Function)
+    nb['renderWithFormatting'] = expect.any(Function)
 
     expect(resultNO.current).toEqual(nb)
   })

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -19,6 +19,7 @@ describe('useTranslation without an ID', () => {
     expect(result.current).toEqual(
       Object.assign({}, nbNO[defaultLocale], {
         formatMessage: expect.any(Function),
+        renderWithLinebreaks: expect.any(Function),
       })
     )
   })
@@ -33,6 +34,7 @@ describe('useTranslation without an ID', () => {
     expect(resultGB.current).toEqual(
       Object.assign({}, enGB['en-GB'], {
         formatMessage: expect.any(Function),
+        renderWithLinebreaks: expect.any(Function),
       })
     )
 
@@ -45,6 +47,7 @@ describe('useTranslation without an ID', () => {
     expect(resultNO.current).toEqual(
       Object.assign({}, nbNO['nb-NO'], {
         formatMessage: expect.any(Function),
+        renderWithLinebreaks: expect.any(Function),
       })
     )
   })
@@ -475,6 +478,44 @@ describe('useTranslation with an ID', () => {
       expect(document.querySelector('span.nested').textContent).toBe(
         expected_nbNO_nested
       )
+    })
+  })
+
+  describe('renderWithLinebreaks', () => {
+    it('should render with JSX line-breaks', () => {
+      const { result } = renderHook(() => useTranslation())
+
+      expect(
+        result.current.renderWithLinebreaks('Hello{br}World')
+      ).toEqual([
+        <React.Fragment key="0">
+          Hello
+          <br />
+        </React.Fragment>,
+        <React.Fragment key="1">
+          World
+          <br />
+        </React.Fragment>,
+      ])
+    })
+
+    it('should support multiple line-breaks', () => {
+      const { result } = renderHook(() => useTranslation())
+
+      expect(result.current.renderWithLinebreaks('A{br}B{br}C')).toEqual([
+        <React.Fragment key="0">
+          A
+          <br />
+        </React.Fragment>,
+        <React.Fragment key="1">
+          B
+          <br />
+        </React.Fragment>,
+        <React.Fragment key="2">
+          C
+          <br />
+        </React.Fragment>,
+      ])
     })
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -19,7 +19,7 @@ describe('useTranslation without an ID', () => {
     expect(result.current).toEqual(
       Object.assign({}, nbNO[defaultLocale], {
         formatMessage: expect.any(Function),
-        renderWithLinebreaks: expect.any(Function),
+        renderWithFormatting: expect.any(Function),
       })
     )
   })
@@ -34,7 +34,7 @@ describe('useTranslation without an ID', () => {
     expect(resultGB.current).toEqual(
       Object.assign({}, enGB['en-GB'], {
         formatMessage: expect.any(Function),
-        renderWithLinebreaks: expect.any(Function),
+        renderWithFormatting: expect.any(Function),
       })
     )
 
@@ -47,7 +47,7 @@ describe('useTranslation without an ID', () => {
     expect(resultNO.current).toEqual(
       Object.assign({}, nbNO['nb-NO'], {
         formatMessage: expect.any(Function),
-        renderWithLinebreaks: expect.any(Function),
+        renderWithFormatting: expect.any(Function),
       })
     )
   })
@@ -481,12 +481,12 @@ describe('useTranslation with an ID', () => {
     })
   })
 
-  describe('renderWithLinebreaks', () => {
+  describe('renderWithFormatting', () => {
     it('should render with JSX line-breaks', () => {
       const { result } = renderHook(() => useTranslation())
 
       expect(
-        result.current.renderWithLinebreaks('Hello{br}World')
+        result.current.renderWithFormatting('Hello{br}World')
       ).toEqual([
         <React.Fragment key="0">
           Hello
@@ -502,7 +502,7 @@ describe('useTranslation with an ID', () => {
     it('should support multiple line-breaks', () => {
       const { result } = renderHook(() => useTranslation())
 
-      expect(result.current.renderWithLinebreaks('A{br}B{br}C')).toEqual([
+      expect(result.current.renderWithFormatting('A{br}B{br}C')).toEqual([
         <React.Fragment key="0">
           A
           <br />

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -19,7 +19,7 @@ describe('useTranslation without an ID', () => {
     expect(result.current).toEqual(
       Object.assign({}, nbNO[defaultLocale], {
         formatMessage: expect.any(Function),
-        renderWithFormatting: expect.any(Function),
+        renderMessage: expect.any(Function),
       })
     )
   })
@@ -34,7 +34,7 @@ describe('useTranslation without an ID', () => {
     expect(resultGB.current).toEqual(
       Object.assign({}, enGB['en-GB'], {
         formatMessage: expect.any(Function),
-        renderWithFormatting: expect.any(Function),
+        renderMessage: expect.any(Function),
       })
     )
 
@@ -47,7 +47,7 @@ describe('useTranslation without an ID', () => {
     expect(resultNO.current).toEqual(
       Object.assign({}, nbNO['nb-NO'], {
         formatMessage: expect.any(Function),
-        renderWithFormatting: expect.any(Function),
+        renderMessage: expect.any(Function),
       })
     )
   })
@@ -481,13 +481,11 @@ describe('useTranslation with an ID', () => {
     })
   })
 
-  describe('renderWithFormatting', () => {
+  describe('renderMessage', () => {
     it('should render with JSX line-breaks', () => {
       const { result } = renderHook(() => useTranslation())
 
-      expect(
-        result.current.renderWithFormatting('Hello{br}World')
-      ).toEqual([
+      expect(result.current.renderMessage('Hello{br}World')).toEqual([
         <React.Fragment key="0">
           Hello
           <br />
@@ -502,7 +500,7 @@ describe('useTranslation with an ID', () => {
     it('should support multiple line-breaks', () => {
       const { result } = renderHook(() => useTranslation())
 
-      expect(result.current.renderWithFormatting('A{br}B{br}C')).toEqual([
+      expect(result.current.renderMessage('A{br}B{br}C')).toEqual([
         <React.Fragment key="0">
           A
           <br />

--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -45,7 +45,7 @@ export type CombineWithExternalTranslationsArgs = {
 }
 export type FormatMessage = {
   formatMessage: typeof formatMessage
-  renderWithFormatting: typeof renderWithFormatting
+  renderMessage: typeof renderMessage
 }
 export type CombineWithExternalTranslationsReturn = Translation &
   TranslationCustomLocales &
@@ -80,7 +80,7 @@ export function combineWithExternalTranslations({
   }
 
   // Support line-breaks
-  combined.renderWithFormatting = renderWithFormatting
+  combined.renderMessage = renderMessage
 
   return combined
 }
@@ -124,14 +124,14 @@ export function formatMessage(
     }
 
     if (str.includes('{br}')) {
-      return renderWithFormatting(str)
+      return renderMessage(str)
     }
   }
 
   return str ?? id
 }
 
-export function renderWithFormatting(
+export function renderMessage(
   text: string | Array<React.ReactNode>
 ): string | React.ReactNode {
   let element = text

--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -45,7 +45,7 @@ export type CombineWithExternalTranslationsArgs = {
 }
 export type FormatMessage = {
   formatMessage: typeof formatMessage
-  renderWithLinebreaks: typeof renderWithLinebreaks
+  renderWithFormatting: typeof renderWithFormatting
 }
 export type CombineWithExternalTranslationsReturn = Translation &
   TranslationCustomLocales &
@@ -80,7 +80,7 @@ export function combineWithExternalTranslations({
   }
 
   // Support line-breaks
-  combined.renderWithLinebreaks = renderWithLinebreaks
+  combined.renderWithFormatting = renderWithFormatting
 
   return combined
 }
@@ -124,14 +124,14 @@ export function formatMessage(
     }
 
     if (str.includes('{br}')) {
-      return renderWithLinebreaks(str)
+      return renderWithFormatting(str)
     }
   }
 
   return str ?? id
 }
 
-export function renderWithLinebreaks(
+export function renderWithFormatting(
   text: string | Array<React.ReactNode>
 ): string | React.ReactNode {
   let element = text

--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import React, { Fragment, useContext, useMemo } from 'react'
 import Context, {
   Translation,
   TranslationLocale,
@@ -45,6 +45,7 @@ export type CombineWithExternalTranslationsArgs = {
 }
 export type FormatMessage = {
   formatMessage: typeof formatMessage
+  renderWithLinebreaks: typeof renderWithLinebreaks
 }
 export type CombineWithExternalTranslationsReturn = Translation &
   TranslationCustomLocales &
@@ -77,6 +78,9 @@ export function combineWithExternalTranslations({
   ) => {
     return formatMessage(id, args, combined)
   }
+
+  // Support line-breaks
+  combined.renderWithLinebreaks = renderWithLinebreaks
 
   return combined
 }
@@ -114,11 +118,36 @@ export function formatMessage(
     str = id(messages)
   }
 
-  if (str) {
+  if (typeof str === 'string') {
     for (const t in args) {
       str = str.replace(new RegExp(`{${t}}`, 'g'), args[t])
     }
+
+    if (str.includes('{br}')) {
+      return renderWithLinebreaks(str)
+    }
   }
 
-  return str
+  return str ?? id
+}
+
+export function renderWithLinebreaks(
+  text: string | Array<React.ReactNode>
+): string | React.ReactNode {
+  let element = text
+
+  if (typeof text === 'string') {
+    element = text.split('{br}')
+  }
+
+  if (Array.isArray(element)) {
+    return element.map((item, index) => (
+      <Fragment key={index}>
+        {item}
+        <br />
+      </Fragment>
+    ))
+  }
+
+  return text
 }


### PR DESCRIPTION
This PR is based on #4121 and #4123

Quick example:

```tsx
const myTranslations = {
  'en-GB': {
    'stringWithLinebreaks':
      'My custom string with a {br}line-break',
  },
}

const MyComponent = () => {
  const t = useTranslation()

  // Render line-breaks
  const jsxOutput = t.renderMessage(t.stringWithLinebreaks)

  return <>{jsxOutput}</>
}

<Provider translations={myTranslations} locale="en-GB">
    <MyComponent />
  </Provider>
```