### PR TITLE
chore: enhance multiple path warning

### DIFF
--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -129,3 +129,16 @@ export const axeComponent = async (...components) => {
     typeof components[1] === 'object' ? components[1] : null
   )
 }
+
+export function spyOnEufemiaWarn() {
+  const originalConsoleLog = console.log
+  const log = jest
+    .spyOn(console, 'log')
+    .mockImplementation((...message) => {
+      if (!message[0].includes('Eufemia')) {
+        originalConsoleLog(...message)
+      }
+    })
+
+  return log
+}

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -3379,6 +3379,8 @@ describe('DataContext.Provider', () => {
     })
 
     it('should contain data on first render, when nested and in side car', () => {
+      const log = spyOnEufemiaWarn()
+
       const initialData = { foo: 'bar' }
       const sidecarMockData = []
       const nestedMockData = []
@@ -3419,6 +3421,8 @@ describe('DataContext.Provider', () => {
       )
       expect(sidecar).toHaveValue('') // Because the field is outside of the context
       expect(nested).toHaveValue('bar')
+
+      log.mockRestore()
     })
 
     it('should be able to update data from side car', async () => {
@@ -3476,6 +3480,8 @@ describe('DataContext.Provider', () => {
     })
 
     it('should support StrictMode', async () => {
+      const log = spyOnEufemiaWarn()
+
       const initialData = { foo: 'bar' }
       const sidecarMockData = []
       const nestedMockData = []
@@ -3523,6 +3529,8 @@ describe('DataContext.Provider', () => {
       )
       expect(sidecar).toHaveValue('') // Because the field is outside of the context
       expect(nested).toHaveValue('bar')
+
+      log.mockRestore()
     })
 
     it('should set Provider data when sessionStorageId was given', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { wait } from '../../../../../core/jest/jestSetup'
+import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
 import { simulateAnimationEnd } from '../../../../../components/height-animation/__tests__/HeightAnimationUtils'
 import { GlobalStatus } from '../../../../../components'
 import { makeUniqueId } from '../../../../../shared/component-helper'
@@ -942,12 +942,7 @@ describe('DataContext.Provider', () => {
   describe('async submit', () => {
     let log: jest.SpyInstance
     beforeEach(() => {
-      const originalConsoleLog = console.log
-      log = jest.spyOn(console, 'log').mockImplementation((...message) => {
-        if (!message[0].includes('Eufemia')) {
-          originalConsoleLog(...message)
-        }
-      })
+      log = spyOnEufemiaWarn()
     })
     afterEach(() => {
       log.mockRestore()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
@@ -85,7 +85,9 @@ function SliderComponent(props: Props) {
     handleChange,
     handleFocus,
     handleBlur,
-  } = useFieldProps(preparedProps)
+  } = useFieldProps(preparedProps, {
+    omitMultiplePathWarning: true,
+  })
 
   const handleLocalChange = useCallback(
     ({ value }: { value: number | number[] }) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { wait } from '../../../../../core/jest/jestSetup'
+import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
 import {
   Form,
   Field,
@@ -491,12 +491,7 @@ describe('Form.Handler', () => {
   describe('async submit', () => {
     let log: jest.SpyInstance
     beforeEach(() => {
-      const originalConsoleLog = console.log
-      log = jest.spyOn(console, 'log').mockImplementation((...message) => {
-        if (!message[0].includes('Eufemia')) {
-          originalConsoleLog(...message)
-        }
-      })
+      log = spyOnEufemiaWarn()
     })
     afterEach(() => {
       log.mockRestore()

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { spyOnEufemiaWarn } from '../../../../../core/jest/jestSetup'
 import {
   act,
   createEvent,
@@ -14,6 +15,14 @@ import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('Form.Isolation', () => {
+  let log = null
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+  afterEach(() => {
+    log.mockRestore()
+  })
+
   it('should have constant of _supportsSpacingProps="undefined"', () => {
     expect(Form.Isolation._supportsSpacingProps).toBeUndefined()
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react'
+import { spyOnEufemiaWarn } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
 import { Field, Form, JSONSchema, Tools, Value } from '../../..'
 import { SectionProps } from '../Section'
@@ -1155,6 +1156,8 @@ describe('Form.Section', () => {
     })
 
     it('should not mutate translations object', () => {
+      const log = spyOnEufemiaWarn()
+
       const sectionTranslations = {
         'nb-NO': { MySection: { CustomField: { label: 'Section nb' } } },
         'en-GB': { MySection: { CustomField: { label: 'Section en' } } },
@@ -1207,6 +1210,8 @@ describe('Form.Section', () => {
       expect(
         sectionTranslations['en-GB'].MySection.CustomField.label
       ).toBe('Section en')
+
+      log.mockRestore()
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -103,6 +103,7 @@ function ArrayComponent(props: Props) {
     // To ensure the defaultValue set on the Iterate.Array is set in the data context,
     // and will not overwrite defaultValues set by fields inside the Iterate.Array.
     updateContextDataInSync: true,
+    omitMultiplePathWarning: true,
   })
 
   useMountEffect(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -499,7 +499,6 @@ describe('Iterate.Array', () => {
               { mem: 'D', second: '2nd' },
             ]}
           >
-            <Field.String itemPath="/" />
             {renderProp1}
             {renderProp2}
           </Iterate.Array>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { wait } from '../../../../../core/jest/jestSetup'
+import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
 import { Field, Form, Iterate, OnSubmit, Wizard } from '../../..'
 
 import nbNO from '../../../constants/locales/nb-NO'
@@ -2296,6 +2296,8 @@ describe('Wizard.Container', () => {
     })
 
     it('should remember an entered value between step changes', async () => {
+      const log = spyOnEufemiaWarn()
+
       const onChange = jest.fn()
       const onStepChange = jest.fn()
 
@@ -2345,6 +2347,8 @@ describe('Wizard.Container', () => {
         expect.anything()
       )
       expect(document.querySelector('input')).toHaveValue('1234')
+
+      log.mockRestore()
     })
 
     it('should set defaultValue of Iterate.Array only once between step changes', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -4695,7 +4695,7 @@ describe('useFieldProps', () => {
 
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
-        'You have declared the same path several times:',
+        'Path declared multiple times: times:',
         '/myPath'
       )
     })
@@ -4746,7 +4746,7 @@ describe('useFieldProps', () => {
 
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
-        'You have declared the same path several times:',
+        'Path declared multiple times: times:',
         '/0/myPath'
       )
     })
@@ -4765,7 +4765,7 @@ describe('useFieldProps', () => {
 
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
-        'You have declared the same path several times:',
+        'Path declared multiple times: times:',
         '/0/myPath'
       )
     })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -4605,14 +4605,7 @@ describe('useFieldProps', () => {
     })
 
     it('should set isMounted to true when Wizard step has changed', () => {
-      const originalConsoleLog = console.log
-      const log = jest
-        .spyOn(console, 'log')
-        .mockImplementation((...message) => {
-          if (!message[0].includes('Eufemia')) {
-            originalConsoleLog(...message)
-          }
-        })
+      const log = spyOnEufemiaWarn()
       const setMountedFieldState = jest.fn()
 
       let activeIndex = 0

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1555,7 +1555,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       (hasPath ? !iterateItemContext : true)
     ) {
       if (existingFields.has(identifier)) {
-        warn('You have declared the same path several times:', identifier)
+        warn('Path declared multiple times: times:', identifier)
       } else {
         existingFields.set(identifier, true)
         return () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -88,6 +88,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   {
     executeOnChangeRegardlessOfError = false,
     updateContextDataInSync = false,
+    omitMultiplePathWarning = false,
   } = {}
 ): typeof localeProps & ReturnAdditional<Value> {
   const { extend } = useContext(FieldProviderContext)
@@ -1547,7 +1548,12 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
   // - Warn when a field path is used multiple times
   useEffect(() => {
-    if (hasPath || hasItemPath) {
+    if (
+      !omitMultiplePathWarning &&
+      process.env.NODE_ENV !== 'production' &&
+      (hasPath || hasItemPath) &&
+      (hasPath ? !iterateItemContext : true)
+    ) {
       if (existingFields.has(identifier)) {
         warn('You have declared the same path several times:', identifier)
       } else {
@@ -1557,7 +1563,13 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         }
       }
     }
-  }, [hasItemPath, hasPath, identifier])
+  }, [
+    hasItemPath,
+    hasPath,
+    identifier,
+    iterateItemContext,
+    omitMultiplePathWarning,
+  ])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- Shorten the message.
- Avoid showing the warning in our logs.
- Avoid showing the warning when not needed.
- Use `spyOnEufemiaWarn` in other tests as well.

The origin of this PR:

<img width="817" alt="Screenshot 2024-10-15 at 21 30 06" src="https://github.com/user-attachments/assets/fd5d1329-5668-4247-8094-30f6b7b77d85">
