### PR TITLE
chore(useTranslation): ensure `formatMessage` and `renderMessage` have the same instance after rerender

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
@@ -5,6 +5,7 @@ import SharedContext, {
 import {
   combineWithExternalTranslations,
   FormatMessage,
+  useAdditionalUtils,
 } from '../../../shared/useTranslation'
 import { extendDeep } from '../../../shared/component-helper'
 import { DeepPartial } from '../../../shared/types'
@@ -35,6 +36,7 @@ export default function useTranslation<T = FormsTranslation>(
 ) {
   const { locale, translation: globalTranslation } =
     useContext(SharedContext)
+  const { assignUtils } = useAdditionalUtils()
 
   return useMemo(() => {
     const translation = extendDeep(
@@ -43,10 +45,12 @@ export default function useTranslation<T = FormsTranslation>(
       globalTranslation
     )
 
-    return combineWithExternalTranslations({
-      translation,
-      messages,
-      locale,
-    }) as T & FormatMessage
-  }, [globalTranslation, locale, messages])
+    return assignUtils(
+      combineWithExternalTranslations({
+        translation,
+        messages,
+        locale,
+      })
+    ) as T & FormatMessage
+  }, [assignUtils, globalTranslation, locale, messages])
 }

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -12,7 +12,7 @@ import enGB from '../locales/en-GB'
 
 describe('useTranslation without an ID', () => {
   it('should default to nb-NO if no locale is specified in context', () => {
-    const { result } = renderHook(() => useTranslation(), {
+    const { result } = renderHook(useTranslation, {
       wrapper: ({ children }) => <Provider>{children}</Provider>,
     })
 
@@ -25,7 +25,7 @@ describe('useTranslation without an ID', () => {
   })
 
   it('should inherit locale from shared context', () => {
-    const { result: resultGB } = renderHook(() => useTranslation(), {
+    const { result: resultGB } = renderHook(useTranslation, {
       wrapper: ({ children }) => (
         <Provider locale="en-GB">{children}</Provider>
       ),
@@ -38,7 +38,7 @@ describe('useTranslation without an ID', () => {
       })
     )
 
-    const { result: resultNO } = renderHook(() => useTranslation(), {
+    const { result: resultNO } = renderHook(useTranslation, {
       wrapper: ({ children }) => (
         <Provider locale="nb-NO">{children}</Provider>
       ),
@@ -162,6 +162,16 @@ describe('useTranslation without an ID', () => {
       },
     }
     type Translation = (typeof myTranslations)[keyof typeof myTranslations]
+
+    it('should have the same instance after rerendering', () => {
+      const { result, rerender } = renderHook(useTranslation, {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      })
+
+      const firstInstance = result.current.formatMessage
+      rerender()
+      expect(result.current.formatMessage).toBe(firstInstance)
+    })
 
     it('should return translation', () => {
       const { result } = renderHook(useTranslation)
@@ -301,7 +311,7 @@ describe('useTranslation without an ID', () => {
         },
       }
 
-      const result = renderHook(() => useTranslation(), {
+      const result = renderHook(useTranslation, {
         wrapper: ({ children }) => (
           <Provider translations={customTranslation} locale="en-GB">
             {children}
@@ -482,8 +492,18 @@ describe('useTranslation with an ID', () => {
   })
 
   describe('renderMessage', () => {
+    it('should have the same instance after rerendering', () => {
+      const { result, rerender } = renderHook(useTranslation, {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      })
+
+      const firstInstance = result.current.renderMessage
+      rerender()
+      expect(result.current.renderMessage).toBe(firstInstance)
+    })
+
     it('should render with JSX line-breaks', () => {
-      const { result } = renderHook(() => useTranslation())
+      const { result } = renderHook(useTranslation)
 
       expect(result.current.renderMessage('Hello{br}World')).toEqual([
         <React.Fragment key="0">
@@ -498,7 +518,7 @@ describe('useTranslation with an ID', () => {
     })
 
     it('should support multiple line-breaks', () => {
-      const { result } = renderHook(() => useTranslation())
+      const { result } = renderHook(useTranslation)
 
       expect(result.current.renderMessage('A{br}B{br}C')).toEqual([
         <React.Fragment key="0">


### PR DESCRIPTION
The reason is to avoid re-renders or maximum callstack problems.

The test does fail without the changes:
<img width="676" alt="Screenshot 2024-10-17 at 09 39 34" src="https://github.com/user-attachments/assets/b048732b-1717-4423-b1d2-0184453849f2">
