### PR TITLE
fix(Field.Number): `decimalLimit={0}` when `currency` should work

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -739,7 +739,7 @@ describe('InputMasked component with currency_mask', () => {
     expect(document.querySelector('input').value).toBe('1 234 NOK')
   })
 
-  it('should not append a comma when entering a dot', () => {
+  it('should not append a comma when entering a comma', () => {
     render(<InputMasked value="12345,1" as_currency decimalLimit={0} />)
 
     expect(document.querySelector('input').value).toBe('12 345 kr')

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -739,6 +739,12 @@ describe('InputMasked component with currency_mask', () => {
     expect(document.querySelector('input').value).toBe('1 234 NOK')
   })
 
+  it('should not append a comma when entering a dot', () => {
+    render(<InputMasked value="12345,1" as_currency decimalLimit={0} />)
+
+    expect(document.querySelector('input').value).toBe('12 345 kr')
+  })
+
   it('should not show mask if placeholder is set', () => {
     const placeholderText = 'Placeholder-text'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -3,6 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import { Field } from '../../..'
 import { Provider } from '../../../../../shared'
+import userEvent from '@testing-library/user-event'
 
 describe('Field.Currency', () => {
   it('defaults to "kr" and use "NOK" when locale is en-GB', () => {
@@ -122,6 +123,22 @@ describe('Field.Currency', () => {
     const input = document.querySelector('.dnb-input__input')
 
     expect(input).toHaveAttribute('inputmode', 'decimal')
+  })
+
+  it('should work with decimal limit', async () => {
+    render(<Field.Currency decimalLimit={0} />)
+
+    const input = document.querySelector('.dnb-input__input')
+
+    expect(input).toHaveValue('')
+
+    await userEvent.type(document.querySelector('input'), '1')
+
+    expect(input).toHaveValue('1 kr')
+
+    await userEvent.type(document.querySelector('input'), ',')
+
+    expect(input).toHaveValue('1 kr')
   })
 
   describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -125,7 +125,7 @@ describe('Field.Currency', () => {
     expect(input).toHaveAttribute('inputmode', 'decimal')
   })
 
-  it('should work with decimal limit', async () => {
+  it('should work with decimal limit 0', async () => {
     render(<Field.Currency decimalLimit={0} />)
 
     const input = document.querySelector('.dnb-input__input')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -197,6 +197,13 @@ describe('Field.Number', () => {
         expect(document.querySelector('input')).toHaveValue('1 234,56 kr')
       })
 
+      it('formats with currency and decimalLimit 0', () => {
+        render(
+          <Field.Number value={1234.56789} currency decimalLimit={0} />
+        )
+        expect(document.querySelector('input')).toHaveValue('1 234 kr')
+      })
+
       it('formats in different locale', () => {
         render(
           <Provider locale="en-GB">

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -182,6 +182,13 @@ describe('Field.Number', () => {
         )
         expect(document.querySelector('input')).toHaveValue('1 234,56 %')
       })
+
+      it('formats with percent and decimalLimit 0', () => {
+        render(
+          <Field.Number value={1234.56789} percent decimalLimit={0} />
+        )
+        expect(document.querySelector('input')).toHaveValue('1 234 %')
+      })
     })
 
     describe('currency', () => {
@@ -273,6 +280,11 @@ describe('Field.Number', () => {
       it('formats with higher decimal limit', () => {
         render(<Field.Number value={123.456} decimalLimit={4} />)
         expect(screen.getByDisplayValue('123,456')).toBeInTheDocument()
+      })
+
+      it('formats with decimal limit 0', () => {
+        render(<Field.Number value={123.456} decimalLimit={0} />)
+        expect(screen.getByDisplayValue('123')).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
I'll have to add the actual fix, not only the tests.
Not entirely sure what and where to put the fix.