### PR TITLE
chore: fixes faulty links to /contribute/naming

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -145,4 +145,4 @@ text-shadow: none;
 
 ## HTML class naming
 
-To ensure a consistent class structure and to ensure that the class is owned by the DNB UI Library, all classes in the UI Library are prefixed with `dnb-`. Read more about that in the [Naming conventions](/contribute/naming).
+To ensure a consistent class structure and to ensure that the class is owned by the DNB UI Library, all classes in the UI Library are prefixed with `dnb-`. Read more about that in the [Naming conventions](/contribute/style-guides/naming).

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -31,7 +31,7 @@ isTouchDevice() // returns Boolean
 
 ### toPascalCase
 
-Transforms a string from **snake_case** to [PascalCase](!/contribute/naming).
+Transforms a string from **snake_case** to [PascalCase](!/contribute/style-guides/naming).
 
 ```js
 import { toPascalCase } from '@dnb/eufemia/shared/component-helper'
@@ -41,7 +41,7 @@ toPascalCase(String) // returns String
 
 ### toCamelCase
 
-Transforms a string from **snake_case** to [camelCase](!/contribute/naming).
+Transforms a string from **snake_case** to [camelCase](!/contribute/style-guides/naming).
 
 ```js
 import { toCamelCase } from '@dnb/eufemia/shared/component-helper'
@@ -51,7 +51,7 @@ toCamelCase(String) // returns String
 
 ### toSnakeCase
 
-Transforms a string from **PascalCase** to [snake_case](!/contribute/naming).
+Transforms a string from **PascalCase** to [snake_case](!/contribute/style-guides/naming).
 
 ```js
 import { toSnakeCase } from '@dnb/eufemia/shared/component-helper'
@@ -61,7 +61,7 @@ toSnakeCase(String) // returns String
 
 ### toKebabCase
 
-Transforms a string from **PascalCase** to [kebab-case](!/contribute/naming).
+Transforms a string from **PascalCase** to [kebab-case](!/contribute/style-guides/naming).
 
 ```js
 import { toKebabCase } from '@dnb/eufemia/shared/component-helper'

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/component-properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/component-properties.mdx
@@ -14,7 +14,7 @@ Every [Component](/uilib/components) has its own `properties` to make them work 
 
 ## Naming
 
-Both the properties- and event names should use **camelCase** to support a universal [naming convention](/contribute/naming).
+Both the properties- and event names should use **camelCase** to support a universal [naming convention](/contribute/style-guides/naming).
 
 ## Large Buttons & Icons
 


### PR DESCRIPTION
Fixes a few links in the following page: https://eufemia.dnb.no/uilib/helpers/functions/#topascalcase
Which would link/redirect to a non-existing page:

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/8a58faeb-d233-4812-8b0d-60e730079227">
