### PR TITLE
chore(CI): set timeout on the verify GitHub Action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,6 +31,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 20
+
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I have had issues where the verify step has run for several hours. This timeout will fix such issues.