### PR TITLE
fix(Field.Number): `decimalLimit={0}` when `currency` should work

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -308,6 +308,13 @@ export const handleCurrencyMask = ({ mask_options, currency_mask }) => {
 
   maskParams.suffix = ` ${fix}`
 
+  if (
+    typeof currency_mask?.allowDecimal === 'undefined' &&
+    typeof currency_mask?.decimalLimit !== 'undefined'
+  ) {
+    maskParams.allowDecimal = currency_mask.decimalLimit > 0
+  }
+
   return maskParams
 }
 

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -289,33 +289,35 @@ export const handlePercentMask = ({ props, locale, maskParams }) => {
  * @returns object maskParams
  */
 export const handleCurrencyMask = ({ mask_options, currency_mask }) => {
-  const maskParams = {
+  const givenParams = {
+    ...mask_options,
+    ...currency_mask,
+  }
+  const paramsWithDefaults = {
     showMask: true,
     placeholderChar: null,
     allowDecimal: true,
     decimalLimit: 2,
     decimalSymbol: ',',
-    ...mask_options,
-    ...currency_mask,
+    ...givenParams,
   }
 
-  const fix =
+  const suffix =
     typeof currency_mask === 'string'
       ? currency_mask
-      : typeof maskParams.currency === 'string'
-      ? maskParams.currency
+      : typeof givenParams.currency === 'string'
+      ? givenParams.currency
       : 'kr'
-
-  maskParams.suffix = ` ${fix}`
+  paramsWithDefaults.suffix = ` ${suffix}`
 
   if (
-    typeof currency_mask?.allowDecimal === 'undefined' &&
-    typeof currency_mask?.decimalLimit !== 'undefined'
+    typeof givenParams?.allowDecimal === 'undefined' &&
+    typeof givenParams?.decimalLimit === 'number'
   ) {
-    maskParams.allowDecimal = currency_mask.decimalLimit > 0
+    paramsWithDefaults.allowDecimal = givenParams.decimalLimit > 0
   }
 
-  return maskParams
+  return paramsWithDefaults
 }
 
 /**

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -1412,6 +1412,33 @@ describe('InputMasked component as_currency', () => {
     expect(document.querySelector('input').value).toBe('12 345,67 kr')
   })
 
+  it('should prevent a comma when decimalLimit=0', () => {
+    render(<InputMasked as_currency currency_mask={{ decimalLimit: 0 }} />)
+
+    const preventDefault = jest.fn()
+    const event = { preventDefault }
+
+    const newValue = '12 345'
+
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: newValue },
+      ...event,
+    })
+
+    const pressDotAndUseItAscomma = () => {
+      const keyCode = 188 // comma
+      fireEvent.keyDown(document.querySelector('input'), {
+        keyCode,
+        ...event,
+      })
+    }
+
+    pressDotAndUseItAscomma()
+    pressDotAndUseItAscomma() // try a second time
+
+    expect(document.querySelector('input').value).toBe('12 345 kr')
+  })
+
   it('should inherit currency_mask from provider', () => {
     const { rerender } = render(
       <Provider

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -3,6 +3,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import { Field } from '../../..'
 import { Provider } from '../../../../../shared'
+import userEvent from '@testing-library/user-event'
 
 describe('Field.Currency', () => {
   it('defaults to "kr" and use "NOK" when locale is en-GB', () => {
@@ -122,6 +123,22 @@ describe('Field.Currency', () => {
     const input = document.querySelector('.dnb-input__input')
 
     expect(input).toHaveAttribute('inputmode', 'decimal')
+  })
+
+  it('should work with decimal limit 0', async () => {
+    render(<Field.Currency decimalLimit={0} />)
+
+    const input = document.querySelector('.dnb-input__input')
+
+    expect(input).toHaveValue('')
+
+    await userEvent.type(document.querySelector('input'), '1')
+
+    expect(input).toHaveValue('1 kr')
+
+    await userEvent.type(document.querySelector('input'), ',')
+
+    expect(input).toHaveValue('1 kr')
   })
 
   describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -307,6 +307,7 @@ function NumberComponent(props: Props) {
         mask_options,
         currency_mask: {
           currencyDisplay,
+          decimalLimit,
         },
       }
     }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -182,6 +182,13 @@ describe('Field.Number', () => {
         )
         expect(document.querySelector('input')).toHaveValue('1 234,56 %')
       })
+
+      it('formats with percent and decimalLimit 0', () => {
+        render(
+          <Field.Number value={1234.56789} percent decimalLimit={0} />
+        )
+        expect(document.querySelector('input')).toHaveValue('1 234 %')
+      })
     })
 
     describe('currency', () => {
@@ -195,6 +202,13 @@ describe('Field.Number', () => {
           <Field.Number value={1234.56789} currency decimalLimit={2} />
         )
         expect(document.querySelector('input')).toHaveValue('1 234,56 kr')
+      })
+
+      it('formats with currency and decimalLimit 0', () => {
+        render(
+          <Field.Number value={1234.56789} currency decimalLimit={0} />
+        )
+        expect(document.querySelector('input')).toHaveValue('1 234 kr')
       })
 
       it('formats in different locale', () => {
@@ -266,6 +280,11 @@ describe('Field.Number', () => {
       it('formats with higher decimal limit', () => {
         render(<Field.Number value={123.456} decimalLimit={4} />)
         expect(screen.getByDisplayValue('123,456')).toBeInTheDocument()
+      })
+
+      it('formats with decimal limit 0', () => {
+        render(<Field.Number value={123.456} decimalLimit={0} />)
+        expect(screen.getByDisplayValue('123')).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
This PR makes it so that the user can't enter any decimals while doing:
`<Field.Currency decimalLimit={0} />`