### PR TITLE
chore(InputMasked): improves number_format test

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -1381,7 +1381,11 @@ describe('InputMasked component as_currency', () => {
     expect(document.querySelector('input').value).toBe('12 345,01 kr')
 
     rerender(
-      <InputMasked value="12345.016" as_currency="NOK" number_format />
+      <InputMasked
+        value="12345.016"
+        as_currency="NOK"
+        number_format={{}}
+      />
     )
 
     expect(document.querySelector('input').value).toBe('12 345,02 kr')


### PR DESCRIPTION
Removes the following warning/error in our tests:
`Warning: Failed prop type: Invalid prop `number_format` supplied to `InputMasked`.`