### PR TITLE
fix(NumberFormat): should not throw exception when providing an invalid currency

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -486,7 +486,7 @@ const prepareMinus = (display, locale) => {
  * @returns {string} The aligned output string.
  */
 function alignCurrencySymbol(output, currencyDisplay) {
-  if (output && currencyDisplay === 'name') {
+  if (typeof output === 'string' && currencyDisplay === 'name') {
     output = output.replace(/(nor[^\s]+?)\s(\w+)/i, '$2')
   }
   return output

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -486,7 +486,7 @@ const prepareMinus = (display, locale) => {
  * @returns {string} The aligned output string.
  */
 function alignCurrencySymbol(output, currencyDisplay) {
-  if (currencyDisplay === 'name') {
+  if (output && currencyDisplay === 'name') {
     output = output.replace(/(nor[^\s]+?)\s(\w+)/i, '$2')
   }
   return output

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -109,6 +109,11 @@ describe('Decimals format', () => {
         decimals: undefined,
       })
     ).toBe('-1,1234567891234568')
+
+    expect(format(null, { currency: 'non-valid value' })).toBe('null')
+    expect(format(undefined, { currency: 'non-valid value' })).toBe(
+      'undefined'
+    )
   })
 
   describe('rounding', () => {

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -109,7 +109,6 @@ describe('Decimals format', () => {
         decimals: undefined,
       })
     ).toBe('-1,1234567891234568')
-
     expect(format(null, { currency: 'non-valid value' })).toBe('null')
     expect(format(undefined, { currency: 'non-valid value' })).toBe(
       'undefined'


### PR DESCRIPTION
In this PR, not providing a valid currency when providing value `null` will result in `"null"`. 
And when not providing a valid currency when providing value `undefined` will result in `"undefined"`.  

I don't think it's optimal, but I think it's good enough, as I believe this is an edge-case.

Initially, I would want it to result in the same as using default currency(when not providing a valid one).
Which is `NOK 0.00`.
But to figure out that you have not provided a valid currency, one would have to check up against all valid currencies(https://en.wikipedia.org/wiki/ISO_4217), which is too much job 😅 

I guess we could just return `0` if value is `null` or `undefined`, and then don't care about the other options/properties? 🤔 

