### PR TITLE
chore: remove leftover infinity loop test code

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,11 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 import { Field, Form } from '../../..'
-import {
-  Button,
-  Card,
-  GlobalStatus,
-  Flex,
-} from '../../../../../components'
+import { Button, Card, GlobalStatus } from '../../../../../components'
 import { debounceAsync } from '../../../../../shared/helpers'
 
 export default {
@@ -390,39 +385,4 @@ function UseValidationComponent() {
   }, [setFieldStatus])
 
   return null
-}
-
-export function InfinityLoopStory() {
-  const MyForm = () => {
-    const [, setSubmitData] = React.useState({})
-    const onSubmit = (data, { transformData }) => {
-      const transformedData = transformData(
-        data,
-        ({ value, displayValue, label }) => {
-          return {
-            value,
-            displayValue,
-            label,
-          }
-        }
-      )
-      setSubmitData(transformedData)
-      console.log('onSubmit', transformedData)
-    }
-    return (
-      <Form.Handler onSubmit={onSubmit}>
-        <Flex.Stack>
-          <Field.Number
-            label="Field.Number"
-            path="/myNumber"
-            defaultValue={1}
-          />
-
-          <Form.SubmitButton />
-        </Flex.Stack>
-      </Form.Handler>
-    )
-  }
-
-  return <MyForm />
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect } from 'react'
 import { Field, Form } from '../../..'
-import { Button, Card, GlobalStatus } from '../../../../../components'
+import {
+  Button,
+  Card,
+  GlobalStatus,
+  Flex,
+} from '../../../../../components'
 import { debounceAsync } from '../../../../../shared/helpers'
 
 export default {
@@ -385,4 +390,39 @@ function UseValidationComponent() {
   }, [setFieldStatus])
 
   return null
+}
+
+export function InfinityLoopStory() {
+  const MyForm = () => {
+    const [, setSubmitData] = React.useState({})
+    const onSubmit = (data, { transformData }) => {
+      const transformedData = transformData(
+        data,
+        ({ value, displayValue, label }) => {
+          return {
+            value,
+            displayValue,
+            label,
+          }
+        }
+      )
+      setSubmitData(transformedData)
+      console.log('onSubmit', transformedData)
+    }
+    return (
+      <Form.Handler onSubmit={onSubmit}>
+        <Flex.Stack>
+          <Field.Number
+            label="Field.Number"
+            path="/myNumber"
+            defaultValue={1}
+          />
+
+          <Form.SubmitButton />
+        </Flex.Stack>
+      </Form.Handler>
+    )
+  }
+
+  return <MyForm />
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -480,12 +480,6 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     )
   }, [contextErrorMessages, errorMessages, identifier])
 
-  const loopCounterRef = useRef(0)
-  loopCounterRef.current += 1
-  if (loopCounterRef.current > 100) {
-    throw new Error('Infinity loop detected and stopped.')
-  }
-
   /**
    * Prepare error from validation logic with correct error messages based on props
    */


### PR DESCRIPTION
Even the simple scenario `<Field.Number />` can result in:

```
Error: Infinity loop detected and stopped.
    at useFieldProps (http://localhost:8002/src_extensions_forms_Form_index_ts.iframe.bundle.js:6112:11)
    at NumberComponent (http://localhost:8002/src_extensions_forms_index_ts.iframe.bundle.js:1878:49)
```


Not sure what the cause is, I just randomly type random values, then remove them all(using command + A -> backspace) before entering new random values:


https://github.com/user-attachments/assets/7168d150-0119-4f21-9894-281d6e7982fb


Here's one where I only enter 1 and backspace * repeat:



https://github.com/user-attachments/assets/9c641c5a-9b70-4d8d-bda1-e4ba9b75a9fc


