### PR TITLE
chore(Portal): fix Tools.Log exception in portal example (Iterate.Array)

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
@@ -54,7 +54,7 @@ function replaceUndefinedValues(
 ): unknown {
   if (typeof value === 'undefined') {
     return replaceWith
-  } else if (typeof value === 'object' && value !== replaceWith) {
+  } else if (value && typeof value === 'object' && value !== replaceWith) {
     return {
       ...value,
       ...Object.fromEntries(


### PR DESCRIPTION
This fixes an issue occurring in this example: https://eufemia.dnb.no/uilib/extensions/forms/Iterate/Array/#minium-one-item

