### PR TITLE
chore: fix inverted test description for autoComplete property

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -177,7 +177,7 @@ describe('Form.Handler', () => {
   })
 
   describe('autocomplete', () => {
-    it('should set autocomplete="on" when autoComplete is false', () => {
+    it('should set autocomplete="on" when autoComplete is true', () => {
       const { rerender } = render(
         <Form.Handler autoComplete>
           <Field.String path="/firstName" />


### PR DESCRIPTION
Updates a test description from https://github.com/dnbexperience/eufemia/pull/4184 for when `autoComplete` is set to `true`. The one for `false` is right below this test.