### PR TITLE
refactor: center cards on ultra-wide monitors and fix capitalization typo

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'more fields...'
+title: 'More fields...'
 order: -1
 breadcrumb:
   - text: Forms

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'More fields...'
+title: 'more fields...'
 order: -1
 breadcrumb:
   - text: Forms

--- a/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
@@ -100,7 +100,6 @@ function MainMenu() {
               </figcaption>
             </figure>
             <SearchBarInput />
-          </div>
           <ul className={listStyle}>
             <Card
               url={items['design-system']?.url}
@@ -111,44 +110,45 @@ function MainMenu() {
                   <span
                     className={lastUpdatedStyle}
                     title="Last Change log update"
-                  >
+                    >
                     Updated: {packageJson.changelogVersion}
                   </span>
                 </>
               }
               icon={DesignSystemSvg}
-            />
+              />
             <Card
               url={items['uilib']?.url}
               title={items['uilib']?.title}
               about={items['uilib']?.description}
               icon={UilibSvg}
-            />
+              />
             <Card
               url={items['quickguide-designer']?.url}
               title={items['quickguide-designer']?.title}
               about={items['quickguide-designer']?.description}
               icon={QuickguideDesignerSvg}
-            />
+              />
             <Card
               url={items['icons']?.url}
               title={items['icons']?.title}
               about={items['icons']?.description}
               icon={IconsSvg}
-            />
+              />
             <Card
               url={items['brand']?.url}
               title={items['brand']?.title}
               about={items['brand']?.description}
               icon={BrandSvg}
-            />
+              />
             <Card
               url={items['contribute']?.url}
               title={items['contribute']?.title}
               about={items['contribute']?.description}
               icon={DevelopmentSvg}
-            />
+              />
           </ul>
+          </div>
         </>
       </div>
     </nav>

--- a/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
+++ b/packages/dnb-design-system-portal/src/shared/menu/MainMenu.js
@@ -100,54 +100,54 @@ function MainMenu() {
               </figcaption>
             </figure>
             <SearchBarInput />
-          <ul className={listStyle}>
-            <Card
-              url={items['design-system']?.url}
-              title={items['design-system']?.title}
-              about={
-                <>
-                  {items['design-system']?.description}
-                  <span
-                    className={lastUpdatedStyle}
-                    title="Last Change log update"
+            <ul className={listStyle}>
+              <Card
+                url={items['design-system']?.url}
+                title={items['design-system']?.title}
+                about={
+                  <>
+                    {items['design-system']?.description}
+                    <span
+                      className={lastUpdatedStyle}
+                      title="Last Change log update"
                     >
-                    Updated: {packageJson.changelogVersion}
-                  </span>
-                </>
-              }
-              icon={DesignSystemSvg}
+                      Updated: {packageJson.changelogVersion}
+                    </span>
+                  </>
+                }
+                icon={DesignSystemSvg}
               />
-            <Card
-              url={items['uilib']?.url}
-              title={items['uilib']?.title}
-              about={items['uilib']?.description}
-              icon={UilibSvg}
+              <Card
+                url={items['uilib']?.url}
+                title={items['uilib']?.title}
+                about={items['uilib']?.description}
+                icon={UilibSvg}
               />
-            <Card
-              url={items['quickguide-designer']?.url}
-              title={items['quickguide-designer']?.title}
-              about={items['quickguide-designer']?.description}
-              icon={QuickguideDesignerSvg}
+              <Card
+                url={items['quickguide-designer']?.url}
+                title={items['quickguide-designer']?.title}
+                about={items['quickguide-designer']?.description}
+                icon={QuickguideDesignerSvg}
               />
-            <Card
-              url={items['icons']?.url}
-              title={items['icons']?.title}
-              about={items['icons']?.description}
-              icon={IconsSvg}
+              <Card
+                url={items['icons']?.url}
+                title={items['icons']?.title}
+                about={items['icons']?.description}
+                icon={IconsSvg}
               />
-            <Card
-              url={items['brand']?.url}
-              title={items['brand']?.title}
-              about={items['brand']?.description}
-              icon={BrandSvg}
+              <Card
+                url={items['brand']?.url}
+                title={items['brand']?.title}
+                about={items['brand']?.description}
+                icon={BrandSvg}
               />
-            <Card
-              url={items['contribute']?.url}
-              title={items['contribute']?.title}
-              about={items['contribute']?.description}
-              icon={DevelopmentSvg}
+              <Card
+                url={items['contribute']?.url}
+                title={items['contribute']?.title}
+                about={items['contribute']?.description}
+                icon={DevelopmentSvg}
               />
-          </ul>
+            </ul>
           </div>
         </>
       </div>


### PR DESCRIPTION
Currently on ultra wide monitors or if you have zoom set to  =< 67%, the cards on https://eufemia.dnb.no/ will not be aligned properly to the search bar.

This was a quick fix I found, but I am not an UX/UI expert so let me know if this breaks some accessibility rules :)  

Not centered:
![not-centered](https://github.com/user-attachments/assets/96680f02-1292-4944-b175-241d1a347a83)

Centered correctly:
![centered](https://github.com/user-attachments/assets/76c8a955-395e-4090-9473-31a6cbf4e465)

