### PR TITLE
feat(Forms): add `hideDivider` prop to Iterate.Toolbar

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
@@ -8,18 +8,26 @@ import ToolbarContext from './ToolbarContext'
 import FieldBoundaryContext from '../../DataContext/FieldBoundary/FieldBoundaryContext'
 import { useTranslation } from '../../hooks'
 
+type ToolbarProps = {
+  hideDivider?: boolean
+}
+
 export type ToolbarParams = {
   index: number
   items: Array<unknown>
   value: unknown
 }
-export type Props = Omit<SpaceAllProps, 'children'> & {
-  children?: React.ReactNode | ((params: ToolbarParams) => React.ReactNode)
-}
+export type Props = ToolbarProps &
+  Omit<SpaceAllProps, 'children'> & {
+    children?:
+      | React.ReactNode
+      | ((params: ToolbarParams) => React.ReactNode)
+  }
 
 export default function Toolbar({
   children,
   className,
+  hideDivider,
   ...rest
 }: Props = {}) {
   const {
@@ -48,16 +56,14 @@ export default function Toolbar({
 
   return (
     <Space
-      top="medium"
+      top="large"
       className={classnames('dnb-forms-iterate-toolbar', className)}
       {...rest}
     >
-      <Hr space={0} />
+      {!hideDivider && <Hr space={0} />}
 
       <ToolbarContext.Provider value={{ setShowError }}>
-        <Flex.Horizontal top="x-small" gap="large">
-          {children}
-        </Flex.Horizontal>
+        <Flex.Horizontal gap="large">{children}</Flex.Horizontal>
       </ToolbarContext.Provider>
 
       <FormStatus

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/ToolbarDocs.ts
@@ -1,5 +1,11 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 
-export const ToolbarProperties: PropertiesTableProps = {}
+export const ToolbarProperties: PropertiesTableProps = {
+  hideDivider: {
+    doc: 'Hide the toolbar divider line',
+    type: 'boolean',
+    status: 'optional',
+  },
+}
 
 export const ToolbarEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
@@ -48,6 +48,16 @@ describe('Toolbar', () => {
     expect(handleRemove).toHaveBeenCalledTimes(1)
   })
 
+  it('hides divider when hideDivider is true', () => {
+    render(
+      <IterateItemContext.Provider value={{}}>
+        <Toolbar hideDivider>content</Toolbar>
+      </IterateItemContext.Provider>
+    )
+
+    expect(document.querySelector('dnb-hr')).not.toBeInTheDocument()
+  })
+
   describe('to have buttons with correct text', () => {
     it('and isNew is true', () => {
       render(

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react'
 import { Field, Form, Iterate, Tools, Value, Wizard } from '../..'
 import { Card, Flex } from '../../../../components'
+import ArrayItemArea from '../Array/ArrayItemArea'
+import Toolbar from '../Toolbar'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Iterate',
@@ -318,5 +320,93 @@ export function InWizard() {
         <Tools.Log top />
       </Form.Handler>
     </React.StrictMode>
+  )
+}
+
+export const CustomContainers = () => {
+  return (
+    <>
+      <Form.Handler
+        data={{
+          owners: [
+            {
+              name: 'Bedriften AS',
+              share: 33,
+            },
+            {
+              name: 'Bedriften AS',
+              share: 66,
+            },
+          ],
+        }}
+      >
+        <Flex.Vertical>
+          <Form.MainHeading>Accounts</Form.MainHeading>
+          <Card stack>
+            <Iterate.Array path="/owners">
+              <ArrayItemArea mode="view" variant="basic">
+                <Card filled space="0" innerSpace="x-small" shrink>
+                  <Flex.Horizontal
+                    justify="space-between"
+                    align="center"
+                    right="xx-small"
+                    stretch
+                  >
+                    <Value.Composition>
+                      <Value.String itemPath="/name" />,
+                      <Value.Number itemPath="/share" /> eierandel
+                    </Value.Composition>
+                    <Toolbar hideDivider top="0">
+                      <Iterate.ViewContainer.EditButton />
+                    </Toolbar>
+                  </Flex.Horizontal>
+                </Card>
+              </ArrayItemArea>
+              <ArrayItemArea mode="edit" variant="basic">
+                <Card filled shrink>
+                  <Value.String itemPath="/name" label="Navn" />
+                  <Field.Number
+                    required
+                    itemPath="/share"
+                    label="Eierandel"
+                  />
+
+                  <Flex.Horizontal justify="space-between" stretch>
+                    <Flex.Item>
+                      <Toolbar hideDivider>
+                        <Iterate.EditContainer.DoneButton
+                          right="x-small"
+                          variant="primary"
+                          icon={null}
+                        />
+                        <Iterate.EditContainer.CancelButton />
+                      </Toolbar>
+                    </Flex.Item>
+                    <Flex.Item>
+                      <Toolbar hideDivider>
+                        <Iterate.RemoveButton />
+                      </Toolbar>
+                    </Flex.Item>
+                  </Flex.Horizontal>
+                </Card>
+              </ArrayItemArea>
+            </Iterate.Array>
+            <Iterate.PushContainer
+              path="/owners"
+              title="New owner"
+              openButton={
+                <Iterate.PushContainer.OpenButton text="Add another owner" />
+              }
+              showOpenButtonWhen={(list) => list.length > 0}
+            >
+              <Field.String itemPath="/name" />
+              <Field.Number percent itemPath="/share" defaultValue={1} />
+            </Iterate.PushContainer>
+          </Card>
+
+          <Form.SubmitButton variant="send" />
+        </Flex.Vertical>
+      </Form.Handler>
+    </>
   )
 }


### PR DESCRIPTION
This PR serves two purposes, based on me trying to implement a design...

1. To be able to implement the design I need to remove the divider from the toolbar. So I introduced a prop to do this, so that I can move the toolbar around.
2. I made a POC of an implementation of our design as a story in Storybook. I would like to know your thoughts on it.  
At first I tried making another version of `ViewContainer`, but I quickly figured out that when I stripped the component down, I was left with `ArrayItemArea`, which is available for consumers, but seems to be made for internal use.

I think this serves as a good example on how to make custom iterate-based components, which is nice to have IMO.

Here is the design I want to implement as well as the POC story:
![image](https://github.com/user-attachments/assets/3bfd3205-6206-4cd3-816e-72fc2246d601)

---

![image](https://github.com/user-attachments/assets/2ac4e222-de7f-4be6-968b-083e752d78bc)

Storybook POC
![image](https://github.com/user-attachments/assets/31aafc1f-c6e4-43eb-804a-56d8063e2c44)

(I wish the height of the `Card` component was easy to configure...)
