### PR TITLE
feat(CountryFlag): add iso to properties table

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
@@ -16,7 +16,7 @@ import '@dnb/eufemia/components/country-flag/style/dnb-country-flag-icons.scss'
 
 ## Description
 
-The CountryFlag component lets you display a country flag based on a [ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) like `NO` for Norway.
+The `CountryFlag` component lets you display a country flag based on a [ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) like `NO` for Norway.
 
 In order to use the CountryFlag component, you need to import the flag styles as CSS or SASS. The flag styles are available in the `dnb-country-flag-icons.min.css` and `dnb-country-flag-icons.scss` files. See the import example above.
 

--- a/packages/dnb-eufemia/src/components/country-flag/CountryFlagDocs.ts
+++ b/packages/dnb-eufemia/src/components/country-flag/CountryFlagDocs.ts
@@ -1,6 +1,11 @@
 import { PropertiesTableProps } from '../../shared/types'
 
 export const CountryFlagProperties: PropertiesTableProps = {
+  iso: {
+    doc: '[ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) representing the country, such as `NO` for Norway. Defaults to `empty` string.',
+    type: 'string',
+    status: 'optional',
+  },
   size: {
     doc: 'The size of the component. Can be `auto`, `small`, `medium`, `large` or `x-large`. Defaults to `auto` (1em).',
     type: 'string',


### PR DESCRIPTION
Added `iso`-field to the properties table of `CountryFlag`.