### PR TITLE
fix: ensure components having `fieldset` inside still can use spacing

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3308,9 +3308,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
   flex-grow: 1;
 }
 .dnb-radio-group fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-radio-group fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;
@@ -3606,9 +3617,20 @@ button .dnb-form-status__text {
   flex-grow: 1;
 }
 .dnb-toggle-button-group fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-toggle-button-group--column .dnb-toggle-button {
   display: flex;
@@ -4187,9 +4209,20 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   visibility: hidden;
 }
 .dnb-date-picker__fieldset, .dnb-core-style .dnb-date-picker__fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-date-picker__fieldset:not([class*=space__top]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-date-picker__fieldset:not([class*=space__right]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-date-picker__fieldset:not([class*=space__bottom]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-date-picker__fieldset:not([class*=space__left]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 
 @keyframes date-picker-slide-down {

--- a/packages/dnb-eufemia/src/components/form-row/__tests__/__snapshots__/FormRow.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/form-row/__tests__/__snapshots__/FormRow.test.tsx.snap
@@ -79,10 +79,21 @@ exports[`FormRow scss has to match style dependencies css 1`] = `
   margin: 0;
 }
 .dnb-form-row__fieldset, .dnb-core-style .dnb-form-row__fieldset {
-  margin: 0;
   padding: 0;
   border: none;
   width: 100%;
+}
+.dnb-form-row__fieldset:not([class*=space__top]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-form-row__fieldset:not([class*=space__right]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-form-row__fieldset:not([class*=space__bottom]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-form-row__fieldset:not([class*=space__left]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }"
 `;
 

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1339,9 +1339,20 @@ html[data-visual-test] .dnb-input__input {
 }
 
 .dnb-multi-input-mask__fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-multi-input-mask__fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-multi-input-mask__fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-multi-input-mask__fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-multi-input-mask__fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-multi-input-mask__fieldset--horizontal {
   display: inline-flex;

--- a/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -338,9 +338,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
   flex-grow: 1;
 }
 .dnb-radio-group fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-radio-group fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -1429,9 +1429,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
   flex-grow: 1;
 }
 .dnb-radio-group fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-radio-group fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;
@@ -1727,9 +1738,20 @@ button .dnb-form-status__text {
   flex-grow: 1;
 }
 .dnb-toggle-button-group fieldset {
-  margin: 0;
   padding: 0;
   border: none;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__left]) {
+  margin-left: 0;
 }
 .dnb-toggle-button-group--column .dnb-toggle-button {
   display: flex;

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -20,7 +20,7 @@ $breakpoints: map.merge(
 }
 
 fieldset.dnb-forms-field-block {
-  @include fieldsetReset(true);
+  @include fieldsetReset();
 }
 
 .dnb-forms-field-block {

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -377,22 +377,18 @@ $breakpoint-offset: 0;
   }
 }
 
-@mixin fieldsetReset($checkSpaceProps: false) {
-  @if $checkSpaceProps {
-    &:not([class*='space__top']) {
-      margin-top: 0;
-    }
-    &:not([class*='space__right']) {
-      margin-right: 0;
-    }
-    &:not([class*='space__bottom']) {
-      margin-bottom: 0;
-    }
-    &:not([class*='space__left']) {
-      margin-left: 0;
-    }
-  } @else {
-    margin: 0;
+@mixin fieldsetReset() {
+  &:not([class*='space__top']) {
+    margin-top: 0;
+  }
+  &:not([class*='space__right']) {
+    margin-right: 0;
+  }
+  &:not([class*='space__bottom']) {
+    margin-bottom: 0;
+  }
+  &:not([class*='space__left']) {
+    margin-left: 0;
   }
   padding: 0;
   border: none;


### PR DESCRIPTION
For fields/components that uses a `fieldset` the `gap` spacing did not apply properly:

<img width="376" alt="Screenshot 2024-11-06 at 14 21 27" src="https://github.com/user-attachments/assets/4c289385-bf99-4b84-b1f7-d6ab7e128c08">

---

I'm not 100% sure why we not did always make the margin check. But it should actually not effect other styles, as we now check if a spacing class is applied or not.

When this is in main, we may add an example to #4225