### PR TITLE
chore(Anchor): make it possible to remove launch icon

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -125,7 +125,7 @@ export function AnchorInstance(localProps: AnchorAllProps) {
   const _opensNewTab = opensNewTab(allProps.target, href)
   const showLaunchIcon =
     _opensNewTab &&
-    !className?.includes('dnb-anchor--no-icon') &&
+    !className?.includes('dnb-anchor--no-launch-icon') &&
     !omitClass
   const showTooltip = (tooltip || _opensNewTab) && !allProps.title
 

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -125,6 +125,7 @@ export function AnchorInstance(localProps: AnchorAllProps) {
   const _opensNewTab = opensNewTab(allProps.target, href)
   const showLaunchIcon =
     _opensNewTab &&
+    !className?.includes('dnb-anchor--no-icon') &&
     !className?.includes('dnb-anchor--no-launch-icon') &&
     !omitClass
   const showTooltip = (tooltip || _opensNewTab) && !allProps.title

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -117,6 +117,21 @@ describe('Anchor element', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('has no "__launch-icon" class when adding class dnb-anchor--no-launch-icon', () => {
+      render(
+        <Anchor
+          href="/url"
+          target="_blank"
+          className="dnb-anchor--no-launch-icon"
+        >
+          <span>text</span>
+        </Anchor>
+      )
+      expect(
+        document.querySelector('.dnb-anchor--launch-icon')
+      ).not.toBeInTheDocument()
+    })
+
     it('has no tooltip when title was given', () => {
       render(
         <Anchor href="/url" target="_blank" title="Title">

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import classnames from 'classnames'
 
 // Components
+import Anchor from '../components/Anchor'
 import Button from '../button/Button'
 import Icon from '../../components/Icon'
 import FormStatus from '../../components/FormStatus'
@@ -163,18 +164,19 @@ const UploadFileListCell = ({
       </div>
     ) : (
       <div className="dnb-upload__file-cell__text-container">
-        <a
+        <Anchor
           target="_blank"
           href={imageUrl}
           download={download ? file.name : null}
           className={classnames(
             'dnb-anchor',
+            'dnb-anchor--no-launch-icon',
             'dnb-upload__file-cell__title'
           )}
           rel="noopener noreferrer"
         >
           {file.name}
-        </a>
+        </Anchor>
       </div>
     )
   }

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import classnames from 'classnames'
 
 // Components
-import Anchor from '../components/Anchor'
+import Anchor from '../../components/Anchor'
 import Button from '../button/Button'
 import Icon from '../../components/Icon'
 import FormStatus from '../../components/FormStatus'

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -169,7 +169,6 @@ const UploadFileListCell = ({
           href={imageUrl}
           download={download ? file.name : null}
           className={classnames(
-            'dnb-anchor',
             'dnb-anchor--no-launch-icon',
             'dnb-upload__file-cell__title'
           )}


### PR DESCRIPTION
I think it should be possible to remove(not display launch icon) when an anchor has target '_blank'.

It also makes the Anchor more usable, as that's the only reason why it was not used in Upload, and rather an `<a>` with class `'dnb-anchor'` was used.