### PR TITLE
chore: updates docs and types for lists who dont support skeleton

### DIFF
--- a/packages/dnb-eufemia/src/elements/ElementDocs.ts
+++ b/packages/dnb-eufemia/src/elements/ElementDocs.ts
@@ -20,14 +20,14 @@ export const ElementPropertiesWithoutSkeleton: PropertiesTableProps = {
 
 export const ElementProperties: PropertiesTableProps = {
   ...ElementPropertiesWithoutSkeleton,
-  children: {
-    doc: 'Contents.',
-    type: 'React.Node',
+  skeleton: {
+    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
+    type: 'boolean',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
+  skeletonMethod: {
+    doc: 'Can be `shape`, `font` or `form`. Defaults to `font`.',
+    type: 'string',
     status: 'optional',
   },
 }

--- a/packages/dnb-eufemia/src/elements/ElementDocs.ts
+++ b/packages/dnb-eufemia/src/elements/ElementDocs.ts
@@ -1,21 +1,25 @@
 import { PropertiesTableProps } from '../shared/types'
 
-export const ElementProperties: PropertiesTableProps = {
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
-  skeletonMethod: {
-    doc: 'Can be `shape`, `font` or `form`. Defaults to `font`.',
-    type: 'string',
-    status: 'optional',
-  },
+export const ElementPropertiesWithoutSkeleton: PropertiesTableProps = {
   innerRef: {
     doc: 'Send along a custom React Ref.',
     type: 'React.RefObject',
     status: 'optional',
   },
+  children: {
+    doc: 'Contents.',
+    type: 'React.Node',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const ElementProperties: PropertiesTableProps = {
+  ...ElementPropertiesWithoutSkeleton,
   children: {
     doc: 'Contents.',
     type: 'React.Node',

--- a/packages/dnb-eufemia/src/elements/lists/Dl.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Dl.tsx
@@ -22,7 +22,7 @@ export type DlProps = {
 
 export type DlAllProps = DlProps &
   React.AllHTMLAttributes<HTMLDListElement> &
-  ElementProps
+  Omit<ElementProps, 'skeleton' | 'skeletonMethod'>
 
 const Dl = ({ direction, layout, ...props }: DlAllProps) => {
   if (layout || direction) {

--- a/packages/dnb-eufemia/src/elements/lists/DlDocs.ts
+++ b/packages/dnb-eufemia/src/elements/lists/DlDocs.ts
@@ -1,5 +1,5 @@
 import { PropertiesTableProps } from '../../shared/types'
-import { ElementProperties } from './../ElementDocs'
+import { ElementPropertiesWithoutSkeleton } from './../ElementDocs'
 
 export const DlProperties: PropertiesTableProps = {
   layout: {
@@ -7,6 +7,5 @@ export const DlProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-
-  ...ElementProperties,
+  ...ElementPropertiesWithoutSkeleton,
 }

--- a/packages/dnb-eufemia/src/elements/lists/Li.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Li.tsx
@@ -12,22 +12,22 @@ import Ol from './Ol'
 export type LiAllProps = React.AllHTMLAttributes<HTMLLIElement> &
   ElementProps
 
-const Li = ({ className, ...p }: LiAllProps = {}) => {
+const Li = ({ className, ...props }: LiAllProps = {}) => {
   /**
    * Check if we have a nested list,
    * then we set the class "is-nested" and give it a max-height,
    * if it is a skeleton
    */
 
-  if (Array.isArray(p.children)) {
-    p.children.forEach((Comp) => {
+  if (Array.isArray(props.children)) {
+    props.children.forEach((Comp) => {
       if (Comp && (Comp.type === Ul || Comp.type === Ol)) {
         className = classnames(className, 'is-nested')
       }
     })
   }
 
-  return <E as="li" {...p} className={className} />
+  return <E as="li" {...props} className={className} />
 }
 
 export default Li

--- a/packages/dnb-eufemia/src/elements/lists/Ol.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ol.tsx
@@ -26,15 +26,15 @@ export type OlProps = {
 
 export type OlAllProps = OlProps &
   React.AllHTMLAttributes<HTMLOListElement> &
-  ElementProps
+  Omit<ElementProps, 'skeleton' | 'skeletonMethod'>
 
-const Ol = ({ nested, inside, outside, ...p }: OlAllProps = {}) => {
+const Ol = ({ nested, inside, outside, ...props }: OlAllProps = {}) => {
   return (
     <E
       as="ol"
-      {...p}
+      {...props}
       className={classnames(
-        p.className,
+        props.className,
         nested && 'dnb-ol--nested',
         inside && 'dnb-ol--inside',
         outside && 'dnb-ol--outside'

--- a/packages/dnb-eufemia/src/elements/lists/OlDocs.ts
+++ b/packages/dnb-eufemia/src/elements/lists/OlDocs.ts
@@ -1,6 +1,6 @@
 import { PropertiesTableProps } from '../../shared/types'
 
-import { ElementProperties } from './../ElementDocs'
+import { ElementPropertiesWithoutSkeleton } from './../ElementDocs'
 
 export const OlProperties: PropertiesTableProps = {
   inside: {
@@ -18,5 +18,5 @@ export const OlProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  ...ElementProperties,
+  ...ElementPropertiesWithoutSkeleton,
 }

--- a/packages/dnb-eufemia/src/elements/lists/Ul.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ul.tsx
@@ -26,15 +26,15 @@ export type UlProps = {
 
 export type UlAllProps = UlProps &
   React.AllHTMLAttributes<HTMLUListElement> &
-  ElementProps
+  Omit<ElementProps, 'skeleton' | 'skeletonMethod'>
 
-const Ul = ({ nested, inside, outside, ...p }: UlAllProps = {}) => {
+const Ul = ({ nested, inside, outside, ...props }: UlAllProps = {}) => {
   return (
     <E
       as="ul"
-      {...p}
+      {...props}
       className={classnames(
-        p.className,
+        props.className,
         nested && 'dnb-ol--nested',
         inside && 'dnb-ol--inside',
         outside && 'dnb-ol--outside'

--- a/packages/dnb-eufemia/src/elements/lists/UlDocs.ts
+++ b/packages/dnb-eufemia/src/elements/lists/UlDocs.ts
@@ -1,5 +1,5 @@
 import { PropertiesTableProps } from '../../shared/types'
-import { ElementProperties } from './../ElementDocs'
+import { ElementPropertiesWithoutSkeleton } from './../ElementDocs'
 
 export const UlProperties: PropertiesTableProps = {
   inside: {
@@ -17,5 +17,5 @@ export const UlProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  ...ElementProperties,
+  ...ElementPropertiesWithoutSkeleton,
 }


### PR DESCRIPTION
As of today the following elements DL, UL, OL [say they have support](https://eufemia.dnb.no/uilib/elements/lists/properties/#ol-properties) for skeleton and skeletonMethod, but they don't as they internally in the component/element set skeleton to false(`skeleton=false`).

This PR removes docs and type support for skeleton(as it is not actually supported) in:
- Dl
- Ul
- Ol