### PR TITLE
chore: reduces unnecessary logs in NumberUtils test

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -80,6 +80,8 @@ describe('Decimals format', () => {
   })
 
   it('should handle unusual cases', () => {
+    global.console.log = jest.fn()
+
     expect(format(num, { decimals: 0 })).toBe('-12 346')
     expect(format(num, { decimals: 1 })).toBe('-12 345,7')
     expect(format(num, { decimals: 2 })).toBe('-12 345,68')
@@ -114,6 +116,7 @@ describe('Decimals format', () => {
     expect(format(undefined, { currency: 'non-valid value' })).toBe(
       'undefined'
     )
+    expect(global.console.log).toHaveBeenCalledTimes(4)
   })
 
   describe('rounding', () => {


### PR DESCRIPTION
Removes the following unnecessary logs:
```

 console.log
    Eufemia RangeError: Invalid currency code : non-valid value
        at Intl.NumberFormat (<anonymous>)
        at NumberFormat (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:1171:25)
        at formatToParts (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:551:16)
        at formatNumber (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:243:15)
        at Object.<anonymous> (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts:113:18)
        at Promise.then.completed (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:316:40)
        at _runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:121:9)
        at run (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:444:34)

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia Number could not be formatted: [null,"nb-NO",{"minimumFractionDigits":2,"maximumFractionDigits":2,"currency":"non-valid value","style":"currency","currencyDisplay":"name"}] RangeError: Invalid currency code : non-valid value
        at Number.toLocaleString (<anonymous>)
        at toLocaleString (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:558:35)
        at formatNumber (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:257:12)
        at Object.<anonymous> (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts:113:18)
        at Promise.then.completed (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:316:40)
        at _runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:121:9)
        at run (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:444:34)

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia RangeError: Invalid currency code : non-valid value
        at Intl.NumberFormat (<anonymous>)
        at NumberFormat (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:1171:25)
        at formatToParts (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:551:16)
        at formatNumber (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:243:15)
        at Object.<anonymous> (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts:114:18)
        at Promise.then.completed (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:316:40)
        at _runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:121:9)
        at run (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:444:34)

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia Number could not be formatted: [null,"nb-NO",{"minimumFractionDigits":2,"maximumFractionDigits":2,"currency":"non-valid value","style":"currency","currencyDisplay":"name"}] RangeError: Invalid currency code : non-valid value
        at Number.toLocaleString (<anonymous>)
        at toLocaleString (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:558:35)
        at formatNumber (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/NumberUtils.js:257:12)
        at Object.<anonymous> (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts:114:18)
        at Promise.then.completed (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:316:40)
        at _runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:121:9)
        at run (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/anderslangseth/dev/eufemia/node_modules/jest-config/node_modules/jest-runner/build/runTest.js:444:34)

      at log (src/shared/helpers.js:407:15)
```