### PR TITLE
chore: reduces unnecessary logs in Field.Date tests

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
@@ -251,7 +251,7 @@ export function convertStringToDate(
   date: string | Date,
   { date_format = null }: { date_format?: string | null } = {}
 ): Date {
-  if (!date) {
+  if (!date || date === 'undefined') {
     return null
   }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
@@ -251,7 +251,7 @@ export function convertStringToDate(
   date: string | Date,
   { date_format = null }: { date_format?: string | null } = {}
 ): Date {
-  if (!date || date === 'undefined') {
+  if (!date || date === 'undefined' || date === 'null') {
     return null
   }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
@@ -251,7 +251,7 @@ export function convertStringToDate(
   date: string | Date,
   { date_format = null }: { date_format?: string | null } = {}
 ): Date {
-  if (!date || date === 'undefined' || date === 'null') {
+  if (!date) {
     return null
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -95,12 +95,14 @@ function DateComponent(props: Props) {
       return { value: valueProp, startDate: undefined, endDate: undefined }
     }
 
-    const [startDate, endDate] = valueProp.split('|')
+    const [startDate, endDate] = valueProp
+      .split('|')
+      .map((value) => (/(undefined|null)/.test(value) ? undefined : value))
 
     return {
       value: undefined,
-      startDate: convertNullOrUndefinedString(startDate),
-      endDate: convertNullOrUndefinedString(endDate),
+      startDate,
+      endDate,
     }
   }, [range, valueProp])
 
@@ -143,18 +145,6 @@ function DateComponent(props: Props) {
       />
     </FieldBlock>
   )
-}
-
-function convertNullOrUndefinedString(value: string) {
-  if (value === 'undefined') {
-    return undefined
-  }
-
-  if (value === 'null') {
-    return null
-  }
-
-  return value
 }
 
 DateComponent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -78,7 +78,7 @@ function DateComponent(props: Props) {
     path,
     className,
     label,
-    value,
+    value: valueProp,
     help,
     hasError,
     disabled,
@@ -90,15 +90,19 @@ function DateComponent(props: Props) {
     range,
   } = useFieldProps(preparedProps)
 
-  const rangeValue = useMemo(() => {
-    if (!range) {
-      return
+  const { value, startDate, endDate } = useMemo(() => {
+    if (!range || !valueProp) {
+      return { value: valueProp, startDate: undefined, endDate: undefined }
     }
 
-    const [startDate, endDate] = value.split('|')
+    const [startDate, endDate] = valueProp.split('|')
 
-    return { startDate, endDate }
-  }, [range, value])
+    return {
+      value: undefined,
+      startDate: convertNullOrUndefinedString(startDate),
+      endDate: convertNullOrUndefinedString(endDate),
+    }
+  }, [range, valueProp])
 
   useMemo(() => {
     if (path && value) {
@@ -117,13 +121,13 @@ function DateComponent(props: Props) {
     <FieldBlock {...fieldBlockProps}>
       <DatePicker
         id={id}
-        date={!range ? value : undefined}
+        date={value}
         disabled={disabled}
         show_input={true}
         show_cancel_button={true}
         show_reset_button={true}
-        start_date={range ? rangeValue.startDate : undefined}
-        end_date={range ? rangeValue.endDate : undefined}
+        start_date={startDate}
+        end_date={endDate}
         status={hasError ? 'error' : undefined}
         suffix={
           help ? (
@@ -139,6 +143,18 @@ function DateComponent(props: Props) {
       />
     </FieldBlock>
   )
+}
+
+function convertNullOrUndefinedString(value: string) {
+  if (value === 'undefined') {
+    return undefined
+  }
+
+  if (value === 'null') {
+    return null
+  }
+
+  return value
 }
 
 DateComponent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -5,7 +5,7 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { DataContext, Field, FieldBlock, Form } from '../../..'
 
 describe('Field.Date', () => {
-  it('should render with props', () => {
+  it('should render without props', () => {
     render(<Field.Date />)
     expect(screen.getByLabelText('Dato')).toBeInTheDocument()
   })
@@ -126,7 +126,9 @@ describe('Field.Date', () => {
 
     describe('with validateUnchanged', () => {
       it('should show error message when blurring without any changes', async () => {
-        jest.spyOn(console, 'log').mockImplementationOnce(jest.fn()) // because of the invalid date
+        // Because of the invalid date
+        const log = jest.spyOn(console, 'log').mockImplementation()
+
         render(
           <Field.Date
             value="2023-12-0"
@@ -134,13 +136,19 @@ describe('Field.Date', () => {
             validateUnchanged
           />
         )
+
         const input = document.querySelector('input')
+
         expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
         input.focus()
         fireEvent.blur(input)
+
         await waitFor(() => {
           expect(screen.getByRole('alert')).toBeInTheDocument()
         })
+
+        log.mockRestore()
       })
     })
   })


### PR DESCRIPTION
I don't think this PR fixes anything, but rather highlights some kind of type mismatch or casting gone wrong in `Field.Date` component, as it comes a lot of string values with value `"undefined"` and `"null"` to the function.

It aims to fix all the console.logs when running `yarn test packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx` in `main` branch:

```
  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: undefined

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: null

      at log (src/shared/helpers.js:407:15)

  console.log
    Eufemia convertStringToDate got invalid date: 2023-12-0

      at console.<anonymous> (../../node_modules/jest-mock/build/index.js:794:25)

  console.log
    Eufemia convertStringToDate got invalid date: 2023-12-0
```