### PR TITLE
chore: improves wording in appearance

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
@@ -6,7 +6,7 @@ showTabs: true
 
 `Form.Appearance` is a provider for theming form fields.
 
-For now, it only provides theming of sizes of [base fields](/uilib/extensions/forms/base-fields/). See example below.
+For now, it only provides theming of sizes for [base fields](/uilib/extensions/forms/base-fields/) and all [feature fields](/uilib/extensions/forms/feature-fields/) that utilize them. See example below.
 
 You can nest `Form.Appearance` to provide different themes for different parts of the form.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
@@ -6,7 +6,7 @@ showTabs: true
 
 `Form.Appearance` is a provider for theming form fields.
 
-For now, it only provides theming of sizes of input fields, including Autocomplete and Dropdown. See example below.
+For now, it only provides theming of sizes of [base fields](/uilib/extensions/forms/base-fields/). See example below.
 
 You can nest `Form.Appearance` to provide different themes for different parts of the form.
 


### PR DESCRIPTION
This is not correct/finished.

The motivation behind this change is that when reading the [description](https://eufemia.dnb.no/uilib/extensions/forms/Form/Appearance/info/#description), I don't easily understand which Field.X-components I can use or not with the `Form.Appearance`.

The description doesn't use commonly known names in the forms world as base fields or feature fields, etc, but it rather says  `provides theming of sizes of input fields, including Autocomplete and Dropdown`, thoughts:
- What's input fields?
- Why do we mention the base Eufemia component Autocomplete, instead of the Field equivalent?
- Why do we mention the base Eufemia component Dropdown, instead of the Field equivalent?