### PR TITLE
feat(Forms): add `asyncFileHandler` to Field.Upload to support async file handling during upload

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -1,7 +1,11 @@
 import { Flex } from '@dnb/eufemia/src'
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
-import { Field, Form } from '@dnb/eufemia/src/extensions/forms'
-import { createMockFile } from '../../../../../../../docs/uilib/components/upload/Examples'
+import { Field, Form, Tools } from '@dnb/eufemia/src/extensions/forms'
+import {
+  createMockFile,
+  mockAsyncFileUpload,
+} from '../../../../../../../docs/uilib/components/upload/Examples'
+import useUpload from '@dnb/eufemia/src/components/upload/useUpload'
 
 export const BasicUsage = () => {
   return (
@@ -75,6 +79,39 @@ export const WithPath = () => {
       >
         <Field.Upload path="/myFiles" />
       </Form.Handler>
+    </ComponentBox>
+  )
+}
+
+export const WithAsyncFileHandler = () => {
+  return (
+    <ComponentBox scope={{ mockAsyncFileUpload, useUpload, Tools }}>
+      {() => {
+        const MyForm = () => {
+          return (
+            <Form.Handler onSubmit={async (form) => console.log(form)}>
+              <Flex.Stack>
+                <Field.Upload
+                  id="async_upload_context_id"
+                  path="/attachments"
+                  labelDescription="Upload multiple files at once to see the upload error message. This demo has been set up so that every other file in a batch will fail."
+                  asyncFileHandler={mockAsyncFileUpload}
+                  required
+                />
+                <Form.SubmitButton />
+              </Flex.Stack>
+              <Output />
+            </Form.Handler>
+          )
+        }
+
+        const Output = () => {
+          const { files } = useUpload('async_upload_context_id')
+          return <Tools.Log data={files} top />
+        }
+
+        return <MyForm />
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
@@ -25,3 +25,7 @@ import * as Examples from './Examples'
 ### Customized
 
 <Examples.Customized />
+
+### With asynchronous file handler
+
+<Examples.WithAsyncFileHandler />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
@@ -58,3 +58,36 @@ The `value` property represents an array with an object described above:
 ```tsx
 render(<Field.Upload value={files} />)
 ```
+
+## About the `asyncFileHandler` property
+
+The `asyncFileHandler` is an asynchronous callback function that takes newly added files as a parameter and returns a promise containing the processed files. The component will automatically handle loading states during the upload process. This feature is useful for tasks like uploading files to a virus checker, which returns a new file ID if the file passes the check. To indicate a failed upload, set the `errorMessage` on the specific file object with the desired message to display next to the file in the upload list.
+
+```js
+async function virusCheck(newFiles) {
+  const promises = newFiles.map(async (file) => {
+    const formData = new FormData()
+    formData.append('file', file.file, file.file.name)
+
+    return await fetch('/', { method: 'POST', body: formData })
+      .then((response) => {
+        if (response.ok) return response.json()
+        throw new Error('Unable to upload this file')
+      })
+      .then((data) => {
+        return {
+          ...file,
+          id: data.server_generated_id,
+        }
+      })
+      .catch((error) => {
+        return {
+          ...file,
+          errorMessage: error.message,
+        }
+      })
+  })
+
+  return await Promise.all(promises)
+}
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
@@ -61,7 +61,7 @@ render(<Field.Upload value={files} />)
 
 ## About the `asyncFileHandler` property
 
-The `asyncFileHandler` is an asynchronous callback function that takes newly added files as a parameter and returns a promise containing the processed files. The component will automatically handle loading states during the upload process. This feature is useful for tasks like uploading files to a virus checker, which returns a new file ID if the file passes the check. To indicate a failed upload, set the `errorMessage` on the specific file object with the desired message to display next to the file in the upload list.
+The `asyncFileHandler` is an asynchronous handler function that takes newly added files as a parameter and returns a promise containing the processed files. The component will automatically handle loading states during the upload process. This feature is useful for tasks like uploading files to a virus checker, which returns a new file ID if the file passes the check. To indicate a failed upload, set the `errorMessage` on the specific file object with the desired message to display next to the file in the upload list.
 
 ```js
 async function virusCheck(newFiles) {


### PR DESCRIPTION
Add support for asynchronously processing/handling files so a virus checker can be used with the Field.Upload component.