### PR TITLE
chore(Field.Upload): adds asyncFileHandler test

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
@@ -8,11 +8,6 @@ export const UploadFieldProperties: PropertiesTableProps = {
   ...UploadProperties,
   title: undefined,
   text: undefined,
-  asyncFileHandler: {
-    doc: 'Handler function that is triggered when new files are added to the upload field. Takes said new files as a parameter and returns a promise containing the processed files.',
-    type: 'function',
-    status: 'optional',
-  },
 }
 
 export const UploadFieldEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
@@ -8,6 +8,11 @@ export const UploadFieldProperties: PropertiesTableProps = {
   ...UploadProperties,
   title: undefined,
   text: undefined,
+  asyncFileHandler: {
+    doc: 'Handler function that is triggered when new files are added to the upload field. Takes said new files as a parameter and returns a promise containing the processed files.',
+    type: 'function',
+    status: 'optional',
+  },
 }
 
 export const UploadFieldEvents: PropertiesTableProps = {


### PR DESCRIPTION
Adds missing `asyncFileHandler` property from docs and adds test for mixed `asyncFileHandler`handler results