### PR TITLE
feat(Field.Upload): adds support for async and sync fn in `fileHandler`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
@@ -12,7 +12,6 @@ import {
   Section,
   Upload,
 } from '@dnb/eufemia/src'
-import { UploadValue } from '@dnb/eufemia/src/extensions/forms/Field/Upload'
 
 export function createMockFile(name: string, size: number, type: string) {
   const file = new File([], name, { type })
@@ -33,46 +32,6 @@ const useMockFiles = (setFiles, extend) => {
       },
     ])
   }, [])
-}
-
-export async function mockAsyncFileUpload(
-  newFiles: UploadValue,
-): Promise<UploadValue> {
-  const promises = newFiles.map(async (file, index) => {
-    const formData = new FormData()
-    formData.append('file', file.file, file.file.name)
-
-    await new Promise((resolve) =>
-      setTimeout(resolve, Math.floor(Math.random() * 2000) + 1000),
-    )
-
-    const mockResponse = {
-      ok: (index + 2) % 2 === 0, // Every other request will fail
-      json: async () => ({
-        server_generated_id: `${file.file.name}_${crypto.randomUUID()}`,
-      }),
-    }
-
-    return await Promise.resolve(mockResponse)
-      .then((res) => {
-        if (res.ok) return res.json()
-        throw new Error('Unable to upload this file')
-      })
-      .then((data) => {
-        return {
-          ...file,
-          id: data.server_generated_id,
-        }
-      })
-      .catch((error) => {
-        return {
-          ...file,
-          errorMessage: error.message,
-        }
-      })
-  })
-
-  return await Promise.all(promises)
 }
 
 export const UploadPrefilledFileList = () => (

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -13,7 +13,7 @@ breadcrumb:
 
 Change log for the Eufemia Forms extension.
 
-## v10.57
+## v10.56.1
 
 - Renamed `asyncFileHandler` to `fileHandler` in [Field.Upload](/uilib/extensions/forms/feature-fields/more-fields/Upload/), to support both async and sync file handling.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -13,6 +13,10 @@ breadcrumb:
 
 Change log for the Eufemia Forms extension.
 
+## v10.57
+
+- Renamed `asyncFileHandler` to `fileHandler` in [Field.Upload](/uilib/extensions/forms/feature-fields/more-fields/Upload/), to support both async and sync file handling.
+
 ## v10.56
 
 - Added inline help button (`help`) to all `Field.*` components as default (with option to open in Dialog).

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -109,7 +109,7 @@ export const WithAsyncFileHandler = () => {
         ): Promise<UploadValue> {
           const updatedFiles: UploadValue = []
 
-          for (const [index, file] of Object.entries(newFiles)) {
+          for (const [, file] of Object.entries(newFiles)) {
             const formData = new FormData()
             formData.append('file', file.file, file.file.name)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -1,11 +1,10 @@
 import { Flex } from '@dnb/eufemia/src'
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
 import { Field, Form, Tools } from '@dnb/eufemia/src/extensions/forms'
-import {
-  createMockFile,
-  mockAsyncFileUpload,
-} from '../../../../../../../docs/uilib/components/upload/Examples'
+import { createMockFile } from '../../../../../../../docs/uilib/components/upload/Examples'
 import useUpload from '@dnb/eufemia/src/components/upload/useUpload'
+import { UploadValue } from '@dnb/eufemia/src/extensions/forms/Field/Upload'
+import { createRequest } from '../../../Form/SubmitIndicator/Examples'
 
 export const BasicUsage = () => {
   return (
@@ -85,7 +84,7 @@ export const WithPath = () => {
 
 export const WithAsyncFileHandler = () => {
   return (
-    <ComponentBox scope={{ mockAsyncFileUpload, useUpload, Tools }}>
+    <ComponentBox scope={{ createRequest, useUpload, Tools }}>
       {() => {
         const MyForm = () => {
           return (
@@ -95,7 +94,7 @@ export const WithAsyncFileHandler = () => {
                   id="async_upload_context_id"
                   path="/attachments"
                   labelDescription="Upload multiple files at once to see the upload error message. This demo has been set up so that every other file in a batch will fail."
-                  asyncFileHandler={mockAsyncFileUpload}
+                  fileHandler={mockAsyncFileUpload}
                   required
                 />
                 <Form.SubmitButton />
@@ -105,8 +104,91 @@ export const WithAsyncFileHandler = () => {
           )
         }
 
+        async function mockAsyncFileUpload(
+          newFiles: UploadValue,
+        ): Promise<UploadValue> {
+          const updatedFiles: UploadValue = []
+
+          for (const [index, file] of Object.entries(newFiles)) {
+            const formData = new FormData()
+            formData.append('file', file.file, file.file.name)
+
+            const request = createRequest()
+            await request(Math.floor(Math.random() * 2000) + 1000) // Simulate a request
+
+            try {
+              const mockResponse = {
+                ok: false, // Fails virus check
+                json: async () => ({
+                  server_generated_id:
+                    file.file.name + '_' + crypto.randomUUID(),
+                }),
+              }
+
+              if (!mockResponse.ok) {
+                throw new Error('Unable to upload this file')
+              }
+
+              const data = await mockResponse.json()
+              updatedFiles.push({
+                ...file,
+                id: data.server_generated_id,
+              })
+            } catch (error) {
+              updatedFiles.push({
+                ...file,
+                errorMessage: error.message,
+              })
+            }
+          }
+
+          return updatedFiles
+        }
+
         const Output = () => {
           const { files } = useUpload('async_upload_context_id')
+          return <Tools.Log data={files} top />
+        }
+
+        return <MyForm />
+      }}
+    </ComponentBox>
+  )
+}
+
+export const WithSyncFileHandler = () => {
+  return (
+    <ComponentBox scope={{ createRequest, useUpload, Tools }}>
+      {() => {
+        const MyForm = () => {
+          return (
+            <Form.Handler onSubmit={async (form) => console.log(form)}>
+              <Flex.Stack>
+                <Field.Upload
+                  id="sync_upload_context_id"
+                  path="/myattachments"
+                  fileHandler={mockSyncFileUpload}
+                  required
+                />
+                <Form.SubmitButton />
+              </Flex.Stack>
+              <Output />
+            </Form.Handler>
+          )
+        }
+
+        function mockSyncFileUpload(newFiles: UploadValue) {
+          console.log(newFiles)
+          return newFiles.map((file) => {
+            if (file.file.name.length > 5) {
+              file.errorMessage = 'File length is too long'
+            }
+            return file
+          })
+        }
+
+        const Output = () => {
+          const { files } = useUpload('sync_upload_context_id')
           return <Tools.Log data={files} top />
         }
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
@@ -28,4 +28,12 @@ import * as Examples from './Examples'
 
 ### With asynchronous file handler
 
+The `fileHandler` property supports an asynchronous function, and can be used for handling/validating files asynchronously, like to upload files to a virus checker and display errors based on the outcome:
+
 <Examples.WithAsyncFileHandler />
+
+### With synchronous file handler
+
+The `fileHandler` property supports a synchronous function, and can be used for handling/validating files synchronously, like to check for file names that's too long:
+
+<Examples.WithSyncFileHandler />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
@@ -59,9 +59,10 @@ The `value` property represents an array with an object described above:
 render(<Field.Upload value={files} />)
 ```
 
-## About the `asyncFileHandler` property
+## About the `fileHandler` property
 
-The `asyncFileHandler` is an asynchronous handler function that takes newly added files as a parameter and returns a promise containing the processed files. The component will automatically handle loading states during the upload process. This feature is useful for tasks like uploading files to a virus checker, which returns a new file ID if the file passes the check. To indicate a failed upload, set the `errorMessage` on the specific file object with the desired message to display next to the file in the upload list.
+The `fileHandler` is a handler function that supports both an asynchronous and synchronous function. It takes newly added files as a parameter and returns processed files (a promise when asynchronous).
+The component will automatically handle asynchronous loading states during the upload process. This feature is useful for tasks like uploading files to a virus checker, which returns a new file ID if the file passes the check. To indicate a failed upload, set the `errorMessage` on the specific file object with the desired message to display next to the file in the upload list.
 
 ```js
 async function virusCheck(newFiles) {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
@@ -64,7 +64,7 @@ const validateRequired = (
 
 const updateFileLoadingState = (
   files: UploadValue,
-  { isLoading } = { isLoading: true }
+  { isLoading } = { isLoading: false }
 ) => {
   return files.map((file) => ({ ...file, isLoading }))
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/UploadDocs.ts
@@ -5,8 +5,8 @@ import {
 import { PropertiesTableProps } from '../../../../shared/types'
 
 export const UploadFieldProperties: PropertiesTableProps = {
-  asyncFileHandler: {
-    doc: 'Asynchronous handler function that takes newly added files (`newFiles: UploadValue`) as a parameter and returns a promise containing the processed files (`Promise<UploadValue>`).',
+  fileHandler: {
+    doc: 'File handler function that takes newly added files (`newFiles: UploadValue`) as a parameter and returns the processed files. The function can either be synchronous or asynchronous. It returns a promise (`Promise<UploadValue>`) containing the processed files when asynchronous.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -905,7 +905,51 @@ describe('Field.Upload', () => {
       ).toHaveTextContent(nbForms.Upload.errorRequired)
     })
 
-    it('should handle displaying error from asyncFileHandler', async () => {
+    it('should handle displaying error from fileHandler with sync function', async () => {
+      const fileValid = createMockFile('1.png', 100, 'image/png')
+      const fileInValid = createMockFile('invalid.png', 100, 'image/png')
+
+      const syncFileHandlerFnError = function mockSyncFileUpload(
+        newFiles: UploadValue
+      ) {
+        return newFiles.map((file) => {
+          if (file.file.name.length > 5) {
+            file.errorMessage = 'File length is too long'
+          }
+          return file
+        })
+      }
+
+      render(<Field.Upload fileHandler={syncFileHandlerFnError} />)
+
+      const element = getRootElement()
+
+      await waitFor(() =>
+        fireEvent.drop(element, {
+          dataTransfer: {
+            files: [fileValid],
+          },
+        })
+      )
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      await waitFor(() =>
+        fireEvent.drop(element, {
+          dataTransfer: {
+            files: [fileInValid],
+          },
+        })
+      )
+
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'File length is too long'
+      )
+    })
+
+    it('should handle displaying error from fileHandler with async function', async () => {
       const file = createMockFile('fileName-1.png', 100, 'image/png')
 
       const asyncValidatorResolvingWithErrorMessage = () =>
@@ -928,7 +972,7 @@ describe('Field.Upload', () => {
         asyncValidatorResolvingWithErrorMessage
       )
 
-      render(<Field.Upload asyncFileHandler={asyncFileHandlerFnError} />)
+      render(<Field.Upload fileHandler={asyncFileHandlerFnError} />)
 
       const element = getRootElement()
 
@@ -949,7 +993,7 @@ describe('Field.Upload', () => {
       })
     })
 
-    it('should handle displaying success from asyncFileHandler', async () => {
+    it('should handle displaying success from fileHandler with async function', async () => {
       const file = createMockFile('fileName-1.png', 100, 'image/png')
 
       const asyncValidatorResolvingWithSuccess = () =>
@@ -971,7 +1015,7 @@ describe('Field.Upload', () => {
         asyncValidatorResolvingWithSuccess
       )
 
-      render(<Field.Upload asyncFileHandler={asyncFileHandlerFnSuccess} />)
+      render(<Field.Upload fileHandler={asyncFileHandlerFnSuccess} />)
 
       const element = getRootElement()
 
@@ -992,16 +1036,14 @@ describe('Field.Upload', () => {
       })
     })
 
-    it('should display spinner when loading asyncFileHandler', async () => {
+    it('should display spinner when loading fileHandler with async function', async () => {
       const file = createMockFile('fileName-1.png', 100, 'image/png')
 
       const asyncValidatorResolvingWithSuccess = () =>
         new Promise<UploadValue>(() => jest.fn())
 
       render(
-        <Field.Upload
-          asyncFileHandler={asyncValidatorResolvingWithSuccess}
-        />
+        <Field.Upload fileHandler={asyncValidatorResolvingWithSuccess} />
       )
 
       const element = getRootElement()
@@ -1028,7 +1070,7 @@ describe('Field.Upload', () => {
       })
     })
 
-    it('should add new files from asyncFileHandler', async () => {
+    it('should add new files from fileHandler with async function', async () => {
       const fileExisting = createMockFile(
         'fileName-existing.png',
         100,
@@ -1071,7 +1113,7 @@ describe('Field.Upload', () => {
 
       render(
         <Field.Upload
-          asyncFileHandler={asyncFileHandlerFnSuccess}
+          fileHandler={asyncFileHandlerFnSuccess}
           value={[{ file: fileExisting }]}
         />
       )
@@ -1112,7 +1154,7 @@ describe('Field.Upload', () => {
       })
     })
 
-    it('should not add existing file using asyncFileHandler', async () => {
+    it('should not add existing file using fileHandler with async function', async () => {
       const file = createMockFile('fileName.png', 100, 'image/png')
 
       const asyncValidatorResolvingWithSuccess = () =>
@@ -1134,7 +1176,7 @@ describe('Field.Upload', () => {
 
       render(
         <Field.Upload
-          asyncFileHandler={asyncFileHandlerFnSuccess}
+          fileHandler={asyncFileHandlerFnSuccess}
           value={[{ file }]}
         />
       )
@@ -1160,7 +1202,7 @@ describe('Field.Upload', () => {
     })
   })
 
-  it('should handle a mix of successful and failed files in asyncFileHandler', async () => {
+  it('should handle a mix of successful and failed files in fileHandler with async function', async () => {
     const successFile = createMockFile('successFile.png', 100, 'image/png')
     const failFile = createMockFile('failFile.png', 100, 'image/png')
 
@@ -1187,7 +1229,7 @@ describe('Field.Upload', () => {
 
     const asyncFileHandlerFn = jest.fn(asyncValidatorWithMixedResults)
 
-    render(<Field.Upload asyncFileHandler={asyncFileHandlerFn} />)
+    render(<Field.Upload fileHandler={asyncFileHandlerFn} />)
 
     const element = getRootElement()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
@@ -3,28 +3,17 @@ import { Flex } from '../../../../../components'
 import useUpload from '../../../../../components/upload/useUpload'
 import { createRequest } from '../../../Form/Handler/stories/FormHandler.stories'
 import { UploadValue } from '../Upload'
-// import { createMockFile } from '../../../../../components/upload/__tests__/testHelpers'
 
 export default {
   title: 'Eufemia/Extensions/Forms/Upload',
 }
 
 export function Upload() {
-  // const { setFiles } = OriginalUpload.useUpload('unique-id')
-
-  // React.useEffect(() => {
-  //   setFiles([
-  // { file: createMockFile('fileName-1.png', 100, 'image/png') },
-  //   ])
-  // }, [setFiles])
-
   return (
     <Form.Handler
       top
       defaultData={{
-        myFiles: [
-          // { file: createMockFile('fileName-1.png', 100, 'image/png') },
-        ],
+        myFiles: [],
       }}
       onChange={(data) => {
         console.log('global onChange', data)
@@ -49,15 +38,6 @@ export function Upload() {
       </Flex.Stack>
     </Form.Handler>
   )
-}
-
-function mockSyncFileUpload(newFiles: UploadValue) {
-  return newFiles.map((file) => {
-    if (file.file.name.length > 5) {
-      file.errorMessage = 'File length is too long'
-    }
-    return file
-  })
 }
 
 async function mockAsyncFileUpload__withoutPromises(
@@ -112,7 +92,7 @@ export const WithAsyncFileHandler = () => {
           id="async_upload_context_id"
           path="/attachments"
           labelDescription="Upload multiple files at once to see the upload error message. This demo has been set up so that every other file in a batch will fail."
-          fileHandler={mockSyncFileUpload}
+          fileHandler={mockAsyncFileUpload__withoutPromises}
           required
         />
         <Form.SubmitButton />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
@@ -1,5 +1,8 @@
-import { Field, Form } from '../../..'
+import { Field, Form, Tools } from '../../..'
 import { Flex } from '../../../../../components'
+import useUpload from '../../../../../components/upload/useUpload'
+import { createRequest } from '../../../Form/Handler/stories/FormHandler.stories'
+import { UploadValue } from '../Upload'
 // import { createMockFile } from '../../../../../components/upload/__tests__/testHelpers'
 
 export default {
@@ -44,6 +47,77 @@ export function Upload() {
 
         <Form.SubmitButton />
       </Flex.Stack>
+    </Form.Handler>
+  )
+}
+
+function mockSyncFileUpload(newFiles: UploadValue) {
+  return newFiles.map((file) => {
+    if (file.file.name.length > 5) {
+      file.errorMessage = 'File length is too long'
+    }
+    return file
+  })
+}
+
+async function mockAsyncFileUpload__withoutPromises(
+  newFiles: UploadValue
+): Promise<UploadValue> {
+  const updatedFiles: UploadValue = []
+
+  for (const [index, file] of Object.entries(newFiles)) {
+    const formData = new FormData()
+    formData.append('file', file.file, file.file.name)
+
+    const request = createRequest()
+    await request(Math.floor(Math.random() * 2000) + 1000) // Simulate a request
+
+    try {
+      const mockResponse = {
+        ok: (parseFloat(index) + 2) % 2 === 0, // Every other request will fail
+        json: async () => ({
+          server_generated_id: `${file.file.name}_${crypto.randomUUID()}`,
+        }),
+      }
+
+      if (!mockResponse.ok) {
+        throw new Error('Unable to upload this file')
+      }
+
+      const data = await mockResponse.json()
+      updatedFiles.push({
+        ...file,
+        id: data.server_generated_id,
+      })
+    } catch (error: any) {
+      updatedFiles.push({
+        ...file,
+        errorMessage: error.message,
+      })
+    }
+  }
+
+  return updatedFiles
+}
+
+const Output = () => {
+  const { files } = useUpload('async_upload_context_id')
+  return <Tools.Log data={files} top />
+}
+export const WithAsyncFileHandler = () => {
+  return (
+    <Form.Handler onSubmit={async (form) => console.log(form)}>
+      <Flex.Stack>
+        <Field.Upload
+          id="async_upload_context_id"
+          path="/attachments"
+          labelDescription="Upload multiple files at once to see the upload error message. This demo has been set up so that every other file in a batch will fail."
+          fileHandler={mockSyncFileUpload}
+          required
+        />
+        <Form.SubmitButton />
+      </Flex.Stack>
+      <Output />
     </Form.Handler>
   )
 }


### PR DESCRIPTION
This PR:
- Renames `asyncFileHandler` -> `fileHandler`.
- Adds support for sync function in `fileHandler`.
- Adds test with error messages and sync function.
- Adds example of sync function.
- Updates examples and docs to match the new fileHandler which can have both a sync and async function.