### PR TITLE
chore(Foms): simplify upload example outupt

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -91,15 +91,14 @@ export const WithAsyncFileHandler = () => {
             <Form.Handler onSubmit={async (form) => console.log(form)}>
               <Flex.Stack>
                 <Field.Upload
-                  id="async_upload_context_id"
                   path="/attachments"
                   labelDescription="Upload multiple files at once to see the upload error message. This demo has been set up so that every other file in a batch will fail."
                   fileHandler={mockAsyncFileUpload}
                   required
                 />
                 <Form.SubmitButton />
+                <Tools.Log />
               </Flex.Stack>
-              <Output />
             </Form.Handler>
           )
         }
@@ -145,11 +144,6 @@ export const WithAsyncFileHandler = () => {
           return updatedFiles
         }
 
-        const Output = () => {
-          const { files } = useUpload('async_upload_context_id')
-          return <Tools.Log data={files} top />
-        }
-
         return <MyForm />
       }}
     </ComponentBox>
@@ -165,14 +159,13 @@ export const WithSyncFileHandler = () => {
             <Form.Handler onSubmit={async (form) => console.log(form)}>
               <Flex.Stack>
                 <Field.Upload
-                  id="sync_upload_context_id"
                   path="/myattachments"
                   fileHandler={mockSyncFileUpload}
                   required
                 />
                 <Form.SubmitButton />
+                <Tools.Log />
               </Flex.Stack>
-              <Output />
             </Form.Handler>
           )
         }
@@ -184,11 +177,6 @@ export const WithSyncFileHandler = () => {
             }
             return file
           })
-        }
-
-        const Output = () => {
-          const { files } = useUpload('sync_upload_context_id')
-          return <Tools.Log data={files} top />
         }
 
         return <MyForm />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, Form, Tools } from '../../..'
 import { Flex } from '../../../../../components'
-import useUpload from '../../../../../components/upload/useUpload'
 import { createRequest } from '../../../Form/Handler/stories/FormHandler.stories'
 import { UploadValue } from '../Upload'
 
@@ -80,10 +79,6 @@ async function mockAsyncFileUpload__withoutPromises(
   return updatedFiles
 }
 
-const Output = () => {
-  const { files } = useUpload('async_upload_context_id')
-  return <Tools.Log data={files} top />
-}
 export const WithAsyncFileHandler = () => {
   return (
     <Form.Handler onSubmit={async (form) => console.log(form)}>
@@ -96,8 +91,8 @@ export const WithAsyncFileHandler = () => {
           required
         />
         <Form.SubmitButton />
+        <Tools.Log />
       </Flex.Stack>
-      <Output />
     </Form.Handler>
   )
 }


### PR DESCRIPTION
Because a `path` is defined, we can omit the `data` property from Tools.Log, as it will use the data context.