### PR TITLE
ci: only run GitHub Actions on git commits

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,11 @@ on:
       - '!alpha'
   pull_request:
     branches:
-      - 'main'
+      - 'portal'
+      - 'release'
+      - 'beta'
+      - 'alpha'
+      - 'next'
     types: [opened]
 
 concurrency:

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'icon*/**'
-  pull_request:
-    branches:
-      - 'icon*/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,11 @@ on:
       - '!experiments/**'
   pull_request:
     branches:
-      - 'main'
+      - 'portal'
+      - 'release'
+      - 'beta'
+      - 'alpha'
+      - 'next'
     types: [opened]
 
 concurrency:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -14,7 +14,11 @@ on:
       - '!alpha'
   pull_request:
     branches:
-      - 'main'
+      - 'portal'
+      - 'release'
+      - 'beta'
+      - 'alpha'
+      - 'next'
     types: [opened]
 
 concurrency:


### PR DESCRIPTION
... except when opening a PR from main to release etc.

With that change, we lower the amount of unnecessary runs.
