### PR TITLE
feat(Forms): add `showConfirmDialog` to Iterate.RemoveButton

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -205,7 +205,7 @@ export const ArrayFromFormHandler = () => {
                 </Field.Composition>
 
                 <Iterate.Toolbar>
-                  <Iterate.RemoveButton confirm />
+                  <Iterate.RemoveButton showConfirmDialog />
                 </Iterate.Toolbar>
               </Iterate.AnimatedContainer>
             </Iterate.Array>
@@ -549,7 +549,7 @@ export const WithArrayValidator = () => {
                 width="medium"
                 size="medium"
               />
-              <Iterate.RemoveButton confirmRemove />
+              <Iterate.RemoveButton showConfirmDialog />
             </Flex.Horizontal>
           </Iterate.Array>
 
@@ -594,7 +594,7 @@ export const FilledViewAndEditContainer = () => {
                   <Iterate.EditContainer.CancelButton />
                 </Flex.Horizontal>
                 <Iterate.ViewContainer.RemoveButton
-                  confirmRemove
+                  showConfirmDialog
                   left={false}
                 />
               </Flex.Horizontal>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -205,7 +205,7 @@ export const ArrayFromFormHandler = () => {
                 </Field.Composition>
 
                 <Iterate.Toolbar>
-                  <Iterate.RemoveButton confirmRemove />
+                  <Iterate.RemoveButton confirm />
                 </Iterate.Toolbar>
               </Iterate.AnimatedContainer>
             </Iterate.Array>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -205,7 +205,7 @@ export const ArrayFromFormHandler = () => {
                 </Field.Composition>
 
                 <Iterate.Toolbar>
-                  <Iterate.RemoveButton />
+                  <Iterate.RemoveButton confirmRemove />
                 </Iterate.Toolbar>
               </Iterate.AnimatedContainer>
             </Iterate.Array>
@@ -549,7 +549,7 @@ export const WithArrayValidator = () => {
                 width="medium"
                 size="medium"
               />
-              <Iterate.RemoveButton />
+              <Iterate.RemoveButton confirmRemove />
             </Flex.Horizontal>
           </Iterate.Array>
 
@@ -593,7 +593,10 @@ export const FilledViewAndEditContainer = () => {
                   <Iterate.EditContainer.DoneButton />
                   <Iterate.EditContainer.CancelButton />
                 </Flex.Horizontal>
-                <Iterate.ViewContainer.RemoveButton left={false} />
+                <Iterate.ViewContainer.RemoveButton
+                  confirmRemove
+                  left={false}
+                />
               </Flex.Horizontal>
             </Iterate.Toolbar>
           )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
@@ -23,8 +23,8 @@ render(
 
 ## Confirm removal
 
-You can use the `confirmRemove` property to open a confirmation dialog before removing the item.
+You can use the `showConfirmDialog` property to open a confirmation dialog before removing the item.
 
 ```tsx
-<Iterate.RemoveButton confirmRemove />
+<Iterate.RemoveButton showConfirmDialog />
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
@@ -23,7 +23,7 @@ render(
 
 ## Confirm removal
 
-You can adding the `confirmRemove` property open a confirmation dialog before removing the item.
+You can use the `confirmRemove` property to open a confirmation dialog before removing the item.
 
 ```tsx
 <Iterate.RemoveButton confirmRemove />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/RemoveButton/info.mdx
@@ -20,3 +20,11 @@ render(
   </>,
 )
 ```
+
+## Confirm removal
+
+You can adding the `confirmRemove` property open a confirmation dialog before removing the item.
+
+```tsx
+<Iterate.RemoveButton confirmRemove />
+```

--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useCallback, useContext } from 'react'
 import classNames from 'classnames'
 import Button from '../../button/Button'
 import Space from '../../space/Space'
@@ -71,6 +71,25 @@ const DialogAction = ({
   const { close } = useContext(ModalContext)
   let childrenWithCloseFunc: Array<React.ReactChild>
 
+  const onConfirmHandler = useCallback(
+    (event) => {
+      dispatchCustomElementEvent({ onConfirm }, 'onConfirm', {
+        event,
+        close,
+      })
+    },
+    [close, onConfirm]
+  )
+  const onDeclineHandler = useCallback(
+    (event) => {
+      dispatchCustomElementEvent({ onDecline }, 'onDecline', {
+        event,
+        close,
+      })
+    },
+    [close, onDecline]
+  )
+
   if (children) {
     childrenWithCloseFunc = React.Children.map(children, (child) => {
       if (child.type === Button) {
@@ -105,12 +124,7 @@ const DialogAction = ({
         <Button
           text={declineText || translation?.Dialog?.declineText}
           variant="secondary"
-          onClick={(event) => {
-            dispatchCustomElementEvent({ onDecline }, 'onDecline', {
-              event,
-              close,
-            })
-          }}
+          onClick={onDeclineHandler}
           size={ButtonContext?.size || 'large'}
         />
       )}
@@ -118,12 +132,7 @@ const DialogAction = ({
         <Button
           text={confirmText || translation?.Dialog?.confirmText}
           variant="primary"
-          onClick={(event) => {
-            dispatchCustomElementEvent({ onConfirm }, 'onConfirm', {
-              event,
-              close,
-            })
-          }}
+          onClick={onConfirmHandler}
           size={ButtonContext?.size || 'large'}
         />
       )}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
@@ -165,8 +165,8 @@ function ArrayItemArea(props: Props & FlexContainerProps) {
       //
     }
     isRemoving.current = true
-    handleRemove?.({ keepItems: true })
     setOpenState(false)
+    handleRemove?.({ keepItems: true })
   }, [handleRemove, index, setOpenState])
 
   return (

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
@@ -13,7 +13,7 @@ import { trash } from '../../../../icons'
 
 export type Props = ButtonProps &
   DataValueReadWriteComponentProps<unknown[]> & {
-    confirmRemove?: boolean
+    showConfirmDialog?: boolean
   }
 
 function RemoveButton(props: Props) {
@@ -24,7 +24,8 @@ function RemoveButton(props: Props) {
     throw new Error('RemoveButton must be inside an Iterate.Array')
   }
 
-  const { text, children, className, confirmRemove, ...restProps } = props
+  const { text, children, className, showConfirmDialog, ...restProps } =
+    props
   const buttonProps = omitDataValueReadWriteProps(restProps)
   const translation = useTranslation().RemoveButton
   const textContent = text || children || translation.text
@@ -52,7 +53,7 @@ function RemoveButton(props: Props) {
     ...buttonProps,
   }
 
-  if (confirmRemove) {
+  if (showConfirmDialog) {
     return (
       <Dialog
         variant="confirmation"

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
@@ -33,13 +33,18 @@ function RemoveButton(props: Props) {
   const elementBlockContext = useContext(ArrayItemAreaContext)
   const { handleRemoveItem } = elementBlockContext || {}
 
-  const handleClick = useCallback(() => {
-    if (handleRemoveItem) {
-      handleRemoveItem?.()
-    } else {
-      handleRemove?.()
-    }
-  }, [handleRemove, handleRemoveItem])
+  const handleClick = useCallback(
+    ({ close }) => {
+      close?.()
+
+      if (handleRemoveItem) {
+        handleRemoveItem?.()
+      } else {
+        handleRemove?.()
+      }
+    },
+    [handleRemove, handleRemoveItem]
+  )
 
   const triggerAttributes: ButtonProps = {
     className: classnames(
@@ -57,11 +62,10 @@ function RemoveButton(props: Props) {
     return (
       <Dialog
         variant="confirmation"
+        title={translation.confirmRemoveText}
         triggerAttributes={triggerAttributes}
         onConfirm={handleClick}
-      >
-        {translation.confirmRemoveText}
-      </Dialog>
+      />
     )
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext } from 'react'
 import classnames from 'classnames'
-import { Button } from '../../../../components'
+import { Button, Dialog } from '../../../../components'
 import { ButtonProps } from '../../../../components/Button'
 import IterateItemContext from '../IterateItemContext'
 import { useTranslation } from '../../hooks'
@@ -12,7 +12,9 @@ import {
 import { trash } from '../../../../icons'
 
 export type Props = ButtonProps &
-  DataValueReadWriteComponentProps<unknown[]>
+  DataValueReadWriteComponentProps<unknown[]> & {
+    confirmRemove?: boolean
+  }
 
 function RemoveButton(props: Props) {
   const iterateItemContext = useContext(IterateItemContext)
@@ -22,7 +24,7 @@ function RemoveButton(props: Props) {
     throw new Error('RemoveButton must be inside an Iterate.Array')
   }
 
-  const { text, children, className, ...restProps } = props
+  const { text, children, className, confirmRemove, ...restProps } = props
   const buttonProps = omitDataValueReadWriteProps(restProps)
   const translation = useTranslation().RemoveButton
   const textContent = text || children || translation.text
@@ -38,20 +40,36 @@ function RemoveButton(props: Props) {
     }
   }, [handleRemove, handleRemoveItem])
 
+  const triggerAttributes: ButtonProps = {
+    className: classnames(
+      'dnb-forms-iterate-remove-element-button',
+      className
+    ),
+    text: textContent,
+    variant: textContent ? 'tertiary' : 'secondary',
+    icon: trash,
+    icon_position: 'left',
+    ...buttonProps,
+  }
+
+  if (confirmRemove) {
+    return (
+      <Dialog
+        variant="confirmation"
+        triggerAttributes={triggerAttributes}
+        onConfirm={handleClick}
+      >
+        {translation.confirmRemoveText}
+      </Dialog>
+    )
+  }
+
   return (
     <Button
-      className={classnames(
-        'dnb-forms-iterate-remove-element-button',
-        className
-      )}
-      variant={textContent ? 'tertiary' : 'secondary'}
-      icon={trash}
-      icon_position="left"
+      {...triggerAttributes}
       on_click={handleClick}
       {...buttonProps}
-    >
-      {textContent}
-    </Button>
+    />
   )
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
@@ -1,6 +1,11 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 
 export const RemoveButtonProperties: PropertiesTableProps = {
+  confirmRemove: {
+    doc: 'Use `true` to show a confirmation dialog before removing the item.',
+    type: 'boolean',
+    status: 'optional',
+  },
   '[Button](/uilib/components/button/properties)': {
     doc: 'All button properties.',
     type: 'Various',

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
@@ -1,7 +1,7 @@
 import { PropertiesTableProps } from '../../../../shared/types'
 
 export const RemoveButtonProperties: PropertiesTableProps = {
-  confirmRemove: {
+  showConfirmDialog: {
     doc: 'Use `true` to show a confirmation dialog before removing the item.',
     type: 'boolean',
     status: 'optional',

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import IterateItemContext from '../../IterateItemContext'
 import RemoveButton from '../RemoveButton'
 import nbNO from '../../../constants/locales/nb-NO'
@@ -15,6 +16,10 @@ describe('RemoveButton', () => {
       {children}
     </IterateItemContext.Provider>
   )
+
+  afterEach(() => {
+    handleRemove.mockReset()
+  })
 
   it('should call handleRemove when clicked inside an Iterate element', () => {
     render(<RemoveButton>Remove Button</RemoveButton>, { wrapper })
@@ -119,5 +124,33 @@ describe('RemoveButton', () => {
     )
 
     expect(screen.getByText(remove)).toBeInTheDocument()
+  })
+
+  describe('confirmRemove', () => {
+    it('should show Dialog before removing', async () => {
+      render(<RemoveButton confirmRemove />, { wrapper })
+
+      await userEvent.click(document.querySelector('button'))
+
+      expect(handleRemove).toHaveBeenCalledTimes(0)
+
+      await userEvent.click(
+        document.querySelector(
+          '.dnb-dialog__inner button.dnb-button--primary'
+        )
+      )
+
+      expect(handleRemove).toHaveBeenCalledTimes(1)
+    })
+
+    it('should show Dialog with translation before removing', async () => {
+      render(<RemoveButton confirmRemove />, { wrapper })
+
+      await userEvent.click(document.querySelector('button'))
+
+      expect(
+        document.querySelector('.dnb-dialog__inner')
+      ).toHaveTextContent(nb.confirmRemoveText)
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/__tests__/RemoveButton.test.tsx
@@ -126,9 +126,9 @@ describe('RemoveButton', () => {
     expect(screen.getByText(remove)).toBeInTheDocument()
   })
 
-  describe('confirmRemove', () => {
+  describe('showConfirmDialog', () => {
     it('should show Dialog before removing', async () => {
-      render(<RemoveButton confirmRemove />, { wrapper })
+      render(<RemoveButton showConfirmDialog />, { wrapper })
 
       await userEvent.click(document.querySelector('button'))
 
@@ -144,7 +144,7 @@ describe('RemoveButton', () => {
     })
 
     it('should show Dialog with translation before removing', async () => {
-      render(<RemoveButton confirmRemove />, { wrapper })
+      render(<RemoveButton showConfirmDialog />, { wrapper })
 
       await userEvent.click(document.querySelector('button'))
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -33,6 +33,7 @@ export default {
     },
     RemoveButton: {
       text: 'Remove',
+      confirmRemoveText: 'Are you sure you want to delete this?',
     },
     SectionViewContainer: {
       editButton: 'Edit',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -32,7 +32,7 @@ export default {
     },
     RemoveButton: {
       text: 'Fjern',
-      confirmRemoveText: 'Er du sikker på at du vil slette dette?',
+      confirmRemoveText: 'Er du sikker på at du vil slette?',
     },
     SectionViewContainer: {
       editButton: 'Endre',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -32,6 +32,7 @@ export default {
     },
     RemoveButton: {
       text: 'Fjern',
+      confirmRemoveText: 'Er du sikker på at du vil slette dette?',
     },
     SectionViewContainer: {
       editButton: 'Endre',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -32,7 +32,7 @@ export default {
     },
     RemoveButton: {
       text: 'Fjern',
-      confirmRemoveText: 'Er du sikker på at du vil slette?',
+      confirmRemoveText: 'Er du sikker på at du vil slette dette?',
     },
     SectionViewContainer: {
       editButton: 'Endre',


### PR DESCRIPTION
Based on #4329

Here is a PR [Preview](https://eufemia-git-feat-forms-confirm-remove-eufemia.vercel.app/uilib/extensions/forms/Iterate/Array/demos/#customize-the-view-and-edit-containers).