### PR TITLE
feat(Forms): introduce `decoupleForm` prop to Form.Handler

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Handler'
-description: '`Form.Handler` provides both the DataContext.Provider and a HTML form element.'
+description: 'The `Form.Handler` is the root component of your form. It provides a HTML form element and handles the form data.'
 showTabs: true
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -7,32 +7,57 @@ import AsyncChangeExample from './parts/async-change-example.mdx'
 
 ## Description
 
-The `Form.Handler` component provides a HTML form element.
+The `Form.Handler` is the root component of your form. It provides a HTML form element and handles the form data.
 
 ```jsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
-render(
-  <Form.Handler
-    data={existingData}
-    onChange={...}
-    onSubmit={...}
-  >
-    Your Form
-  </Form.Handler>,
-)
+const existingData = { firstName: 'Nora' }
+
+function MyForm() {
+  return (
+    <Form.Handler
+      defaultData={existingData}
+      onSubmit={...}
+    >
+      Your Form
+    </Form.Handler>
+  )
+}
+```
+
+## Decoupling the form element
+
+For more flexibility, you can decouple the form element from the form context by using the `decoupleFormElement` property. It is recommended to use the `Form.Element` to wrap your rest of your form:
+
+```jsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+function MyApp() {
+  return (
+    <Form.Handler decoupleFormElement>
+      <AppRelatedThings>
+        <Form.Element>
+          <Form.MainHeading>Heading</Form.MainHeading>
+          <Form.Card>
+            <Field.Email />
+          </Form.Card>
+          <Form.SubmitButton />
+        </Form.Element>
+      </AppRelatedThings>
+    </Form.Handler>
+  )
+}
 ```
 
 ## Data handling
 
-The form data can be handled outside of the form. This is useful if you want to use the form data in other components:
+You can access, mutate and filter data inside of the form context by using the `Form.useData` hook:
 
 ```jsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
-const myFormId = 'unique-id' // or a function, object or React Context reference
-
-function MyForm() {
+function MyComponent() {
   const {
     getValue,
     update,
@@ -41,9 +66,18 @@ function MyForm() {
     data,
     filterData,
     reduceToVisibleFields,
-  } = Form.useData(myFormId)
+  } = Form.useData()
 
-  return <Form.Handler id={myFormId}>...</Form.Handler>
+  return <>...</>
+}
+
+function MyApp() {
+  return (
+    <>
+      <Form.Handler>...</Form.Handler>
+      <MyComponent />
+    </>
+  )
 }
 ```
 
@@ -54,6 +88,31 @@ function MyForm() {
 - `data` will return the whole dataset (unvalidated).
 - `filterData` will filter the data based on your own logic.
 - `reduceToVisibleFields` will reduce the given data set to only contain the visible fields (mounted fields).
+
+### Using a form ID
+
+The form data can be handled outside of the form. This is useful if you want to use the form data in other components:
+
+```jsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+const myFormId = 'unique-id' // or a function, object or React Context reference
+
+function MyComponent() {
+  const { data } = Form.useData(myFormId)
+
+  return <>...</>
+}
+
+function MyApp() {
+  return (
+    <>
+      <Form.Handler id={myFormId}>...</Form.Handler>
+      <MyComponent />
+    </>
+  )
+}
+```
 
 More examples can be found in the [useData](/uilib/extensions/forms/Form/useData/) hook docs.
 
@@ -76,7 +135,7 @@ const data: MyDataSet = {
 function MyForm() {
   return (
     <Form.Handler
-      data={data}
+      defaultData={data}
       onSubmit={(data) => {
         console.log(data.firstName)
       }}
@@ -89,7 +148,7 @@ const submitHandler = (data: MyDataSet) => {
   console.log(data.firstName)
 }
 function MyForm() {
-  return <Form.Handler data={data} onSubmit={submitHandler} />
+  return <Form.Handler defaultData={data} onSubmit={submitHandler} />
 }
 
 // Method #3
@@ -98,7 +157,7 @@ const submitHandler: OnSubmit<MyDataSet> = (data) => {
   console.log(data.firstName)
 }
 function MyForm() {
-  return <Form.Handler data={data} onSubmit={submitHandler} />
+  return <Form.Handler defaultData={data} onSubmit={submitHandler} />
 }
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/info.mdx
@@ -6,14 +6,30 @@ showTabs: true
 
 `Form` provides the main forms-helpers including data provider and event handling.
 
-```jsx
+```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
-render(
-  <Form.Handler data={existingData} onSubmit={submitHandler}>
-    <Field.Email path="/email" />
-    <Form.ButtonRow>
-      <Form.SubmitButton />
-    </Form.ButtonRow>
-  </Form.Handler>,
-)
+
+const existingData = {
+  email: 'name@email.no',
+}
+
+function MyForm() {
+  return (
+    <Form.Handler
+      defaultData={existingData}
+      onSubmit={async (data) => {
+        await makeRequest(data)
+      }}
+    >
+      <Form.MainHeading>Heading</Form.MainHeading>
+      <Form.Card>
+        <Field.Email path="/email" />
+      </Form.Card>
+
+      <Form.ButtonRow>
+        <Form.SubmitButton />
+      </Form.ButtonRow>
+    </Form.Handler>
+  )
+}
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/all-features.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/all-features.mdx
@@ -56,7 +56,7 @@ const submitHandler = async (data) => {
 
 function Component() {
   return (
-    <Form.Handler data={existingData} onSubmit={submitHandler}>
+    <Form.Handler defaultData={existingData} onSubmit={submitHandler}>
       <Field.Email path="/email" />
       <Value.Date path="/date" />
       <Form.SubmitButton />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -231,16 +231,16 @@ You may check out an [interactive example](/uilib/extensions/forms/Form/useData/
 For filtering data during form submit (`onSubmit`), you can use the `filterData` method given as a parameter to the `onSubmit` event callback:
 
 ```tsx
-const onSubmit = (data, { filterData }) => {
-  // Same method as in the previous example
-  const filteredDataA = filterData(filterDataPaths)
-  const filteredDataB = filterData(filterDataHandler)
-  console.log(filteredDataA)
-  console.log(filteredDataB)
-}
-
 render(
-  <Form.Handler onSubmit={onSubmit}>
+  <Form.Handler
+    onSubmit={(data, { filterData }) => {
+      // Same method as in the previous example
+      const filteredDataA = filterData(filterDataPaths)
+      const filteredDataB = filterData(filterDataHandler)
+      console.log(filteredDataA)
+      console.log(filteredDataB)
+    }}
+  >
     <Field.String path="/foo" />
   </Form.Handler>,
 )
@@ -428,7 +428,7 @@ Eufemia Forms will easily link up with the [GlobalStatus](/uilib/components/glob
 ```tsx
 <GlobalStatus />
 
-<Form.Handler >
+<Form.Handler>
   My Form
 </Form.Handler>
 ```

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -181,8 +181,10 @@ export interface ContextState {
   disabled?: boolean
   required?: boolean
   submitState: Partial<EventStateObject>
-  isInsideFormElement?: boolean
   prerenderFieldProps?: boolean
+  decoupleFormElement?: boolean
+  hasElementRef?: React.MutableRefObject<boolean>
+  restHandlerProps?: Record<string, unknown>
   props: ProviderProps<unknown>
 }
 
@@ -211,7 +213,6 @@ export const defaultContextState: ContextState = {
   hasFieldError: () => false,
   ajvInstance: makeAjvInstance(),
   contextErrorMessages: undefined,
-  isInsideFormElement: false,
   props: null,
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -73,122 +73,122 @@ export type SharedAttachments<Data = unknown> = {
   fieldConnectionsRef?: ContextState['fieldConnectionsRef']
 }
 
-export interface Props<Data extends JsonObject>
-  extends IsolationProviderProps<Data> {
-  /**
-   * Unique ID to communicate with the hook Form.useData
-   */
-  id?: SharedStateId
-  /**
-   * Unique ID to connect with a GlobalStatus
-   */
-  globalStatusId?: string
-  /**
-   * Source data, will be used instead of defaultData, and leading to updates if changed after mount
-   */
-  data?: Data
-  /**
-   * Default source data, only used if no other source is available, and not leading to updates if changed after mount
-   */
-  defaultData?: Data
-  /**
-   * Empty data, used to clear the data set.
-   */
-  emptyData?: unknown
-  /**
-   * JSON Schema to validate the data against.
-   */
-  schema?: AllJSONSchemaVersions<Data>
-  /**
-   * Custom Ajv instance, if you want to use your own
-   */
-  ajvInstance?: Ajv
-  /**
-   * Custom error messages for the whole data set
-   */
-  errorMessages?: GlobalErrorMessagesWithPaths
-  /**
-   * @deprecated Use the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
-   */
-  filterSubmitData?: FilterData
-  /**
-   * Transform the data context (internally as well) based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
-   */
-  transformIn?: TransformData
-  /**
-   * Mutate the data before it enters onSubmit or onChange based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
-   */
-  transformOut?: TransformData
-  /**
-   * Change handler for the whole data set.
-   * You can provide an async function to show an indicator on the current label during a field change.
-   */
-  onChange?: OnChange<Data>
-  /**
-   * Change handler for each value
-   */
-  onPathChange?: (
-    path: Path,
-    value: unknown
-  ) =>
-    | EventReturnWithStateObject
-    | void
-    | Promise<EventReturnWithStateObject | void>
-  /**
-   * Will emit on a form submit – if validation has passed.
-   * You can provide an async function to shows a submit indicator during submit. All form elements will be disabled during the submit.
-   */
-  onSubmit?: OnSubmit<Data>
-  /**
-   * Submit was requested, but data was invalid
-   */
-  onSubmitRequest?: () => void
-  /**
-   * Will be called when the onSubmit is finished and had not errors
-   */
-  onSubmitComplete?: (
-    data: Data,
+export type Props<Data extends JsonObject> =
+  IsolationProviderProps<Data> & {
     /**
-     * The result of the onSubmit function
+     * Unique ID to communicate with the hook Form.useData
      */
-    result: unknown
-  ) =>
-    | EventReturnWithStateObject
-    | void
-    | Promise<EventReturnWithStateObject | void>
-  /**
-   * Minimum time to display the submit indicator.
-   */
-  minimumAsyncBehaviorTime?: number
-  /**
-   * The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission.
-   */
-  asyncSubmitTimeout?: number
-  /**
-   * Scroll to top on submit
-   */
-  scrollTopOnSubmit?: boolean
-  /**
-   * Key for caching the data in session storage
-   */
-  sessionStorageId?: string
-  /**
-   * Locale to use for all nested Eufemia components
-   */
-  locale?: ContextProps['locale']
-  /**
-   * Provide your own translations. Use the same format as defined in the translation files
-   */
-  translations?: ContextProps['translations']
-  /**
-   * Make all fields required
-   */
-  required?: boolean
-  /**
-   * The children of the context provider
-   */
-  children: React.ReactNode
-}
+    id?: SharedStateId
+    /**
+     * Unique ID to connect with a GlobalStatus
+     */
+    globalStatusId?: string
+    /**
+     * Source data, will be used instead of defaultData, and leading to updates if changed after mount
+     */
+    data?: Data
+    /**
+     * Default source data, only used if no other source is available, and not leading to updates if changed after mount
+     */
+    defaultData?: Data
+    /**
+     * Empty data, used to clear the data set.
+     */
+    emptyData?: unknown
+    /**
+     * JSON Schema to validate the data against.
+     */
+    schema?: AllJSONSchemaVersions<Data>
+    /**
+     * Custom Ajv instance, if you want to use your own
+     */
+    ajvInstance?: Ajv
+    /**
+     * Custom error messages for the whole data set
+     */
+    errorMessages?: GlobalErrorMessagesWithPaths
+    /**
+     * @deprecated Use the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
+     */
+    filterSubmitData?: FilterData
+    /**
+     * Transform the data context (internally as well) based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
+     */
+    transformIn?: TransformData
+    /**
+     * Mutate the data before it enters onSubmit or onChange based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
+     */
+    transformOut?: TransformData
+    /**
+     * Change handler for the whole data set.
+     * You can provide an async function to show an indicator on the current label during a field change.
+     */
+    onChange?: OnChange<Data>
+    /**
+     * Change handler for each value
+     */
+    onPathChange?: (
+      path: Path,
+      value: unknown
+    ) =>
+      | EventReturnWithStateObject
+      | void
+      | Promise<EventReturnWithStateObject | void>
+    /**
+     * Will emit on a form submit – if validation has passed.
+     * You can provide an async function to shows a submit indicator during submit. All form elements will be disabled during the submit.
+     */
+    onSubmit?: OnSubmit<Data>
+    /**
+     * Submit was requested, but data was invalid
+     */
+    onSubmitRequest?: () => void
+    /**
+     * Will be called when the onSubmit is finished and had not errors
+     */
+    onSubmitComplete?: (
+      data: Data,
+      /**
+       * The result of the onSubmit function
+       */
+      result: unknown
+    ) =>
+      | EventReturnWithStateObject
+      | void
+      | Promise<EventReturnWithStateObject | void>
+    /**
+     * Minimum time to display the submit indicator.
+     */
+    minimumAsyncBehaviorTime?: number
+    /**
+     * The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission.
+     */
+    asyncSubmitTimeout?: number
+    /**
+     * Scroll to top on submit
+     */
+    scrollTopOnSubmit?: boolean
+    /**
+     * Key for caching the data in session storage
+     */
+    sessionStorageId?: string
+    /**
+     * Locale to use for all nested Eufemia components
+     */
+    locale?: ContextProps['locale']
+    /**
+     * Provide your own translations. Use the same format as defined in the translation files
+     */
+    translations?: ContextProps['translations']
+    /**
+     * Make all fields required
+     */
+    required?: boolean
+    /**
+     * The children of the context provider
+     */
+    children: React.ReactNode
+  }
 
 const isArrayJsonPointer = /^\/\d+(\/|$)/
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Element/__tests__/Element.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Element/__tests__/Element.test.tsx
@@ -56,7 +56,11 @@ describe('Form.Element', () => {
       { foo: 'Value' },
       expect.anything()
     )
+
     expect(onSubmitElement).toHaveBeenCalledTimes(1)
+    expect(onSubmitElement).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'submit', target: inputElement })
+    )
 
     fireEvent.click(buttonElement)
 
@@ -65,8 +69,8 @@ describe('Form.Element', () => {
       { foo: 'Value' },
       expect.anything()
     )
-    expect(onSubmitElement).toHaveBeenCalledTimes(2)
 
+    expect(onSubmitElement).toHaveBeenCalledTimes(2)
     expect(onSubmitElement).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'submit', target: inputElement })
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -1,125 +1,96 @@
-import React, { useContext } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { JsonObject } from '../../utils/json-pointer'
+import { warn } from '../../../../shared/helpers'
 import DataContextProvider, {
   Props as ProviderProps,
 } from '../../DataContext/Provider'
-import DataContext from '../../DataContext/Context'
-import FormElement from '../Element'
-import type { ElementAllProps } from '../../../../elements/Element'
-import FormStatus from '../../../../components/FormStatus'
-import useId from '../../../../shared/helpers/useId'
-import { combineLabelledBy } from '../../../../shared/component-helper'
+import FormElement, { Props as FormElementProps } from '../Element'
+import { ContextState } from '../../DataContext'
 
-export type Props = Omit<
-  ElementAllProps,
-  'data' | 'as' | 'autoComplete'
-> & {
+export type Props = FormElementProps & {
   /**
    * Will enable autoComplete for all nested Field.String fields
    */
   autoComplete?: boolean
+
+  /**
+   * Will decouple the form element from rendering
+   */
+  decoupleFormElement?: boolean
 }
 
-export default function FormHandler<Data extends JsonObject>({
-  children,
-  defaultData,
-  data,
-  schema,
-  ajvInstance,
-  errorMessages,
-  globalStatusId,
-  filterSubmitData,
-  transformIn,
-  transformOut,
-  onChange,
-  onPathChange,
-  onSubmit,
-  onSubmitRequest,
-  onSubmitComplete,
-  onClear,
-  minimumAsyncBehaviorTime,
-  asyncSubmitTimeout,
-  scrollTopOnSubmit,
-  sessionStorageId,
-  autoComplete,
-  locale,
-  translations,
-  disabled,
-  required,
-  ...rest
-}: ProviderProps<Data> & Omit<Props, keyof ProviderProps<Data>>) {
+type AllowedProviderContextProps = ProviderProps<unknown> &
+  Pick<Props, 'decoupleFormElement' | 'autoComplete' | 'disabled'> &
+  Pick<ContextState, 'restHandlerProps' | 'hasElementRef'>
+
+const allowedProviderContextProps: Array<
+  keyof AllowedProviderContextProps
+> = [
+  'id',
+  'defaultData',
+  'data',
+  'schema',
+  'ajvInstance',
+  'errorMessages',
+  'globalStatusId',
+  'filterSubmitData',
+  'transformIn',
+  'transformOut',
+  'onChange',
+  'onPathChange',
+  'onSubmit',
+  'onSubmitRequest',
+  'onSubmitComplete',
+  'onClear',
+  'minimumAsyncBehaviorTime',
+  'asyncSubmitTimeout',
+  'scrollTopOnSubmit',
+  'sessionStorageId',
+  'locale',
+  'translations',
+  'autoComplete',
+  'disabled',
+  'required',
+  'decoupleFormElement',
+  'restHandlerProps',
+]
+
+export default function FormHandler<Data extends JsonObject>(
+  props: ProviderProps<Data> & Omit<Props, keyof ProviderProps<Data>>
+) {
+  const { decoupleFormElement, children } = props
+
+  const hasElementRef = useRef(false)
+  useEffect(() => {
+    if (decoupleFormElement && !hasElementRef.current) {
+      warn('Please include a Form.Element when using decoupleFormElement!')
+    }
+  }, [decoupleFormElement])
+
   const providerProps = {
-    id: rest.id,
-    defaultData,
-    data,
-    schema,
-    ajvInstance,
-    errorMessages,
-    globalStatusId,
-    filterSubmitData,
-    transformIn,
-    transformOut,
-    onChange,
-    onPathChange,
-    onSubmit,
-    onSubmitRequest,
-    onSubmitComplete,
-    onClear,
-    minimumAsyncBehaviorTime,
-    asyncSubmitTimeout,
-    scrollTopOnSubmit,
-    sessionStorageId,
-    autoComplete,
-    locale,
-    translations,
-    disabled,
-    required,
+    hasElementRef,
+    restHandlerProps: {},
+  } as AllowedProviderContextProps
+
+  for (const key in props) {
+    if (
+      allowedProviderContextProps.includes(
+        key as keyof AllowedProviderContextProps
+      )
+    ) {
+      providerProps[key] = props[key]
+    } else if (key !== 'children') {
+      providerProps.restHandlerProps[key] = props[key]
+    }
   }
 
   return (
     <DataContextProvider {...providerProps}>
-      <FormElementWithState {...rest}>{children}</FormElementWithState>
+      {decoupleFormElement ? (
+        children
+      ) : (
+        <FormElement>{children}</FormElement>
+      )}
     </DataContextProvider>
-  )
-}
-
-function FormElementWithState({ children, ...rest }) {
-  const id = useId()
-  const { submitState } = useContext(DataContext) || {}
-  const states = Object.entries(submitState || {}).filter(
-    ([, value]) => value
-  )
-
-  return (
-    <FormElement
-      {...rest}
-      aria-labelledby={
-        combineLabelledBy(
-          rest,
-          states.map(([key]) => {
-            return `${id}-form-status-${key}`
-          })
-        ) || undefined
-      }
-    >
-      {children}
-
-      {['error', 'warning', 'info'].map((key) => {
-        const value = submitState?.[key]
-        return (
-          <FormStatus
-            key={key}
-            state={key}
-            id={`${id}-form-status-${key}`}
-            className="dnb-forms-status"
-            show={Boolean(value)}
-            no_animation={false}
-            shellSpace={{ top: 'small' }}
-          >
-            {String(value?.['message'] || value || '')}
-          </FormStatus>
-        )
-      })}
-    </FormElement>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1160,4 +1160,84 @@ describe('Form.Handler', () => {
       expect(document.body).toHaveTextContent('content')
     })
   })
+
+  describe('decoupleFormElement', () => {
+    it('should contain one form element', () => {
+      render(
+        <Form.Handler decoupleFormElement>
+          <Form.Element>content</Form.Element>
+        </Form.Handler>
+      )
+
+      const formElements = document.querySelectorAll('form')
+      expect(formElements).toHaveLength(1)
+    })
+
+    it('should call onSubmit when form is submitted', () => {
+      const onSubmit = jest.fn()
+
+      render(
+        <Form.Handler decoupleFormElement onSubmit={onSubmit}>
+          <Form.Element>content</Form.Element>
+        </Form.Handler>
+      )
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    it('should spread rest props to form element', () => {
+      render(
+        <Form.Handler decoupleFormElement aria-label="Aria Label">
+          <Form.Element>content</Form.Element>
+        </Form.Handler>
+      )
+
+      expect(document.querySelector('form')).toHaveAttribute(
+        'aria-label',
+        'Aria Label'
+      )
+    })
+
+    it('should overwrite rest props from handler', () => {
+      render(
+        <Form.Handler decoupleFormElement aria-label="Aria Label">
+          <Form.Element aria-label="Overwrite">content</Form.Element>
+        </Form.Handler>
+      )
+
+      expect(document.querySelector('form')).toHaveAttribute(
+        'aria-label',
+        'Overwrite'
+      )
+    })
+
+    it('should render form element inside wrapper', () => {
+      render(
+        <Form.Handler decoupleFormElement>
+          <div className="wrapper">
+            <Form.Element>content</Form.Element>
+          </div>
+        </Form.Handler>
+      )
+
+      const formElements = document.querySelectorAll('.wrapper > form')
+      expect(formElements).toHaveLength(1)
+    })
+
+    it('should warn when no form element is found', () => {
+      const log = jest.spyOn(global.console, 'log').mockImplementation()
+
+      render(<Form.Handler decoupleFormElement>content</Form.Handler>)
+
+      expect(log).toHaveBeenCalledTimes(1)
+      expect(log).toHaveBeenCalledWith(
+        expect.any(String),
+        'Please include a Form.Element when using decoupleFormElement!'
+      )
+
+      log.mockRestore()
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -32,16 +32,16 @@ function SubmitButton(props: Props) {
   const {
     formState,
     handleSubmit,
-    isInsideFormElement,
+    hasElementRef,
     props: dataContextProps,
   } = useContext(DataContext) || {}
   const { isolate } = dataContextProps || {}
 
   const onClickHandler = useCallback(() => {
-    if (!isInsideFormElement) {
+    if (!hasElementRef?.current) {
       handleSubmit?.()
     }
-  }, [isInsideFormElement, handleSubmit])
+  }, [hasElementRef, handleSubmit])
 
   return (
     <Button


### PR DESCRIPTION
This change allows devs to use the data context in a more flexible way:

Before:

```tsx
<App>
  <AppRelatedThings>
    <Form.Handler> 👈 Data context, form element and status message
      ...
    </Form.Handler>
  </AppRelatedThings>
</App>
```


After:

```tsx
<App>
  <Form.Handler decoupleForm> 👈 Data context
    <AppRelatedThings>
      <Form.Element> 👈 form element and status message
        ...
      </Form.Element>
    </AppRelatedThings>
  </Form.Handler>
</App>
```


- [x] Add docs