### PR TITLE
fix(DatePicker): make sure the picker and input only reacts to the props that have changed

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -23,7 +23,7 @@ export type DatePickerContextValues = ContextProps &
     translation: ContextProps['translation']
     views: Array<CalendarView>
     hasHadValidDate: boolean
-    previousDates: DatePickerDateProps
+    previousDateProps: DatePickerDateProps
     updateDates: (
       dates: DatePickerDates,
       callback?: (dates: DatePickerDates) => void

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
@@ -39,7 +39,7 @@ function DatePickerFooter({
 }: DatePickerFooterProps) {
   const {
     updateDates,
-    previousDates,
+    previousDateProps,
     props: contextProps,
   } = useContext(DatePickerContext)
 
@@ -69,18 +69,18 @@ function DatePickerFooter({
         args.event.persist()
       }
 
-      const startDate = previousDates.startDate
-        ? convertStringToDate(previousDates.startDate, {
+      const startDate = previousDateProps.startDate
+        ? convertStringToDate(previousDateProps.startDate, {
             dateFormat,
           })
-        : previousDates.date
-        ? convertStringToDate(previousDates.date, {
+        : previousDateProps.date
+        ? convertStringToDate(previousDateProps.date, {
             dateFormat,
           })
         : null
 
-      const endDate = previousDates.endDate
-        ? convertStringToDate(previousDates.endDate, {
+      const endDate = previousDateProps.endDate
+        ? convertStringToDate(previousDateProps.endDate, {
             dateFormat,
           })
         : startDate
@@ -95,7 +95,7 @@ function DatePickerFooter({
         }
       )
     },
-    [dateFormat, updateDates, previousDates, onCancel]
+    [dateFormat, updateDates, previousDateProps, onCancel]
   )
 
   const onResetHandler = useCallback(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -91,22 +91,23 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
 
   const sharedContext = useContext(SharedContext)
 
-  const { dates, updateDates, hasHadValidDate, previousDates } = useDates(
-    {
-      date,
-      startDate,
-      endDate,
-      startMonth,
-      endMonth,
-      minDate,
-      maxDate,
-    },
-    {
-      dateFormat: dateFormat,
-      isRange: range,
-      shouldCorrectDate: correctInvalidDate,
-    }
-  )
+  const { dates, updateDates, hasHadValidDate, previousDateProps } =
+    useDates(
+      {
+        date,
+        startDate,
+        endDate,
+        startMonth,
+        endMonth,
+        minDate,
+        maxDate,
+      },
+      {
+        dateFormat: dateFormat,
+        isRange: range,
+        shouldCorrectDate: correctInvalidDate,
+      }
+    )
 
   const { views, setViews, forceViewMonthChange } = useViews({
     startMonth: dates.startMonth,
@@ -225,7 +226,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         hidePicker: hidePicker,
         props,
         ...dates,
-        previousDates,
+        previousDateProps,
         hasHadValidDate,
         views,
         setViews,

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -296,7 +296,7 @@ describe('DatePicker component', () => {
     expect(year.value).toBe('åååå')
   })
 
-  it('should delete input content one number at a time when `startDate` and `endDate` is prop controlled and in ranged mode', async () => {
+  it('should delete input content one number at a time when `startDate` and `endDate` is "prop controlled" and in ranged mode', async () => {
     const Component = () => {
       const [startDate, setStartDate] = useState('2024-05-01')
       const [endDate, setEndDate] = useState('2025-06-30')

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -247,49 +247,49 @@ describe('DatePicker component', () => {
     expect(year.value).toBe('2024')
 
     await userEvent.click(year)
-    await userEvent.keyboard('{ArrowRight>4}{backspace}')
+    await userEvent.keyboard('{ArrowRight>4}{Backspace}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('05')
     expect(year.value).toBe('202å')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('05')
     expect(year.value).toBe('20åå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('05')
     expect(year.value).toBe('2ååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('05')
     expect(year.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('0m')
     expect(year.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(day.value).toBe('17')
     expect(month.value).toBe('mm')
     expect(year.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(day.value).toBe('1d')
     expect(month.value).toBe('mm')
     expect(year.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(day.value).toBe('dd')
     expect(month.value).toBe('mm')
@@ -336,7 +336,7 @@ describe('DatePicker component', () => {
     expect(endYear.value).toBe('2025')
 
     await userEvent.click(endYear)
-    await userEvent.keyboard('{ArrowRight>4}{backspace}')
+    await userEvent.keyboard('{ArrowRight>4}{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -345,7 +345,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('06')
     expect(endYear.value).toBe('202å')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -354,7 +354,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('06')
     expect(endYear.value).toBe('20åå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -363,7 +363,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('06')
     expect(endYear.value).toBe('2ååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -372,7 +372,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('06')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -381,7 +381,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('0m')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -390,7 +390,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -399,7 +399,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -408,7 +408,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -417,7 +417,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -426,7 +426,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -435,7 +435,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('05')
@@ -444,7 +444,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('0m')
@@ -453,7 +453,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('01')
     expect(startMonth.value).toBe('mm')
@@ -462,7 +462,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace>2}')
+    await userEvent.keyboard('{Backspace>2}')
 
     expect(startDay.value).toBe('0d')
     expect(startMonth.value).toBe('mm')
@@ -471,7 +471,7 @@ describe('DatePicker component', () => {
     expect(endMonth.value).toBe('mm')
     expect(endYear.value).toBe('åååå')
 
-    await userEvent.keyboard('{backspace}')
+    await userEvent.keyboard('{Backspace}')
 
     expect(startDay.value).toBe('dd')
     expect(startMonth.value).toBe('mm')

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { axeComponent, loadScss, wait } from '../../../core/jest/jestSetup'
 import userEvent from '@testing-library/user-event'
 import DatePicker, { DatePickerAllProps } from '../DatePicker'
@@ -221,6 +221,264 @@ describe('DatePicker component', () => {
     expect(
       document.querySelector('.dnb-date-picker').getAttribute('class')
     ).not.toContain('dnb-date-picker--opened')
+  })
+
+  it('should delete input content one number at a time when date is prop controlled', async () => {
+    const Component = () => {
+      const [date, setDate] = useState('2024-05-17')
+
+      return (
+        <DatePicker
+          showInput
+          date={date}
+          onChange={({ date }) => setDate(date)}
+        />
+      )
+    }
+
+    render(<Component />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('input.dnb-input__input')
+    )
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('05')
+    expect(year.value).toBe('2024')
+
+    await userEvent.click(year)
+    await userEvent.keyboard('{ArrowRight>4}{backspace}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('05')
+    expect(year.value).toBe('202å')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('05')
+    expect(year.value).toBe('20åå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('05')
+    expect(year.value).toBe('2ååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('05')
+    expect(year.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('0m')
+    expect(year.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(day.value).toBe('17')
+    expect(month.value).toBe('mm')
+    expect(year.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(day.value).toBe('1d')
+    expect(month.value).toBe('mm')
+    expect(year.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(day.value).toBe('dd')
+    expect(month.value).toBe('mm')
+    expect(year.value).toBe('åååå')
+  })
+
+  it('should delete input content one number at a time when date is prop controlled and in ranged mode', async () => {
+    const Component = () => {
+      const [startDate, setStartDate] = useState('2024-05-01')
+      const [endDate, setEndDate] = useState('2025-06-30')
+
+      return (
+        <DatePicker
+          showInput
+          range
+          startDate={startDate}
+          endDate={endDate}
+          onChange={({ start_date, end_date }) => {
+            setStartDate(start_date)
+            setEndDate(end_date)
+          }}
+        />
+      )
+    }
+
+    render(<Component />)
+
+    const [
+      startDay,
+      startMonth,
+      startYear,
+      endDay,
+      endMonth,
+      endYear,
+    ]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('input.dnb-input__input')
+    )
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('06')
+    expect(endYear.value).toBe('2025')
+
+    await userEvent.click(endYear)
+    await userEvent.keyboard('{ArrowRight>4}{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('06')
+    expect(endYear.value).toBe('202å')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('06')
+    expect(endYear.value).toBe('20åå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('06')
+    expect(endYear.value).toBe('2ååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('06')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('0m')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('30')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('3d')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('202å')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('20åå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('2ååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('05')
+    expect(startYear.value).toBe('åååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('0m')
+    expect(startYear.value).toBe('åååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('mm')
+    expect(startYear.value).toBe('åååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace>2}')
+
+    expect(startDay.value).toBe('0d')
+    expect(startMonth.value).toBe('mm')
+    expect(startYear.value).toBe('åååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
+
+    await userEvent.keyboard('{backspace}')
+
+    expect(startDay.value).toBe('dd')
+    expect(startMonth.value).toBe('mm')
+    expect(startYear.value).toBe('åååå')
+    expect(endDay.value).toBe('dd')
+    expect(endMonth.value).toBe('mm')
+    expect(endYear.value).toBe('åååå')
   })
 
   it('will render the result of "onDaysRender"', () => {
@@ -2314,51 +2572,6 @@ describe('DatePicker calc', () => {
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
     ).toHaveTextContent('november 2024')
-  })
-
-  it('should remove end date from ranged input, where dates are prop controlled, when pressing backspace', async () => {
-    const Component = () => {
-      const [startDate, setStartDate] = React.useState('2024-10-10')
-      const [endDate, setEndDate] = React.useState('2024-11-21')
-
-      return (
-        <DatePicker
-          range
-          showInput
-          date={startDate}
-          startDate={startDate}
-          endDate={endDate}
-          onChange={({ start_date, end_date }) => {
-            setStartDate(start_date)
-            setEndDate(end_date)
-          }}
-        />
-      )
-    }
-
-    render(<Component />)
-
-    const [startDay, startMonth, startYear, endDay, endMonth, endYear] =
-      Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      ) as Array<HTMLInputElement>
-
-    expect(startDay.value).toBe('10')
-    expect(startMonth.value).toBe('10')
-    expect(startYear.value).toBe('2024')
-    expect(endDay.value).toBe('21')
-    expect(endMonth.value).toBe('11')
-    expect(endYear.value).toBe('2024')
-
-    await userEvent.click(endYear)
-    await userEvent.keyboard('{backspace>3}')
-
-    expect(startDay.value).toBe('10')
-    expect(startMonth.value).toBe('10')
-    expect(startYear.value).toBe('2024')
-    expect(endDay.value).toBe('dd')
-    expect(endMonth.value).toBe('mm')
-    expect(endYear.value).toBe('åååå')
   })
 })
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -223,7 +223,7 @@ describe('DatePicker component', () => {
     ).not.toContain('dnb-date-picker--opened')
   })
 
-  it('should delete input content one number at a time when date is prop controlled', async () => {
+  it('should delete input content one number at a time when `date` is prop controlled', async () => {
     const Component = () => {
       const [date, setDate] = useState('2024-05-17')
 
@@ -296,7 +296,7 @@ describe('DatePicker component', () => {
     expect(year.value).toBe('åååå')
   })
 
-  it('should delete input content one number at a time when date is prop controlled and in ranged mode', async () => {
+  it('should delete input content one number at a time when `startDate` and `endDate` is prop controlled and in ranged mode', async () => {
     const Component = () => {
       const [startDate, setStartDate] = useState('2024-05-01')
       const [endDate, setEndDate] = useState('2025-06-30')

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -223,7 +223,7 @@ describe('DatePicker component', () => {
     ).not.toContain('dnb-date-picker--opened')
   })
 
-  it('should delete input content one number at a time when `date` is prop controlled', async () => {
+  it('should delete input content one number at a time when `date` is "prop controlled"', async () => {
     const Component = () => {
       const [date, setDate] = useState('2024-05-17')
 

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -315,9 +315,7 @@ function updateDatesBasedOnProps({
     dates['startMonth'] =
       convertStringToDate(dateProps.startMonth, {
         dateFormat,
-      }) ??
-      dates['startDate'] ??
-      undefined
+      }) ?? undefined
   }
 
   if (dateProps.endMonth !== previousDates.endMonth) {

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -288,22 +288,9 @@ function updateDatesBasedOnProps({
 }) {
   const dates = {}
 
-  let startDate = undefined
+  const startDate = getStartDate(dateProps, previousDateProps)
 
   // Handle startDate/endDate
-  if (
-    typeof dateProps.date !== 'undefined' &&
-    dateProps.date !== previousDateProps.date
-  ) {
-    startDate = dateProps.date
-  }
-  if (
-    typeof dateProps.startDate !== 'undefined' &&
-    dateProps.startDate !== previousDateProps.startDate
-  ) {
-    startDate = dateProps.startDate
-  }
-
   if (
     typeof startDate !== 'undefined' &&
     startDate !== previousDates.startDate
@@ -428,6 +415,23 @@ function getDate(date: DateType, dateFormat: string) {
     : convertStringToDate(date ?? '', {
         dateFormat,
       })
+}
+
+function getStartDate(dateProps, previousDateProps) {
+  if (
+    typeof dateProps.date !== 'undefined' &&
+    dateProps.date !== previousDateProps.date
+  ) {
+    return dateProps.date
+  }
+  if (
+    typeof dateProps.startDate !== 'undefined' &&
+    dateProps.startDate !== previousDateProps.startDate
+  ) {
+    return dateProps.startDate
+  }
+
+  return undefined
 }
 
 export function pad(date: string, size: number) {

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -285,8 +285,14 @@ function updateDatesBasedOnProps({
   previousDates,
   dateFormat,
   isRange,
+}: {
+  dateProps: DatePickerDateProps
+  previousDateProps: DatePickerDateProps
+  previousDates: DatePickerDates
+  dateFormat: UseDatesOptions['dateFormat']
+  isRange: UseDatesOptions['isRange']
 }) {
-  const dates = {}
+  const dates: DatePickerDates = {}
 
   const startDate = getStartDate(dateProps, previousDateProps)
 
@@ -295,27 +301,25 @@ function updateDatesBasedOnProps({
     typeof startDate !== 'undefined' &&
     startDate !== previousDates.startDate
   ) {
-    dates['startDate'] =
+    dates.startDate =
       convertStringToDate(startDate, {
         dateFormat,
       }) || undefined
 
-    dates['startMonth'] =
+    dates.startMonth =
       convertStringToDate(startDate, {
         dateFormat,
       }) || undefined
-
-    if (!isRange) {
-      dates['endDate'] = dates['startDate']
-    }
   }
 
-  if (
+  if (!isRange) {
+    dates.endDate = dates.startDate
+  } else if (
     typeof dateProps.endDate !== 'undefined' &&
     isRange &&
     dateProps.endDate !== previousDates.endDate
   ) {
-    dates['endDate'] =
+    dates.endDate =
       convertStringToDate(dateProps.endDate, {
         dateFormat,
       }) || undefined
@@ -326,7 +330,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.startMonth !== 'undefined' &&
     dateProps.startMonth !== previousDateProps.startMonth
   ) {
-    dates['startMonth'] = convertStringToDate(dateProps.startMonth, {
+    dates.startMonth = convertStringToDate(dateProps.startMonth, {
       dateFormat,
     })
   }
@@ -334,7 +338,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.endMonth !== 'undefined' &&
     dateProps.endMonth !== previousDateProps.endMonth
   ) {
-    dates['endMonth'] = convertStringToDate(previousDates.endMonth, {
+    dates.endMonth = convertStringToDate(previousDates.endMonth, {
       dateFormat,
     })
   }
@@ -344,7 +348,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.minDate !== 'undefined' &&
     dateProps.minDate !== previousDateProps.minDate
   ) {
-    dates['minDate'] = convertStringToDate(dateProps.minDate, {
+    dates.minDate = convertStringToDate(dateProps.minDate, {
       dateFormat,
     })
   }
@@ -352,7 +356,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.maxDate !== 'undefined' &&
     dateProps.maxDate !== previousDateProps.maxDate
   ) {
-    dates['maxDate'] = convertStringToDate(dateProps.maxDate, {
+    dates.maxDate = convertStringToDate(dateProps.maxDate, {
       dateFormat,
     })
   }
@@ -417,18 +421,22 @@ function getDate(date: DateType, dateFormat: string) {
       })
 }
 
-function getStartDate(dateProps, previousDateProps) {
-  if (
-    typeof dateProps.date !== 'undefined' &&
-    dateProps.date !== previousDateProps.date
-  ) {
-    return dateProps.date
-  }
+function getStartDate(
+  dateProps: DatePickerDateProps,
+  previousDateProps: DatePickerDateProps
+) {
   if (
     typeof dateProps.startDate !== 'undefined' &&
     dateProps.startDate !== previousDateProps.startDate
   ) {
     return dateProps.startDate
+  }
+
+  if (
+    typeof dateProps.date !== 'undefined' &&
+    dateProps.date !== previousDateProps.date
+  ) {
+    return dateProps.date
   }
 
   return undefined

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -53,10 +53,9 @@ export default function useDates(
     shouldCorrectDate = false,
   }: UseDatesOptions
 ) {
-  const [previousDates, setPreviousDates] = useState({})
   const [previousDateProps, setPreviousDateProps] = useState(dateProps)
   const [dates, setDates] = useState<DatePickerDates>({
-    ...mapDates(dateProps, previousDates, {
+    ...mapDates(dateProps, {
       dateFormat,
       isRange,
       shouldCorrectDate,
@@ -92,9 +91,9 @@ export default function useDates(
   // Update dates on prop change
   if (hasDatePropChanges) {
     const updatedDates = updateDatesBasedOnProps({
+      dates,
       dateProps,
       previousDateProps,
-      previousDates,
       dateFormat,
       isRange,
     })
@@ -135,13 +134,6 @@ export default function useDates(
           ...correctedDates,
         }
       })
-
-      setPreviousDates((currentPreviousDates) => ({
-        ...currentPreviousDates,
-        ...newDates,
-        ...months,
-        ...correctedDates,
-      }))
 
       callback?.({
         ...dates,
@@ -197,17 +189,13 @@ function updateInputDates(type: 'start' | 'end', date: Date | undefined) {
 
 function mapDates(
   dateProps: DatePickerDateProps,
-  previousDates: DatePickerDateProps,
   {
     dateFormat,
     isRange,
     shouldCorrectDate,
   }: Omit<UseDatesOptions, 'isLinked'>
 ) {
-  const date =
-    previousDates.date !== dateProps.date
-      ? dateProps.date
-      : previousDates.date
+  const date = dateProps.date
 
   const startDate =
     typeof dateProps?.startDate !== 'undefined'
@@ -251,6 +239,7 @@ function mapDates(
     : {}
 
   const dates = {
+    date,
     startDate,
     endDate,
     startMonth,
@@ -280,40 +269,37 @@ function mapDates(
 }
 
 function updateDatesBasedOnProps({
+  dates,
   dateProps,
   previousDateProps,
-  previousDates,
   dateFormat,
   isRange,
 }: {
+  dates: DatePickerDates
   dateProps: DatePickerDateProps
   previousDateProps: DatePickerDateProps
-  previousDates: DatePickerDates
   dateFormat: UseDatesOptions['dateFormat']
   isRange: UseDatesOptions['isRange']
 }) {
-  const dates: DatePickerDates = {}
+  const updatedDates: DatePickerDates = {}
 
   const startDate = getStartDate(dateProps, previousDateProps)
 
   // Handle updates related to date and startDate changes when not in range mode
-  if (
-    typeof startDate !== 'undefined' &&
-    startDate !== previousDates.startDate
-  ) {
-    dates.startDate =
+  if (typeof startDate !== 'undefined' && startDate !== dates.startDate) {
+    updatedDates.startDate =
       convertStringToDate(startDate, {
         dateFormat,
       }) || undefined
 
     // Set endDate and startMonth to startDate if not in range mode
     if (!isRange) {
-      dates.startMonth =
+      updatedDates.startMonth =
         convertStringToDate(startDate, {
           dateFormat,
         }) || undefined
 
-      dates.endDate = dates.startDate
+      updatedDates.endDate = updatedDates.startDate
     }
   }
 
@@ -321,9 +307,9 @@ function updateDatesBasedOnProps({
   if (
     isRange &&
     typeof dateProps.endDate !== 'undefined' &&
-    dateProps.endDate !== previousDates.endDate
+    dateProps.endDate !== dates.endDate
   ) {
-    dates.endDate =
+    updatedDates.endDate =
       convertStringToDate(dateProps.endDate, {
         dateFormat,
       }) || undefined
@@ -334,7 +320,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.startMonth !== 'undefined' &&
     dateProps.startMonth !== previousDateProps.startMonth
   ) {
-    dates.startMonth = convertStringToDate(dateProps.startMonth, {
+    updatedDates.startMonth = convertStringToDate(dateProps.startMonth, {
       dateFormat,
     })
   }
@@ -342,7 +328,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.endMonth !== 'undefined' &&
     dateProps.endMonth !== previousDateProps.endMonth
   ) {
-    dates.endMonth = convertStringToDate(previousDates.endMonth, {
+    updatedDates.endMonth = convertStringToDate(dateProps.endMonth, {
       dateFormat,
     })
   }
@@ -352,7 +338,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.minDate !== 'undefined' &&
     dateProps.minDate !== previousDateProps.minDate
   ) {
-    dates.minDate = convertStringToDate(dateProps.minDate, {
+    updatedDates.minDate = convertStringToDate(dateProps.minDate, {
       dateFormat,
     })
   }
@@ -360,12 +346,12 @@ function updateDatesBasedOnProps({
     typeof dateProps.maxDate !== 'undefined' &&
     dateProps.maxDate !== previousDateProps.maxDate
   ) {
-    dates.maxDate = convertStringToDate(dateProps.maxDate, {
+    updatedDates.maxDate = convertStringToDate(dateProps.maxDate, {
       dateFormat,
     })
   }
 
-  return dates
+  return updatedDates
 }
 
 function correctDates({

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -90,7 +90,7 @@ export default function useDates(
 
   // Update dates on prop change
   if (hasDatePropChanges) {
-    const updatedDates = updateDatesBasedOnProps({
+    const derivedDates = deriveDatesFromProps({
       dates,
       dateProps,
       previousDateProps,
@@ -98,7 +98,7 @@ export default function useDates(
       isRange,
     })
 
-    setDates((currentDates) => ({ ...currentDates, ...updatedDates }))
+    setDates((currentDates) => ({ ...currentDates, ...derivedDates }))
     setPreviousDateProps(dateProps)
   }
 
@@ -268,7 +268,7 @@ function mapDates(
   }
 }
 
-function updateDatesBasedOnProps({
+function deriveDatesFromProps({
   dates,
   dateProps,
   previousDateProps,
@@ -281,25 +281,25 @@ function updateDatesBasedOnProps({
   dateFormat: UseDatesOptions['dateFormat']
   isRange: UseDatesOptions['isRange']
 }) {
-  const updatedDates: DatePickerDates = {}
+  const derivedDates: DatePickerDates = {}
 
   const startDate = getStartDate(dateProps, previousDateProps)
 
   // Handle updates related to date and startDate changes when not in range mode
   if (typeof startDate !== 'undefined' && startDate !== dates.startDate) {
-    updatedDates.startDate =
+    derivedDates.startDate =
       convertStringToDate(startDate, {
         dateFormat,
       }) || undefined
 
     // Set endDate and startMonth to startDate if not in range mode
     if (!isRange) {
-      updatedDates.startMonth =
+      derivedDates.startMonth =
         convertStringToDate(startDate, {
           dateFormat,
         }) || undefined
 
-      updatedDates.endDate = updatedDates.startDate
+      derivedDates.endDate = derivedDates.startDate
     }
   }
 
@@ -309,7 +309,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.endDate !== 'undefined' &&
     dateProps.endDate !== dates.endDate
   ) {
-    updatedDates.endDate =
+    derivedDates.endDate =
       convertStringToDate(dateProps.endDate, {
         dateFormat,
       }) || undefined
@@ -320,7 +320,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.startMonth !== 'undefined' &&
     dateProps.startMonth !== previousDateProps.startMonth
   ) {
-    updatedDates.startMonth = convertStringToDate(dateProps.startMonth, {
+    derivedDates.startMonth = convertStringToDate(dateProps.startMonth, {
       dateFormat,
     })
   }
@@ -328,7 +328,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.endMonth !== 'undefined' &&
     dateProps.endMonth !== previousDateProps.endMonth
   ) {
-    updatedDates.endMonth = convertStringToDate(dateProps.endMonth, {
+    derivedDates.endMonth = convertStringToDate(dateProps.endMonth, {
       dateFormat,
     })
   }
@@ -338,7 +338,7 @@ function updateDatesBasedOnProps({
     typeof dateProps.minDate !== 'undefined' &&
     dateProps.minDate !== previousDateProps.minDate
   ) {
-    updatedDates.minDate = convertStringToDate(dateProps.minDate, {
+    derivedDates.minDate = convertStringToDate(dateProps.minDate, {
       dateFormat,
     })
   }
@@ -346,12 +346,12 @@ function updateDatesBasedOnProps({
     typeof dateProps.maxDate !== 'undefined' &&
     dateProps.maxDate !== previousDateProps.maxDate
   ) {
-    updatedDates.maxDate = convertStringToDate(dateProps.maxDate, {
+    derivedDates.maxDate = convertStringToDate(dateProps.maxDate, {
       dateFormat,
     })
   }
 
-  return updatedDates
+  return derivedDates
 }
 
 function correctDates({

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -296,7 +296,7 @@ function updateDatesBasedOnProps({
 
   const startDate = getStartDate(dateProps, previousDateProps)
 
-  // Handle startDate/endDate
+  // Handle updates related to date and startDate changes when not in range mode
   if (
     typeof startDate !== 'undefined' &&
     startDate !== previousDates.startDate
@@ -306,17 +306,21 @@ function updateDatesBasedOnProps({
         dateFormat,
       }) || undefined
 
-    dates.startMonth =
-      convertStringToDate(startDate, {
-        dateFormat,
-      }) || undefined
+    // Set endDate and startMonth to startDate if not in range mode
+    if (!isRange) {
+      dates.startMonth =
+        convertStringToDate(startDate, {
+          dateFormat,
+        }) || undefined
+
+      dates.endDate = dates.startDate
+    }
   }
 
-  if (!isRange) {
-    dates.endDate = dates.startDate
-  } else if (
-    typeof dateProps.endDate !== 'undefined' &&
+  // update endDate based on endDate prop if in range mode
+  if (
     isRange &&
+    typeof dateProps.endDate !== 'undefined' &&
     dateProps.endDate !== previousDates.endDate
   ) {
     dates.endDate =
@@ -425,6 +429,7 @@ function getStartDate(
   dateProps: DatePickerDateProps,
   previousDateProps: DatePickerDateProps
 ) {
+  // priortize startDate over date if provided
   if (
     typeof dateProps.startDate !== 'undefined' &&
     dateProps.startDate !== previousDateProps.startDate

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -71,18 +71,15 @@ export default function useDates(
         const convertedDateProp = convertStringToDate(dateProp, {
           dateFormat,
         })
-        const convertedPreviousDare = convertStringToDate(previousDate, {
+        const convertedPreviousDate = convertStringToDate(previousDate, {
           dateFormat,
         })
 
         if (
           convertedDateProp instanceof Date &&
-          convertedPreviousDare instanceof Date
+          convertedPreviousDate instanceof Date
         ) {
-          return !isSameDay(
-            convertStringToDate(dateProp, { dateFormat }),
-            convertStringToDate(previousDate, { dateFormat })
-          )
+          return !isSameDay(convertedDateProp, convertedPreviousDate)
         }
 
         return dateProp !== previousDate

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -174,7 +174,7 @@ export default function useDates(
     dates,
     updateDates,
     hasHadValidDate: hasHadValidDate.current,
-    previousDates: previousDateProps,
+    previousDateProps,
   } as const
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -148,6 +148,7 @@ function DateComponent(props: Props) {
   const { value, startDate, endDate } = useMemo(() => {
     if (!range || !valueProp) {
       return {
+        // Assign to null if falsy value, to properly clear input values
         value: valueProp ?? null,
         startDate: undefined,
         endDate: undefined,
@@ -156,6 +157,7 @@ function DateComponent(props: Props) {
 
     const [startDate, endDate] = valueProp
       .split('|')
+      // Assign to null if falsy value, to properly clear input values
       .map((value) => (/(undefined|null)/.test(value) ? null : value))
 
     return {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -147,15 +147,15 @@ function DateComponent(props: Props) {
 
   const { value, startDate, endDate } = useMemo(() => {
     if (!range || !valueProp) {
-      return { value: valueProp, startDate: undefined, endDate: undefined }
+      return { value: valueProp ?? null, startDate: null, endDate: null }
     }
 
     const [startDate, endDate] = valueProp
       .split('|')
-      .map((value) => (/(undefined|null)/.test(value) ? undefined : value))
+      .map((value) => (/(undefined|null)/.test(value) ? null : value))
 
     return {
-      value: undefined,
+      value: null,
       startDate,
       endDate,
     }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -147,7 +147,11 @@ function DateComponent(props: Props) {
 
   const { value, startDate, endDate } = useMemo(() => {
     if (!range || !valueProp) {
-      return { value: valueProp ?? null, startDate: null, endDate: null }
+      return {
+        value: valueProp ?? null,
+        startDate: undefined,
+        endDate: undefined,
+      }
     }
 
     const [startDate, endDate] = valueProp
@@ -155,7 +159,7 @@ function DateComponent(props: Props) {
       .map((value) => (/(undefined|null)/.test(value) ? null : value))
 
     return {
-      value: null,
+      value: undefined,
       startDate,
       endDate,
     }


### PR DESCRIPTION
- [x] Add test
- [x] FIx same issue in `range` mode
- [x] Update failing `Field.Date` test
- [x] Clean up `updateBasedOnProps` code


Should hopefully fix the issue described [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1732031524606929)

Neither of us were able to recreate the issue in csb, so testing this manually might be a challenge

This also improves input deletion behaviour when the dates are prop controlled

Before:

https://github.com/user-attachments/assets/2331ac62-e758-44aa-8a93-fcd042a7fc6e


After:

https://github.com/user-attachments/assets/6c3aa9a3-1d01-415e-8028-6626d42b0e3c


