### PR TITLE
feat(Forms): enhance typing and add docs on how to deal with TypeScript types

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider/Examples.tsx
@@ -8,7 +8,7 @@ import {
 } from '@dnb/eufemia/src/extensions/forms'
 import { Flex } from '@dnb/eufemia/src'
 
-export const TestdataSchema: JSONSchema = {
+export const TestDataSchema: JSONSchema = {
   type: 'object',
   properties: {
     requiredString: { type: 'string' },
@@ -37,7 +37,7 @@ export const TestdataSchema: JSONSchema = {
   required: ['requiredString'],
 }
 
-export interface Testdata {
+export type TestData = {
   requiredString: string
   string?: string
   number?: number
@@ -53,7 +53,7 @@ export interface Testdata {
   }>
 }
 
-export const testdata: Testdata = {
+export const testData: TestData = {
   requiredString: 'This is a text',
   string: 'String value',
   number: 123,
@@ -81,12 +81,12 @@ export const Default = () => {
       scope={{
         DataContext,
         Value,
-        testdata,
-        TestdataSchema,
+        testData,
+        TestDataSchema,
       }}
     >
       <DataContext.Provider
-        defaultData={testdata}
+        defaultData={testData}
         onChange={(data) => console.log('onChange', data)}
         onPathChange={(path, value) =>
           console.log('onPathChange', path, value)
@@ -177,13 +177,13 @@ export const ValidationWithJsonSchema = () => {
       scope={{
         DataContext,
         Value,
-        testdata,
-        TestdataSchema,
+        testData,
+        TestDataSchema,
       }}
     >
       <DataContext.Provider
-        data={testdata}
-        schema={TestdataSchema}
+        data={testData}
+        schema={TestDataSchema}
         onChange={(data) => console.log('onChange', data)}
         onPathChange={(path, value) =>
           console.log('onPathChange', path, value)

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -42,10 +42,12 @@ function MyForm() {
   return (
     <Form.Handler<MyDataContext>
       onSubmit={(data) => {
-        // data.firstName is of type string
+        // "firstName" is of type string
         console.log(data.firstName)
       }}
-    />
+    >
+      ...
+    </Form.Handler>
   )
 }
 
@@ -58,31 +60,39 @@ function MyForm() {
     <Form.Handler
       defaultData={existingData}
       onSubmit={(data) => {
-        // data.firstName is of type string
+        // "firstName" is of type string
         console.log(data.firstName)
       }}
-    />
+    >
+      ...
+    </Form.Handler>
   )
 }
 
 // Method #3 – type definition on the event parameter
 const submitHandler = (data: MyDataContext) => {
-  // data.firstName is of type string
+  // "firstName" is of type string
   console.log(data.firstName)
 }
 function MyForm() {
-  return <Form.Handler onSubmit={submitHandler} />
+  return <Form.Handler onSubmit={submitHandler}>...</Form.Handler>
 }
 
 // Method #4 – type definition for the submit handler
 import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
 const submitHandler: OnSubmit<MyDataContext> = (data) => {
-  // data.firstName is of type string
+  // "firstName" is of type string
   console.log(data.firstName)
 }
 function MyForm() {
-  return <Form.Handler onSubmit={submitHandler} />
+  return <Form.Handler onSubmit={submitHandler}>...</Form.Handler>
 }
+```
+
+To disable types you can:
+
+```tsx
+<Form.Handler<any>>...</Form.Handler>
 ```
 
 ## Decoupling the form element

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -9,7 +9,7 @@ import AsyncChangeExample from './parts/async-change-example.mdx'
 
 The `Form.Handler` is the root component of your form. It provides a HTML form element and handles the form data.
 
-```jsx
+```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 const existingData = { firstName: 'Nora' }
@@ -23,6 +23,65 @@ function MyForm() {
       Your Form
     </Form.Handler>
   )
+}
+```
+
+### TypeScript support
+
+You can define the TypeScript type structure for your data like so:
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+type MyDataContext = {
+  firstName?: string
+}
+
+// Method #1 – without initial data
+function MyForm() {
+  return (
+    <Form.Handler<MyDataContext>
+      onSubmit={(data) => {
+        // data.firstName is of type string
+        console.log(data.firstName)
+      }}
+    />
+  )
+}
+
+// Method #2 – with data (initial values)
+const existingData: MyDataContext = {
+  firstName: 'Nora',
+}
+function MyForm() {
+  return (
+    <Form.Handler
+      defaultData={existingData}
+      onSubmit={(data) => {
+        // data.firstName is of type string
+        console.log(data.firstName)
+      }}
+    />
+  )
+}
+
+// Method #3 – type definition on the event parameter
+const submitHandler = (data: MyDataContext) => {
+  // data.firstName is of type string
+  console.log(data.firstName)
+}
+function MyForm() {
+  return <Form.Handler onSubmit={submitHandler} />
+}
+
+// Method #4 – type definition for the submit handler
+import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
+const submitHandler: OnSubmit<MyDataContext> = (data) => {
+  // data.firstName is of type string
+  console.log(data.firstName)
+}
+function MyForm() {
+  return <Form.Handler onSubmit={submitHandler} />
 }
 ```
 
@@ -115,51 +174,6 @@ function MyApp() {
 ```
 
 More examples can be found in the [useData](/uilib/extensions/forms/Form/useData/) hook docs.
-
-### TypeScript support
-
-You can define the TypeScript type structure for your data like so:
-
-```tsx
-import { Form } from '@dnb/eufemia/extensions/forms'
-
-type MyDataSet = {
-  firstName?: string
-}
-
-const data: MyDataSet = {
-  firstName: 'Nora',
-}
-
-// Method #1
-function MyForm() {
-  return (
-    <Form.Handler
-      defaultData={data}
-      onSubmit={(data) => {
-        console.log(data.firstName)
-      }}
-    />
-  )
-}
-
-// Method #2
-const submitHandler = (data: MyDataSet) => {
-  console.log(data.firstName)
-}
-function MyForm() {
-  return <Form.Handler defaultData={data} onSubmit={submitHandler} />
-}
-
-// Method #3
-import type { OnSubmit } from '@dnb/eufemia/extensions/forms'
-const submitHandler: OnSubmit<MyDataSet> = (data) => {
-  console.log(data.firstName)
-}
-function MyForm() {
-  return <Form.Handler defaultData={data} onSubmit={submitHandler} />
-}
-```
 
 ## Async `onChange` and `onSubmit` event handlers
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/Examples.tsx
@@ -66,14 +66,17 @@ export const CommitHandleRef = () => {
                   <Form.Isolation
                     commitHandleRef={commitHandleRef}
                     transformOnCommit={(isolatedData, handlerData) => {
-                      const value =
-                        isolatedData.newPerson.title.toLowerCase()
+                      // Because of missing TypeScript support
+                      const contactPersons = handlerData['contactPersons']
+                      const newPerson = isolatedData['newPerson']
+
+                      const value = newPerson.title.toLowerCase()
                       const transformedData = {
                         ...handlerData,
                         contactPersons: [
-                          ...handlerData.contactPersons,
+                          ...contactPersons,
                           {
-                            ...isolatedData.newPerson,
+                            ...newPerson,
                             value,
                           },
                         ],
@@ -151,14 +154,18 @@ export const TransformCommitData = () => {
 
                     <Form.Isolation
                       transformOnCommit={(isolatedData, handlerData) => {
+                        // Because of missing TypeScript support
+                        const contactPersons =
+                          handlerData['contactPersons']
+                        const newPerson = isolatedData['newPerson']
+
                         return {
                           ...handlerData,
                           contactPersons: [
-                            ...handlerData.contactPersons,
+                            ...contactPersons,
                             {
-                              ...isolatedData.newPerson,
-                              value:
-                                isolatedData.newPerson.title.toLowerCase(),
+                              ...newPerson,
+                              value: newPerson.title.toLowerCase(),
                             },
                           ],
                         }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
@@ -42,6 +42,37 @@ export function MyForm(props) {
 }
 ```
 
+## TypeScript support
+
+You can define the TypeScript type structure for your data like so:
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+type IsolationData = {
+  persons: Array<{ name: string }>
+  newPerson: Array<{ name: string }>
+}
+
+function MyForm() {
+  return (
+    <Form.Isolation<IsolationData>
+      onCommit={(data) => {
+        data // <-- is of type IsolationData
+      }}
+      transformOnCommit={(isolatedData, handlerData) => {
+        return {
+          ...handlerData,
+          persons: [...handlerData.persons, isolatedData.newPerson],
+        }
+      }}
+    >
+      ...
+    </Form.Isolation>
+  )
+}
+```
+
 ## Commit the data to the form
 
 You can either use the `Form.Isolation.CommitButton` or provide a custom ref handler you can use (call) when you want to commit the data to the `Form.Handler` context:
@@ -111,7 +142,7 @@ render(
 
 ## Clear data from isolated fields
 
-You can clear the isolation by calling `Form.clearData` with the `id` of the form.
+You can clear the isolation by calling `clearData`:
 
 ```jsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
@@ -120,9 +151,8 @@ function MyForm() {
   return (
     <Form.Handler>
       <Form.Isolation
-        id="my-isolated-data"
-        onCommit={() => {
-          Form.clearData('my-isolated-data')
+        onCommit={(data, { clearData }) => {
+          clearData()
         }}
       >
         <Field.String path="/isolated" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
@@ -44,6 +44,16 @@ render(
 
 You can use the `Form.useData` hook with or without an `id` (string, function, object or React Context as the reference) property, which is optional and can be used to link the data to a specific [Form.Handler](/uilib/extensions/forms/Form/Handler/) component.
 
+### TypeScript support
+
+You can define the TypeScript type structure for your data like so:
+
+```tsx
+type Data = { foo: string }
+
+const { data } = Form.useData<Data>()
+```
+
 ### Without an `id` property
 
 Here "Component" is rendered inside the `Form.Handler` component and does not need an `id` property to access the form data:
@@ -88,15 +98,6 @@ function Component() {
 ```
 
 This is beneficial when you need to utilize the form data in other places within your application.
-
-### TypeScript support
-
-You can define the TypeScript type structure for your data like so:
-
-```tsx
-type Data = { foo: string }
-const { data } = Form.useData<Data>('unique')
-```
 
 ### Select a single value
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/Examples.tsx
@@ -143,7 +143,7 @@ export const IsolatedData = () => {
 
         function ExistingPersonDetails() {
           const { data, getValue } = Form.useData()
-          const person = getValue(data.selectedPerson)?.data || {}
+          const person = getValue(data['selectedPerson'])?.data || {}
 
           return (
             <Flex.Stack>
@@ -172,14 +172,15 @@ export const IsolatedData = () => {
 
         function PushContainerContent() {
           const { data, update } = Form.useData()
+          const selectedPerson = data['selectedPerson'] // Because of missing TypeScript support
 
           // Clear the PushContainer data when the selected person is "other",
           // so the fields do not inherit existing data.
           React.useLayoutEffect(() => {
-            if (data.selectedPerson === 'other') {
+            if (selectedPerson === 'other') {
               update('/pushContainerItems/0', {})
             }
-          }, [data.selectedPerson, update])
+          }, [selectedPerson, update])
 
           return (
             <Flex.Stack>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -74,20 +74,25 @@ type MyDataContext = {
   firstName?: string
 }
 
-// Method 1 of 4
 function MyForm() {
   return (
     <Form.Handler<MyDataContext>
       onSubmit={(data) => {
-        // data.firstName is of type string
-        console.log(data.firstName)
+        console.log(data.firstName) // "firstName" is of type string
       }}
-    />
+    >
+      <MyComponent />
+    </Form.Handler>
   )
+}
+
+const MyComponent = () => {
+  const { data } = Form.useData<MyDataContext>()
+  return data.firstName
 }
 ```
 
-Read more about TypeScript support and the other methods in the [Form.Handler](/uilib/extensions/forms/Form/Handler/#typescript-support) section.
+Read more about TypeScript support and the other methods in the [Form.Handler](/uilib/extensions/forms/Form/Handler/#typescript-support) section or in the [Form.useData](/uilib/extensions/forms/Form/useData/#typescript-support) hook docs.
 
 ### State management
 
@@ -148,7 +153,7 @@ How do I handle complex data logic?
 
 You can show or hide parts of your form based on your own logic. This is done by using the [Visibility](/uilib/extensions/forms/Form/Visibility/) component (yes, it even can animate the visibility).
 
-And you can access and modify your form data with [useData](/uilib/extensions/forms/Form/useData/) or [getData](/uilib/extensions/forms/Form/getData/) or even [setData](/uilib/extensions/forms/Form/setData/).
+And you can access and modify your form data with [Form.useData](/uilib/extensions/forms/Form/useData/) or [getData](/uilib/extensions/forms/Form/getData/) or even [setData](/uilib/extensions/forms/Form/setData/).
 
 Here is an example of how to use these methods:
 
@@ -193,7 +198,7 @@ const { getValue, data, filterData, reduceToVisibleFields } =
 - `filterData` will filter the data based on your own logic.
 - `reduceToVisibleFields` will reduce the given data set to only contain the visible fields (mounted fields).
 
-As you can see in the code above, you can even handle the state outside the `Form.Handler` context. You find more details on this topic in the [useData](/uilib/extensions/forms/Form/useData/) documentation.
+As you can see in the code above, you can even handle the state outside the `Form.Handler` context. You find more details on this topic in the [Form.useData](/uilib/extensions/forms/Form/useData/) documentation.
 
 <Examples.GettingStarted />
 
@@ -210,9 +215,9 @@ When submitting data to the server, you might want to exclude data that has been
 
 In this section we will show how to filter out some data based on your own logic. You can filter data by any given criteria. This is done by utilizing the `filterData` method from e.g.:
 
-- [useData](/uilib/extensions/forms/Form/useData/#filter-data) hook.
-- [getData](/uilib/extensions/forms/Form/getData/#filter-data) method.
-- [Visibility](/uilib/extensions/forms/Form/Visibility/#filter-data) component.
+- [Form.useData](/uilib/extensions/forms/Form/useData/#filter-data) hook.
+- [Form.getData](/uilib/extensions/forms/Form/getData/#filter-data) method.
+- [Form.Visibility](/uilib/extensions/forms/Form/Visibility/#filter-data) component.
 
 You can provide either a function handler or an object with the paths (JSON Pointer) you want to filter out.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -20,6 +20,7 @@ import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
 
 - [Getting started](#getting-started)
   - [Creating forms](#creating-forms)
+  - [TypeScript support](#typescript-support)
   - [State management](#state-management)
     - [What is a JSON Pointer?](#what-is-a-json-pointer)
     - [Data handling](#data-handling)
@@ -61,6 +62,32 @@ import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
 To build an entire form, there are surrounding components such as form [Handler](/uilib/extensions/forms/Form/Handler) and [Wizard.Container](/uilib/extensions/forms/Wizard/Container) that make data flow and layout easier and save you a lot of extra code, without compromising flexibility.
 
 The needed styles are included in the Eufemia core package via `dnb-ui-components`.
+
+### TypeScript support
+
+You can define the TypeScript type structure for your data like so:
+
+```tsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+type MyDataContext = {
+  firstName?: string
+}
+
+// Method 1 of 4
+function MyForm() {
+  return (
+    <Form.Handler<MyDataContext>
+      onSubmit={(data) => {
+        // data.firstName is of type string
+        console.log(data.firstName)
+      }}
+    />
+  )
+}
+```
+
+Read more about TypeScript support and the other methods in the [Form.Handler](/uilib/extensions/forms/Form/Handler/#typescript-support) section.
 
 ### State management
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Ajv, FormError, makeAjvInstance } from '../utils'
+import { Ajv, FormError, JsonObject, makeAjvInstance } from '../utils'
 import {
   AllJSONSchemaVersions,
   GlobalErrorMessagesWithPaths,
@@ -185,7 +185,7 @@ export interface ContextState {
   decoupleForm?: boolean
   hasElementRef?: React.MutableRefObject<boolean>
   restHandlerProps?: Record<string, unknown>
-  props: ProviderProps<unknown>
+  props: ProviderProps<JsonObject>
 }
 
 export const defaultContextState: ContextState = {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1156,11 +1156,11 @@ export default function Provider<Data extends JsonObject>(
     }
 
     const transformData = (data: Data, handler: TransformData) => {
-      return mutateDataHandler(data, handler) as TransformData
+      return mutateDataHandler(data, handler)
     }
 
     const formElement = formElementRef.current
-    const params: OnSubmitParams = {
+    const params: OnSubmitParams<Data> = {
       filterData,
       reduceToVisibleFields,
       transformData,

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -1824,7 +1824,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should show error on the field from the event return when complete', async () => {
-      const onChangeForm: OnChange = async ({ myField }) => {
+      const onChangeForm: OnChange<{ myField: string }> = async ({
+        myField,
+      }) => {
         if (myField === 'onChangeForm-error') {
           return Error('onChangeForm-error')
         }
@@ -1874,7 +1876,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should show status message on the field from the event return when complete', async () => {
-      const onChangeForm: OnChange = async ({ myField }) => {
+      const onChangeForm: OnChange<{ myField: string }> = async ({
+        myField,
+      }) => {
         if (myField === 'onChangeForm-info') {
           return { info: 'onChangeForm-info' }
         }
@@ -1926,7 +1930,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should show all status messages on the field from the event return when complete', async () => {
-      const onChangeForm: OnChange = async ({ myField }) => {
+      const onChangeForm: OnChange<{ myField: string }> = async ({
+        myField,
+      }) => {
         return {
           info: 'onChangeForm-info',
           error:
@@ -1989,7 +1995,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should fulfill async onChangeValidator before the form and field event', async () => {
-      const onChangeForm: OnChange = async ({ myField }) => {
+      const onChangeForm: OnChange<{ myField: string }> = async ({
+        myField,
+      }) => {
         return {
           info: 'onChangeForm-info',
           error:

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
@@ -6,6 +6,7 @@ import SharedProvider from '../../../../shared/Provider'
 import { ContextProps } from '../../../../shared/Context'
 import useFieldProvider from './useFieldProvider'
 import { FieldProps, Path } from '../../types'
+import { JsonObject } from '../../utils'
 
 export type FieldProviderProps = FieldProps & {
   children: React.ReactNode
@@ -13,12 +14,12 @@ export type FieldProviderProps = FieldProps & {
   /**
    * Locale to use for all nested Eufemia components
    */
-  locale?: DataContextProps<unknown>['locale']
+  locale?: DataContextProps<JsonObject>['locale']
 
   /**
    * Provide your own translations. Use the same format as defined in the translation files
    */
-  translations?: DataContextProps<unknown>['translations']
+  translations?: DataContextProps<JsonObject>['translations']
 
   /** For internal use only */
   overwriteProps?: {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -19,7 +19,7 @@ export type Props = FormElementProps & {
   decoupleForm?: boolean
 }
 
-type AllowedProviderContextProps = ProviderProps<unknown> &
+type AllowedProviderContextProps = ProviderProps<JsonObject> &
   Pick<Props, 'decoupleForm' | 'autoComplete' | 'disabled'> &
   Pick<ContextState, 'restHandlerProps' | 'hasElementRef'>
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -19,6 +19,52 @@ const nb = nbNO['nb-NO']
 const en = enGB['en-GB']
 
 describe('Form.Handler', () => {
+  it('should support types given to the Form.Handler', () => {
+    let value = null
+
+    type MyDataContext = {
+      firstName?: string
+    }
+
+    render(
+      <Form.Handler<MyDataContext>
+        onSubmit={(data) => {
+          value = data.firstName
+        }}
+      >
+        <Field.String path="/firstName" value="Value" />
+      </Form.Handler>
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+    expect(value).toBe('Value')
+  })
+
+  it('should support types given to the data prop', () => {
+    let value = null
+
+    type MyDataContext = {
+      firstName?: string
+    }
+    const data: MyDataContext = {
+      firstName: 'Value',
+    }
+
+    render(
+      <Form.Handler
+        data={data}
+        onSubmit={(data) => {
+          value = data.firstName
+        }}
+      >
+        <Field.String path="/firstName" />
+      </Form.Handler>
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+    expect(value).toBe('Value')
+  })
+
   it('should call "onSubmit"', () => {
     const onSubmit: OnSubmit = jest.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -30,7 +30,7 @@ import type { OnCommit, Path } from '../../types'
  */
 import structuredClone from '@ungap/structured-clone'
 
-export type IsolationProviderProps<Data> = {
+export type IsolationProviderProps<Data extends JsonObject> = {
   /**
    * Form.Isolation: Will be called when the isolated context is committed.
    */
@@ -44,10 +44,7 @@ export type IsolationProviderProps<Data> = {
    * It will receive the data from the isolated context and the data from the outer context.
    * You can use this to transform the data before it is committed.
    */
-  transformOnCommit?: (
-    isolatedData: JsonObject,
-    handlerData: JsonObject
-  ) => unknown
+  transformOnCommit?: (isolatedData: Data, handlerData: Data) => JsonObject
   /**
    * Prevent the form from being submitted when there are fields with errors inside the Form.Isolation.
    */
@@ -62,7 +59,7 @@ export type IsolationProviderProps<Data> = {
   isolate?: boolean
 }
 
-export type IsolationProps<Data> = Omit<
+export type IsolationProps<Data extends JsonObject> = Omit<
   ProviderProps<Data>,
   | 'onSubmit'
   | 'onSubmitRequest'

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -1367,7 +1367,10 @@ describe('Form.Isolation', () => {
         data={{ existing: 'data', persons: [{ name: 'John' }] }}
         onChange={onChange}
       >
-        <Form.Isolation
+        <Form.Isolation<{
+          persons: Array<{ name: string }>
+          newPerson: Array<{ name: string }>
+        }>
           transformOnCommit={(isolatedData, handlerData) => {
             return {
               ...handlerData,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/stories/Isolation.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/stories/Isolation.stories.tsx
@@ -138,7 +138,10 @@ export const TransformOnCommit = () => {
           <Flex.Stack>
             <Form.SubHeading>Ny hovedkontaktperson</Form.SubHeading>
 
-            <Form.Isolation
+            <Form.Isolation<{
+              newPerson: { title: string }
+              contactPersons: Array<{ title: string; value: string }>
+            }>
               transformOnCommit={(isolatedData, handlerData) => {
                 return {
                   ...handlerData,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
@@ -19,7 +19,10 @@ export type OverwritePropsDefaults = {
     | (FieldProps & SharedFieldBlockProps)
     | OverwritePropsDefaults
 }
-export type SectionProps<overwriteProps = OverwritePropsDefaults> = {
+export type SectionProps<
+  overwriteProps = OverwritePropsDefaults,
+  Data extends JsonObject = JsonObject,
+> = {
   /**
    * Path to the section.
    * When defined, fields inside the section will get this path as a prefix of their own path.
@@ -55,15 +58,18 @@ export type SectionProps<overwriteProps = OverwritePropsDefaults> = {
    */
   errorPrioritization?: SectionContextState['errorPrioritization']
 } & Pick<
-  DataContextProps<JsonObject>,
+  DataContextProps<Data>,
   'data' | 'defaultData' | 'onChange' | 'translations'
 >
 
-export type LocalProps = SectionProps & {
-  children: React.ReactNode
-}
+export type LocalProps<overwriteProps = OverwritePropsDefaults> =
+  SectionProps<overwriteProps> & {
+    children: React.ReactNode
+  }
 
-function SectionComponent(props: LocalProps) {
+function SectionComponent<overwriteProps = OverwritePropsDefaults>(
+  props: LocalProps<overwriteProps>
+) {
   const {
     path,
     overwriteProps,
@@ -108,12 +114,14 @@ function SectionComponent(props: LocalProps) {
     )
   }
 
+  const sectionProps = props as SectionProps
+
   return (
     <SectionContext.Provider
       value={{
         path: identifier,
         errorPrioritization,
-        props,
+        props: sectionProps,
       }}
     >
       <SectionContainerProvider

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/PushContainer.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/PushContainer.stories.tsx
@@ -60,7 +60,7 @@ function RepresentativesEdit() {
 }
 
 function ExistingPersonDetails() {
-  const { data, getValue } = Form.useData()
+  const { data, getValue } = Form.useData<{ selectedPerson: string }>()
   const person = getValue(data.selectedPerson)?.data || {}
 
   return (
@@ -89,7 +89,7 @@ function NewPersonDetails() {
 }
 
 function PushContainerContent() {
-  const { data, update } = Form.useData()
+  const { data, update } = Form.useData<{ selectedPerson: string }>()
 
   // Clear the PushContainer data when the selected person is "other",
   // so the fields do not inherit existing data.

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/ListAllProps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/ListAllProps.tsx
@@ -2,19 +2,22 @@ import { isValidElement, useCallback, useContext, useRef } from 'react'
 import pointer, { JsonObject } from '../utils/json-pointer'
 import DataContext, { FilterData } from '../DataContext/Context'
 
-export type ListAllPropsReturn = {
-  propsOfFields: JsonObject
-  propsOfValues: JsonObject
+export type ListAllPropsReturn<Data> = {
+  propsOfFields: Data
+  propsOfValues: Data
 }
-export type ListAllPropsProps = {
+export type ListAllPropsProps<Data> = {
   log?: boolean
-  generateRef?: React.MutableRefObject<() => ListAllPropsReturn>
+  generateRef?: React.MutableRefObject<() => ListAllPropsReturn<Data>>
   filterData?: FilterData
   children: React.ReactNode
 }
-export type GenerateRef = ListAllPropsProps['generateRef']['current']
+export type GenerateRef<Data extends JsonObject = JsonObject> =
+  ListAllPropsProps<Data>['generateRef']['current']
 
-export default function ListAllProps(props: ListAllPropsProps) {
+export default function ListAllProps<Data extends JsonObject = JsonObject>(
+  props: ListAllPropsProps<Data>
+) {
   const { log, generateRef, filterData, children } = props || {}
   const { fieldPropsRef, valuePropsRef, data, hasContext } =
     useContext(DataContext)
@@ -71,7 +74,7 @@ export default function ListAllProps(props: ListAllPropsProps) {
       return acc
     }, {})
 
-    return { propsOfFields, propsOfValues } as ListAllPropsReturn
+    return { propsOfFields, propsOfValues } as ListAllPropsReturn<Data>
   }, [fieldPropsRef, filterData, valuePropsRef])
 
   if (hasContext) {

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
@@ -635,7 +635,17 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should filter out React elements', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef = React.createRef<
+      GenerateRef<{
+        items: {
+          children: {
+            type: {
+              name: string
+            }
+          }
+        }
+      }>
+    >()
 
     render(
       <Form.Handler data={{ count: 2 }}>

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useSnapshot.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useSnapshot.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useRef } from 'react'
 import { makeUniqueId } from '../../../shared/component-helper'
-import pointer from '../utils/json-pointer'
+import pointer, { JsonObject } from '../utils/json-pointer'
 import { SharedStateId } from '../../../shared/helpers/useSharedState'
 import useDataContext from './useDataContext'
 import { SnapshotId, SnapshotName } from '../Form/Snapshot'
 import useData from '../Form/data-context/useData'
 
 export default function useSnapshot(id?: SharedStateId) {
-  const internalSnapshotsRef = useRef<Map<SnapshotId, unknown>>()
+  const internalSnapshotsRef = useRef<Map<SnapshotId, JsonObject>>()
   if (!internalSnapshotsRef.current) {
     internalSnapshotsRef.current = new Map()
   }
@@ -19,14 +19,14 @@ export default function useSnapshot(id?: SharedStateId) {
     (
       id: SnapshotId = makeUniqueId(),
       name: SnapshotName = null,
-      content: unknown = null
+      content: JsonObject = null
     ): SnapshotId => {
       const { internalDataRef, snapshotsRef } = getContext()
 
       if (!content) {
         const snapshotWithPaths = snapshotsRef?.current?.get?.(name)
         if (snapshotWithPaths) {
-          const collectedData = new Map()
+          const collectedData: Map<string, JsonObject> = new Map()
           snapshotWithPaths.forEach((isMounted, path) => {
             if (isMounted && pointer.has(internalDataRef.current, path)) {
               collectedData.set(
@@ -35,7 +35,7 @@ export default function useSnapshot(id?: SharedStateId) {
               )
             }
           })
-          content = collectedData
+          content = collectedData as unknown as JsonObject
         } else {
           content = internalDataRef.current
         }
@@ -52,7 +52,7 @@ export default function useSnapshot(id?: SharedStateId) {
   )
 
   const getSnapshot = useCallback(
-    (id: SnapshotId, name: SnapshotName = null): unknown => {
+    (id: SnapshotId, name: SnapshotName = null): JsonObject => {
       return internalSnapshotsRef.current.get(combineIdWithName(id, name))
     },
     []

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -562,21 +562,18 @@ export type EventReturnWithStateObjectAndSuccess =
   | Error
   | EventStateObjectWithSuccess
 
-export type OnSubmitParams = {
+export type OnSubmitParams<Data = JsonObject> = {
   /** Will remove data entries of fields that are not visible */
   reduceToVisibleFields: (
-    data: JsonObject,
+    data: Data,
     options?: VisibleDataOptions
-  ) => Partial<JsonObject>
+  ) => Partial<Data>
 
   /** Will call the given function for each data path. The returned `value` will replace each data entry. It's up to you to define the shape of the value. */
-  transformData: (
-    data: JsonObject,
-    handler: TransformData
-  ) => TransformData
+  transformData: (data: Data, handler: TransformData) => Partial<Data>
 
   /** Will filter data based on the given "filterDataHandler" method */
-  filterData: (filterDataHandler: FilterData) => Partial<JsonObject>
+  filterData: (filterDataHandler: FilterData) => Partial<Data>
 
   /** Will remove browser-side stored autocomplete data  */
   resetForm: () => void

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export type PointerPath = string | Array<string>
-export type JsonValue = any
-export type JsonObject = any
+export type JsonValue = unknown
+export type JsonObject = Record<string | number, unknown> | Array<unknown>
 
 /**
  * Lookup a json pointer in an object


### PR DESCRIPTION
The main change is that we go from:

```tsx
type JsonObject = any
```

to

```tsx
type JsonObject = Record<string | number, unknown> | Array<unknown>
```

and enhance the TypeScript support docs for the "Getting Started" section the `Form.Handler` and `Form.Isolation` docs.

To disable types you can do so by:


```tsx
<Form.Handler<any>>
...
</Form.Handler>
```

or

```tsx
const { data } = Form.useData<any>()
```
