### PR TITLE
feat(DatePicker): render calendar in a react portal

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -252,6 +252,7 @@ export const DatePickerCalendar = () => (
         range={true}
         startDate="2019-05-05"
         endDate="2019-06-05"
+        skipPortal
       />
     </ComponentBox>
   </Wrapper>

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -723,7 +723,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     [setOutsideClickHandler, onShow]
   )
 
-  // Make sure the triangle is positioned correctly after the picker is shown
+  // Make sure the triangle is positioned correctly after calendar is mounted
   useEffect(() => {
     if (!hidden) {
       setTrianglePosition()

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -615,7 +615,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     useRef<DatePickerContextValues['getReturnObject']>()
   const hideTimeout = useRef<NodeJS.Timeout>()
   const outsideClick = useRef<DetectOutsideClickClass>()
-  const pickerContainerRef = useRef<HTMLDivElement>()
+  const calendarContainerRef = useRef<HTMLDivElement>()
 
   const translation = useTranslation().DatePicker
 
@@ -675,7 +675,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
       // as that would lead to the ignoreElement being null/undefined,
       // since the portal has not been rendered yet,
       // causing the calendar to close when clicking on the calendar itself
-      [innerRef.current, pickerContainerRef],
+      [innerRef.current, calendarContainerRef],
       ({ event }: { event: MouseEvent | KeyboardEvent }) => {
         hidePicker({ ...event, focusOnHide: event?.['code'] })
       }
@@ -1005,7 +1005,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                 >
                   <span
                     className="dnb-date-picker__container"
-                    ref={pickerContainerRef}
+                    ref={calendarContainerRef}
                   >
                     <span
                       className="dnb-date-picker__triangle"

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -977,7 +977,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                 />
                 <DatePickerPortal
                   show={!hidden}
-                  targetElement={innerRef.current}
+                  targetElementRef={innerRef}
                 >
                   <DatePickerRange
                     id={id}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -610,6 +610,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     useRef<DatePickerContextValues['getReturnObject']>()
   const hideTimeout = useRef<NodeJS.Timeout>()
   const outsideClick = useRef<DetectOutsideClickClass>()
+  const portalRef = useRef<HTMLDivElement>()
 
   const translation = useTranslation().DatePicker
 
@@ -665,7 +666,11 @@ function DatePicker(externalProps: DatePickerAllProps) {
 
   const setOutsideClickHandler = useCallback(() => {
     outsideClick.current = detectOutsideClick(
-      innerRef.current,
+      // Sending in portalRef, instead of portalRef.current,
+      // as that would lead to the ignoreElement being null/undefined,
+      // since the portal has not been rendered yet,
+      // causing the calendar to close when clicking on the calendar itself
+      [innerRef.current, portalRef],
       ({ event }: { event: MouseEvent | KeyboardEvent }) => {
         hidePicker({ ...event, focusOnHide: event?.['code'] })
       }
@@ -977,6 +982,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                 />
                 <DatePickerPortal
                   show={!hidden}
+                  portalRef={portalRef}
                   targetElementRef={innerRef}
                 >
                   <DatePickerRange

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -915,11 +915,13 @@ function DatePicker(externalProps: DatePickerAllProps) {
     lang: context.locale,
   } as HTMLProps<HTMLSpanElement>
 
-  const portalClassNames = classnames(
-    opened && 'dnb-date-picker__portal--opened',
-    hidden && 'dnb-date-picker__portal--hidden',
-    showInput && 'dnb-date-picker__portal--show-input',
-    alignPicker && `dnb-date-picker__portal--${alignPicker}`,
+  const containerClassNames = classnames(
+    'dnb-date-picker__container',
+    opened && 'dnb-date-picker__container--opened',
+    !opened && 'dnb-date-picker__container--closed',
+    hidden && 'dnb-date-picker__container--hidden',
+    showInput && 'dnb-date-picker__container--show-input',
+    alignPicker && `dnb-date-picker__container--${alignPicker}`,
     size && `dnb-date-picker--${size}`
   )
 
@@ -999,13 +1001,12 @@ function DatePicker(externalProps: DatePickerAllProps) {
 
               {!hidden && (
                 <DatePickerPortal
-                  className={portalClassNames}
                   alignment={alignPicker}
                   skipPortal={skipPortal}
                   targetElementRef={innerRef}
                 >
                   <span
-                    className="dnb-date-picker__container"
+                    className={containerClassNames}
                     ref={calendarContainerRef}
                   >
                     <span

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -724,7 +724,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
   )
 
   // Make sure the triangle is positioned correctly after calendar is mounted
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!hidden) {
       setTrianglePosition()
     }

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -1108,6 +1108,7 @@ const NonAttributes = [
   'endMonth',
   'startMonth',
   'alignPicker',
+  'preventClose',
 ]
 
 function filterOutNonAttributes(props: DatePickerProps) {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -271,6 +271,10 @@ export type DatePickerProps = {
    * Use `right` to change the calendar alignment direction. Defaults to `left`.
    */
   alignPicker?: 'auto' | 'left' | 'right'
+  /**
+   * If set to `true`, the calendar will not be rendered inside a react portal. Defaults to `false`.
+   */
+  skipPortal?: boolean
   className?: string
   /**
    * Will be called right before every new calendar view gets rendered. See the example above.
@@ -569,6 +573,7 @@ const defaultProps: DatePickerProps = {
   opened: false,
   noAnimation: false,
   direction: 'auto',
+  skipPortal: false,
 }
 
 function DatePicker(externalProps: DatePickerAllProps) {
@@ -852,6 +857,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     showResetButton,
     className,
     tooltip,
+    skipPortal,
     ...restProps
   } = extendedProps
 
@@ -990,57 +996,59 @@ function DatePicker(externalProps: DatePickerAllProps) {
                 {...statusProps}
               />
 
-              <DatePickerPortal
-                className={portalClassNames}
-                show={!hidden}
-                alignment={alignPicker}
-                targetElementRef={innerRef}
-              >
-                <span
-                  className="dnb-date-picker__container"
-                  ref={pickerContainerRef}
+              {!hidden && (
+                <DatePickerPortal
+                  className={portalClassNames}
+                  alignment={alignPicker}
+                  skipPortal={skipPortal}
+                  targetElementRef={innerRef}
                 >
                   <span
-                    className="dnb-date-picker__triangle"
-                    ref={triangleRef}
-                  />
-                  <DatePickerRange
-                    id={id}
-                    firstDayOfWeek={firstDay}
-                    resetDate={resetDate}
-                    isRange={range}
-                    isLink={link}
-                    isSync={sync}
-                    hideDays={shouldHideDays}
-                    hideNav={shouldHideNavigation}
-                    views={
-                      hideNavigationButtons
-                        ? [{ nextBtn: false, prevBtn: false }]
-                        : null
-                    }
-                    onlyMonth={onlyMonth}
-                    hideNextMonthWeek={hideLastWeek}
-                    noAutoFocus={disableAutofocus}
-                    onChange={onPickerChange}
-                    locale={context.locale}
-                  />
-                  {(addonElement || shortcuts) && (
-                    <DatePickerAddon
-                      renderElement={addonElement}
-                      shortcuts={shortcuts}
+                    className="dnb-date-picker__container"
+                    ref={pickerContainerRef}
+                  >
+                    <span
+                      className="dnb-date-picker__triangle"
+                      ref={triangleRef}
                     />
-                  )}
-                  <DatePickerFooter
-                    isRange={range}
-                    onSubmit={onSubmitHandler}
-                    onCancel={onCancelHandler}
-                    onReset={onResetHandler}
-                    submitButtonText={submitButtonText}
-                    cancelButtonText={cancelButtonText}
-                    resetButtonText={resetButtonText}
-                  />
-                </span>
-              </DatePickerPortal>
+                    <DatePickerRange
+                      id={id}
+                      firstDayOfWeek={firstDay}
+                      resetDate={resetDate}
+                      isRange={range}
+                      isLink={link}
+                      isSync={sync}
+                      hideDays={shouldHideDays}
+                      hideNav={shouldHideNavigation}
+                      views={
+                        hideNavigationButtons
+                          ? [{ nextBtn: false, prevBtn: false }]
+                          : null
+                      }
+                      onlyMonth={onlyMonth}
+                      hideNextMonthWeek={hideLastWeek}
+                      noAutoFocus={disableAutofocus}
+                      onChange={onPickerChange}
+                      locale={context.locale}
+                    />
+                    {(addonElement || shortcuts) && (
+                      <DatePickerAddon
+                        renderElement={addonElement}
+                        shortcuts={shortcuts}
+                      />
+                    )}
+                    <DatePickerFooter
+                      isRange={range}
+                      onSubmit={onSubmitHandler}
+                      onCancel={onCancelHandler}
+                      onReset={onResetHandler}
+                      submitButtonText={submitButtonText}
+                      cancelButtonText={cancelButtonText}
+                      resetButtonText={resetButtonText}
+                    />
+                  </span>
+                </DatePickerPortal>
+              )}
             </span>
             {suffix && (
               <Suffix

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -57,6 +57,7 @@ import { DatePickerContextValues, DateType } from './DatePickerContext'
 import { DatePickerDates } from './hooks/useDates'
 import { useTranslation } from '../../shared'
 import { convertSnakeCaseProps } from '../../shared/helpers/withSnakeCaseProps'
+import DatePickerPortal from './DatePickerPortal'
 
 export type DatePickerEventAttributes = {
   day?: string
@@ -974,45 +975,46 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   className="dnb-date-picker__triangle"
                   ref={triangleRef}
                 />
-                {!hidden && (
-                  <>
-                    <DatePickerRange
-                      id={id}
-                      firstDayOfWeek={firstDay}
-                      resetDate={resetDate}
-                      isRange={range}
-                      isLink={link}
-                      isSync={sync}
-                      hideDays={shouldHideDays}
-                      hideNav={shouldHideNavigation}
-                      views={
-                        hideNavigationButtons
-                          ? [{ nextBtn: false, prevBtn: false }]
-                          : null
-                      }
-                      onlyMonth={onlyMonth}
-                      hideNextMonthWeek={hideLastWeek}
-                      noAutoFocus={disableAutofocus}
-                      onChange={onPickerChange}
-                      locale={context.locale}
+                <DatePickerPortal
+                  show={!hidden}
+                  targetElement={innerRef.current}
+                >
+                  <DatePickerRange
+                    id={id}
+                    firstDayOfWeek={firstDay}
+                    resetDate={resetDate}
+                    isRange={range}
+                    isLink={link}
+                    isSync={sync}
+                    hideDays={shouldHideDays}
+                    hideNav={shouldHideNavigation}
+                    views={
+                      hideNavigationButtons
+                        ? [{ nextBtn: false, prevBtn: false }]
+                        : null
+                    }
+                    onlyMonth={onlyMonth}
+                    hideNextMonthWeek={hideLastWeek}
+                    noAutoFocus={disableAutofocus}
+                    onChange={onPickerChange}
+                    locale={context.locale}
+                  />
+                  {(addonElement || shortcuts) && (
+                    <DatePickerAddon
+                      renderElement={addonElement}
+                      shortcuts={shortcuts}
                     />
-                    {(addonElement || shortcuts) && (
-                      <DatePickerAddon
-                        renderElement={addonElement}
-                        shortcuts={shortcuts}
-                      />
-                    )}
-                    <DatePickerFooter
-                      isRange={range}
-                      onSubmit={onSubmitHandler}
-                      onCancel={onCancelHandler}
-                      onReset={onResetHandler}
-                      submitButtonText={submitButtonText}
-                      cancelButtonText={cancelButtonText}
-                      resetButtonText={resetButtonText}
-                    />
-                  </>
-                )}
+                  )}
+                  <DatePickerFooter
+                    isRange={range}
+                    onSubmit={onSubmitHandler}
+                    onCancel={onCancelHandler}
+                    onReset={onResetHandler}
+                    submitButtonText={submitButtonText}
+                    cancelButtonText={cancelButtonText}
+                    resetButtonText={resetButtonText}
+                  />
+                </DatePickerPortal>
               </span>
             </span>
             {suffix && (

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -134,6 +134,11 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  skipPortal: {
+    doc: ' If set to `true`, the calendar will not be rendered inside a react portal. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
   onlyMonth: {
     doc: 'Use `true` to only show the defined month. Disables the month navigation possibility. Defaults to `false`.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,21 +1,35 @@
+import { set } from 'date-fns'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
   show?: boolean
-  targetElement?: HTMLElement
+  targetElementRef?: React.RefObject<HTMLElement>
 }
 
 export default function DatePickerPortal({
   show = false,
-  targetElement,
+  targetElementRef,
   children,
 }: DatePickerPortalProps) {
+  // Make sure the portal re-renders when the target element changes
+  const [targetElement, setTargetElement] = useState(
+    targetElementRef?.current
+  )
+
+  // Make sure that the portal has a bounding rect to work with, when setting the position
+  useEffect(() => {
+    if (targetElementRef?.current !== targetElement) {
+      setTargetElement(targetElementRef?.current)
+    }
+  }, [targetElementRef, targetElement])
+
   const scrollY = window.scrollY
   const scrollX = window.scrollX
 
   const rect = targetElement?.getBoundingClientRect()
 
-  return show
+  return targetElement && show
     ? createPortal(
         <span
           className="dnb-datepicker__portal"

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import ReactDOM from 'react-dom'
 import { DatePickerProps } from './DatePicker'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
@@ -26,7 +26,7 @@ export default function DatePickerPortal({
   return (
     position &&
     (!skipPortal
-      ? createPortal(
+      ? ReactDOM.createPortal(
           <div
             className={`${'dnb-date-picker__portal'} ${className}`}
             style={position}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -2,11 +2,11 @@ import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useRef,
   useState,
 } from 'react'
 import ReactDOM from 'react-dom'
 import { DatePickerProps } from './DatePicker'
+import { debounce } from '../../shared/helpers'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
   skipPortal?: DatePickerProps['skipPortal']
@@ -23,8 +23,6 @@ export default function DatePickerPortal({
 }: DatePickerPortalProps) {
   const [position, setPosition] = useState({})
 
-  const positionTimeout = useRef<NodeJS.Timeout>()
-
   useLayoutEffect(() => {
     if (targetElementRef.current) {
       setPosition(getPosition(targetElementRef.current, alignment))
@@ -32,16 +30,13 @@ export default function DatePickerPortal({
   }, [])
 
   const setPositionDebounce = useCallback(() => {
-    if (targetElementRef.current) {
-      setPosition(getPosition(targetElementRef.current, alignment))
-    }
-
-    clearTimeout(positionTimeout.current)
-    positionTimeout.current = setTimeout(() => {
+    const debounced = debounce(() => {
       if (targetElementRef.current) {
         setPosition(getPosition(targetElementRef.current, alignment))
       }
     }, 200)
+
+    debounced()
   }, [alignment, targetElementRef])
 
   useEffect(() => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,22 +1,26 @@
 import React, { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { DatePickerProps } from './DatePicker'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
   show?: boolean
+  alignment?: DatePickerProps['alignPicker']
   portalRef?: React.RefObject<HTMLDivElement>
   targetElementRef?: React.RefObject<HTMLElement>
 }
 
 export default function DatePickerPortal({
   show = false,
-  portalRef,
+  alignment,
   targetElementRef,
   children,
+  className,
 }: DatePickerPortalProps) {
   // Make sure the portal re-renders when the target element changes
   const [targetElement, setTargetElement] = useState(
     targetElementRef?.current
   )
+  const [portal, setPortal] = useState<HTMLDivElement>(undefined)
 
   // Make sure that the portal has a bounding rect to work with, when setting the position
   useEffect(() => {
@@ -25,26 +29,34 @@ export default function DatePickerPortal({
     }
   }, [targetElementRef, targetElement])
 
-  const { top, left } = getPosition(targetElement)
+  if (show && !portal) {
+    const portalRoot = createPortalRoot(className)
+    document.body.appendChild(portalRoot)
+    const { top, left } = getPosition(targetElement, alignment)
+    portalRoot.style.left = left
+    portalRoot.style.top = top
+    setPortal(portalRoot)
+  }
 
-  return show
-    ? createPortal(
-        <div
-          className="dnb-date-picker__portal"
-          style={{
-            top,
-            left,
-          }}
-          ref={portalRef}
-        >
-          {children}
-        </div>,
-        document.body
-      )
-    : null
+  if (!show && portal) {
+    document.body.removeChild(portal)
+    setPortal(undefined)
+  }
+
+  return portal && createPortal(children, portal)
 }
 
-function getPosition(targetElement: HTMLElement) {
+function createPortalRoot(className: string) {
+  const root = document.createElement('div')
+  root.className = `${'dnb-date-picker__portal'} ${className}`
+
+  return root
+}
+
+function getPosition(
+  targetElement: HTMLElement,
+  alignment: DatePickerPortalProps['alignment']
+) {
   if (!targetElement) {
     return { top: '0', left: '0' }
   }
@@ -54,10 +66,12 @@ function getPosition(targetElement: HTMLElement) {
   const scrollY = window.scrollY
   const scrollX = window.scrollX
 
-  const offsetY = rect.height
-
   return {
-    top: `${rect.top + offsetY + scrollY}px`,
-    left: `${rect.left + scrollX}px`,
+    top: `${rect.top + scrollY}px`,
+    left: `${
+      alignment === 'right'
+        ? rect.left + rect.width + scrollX
+        : rect.left + scrollX
+    }px`,
   }
 }

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,0 +1,32 @@
+import { createPortal } from 'react-dom'
+
+type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
+  show?: boolean
+  targetElement?: HTMLElement
+}
+
+export default function DatePickerPortal({
+  show = false,
+  targetElement,
+  children,
+}: DatePickerPortalProps) {
+  const scrollY = window.scrollY
+  const scrollX = window.scrollX
+
+  const rect = targetElement?.getBoundingClientRect()
+
+  return show
+    ? createPortal(
+        <span
+          className="dnb-datepicker__portal"
+          style={{
+            top: `${rect?.top + scrollY}px`,
+            left: `${rect?.left + scrollX}px`,
+          }}
+        >
+          {children}
+        </span>,
+        document.body
+      )
+    : null
+}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -3,64 +3,46 @@ import { createPortal } from 'react-dom'
 import { DatePickerProps } from './DatePicker'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
-  show?: boolean
+  skipPortal?: DatePickerProps['skipPortal']
   alignment?: DatePickerProps['alignPicker']
-  portalRef?: React.RefObject<HTMLDivElement>
   targetElementRef?: React.RefObject<HTMLElement>
 }
 
 export default function DatePickerPortal({
-  show = false,
+  className,
+  skipPortal,
   alignment,
   targetElementRef,
   children,
-  className,
 }: DatePickerPortalProps) {
-  // Make sure the portal re-renders when the target element changes
-  const [targetElement, setTargetElement] = useState(
-    targetElementRef?.current
-  )
-  const [portal, setPortal] = useState<HTMLDivElement>(undefined)
+  const [position, setPosition] = useState({})
 
-  // Make sure that the portal has a bounding rect to work with, when setting the position
   useEffect(() => {
-    if (targetElementRef?.current !== targetElement) {
-      setTargetElement(targetElementRef?.current)
+    if (targetElementRef.current) {
+      setPosition(getPosition(targetElementRef.current, alignment))
     }
-  }, [targetElementRef, targetElement])
+  }, [])
 
-  if (show && !portal) {
-    const portalRoot = createPortalRoot(className)
-    document.body.appendChild(portalRoot)
-    const { top, left } = getPosition(targetElement, alignment)
-    portalRoot.style.left = left
-    portalRoot.style.top = top
-    setPortal(portalRoot)
-  }
-
-  if (!show && portal) {
-    document.body.removeChild(portal)
-    setPortal(undefined)
-  }
-
-  return portal && createPortal(children, portal)
-}
-
-function createPortalRoot(className: string) {
-  const root = document.createElement('div')
-  root.className = `${'dnb-date-picker__portal'} ${className}`
-
-  return root
+  return (
+    position &&
+    (!skipPortal
+      ? createPortal(
+          <div
+            className={`${'dnb-date-picker__portal'} ${className}`}
+            style={position}
+          >
+            {children}
+          </div>,
+          document.body
+        )
+      : children)
+  )
 }
 
 function getPosition(
   targetElement: HTMLElement,
   alignment: DatePickerPortalProps['alignment']
 ) {
-  if (!targetElement) {
-    return { top: '0', left: '0' }
-  }
-
   const rect = targetElement?.getBoundingClientRect()
 
   const scrollY = window.scrollY

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -43,7 +43,7 @@ export default function DatePickerPortal({
     }, 200)
   }, [alignment, targetElementRef])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!skipPortal) {
       window.addEventListener('resize', setPositionDebounce)
       window.addEventListener('scroll', setPositionDebounce)

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -61,6 +61,3 @@ function getPosition(targetElement: HTMLElement) {
     left: `${rect.left + scrollX}px`,
   }
 }
-function userRef<T>() {
-  throw new Error('Function not implemented.')
-}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,4 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react'
 import ReactDOM from 'react-dom'
 import { DatePickerProps } from './DatePicker'
 
@@ -17,9 +22,32 @@ export default function DatePickerPortal({
 }: DatePickerPortalProps) {
   const [position, setPosition] = useState({})
 
+  const positionTimeout = React.useRef(null)
+
   useEffect(() => {
     if (targetElementRef.current) {
       setPosition(getPosition(targetElementRef.current, alignment))
+    }
+  }, [])
+
+  const setPositionAtResize = useCallback(() => {
+    if (targetElementRef.current) {
+      setPosition(getPosition(targetElementRef.current, alignment))
+    }
+
+    clearTimeout(positionTimeout.current)
+    positionTimeout.current = setTimeout(() => {
+      if (targetElementRef.current) {
+        setPosition(getPosition(targetElementRef.current, alignment))
+      }
+    }, 200)
+  }, [alignment, targetElementRef])
+
+  useLayoutEffect(() => {
+    window.addEventListener('resize', setPositionAtResize)
+
+    return () => {
+      window.removeEventListener('resize', setPositionAtResize)
     }
   }, [])
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -30,7 +30,7 @@ export default function DatePickerPortal({
   return show
     ? createPortal(
         <div
-          className="dnb-datepicker__portal"
+          className="dnb-date-picker__portal"
           style={{
             top,
             left,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -22,7 +22,7 @@ export default function DatePickerPortal({
 }: DatePickerPortalProps) {
   const [position, setPosition] = useState({})
 
-  const positionTimeout = React.useRef(null)
+  const positionTimeout = useRef<NodeJS.Timeout>()
 
   useEffect(() => {
     if (targetElementRef.current) {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -30,7 +30,7 @@ export default function DatePickerPortal({
     }
   }, [])
 
-  const setPositionAtResize = useCallback(() => {
+  const setPositionDebounce = useCallback(() => {
     if (targetElementRef.current) {
       setPosition(getPosition(targetElementRef.current, alignment))
     }
@@ -44,10 +44,16 @@ export default function DatePickerPortal({
   }, [alignment, targetElementRef])
 
   useLayoutEffect(() => {
-    window.addEventListener('resize', setPositionAtResize)
+    if (!skipPortal) {
+      window.addEventListener('resize', setPositionDebounce)
+      window.addEventListener('scroll', setPositionDebounce)
+    }
 
     return () => {
-      window.removeEventListener('resize', setPositionAtResize)
+      if (!skipPortal) {
+        window.removeEventListener('resize', setPositionDebounce)
+        window.removeEventListener('scroll', setPositionDebounce)
+      }
     }
   }, [])
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,14 +1,15 @@
-import { set } from 'date-fns'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
   show?: boolean
+  portalRef?: React.RefObject<HTMLDivElement>
   targetElementRef?: React.RefObject<HTMLElement>
 }
 
 export default function DatePickerPortal({
   show = false,
+  portalRef,
   targetElementRef,
   children,
 }: DatePickerPortalProps) {
@@ -24,23 +25,42 @@ export default function DatePickerPortal({
     }
   }, [targetElementRef, targetElement])
 
-  const scrollY = window.scrollY
-  const scrollX = window.scrollX
+  const { top, left } = getPosition(targetElement)
 
-  const rect = targetElement?.getBoundingClientRect()
-
-  return targetElement && show
+  return show
     ? createPortal(
-        <span
+        <div
           className="dnb-datepicker__portal"
           style={{
-            top: `${rect?.top + scrollY}px`,
-            left: `${rect?.left + scrollX}px`,
+            top,
+            left,
           }}
+          ref={portalRef}
         >
           {children}
-        </span>,
+        </div>,
         document.body
       )
     : null
+}
+
+function getPosition(targetElement: HTMLElement) {
+  if (!targetElement) {
+    return { top: '0', left: '0' }
+  }
+
+  const rect = targetElement?.getBoundingClientRect()
+
+  const scrollY = window.scrollY
+  const scrollX = window.scrollX
+
+  const offsetY = rect.height
+
+  return {
+    top: `${rect.top + offsetY + scrollY}px`,
+    left: `${rect.left + scrollX}px`,
+  }
+}
+function userRef<T>() {
+  throw new Error('Function not implemented.')
 }

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -50,7 +50,7 @@ export default function DatePickerPortal({
         window.removeEventListener('scroll', setPositionDebounce)
       }
     }
-  }, [])
+  }, [setPositionDebounce, skipPortal])
 
   return (
     position &&

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import ReactDOM from 'react-dom'
 import { DatePickerProps } from './DatePicker'
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -15,7 +15,6 @@ type DatePickerPortalProps = React.HTMLProps<HTMLDivElement> & {
 }
 
 export default function DatePickerPortal({
-  className,
   skipPortal,
   alignment,
   targetElementRef,
@@ -57,10 +56,7 @@ export default function DatePickerPortal({
     position &&
     (!skipPortal
       ? ReactDOM.createPortal(
-          <div
-            className={`${'dnb-date-picker__portal'} ${className}`}
-            style={position}
-          >
+          <div className="dnb-date-picker__portal" style={position}>
             {children}
           </div>,
           document.body

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { DatePickerProps } from './DatePicker'
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerPortal.tsx
@@ -19,7 +19,7 @@ export default function DatePickerPortal({
 
   const positionTimeout = useRef<NodeJS.Timeout>()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (targetElementRef.current) {
       setPosition(getPosition(targetElementRef.current, alignment))
     }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2652,6 +2652,30 @@ describe('Custom text for buttons', () => {
   })
 })
 
+describe('DatePickerPortal', () => {
+  it('should attatch portal to document body on mount, and detatch on unmount', async () => {
+    render(<DatePicker />)
+
+    const inputButton = screen.getByLabelText('åpne datovelger')
+
+    expect(
+      document.body.querySelector('.dnb-date-picker__portal')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(inputButton)
+
+    expect(
+      document.body.querySelector('.dnb-date-picker__portal')
+    ).toBeInTheDocument()
+
+    await userEvent.click(inputButton)
+
+    expect(
+      document.body.querySelector('.dnb-date-picker__portal')
+    ).not.toBeInTheDocument()
+  })
+})
+
 describe('DatePicker ARIA', () => {
   it('should validate', async () => {
     const Comp = render(

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2678,6 +2678,21 @@ describe('DatePickerPortal', () => {
       ).not.toBeInTheDocument()
     )
   })
+
+  it('should contain calendar views when mounted', async () => {
+    render(<DatePicker />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const portal = document.body.querySelector('.dnb-date-picker__portal')
+
+    expect(
+      portal.querySelector('.dnb-date-picker__views')
+    ).toBeInTheDocument()
+    expect(
+      portal.querySelector('.dnb-date-picker__calendar')
+    ).toBeInTheDocument()
+  })
 })
 
 describe('DatePicker ARIA', () => {
@@ -2689,6 +2704,7 @@ describe('DatePicker ARIA', () => {
         disableAutofocus={true}
         startDate="2019-05-05"
         endDate="2019-06-05"
+        skipPortal
       />
     )
     expect(await axeComponent(Comp)).toHaveNoViolations()
@@ -2703,6 +2719,7 @@ describe('DatePicker ARIA', () => {
         disableAutofocus={true}
         startDate="2019-05-05"
         endDate="2019-06-05"
+        skipPortal
       />
     )
     expect(await axeComponent(Comp)).toHaveNoViolations()

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2664,15 +2664,19 @@ describe('DatePickerPortal', () => {
 
     await userEvent.click(inputButton)
 
-    expect(
-      document.body.querySelector('.dnb-date-picker__portal')
-    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        document.body.querySelector('.dnb-date-picker__portal')
+      ).toBeInTheDocument()
+    )
 
     await userEvent.click(inputButton)
 
-    expect(
-      document.body.querySelector('.dnb-date-picker__portal')
-    ).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        document.body.querySelector('.dnb-date-picker__portal')
+      ).not.toBeInTheDocument()
+    )
   })
 })
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2693,6 +2693,22 @@ describe('DatePickerPortal', () => {
       portal.querySelector('.dnb-date-picker__calendar')
     ).toBeInTheDocument()
   })
+
+  it('should skip portal when "skipPortal" is true', async () => {
+    render(<DatePicker skipPortal />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    // dnb-date-picker__container is a direct descendant of dnb-date-picker__shell when portal is skipped
+    expect(
+      document.querySelector(
+        '.dnb-date-picker__shell > .dnb-date-picker__container'
+      )
+    ).toBeInTheDocument()
+    expect(
+      document.body.querySelector('.dnb-date-picker__portal')
+    ).not.toBeInTheDocument()
+  })
 })
 
 describe('DatePicker ARIA', () => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2653,7 +2653,7 @@ describe('Custom text for buttons', () => {
 })
 
 describe('DatePickerPortal', () => {
-  it('should attatch portal to document body on mount, and detatch on unmount', async () => {
+  it('should attach portal to document body on mount, and detach on unmount', async () => {
     render(<DatePicker />)
 
     const inputButton = screen.getByLabelText('åpne datovelger')

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3879,6 +3879,14 @@ html[data-visual-test] .dnb-date-picker--opened .dnb-date-picker__container, .dn
 html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container, .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation {
   animation: date-picker-slide-up 1ms ease-out 1 forwards;
 }
+.dnb-date-picker__portal {
+  --date-picker-input-height: 2rem;
+  --date-picker-day-width: 2rem;
+  --date-picker-day-horizontal-spacing: 4px;
+  position: absolute;
+  z-index: 1000;
+  background-color: var(--color-white);
+}
 .dnb-date-picker__input,
 .dnb-date-picker .dnb-input__input.dnb-date-picker__input, .dnb-core-style .dnb-date-picker__input {
   display: inline-block;
@@ -4264,6 +4272,11 @@ exports[`DatePicker scss have to match default theme snapshot 1`] = `
   color: var(--color-black);
 }
 .dnb-date-picker__container {
+  box-shadow: var(--shadow-default);
+  border-radius: 0.25rem;
+  background-color: var(--color-white);
+}
+.dnb-date-picker__portal {
   box-shadow: var(--shadow-default);
   border-radius: 0.25rem;
   background-color: var(--color-white);

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3841,6 +3841,44 @@ button .dnb-form-status__text {
   left: -1rem;
   top: var(--date-picker-input-height);
 }
+.dnb-date-picker--small .dnb-date-picker__container {
+  top: 1.5rem;
+}
+.dnb-date-picker--medium .dnb-date-picker__container {
+  top: 2.5rem;
+}
+.dnb-date-picker--large .dnb-date-picker__container {
+  top: 3rem;
+}
+.dnb-date-picker--show-input .dnb-date-picker__container {
+  left: 0;
+}
+.dnb-date-picker--right .dnb-date-picker__container {
+  left: auto;
+  right: -1rem;
+}
+.dnb-date-picker--show-input.dnb-date-picker--right .dnb-date-picker__container {
+  left: auto;
+  right: 0;
+}
+.dnb-date-picker--opened .dnb-date-picker__container {
+  z-index: 100;
+}
+.dnb-date-picker--opened .dnb-date-picker__container:not(.dnb-date-picker--opened .dnb-date-picker__container--no-animation) {
+  animation: date-picker-slide-down 200ms ease-out 1 forwards;
+}
+html[data-visual-test] .dnb-date-picker--opened .dnb-date-picker__container, .dnb-date-picker--opened .dnb-date-picker__container--no-animation {
+  animation: date-picker-slide-down 1ms ease-out 1 forwards;
+}
+.dnb-date-picker--hidden .dnb-date-picker__container {
+  display: none;
+}
+.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container:not(.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation) {
+  animation: date-picker-slide-up 150ms ease-out 1 forwards;
+}
+html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container, .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation {
+  animation: date-picker-slide-up 1ms ease-out 1 forwards;
+}
 .dnb-date-picker__input,
 .dnb-date-picker .dnb-input__input.dnb-date-picker__input, .dnb-core-style .dnb-date-picker__input {
   display: inline-block;
@@ -4099,6 +4137,10 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   transform: translateY(60%) rotate(45deg);
   border: 1px solid var(--color-black-border);
   background-color: var(--color-white);
+}
+.dnb-date-picker--right .dnb-date-picker__triangle {
+  left: auto;
+  right: 0;
 }
 .dnb-date-picker .rtl {
   direction: rtl;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -4291,6 +4291,20 @@ html[data-visual-test] .dnb-date-picker__portal:not(.dnb-date-picker__portal--op
 .dnb-date-picker__portal--right .dnb-date-picker__triangle {
   left: auto;
   right: 0;
+}
+.dnb-date-picker__portal table {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+}
+.dnb-date-picker__portal table.dnb-no-focus:focus {
+  outline: none;
+}
+html[data-whatinput=keyboard] .dnb-date-picker__portal table.dnb-no-focus:focus {
+  --border-color: var(--focus-ring-color);
+  --border-width: var(--focus-ring-width);
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
 }"
 `;
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3834,6 +3834,28 @@ button .dnb-form-status__text {
   white-space: nowrap;
   height: inherit;
 }
+.dnb-date-picker__triangle {
+  pointer-events: none;
+  position: absolute;
+  top: calc(2px - var(--date-picker-input-height) / 2);
+  left: 0;
+  right: auto;
+  margin: 0 1.5rem;
+  width: calc(var(--date-picker-input-height) / 2);
+  height: calc(var(--date-picker-input-height) / 2);
+  overflow: hidden;
+}
+.dnb-date-picker__triangle::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(var(--date-picker-input-height) / 2);
+  height: calc(var(--date-picker-input-height) / 2);
+  transform: translateY(60%) rotate(45deg);
+  border: 1px solid var(--color-black-border);
+  background-color: var(--color-white);
+}
 .dnb-date-picker__container {
   position: absolute;
   display: block;
@@ -3878,6 +3900,10 @@ html[data-visual-test] .dnb-date-picker__container--opened, .dnb-date-picker__co
 }
 html[data-visual-test] .dnb-date-picker__container--closed, .dnb-date-picker__container--closed--no-animation {
   animation: date-picker-slide-up 1ms ease-out 1 forwards;
+}
+.dnb-date-picker__container--right .dnb-date-picker__triangle {
+  left: auto;
+  right: 0;
 }
 .dnb-date-picker__container table {
   position: relative;
@@ -4115,32 +4141,6 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 }
 .dnb-date-picker__day--start-date.dnb-date-picker__day--end-date::after {
   content: none;
-}
-.dnb-date-picker__triangle {
-  pointer-events: none;
-  position: absolute;
-  top: calc(2px - var(--date-picker-input-height) / 2);
-  left: 0;
-  right: auto;
-  margin: 0 1.5rem;
-  width: calc(var(--date-picker-input-height) / 2);
-  height: calc(var(--date-picker-input-height) / 2);
-  overflow: hidden;
-}
-.dnb-date-picker__triangle::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: calc(var(--date-picker-input-height) / 2);
-  height: calc(var(--date-picker-input-height) / 2);
-  transform: translateY(60%) rotate(45deg);
-  border: 1px solid var(--color-black-border);
-  background-color: var(--color-white);
-}
-.dnb-date-picker--right .dnb-date-picker__triangle {
-  left: auto;
-  right: 0;
 }
 .dnb-date-picker .rtl {
   direction: rtl;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -4221,8 +4221,19 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker__fieldset:not([class*=space__left]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__left]) {
   margin-left: 0;
 }
+<<<<<<< HEAD
 .dnb-date-picker__fieldset:not([class*=space__right]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__right]) {
   margin-right: 0;
+=======
+.dnb-date-picker__portal {
+  --date-picker-input-height: 2rem;
+  --date-picker-day-width: 2rem;
+  --date-picker-day-horizontal-spacing: 4px;
+  position: absolute;
+  left: 0;
+  z-index: var(--modal-z-index10);
+  line-height: var(--date-picker-input-height);
+>>>>>>> a16a9abf31 (re-add missing portal styles)
 }
 
 @keyframes date-picker-slide-down {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -4221,10 +4221,9 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker__fieldset:not([class*=space__left]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__left]) {
   margin-left: 0;
 }
-<<<<<<< HEAD
 .dnb-date-picker__fieldset:not([class*=space__right]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__right]) {
   margin-right: 0;
-=======
+}
 .dnb-date-picker__portal {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
@@ -4233,7 +4232,6 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   left: 0;
   z-index: var(--modal-z-index10);
   line-height: var(--date-picker-input-height);
->>>>>>> a16a9abf31 (re-add missing portal styles)
 }
 
 @keyframes date-picker-slide-down {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -4248,6 +4248,7 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   position: absolute;
   left: 0;
   z-index: 1000;
+  line-height: var(--date-picker-input-height);
 }
 .dnb-date-picker__portal--small .dnb-date-picker__container {
   top: 1.5rem;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3841,52 +3841,6 @@ button .dnb-form-status__text {
   left: -1rem;
   top: var(--date-picker-input-height);
 }
-.dnb-date-picker--small .dnb-date-picker__container {
-  top: 1.5rem;
-}
-.dnb-date-picker--medium .dnb-date-picker__container {
-  top: 2.5rem;
-}
-.dnb-date-picker--large .dnb-date-picker__container {
-  top: 3rem;
-}
-.dnb-date-picker--show-input .dnb-date-picker__container {
-  left: 0;
-}
-.dnb-date-picker--right .dnb-date-picker__container {
-  left: auto;
-  right: -1rem;
-}
-.dnb-date-picker--show-input.dnb-date-picker--right .dnb-date-picker__container {
-  left: auto;
-  right: 0;
-}
-.dnb-date-picker--opened .dnb-date-picker__container {
-  z-index: 100;
-}
-.dnb-date-picker--opened .dnb-date-picker__container:not(.dnb-date-picker--opened .dnb-date-picker__container--no-animation) {
-  animation: date-picker-slide-down 200ms ease-out 1 forwards;
-}
-html[data-visual-test] .dnb-date-picker--opened .dnb-date-picker__container, .dnb-date-picker--opened .dnb-date-picker__container--no-animation {
-  animation: date-picker-slide-down 1ms ease-out 1 forwards;
-}
-.dnb-date-picker--hidden .dnb-date-picker__container {
-  display: none;
-}
-.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container:not(.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation) {
-  animation: date-picker-slide-up 150ms ease-out 1 forwards;
-}
-html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container, .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation {
-  animation: date-picker-slide-up 1ms ease-out 1 forwards;
-}
-.dnb-date-picker__portal {
-  --date-picker-input-height: 2rem;
-  --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
-  position: absolute;
-  z-index: 1000;
-  background-color: var(--color-white);
-}
 .dnb-date-picker__input,
 .dnb-date-picker .dnb-input__input.dnb-date-picker__input, .dnb-core-style .dnb-date-picker__input {
   display: inline-block;
@@ -4146,10 +4100,6 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   border: 1px solid var(--color-black-border);
   background-color: var(--color-white);
 }
-.dnb-date-picker--right .dnb-date-picker__triangle {
-  left: auto;
-  right: 0;
-}
 .dnb-date-picker .rtl {
   direction: rtl;
 }
@@ -4248,6 +4198,56 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   to {
     opacity: 0;
   }
+}
+.dnb-date-picker__portal {
+  --date-picker-input-height: 2rem;
+  --date-picker-day-width: 2rem;
+  --date-picker-day-horizontal-spacing: 4px;
+  position: absolute;
+  left: 0;
+  z-index: 1000;
+}
+.dnb-date-picker__portal--small .dnb-date-picker__container {
+  top: 1.5rem;
+}
+.dnb-date-picker__portal--medium .dnb-date-picker__container {
+  top: 2.5rem;
+}
+.dnb-date-picker__portal--large .dnb-date-picker__container {
+  top: 3rem;
+}
+.dnb-date-picker__portal--show-input .dnb-date-picker__container {
+  left: 0;
+}
+.dnb-date-picker__portal--right .dnb-date-picker__container {
+  left: auto;
+  right: -1rem;
+}
+.dnb-date-picker__portal--show-input.dnb-date-picker__portal--right .dnb-date-picker__container {
+  left: auto;
+  right: 0;
+}
+.dnb-date-picker__portal--opened .dnb-date-picker__container {
+  z-index: 100;
+}
+.dnb-date-picker__portal--opened .dnb-date-picker__container:not(.dnb-date-picker__portal--opened .dnb-date-picker__container--no-animation) {
+  animation: date-picker-slide-down 200ms ease-out 1 forwards;
+}
+html[data-visual-test] .dnb-date-picker__portal--opened .dnb-date-picker__container, .dnb-date-picker__portal--opened .dnb-date-picker__container--no-animation {
+  animation: date-picker-slide-down 1ms ease-out 1 forwards;
+}
+.dnb-date-picker__portal--hidden .dnb-date-picker__container {
+  display: none;
+}
+.dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container:not(.dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container--no-animation) {
+  animation: date-picker-slide-up 150ms ease-out 1 forwards;
+}
+html[data-visual-test] .dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container, .dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container--no-animation {
+  animation: date-picker-slide-up 1ms ease-out 1 forwards;
+}
+.dnb-date-picker__portal--right .dnb-date-picker__triangle {
+  left: auto;
+  right: 0;
 }"
 `;
 
@@ -4272,11 +4272,6 @@ exports[`DatePicker scss have to match default theme snapshot 1`] = `
   color: var(--color-black);
 }
 .dnb-date-picker__container {
-  box-shadow: var(--shadow-default);
-  border-radius: 0.25rem;
-  background-color: var(--color-white);
-}
-.dnb-date-picker__portal {
   box-shadow: var(--shadow-default);
   border-radius: 0.25rem;
   background-color: var(--color-white);

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3841,43 +3841,57 @@ button .dnb-form-status__text {
   left: -1rem;
   top: var(--date-picker-input-height);
 }
-.dnb-date-picker--small .dnb-date-picker__container {
+.dnb-date-picker__container--small {
   top: 1.5rem;
 }
-.dnb-date-picker--medium .dnb-date-picker__container {
+.dnb-date-picker__container--medium {
   top: 2.5rem;
 }
-.dnb-date-picker--large .dnb-date-picker__container {
+.dnb-date-picker__container--large {
   top: 3rem;
 }
-.dnb-date-picker--show-input .dnb-date-picker__container {
+.dnb-date-picker__container--show-input {
   left: 0;
 }
-.dnb-date-picker--right .dnb-date-picker__container {
+.dnb-date-picker__container--right {
   left: auto;
   right: -1rem;
 }
-.dnb-date-picker--show-input.dnb-date-picker--right .dnb-date-picker__container {
+.dnb-date-picker__container--show-input.dnb-date-picker__container--right {
   left: auto;
   right: 0;
 }
-.dnb-date-picker--opened .dnb-date-picker__container {
+.dnb-date-picker__container--opened {
   z-index: 100;
 }
-.dnb-date-picker--opened .dnb-date-picker__container:not(.dnb-date-picker--opened .dnb-date-picker__container--no-animation) {
+.dnb-date-picker__container--opened:not(.dnb-date-picker__container--opened--no-animation) {
   animation: date-picker-slide-down 200ms ease-out 1 forwards;
 }
-html[data-visual-test] .dnb-date-picker--opened .dnb-date-picker__container, .dnb-date-picker--opened .dnb-date-picker__container--no-animation {
+html[data-visual-test] .dnb-date-picker__container--opened, .dnb-date-picker__container--opened--no-animation {
   animation: date-picker-slide-down 1ms ease-out 1 forwards;
 }
-.dnb-date-picker--hidden .dnb-date-picker__container {
+.dnb-date-picker__container--hidden {
   display: none;
 }
-.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container:not(.dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation) {
+.dnb-date-picker__container--closed:not(.dnb-date-picker__container--closed--no-animation) {
   animation: date-picker-slide-up 150ms ease-out 1 forwards;
 }
-html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container, .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-picker__container--no-animation {
+html[data-visual-test] .dnb-date-picker__container--closed, .dnb-date-picker__container--closed--no-animation {
   animation: date-picker-slide-up 1ms ease-out 1 forwards;
+}
+.dnb-date-picker__container table {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+}
+.dnb-date-picker__container table.dnb-no-focus:focus {
+  outline: none;
+}
+html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:focus {
+  --border-color: var(--focus-ring-color);
+  --border-width: var(--focus-ring-width);
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
 }
 .dnb-date-picker__input,
 .dnb-date-picker .dnb-input__input.dnb-date-picker__input, .dnb-core-style .dnb-date-picker__input {
@@ -4048,20 +4062,6 @@ html[data-visual-test] .dnb-date-picker:not(.dnb-date-picker--opened) .dnb-date-
   margin: 0;
   padding: 0;
   list-style: none;
-}
-.dnb-date-picker table {
-  position: relative;
-  z-index: 1;
-  margin: 0;
-}
-.dnb-date-picker table.dnb-no-focus:focus {
-  outline: none;
-}
-html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
-  --border-color: var(--focus-ring-color);
-  --border-width: var(--focus-ring-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
 }
 .dnb-date-picker__day, .dnb-date-picker__labels__day {
   display: flex;
@@ -4240,71 +4240,6 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
   to {
     opacity: 0;
   }
-}
-.dnb-date-picker__portal {
-  --date-picker-input-height: 2rem;
-  --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
-  position: absolute;
-  left: 0;
-  z-index: 1000;
-  line-height: var(--date-picker-input-height);
-}
-.dnb-date-picker__portal--small .dnb-date-picker__container {
-  top: 1.5rem;
-}
-.dnb-date-picker__portal--medium .dnb-date-picker__container {
-  top: 2.5rem;
-}
-.dnb-date-picker__portal--large .dnb-date-picker__container {
-  top: 3rem;
-}
-.dnb-date-picker__portal--show-input .dnb-date-picker__container {
-  left: 0;
-}
-.dnb-date-picker__portal--right .dnb-date-picker__container {
-  left: auto;
-  right: -1rem;
-}
-.dnb-date-picker__portal--show-input.dnb-date-picker__portal--right .dnb-date-picker__container {
-  left: auto;
-  right: 0;
-}
-.dnb-date-picker__portal--opened .dnb-date-picker__container {
-  z-index: 100;
-}
-.dnb-date-picker__portal--opened .dnb-date-picker__container:not(.dnb-date-picker__portal--opened .dnb-date-picker__container--no-animation) {
-  animation: date-picker-slide-down 200ms ease-out 1 forwards;
-}
-html[data-visual-test] .dnb-date-picker__portal--opened .dnb-date-picker__container, .dnb-date-picker__portal--opened .dnb-date-picker__container--no-animation {
-  animation: date-picker-slide-down 1ms ease-out 1 forwards;
-}
-.dnb-date-picker__portal--hidden .dnb-date-picker__container {
-  display: none;
-}
-.dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container:not(.dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container--no-animation) {
-  animation: date-picker-slide-up 150ms ease-out 1 forwards;
-}
-html[data-visual-test] .dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container, .dnb-date-picker__portal:not(.dnb-date-picker__portal--opened) .dnb-date-picker__container--no-animation {
-  animation: date-picker-slide-up 1ms ease-out 1 forwards;
-}
-.dnb-date-picker__portal--right .dnb-date-picker__triangle {
-  left: auto;
-  right: 0;
-}
-.dnb-date-picker__portal table {
-  position: relative;
-  z-index: 1;
-  margin: 0;
-}
-.dnb-date-picker__portal table.dnb-no-focus:focus {
-  outline: none;
-}
-html[data-whatinput=keyboard] .dnb-date-picker__portal table.dnb-no-focus:focus {
-  --border-color: var(--focus-ring-color);
-  --border-width: var(--focus-ring-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
 }"
 `;
 

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -30,6 +30,58 @@
   display: none;
 }
 
+@mixin sharedDatePickerContainerStyles() {
+  &--small .dnb-date-picker__container {
+    top: 1.5rem; // --input-height--small;
+  }
+  &--medium .dnb-date-picker__container {
+    top: 2.5rem; // --input-height--medium;
+  }
+  &--large .dnb-date-picker__container {
+    top: 3rem; // --input-height--large;
+  }
+
+  &--show-input .dnb-date-picker__container {
+    left: 0;
+  }
+
+  // alignment
+  &--right .dnb-date-picker__container {
+    left: auto;
+    right: -1rem;
+  }
+  &--show-input#{&}--right .dnb-date-picker__container {
+    left: auto;
+    right: 0;
+  }
+
+  &--opened .dnb-date-picker__container {
+    @include openDatePicker();
+  }
+  &--hidden .dnb-date-picker__container {
+    @include datePickerClosed();
+  }
+  &:not(#{&}--opened) .dnb-date-picker__container {
+    @include closeDatePicker();
+  }
+
+  &--right .dnb-date-picker__triangle {
+    left: auto;
+    right: 0;
+  }
+
+  table {
+    position: relative;
+    z-index: 1; // to make sure we show the focus ring over the header line on top
+
+    margin: 0;
+
+    &.dnb-no-focus:focus {
+      @include focusRing();
+    }
+  }
+}
+
 .dnb-date-picker {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
@@ -74,39 +126,7 @@
     top: var(--date-picker-input-height);
   }
 
-  &--small &__container {
-    top: 1.5rem; // --input-height--small;
-  }
-  &--medium &__container {
-    top: 2.5rem; // --input-height--medium;
-  }
-  &--large &__container {
-    top: 3rem; // --input-height--large;
-  }
-
-  &--show-input &__container {
-    left: 0;
-  }
-
-  // alignment
-  &--right &__container {
-    left: auto;
-    right: -1rem;
-  }
-  &--show-input#{&}--right &__container {
-    left: auto;
-    right: 0;
-  }
-
-  &--opened &__container {
-    @include openDatePicker();
-  }
-  &--hidden &__container {
-    @include datePickerClosed();
-  }
-  &:not(#{&}--opened) &__container {
-    @include closeDatePicker();
-  }
+  @include sharedDatePickerContainerStyles();
 
   // stylelint-disable-next-line
   &__input,
@@ -310,17 +330,6 @@
     list-style: none;
   }
 
-  table {
-    position: relative;
-    z-index: 1; // to make sure we show the focus ring over the header line on top
-
-    margin: 0;
-
-    &.dnb-no-focus:focus {
-      @include focusRing();
-    }
-  }
-
   &__day,
   &__labels__day {
     display: flex;
@@ -415,11 +424,6 @@
       border: 1px solid var(--color-black-border);
       background-color: var(--color-white);
     }
-  }
-
-  &--right &__triangle {
-    left: auto;
-    right: 0;
   }
 
   .rtl {
@@ -537,53 +541,5 @@
 
   line-height: var(--date-picker-input-height);
 
-  &--small .dnb-date-picker__container {
-    top: 1.5rem; // --input-height--small;
-  }
-  &--medium .dnb-date-picker__container {
-    top: 2.5rem; // --input-height--medium;
-  }
-  &--large .dnb-date-picker__container {
-    top: 3rem; // --input-height--large;
-  }
-
-  &--show-input .dnb-date-picker__container {
-    left: 0;
-  }
-
-  // alignment
-  &--right .dnb-date-picker__container {
-    left: auto;
-    right: -1rem;
-  }
-  &--show-input#{&}--right .dnb-date-picker__container {
-    left: auto;
-    right: 0;
-  }
-
-  &--opened .dnb-date-picker__container {
-    @include openDatePicker();
-  }
-  &--hidden .dnb-date-picker__container {
-    @include datePickerClosed();
-  }
-  &:not(#{&}--opened) .dnb-date-picker__container {
-    @include closeDatePicker();
-  }
-
-  &--right .dnb-date-picker__triangle {
-    left: auto;
-    right: 0;
-  }
-
-  table {
-    position: relative;
-    z-index: 1; // to make sure we show the focus ring over the header line on top
-
-    margin: 0;
-
-    &.dnb-no-focus:focus {
-      @include focusRing();
-    }
-  }
+  @include sharedDatePickerContainerStyles();
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -532,7 +532,8 @@
 
   position: absolute;
   left: 0;
-  z-index: 1000;
+  // Over modal, but below tooltip
+  z-index: var(--modal-z-index + 10);
 
   line-height: var(--date-picker-input-height);
 

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -574,4 +574,15 @@
     left: auto;
     right: 0;
   }
+
+  table {
+    position: relative;
+    z-index: 1; // to make sure we show the focus ring over the header line on top
+
+    margin: 0;
+
+    &.dnb-no-focus:focus {
+      @include focusRing();
+    }
+  }
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -108,6 +108,18 @@
     @include closeDatePicker();
   }
 
+  &__portal {
+    // make variables available inside the portal
+    --date-picker-input-height: 2rem;
+    --date-picker-day-width: 2rem;
+    --date-picker-day-horizontal-spacing: 4px;
+
+    position: absolute;
+    z-index: 1000;
+
+    background-color: var(--color-white);
+  }
+
   // stylelint-disable-next-line
   &__input,
   .dnb-input__input#{&}__input,
@@ -522,15 +534,4 @@
   to {
     opacity: 0;
   }
-}
-
-.dnb-datepicker__portal {
-  position: absolute;
-  z-index: 1000;
-
-  background-color: var(--color-white);
-
-  --date-picker-input-height: 2rem;
-  --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -66,6 +66,35 @@
     height: inherit;
   }
 
+  &__triangle {
+    pointer-events: none;
+
+    position: absolute;
+    top: calc(1px + 1px - var(--date-picker-input-height) / 2);
+    left: 0;
+    right: auto;
+    margin: 0 1.5rem;
+
+    width: calc(var(--date-picker-input-height) / 2);
+    height: calc(var(--date-picker-input-height) / 2);
+
+    overflow: hidden;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      width: calc(var(--date-picker-input-height) / 2);
+      height: calc(var(--date-picker-input-height) / 2);
+      transform: translateY(60%) rotate(45deg);
+
+      border: 1px solid var(--color-black-border);
+      background-color: var(--color-white);
+    }
+  }
+
   &__container {
     position: absolute;
     display: block;
@@ -391,35 +420,6 @@
     }
     &--start-date#{&}--end-date::after {
       content: none;
-    }
-  }
-
-  &__triangle {
-    pointer-events: none;
-
-    position: absolute;
-    top: calc(1px + 1px - var(--date-picker-input-height) / 2);
-    left: 0;
-    right: auto;
-    margin: 0 1.5rem;
-
-    width: calc(var(--date-picker-input-height) / 2);
-    height: calc(var(--date-picker-input-height) / 2);
-
-    overflow: hidden;
-
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-
-      width: calc(var(--date-picker-input-height) / 2);
-      height: calc(var(--date-picker-input-height) / 2);
-      transform: translateY(60%) rotate(45deg);
-
-      border: 1px solid var(--color-black-border);
-      background-color: var(--color-white);
     }
   }
 

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -74,6 +74,40 @@
     top: var(--date-picker-input-height);
   }
 
+  &--small &__container {
+    top: 1.5rem; // --input-height--small;
+  }
+  &--medium &__container {
+    top: 2.5rem; // --input-height--medium;
+  }
+  &--large &__container {
+    top: 3rem; // --input-height--large;
+  }
+
+  &--show-input &__container {
+    left: 0;
+  }
+
+  // alignment
+  &--right &__container {
+    left: auto;
+    right: -1rem;
+  }
+  &--show-input#{&}--right &__container {
+    left: auto;
+    right: 0;
+  }
+
+  &--opened &__container {
+    @include openDatePicker();
+  }
+  &--hidden &__container {
+    @include datePickerClosed();
+  }
+  &:not(#{&}--opened) &__container {
+    @include closeDatePicker();
+  }
+
   // stylelint-disable-next-line
   &__input,
   .dnb-input__input#{&}__input,
@@ -381,6 +415,11 @@
       border: 1px solid var(--color-black-border);
       background-color: var(--color-white);
     }
+  }
+
+  &--right &__triangle {
+    left: auto;
+    right: 0;
   }
 
   .rtl {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -30,58 +30,6 @@
   display: none;
 }
 
-@mixin sharedDatePickerContainerStyles() {
-  &--small .dnb-date-picker__container {
-    top: 1.5rem; // --input-height--small;
-  }
-  &--medium .dnb-date-picker__container {
-    top: 2.5rem; // --input-height--medium;
-  }
-  &--large .dnb-date-picker__container {
-    top: 3rem; // --input-height--large;
-  }
-
-  &--show-input .dnb-date-picker__container {
-    left: 0;
-  }
-
-  // alignment
-  &--right .dnb-date-picker__container {
-    left: auto;
-    right: -1rem;
-  }
-  &--show-input#{&}--right .dnb-date-picker__container {
-    left: auto;
-    right: 0;
-  }
-
-  &--opened .dnb-date-picker__container {
-    @include openDatePicker();
-  }
-  &--hidden .dnb-date-picker__container {
-    @include datePickerClosed();
-  }
-  &:not(#{&}--opened) .dnb-date-picker__container {
-    @include closeDatePicker();
-  }
-
-  &--right .dnb-date-picker__triangle {
-    left: auto;
-    right: 0;
-  }
-
-  table {
-    position: relative;
-    z-index: 1; // to make sure we show the focus ring over the header line on top
-
-    margin: 0;
-
-    &.dnb-no-focus:focus {
-      @include focusRing();
-    }
-  }
-}
-
 .dnb-date-picker {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
@@ -124,9 +72,58 @@
     z-index: 3;
     left: -1rem;
     top: var(--date-picker-input-height);
-  }
 
-  @include sharedDatePickerContainerStyles();
+    &--small {
+      top: 1.5rem; // --input-height--small;
+    }
+    &--medium {
+      top: 2.5rem; // --input-height--medium;
+    }
+    &--large {
+      top: 3rem; // --input-height--large;
+    }
+
+    &--show-input {
+      left: 0;
+    }
+
+    // alignment
+    &--right {
+      left: auto;
+      right: -1rem;
+    }
+    &--show-input#{&}--right {
+      left: auto;
+      right: 0;
+    }
+
+    &--opened {
+      @include openDatePicker();
+    }
+    &--hidden {
+      @include datePickerClosed();
+    }
+
+    &--closed {
+      @include closeDatePicker();
+    }
+
+    &--right .dnb-date-picker__triangle {
+      left: auto;
+      right: 0;
+    }
+
+    table {
+      position: relative;
+      z-index: 1; // to make sure we show the focus ring over the header line on top
+
+      margin: 0;
+
+      &.dnb-no-focus:focus {
+        @include focusRing();
+      }
+    }
+  }
 
   // stylelint-disable-next-line
   &__input,
@@ -526,20 +523,4 @@
   to {
     opacity: 0;
   }
-}
-
-.dnb-date-picker__portal {
-  // make variables available inside the portal
-  --date-picker-input-height: 2rem;
-  --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
-
-  position: absolute;
-  left: 0;
-  // Over modal, but below tooltip
-  z-index: var(--modal-z-index + 10);
-
-  line-height: var(--date-picker-input-height);
-
-  @include sharedDatePickerContainerStyles();
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -74,52 +74,6 @@
     top: var(--date-picker-input-height);
   }
 
-  &--small &__container {
-    top: 1.5rem; // --input-height--small;
-  }
-  &--medium &__container {
-    top: 2.5rem; // --input-height--medium;
-  }
-  &--large &__container {
-    top: 3rem; // --input-height--large;
-  }
-
-  &--show-input &__container {
-    left: 0;
-  }
-
-  // alignment
-  &--right &__container {
-    left: auto;
-    right: -1rem;
-  }
-  &--show-input#{&}--right &__container {
-    left: auto;
-    right: 0;
-  }
-
-  &--opened &__container {
-    @include openDatePicker();
-  }
-  &--hidden &__container {
-    @include datePickerClosed();
-  }
-  &:not(#{&}--opened) &__container {
-    @include closeDatePicker();
-  }
-
-  &__portal {
-    // make variables available inside the portal
-    --date-picker-input-height: 2rem;
-    --date-picker-day-width: 2rem;
-    --date-picker-day-horizontal-spacing: 4px;
-
-    position: absolute;
-    z-index: 1000;
-
-    background-color: var(--color-white);
-  }
-
   // stylelint-disable-next-line
   &__input,
   .dnb-input__input#{&}__input,
@@ -429,11 +383,6 @@
     }
   }
 
-  &--right &__triangle {
-    left: auto;
-    right: 0;
-  }
-
   .rtl {
     direction: rtl;
 
@@ -533,5 +482,55 @@
   }
   to {
     opacity: 0;
+  }
+}
+
+.dnb-date-picker__portal {
+  // make variables available inside the portal
+  --date-picker-input-height: 2rem;
+  --date-picker-day-width: 2rem;
+  --date-picker-day-horizontal-spacing: 4px;
+
+  position: absolute;
+  left: 0;
+  z-index: 1000;
+
+  &--small .dnb-date-picker__container {
+    top: 1.5rem; // --input-height--small;
+  }
+  &--medium .dnb-date-picker__container {
+    top: 2.5rem; // --input-height--medium;
+  }
+  &--large .dnb-date-picker__container {
+    top: 3rem; // --input-height--large;
+  }
+
+  &--show-input .dnb-date-picker__container {
+    left: 0;
+  }
+
+  // alignment
+  &--right .dnb-date-picker__container {
+    left: auto;
+    right: -1rem;
+  }
+  &--show-input#{&}--right .dnb-date-picker__container {
+    left: auto;
+    right: 0;
+  }
+
+  &--opened .dnb-date-picker__container {
+    @include openDatePicker();
+  }
+  &--hidden .dnb-date-picker__container {
+    @include datePickerClosed();
+  }
+  &:not(#{&}--opened) .dnb-date-picker__container {
+    @include closeDatePicker();
+  }
+
+  &--right .dnb-date-picker__triangle {
+    left: auto;
+    right: 0;
   }
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -505,6 +505,20 @@
   .dnb-core-style &__fieldset {
     @include fieldsetReset();
   }
+
+  &__portal {
+    // make variables available inside the portal
+    --date-picker-input-height: 2rem;
+    --date-picker-day-width: 2rem;
+    --date-picker-day-horizontal-spacing: 4px;
+
+    position: absolute;
+    left: 0;
+    // Over modal, but below tooltip
+    z-index: var(--modal-z-index + 10);
+
+    line-height: var(--date-picker-input-height);
+  }
 }
 
 @keyframes date-picker-slide-down {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -528,6 +528,8 @@
   position: absolute;
   z-index: 1000;
 
+  background-color: var(--color-white);
+
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
   --date-picker-day-horizontal-spacing: 4px;

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -523,3 +523,12 @@
     opacity: 0;
   }
 }
+
+.dnb-datepicker__portal {
+  position: absolute;
+  z-index: 1000;
+
+  --date-picker-input-height: 2rem;
+  --date-picker-day-width: 2rem;
+  --date-picker-day-horizontal-spacing: 4px;
+}

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -534,6 +534,8 @@
   left: 0;
   z-index: 1000;
 
+  line-height: var(--date-picker-input-height);
+
   &--small .dnb-date-picker__container {
     top: 1.5rem; // --input-height--small;
   }

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -28,12 +28,6 @@
     background-color: var(--color-white);
   }
 
-  &__portal {
-    @include defaultDropShadow();
-    border-radius: 0.25rem;
-    background-color: var(--color-white);
-  }
-
   &__addon,
   &__calendar {
     // border

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -28,6 +28,12 @@
     background-color: var(--color-white);
   }
 
+  &__portal {
+    @include defaultDropShadow();
+    border-radius: 0.25rem;
+    background-color: var(--color-white);
+  }
+
   &__addon,
   &__calendar {
     // border

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -553,12 +553,19 @@ export class DetectOutsideClickClass {
 
       // check the rest
       for (let i = 0, elem, l = ignoreElements.length; i < l; ++i) {
+        // Allow for comparing ref elements that are rendered conditionally,
+        // That might be `null` or ´undefined` during the construction stage of this class
+        const ignoreElement =
+          'current' in ignoreElements[i]
+            ? ignoreElements[i].current
+            : ignoreElements[i]
+
         elem = currentElement
         if (!ignoreElements[i]) {
           continue
         }
         do {
-          if (elem === ignoreElements[i]) {
+          if (elem === ignoreElement) {
             return // stop here
           }
           elem = elem && elem.parentNode


### PR DESCRIPTION
- [x] Make calendar placement more precise
- [x] Make sure calendar inherits all the styles like in previous iteration (background color etc.)
- [x] Make sure `onClickOutside`does not fire when clicking anywhere on the calendar
- [x] Implement the `alignPicker` prop in the portal
- [x] Make sure portal is position correctly on initial render when `opened` is true
- [x] Fix positions based on input size
- [x] Add tests
- [x] Fix screenshot tests
- [x] Fix Implement animations
- [x] Correct days padding
- [x] FIx calendar position on screen resize
- [x] Fix calendar focus styling when opening with keyboard
- [x] Fix position on document scroll
- [x] add `skipPortal` test
- [x] add new test for `detectOutsideClick`
- [x] update z-index
- [x] create shared scope for calendar styles
- [x] Fix errors caused by moving shared container styles