### PR TITLE
feat(Forms): add `wrapper` property to Form.Handler

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/HandlerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/HandlerDocs.ts
@@ -21,6 +21,11 @@ export const HandlerProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  wrapper: {
+    doc: 'A wrapper component to wrap the form element. You can provide an array of components to wrap the form. Use it instead of wrapping your form with multiple providers.',
+    type: ['ReactNode', 'Array<ReactNode>'],
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1286,4 +1286,41 @@ describe('Form.Handler', () => {
       log.mockRestore()
     })
   })
+
+  describe('wrapper', () => {
+    it('should render a custom wrapper', () => {
+      render(
+        <Form.Handler
+          wrapper={({ children }) => (
+            <div className="wrapper">{children}</div>
+          )}
+        >
+          content
+        </Form.Handler>
+      )
+
+      expect(document.body).toHaveTextContent('content')
+      expect(document.querySelector('.wrapper')).toBeInTheDocument()
+    })
+
+    it('should render multiple custom wrappers', () => {
+      render(
+        <Form.Handler
+          wrapper={[
+            ({ children }) => <div className="wrapper1">{children}</div>,
+            ({ children }) => <div className="wrapper2">{children}</div>,
+          ]}
+        >
+          content
+        </Form.Handler>
+      )
+
+      expect(document.body).toHaveTextContent('content')
+      expect(document.querySelector('.wrapper1')).toBeInTheDocument()
+      expect(document.querySelector('.wrapper2')).toBeInTheDocument()
+      expect(
+        document.querySelector('.wrapper1 > .wrapper2')
+      ).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
This allows a dev to wrap multiple providers or other wrappers, without creating a Christmas tree of wrappers/providers.

This is my use-case coming in a new PR:

```tsx
<Form.Handler
  wrapper={[Form.Status.Error, Form.Status.Success]}
>
  content
</Form.Handler>
```