### PR TITLE
feat(Forms): add `onVisible` property to Form.Visibility

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -76,6 +76,7 @@ export type Props = {
   animate?: boolean
   /** Keep the content in the DOM, even if it's not visible */
   keepInDOM?: boolean
+  onOpen?: HeightAnimationProps['onOpen']
   /** To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`. */
   compensateForGap?: HeightAnimationProps['compensateForGap']
   /** When visibility is hidden, and `keepInDOM` is true, pass these props to the children */

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -77,7 +77,7 @@ export type Props = {
   /** Keep the content in the DOM, even if it's not visible */
   keepInDOM?: boolean
   /** Callback when the content is visible. Only for when `animate` is true. */
-  onOpen?: HeightAnimationProps['onOpen']
+  onVisible?: HeightAnimationProps['onOpen']
   /** To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`. */
   compensateForGap?: HeightAnimationProps['compensateForGap']
   /** When visibility is hidden, and `keepInDOM` is true, pass these props to the children */
@@ -105,6 +105,7 @@ function Visibility({
   visibleWhenNot,
   inferData,
   filterData,
+  onVisible,
   animate,
   keepInDOM,
   compensateForGap,
@@ -150,6 +151,7 @@ function Visibility({
     return (
       <HeightAnimation
         open={open}
+        onOpen={onVisible}
         keepInDOM={Boolean(keepInDOM)}
         className="dnb-forms-visibility"
         compensateForGap={compensateForGap}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -76,6 +76,7 @@ export type Props = {
   animate?: boolean
   /** Keep the content in the DOM, even if it's not visible */
   keepInDOM?: boolean
+  /** Callback when the content is visible. Only for when `animate` is true. */
   onOpen?: HeightAnimationProps['onOpen']
   /** To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`. */
   compensateForGap?: HeightAnimationProps['compensateForGap']

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -61,7 +61,7 @@ export const VisibilityProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  onOpen: {
+  onVisible: {
     doc: 'Callback when the content is visible. Only for when `animate` is true.',
     type: 'function',
     status: 'optional',

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -61,6 +61,11 @@ export const VisibilityProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  onOpen: {
+    doc: 'Callback when the content is visible. Only for when `animate` is true.',
+    type: 'function',
+    status: 'optional',
+  },
   compensateForGap: {
     doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
     type: 'string',

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
@@ -437,27 +437,51 @@ describe('Visibility', () => {
     `)
   })
 
-  it('should have "height-animation" wrapper when animate is true', async () => {
-    render(
-      <Provider data={{ myPath: 'checked' }}>
-        <Visibility
-          visibleWhen={{
-            path: '/myPath',
-            hasValue: 'checked',
-          }}
-          animate
-        >
+  describe('animate', () => {
+    it('should have "height-animation" wrapper when animate is true', async () => {
+      render(
+        <Provider data={{ myPath: 'checked' }}>
+          <Visibility
+            visibleWhen={{
+              path: '/myPath',
+              hasValue: 'checked',
+            }}
+            animate
+          >
+            Child
+          </Visibility>
+        </Provider>
+      )
+
+      const element = document.querySelector('.dnb-height-animation')
+
+      expect(element).toBeInTheDocument()
+      expect(element).toHaveClass(
+        'dnb-space dnb-height-animation dnb-height-animation--is-in-dom dnb-height-animation--parallax'
+      )
+    })
+
+    it('should call onVisible when animation is done', async () => {
+      const onVisible = jest.fn()
+
+      const { rerender } = render(
+        <Visibility visible={false} onVisible={onVisible} animate>
           Child
         </Visibility>
-      </Provider>
-    )
+      )
 
-    const element = document.querySelector('.dnb-height-animation')
+      expect(onVisible).toHaveBeenCalledTimes(1)
+      expect(onVisible).toHaveBeenLastCalledWith(false)
 
-    expect(element).toBeInTheDocument()
-    expect(element).toHaveClass(
-      'dnb-space dnb-height-animation dnb-height-animation--is-in-dom dnb-height-animation--parallax'
-    )
+      rerender(
+        <Visibility visible={true} onVisible={onVisible} animate>
+          Child
+        </Visibility>
+      )
+
+      expect(onVisible).toHaveBeenCalledTimes(2)
+      expect(onVisible).toHaveBeenLastCalledWith(true)
+    })
   })
 
   it('should use given "element"', () => {


### PR DESCRIPTION
We forward the props to HeightAnimation, so we just need the types and the docs to make this work.

Maybe we should call it `onVisible`? But on the other hand, it's meant to be used only when `animate` is set to true.