### PR TITLE
feat(Forms): add `onAnimationEnd` property to Form.Visibility

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility.mdx
@@ -9,6 +9,8 @@ tabs:
     key: '/demos'
   - title: Properties
     key: '/properties'
+  - title: Events
+    key: '/events'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/events.mdx
@@ -1,0 +1,10 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { VisibilityEvents } from '@dnb/eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs'
+
+## Events
+
+<PropertiesTable props={VisibilityEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/properties.mdx
@@ -3,8 +3,15 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import { VisibilityProperties } from '@dnb/eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs'
+import {
+  VisibilityProperties,
+  VisibilityEvents,
+} from '@dnb/eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs'
 
 ## Properties
 
 <PropertiesTable props={VisibilityProperties} />
+
+## Events
+
+<PropertiesTable props={VisibilityEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility/properties.mdx
@@ -3,15 +3,8 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import {
-  VisibilityProperties,
-  VisibilityEvents,
-} from '@dnb/eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs'
+import { VisibilityProperties } from '@dnb/eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs'
 
 ## Properties
 
 <PropertiesTable props={VisibilityProperties} />
-
-## Events
-
-<PropertiesTable props={VisibilityEvents} />

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -60,7 +60,7 @@ export const HeightAnimationEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onAnimationStart: {
-    doc: 'Is called when animation has started. The first parameter is a string, depending on the state. It can be `opening`, `closing` or `adjusting`.',
+    doc: 'Is called when animation has started. The first parameter is a string. Depending on the state, the value can be `opening`, `closing` or `adjusting`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -60,12 +60,12 @@ export const HeightAnimationEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onAnimationStart: {
-    doc: 'Is called when animation has started.',
+    doc: 'Is called when animation has started. The first parameter is a string, depending on the state. It can be `opening`, `closing` or `adjusting`.',
     type: 'function',
     status: 'optional',
   },
   onAnimationEnd: {
-    doc: 'Is called when animation is done and the full height is reached.',
+    doc: 'Is called when animation is done and the full height is reached. The first parameter is a string, depending on the state. It can be `opened`, `closed` or `adjusted`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -65,7 +65,7 @@ export const HeightAnimationEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onAnimationEnd: {
-    doc: 'Is called when animation is done and the full height is reached. The first parameter is a string, depending on the state. It can be `opened`, `closed` or `adjusted`.',
+    doc: 'Is called when animation is done and the full height is reached. The first parameter is a string. Depending on the state, the value can be `opened`, `closed` or `adjusted`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -1,17 +1,18 @@
-import React, { AriaAttributes } from 'react'
+import React, { AriaAttributes, useCallback } from 'react'
 
 import { warn } from '../../../../shared/helpers'
 import useMountEffect from '../../../../shared/helpers/useMountEffect'
+import useMounted from '../../../../shared/helpers/useMounted'
 import HeightAnimation, {
-  HeightAnimationProps,
+  HeightAnimationAllProps,
 } from '../../../../components/HeightAnimation'
 import FieldProvider from '../../Field/Provider'
 import useVisibility from './useVisibility'
+import VisibilityContext from './VisibilityContext'
 
 import type { Path, UseFieldProps } from '../../types'
 import type { DataAttributes } from '../../hooks/useFieldProps'
 import { FilterData } from '../../DataContext'
-import VisibilityContext from './VisibilityContext'
 
 export type VisibleWhen =
   | {
@@ -76,13 +77,15 @@ export type Props = {
   animate?: boolean
   /** Keep the content in the DOM, even if it's not visible */
   keepInDOM?: boolean
-  /** Callback when the content is visible. Only for when `animate` is true. */
-  onVisible?: HeightAnimationProps['onOpen']
+  /** Callback for when the content gets visible. */
+  onVisible?: HeightAnimationAllProps['onOpen']
+  /** Callback for when the content is visible. Only for when `animate` is true. */
+  onAnimationEnd?: HeightAnimationAllProps['onAnimationEnd']
   /** To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`. */
-  compensateForGap?: HeightAnimationProps['compensateForGap']
+  compensateForGap?: HeightAnimationAllProps['compensateForGap']
   /** When visibility is hidden, and `keepInDOM` is true, pass these props to the children */
   fieldPropsWhenHidden?: UseFieldProps & DataAttributes & AriaAttributes
-  element?: HeightAnimationProps['element']
+  element?: HeightAnimationAllProps['element']
   children: React.ReactNode
 
   /** @deprecated Use `visibleWhen` instead */
@@ -106,6 +109,7 @@ function Visibility({
   inferData,
   filterData,
   onVisible,
+  onAnimationEnd,
   animate,
   keepInDOM,
   compensateForGap,
@@ -144,6 +148,16 @@ function Visibility({
       {children}
     </VisibilityContext.Provider>
   )
+  const mountedRef = useMounted()
+
+  const onOpen: HeightAnimationAllProps['onOpen'] = useCallback(
+    (state) => {
+      if (mountedRef.current) {
+        onVisible?.(state)
+      }
+    },
+    [mountedRef, onVisible]
+  )
 
   if (animate) {
     const props = !open ? fieldPropsWhenHidden : null
@@ -151,7 +165,8 @@ function Visibility({
     return (
       <HeightAnimation
         open={open}
-        onOpen={onVisible}
+        onAnimationEnd={onAnimationEnd}
+        onOpen={onOpen}
         keepInDOM={Boolean(keepInDOM)}
         className="dnb-forms-visibility"
         compensateForGap={compensateForGap}
@@ -160,6 +175,10 @@ function Visibility({
         <FieldProvider {...props}>{content}</FieldProvider>
       </HeightAnimation>
     )
+  }
+
+  if (mountedRef.current) {
+    onVisible?.(open)
   }
 
   if (keepInDOM) {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -79,7 +79,7 @@ export type Props = {
   keepInDOM?: boolean
   /** Callback for when the content gets visible. */
   onVisible?: HeightAnimationAllProps['onOpen']
-  /** Callback for when the content is visible. Only for when `animate` is true. */
+  /** Callback for when animation has ended */
   onAnimationEnd?: HeightAnimationAllProps['onAnimationEnd']
   /** To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`. */
   compensateForGap?: HeightAnimationAllProps['compensateForGap']

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -1,4 +1,5 @@
 import { PropertiesTableProps } from '../../../../shared/types'
+import { HeightAnimationEvents } from '../../../../components/height-animation/HeightAnimationDocs'
 
 export const VisibilityProperties: PropertiesTableProps = {
   visibleWhen: {
@@ -61,11 +62,6 @@ export const VisibilityProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  onVisible: {
-    doc: 'Callback when the content is visible. Only for when `animate` is true.',
-    type: 'function',
-    status: 'optional',
-  },
   compensateForGap: {
     doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
     type: 'string',
@@ -91,4 +87,13 @@ export const VisibilityProperties: PropertiesTableProps = {
     type: 'React.Node',
     status: 'required',
   },
+}
+
+export const VisibilityEvents: PropertiesTableProps = {
+  onVisible: {
+    doc: 'Callback for when the content gets visible. Returns a boolean as the first parameter.',
+    type: 'function',
+    status: 'optional',
+  },
+  onAnimationEnd: HeightAnimationEvents.onAnimationEnd,
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -92,7 +92,7 @@ export const VisibilityProperties: PropertiesTableProps = {
 export const VisibilityEvents: PropertiesTableProps = {
   onVisible: {
     doc: 'Callback for when the content gets visible. Returns a boolean as the first parameter.',
-    type: 'function',
+    type: HeightAnimationEvents.onOpen.type,
     status: 'optional',
   },
   onAnimationEnd: HeightAnimationEvents.onAnimationEnd,


### PR DESCRIPTION
I think we should use `onVisible` for both the animated and non-animated state change. Here is the related PR #4350

While `onAnimationEnd` should be used to determine if the animated has "ended". Pretty much like HeightAnimation works.