### PR TITLE
fix(Forms): avoid unnecessary rerenders in Form.Handler

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -718,7 +718,7 @@ export default function Provider<Data extends JsonObject>(
       (Array.isArray(internalDataRef.current) ? [] : clearedData)) as Data
 
     if (id) {
-      setSharedData?.(internalDataRef.current)
+      setSharedData(internalDataRef.current)
     }
 
     forceUpdate()
@@ -731,29 +731,28 @@ export default function Provider<Data extends JsonObject>(
 
   useLayoutEffect(() => {
     // Set the shared state, if initialData was given
-    if (id && initialData && !sharedData.data) {
-      extendSharedData?.(initialData)
+    if (id) {
+      if (initialData && !sharedData.data) {
+        extendSharedData(initialData, { preventSyncOfSameInstance: true })
+      }
     }
   }, [id, initialData, extendSharedData, sharedData.data])
 
-  useMemo(() => {
-    executeAjvValidator()
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [internalDataRef.current]) // run validation when internal data has changed
-
   useLayoutEffect(() => {
     if (id) {
-      extendAttachment?.({
-        visibleDataHandler,
-        filterDataHandler,
-        hasErrors,
-        hasFieldError,
-        setShowAllErrors,
-        setSubmitState,
-        clearData,
-        fieldConnectionsRef,
-      })
+      extendAttachment(
+        {
+          visibleDataHandler,
+          filterDataHandler,
+          hasErrors,
+          hasFieldError,
+          setShowAllErrors,
+          setSubmitState,
+          clearData,
+          fieldConnectionsRef,
+        },
+        { preventSyncOfSameInstance: true }
+      )
       if (filterSubmitData) {
         rerenderUseDataHook?.()
       }
@@ -770,7 +769,14 @@ export default function Provider<Data extends JsonObject>(
     setShowAllErrors,
     setSubmitState,
     clearData,
+    extendSharedData,
   ])
+
+  useMemo(() => {
+    executeAjvValidator()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [internalDataRef.current]) // run validation when internal data has changed
 
   const storeInSession = useMemo(() => {
     return debounce(
@@ -795,7 +801,7 @@ export default function Provider<Data extends JsonObject>(
 
       if (id) {
         // Will ensure that Form.getData() gets the correct data
-        extendSharedData?.(newData)
+        extendSharedData(newData, { preventSyncOfSameInstance: true })
         if (filterSubmitData) {
           rerenderUseDataHook?.()
         }

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -3423,12 +3423,8 @@ describe('DataContext.Provider', () => {
         </DataContext.Provider>
       )
 
-      expect(nestedMockData).toHaveLength(3)
-      expect(nestedMockData).toEqual([
-        initialData,
-        initialData,
-        initialData,
-      ])
+      expect(nestedMockData).toHaveLength(2)
+      expect(nestedMockData).toEqual([initialData, initialData])
 
       const inputElement = document.querySelector('input')
       expect(inputElement).toHaveValue('bar')
@@ -3462,12 +3458,8 @@ describe('DataContext.Provider', () => {
         </>
       )
 
-      expect(sidecarMockData).toHaveLength(3)
-      expect(sidecarMockData).toEqual([
-        undefined,
-        initialData,
-        initialData,
-      ])
+      expect(sidecarMockData).toHaveLength(2)
+      expect(sidecarMockData).toEqual([undefined, initialData])
 
       expect(nestedMockData).toHaveLength(2)
       expect(nestedMockData).toEqual([initialData, initialData])

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -362,9 +362,9 @@ function WizardContainer(props: Props) {
   // - Handle shared state
   useLayoutEffect(() => {
     if (id && hasContext) {
-      sharedStateRef.current?.extend?.(providerValue)
+      sharedStateRef.current.extend(providerValue)
     }
-  }, [id, providerValue]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hasContext, id, providerValue])
 
   useLayoutEffect(() => {
     updateTitlesRef.current?.()

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
@@ -220,6 +220,37 @@ describe('useSharedState', () => {
     expect(resultA.current.data).toEqual({ foo: 'baz' })
     expect(resultB.current.data).toEqual({ foo: 'baz' })
   })
+
+  it('should sync all hooks, except the one that is set to "preventSyncOfSameInstance"', () => {
+    const { result: resultA } = renderHook(() =>
+      useSharedState(identifier)
+    )
+    const { result: resultB } = renderHook(() =>
+      useSharedState(identifier)
+    )
+
+    expect(resultA.current.data).toEqual(undefined)
+    expect(resultB.current.data).toEqual(undefined)
+
+    act(() => {
+      resultA.current.update({ foo: 'bar' })
+    })
+
+    expect(resultA.current.data).toEqual({ foo: 'bar' })
+    expect(resultB.current.data).toEqual({ foo: 'bar' })
+
+    act(() => {
+      // If "preventSyncOfSameInstance" is set to true,
+      // then the "resultA" will not be synced, so resultA will still have "bar".
+      resultB.current.update(
+        { foo: 'baz' },
+        { preventSyncOfSameInstance: true }
+      )
+    })
+
+    expect(resultA.current.data).toEqual({ foo: 'bar' })
+    expect(resultB.current.data).toEqual({ foo: 'baz' })
+  })
 })
 
 describe('createReferenceKey', () => {


### PR DESCRIPTION
The reason behind this is that I saw a negative side-effect in PR #4357 when it comes to the initial render, where we don't want an animation, but it did animate.