### PR TITLE
chore(Upload): fix test warning

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -190,6 +190,7 @@ const UploadFileListCell = ({
       <div className="dnb-upload__file-cell__text-container">
         {onClick ? (
           <Button
+            icon={false}
             variant="tertiary"
             className={classnames('dnb-upload__file-cell__title')}
             onClick={onClick}

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
@@ -56,6 +56,7 @@ function Upload(props: Props) {
             {getIcon(file)}
             {onFileClick ? (
               <Button
+                icon={false}
                 size="small"
                 variant="tertiary"
                 className={classnames('dnb-upload__file-cell__title')}


### PR DESCRIPTION
Removes the warning:
```
      Eufemia Icon required: A Tertiary Button requires an icon to be WCAG compliant in most cases, because variant tertiary has no underline.
      (Override this warning using icon={false}, or consider using one of the other variants) 
```