### PR TITLE
fix(Dropdown): correct 'data' type to support interface-based types

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -1014,13 +1014,7 @@ export const TypesExample = () => {
 
   const myData: MyInterface[] = []
 
-  return (
-    <Dropdown
-      title="Default"
-      data={myData}
-      status="Message"
-    />
-  )
+  return <Dropdown data={myData} />
 }
 
 export function InDialog() {

--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -1006,6 +1006,24 @@ export const GlobalStatusExample = () => {
   )
 }
 
+export const TypesExample = () => {
+  interface MyInterface {
+    content: string
+    selected_key: string
+  }
+
+  const myData: MyInterface[] = []
+
+  return (
+    <Dropdown
+      title="Default"
+      data={myData}
+      globalStatus={{ id: 'my-id', message: 'my message' }}
+      status="Message"
+    />
+  )
+}
+
 export function InDialog() {
   const list = Array(30).fill('Content')
   return (

--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -1018,7 +1018,6 @@ export const TypesExample = () => {
     <Dropdown
       title="Default"
       data={myData}
-      globalStatus={{ id: 'my-id', message: 'my message' }}
       status="Message"
     />
   )

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
@@ -16,7 +16,6 @@ export type DrawerListValue = string | number;
 /** @deprecated use `DrawerListDataArrayObject` */
 export type DrawerListDataObject = DrawerListDataArrayObject;
 export type DrawerListDataArrayObject = {
-  [customProperty: string]: unknown;
   selected_value?: string | React.ReactNode;
   selectedKey?: string | number;
   selected_key?: string | number;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.d.ts
@@ -16,6 +16,7 @@ export type DrawerListValue = string | number;
 /** @deprecated use `DrawerListDataArrayObject` */
 export type DrawerListDataObject = DrawerListDataArrayObject;
 export type DrawerListDataArrayObject = {
+  [customProperty: string]: any;
   selected_value?: string | React.ReactNode;
   selectedKey?: string | number;
   selected_key?: string | number;


### PR DESCRIPTION
Fixes the following error when using an `interface` for the `data` property:

```
No overload matches this call.
  Overload 1 of 2, '(props: DropdownAllProps | Readonly<DropdownAllProps>): Dropdown', gave the following error.
    Type 'MyInterface[]' is not assignable to type 'DrawerListData'.
      Type 'MyInterface[]' is not assignable to type 'DrawerListDataArray'.
        Type 'MyInterface' is not assignable to type 'DrawerListDataArrayItem'.
          Type 'MyInterface' is not assignable to type 'DrawerListDataArrayObject'.
            Index signature for type 'string' is missing in type 'MyInterface'.
  Overload 2 of 2, '(props: DropdownAllProps, context: any): Dropdown', gave the following error.
    Type 'MyInterface[]' is not assignable to type 'DrawerListData'.ts(2769)
```

If I would use a `type` instead of an `interface` it will work.
Here's a [CSB using interface](https://codesandbox.io/p/sandbox/sleepy-fire-y58qqv), here's a [CSB using type](https://codesandbox.io/p/sandbox/stupefied-shtern-2kzvt4?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE).
But shouldn't I be able to use an `interface`?

Here's a [CSB using interface and the fix from this PR](https://codesandbox.io/p/sandbox/cranky-saha-728m3q?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)