### PR TITLE
docs(Upload): add `id` property

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
@@ -1,6 +1,11 @@
 import { PropertiesTableProps } from '../../shared/types'
 
 export const UploadProperties: PropertiesTableProps = {
+  id: {
+    doc: 'Unique id used with the useUpload hook to manage the files.',
+    type: 'string',
+    status: 'required',
+  },
   acceptedFileTypes: {
     doc: 'List of accepted file types. Either as string or [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype). When providing a list of [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype), the accepted file types will be presented in a table(see [example](/uilib/components/upload/demos/#upload-with-file-max-size-based-on-file-type)).',
     type: ['Array<string>', 'Array<AcceptedFileType>'],


### PR DESCRIPTION
`id` property is [required](https://github.com/dnbexperience/eufemia/blob/ee948ede2201b8bcc489e49874be400187809c85/packages/dnb-eufemia/src/components/upload/types.ts#L19), so makes sense to document it.