### PR TITLE
chore: add `useWeakSharedState` for internal use

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
@@ -5,6 +5,7 @@ import {
   createSharedState,
   SharedStateId,
   createReferenceKey,
+  useWeakSharedState,
 } from '../useSharedState'
 import { createContext } from 'react'
 
@@ -108,30 +109,6 @@ describe('useSharedState', () => {
     })
 
     expect(result.current.data).toEqual({ test: 'initial' })
-  })
-
-  it('should delete the shared state when all components have been unmounted', () => {
-    const identifier = {}
-
-    const { unmount: unmountA } = renderHook(() =>
-      useSharedState(identifier, { test: 'initial' })
-    )
-    const { unmount: unmountB } = renderHook(() =>
-      useSharedState(identifier)
-    )
-
-    const getStateOf = (identifier) => {
-      return createSharedState(identifier).get()
-    }
-
-    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
-    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
-
-    unmountA()
-    unmountB()
-
-    expect(getStateOf(identifier)).toEqual(undefined)
-    expect(getStateOf(identifier)).toEqual(undefined)
   })
 
   it('should return undefined data when no ID is given', () => {
@@ -273,6 +250,56 @@ describe('useSharedState', () => {
 
     expect(resultA.current.data).toEqual({ foo: 'bar' })
     expect(resultB.current.data).toEqual({ foo: 'baz' })
+  })
+})
+
+describe('useWeakSharedState', () => {
+  it('should delete the shared state when all components have been unmounted', () => {
+    const identifier = {}
+
+    const { unmount: unmountA } = renderHook(() =>
+      useWeakSharedState(identifier, { test: 'initial' })
+    )
+    const { unmount: unmountB } = renderHook(() =>
+      useWeakSharedState(identifier)
+    )
+
+    const getStateOf = (identifier) => {
+      return createSharedState(identifier).get()
+    }
+
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+
+    unmountA()
+    unmountB()
+
+    expect(getStateOf(identifier)).toEqual(undefined)
+    expect(getStateOf(identifier)).toEqual(undefined)
+  })
+
+  it('when not using weak, should not delete the shared state when all components have been unmounted', () => {
+    const identifier = {}
+
+    const { unmount: unmountA } = renderHook(() =>
+      useSharedState(identifier, { test: 'initial' })
+    )
+    const { unmount: unmountB } = renderHook(() =>
+      useSharedState(identifier)
+    )
+
+    const getStateOf = (identifier) => {
+      return createSharedState(identifier).get()
+    }
+
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+
+    unmountA()
+    unmountB()
+
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useSharedState.test.ts
@@ -44,9 +44,7 @@ describe('useSharedState', () => {
     const { result } = renderHook(() =>
       useSharedState(identifier, { test: 'initial' })
     )
-    const sharedState = createSharedState(identifier, {
-      test: 'initial',
-    })
+    const sharedState = createSharedState(identifier)
     act(() => {
       sharedState.update({ test: 'changed' })
     })
@@ -101,14 +99,39 @@ describe('useSharedState', () => {
     const { result, unmount } = renderHook(() =>
       useSharedState(identifier, { test: 'initial' })
     )
-    const sharedState = createSharedState(identifier, {
-      test: 'initial',
-    })
+    const sharedState = createSharedState(identifier)
+
     unmount()
+
     act(() => {
       sharedState.update({ test: 'unmounted' })
     })
+
     expect(result.current.data).toEqual({ test: 'initial' })
+  })
+
+  it('should delete the shared state when all components have been unmounted', () => {
+    const identifier = {}
+
+    const { unmount: unmountA } = renderHook(() =>
+      useSharedState(identifier, { test: 'initial' })
+    )
+    const { unmount: unmountB } = renderHook(() =>
+      useSharedState(identifier)
+    )
+
+    const getStateOf = (identifier) => {
+      return createSharedState(identifier).get()
+    }
+
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+    expect(getStateOf(identifier)).toEqual({ test: 'initial' })
+
+    unmountA()
+    unmountB()
+
+    expect(getStateOf(identifier)).toEqual(undefined)
+    expect(getStateOf(identifier)).toEqual(undefined)
   })
 
   it('should return undefined data when no ID is given', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/useSharedState.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/useSharedState.tsx
@@ -20,7 +20,7 @@ export type SharedStateId =
   | Record<string, unknown>
 
 /**
- * Custom hook that provides shared state functionality.
+ * The shared state will be deleted when all components have been unmounted.
  */
 export function useWeakSharedState<
   Data,
@@ -45,7 +45,10 @@ export function useSharedState<Data>(
   /** Optional callback function to be called when the shared state is set from another instance/component. */
   onChange = null,
   /** Optional configuration options. */
-  { weak = false } = {}
+  {
+    /** When set to `true`, the shared state will be deleted when all components have been unmounted. */
+    weak = false,
+  } = {}
 ) {
   const [, forceUpdate] = useReducer(() => ({}), {})
   const hasMountedRef = useMounted()


### PR DESCRIPTION
When using `useWeakSharedState` it will clean up data when each subscriber has unmounted (when using `id` to sync components with each other).

The term "Weak" is inherited from [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap).