### PR TITLE
feat(Typography): change iOS Safari basis font-size from 17px to 15px for DNB

### DIFF
--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -69,14 +69,17 @@
 
 @mixin htmlDefault() {
   html {
+    font-size: 100%;
+
     &:not([data-visual-test]) {
       scroll-behavior: smooth;
     }
-    font-size: 100%;
 
-    // IS_SAFARI_MOBILE
-    @supports (-webkit-touch-callout: none) {
-      @supports (font: -apple-system-body) {
+    // In order to let Safari know the font-size set on the system level
+    @supports (font: -apple-system-body) {
+      // Safari on iOS
+      @supports (-webkit-touch-callout: none) {
+        // Sets the base font-size to 17px
         font: -apple-system-body; /* stylelint-disable-line */
       }
     }

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -72,9 +72,11 @@
 
     font-size: 100%;
 
-    // IS_SAFARI_MOBILE
-    @supports (-webkit-touch-callout: none) {
-      @supports (font: -apple-system-body) {
+    // In order to let Safari know the font-size set on the system level
+    @supports (font: -apple-system-body) {
+      // Safari on iOS
+      @supports (-webkit-touch-callout: none) {
+        // Sets the base font-size to 17px
         font: -apple-system-body; /* stylelint-disable-line */
       }
     }

--- a/packages/dnb-eufemia/src/style/themes/theme-ui/ui-theme-basis.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-ui/ui-theme-basis.scss
@@ -7,3 +7,15 @@
 @import './fonts.scss';
 @import './ui-theme-elements.scss';
 @import './globals.scss';
+
+html {
+  // In order to let Safari know the font-size set on the system level
+  // Because the default font-size is 18px, we lower the basis font-size to 15px instead of 17px
+  @supports (font: -apple-system-subheadline) {
+    // Safari on iOS
+    @supports (-webkit-touch-callout: none) {
+      // Sets the base font-size to 15px
+      font: -apple-system-subheadline; /* stylelint-disable-line */
+    }
+  }
+}

--- a/packages/dnb-eufemia/src/style/themes/ui/ui-theme-basis.scss
+++ b/packages/dnb-eufemia/src/style/themes/ui/ui-theme-basis.scss
@@ -9,3 +9,15 @@
 @use './fonts.scss';
 @use './ui-theme-elements.scss';
 @use '../shared-globals.scss';
+
+html {
+  // In order to let Safari know the font-size set on the system level
+  // Because the default font-size is 18px, we lower the basis font-size to 15px instead of 17px
+  @supports (font: -apple-system-subheadline) {
+    // Safari on iOS
+    @supports (-webkit-touch-callout: none) {
+      // Sets the base font-size to 15px
+      font: -apple-system-subheadline; /* stylelint-disable-line */
+    }
+  }
+}


### PR DESCRIPTION
**Why?**

In order to let Safari know the font-size of iOS, we use `font: -apple-system-body`. iOS uses 17px as its default font-size. But because the DNB body text size is `18px` we get `19.125px`, which is extensively larger than e.g. the iOS default of 17px. So with this change, the DNB body text size will be `16.875px`. Which is much closer to the native iOS body text size.

- [ ] Sort out any negative side effects of this change.