### PR TITLE
chore(Drawer): use `none` instead of `auto` for min and max width

### DIFF
--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1014,8 +1014,8 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
 @media screen and (max-width: 40em) {
   .dnb-drawer {
     width: 100vw;
-    min-width: auto;
-    max-width: auto;
+    min-width: none;
+    max-width: none;
   }
 }
 @media screen and (max-width: 40em) {

--- a/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
@@ -39,8 +39,8 @@
 
   @include allBelow(small) {
     width: 100vw;
-    min-width: auto;
-    max-width: auto;
+    min-width: none;
+    max-width: none;
   }
 
   @include defaultDropShadow();


### PR DESCRIPTION
I don't think this has any effect, as `auto` was a non-valid value. Here are the [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width).