### PR TITLE
chore(Visibility): fix flaky test

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
@@ -570,7 +570,7 @@ describe('Visibility', () => {
           <Form.Visibility
             pathTrue="/toggleValue"
             onAnimationEnd={onAnimationEnd}
-            animate
+            animate={false}
           >
             content
           </Form.Visibility>
@@ -583,8 +583,8 @@ describe('Visibility', () => {
 
       await userEvent.click(checkbox)
 
-      expect(() => {
-        expect(onAnimationEnd).toHaveBeenCalledTimes(0)
+      await expect(() => {
+        expect(onAnimationEnd).toHaveBeenCalledTimes(1)
       }).toNeverResolve()
     })
   })


### PR DESCRIPTION
The main reason was due to a missing `await`. My bad.
It did [fail here](https://github.com/dnbexperience/eufemia/actions/runs/12377018356/job/34554639319?pr=4414).