### PR TITLE
fix(Autocomplete): support query with unicodes when using `search_numbers`

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1353,7 +1353,7 @@ class AutocompleteInstance extends React.PureComponent {
         .filter(({ word, wordIndex }) => {
           if (searchNumbers) {
             // Remove all other chars, except numbers, so we can compare
-            word = word.replace(/[^\d\wÆØÅæøå]/g, '')
+            word = word.replace(/[^\p{L}\p{N}]+/gu, '')
           } else {
             // To ensure we escape regex chars
             word = escapeRegexChars(word)

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1353,7 +1353,7 @@ class AutocompleteInstance extends React.PureComponent {
         .filter(({ word, wordIndex }) => {
           if (searchNumbers) {
             // Remove all other chars, except numbers, so we can compare
-            word = word.replace(/[^\d\w\æøå]/g, '')
+            word = word.replace(/[^\d\wÆØÅæøå]/g, '')
           } else {
             // To ensure we escape regex chars
             word = escapeRegexChars(word)
@@ -1474,7 +1474,7 @@ class AutocompleteInstance extends React.PureComponent {
 
               if (searchNumbers) {
                 word.split('').forEach((char) => {
-                  if (/[\d\w\æøå]/.test(char)) {
+                  if (/[\d\wÆØÅæøå]/.test(char)) {
                     segment = segment.replace(
                       new RegExp(`(${char})`, 'gi'),
                       `${strS}$1${strE}`

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1474,7 +1474,7 @@ class AutocompleteInstance extends React.PureComponent {
 
               if (searchNumbers) {
                 word.split('').forEach((char) => {
-                  if (/[\d\wÆØÅæøå]/.test(char)) {
+                  if (/[\p{L}\p{N}]/u.test(char)) {
                     segment = segment.replace(
                       new RegExp(`(${char})`, 'gi'),
                       `${strS}$1${strE}`

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1353,7 +1353,7 @@ class AutocompleteInstance extends React.PureComponent {
         .filter(({ word, wordIndex }) => {
           if (searchNumbers) {
             // Remove all other chars, except numbers, so we can compare
-            word = word.replace(/[^\d\w]/g, '')
+            word = word.replace(/[^\d\w\æøå]/g, '')
           } else {
             // To ensure we escape regex chars
             word = escapeRegexChars(word)
@@ -1474,7 +1474,7 @@ class AutocompleteInstance extends React.PureComponent {
 
               if (searchNumbers) {
                 word.split('').forEach((char) => {
-                  if (/[\d\w]/.test(char)) {
+                  if (/[\d\w\æøå]/.test(char)) {
                     segment = segment.replace(
                       new RegExp(`(${char})`, 'gi'),
                       `${strS}$1${strE}`

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -687,7 +687,7 @@ describe('Autocomplete component', () => {
   it('has correct options when using search_numbers, and searching with æøå', () => {
     const mockData = [
       ['Åge Ørn Ærlig', format('12345678901')],
-      ["Andrè O'Neill", format('12345678901')],
+      ["Andrè Ørjåsæter O'Neill", format('12345678901')],
     ] as DrawerListData
 
     render(
@@ -710,12 +710,12 @@ describe('Autocomplete component', () => {
     ).toBe('Åge Ørn Ærlig12 345 678 901')
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
-      target: { value: "Andrè O'Neill" },
+      target: { value: "Andrè Ørjåsæter O'Neill" },
     })
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0]
         .textContent
-    ).toBe("Andrè O'Neill12 345 678 901")
+    ).toBe("Andrè Ørjåsæter O'Neill12 345 678 901")
   })
 
   it('has correct options when using search_numbers and search_in_word_index=1', () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -684,6 +684,40 @@ describe('Autocomplete component', () => {
     ).toBe(mockData[3])
   })
 
+  it('has correct options when using search_numbers, and searching with æøå', () => {
+    const mockData = [
+      ['Åge Ørn Ærlig', format('12345678901')],
+      ["Andrè O'Neill", format('12345678901')],
+    ] as DrawerListData
+
+    render(
+      <Autocomplete
+        data={mockData}
+        search_numbers
+        show_submit_button
+        {...mockProps}
+      />
+    )
+
+    toggle()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: 'Åge Ørn Ærlig' },
+    })
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+        .textContent
+    ).toBe('Åge Ørn Ærlig12 345 678 901')
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: "Andrè O'Neill" },
+    })
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')[0]
+        .textContent
+    ).toBe("Andrè O'Neill12 345 678 901")
+  })
+
   it('has correct options when using search_numbers and search_in_word_index=1', () => {
     const mockData = ['100.222.333,40', '123456', '100 222 444,50']
 

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -53,6 +53,21 @@ export const SearchNumbers = () => {
   )
 }
 
+export const SearchNumbersNonAlphaNumericChars = () => {
+  return (
+    <Autocomplete
+      label="Label:"
+      data={[
+        ['Edgar Wuckert', '1234.56.78901'],
+        ['Megan Abshire Jr.', '1234 56 78901'],
+        ['Åge Ørn Ærlig', '12345678901'],
+        ["Andrè O'Neill", '12345678901'],
+      ]}
+      search_numbers
+    />
+  )
+}
+
 const accounts = [
   { selectedKey: 1, content: 'A' },
   { selectedKey: 2, content: 'B' },


### PR DESCRIPTION
fixes https://github.com/dnbexperience/eufemia/issues/4293

As of now, I've just added support for the characters ÆØÅ, not sure if there's other non-alphanumeric characters we should support, and perhaps improve the regex to something better than just`\wÆØÅæøå`.

[Original CSB from the issue](https://codesandbox.io/p/sandbox/stoic-feather-8ymh7s)
[CSB with the fix](https://codesandbox.io/p/sandbox/relaxed-paper-gyxyf8?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE) using commit https://github.com/dnbexperience/eufemia/pull/4419/commits/aa28f0c632f1baf57ff2b234157f88ebbe49c043
[CSB with the fix](https://codesandbox.io/p/sandbox/flamboyant-feistel-klw9c2?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE) using commit https://github.com/dnbexperience/eufemia/pull/4419/commits/2334c879516dd658db048778439e4efbb9f62cd5
