### PR TITLE
fix(Forms): correct font-size of non-clickable Field.Upload item

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
@@ -13,7 +13,11 @@ export const UploadFileLink = (props: UploadFileLinkProps) => {
   const { onClick, text, href, download, ...rest } = props
 
   if (!onClick && !href) {
-    return <Span {...rest}>{text}</Span>
+    return (
+      <Span className="dnb-p" {...rest}>
+        {text}
+      </Span>
+    )
   }
 
   if (onClick) {


### PR DESCRIPTION
From:

<img width="385" alt="Screenshot 2024-12-23 at 06 52 49" src="https://github.com/user-attachments/assets/cb93519c-4089-4176-8ef9-7060cba75181" />

To:

<img width="424" alt="Screenshot 2024-12-23 at 06 53 11" src="https://github.com/user-attachments/assets/95bc6da8-6370-4511-b30a-b2006aa72d92" />
