### PR TITLE
fix(InputMasked): should work without any properties

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedDocs.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedDocs.ts
@@ -42,7 +42,7 @@ export const inputMaskedProperties: PropertiesTableProps = {
     status: 'optional',
   },
   mask: {
-    doc: 'A mask can be defined both as a [RegExp style of characters](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme) or a callback function. Example below.',
+    doc: 'A mask can be defined both as a [RegExp style of characters](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme) or a callback function. Example below. Defaults to number mask.',
     type: ['RegExp', 'function'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
@@ -239,7 +239,7 @@ export const useInputElement = () => {
         inputRef={ref}
         inputElement={inputElementRef.current}
         pipe={pipe}
-        mask={mask || []}
+        mask={mask || createNumberMask()}
         showMask={showMask}
         guide={showGuide}
         keepCharPositions={keepCharPositions}

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -918,7 +918,7 @@ describe('InputMasked component as_percent', () => {
 })
 
 describe('InputMasked component without any properties', () => {
-  it('should accept inputs', async () => {
+  it('defaults to number mask', () => {
     const newValue = '1'
 
     render(<InputMasked />)

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -917,6 +917,22 @@ describe('InputMasked component as_percent', () => {
   })
 })
 
+describe('InputMasked component without any properties', () => {
+  it('should accept inputs', async () => {
+    const newValue = '1'
+
+    render(<InputMasked />)
+
+    expect(document.querySelector('input').value).toBe('')
+
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: newValue },
+    })
+
+    expect(document.querySelector('input').value).toBe(newValue)
+  })
+})
+
 describe('InputMasked component as_number', () => {
   it('should create a "number_mask" accordingly the defined properties', () => {
     const { rerender } = render(

--- a/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
@@ -27,6 +27,10 @@ export function TypeNumber() {
   return <InputMasked label="Number:" as_currency value="12" />
 }
 
+export function NoProps() {
+  return <InputMasked label="what" />
+}
+
 export function Sandbox() {
   const [locale, setLocale] = React.useState<InternalLocale>('nb-NO')
   return (


### PR DESCRIPTION
This PR aims to make InputMasked work without providing any props.
Reason why it should work without providing any props, is because all its props is optional.

Defaults to using number mask, as a mask is required.

fixes https://github.com/dnbexperience/eufemia/issues/3134