### PR TITLE
chore(TabBar): fix navigation on next and prev button click

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
@@ -111,7 +111,7 @@ export default function TabBar({
       )}
       <Tabs
         id="tab-bar"
-        on_open_tab_navigation_fn={navigate}
+        onOpenTabNavigationFn={navigate}
         tab_element={Link}
         data={preparedTabs}
         selected_key={selectedKey}

--- a/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
@@ -9,6 +9,7 @@ import { fullscreen as fullscreenIcon } from '@dnb/eufemia/src/icons'
 import AutoLinkHeader from './AutoLinkHeader'
 import { tabsWrapperStyle } from './TabBar.module.scss'
 import { Link } from './Anchor'
+import { navigate } from 'gatsby'
 
 export const defaultTabsValue = [
   { title: 'Info', key: '/info' },
@@ -110,6 +111,7 @@ export default function TabBar({
       )}
       <Tabs
         id="tab-bar"
+        on_open_tab_navigation_fn={navigate}
         tab_element={Link}
         data={preparedTabs}
         selected_key={selectedKey}

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -82,7 +82,7 @@ export interface TabsProps
   /**
    * Only used internally for TabBar navigation when clicking next or previous buttons.
    */
-  on_open_tab_navigation_fn?: (...args: any[]) => any;
+  onOpenTabNavigationFn?: (...args: any[]) => any;
   /**
    * If set to `true`, the Tabs content will pre-render all contents. The visibility will be handled by using the `hidden` and `aria-hidden` HTML attributes. Defaults to `false`.
    */

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.d.ts
@@ -79,7 +79,10 @@ export interface TabsProps
    * If set to `true`, the navigation icons will have a straight border at their outside. This feature is meant to be used when the Tabs component goes all the way to the browser window. Defaults to `false`.
    */
   nav_button_edge?: boolean;
-  use_hash?: boolean;
+  /**
+   * Only used internally for TabBar navigation when clicking next or previous buttons.
+   */
+  on_open_tab_navigation_fn?: (...args: any[]) => any;
   /**
    * If set to `true`, the Tabs content will pre-render all contents. The visibility will be handled by using the `hidden` and `aria-hidden` HTML attributes. Defaults to `false`.
    */

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.js
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.js
@@ -90,7 +90,7 @@ export default class Tabs extends React.PureComponent {
       PropTypes.string,
       PropTypes.bool,
     ]),
-    use_hash: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    on_open_tab_navigation_fn: PropTypes.func,
     prerender: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     prevent_rerender: PropTypes.oneOfType([
       PropTypes.string,
@@ -129,7 +129,7 @@ export default class Tabs extends React.PureComponent {
     tabs_spacing: null,
     no_border: false,
     nav_button_edge: false,
-    use_hash: false,
+    on_open_tab_navigation_fn: null,
     prerender: false,
     prevent_rerender: false,
     scroll: null,
@@ -301,18 +301,6 @@ export default class Tabs extends React.PureComponent {
       props.selected_key,
       data
     )
-
-    // check if we have to open a different tab
-    if (props.use_hash && typeof window !== 'undefined') {
-      try {
-        const useHashKey = String(window.location.hash).replace('#', '')
-        if (useHashKey && String(useHashKey).length > 0) {
-          selected_key = Tabs.getSelectedKeyOrFallback(useHashKey, data)
-        }
-      } catch (e) {
-        // do nothing
-      }
-    }
 
     const lastPosition = this.getLastPosition()
     this.state = {
@@ -831,13 +819,12 @@ export default class Tabs extends React.PureComponent {
       this.getEventArgs({ event, selected_key })
     )
 
-    if (this.props.use_hash && typeof window !== 'undefined') {
+    if (
+      this.props.on_open_tab_navigation_fn &&
+      typeof window !== 'undefined'
+    ) {
       try {
-        window.history.replaceState(
-          undefined,
-          undefined,
-          `#${selected_key}`
-        )
+        this.props.on_open_tab_navigation_fn(selected_key)
       } catch (e) {
         warn('Tabs Error:', e)
       }

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.js
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.js
@@ -90,7 +90,7 @@ export default class Tabs extends React.PureComponent {
       PropTypes.string,
       PropTypes.bool,
     ]),
-    on_open_tab_navigation_fn: PropTypes.func,
+    onOpenTabNavigationFn: PropTypes.func,
     prerender: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     prevent_rerender: PropTypes.oneOfType([
       PropTypes.string,
@@ -129,7 +129,7 @@ export default class Tabs extends React.PureComponent {
     tabs_spacing: null,
     no_border: false,
     nav_button_edge: false,
-    on_open_tab_navigation_fn: null,
+    onOpenTabNavigationFn: null,
     prerender: false,
     prevent_rerender: false,
     scroll: null,
@@ -820,11 +820,11 @@ export default class Tabs extends React.PureComponent {
     )
 
     if (
-      this.props.on_open_tab_navigation_fn &&
+      this.props.onOpenTabNavigationFn &&
       typeof window !== 'undefined'
     ) {
       try {
-        this.props.on_open_tab_navigation_fn(selected_key)
+        this.props.onOpenTabNavigationFn(selected_key)
       } catch (e) {
         warn('Tabs Error:', e)
       }


### PR DESCRIPTION
fixes https://github.com/dnbexperience/eufemia/issues/3116

Removes `use_hash` which was an internally used property(but was not used anywhere), which was not publicly documented.

Added a new internal property `onOpenTabNavigationFn ` to be able to use Gatsby `navigate` when user presses the next and prev buttons in Tabs:
<img width="235" alt="image" src="https://github.com/user-attachments/assets/5260970b-7cdc-4f54-93f6-7a05dc93a42e" />
