### PR TITLE
fix(Spacing): ensure HTML elements like h1 use always a spacing reset

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3314,14 +3314,14 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio-group fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-radio-group fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-radio-group fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-radio-group fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;
@@ -3623,14 +3623,14 @@ button .dnb-form-status__text {
 .dnb-toggle-button-group fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-toggle-button-group fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-toggle-button-group fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-toggle-button-group fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-toggle-button-group--column .dnb-toggle-button {
   display: flex;
@@ -4215,14 +4215,14 @@ html[data-whatinput=keyboard] .dnb-date-picker table.dnb-no-focus:focus {
 .dnb-date-picker__fieldset:not([class*=space__top]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-date-picker__fieldset:not([class*=space__right]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-date-picker__fieldset:not([class*=space__bottom]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-date-picker__fieldset:not([class*=space__left]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-date-picker__fieldset:not([class*=space__right]), .dnb-core-style .dnb-date-picker__fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 
 @keyframes date-picker-slide-down {

--- a/packages/dnb-eufemia/src/components/form-row/__tests__/__snapshots__/FormRow.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/form-row/__tests__/__snapshots__/FormRow.test.tsx.snap
@@ -86,14 +86,14 @@ exports[`FormRow scss has to match style dependencies css 1`] = `
 .dnb-form-row__fieldset:not([class*=space__top]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-form-row__fieldset:not([class*=space__right]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-form-row__fieldset:not([class*=space__bottom]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-form-row__fieldset:not([class*=space__left]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-form-row__fieldset:not([class*=space__right]), .dnb-core-style .dnb-form-row__fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }"
 `;
 

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1345,14 +1345,14 @@ html[data-visual-test] .dnb-input__input {
 .dnb-multi-input-mask__fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-multi-input-mask__fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-multi-input-mask__fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-multi-input-mask__fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-multi-input-mask__fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-multi-input-mask__fieldset--horizontal {
   display: inline-flex;

--- a/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -344,14 +344,14 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio-group fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-radio-group fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-radio-group fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-radio-group fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;

--- a/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
@@ -559,16 +559,16 @@ exports[`Space scss has to match style dependencies css 1`] = `
 .dnb-space__left--xx-large-x2.dnb-space__left--x-large {
   margin-left: calc(var(--spacing-xx-large) + var(--spacing-xx-large) + var(--spacing-x-large));
 }
-.dnb-space__reset:not([class*=dnb-space__top]) {
+.dnb-space__reset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-space__reset:not([class*=dnb-space__bottom]) {
+.dnb-space__reset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
-.dnb-space__reset:not([class*=dnb-space__left]) {
+.dnb-space__reset:not([class*=space__left]) {
   margin-left: 0;
 }
-.dnb-space__reset:not([class*=dnb-space__right]) {
+.dnb-space__reset:not([class*=space__right]) {
   margin-right: 0;
 }
 .dnb-space[style*="--space-t-"] {

--- a/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
@@ -174,18 +174,7 @@
     @include direction(left);
   }
   &__reset {
-    &:not([class*='dnb-space__top']) {
-      margin-top: 0;
-    }
-    &:not([class*='dnb-space__bottom']) {
-      margin-bottom: 0;
-    }
-    &:not([class*='dnb-space__left']) {
-      margin-left: 0;
-    }
-    &:not([class*='dnb-space__right']) {
-      margin-right: 0;
-    }
+    @include spaceReset();
   }
 
   // innerSpace

--- a/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
@@ -6,6 +6,7 @@
  */
 
 @import '../../../style/core/utilities.scss';
+@import './space-mixins.scss';
 
 @mixin direction($direction) {
   // 0rem

--- a/packages/dnb-eufemia/src/components/space/style/space-mixins.scss
+++ b/packages/dnb-eufemia/src/components/space/style/space-mixins.scss
@@ -1,0 +1,21 @@
+@mixin spaceVerticalReset() {
+  &:not([class*='space__top']) {
+    margin-top: 0;
+  }
+  &:not([class*='space__bottom']) {
+    margin-bottom: 0;
+  }
+}
+@mixin spaceHorizontalReset() {
+  &:not([class*='space__left']) {
+    margin-left: 0;
+  }
+  &:not([class*='space__right']) {
+    margin-right: 0;
+  }
+}
+
+@mixin spaceReset() {
+  @include spaceVerticalReset();
+  @include spaceHorizontalReset();
+}

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -1435,14 +1435,14 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio-group fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-radio-group fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-radio-group fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-radio-group fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-radio-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-radio-group--column .dnb-radio {
   display: flex;
@@ -1744,14 +1744,14 @@ button .dnb-form-status__text {
 .dnb-toggle-button-group fieldset:not([class*=space__top]) {
   margin-top: 0;
 }
-.dnb-toggle-button-group fieldset:not([class*=space__right]) {
-  margin-right: 0;
-}
 .dnb-toggle-button-group fieldset:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
 .dnb-toggle-button-group fieldset:not([class*=space__left]) {
   margin-left: 0;
+}
+.dnb-toggle-button-group fieldset:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-toggle-button-group--column .dnb-toggle-button {
   display: flex;

--- a/packages/dnb-eufemia/src/elements/blockquote/style/blockquote-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/blockquote/style/blockquote-mixins.scss
@@ -1,5 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
-@import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 @mixin blockquoteStyle() {
   --blockquote-padding-top: 2rem;

--- a/packages/dnb-eufemia/src/elements/blockquote/style/blockquote-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/blockquote/style/blockquote-mixins.scss
@@ -1,4 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
+@import '../../../style/core/utilities.scss';
 
 @mixin blockquoteStyle() {
   --blockquote-padding-top: 2rem;
@@ -15,9 +16,7 @@
   display: inline-block;
   width: auto;
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
   padding: 1.5rem;
 
   font-size: var(--font-size-small);

--- a/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
@@ -1,5 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
-@import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 @mixin codeStyle() {
   $code-scale: 0.875;

--- a/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
@@ -1,4 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
+@import '../../../style/core/utilities.scss';
 
 @mixin codeStyle() {
   $code-scale: 0.875;
@@ -27,9 +28,7 @@
   display: block;
   overflow: auto;
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
   padding: 1rem;
 
   border-radius: 0.5rem;

--- a/packages/dnb-eufemia/src/elements/hr/style/hr-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/hr/style/hr-mixins.scss
@@ -1,5 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
-@import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 @mixin hrStyle() {
   position: relative;

--- a/packages/dnb-eufemia/src/elements/hr/style/hr-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/hr/style/hr-mixins.scss
@@ -1,4 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
+@import '../../../style/core/utilities.scss';
 
 @mixin hrStyle() {
   position: relative;
@@ -8,9 +9,7 @@
 
   display: flow-root; // avoid margin collapsing on Safari
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
 
   border: 0;
 

--- a/packages/dnb-eufemia/src/elements/img/style/img-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/img/style/img-mixins.scss
@@ -3,7 +3,7 @@
  *
  */
 
-@import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 @mixin imageStyle() {
   position: relative;

--- a/packages/dnb-eufemia/src/elements/img/style/img-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/img/style/img-mixins.scss
@@ -3,6 +3,8 @@
  *
  */
 
+@import '../../../style/core/utilities.scss';
+
 @mixin imageStyle() {
   position: relative;
   z-index: 2;
@@ -35,9 +37,7 @@
   display: inline-flex;
   flex-direction: column;
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
   padding: 0;
 
   text-align: center; // works on Chrome – hides the alt text

--- a/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
@@ -42,9 +42,7 @@
 }
 
 @mixin ulStyle() {
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
 
   padding: 0;
   &:not([class*='dnb-space__left']) {
@@ -277,9 +275,7 @@
 @mixin unstyledList() {
   list-style-type: none;
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
   &:not([class*='dnb-space__left']) {
     padding-left: 0;
   }

--- a/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
@@ -5,6 +5,7 @@
 
 @use '../../../style/elements/ui-spacing.scss';
 @import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 @mixin listDefaults() {
   & ul,

--- a/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
@@ -1,5 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
-@import '../../../style/core/utilities.scss';
+@import '../../../components/space/style/space-mixins.scss';
 
 // includes all classes, tags, etc. needed for "global" typography rules (like css variables)
 @mixin typographySelectors() {

--- a/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
@@ -1,4 +1,5 @@
 @use '../../../style/elements/ui-spacing.scss';
+@import '../../../style/core/utilities.scss';
 
 // includes all classes, tags, etc. needed for "global" typography rules (like css variables)
 @mixin typographySelectors() {
@@ -92,9 +93,7 @@
 @mixin headingDefaults() {
   padding: 0;
 
-  &:not([class*='dnb-space']) {
-    margin: 0;
-  }
+  @include spaceReset();
 
   font-family: var(--font-family-heading);
 

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -377,19 +377,30 @@ $breakpoint-offset: 0;
   }
 }
 
-@mixin fieldsetReset() {
+@mixin spaceVerticalReset() {
   &:not([class*='space__top']) {
     margin-top: 0;
-  }
-  &:not([class*='space__right']) {
-    margin-right: 0;
   }
   &:not([class*='space__bottom']) {
     margin-bottom: 0;
   }
+}
+@mixin spaceHorizontalReset() {
   &:not([class*='space__left']) {
     margin-left: 0;
   }
+  &:not([class*='space__right']) {
+    margin-right: 0;
+  }
+}
+
+@mixin spaceReset() {
+  @include spaceVerticalReset();
+  @include spaceHorizontalReset();
+}
+
+@mixin fieldsetReset() {
+  @include spaceReset();
   padding: 0;
   border: none;
 }

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -2,6 +2,8 @@
  * Utilities
  */
 
+@import '../../components/space/style/space-mixins.scss';
+
 @mixin defaultDropShadow() {
   box-shadow: var(--shadow-default);
 }
@@ -375,28 +377,6 @@ $breakpoint-offset: 0;
       margin-top: 0.5rem;
     }
   }
-}
-
-@mixin spaceVerticalReset() {
-  &:not([class*='space__top']) {
-    margin-top: 0;
-  }
-  &:not([class*='space__bottom']) {
-    margin-bottom: 0;
-  }
-}
-@mixin spaceHorizontalReset() {
-  &:not([class*='space__left']) {
-    margin-left: 0;
-  }
-  &:not([class*='space__right']) {
-    margin-right: 0;
-  }
-}
-
-@mixin spaceReset() {
-  @include spaceVerticalReset();
-  @include spaceHorizontalReset();
 }
 
 @mixin fieldsetReset() {

--- a/packages/dnb-eufemia/src/style/dnb-ui-forms.scss
+++ b/packages/dnb-eufemia/src/style/dnb-ui-forms.scss
@@ -21,7 +21,7 @@
 @import '../extensions/forms/Form/SubHeading/style/dnb-form-sub-heading.scss';
 @import '../extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss';
 @import '../extensions/forms/Iterate/style/dnb-iterate.scss';
-@import '../extensions/forms/ValueBlock/style/dnb-value-block.scss';
 @import '../extensions/forms/Value/Upload/style/dnb-value-upload.scss';
+@import '../extensions/forms/ValueBlock/style/dnb-value-block.scss';
 @import '../extensions/forms/Wizard/style/dnb-wizard-layout.scss';
 @import '../extensions/forms/utils/TestElement/style/dnb-test-element.scss';

--- a/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
+++ b/packages/dnb-eufemia/src/style/elements/__tests__/__snapshots__/Elements.test.js.snap
@@ -39,8 +39,17 @@ exports[`Elements scss has to match style dependencies css 1`] = `
   border-radius: 1rem;
   position: relative;
 }
-.dnb-blockquote:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-blockquote:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-blockquote:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-blockquote:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-blockquote:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-blockquote::before {
   content: "";
@@ -156,8 +165,17 @@ del .dnb-code {
   font-size: inherit;
   font-family: var(--font-family-monospace);
 }
-.dnb-pre:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-pre:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-pre:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-pre:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-pre:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-pre pre {
   padding: 1rem;
@@ -203,8 +221,17 @@ del .dnb-code {
   border: 0;
   --thickness: calc(var(--hr-thickness, 0.0625rem) + var(--modifier, 0px));
 }
-.dnb-hr:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-hr:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-hr:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-hr:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-hr:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-hr::after {
   content: "";
@@ -254,8 +281,17 @@ del .dnb-code {
   text-align: center;
   align-items: center;
 }
-.dnb-img:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-img:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-img:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-img:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-img:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-img img,
 .dnb-img figcaption {
@@ -327,8 +363,17 @@ del .dnb-code {
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
 }
-.dnb-ul:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-ul:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-ul:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-ul:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-ul:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-ul:not([class*=dnb-space__left]) {
   padding-left: 2rem;
@@ -369,8 +414,17 @@ del .dnb-code {
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
 }
-.dnb-ol:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-ol:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-ol:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-ol:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-ol:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-ol:not([class*=dnb-space__left]) {
   padding-left: 2rem;
@@ -581,8 +635,17 @@ del .dnb-code {
 .dnb-unstyled-list {
   list-style-type: none;
 }
-.dnb-unstyled-list:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-unstyled-list:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-unstyled-list:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-unstyled-list:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-unstyled-list:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-unstyled-list:not([class*=dnb-space__left]) {
   padding-left: 0;
@@ -676,23 +739,77 @@ del .dnb-code {
   padding: 0;
   font-family: var(--font-family-heading);
 }
-.dnb-lead:not([class*=dnb-space]),
-.dnb-h--xx-large:not([class*=dnb-space]),
-.dnb-h--x-large:not([class*=dnb-space]),
-.dnb-h--large:not([class*=dnb-space]),
-.dnb-h--medium:not([class*=dnb-space]),
-.dnb-h--basis:not([class*=dnb-space]),
-.dnb-h--small:not([class*=dnb-space]),
-.dnb-h--x-small:not([class*=dnb-space]),
-.dnb-core-style .dnb-lead:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--xx-large:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--x-large:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--large:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--medium:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--basis:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--small:not([class*=dnb-space]),
-.dnb-core-style .dnb-h--x-small:not([class*=dnb-space]) {
-  margin: 0;
+.dnb-lead:not([class*=space__top]),
+.dnb-h--xx-large:not([class*=space__top]),
+.dnb-h--x-large:not([class*=space__top]),
+.dnb-h--large:not([class*=space__top]),
+.dnb-h--medium:not([class*=space__top]),
+.dnb-h--basis:not([class*=space__top]),
+.dnb-h--small:not([class*=space__top]),
+.dnb-h--x-small:not([class*=space__top]),
+.dnb-core-style .dnb-lead:not([class*=space__top]),
+.dnb-core-style .dnb-h--xx-large:not([class*=space__top]),
+.dnb-core-style .dnb-h--x-large:not([class*=space__top]),
+.dnb-core-style .dnb-h--large:not([class*=space__top]),
+.dnb-core-style .dnb-h--medium:not([class*=space__top]),
+.dnb-core-style .dnb-h--basis:not([class*=space__top]),
+.dnb-core-style .dnb-h--small:not([class*=space__top]),
+.dnb-core-style .dnb-h--x-small:not([class*=space__top]) {
+  margin-top: 0;
+}
+.dnb-lead:not([class*=space__bottom]),
+.dnb-h--xx-large:not([class*=space__bottom]),
+.dnb-h--x-large:not([class*=space__bottom]),
+.dnb-h--large:not([class*=space__bottom]),
+.dnb-h--medium:not([class*=space__bottom]),
+.dnb-h--basis:not([class*=space__bottom]),
+.dnb-h--small:not([class*=space__bottom]),
+.dnb-h--x-small:not([class*=space__bottom]),
+.dnb-core-style .dnb-lead:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--xx-large:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--x-large:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--large:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--medium:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--basis:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--small:not([class*=space__bottom]),
+.dnb-core-style .dnb-h--x-small:not([class*=space__bottom]) {
+  margin-bottom: 0;
+}
+.dnb-lead:not([class*=space__left]),
+.dnb-h--xx-large:not([class*=space__left]),
+.dnb-h--x-large:not([class*=space__left]),
+.dnb-h--large:not([class*=space__left]),
+.dnb-h--medium:not([class*=space__left]),
+.dnb-h--basis:not([class*=space__left]),
+.dnb-h--small:not([class*=space__left]),
+.dnb-h--x-small:not([class*=space__left]),
+.dnb-core-style .dnb-lead:not([class*=space__left]),
+.dnb-core-style .dnb-h--xx-large:not([class*=space__left]),
+.dnb-core-style .dnb-h--x-large:not([class*=space__left]),
+.dnb-core-style .dnb-h--large:not([class*=space__left]),
+.dnb-core-style .dnb-h--medium:not([class*=space__left]),
+.dnb-core-style .dnb-h--basis:not([class*=space__left]),
+.dnb-core-style .dnb-h--small:not([class*=space__left]),
+.dnb-core-style .dnb-h--x-small:not([class*=space__left]) {
+  margin-left: 0;
+}
+.dnb-lead:not([class*=space__right]),
+.dnb-h--xx-large:not([class*=space__right]),
+.dnb-h--x-large:not([class*=space__right]),
+.dnb-h--large:not([class*=space__right]),
+.dnb-h--medium:not([class*=space__right]),
+.dnb-h--basis:not([class*=space__right]),
+.dnb-h--small:not([class*=space__right]),
+.dnb-h--x-small:not([class*=space__right]),
+.dnb-core-style .dnb-lead:not([class*=space__right]),
+.dnb-core-style .dnb-h--xx-large:not([class*=space__right]),
+.dnb-core-style .dnb-h--x-large:not([class*=space__right]),
+.dnb-core-style .dnb-h--large:not([class*=space__right]),
+.dnb-core-style .dnb-h--medium:not([class*=space__right]),
+.dnb-core-style .dnb-h--basis:not([class*=space__right]),
+.dnb-core-style .dnb-h--small:not([class*=space__right]),
+.dnb-core-style .dnb-h--x-small:not([class*=space__right]) {
+  margin-right: 0;
 }
 .dnb-lead .dnb-icon--default,
 .dnb-h--xx-large .dnb-icon--default,


### PR DESCRIPTION
This PR changes basically all margin resets with a better check. More info [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1736775869816959).

So this reset:

```scss
&:not([class*='dnb-space']) {
  margin: 0;
}
```

Is now like this:

```scss
@include spaceReset();
```

Which again checks for all directions:


```scss
&:not([class*='space__top']) {
  margin-top: 0;
}
etc...
```