### PR TITLE
chore: rename internal context (`IterateElementContext` to `IterateItemContext`)

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -20,7 +20,7 @@ import FieldBlockContext, {
   StateBasis,
 } from './FieldBlockContext'
 import DataContext from '../DataContext/Context'
-import IterateElementContext from '../Iterate/IterateItemContext'
+import IterateItemContext from '../Iterate/IterateItemContext'
 import { Space, FormLabel, FormStatus } from '../../../components'
 import { Ul, Li } from '../../../elements'
 import {
@@ -175,7 +175,7 @@ function FieldBlock(props: Props) {
   const hasCustomWidth = /\d(rem)$/.test(String(width))
   const hasCustomContentWidth = /\d(rem)$/.test(String(contentWidth))
 
-  const iterateItemContext = useContext(IterateElementContext)
+  const iterateItemContext = useContext(IterateItemContext)
   const { index: iterateIndex } = iterateItemContext ?? {}
 
   const blockId = useId(props.id)

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -14,7 +14,7 @@ import ValueBlockContext from './ValueBlockContext'
 import DataContext from '../DataContext/Context'
 import { Path, ValueProps } from '../types'
 import { pickSpacingProps } from '../../../components/flex/utils'
-import IterateElementContext from '../Iterate/IterateItemContext'
+import IterateItemContext from '../Iterate/IterateItemContext'
 import { convertJsxToString } from '../../../shared/component-helper'
 
 /**
@@ -38,7 +38,7 @@ function ValueBlock(props: Props) {
   const summaryListContext = useContext(SummaryListContext)
   const valueBlockContext = useContext(ValueBlockContext)
   const { prerenderFieldProps } = useContext(DataContext) || {}
-  const { index: iterateIndex } = useContext(IterateElementContext) || {}
+  const { index: iterateIndex } = useContext(IterateItemContext) || {}
 
   const {
     className,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useExternalValue.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useExternalValue.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { renderHook } from '@testing-library/react'
 import useExternalValue from '../useExternalValue'
 import { DataContext } from '../..'
-import IterateElementContext from '../../Iterate/IterateItemContext'
+import IterateItemContext from '../../Iterate/IterateItemContext'
 
 describe('useExternalValue', () => {
   const transformers = {
@@ -55,13 +55,13 @@ describe('useExternalValue', () => {
   describe('with iterate context', () => {
     it('should return iterate element value when itemPath is "/"', () => {
       const wrapper = ({ children }) => (
-        <IterateElementContext.Provider
+        <IterateItemContext.Provider
           value={{
             value: 'iterate-value',
           }}
         >
           {children}
-        </IterateElementContext.Provider>
+        </IterateItemContext.Provider>
       )
 
       const { result } = renderHook(
@@ -78,7 +78,7 @@ describe('useExternalValue', () => {
 
     it('should return value from iterate element using itemPath', () => {
       const wrapper = ({ children }) => (
-        <IterateElementContext.Provider
+        <IterateItemContext.Provider
           value={{
             value: {
               nested: 'nested-value',
@@ -86,7 +86,7 @@ describe('useExternalValue', () => {
           }}
         >
           {children}
-        </IterateElementContext.Provider>
+        </IterateItemContext.Provider>
       )
 
       const { result } = renderHook(
@@ -109,7 +109,7 @@ describe('useExternalValue', () => {
       }
 
       const wrapper = ({ children }) => (
-        <IterateElementContext.Provider
+        <IterateItemContext.Provider
           value={{
             value: {
               nested: 'nested-value',
@@ -117,7 +117,7 @@ describe('useExternalValue', () => {
           }}
         >
           {children}
-        </IterateElementContext.Provider>
+        </IterateItemContext.Provider>
       )
 
       const { result } = renderHook(
@@ -234,13 +234,13 @@ describe('useExternalValue', () => {
 
   it('should handle priority order: value > iterate > data context', () => {
     const wrapper = ({ children }) => (
-      <IterateElementContext.Provider
+      <IterateItemContext.Provider
         value={{
           value: 'iterate-value',
         }}
       >
         {children}
-      </IterateElementContext.Provider>
+      </IterateItemContext.Provider>
     )
 
     const { result } = renderHook(

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useExternalValue.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useExternalValue.ts
@@ -2,7 +2,7 @@ import { useContext, useMemo } from 'react'
 import pointer from '../utils/json-pointer'
 import { FieldProps, Path } from '../types'
 import DataContext from '../DataContext/Context'
-import IterateElementContext from '../Iterate/IterateItemContext'
+import IterateItemContext from '../Iterate/IterateItemContext'
 
 export type Props<Value> = {
   path?: Path | undefined
@@ -23,7 +23,7 @@ export default function useExternalValue<Value>(props: Props<Value>) {
     emptyValue = undefined,
   } = props
   const { data } = useContext(DataContext) || {}
-  const iterateItemContext = useContext(IterateElementContext)
+  const iterateItemContext = useContext(IterateItemContext)
   const inIterate = Boolean(iterateItemContext)
   const { value: iterateElementValue } = iterateItemContext || {}
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -39,7 +39,7 @@ import useUpdateEffect from '../../../shared/helpers/useUpdateEffect'
 import FieldBlockContext, {
   FieldBlockContextProps,
 } from '../FieldBlock/FieldBlockContext'
-import IterateElementContext from '../Iterate/IterateItemContext'
+import IterateItemContext from '../Iterate/IterateItemContext'
 import SectionContext from '../Form/Section/SectionContext'
 import FieldBoundaryContext from '../DataContext/FieldBoundary/FieldBoundaryContext'
 import VisibilityContext from '../Form/Visibility/VisibilityContext'
@@ -172,7 +172,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const id = useId(props.id)
   const dataContext = useContext(DataContext)
   const fieldBlockContext = useContext(FieldBlockContext)
-  const iterateItemContext = useContext(IterateElementContext)
+  const iterateItemContext = useContext(IterateItemContext)
   const sectionContext = useContext(SectionContext)
   const fieldBoundaryContext = useContext(FieldBoundaryContext)
   const wizardContext = useContext(WizardContext)

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/usePath.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/usePath.ts
@@ -2,7 +2,7 @@ import { useCallback, useContext, useMemo } from 'react'
 import { Path } from '../types'
 import useId from '../../../shared/helpers/useId'
 import SectionContext from '../Form/Section/SectionContext'
-import IterateElementContext from '../Iterate/IterateItemContext'
+import IterateItemContext from '../Iterate/IterateItemContext'
 
 export type Props = {
   id?: string
@@ -15,7 +15,7 @@ export default function usePath(props: Props = {}) {
   const id = useId(props.id)
   const { path: sectionPath } = useContext(SectionContext) ?? {}
   const { path: iteratePathProp, index: iterateElementIndex } =
-    useContext(IterateElementContext) ?? {}
+    useContext(IterateItemContext) ?? {}
 
   if (pathProp && !pathProp.startsWith('/')) {
     throw new Error(`path="${pathProp}" must start with a slash`)


### PR DESCRIPTION
Because the "element" is a legacy term we moved away from.