### PR TITLE
feat(Forms): add `transformSelection` to Field.Selection

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/Examples.tsx
@@ -42,17 +42,22 @@ export const DropdownLabel = () => (
   </ComponentBox>
 )
 
-export const DropdownOptionSelected = () => (
-  <ComponentBox>
-    <Field.Selection
-      value="bar"
-      onChange={(value) => console.log('onChange', value)}
-    >
-      <Field.Option value="foo" title="Foo!" />
-      <Field.Option value="bar" title="Baar!" />
-    </Field.Selection>
-  </ComponentBox>
-)
+export function DropdownTransformSelection() {
+  return (
+    <ComponentBox>
+      <Field.Selection
+        label="Label"
+        value="bar"
+        transformSelection={({ title }) => {
+          return title
+        }}
+      >
+        <Field.Option value="foo" title="Foo!" text="Additional text" />
+        <Field.Option value="bar" title="Baar!" text="Additional text" />
+      </Field.Selection>
+    </ComponentBox>
+  )
+}
 
 export const DropdownLabelAndOptionSelected = () => (
   <ComponentBox data-visual-test="selection-dropdown-default">

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection/demos.mdx
@@ -38,9 +38,9 @@ As there are many variants, they are split into separate sections. Here is a sum
 
 <Examples.DropdownPlaceholder />
 
-#### Dropdown option selected
+#### Dropdown with a transformed selection text
 
-<Examples.DropdownOptionSelected />
+<Examples.DropdownTransformSelection />
 
 #### Dropdown label and option selected
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
@@ -11,6 +11,11 @@ export const SelectionProperties: PropertiesTableProps = {
     type: ['number', 'string'],
     status: 'optional',
   },
+  transformSelection: {
+    doc: 'Transform the displayed selection for Dropdown and Autocomplete variant. Use it to display a different value than the one in the data set. The first parameter is the props of the Option component or data item. You can return a React.Node that will be displayed in the selection.',
+    type: 'function',
+    status: 'optional',
+  },
   optionsLayout: {
     doc: 'Layout for the list of options. Can be `horizontal` or `vertical`.',
     type: 'string',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -30,6 +30,67 @@ describe('Selection', () => {
     expect(screen.queryByText('Foo')).not.toBeInTheDocument()
   })
 
+  it('renders selected option with a text property', () => {
+    render(
+      <Field.Selection value="bar">
+        <Field.Option value="foo" title="Foo!" text="Text" />
+        <Field.Option value="bar" title="Bar!" text="Text" />
+      </Field.Selection>
+    )
+    expect(
+      document.querySelector('.dnb-dropdown__text__inner')
+    ).toHaveTextContent('Bar! Text')
+  })
+
+  it('renders selected option with the "transformSelection" return', () => {
+    render(
+      <Field.Selection
+        value="bar"
+        transformSelection={(item) => item.title}
+      >
+        <Field.Option value="foo" title="Foo!" text="Text" />
+        <Field.Option value="bar" title="Bar!" text="Text" />
+      </Field.Selection>
+    )
+    expect(
+      document.querySelector('.dnb-dropdown__text__inner').textContent
+    ).toBe('Bar!')
+  })
+
+  it('renders selected data context with the "transformSelection" return', () => {
+    render(
+      <Form.Handler
+        defaultData={{
+          mySelection: 'bar',
+          myList: [
+            {
+              value: 'foo',
+              title: 'Foo!',
+              text: 'Text',
+            },
+            {
+              value: 'bar',
+              title: 'Bar!',
+              text: 'Text',
+            },
+          ],
+        }}
+      >
+        <Field.Selection
+          path="/mySelection"
+          dataPath="/myList"
+          transformSelection={(item) => item.title}
+        >
+          <Field.Option value="foo" title="Foo" text="Text" />
+          <Field.Option value="bar" title="Bar" text="Text" />
+        </Field.Selection>
+      </Form.Handler>
+    )
+    expect(
+      document.querySelector('.dnb-dropdown__text__inner').textContent
+    ).toBe('Bar!')
+  })
+
   it('renders selected option with number values', () => {
     render(
       <Field.Selection value="20">
@@ -290,8 +351,8 @@ describe('variants', () => {
         <Form.Handler
           data={{
             myList: [
-              { value: 'foo', title: 'Foo!' },
-              { value: 'bar', title: 'Bar!' },
+              { value: 'foo', title: 'Foo!', text: 'Text' },
+              { value: 'bar', title: 'Bar!', text: 'Text' },
             ],
             mySelection: 'bar',
           }}
@@ -343,6 +404,38 @@ describe('variants', () => {
       expect(option1.querySelector('input').id).not.toBe(
         option3.querySelector('label').getAttribute('for')
       )
+    })
+
+    it('should support "dataPath" with title and text property', () => {
+      render(
+        <Form.Handler
+          data={{
+            myList: [
+              { value: 'foo', title: 'Foo!', text: 'Text' },
+              { value: 'bar', title: 'Bar!', text: 'Text' },
+            ],
+            mySelection: 'bar',
+          }}
+        >
+          <Field.Selection
+            variant="dropdown"
+            path="/mySelection"
+            dataPath="/myList"
+          >
+            <Field.Option value="baz">Baz!</Field.Option>
+          </Field.Selection>
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-dropdown__text__inner')
+      ).toHaveTextContent('Bar! Text')
+
+      fireEvent.click(document.querySelector('.dnb-dropdown__trigger'))
+
+      const options = document.querySelectorAll('[role="option"]')
+      expect(options[0]).toHaveTextContent('Foo!')
+      expect(options[1]).toHaveTextContent('Bar!')
     })
 
     it('should support keyboard navigation to select an option', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -42,53 +42,74 @@ describe('Selection', () => {
     ).toHaveTextContent('Bar! Text')
   })
 
-  it('renders selected option with the "transformSelection" return', () => {
-    render(
-      <Field.Selection
-        value="bar"
-        transformSelection={(item) => item.title}
-      >
-        <Field.Option value="foo" title="Foo!" text="Text" />
-        <Field.Option value="bar" title="Bar!" text="Text" />
-      </Field.Selection>
-    )
-    expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
-    ).toBe('Bar!')
-  })
-
-  it('renders selected data context with the "transformSelection" return', () => {
-    render(
-      <Form.Handler
-        defaultData={{
-          mySelection: 'bar',
-          myList: [
-            {
-              value: 'foo',
-              title: 'Foo!',
-              text: 'Text',
-            },
-            {
-              value: 'bar',
-              title: 'Bar!',
-              text: 'Text',
-            },
-          ],
-        }}
-      >
+  describe('transformSelection', () => {
+    it('renders selected option with the "transformSelection" return', () => {
+      render(
         <Field.Selection
-          path="/mySelection"
-          dataPath="/myList"
+          value="bar"
           transformSelection={(item) => item.title}
         >
-          <Field.Option value="foo" title="Foo" text="Text" />
-          <Field.Option value="bar" title="Bar" text="Text" />
+          <Field.Option value="foo" title="Foo!" text="Text" />
+          <Field.Option value="bar" title="Bar!" text="Text" />
         </Field.Selection>
-      </Form.Handler>
-    )
-    expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
-    ).toBe('Bar!')
+      )
+      expect(
+        document.querySelector('.dnb-dropdown__text__inner').textContent
+      ).toBe('Bar!')
+    })
+
+    it('renders selected option with the "transformSelection" return using "children"', () => {
+      render(
+        <Field.Selection
+          value="bar"
+          transformSelection={(item) => item.children}
+        >
+          <Field.Option value="foo" text="Text">
+            Foo!
+          </Field.Option>
+          <Field.Option value="bar" text="Text">
+            Bar!
+          </Field.Option>
+        </Field.Selection>
+      )
+      expect(
+        document.querySelector('.dnb-dropdown__text__inner').textContent
+      ).toBe('Bar!')
+    })
+
+    it('renders selected data context with the "transformSelection" return', () => {
+      render(
+        <Form.Handler
+          defaultData={{
+            mySelection: 'bar',
+            myList: [
+              {
+                value: 'foo',
+                title: 'Foo!',
+                text: 'Text',
+              },
+              {
+                value: 'bar',
+                title: 'Bar!',
+                text: 'Text',
+              },
+            ],
+          }}
+        >
+          <Field.Selection
+            path="/mySelection"
+            dataPath="/myList"
+            transformSelection={(item) => item.title}
+          >
+            <Field.Option value="foo" title="Foo" text="Text" />
+            <Field.Option value="bar" title="Bar" text="Text" />
+          </Field.Selection>
+        </Form.Handler>
+      )
+      expect(
+        document.querySelector('.dnb-dropdown__text__inner').textContent
+      ).toBe('Bar!')
+    })
   })
 
   it('renders selected option with number values', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
@@ -177,3 +177,20 @@ export function NestingWithLogic() {
     </Form.Handler>
   )
 }
+
+export function TransformSelection() {
+  return (
+    <Form.Card>
+      <Field.Selection
+        label="Label"
+        value="bar"
+        transformSelection={({ title }) => {
+          return title
+        }}
+      >
+        <Field.Option value="foo" title="Foo!" text="Additional text" />
+        <Field.Option value="bar" title="Baar!" text="Additional text" />
+      </Field.Selection>
+    </Form.Card>
+  )
+}


### PR DESCRIPTION
This is only for the Dropdown and Autocomplete.

[Demo](https://eufemia-git-feat-forms-selection-transform-eufemia.vercel.app/uilib/extensions/forms/base-fields/Selection/#dropdown-with-a-transformed-selection-text).

![Screenshot 2025-01-21 at 12 51 22](https://github.com/user-attachments/assets/72d1d84e-9a76-4661-bcb8-bee9e4f1461d)
![Screenshot 2025-01-21 at 12 49 00](https://github.com/user-attachments/assets/57900195-6ae3-4936-9cbd-221e9f7090b2)
