### PR TITLE
fix(Forms): add animation support to Form.Visibility when used inside Value.SummaryList

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/Examples.tsx
@@ -1,5 +1,6 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Field, Form, Value } from '@dnb/eufemia/src/extensions/forms'
+import { Flex } from '@dnb/eufemia/src/components'
 
 export const DefaultLayout = () => {
   return (
@@ -156,3 +157,29 @@ export const HorizontalLayoutWithoutLabel = () => (
     </Value.SummaryList>
   </ComponentBox>
 )
+
+export function AnimatedVisibility() {
+  return (
+    <ComponentBox>
+      <Form.Handler>
+        <Flex.Stack>
+          <Field.Boolean
+            label="Make second field visible when toggled"
+            path="/toggleValue"
+            variant="checkbox"
+          />
+
+          <Form.Card>
+            <Value.SummaryList>
+              <Value.String label="Label" value="First field" />
+
+              <Form.Visibility pathTrue="/toggleValue" animate>
+                <Value.String label="Label" value="Second field" />
+              </Form.Visibility>
+            </Value.SummaryList>
+          </Form.Card>
+        </Flex.Stack>
+      </Form.Handler>
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/demos.mdx
@@ -32,6 +32,14 @@ Using [Value.Composition](/uilib/extensions/forms/Value/Composition/) to combine
 
 <Examples.InheritLabel />
 
+### With animated Visibility
+
+Below is a `SummaryList` containing two `Value.*` components. The second value will be shown and hidden with animation using the `Form.Visibility` component.
+
+To maintain the semantic structure of the `dl` element, the `Form.Visibility` component animates the content of the `dl` element instead of wrapping it in a div element.
+
+<Examples.AnimatedVisibility />
+
 <VisibleWhenVisualTest>
   <Examples.HorizontalLayoutWithoutLabel />
 </VisibleWhenVisualTest>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityContext.ts
@@ -1,8 +1,10 @@
 import { createContext } from 'react'
+import { Props } from './Visibility'
 
 type VisibilityContext = {
   inheritVisibility?: boolean
   isVisible?: boolean
+  props?: Props
 }
 
 const VisibilityContext = createContext<VisibilityContext>(null)

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FilterData, Provider } from '../../../DataContext'
+import SummaryListContext from '../../../Value/SummaryList/SummaryListContext'
 import Visibility from '../Visibility'
 import useVisibility from '../useVisibility'
 import { Field, Form, Iterate } from '../../..'
@@ -1167,5 +1168,39 @@ describe('Visibility', () => {
       fireEvent.blur(document.querySelector('input'))
       expect(collectResult).toEqual([false, false, false, true])
     })
+  })
+
+  it('should render without additional wrapper when inside SummaryListContext', async () => {
+    const { container, rerender } = render(
+      <SummaryListContext.Provider value={{ isNested: false }}>
+        <Form.Visibility animate pathFalsy="/myField">
+          Child
+        </Form.Visibility>
+      </SummaryListContext.Provider>
+    )
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`"Child"`)
+
+    rerender(
+      <SummaryListContext.Provider value={{ isNested: true }}>
+        <Form.Visibility animate pathFalsy="/myField">
+          Child
+        </Form.Visibility>
+      </SummaryListContext.Provider>
+    )
+
+    expect(document.querySelector('.dnb-forms-visibility')).toHaveClass(
+      'dnb-height-animation'
+    )
+
+    rerender(
+      <SummaryListContext.Provider value={{ isNested: false }}>
+        <Form.Visibility animate pathFalsy="/myField">
+          Child
+        </Form.Visibility>
+      </SummaryListContext.Provider>
+    )
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`"Child"`)
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SummaryList/stories/SummaryList.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SummaryList/stories/SummaryList.stories.tsx
@@ -70,3 +70,27 @@ function ContactInformationEdit() {
     </Form.Section.EditContainer>
   )
 }
+
+export function AnimatedVisibility() {
+  return (
+    <Form.Handler>
+      <Flex.Stack>
+        <Field.Boolean
+          label="Make second field visible when toggled"
+          path="/toggleValue"
+          variant="checkbox"
+        />
+
+        <Form.Card>
+          <Value.SummaryList>
+            <Value.String label="Label" value="First field" />
+
+            <Form.Visibility pathTrue="/toggleValue" animate>
+              <Value.String label="Label" value="Second field" />
+            </Form.Visibility>
+          </Value.SummaryList>
+        </Form.Card>
+      </Flex.Stack>
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -16,6 +16,8 @@ import { Path, ValueProps } from '../types'
 import { pickSpacingProps } from '../../../components/flex/utils'
 import IterateItemContext from '../Iterate/IterateItemContext'
 import { convertJsxToString } from '../../../shared/component-helper'
+import VisibilityContext from '../Form/Visibility/VisibilityContext'
+import Visibility from '../Form/Visibility/Visibility'
 
 /**
  * Props are documented in ValueDocs.ts
@@ -130,7 +132,9 @@ function ValueBlock(props: Props) {
                 (!label || labelSrOnly) && 'dnb-sr-only'
               )}
             >
-              {label && <strong>{label}</strong>}
+              <VisibilityWrapper>
+                {label && <strong>{label}</strong>}
+              </VisibilityWrapper>
             </Dt>
             <Dd
               className={classnames(
@@ -141,13 +145,15 @@ function ValueBlock(props: Props) {
                 compositionClass
               )}
             >
-              {children ? (
-                <span className={defaultClass}>{children}</span>
-              ) : (
-                <span className="dnb-forms-value-block__placeholder">
-                  {placeholder}
-                </span>
-              )}
+              <VisibilityWrapper>
+                {children ? (
+                  <span className={defaultClass}>{children}</span>
+                ) : (
+                  <span className="dnb-forms-value-block__placeholder">
+                    {placeholder}
+                  </span>
+                )}
+              </VisibilityWrapper>
             </Dd>
           </Item>
         </SummaryListContext.Provider>
@@ -230,3 +236,13 @@ export default ValueBlock
 const transformLabelParameters = {
   convertJsxToString,
 } as unknown as Parameters<Props['transformLabel']>[1]
+
+function VisibilityWrapper({ children }) {
+  const visibilityContext = useContext(VisibilityContext)
+
+  if (visibilityContext) {
+    return <Visibility {...visibilityContext.props}>{children}</Visibility>
+  }
+
+  return children
+}

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -204,6 +204,84 @@ describe('ValueBlock', () => {
         document.querySelector('.dnb-forms-value-block__label strong')
       ).toBeInTheDocument()
     })
+
+    it('should render HeightAnimation inside dt and dd when animate is true', () => {
+      render(
+        <Value.SummaryList>
+          <Value.String label="Label" value="First field" />
+
+          <Form.Visibility pathUndefined="/undefined" animate>
+            <Value.String label="Label" value="Second field" />
+          </Form.Visibility>
+        </Value.SummaryList>
+      )
+
+      const element = document.querySelector('.dnb-forms-summary-list')
+
+      const firstChild = element.children[0]
+      const secondChild = element.children[1]
+      const thirdChild = element.children[2]
+      const fourthChild = element.children[3]
+
+      expect(
+        firstChild.querySelector('.dnb-height-animation')
+      ).not.toBeInTheDocument()
+      expect(
+        secondChild.querySelector('.dnb-height-animation')
+      ).not.toBeInTheDocument()
+
+      expect(
+        thirdChild.querySelector('.dnb-height-animation')
+      ).toBeInTheDocument()
+      expect(
+        fourthChild.querySelector('.dnb-height-animation')
+      ).toBeInTheDocument()
+
+      expect(element.tagName).toBe('DL')
+      expect(firstChild.tagName).toBe('DT')
+      expect(secondChild.tagName).toBe('DD')
+      expect(thirdChild.tagName).toBe('DT')
+      expect(fourthChild.tagName).toBe('DD')
+    })
+
+    it('should render div inside dt and dd when keepInDOM is true', () => {
+      render(
+        <Value.SummaryList>
+          <Value.String label="Label" value="First field" />
+
+          <Form.Visibility pathUndefined="/undefined" keepInDOM>
+            <Value.String label="Label" value="Second field" />
+          </Form.Visibility>
+        </Value.SummaryList>
+      )
+
+      const element = document.querySelector('.dnb-forms-summary-list')
+
+      const firstChild = element.children[0]
+      const secondChild = element.children[1]
+      const thirdChild = element.children[2]
+      const fourthChild = element.children[3]
+
+      expect(
+        firstChild.querySelector('.dnb-forms-visibility')
+      ).not.toBeInTheDocument()
+      expect(
+        secondChild.querySelector('.dnb-forms-visibility')
+      ).not.toBeInTheDocument()
+
+      expect(
+        thirdChild.querySelector('.dnb-forms-visibility')
+      ).toBeInTheDocument()
+      expect(
+        fourthChild.querySelector('.dnb-forms-visibility')
+      ).toBeInTheDocument()
+
+      expect(element.tagName).toBe('DL')
+      expect(firstChild.tagName).toBe('DT')
+      expect(secondChild.tagName).toBe('DD')
+      expect(thirdChild.tagName).toBe('DT')
+      expect(fourthChild.tagName).toBe('DD')
+    })
   })
 
   it('renders support gap', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/style/dnb-value-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/style/dnb-value-block.scss
@@ -1,16 +1,28 @@
 @import '../../../../style/core/utilities.scss';
 
-.dnb-forms-summary-list.dnb-dl:not(.dnb-dl__layout--horizontal) {
-  & .dnb-dt,
-  & > .dnb-dd > .dnb-dl,
-  &:not([class*='dnb-space']) > .dnb-dd > .dnb-dl {
-    margin: 0;
-  }
+.dnb-forms-summary-list.dnb-dl {
+  &:not(.dnb-dl__layout--horizontal) {
+    & .dnb-dt,
+    & > .dnb-dd > .dnb-dl,
+    &:not([class*='dnb-space']) > .dnb-dd > .dnb-dl {
+      margin: 0;
+    }
 
-  &:not(.dnb-dl__layout--grid) > .dnb-dd {
-    margin-bottom: var(--spacing-medium);
-    &:last-of-type {
-      margin-bottom: 0;
+    .dnb-dt:empty,
+    .dnb-dd:empty {
+      display: none;
+    }
+
+    &:not(.dnb-dl__layout--grid) > .dnb-dd {
+      margin-bottom: var(--spacing-medium);
+
+      // Add support for using animated Form.Visibility in a SummaryList (VisibilityWrapper).
+      transition: margin-bottom 300ms var(--easing-default);
+
+      &:last-of-type,
+      &:has(~ .dnb-dt:empty ~ .dnb-dd:empty) {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/__snapshots__/ChildrenWithAge.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/__snapshots__/ChildrenWithAge.test.tsx.snap
@@ -15,9 +15,9 @@ exports[`ChildrenWithAge should match snapshot 1`] = `
             aria-placeholder="0"
             aria-required="true"
             class="dnb-input__input"
-            id="id-rgg"
+            id="id-rgo"
             inputmode="numeric"
-            name="id-rgg"
+            name="id-rgo"
             type="text"
           />,
         },
@@ -125,9 +125,9 @@ exports[`ChildrenWithAge should match snapshot 1`] = `
             aria-placeholder="0"
             aria-required="true"
             class="dnb-input__input"
-            id="id-rgm"
+            id="id-rgu"
             inputmode="numeric"
-            name="id-rgm"
+            name="id-rgu"
             type="text"
           />,
         },
@@ -331,7 +331,7 @@ exports[`ChildrenWithAge should match snapshot 1`] = `
         aria-valuenow="2"
         aria-valuetext="2"
         class="dnb-input__input"
-        id="id-rg4"
+        id="id-rgc"
         inputmode="numeric"
         name="countChildren"
         role="spinbutton"


### PR DESCRIPTION
To maintain the semantic structure of the `dl` element, the `Form.Visibility` component animates the content of the `dl` element instead of wrapping it in a div element.

- More info [here](https://dnb-it.slack.com/archives/C07JEJVSHJR/p1737450029241429).
- [Example](https://eufemia-git-fix-forms-summary-list-visibility-animation-eufemia.vercel.app/uilib/extensions/forms/Value/SummaryList/#with-animated-visibility)