### PR TITLE
fix(HeightAnimation): ensure height does not lock during animation when nested

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -379,6 +379,84 @@ describe('HeightAnimation', () => {
   })
 })
 
+describe('stopOuterAnimations', () => {
+  it('should stop outer height animation by adding the --stop className', async () => {
+    globalThis.readjustTime = 1
+
+    const { rerender } = render(
+      <HeightAnimation className="outer">
+        <HeightAnimation className="inner">123</HeightAnimation>
+      </HeightAnimation>
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-height-animation')
+    ).toHaveLength(2)
+
+    const innerElement = document.querySelector(
+      '.dnb-height-animation .dnb-height-animation'
+    )
+
+    mockHeight(100, innerElement)
+    mockHeight(200, innerElement)
+
+    rerender(
+      <HeightAnimation className="outer">
+        <HeightAnimation className="inner">456</HeightAnimation>
+      </HeightAnimation>
+    )
+
+    expect(
+      document.querySelector('.dnb-height-animation--stop')
+    ).toHaveClass('outer')
+
+    runAnimation()
+
+    expect(
+      document.querySelector('.dnb-height-animation--stop')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not animate when outer height animation has --stop className', async () => {
+    globalThis.readjustTime = 1
+
+    const { rerender } = render(
+      <HeightAnimation open={false}>123</HeightAnimation>
+    )
+
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).not.toBeInTheDocument()
+
+    rerender(<HeightAnimation open>123</HeightAnimation>)
+
+    runAnimation()
+
+    expect(getElement()).toBeInTheDocument()
+    expect(getElement()).toHaveAttribute('style', '')
+
+    mockHeight(100)
+    mockHeight(200)
+
+    rerender(<HeightAnimation open>456</HeightAnimation>)
+
+    rerender(
+      <HeightAnimation open className="dnb-height-animation--stop">
+        789
+      </HeightAnimation>
+    )
+
+    nextAnimationFrame()
+    expect(getElement()).toHaveAttribute('style', '')
+
+    nextAnimationFrame()
+    expect(getElement()).toHaveAttribute('style', '')
+
+    simulateAnimationEnd()
+    expect(getElement()).toHaveAttribute('style', '')
+  })
+})
+
 describe('HeightAnimation without initializeTestSetup()', () => {
   beforeEach(() => {
     globalThis.IS_TEST = false

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -1141,7 +1141,7 @@ describe('Field.PhoneNumber', () => {
     })
 
     fireEvent.focus(input)
-    await userEvent.type(input, '{ArrowRight>5}8888')
+    await userEvent.type(input, '{ArrowRight>6} 8888')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
       '/myValue': '+47 99 99 88 88',


### PR DESCRIPTION
The animation is slowed down to 4s in order to see the issue. 
Keep an eye on the container edge, just below the "Velg land" field.
The outer height animation sets a "fixed" height, even only the inner content height gets updated. The fix is to tell all "outer" height animations to not animated (keep the auto height), when an "inner" height gets changed.

Before:



https://github.com/user-attachments/assets/5c53d017-c344-4a4f-8179-75908df7e3aa


After:


https://github.com/user-attachments/assets/84229310-1b39-4790-b5d4-a7c70ba1f6da


