### PR TITLE
feat(Forms): ensure Form.Iterate and Form.Section containers close when cancel button is pressed

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
@@ -10,35 +10,18 @@ import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBounda
 export default function CancelButton() {
   const { onCancel, setShowError } = useContext(ToolbarContext) || {}
   const { restoreOriginalData } = useContainerDataStore()
-  const { switchContainerMode, initialContainerMode } =
-    useContext(SectionContainerContext) || {}
-  const {
-    hasVisibleError,
-    hasSubmitError,
-    hasError,
-    setShowBoundaryErrors,
-  } = useContext(FieldBoundaryContext) || {}
+  const { switchContainerMode } = useContext(SectionContainerContext) || {}
+  const { setShowBoundaryErrors } = useContext(FieldBoundaryContext) || {}
 
   const translation = useTranslation().SectionEditContainer
 
   const cancelHandler = useCallback(() => {
-    if (hasSubmitError || (initialContainerMode === 'auto' && hasError)) {
-      setShowBoundaryErrors?.(true)
-      if (hasVisibleError) {
-        setShowError(true)
-      }
-    } else {
-      setShowError(false)
-      setShowBoundaryErrors?.(false)
-      restoreOriginalData()
-      switchContainerMode?.('view')
-      onCancel?.()
-    }
+    setShowError(false)
+    setShowBoundaryErrors?.(false)
+    restoreOriginalData()
+    switchContainerMode?.('view')
+    onCancel?.()
   }, [
-    hasError,
-    hasSubmitError,
-    hasVisibleError,
-    initialContainerMode,
     onCancel,
     restoreOriginalData,
     setShowBoundaryErrors,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/CancelButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/CancelButton.test.tsx
@@ -45,7 +45,7 @@ describe('CancelButton', () => {
     expect(button).toHaveTextContent(nb.cancelButton)
   })
 
-  it('should not call "setShowError" when hasSubmitError is true and hasVisibleError is false', () => {
+  it('should call "setShowError" when hasSubmitError is true and hasVisibleError is false', () => {
     const setShowError = jest.fn()
     const setShowBoundaryErrors = jest.fn()
 
@@ -72,12 +72,12 @@ describe('CancelButton', () => {
     )
 
     fireEvent.click(document.querySelector('button'))
-    expect(setShowError).toHaveBeenCalledTimes(0)
+    expect(setShowError).toHaveBeenCalledTimes(1)
     expect(setShowBoundaryErrors).toHaveBeenCalledTimes(1)
-    expect(setShowBoundaryErrors).toHaveBeenCalledWith(true)
+    expect(setShowBoundaryErrors).toHaveBeenCalledWith(false)
   })
 
-  it('should call "setShowError=true" when hasSubmitError and hasVisibleError is true', () => {
+  it('should call "setShowError=false" when hasSubmitError and hasVisibleError is true', () => {
     const setShowError = jest.fn()
     const setShowBoundaryErrors = jest.fn()
 
@@ -105,12 +105,12 @@ describe('CancelButton', () => {
 
     fireEvent.click(document.querySelector('button'))
     expect(setShowError).toHaveBeenCalledTimes(1)
-    expect(setShowError).toHaveBeenCalledWith(true)
+    expect(setShowError).toHaveBeenCalledWith(false)
     expect(setShowBoundaryErrors).toHaveBeenCalledTimes(1)
-    expect(setShowBoundaryErrors).toHaveBeenCalledWith(true)
+    expect(setShowBoundaryErrors).toHaveBeenCalledWith(false)
   })
 
-  it('should call "setShowError=true" when hasError and hasVisibleError is true and initialContainerMode is "auto"', () => {
+  it('should call "setShowError=false" when hasError and hasVisibleError is true and initialContainerMode is "auto"', () => {
     const setShowError = jest.fn()
     const setShowBoundaryErrors = jest.fn()
 
@@ -139,9 +139,9 @@ describe('CancelButton', () => {
 
     fireEvent.click(document.querySelector('button'))
     expect(setShowError).toHaveBeenCalledTimes(1)
-    expect(setShowError).toHaveBeenCalledWith(true)
+    expect(setShowError).toHaveBeenCalledWith(false)
     expect(setShowBoundaryErrors).toHaveBeenCalledTimes(1)
-    expect(setShowBoundaryErrors).toHaveBeenCalledWith(true)
+    expect(setShowBoundaryErrors).toHaveBeenCalledWith(false)
   })
 
   it('should call "setShowError=false" when hasSubmitError is false and hasVisibleError is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -265,7 +265,7 @@ describe('EditContainer and ViewContainer', () => {
       ).toHaveTextContent(nb.SectionEditContainer.errorInSection)
     })
 
-    it('the cancel button should not cancel the edit mode', async () => {
+    it('the cancel button should cancel the edit mode', async () => {
       let containerMode = null
 
       const ContextConsumer = () => {
@@ -300,9 +300,13 @@ describe('EditContainer and ViewContainer', () => {
 
       await userEvent.click(cancelButton)
 
-      expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(3)
+      await waitFor(() => {
+        expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(
+          0
+        )
+      })
 
-      expect(containerMode).toBe('edit')
+      expect(containerMode).toBe('view')
     })
   })
 
@@ -635,7 +639,7 @@ describe('EditContainer and ViewContainer', () => {
     expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
     expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(1)
 
-    await userEvent.click(cancelButton)
+    await userEvent.click(doneButton)
 
     expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(2)
 
@@ -694,12 +698,12 @@ describe('EditContainer and ViewContainer', () => {
       document.querySelectorAll('button')
     )
     await userEvent.click(cancelButton)
-    expect(onCancel).toHaveBeenCalledTimes(0)
+    expect(onCancel).toHaveBeenCalledTimes(1)
 
     await userEvent.type(document.querySelector('input'), 'foo')
 
     await userEvent.click(cancelButton)
-    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledTimes(2)
   })
 
   it('should emit "onEdit" event when cancel button is clicked', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/CancelButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/CancelButton.tsx
@@ -17,13 +17,11 @@ export default function CancelButton(props: Props) {
     restoreOriginalValue,
     switchContainerMode,
     containerMode,
-    initialContainerMode,
     arrayValue,
     isNew,
     index,
   } = useContext(IterateItemContext) || {}
-  const { hasError, hasVisibleError, setShowBoundaryErrors } =
-    useContext(FieldBoundaryContext) || {}
+  const { setShowBoundaryErrors } = useContext(FieldBoundaryContext) || {}
   const { setShowError } = useContext(ToolbarContext) || {}
 
   const { cancelButton, removeButton } =
@@ -42,22 +40,12 @@ export default function CancelButton(props: Props) {
   const cancelHandler = useCallback(
     ({ event }: { event: React.MouseEvent<HTMLButtonElement> }) => {
       onClick?.(event)
-      if (hasError && initialContainerMode === 'auto') {
-        setShowBoundaryErrors?.(true)
-        if (hasVisibleError) {
-          setShowError(true)
-        }
-      } else {
-        restoreOriginalValue?.(valueBackupRef.current)
-        setShowError(false)
-        setShowBoundaryErrors?.(false)
-        switchContainerMode?.('view')
-      }
+      restoreOriginalValue?.(valueBackupRef.current)
+      setShowError(false)
+      setShowBoundaryErrors?.(false)
+      switchContainerMode?.('view')
     },
     [
-      hasError,
-      hasVisibleError,
-      initialContainerMode,
       onClick,
       restoreOriginalValue,
       setShowBoundaryErrors,

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/CancelButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/CancelButton.test.tsx
@@ -135,7 +135,7 @@ describe('CancelButton', () => {
     expect(setShowBoundaryErrors).toHaveBeenCalledWith(false)
   })
 
-  it('should call "setShowError=true" when hasError and hasVisibleError is true and initialContainerMode is "auto"', () => {
+  it('should call "setShowError=false" when hasError and hasVisibleError is true and initialContainerMode is "auto"', () => {
     const setShowError = jest.fn()
     const setShowBoundaryErrors = jest.fn()
 
@@ -164,9 +164,9 @@ describe('CancelButton', () => {
 
     fireEvent.click(document.querySelector('button'))
     expect(setShowError).toHaveBeenCalledTimes(1)
-    expect(setShowError).toHaveBeenCalledWith(true)
+    expect(setShowError).toHaveBeenCalledWith(false)
     expect(setShowBoundaryErrors).toHaveBeenCalledTimes(1)
-    expect(setShowBoundaryErrors).toHaveBeenCalledWith(true)
+    expect(setShowBoundaryErrors).toHaveBeenCalledWith(false)
   })
 
   it('should call "setShowError=false" when hasError is false and hasVisibleError is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -552,11 +552,15 @@ describe('EditContainer and ViewContainer', () => {
 
     await userEvent.click(cancelButton)
 
-    expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
 
     await userEvent.click(editButton)
 
-    expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
 
     await userEvent.click(doneButton)
 
@@ -983,9 +987,7 @@ describe('EditContainer and ViewContainer', () => {
       document.querySelector('.dnb-form-status')
     ).not.toBeInTheDocument()
 
-    const [doneButton, cancelButton] = Array.from(
-      document.querySelectorAll('button')
-    )
+    const [doneButton] = Array.from(document.querySelectorAll('button'))
     const input = document.querySelector('input')
     fireEvent.submit(input)
 
@@ -1005,7 +1007,7 @@ describe('EditContainer and ViewContainer', () => {
       expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(0)
     })
 
-    await userEvent.click(cancelButton)
+    await userEvent.click(doneButton)
 
     // Expect 2, because we already have an error in the field
     expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(2)


### PR DESCRIPTION
This is a behavior change which concern was reported [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1731317705952689). 
I agree that its confusing that a cancel button not can be used, when an error is present. 

We do handle still errors during submit. The container will even switch to the edit mode when the submit button gets pressed.