### PR TITLE
chore(Forms): enhance `required` prop support (before release) for when used in Iterate.Array

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
@@ -12,7 +12,7 @@ export type Props = {
 }
 
 export default function FieldBoundaryProvider(props: Props) {
-  const { showErrors = false, onPathError = null, children } = props
+  const { showErrors = undefined, onPathError = null, children } = props
   const [, forceUpdate] = useReducer(() => ({}), {})
   const { showAllErrors } = useContext(DataContext)
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
@@ -75,7 +75,7 @@ describe('FieldBoundaryProvider', () => {
       hasError: true,
       hasSubmitError: true,
       hasVisibleError: true,
-      showBoundaryErrors: false,
+      showBoundaryErrors: undefined,
       setFieldError: expect.any(Function),
       setVisibleError: expect.any(Function),
       setShowBoundaryErrors: expect.any(Function),
@@ -84,7 +84,7 @@ describe('FieldBoundaryProvider', () => {
     expect(contextRef.current.hasError).toBe(true)
     expect(contextRef.current.hasSubmitError).toBe(true)
     expect(contextRef.current.hasVisibleError).toBe(true)
-    expect(contextRef.current.showBoundaryErrors).toBe(false)
+    expect(contextRef.current.showBoundaryErrors).toBe(undefined)
     expect(contextRef.current.errorsRef.current).toMatchObject({
       'id-r0': true,
     })
@@ -119,7 +119,7 @@ describe('FieldBoundaryProvider', () => {
     expect(contextRef.current.hasError).toBe(true)
     expect(contextRef.current.hasSubmitError).toBe(true)
     expect(contextRef.current.hasVisibleError).toBe(true)
-    expect(contextRef.current.showBoundaryErrors).toBe(false)
+    expect(contextRef.current.showBoundaryErrors).toBe(undefined)
     expect(contextRef.current.errorsRef.current).toMatchObject({
       '/bar': true,
     })
@@ -167,7 +167,7 @@ describe('FieldBoundaryProvider', () => {
     expect(contextRef.current.hasError).toBe(false)
     expect(contextRef.current.hasSubmitError).toBe(false)
     expect(contextRef.current.hasVisibleError).toBe(false)
-    expect(contextRef.current.showBoundaryErrors).toBe(false)
+    expect(contextRef.current.showBoundaryErrors).toBe(undefined)
 
     rerender(
       <Provider>
@@ -234,7 +234,7 @@ describe('FieldBoundaryProvider', () => {
 
     expect(contextRef.current.hasError).toBe(false)
     expect(contextRef.current.hasSubmitError).toBe(false)
-    expect(contextRef.current.hasVisibleError).toBe(false)
+    expect(contextRef.current.hasVisibleError).toBe(true)
     expect(contextRef.current.errorsRef.current).toMatchObject({})
   })
 
@@ -273,7 +273,7 @@ describe('FieldBoundaryProvider', () => {
 
     expect(contextRef.current.hasError).toBe(false)
     expect(contextRef.current.hasSubmitError).toBe(false)
-    expect(contextRef.current.hasVisibleError).toBe(false)
+    expect(contextRef.current.hasVisibleError).toBe(true)
     expect(contextRef.current.errorsRef.current).toMatchObject({})
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -255,11 +255,12 @@ function FieldBlock(props: Props) {
     }
   }, [])
 
+  const setBlockRecordNested = nestedFieldBlockContext?.setBlockRecord
   const setBlockRecord = useCallback(
     (props: StateBasis) => {
-      if (nestedFieldBlockContext) {
+      if (setBlockRecordNested) {
         // If this FieldBlock is inside another one, forward the call to the outer one
-        nestedFieldBlockContext.setBlockRecord(props)
+        setBlockRecordNested(props)
         return
       }
 
@@ -267,7 +268,7 @@ function FieldBlock(props: Props) {
 
       forceUpdate()
     },
-    [nestedFieldBlockContext, setInternalRecord]
+    [setBlockRecordNested, setInternalRecord]
   )
 
   const setFieldState = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -94,15 +94,22 @@ function ArrayComponent(props: Props) {
 
   const validateRequired = useCallback(
     (value: Value, { emptyValue, required, error }) => {
-      return required &&
+      if (
+        required &&
         (!value || value?.length === 0 || value === emptyValue)
-        ? error
-        : undefined
+      ) {
+        return error
+      }
     },
     []
   )
 
   const preparedProps = useMemo(() => {
+    const shared = {
+      required: false,
+      validateRequired,
+    }
+
     if (countPath) {
       const arrayValue = getValueByPath(pathProp)
       const newValue = []
@@ -116,16 +123,14 @@ function ArrayComponent(props: Props) {
       }
 
       return {
-        required: false,
-        validateRequired,
+        ...shared,
         ...props,
         value: newValue,
       }
     }
 
     return {
-      required: false,
-      validateRequired,
+      ...shared,
       ...props,
     }
   }, [
@@ -160,6 +165,7 @@ function ArrayComponent(props: Props) {
     updateContextDataInSync: true,
     omitMultiplePathWarning: true,
     forceUpdateWhenContextDataIsSet: Boolean(countPath),
+    alwaysRevealError: true,
   })
 
   // - Call onChange on the data context, if the count value changes
@@ -347,7 +353,7 @@ function ArrayComponent(props: Props) {
   } = {
     className: classnames(
       'dnb-forms-iterate',
-      'dnb-forms-section',
+      'dnb-forms-section', // To support containers
       props?.className
     ),
     ...pickFlexContainerProps(props as FlexContainerProps),

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -670,10 +670,6 @@ describe('Iterate.Array', () => {
         nb.Field.errorRequired
       )
 
-      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
-        nb.Field.errorRequired
-      )
-
       await userEvent.click(document.querySelector('button'))
 
       await waitFor(() => {
@@ -681,6 +677,71 @@ describe('Iterate.Array', () => {
           document.querySelector('.dnb-form-status')
         ).not.toBeInTheDocument()
       })
+    })
+
+    it('should report error to FieldBlock initially', async () => {
+      render(
+        <Form.Handler>
+          <FieldBlock asFieldset>
+            <Iterate.Array path="/items" required validateInitially>
+              <Field.String itemPath="/" />
+            </Iterate.Array>
+          </FieldBlock>
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector(
+          '.dnb-forms-field-block__status > .dnb-form-status'
+        )
+      ).toHaveTextContent(nb.Field.errorRequired)
+    })
+
+    it('should show and hide error message user interaction', async () => {
+      render(
+        <Form.Handler
+          defaultData={{
+            items: ['foo', 'bar'],
+          }}
+        >
+          <FieldBlock asFieldset>
+            <Iterate.Array path="/items" required>
+              <Field.String itemPath="/" />
+              <Iterate.RemoveButton />
+            </Iterate.Array>
+          </FieldBlock>
+          <Iterate.PushButton path="/items" pushValue="baz" />
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(document.querySelector('button'))
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(document.querySelector('button'))
+
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.Field.errorRequired
+      )
+
+      // Add a new item
+      await userEvent.click(document.querySelector('button'))
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -1089,7 +1150,6 @@ describe('Iterate.Array', () => {
             <Form.Handler onSubmit={onSubmit}>
               <Iterate.Array path="/myList" defaultValue={[null]}>
                 <Field.String itemPath="/" defaultValue="foo" />
-                <Iterate.RemoveButton />
               </Iterate.Array>
             </Form.Handler>
           </React.StrictMode>


### PR DESCRIPTION
As an addition to #4470

With it, we add support for using a `FieldBlock` around `Iterate.Array`. 
