### PR TITLE
feat(Forms): add `itemPath` property support to `Iterate.PushButton` and `Iterate.PushContainer`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -7,6 +7,8 @@ import {
   Form,
   Tools,
   Wizard,
+  ValueBlock,
+  FieldBlock,
 } from '@dnb/eufemia/src/extensions/forms'
 export { Default as AnimatedContainer } from '../AnimatedContainer/Examples'
 
@@ -811,6 +813,126 @@ export const NestedIterate = () => {
 
         <Tools.Log />
       </Form.Handler>
+    </ComponentBox>
+  )
+}
+
+export const NestedIterateWithPushContainer = () => {
+  return (
+    <ComponentBox
+      scope={{ Iterate, Tools, ValueBlock, FieldBlock }}
+      hideCode
+    >
+      {() => {
+        const EditPerson = () => {
+          return (
+            <Flex.Stack>
+              <Field.Name.Last itemPath="/name" />
+
+              <FieldBlock label="Citizenship's" asFieldset>
+                <Iterate.Array
+                  itemPath="/citizenships"
+                  animate
+                  required
+                  errorMessages={{
+                    'Field.errorRequired':
+                      'At least one citizenship is required.',
+                  }}
+                >
+                  <Flex.Horizontal align="center">
+                    <Field.SelectCountry label={false} itemPath="/" />
+                    <Iterate.RemoveButton />
+                  </Flex.Horizontal>
+                </Iterate.Array>
+              </FieldBlock>
+
+              <Iterate.PushContainer
+                itemPath="/citizenships"
+                openButton={
+                  <Iterate.PushContainer.OpenButton
+                    top
+                    text="Add another citizenship"
+                    variant="tertiary"
+                  />
+                }
+                showOpenButtonWhen={(list) => list.length > 0}
+                toolbar={
+                  <Iterate.Toolbar>
+                    <Iterate.EditContainer.DoneButton text="Add citizenship" />
+                  </Iterate.Toolbar>
+                }
+              >
+                <Field.SelectCountry
+                  label="New citizenship"
+                  itemPath="/"
+                />
+              </Iterate.PushContainer>
+            </Flex.Stack>
+          )
+        }
+
+        return (
+          <Form.Handler
+            required
+            onSubmit={(data) => console.log('onSubmit', data)}
+          >
+            <Flex.Stack>
+              <Iterate.PushContainer
+                path="/persons"
+                title="New person"
+                openButton={
+                  <Iterate.PushContainer.OpenButton
+                    text="Add new person"
+                    variant="tertiary"
+                  />
+                }
+                showOpenButtonWhen={(list) => list.length > 0}
+              >
+                <EditPerson />
+              </Iterate.PushContainer>
+
+              <Iterate.Array
+                path="/persons"
+                required
+                errorMessages={{
+                  required: 'Please add at least one person.',
+                }}
+              >
+                <Iterate.ViewContainer title="Persons">
+                  <Value.SummaryList>
+                    <Value.Name.Last itemPath="/name" />
+
+                    <ValueBlock label="Citizenship's">
+                      <Iterate.Array itemPath="/citizenships">
+                        <Value.SelectCountry
+                          inline
+                          label={false}
+                          itemPath="/"
+                        />
+                      </Iterate.Array>
+                    </ValueBlock>
+                  </Value.SummaryList>
+
+                  <Iterate.Toolbar>
+                    <Iterate.ViewContainer.EditButton />
+                    <Iterate.ViewContainer.RemoveButton
+                      showConfirmDialog
+                    />
+                  </Iterate.Toolbar>
+                </Iterate.ViewContainer>
+
+                <Iterate.EditContainer title="Edit person">
+                  <EditPerson />
+                </Iterate.EditContainer>
+              </Iterate.Array>
+
+              <Form.SubmitButton text="Save" />
+
+              <Tools.Log />
+            </Flex.Stack>
+          </Form.Handler>
+        )
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -824,7 +824,7 @@ export const NestedIterateWithPushContainer = () => {
       hideCode
     >
       {() => {
-        const EditPerson = () => {
+        function EditPerson() {
           return (
             <Flex.Stack>
               <Field.Name.Last itemPath="/name" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/demos.mdx
@@ -105,3 +105,9 @@ const validator = (arrayValue) => {
 ### Nested Iterate
 
 <Examples.NestedIterate />
+
+### Nested Iterate with PushContainer
+
+This demo uses the [PushContainer](/uilib/extensions/forms/Iterate/PushContainer/) component to add new items to an nested array by using the `itemPath` property.
+
+<Examples.NestedIterateWithPushContainer />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/PushContainer/Examples.tsx
@@ -1,3 +1,6 @@
+import React from 'react'
+import ComponentBox from '../../../../../../shared/tags/ComponentBox'
+import { Flex } from '@dnb/eufemia/src'
 import {
   Field,
   Form,
@@ -5,9 +8,6 @@ import {
   Tools,
   Value,
 } from '@dnb/eufemia/src/extensions/forms'
-import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { Flex } from '@dnb/eufemia/src'
-import React from 'react'
 
 export { ViewAndEditContainer } from '../Array/Examples'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/demos.mdx
@@ -8,6 +8,7 @@ import {
   PrimitiveItemsFields,
   PrimitiveItemsValues,
   WithTable,
+  NestedIterateWithPushContainer,
 } from './Array/Examples'
 import { Default as AnimatedContainer } from './AnimatedContainer/Examples'
 
@@ -38,3 +39,7 @@ Using the [AnimatedContainer](/uilib/extensions/forms/Iterate/AnimatedContainer/
 Using the [ViewContainer](/uilib/extensions/forms/Iterate/ViewContainer/) and [EditContainer](/uilib/extensions/forms/Iterate/EditContainer/).
 
 <ViewAndEditContainer />
+
+### Nested Iterate with PushContainer
+
+<NestedIterateWithPushContainer />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -107,6 +107,10 @@ function IsolationProvider<Data extends JsonObject>(
         localDataRef.current = {}
       }
 
+      // Depending on the usage, we can get a path like so: "/pushContainerItems/0/somePath"
+      // where "somePath" is a frozen object. In order to still be able to modify it,
+      // pointer.set will unfreeze the object and then modify it. (Object.isFrozen(obj[tok]))
+
       pointer.set(localDataRef.current, path, value)
 
       if (pathSection) {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react'
 import classnames from 'classnames'
 import pointer from '../../utils/json-pointer'
-import { useFieldProps, usePath } from '../../hooks'
+import { useFieldProps } from '../../hooks'
 import { makeUniqueId } from '../../../../shared/component-helper'
 import { Flex, FormStatus, HeightAnimation } from '../../../../components'
 import { Span } from '../../../../elements'
@@ -30,7 +30,11 @@ import ValueBlockContext from '../../ValueBlock/ValueBlockContext'
 import FieldBoundaryProvider from '../../DataContext/FieldBoundary/FieldBoundaryProvider'
 import DataContext from '../../DataContext/Context'
 import useDataValue from '../../hooks/useDataValue'
-import { useArrayLimit, useSwitchContainerMode } from '../hooks'
+import {
+  useArrayLimit,
+  useItemPath,
+  useSwitchContainerMode,
+} from '../hooks'
 import { getMessagesFromError } from '../../FieldBlock'
 
 import type { ContainerMode, ElementChild, Props, Value } from './types'
@@ -55,21 +59,10 @@ function ArrayComponent(props: Props) {
     countPathLimit = Infinity,
   } = props || {}
 
-  // Support for "itemPath"
-  const nestedIterateItemContext = useContext(IterateItemContext)
-  const { joinPath } = usePath()
-  const nestedIteratePath =
-    itemPathProp && nestedIterateItemContext
-      ? joinPath([
-          nestedIterateItemContext.path,
-          String(nestedIterateItemContext.index),
-          itemPathProp,
-        ])
-      : undefined
-
   const dataContext = useContext(DataContext)
   const summaryListContext = useContext(SummaryListContext)
   const valueBlockContext = useContext(ValueBlockContext)
+  const nestedIteratePath = useItemPath(itemPathProp)
   const { setLimitProps, error: limitWarning } = useArrayLimit(
     pathProp || nestedIteratePath
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -62,9 +62,9 @@ function ArrayComponent(props: Props) {
   const dataContext = useContext(DataContext)
   const summaryListContext = useContext(SummaryListContext)
   const valueBlockContext = useContext(ValueBlockContext)
-  const nestedIteratePath = useItemPath(itemPathProp)
+  const { absolutePath } = useItemPath(itemPathProp)
   const { setLimitProps, error: limitWarning } = useArrayLimit(
-    pathProp || nestedIteratePath
+    pathProp || absolutePath
   )
 
   const { getValueByPath } = useDataValue()
@@ -245,7 +245,7 @@ function ArrayComponent(props: Props) {
         previousContainerMode: modesRef.current[id].previous,
         initialContainerMode: containerMode || 'auto',
         modeOptions: modesRef.current[id].options,
-        nestedIteratePath,
+        absolutePath,
         switchContainerMode: (mode, options = {}) => {
           modesRef.current[id].previous = modesRef.current[id].current
           modesRef.current[id].current = mode
@@ -305,15 +305,7 @@ function ArrayComponent(props: Props) {
 
     // In order to update "valueWhileClosingRef" we need to have "salt" in the deps array
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    salt,
-    arrayValue,
-    limit,
-    path,
-    itemPath,
-    nestedIteratePath,
-    handleChange,
-  ])
+  }, [salt, arrayValue, limit, path, itemPath, absolutePath, handleChange])
 
   const total = arrayItems.length
   useEffect(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/DoneButton.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useEffect, useRef } from 'react'
+import classnames from 'classnames'
 import { Button } from '../../../../components'
 import useTranslation from '../../hooks/useTranslation'
 import IterateItemContext from '../IterateItemContext'
@@ -11,6 +12,7 @@ import { ButtonProps } from '../../../../components/Button'
 type Props = ButtonProps
 
 export default function DoneButton(props: Props) {
+  const { className, ...restProps } = props
   const { switchContainerMode, containerMode, arrayValue, index } =
     useContext(IterateItemContext) || {}
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
@@ -57,10 +59,11 @@ export default function DoneButton(props: Props) {
   return (
     <Button
       variant="tertiary"
+      className={classnames('dnb-push-container__done-button', className)}
       icon={check}
       icon_position="left"
       on_click={doneHandler}
-      {...props}
+      {...restProps}
     >
       {doneButton}
     </Button>

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/IterateItemContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/IterateItemContext.ts
@@ -14,7 +14,7 @@ export interface IterateItemContextState {
   isNew?: boolean
   path?: Path
   itemPath?: Path
-  nestedIteratePath?: Path
+  absolutePath?: Path
   arrayValue?: Array<unknown>
   containerMode?: ContainerMode
   previousContainerMode?: ContainerMode

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButton.tsx
@@ -73,9 +73,11 @@ function PushButton(props: Props) {
       ])
     }
 
-    setTimeout(() => {
-      setLastItemContainerMode('view')
-    }, 100) // UX improvement because of the "openDelay"
+    if (!absolutePath) {
+      setTimeout(() => {
+        setLastItemContainerMode('view')
+      }, 100) // UX improvement because of the "openDelay"
+    }
   }, [
     arrayValue,
     absolutePath,

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButton.tsx
@@ -34,16 +34,16 @@ function PushButton(props: Props) {
     pushValue,
     className,
     path,
-    itemPath: itemPathProp,
+    itemPath,
     text,
     children,
     ...restProps
   } = props
   const buttonProps = omitDataValueReadWriteProps(restProps)
 
-  const itemPath = useItemPath(itemPathProp)
+  const { absolutePath } = useItemPath(itemPath)
 
-  const arrayValue = useDataValue().getValueByPath(path || itemPath)
+  const arrayValue = useDataValue().getValueByPath(path || absolutePath)
 
   const { hasReachedLimit, setShowStatus } = useArrayLimit(path)
 
@@ -62,12 +62,12 @@ function PushButton(props: Props) {
     const newValue =
       typeof pushValue === 'function' ? pushValue(arrayValue) : pushValue
 
-    if (handlePush && !itemPath) {
+    if (handlePush && !absolutePath) {
       // Inside an Iterate element - make the change through the Iterate component
       handlePush(newValue)
     } else {
       // If not inside an iterate, it could still manipulate a source data set through useFieldProps
-      await handlePathChange?.(path || itemPath, [
+      await handlePathChange?.(path || absolutePath, [
         ...(arrayValue ?? []),
         newValue,
       ])
@@ -78,7 +78,7 @@ function PushButton(props: Props) {
     }, 100) // UX improvement because of the "openDelay"
   }, [
     arrayValue,
-    itemPath,
+    absolutePath,
     handlePathChange,
     handlePush,
     hasReachedLimit,

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
@@ -6,6 +6,11 @@ export const PushButtonProperties: PropertiesTableProps = {
     type: 'string',
     status: 'required',
   },
+  itemPath: {
+    doc: 'The path to the item in a nested array to add the new item to.',
+    type: 'string',
+    status: 'optional',
+  },
   pushValue: {
     doc: 'The element to add to the array when the button is clicked. Can be a function to returns the push value.',
     type: 'unknown',

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
@@ -7,7 +7,7 @@ export const PushButtonProperties: PropertiesTableProps = {
     status: 'required',
   },
   itemPath: {
-    doc: 'The path to the item in a nested array to add the new item to.',
+    doc: 'The path to the item in a nested array, to add the new item to.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/__tests__/PushButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/__tests__/PushButton.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import IterateItemContext from '../../IterateItemContext'
-import { Field, Form, Iterate } from '../../..'
+import { DataContext, Field, Form, Iterate } from '../../..'
 
 describe('PushButton', () => {
   it('should call handlePush when clicked inside an Iterate element', () => {
@@ -252,6 +252,72 @@ describe('PushButton', () => {
 
     await waitFor(() => {
       expect(document.querySelector('.dnb-form-status')).toBeNull()
+    })
+  })
+
+  describe('itemPath', () => {
+    it('should add item to the correct array', async () => {
+      let collectedData = null
+
+      render(
+        <Form.Handler
+          data={{
+            outer: [{ inner: ['foo'] }],
+          }}
+        >
+          <Iterate.Array path="/outer">
+            <Iterate.Array itemPath="/inner">
+              <Field.String itemPath="/" />
+              <Iterate.RemoveButton />
+            </Iterate.Array>
+
+            <Iterate.PushButton itemPath="/inner" pushValue="bar" />
+          </Iterate.Array>
+
+          <DataContext.Consumer>
+            {(context) => {
+              collectedData = context.data
+              return null
+            }}
+          </DataContext.Consumer>
+        </Form.Handler>
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['foo'] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-push-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['foo', 'bar'] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-remove-element-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['bar'] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-remove-element-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: [] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-push-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['bar'] }],
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -17,18 +17,43 @@ import OpenButton from './OpenButton'
 import { Flex, HeightAnimation } from '../../../../components'
 import { OnCommit, Path } from '../../types'
 import { SpacingProps } from '../../../../shared/types'
-import { useArrayLimit, useSwitchContainerMode } from '../hooks'
+import {
+  useArrayLimit,
+  useSwitchContainerMode,
+  useItemPath,
+} from '../hooks'
 import Toolbar from '../Toolbar'
 import { useTranslation } from '../../hooks'
 import { ArrayItemAreaProps } from '../Array/ArrayItemArea'
 import { clearedData } from '../../DataContext/Provider'
 
-export type Props = {
+/**
+ * Deprecated, as it is supported by all major browsers and Node.js >=v18
+ * So it's a question of time, when we will remove this polyfill
+ */
+import structuredClone from '@ungap/structured-clone'
+
+type OnlyPath = {
   /**
    * The path to the array to add the new item to.
    */
   path: Path
 
+  /** The sub path to the array to add the new item to. */
+  itemPath?: Path
+}
+
+type OnlyItemPath = {
+  /**
+   * The path to the array to add the new item to.
+   */
+  path?: Path
+
+  /** The sub path to the array to add the new item to. */
+  itemPath: Path
+}
+
+export type Props = (OnlyPath | OnlyItemPath) & {
   /**
    * The title of the container.
    */
@@ -98,6 +123,7 @@ function PushContainer(props: AllProps) {
     isolatedData,
     bubbleValidation,
     path,
+    itemPath: itemPathProp,
     title,
     required = requiredInherited,
     children,
@@ -107,14 +133,21 @@ function PushContainer(props: AllProps) {
     ...rest
   } = props
 
+  const itemPath = useItemPath(itemPathProp)
+
   const commitHandleRef = useRef<() => void>()
   const switchContainerModeRef = useRef<(mode: ContainerMode) => void>()
   const containerModeRef = useRef<ContainerMode>()
-  const { value: entries = [], moveValueToPath } =
-    useDataValue<Array<unknown>>(path)
+  const {
+    value: entries = [],
+    moveValueToPath,
+    getValueByPath,
+  } = useDataValue<Array<unknown>>(path || itemPath)
 
-  const { setNextContainerMode } = useSwitchContainerMode(path)
-  const { hasReachedLimit, setShowStatus } = useArrayLimit(path)
+  const { setNextContainerMode } = useSwitchContainerMode(path || itemPath)
+  const { hasReachedLimit, setShowStatus } = useArrayLimit(
+    path || itemPath
+  )
   const cancelHandler = useCallback(() => {
     if (hasReachedLimit) {
       setShowStatus(false)
@@ -124,6 +157,7 @@ function PushContainer(props: AllProps) {
   const showOpenButton = showOpenButtonWhen?.(entries)
   const newItemContextProps: PushContainerContext = {
     path,
+    itemPath,
     entries,
     commitHandleRef,
     switchContainerMode: switchContainerModeRef.current,
@@ -171,7 +205,11 @@ function PushContainer(props: AllProps) {
       }
       commitHandleRef={commitHandleRef}
       transformOnCommit={({ pushContainerItems }) => {
-        return moveValueToPath(path, [...entries, ...pushContainerItems])
+        return moveValueToPath(
+          path || itemPath,
+          [...entries, ...pushContainerItems],
+          itemPath ? structuredClone(getValueByPath('/')) : {}
+        )
       }}
       onCommit={(data, options) => {
         const { clearData, preventCommit } = options

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -39,7 +39,7 @@ type OnlyPath = {
    */
   path: Path
 
-  /** The sub path to the array to add the new item to. */
+  /** The sub path to the array, to add the new item to. */
   itemPath?: Path
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -19,8 +19,8 @@ import { OnCommit, Path } from '../../types'
 import { SpacingProps } from '../../../../shared/types'
 import {
   useArrayLimit,
-  useSwitchContainerMode,
   useItemPath,
+  useSwitchContainerMode,
 } from '../hooks'
 import Toolbar from '../Toolbar'
 import { useTranslation } from '../../hooks'
@@ -33,27 +33,27 @@ import { clearedData } from '../../DataContext/Provider'
  */
 import structuredClone from '@ungap/structured-clone'
 
-type OnlyPath = {
+type OnlyPathRequired = {
   /**
-   * The path to the array, to add the new item to.
+   * The path to the array to add the new item to.
    */
   path: Path
 
-  /** The sub path to the array, to add the new item to. */
+  /** The sub path to the array to add the new item to. */
   itemPath?: Path
 }
 
-type OnlyItemPath = {
+type OnlyItemPathRequired = {
   /**
-   * The path to the array, to add the new item to.
+   * The path to the array to add the new item to.
    */
   path?: Path
 
-  /** The sub path to the array, to add the new item to. */
+  /** The sub path to the array to add the new item to. */
   itemPath: Path
 }
 
-export type Props = (OnlyPath | OnlyItemPath) & {
+export type Props = (OnlyPathRequired | OnlyItemPathRequired) & {
   /**
    * The title of the container.
    */
@@ -123,7 +123,7 @@ function PushContainer(props: AllProps) {
     isolatedData,
     bubbleValidation,
     path,
-    itemPath: itemPathProp,
+    itemPath,
     title,
     required = requiredInherited,
     children,
@@ -133,8 +133,7 @@ function PushContainer(props: AllProps) {
     ...rest
   } = props
 
-  const itemPath = useItemPath(itemPathProp)
-
+  const { absolutePath } = useItemPath(itemPath)
   const commitHandleRef = useRef<() => void>()
   const switchContainerModeRef = useRef<(mode: ContainerMode) => void>()
   const containerModeRef = useRef<ContainerMode>()
@@ -144,9 +143,11 @@ function PushContainer(props: AllProps) {
     getValueByPath,
   } = useDataValue<Array<unknown>>(path || itemPath)
 
-  const { setNextContainerMode } = useSwitchContainerMode(path || itemPath)
+  const { setNextContainerMode } = useSwitchContainerMode(
+    path || absolutePath
+  )
   const { hasReachedLimit, setShowStatus } = useArrayLimit(
-    path || itemPath
+    path || absolutePath
   )
   const cancelHandler = useCallback(() => {
     if (hasReachedLimit) {
@@ -206,9 +207,9 @@ function PushContainer(props: AllProps) {
       commitHandleRef={commitHandleRef}
       transformOnCommit={({ pushContainerItems }) => {
         return moveValueToPath(
-          path || itemPath,
+          path || absolutePath,
           [...entries, ...pushContainerItems],
-          itemPath ? structuredClone(getValueByPath('/')) : {}
+          absolutePath ? structuredClone(getValueByPath('/')) : {}
         )
       }}
       onCommit={(data, options) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -45,7 +45,7 @@ type OnlyPath = {
 
 type OnlyItemPath = {
   /**
-   * The path to the array to add the new item to.
+   * The path to the array, to add the new item to.
    */
   path?: Path
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -49,7 +49,7 @@ type OnlyItemPath = {
    */
   path?: Path
 
-  /** The sub path to the array to add the new item to. */
+  /** The sub path to the array, to add the new item to. */
   itemPath: Path
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -35,7 +35,7 @@ import structuredClone from '@ungap/structured-clone'
 
 type OnlyPath = {
   /**
-   * The path to the array to add the new item to.
+   * The path to the array, to add the new item to.
    */
   path: Path
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerContext.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerContext.tsx
@@ -4,6 +4,7 @@ import { ContainerMode } from '../Array'
 
 type PushContainerContext = {
   path: Path
+  itemPath: Path
   entries?: Array<unknown>
   commitHandleRef: React.MutableRefObject<() => void>
   switchContainerMode?: (mode: ContainerMode) => void

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
@@ -8,7 +8,7 @@ export const PushContainerProperties: PropertiesTableProps = {
     status: 'required',
   },
   itemPath: {
-    doc: 'The path to the item in a nested array to add the new item to.',
+    doc: 'The path to the item in a nested array, to add the new item to.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainerDocs.ts
@@ -7,6 +7,11 @@ export const PushContainerProperties: PropertiesTableProps = {
     type: 'string',
     status: 'required',
   },
+  itemPath: {
+    doc: 'The path to the item in a nested array to add the new item to.',
+    type: 'string',
+    status: 'optional',
+  },
   title: {
     doc: 'The title of the container.',
     type: 'React.Node',

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -1118,5 +1118,83 @@ describe('PushContainer', () => {
         outer: [{ inner: ['bar'] }],
       })
     })
+
+    it('should use itemPath to determine the initial amount of items when "showOpenButtonWhen" is used', async () => {
+      render(
+        <Form.Handler
+          data={{
+            outer: [{ inner: ['existing item'] }],
+          }}
+        >
+          <Iterate.Array path="/outer">
+            <Iterate.Array itemPath="/inner">
+              <Field.String itemPath="/" />
+            </Iterate.Array>
+
+            <Iterate.PushContainer
+              itemPath="/inner"
+              openButton={<Iterate.PushContainer.OpenButton />}
+              showOpenButtonWhen={() => true}
+            >
+              <Field.String itemPath="/" />
+            </Iterate.PushContainer>
+          </Iterate.Array>
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-forms-iterate-open-button')
+      ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-forms-section-block')
+      ).toHaveClass('dnb-height-animation--hidden')
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-open-button')
+      )
+
+      expect(
+        document.querySelector('.dnb-forms-section-block')
+      ).toHaveClass('dnb-height-animation--is-visible')
+    })
+
+    it('should show PushContainer based on the amount of items', async () => {
+      render(
+        <Form.Handler
+          data={{
+            outer: [{ inner: ['existing item'] }],
+          }}
+        >
+          <Iterate.Array path="/outer">
+            <Iterate.Array itemPath="/inner">
+              <Field.String itemPath="/" />
+              <Iterate.RemoveButton />
+            </Iterate.Array>
+
+            <Iterate.PushContainer
+              itemPath="/inner"
+              openButton={<Iterate.PushContainer.OpenButton />}
+              showOpenButtonWhen={(list) => list.length > 0}
+            >
+              <Field.String itemPath="/" />
+            </Iterate.PushContainer>
+          </Iterate.Array>
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-forms-section-block')
+      ).toHaveClass('dnb-height-animation--hidden')
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-remove-element-button')
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      expect(
+        document.querySelector('.dnb-forms-section-block')
+      ).toHaveClass('dnb-height-animation--is-visible')
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -1059,4 +1059,64 @@ describe('PushContainer', () => {
       expect(document.querySelector('.dnb-form-status')).toBeNull()
     })
   })
+
+  describe('itemPath', () => {
+    it('should add item to the correct array', async () => {
+      let collectedData = null
+
+      render(
+        <Form.Handler
+          data={{
+            outer: [{ inner: [] }],
+          }}
+        >
+          <Iterate.Array path="/outer">
+            <Iterate.Array itemPath="/inner">
+              <Field.String itemPath="/" />
+              <Iterate.RemoveButton />
+            </Iterate.Array>
+
+            <Iterate.PushContainer itemPath="/inner">
+              <Field.String itemPath="/" defaultValue="bar" />
+            </Iterate.PushContainer>
+          </Iterate.Array>
+
+          <DataContext.Consumer>
+            {(context) => {
+              collectedData = context.data
+              return null
+            }}
+          </DataContext.Consumer>
+        </Form.Handler>
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: [] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-push-container__done-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['bar'] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate-remove-element-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: [] }],
+      })
+
+      await userEvent.click(
+        document.querySelector('.dnb-push-container__done-button')
+      )
+
+      expect(collectedData).toEqual({
+        outer: [{ inner: ['bar'] }],
+      })
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/EditButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/EditButton.tsx
@@ -16,6 +16,7 @@ export default function EditButton() {
   return (
     <Button
       variant="tertiary"
+      className="dnb-push-container__edit-button"
       icon={edit}
       icon_position="left"
       on_click={editHandler}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/index.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useItem } from './useItem'
 export { default as useSwitchContainerMode } from './useSwitchContainerMode'
 export { default as useArrayLimit } from './useArrayLimit'
+export { default as useItemPath } from './useItemPath'

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useItemPath.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useItemPath.ts
@@ -7,7 +7,7 @@ export default function useItemPath(itemPath: Path) {
   const { joinPath } = usePath()
   const iterateItemContext = useContext(IterateItemContext)
 
-  return (
+  const absolutePath =
     itemPath &&
     iterateItemContext &&
     joinPath([
@@ -15,5 +15,6 @@ export default function useItemPath(itemPath: Path) {
       String(iterateItemContext.index),
       itemPath,
     ])
-  )
+
+  return { absolutePath }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useItemPath.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useItemPath.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react'
+import IterateItemContext from '../IterateItemContext'
+import { usePath } from '../../hooks'
+import type { Path } from '../../types'
+
+export default function useItemPath(itemPath: Path) {
+  const { joinPath } = usePath()
+  const iterateItemContext = useContext(IterateItemContext)
+
+  return (
+    itemPath &&
+    iterateItemContext &&
+    joinPath([
+      iterateItemContext.path,
+      String(iterateItemContext.index),
+      itemPath,
+    ])
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/stories/Iterate.stories.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback } from 'react'
-import { Field, Form, Iterate, Tools, Value, Wizard } from '../..'
+import {
+  Field,
+  FieldBlock,
+  Form,
+  Iterate,
+  Tools,
+  Value,
+  ValueBlock,
+  Wizard,
+} from '../..'
 import { Flex } from '../../../../components'
 
 export default {
@@ -23,7 +32,7 @@ export const AnimatedContainer = () => {
               <Field.String label="Label" itemPath="/" />
 
               <Iterate.Toolbar>
-                <Iterate.RemoveButton />
+                <Iterate.RemoveButton showConfirmDialog />
               </Iterate.Toolbar>
             </Iterate.AnimatedContainer>
           </Iterate.Array>
@@ -357,6 +366,114 @@ export function IterateRequired() {
       </Iterate.Array>
       <Iterate.PushButton path="/items" pushValue="baz" />
       <Form.SubmitButton />
+    </Form.Handler>
+  )
+}
+
+export function IterateInIterate() {
+  const EditPerson = () => {
+    return (
+      <Flex.Stack>
+        <Field.Name.Last itemPath="/name" />
+
+        <FieldBlock label="Citizenship's" asFieldset>
+          <Iterate.Array
+            itemPath="/citizenships"
+            animate
+            required
+            errorMessages={{
+              'Field.errorRequired':
+                'At least one citizenship is required.',
+            }}
+          >
+            <Flex.Horizontal align="center">
+              <Field.SelectCountry label={false} itemPath="/" />
+              <Iterate.RemoveButton />
+            </Flex.Horizontal>
+          </Iterate.Array>
+        </FieldBlock>
+
+        <Iterate.PushContainer
+          itemPath="/citizenships"
+          openButton={
+            <Iterate.PushContainer.OpenButton
+              top
+              text="Add another citizenship"
+              variant="tertiary"
+            />
+          }
+          showOpenButtonWhen={(list) => list.length > 0}
+          toolbar={
+            <Iterate.Toolbar>
+              <Iterate.EditContainer.DoneButton text="Add citizenship" />
+            </Iterate.Toolbar>
+          }
+        >
+          <Field.SelectCountry label="New citizenship" itemPath="/" />
+        </Iterate.PushContainer>
+      </Flex.Stack>
+    )
+  }
+
+  return (
+    <Form.Handler
+      required
+      onSubmit={(data) => console.log('onSubmit', data)}
+      // defaultData={{
+      //   persons: [
+      //     {
+      //       name: 'Tony',
+      //       citizenships: ['NO', 'SE'],
+      //     },
+      //   ],
+      // }}
+    >
+      <Flex.Stack>
+        <Iterate.PushContainer
+          path="/persons"
+          title="New person"
+          openButton={
+            <Iterate.PushContainer.OpenButton
+              text="Add new person"
+              variant="tertiary"
+            />
+          }
+          showOpenButtonWhen={(list) => list.length > 0}
+        >
+          <EditPerson />
+        </Iterate.PushContainer>
+
+        <Iterate.Array
+          path="/persons"
+          required
+          errorMessages={{
+            required: 'Please add at least one person.',
+          }}
+        >
+          <Iterate.ViewContainer title="Persons">
+            <Value.SummaryList>
+              <Value.Name.Last itemPath="/name" />
+
+              <ValueBlock label="Citizenship's">
+                <Iterate.Array itemPath="/citizenships">
+                  <Value.SelectCountry inline label={false} itemPath="/" />
+                </Iterate.Array>
+              </ValueBlock>
+            </Value.SummaryList>
+
+            <Iterate.Toolbar>
+              <Iterate.ViewContainer.EditButton />
+              <Iterate.ViewContainer.RemoveButton showConfirmDialog />
+            </Iterate.Toolbar>
+          </Iterate.ViewContainer>
+
+          <Iterate.EditContainer title="Edit person">
+            <EditPerson />
+          </Iterate.EditContainer>
+        </Iterate.Array>
+        <Form.SubmitButton text="Save" />
+        <Tools.Log />
+      </Flex.Stack>
     </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -238,7 +238,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     handleChange: handleChangeIterateContext,
     index: iterateIndex,
     arrayValue: iterateArrayValue,
-    nestedIteratePath,
+    absolutePath,
   } = iterateItemContext || {}
   const { path: sectionPath, errorPrioritization } = sectionContext || {}
   const {
@@ -1929,8 +1929,8 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         ? dataContext.data
         : dataContext.internalDataRef?.current
 
-      const storePath = nestedIteratePath
-        ? makeIteratePath(itemPath, nestedIteratePath)
+      const storePath = absolutePath
+        ? makeIteratePath(itemPath, absolutePath)
         : identifier
 
       // First, look for existing data in the context
@@ -2070,7 +2070,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       // We know when the last item is reached, so we can prevent rerenders during the iteration.
       if (
         hasItemPath &&
-        !nestedIteratePath && // Ensure we still rerender when nestedIteratePath is set
+        !absolutePath && // Ensure we still rerender when absolutePath is set
         iterateIndex < iterateArrayValue?.length - 1
       ) {
         preventUpdate = true
@@ -2098,7 +2098,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       iterateArrayValue?.length,
       iterateIndex,
       makeIteratePath,
-      nestedIteratePath,
+      absolutePath,
       updateContextDataInSync,
       updateDataValueDataContext,
       validateDataDataContext,

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
@@ -130,6 +130,15 @@ describe('json-pointer', () => {
       expect(obj['first-level']).toBe('expected')
     })
 
+    it('should work on frozen objects', () => {
+      const obj = {
+        frozen: Object.freeze({}),
+      }
+
+      set(obj, '/frozen/first-level', 'expected')
+      expect(obj['frozen']['first-level']).toBe('expected')
+    })
+
     it('should work on first level with tokens', () => {
       const obj = {
         existing: 'bla',

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -62,6 +62,9 @@ export function set<T = JsonObject>(
         obj[tok] = {}
       }
     }
+    if (Object.isFrozen(obj[tok])) {
+      obj[tok] = { ...obj[tok] }
+    }
     obj = obj[tok] as T
   }
 


### PR DESCRIPTION
Closes #4417

Here is a [working example](https://eufemia-git-feat-iterate-push-container-item-path-eufemia.vercel.app/uilib/extensions/forms/Iterate/demos/#nested-iterate-with-pushcontainer) based on the issue reprod from @andlbrei .