### PR TITLE
chore: ReferenceError: Tools is not defined

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -260,7 +260,7 @@ export const WithAsyncOnFileClick = () => {
 
 export function SessionStorage() {
   return (
-    <ComponentBox>
+    <ComponentBox scope={{ Tools }}>
       <Form.Handler sessionStorageId="documents">
         <Flex.Stack>
           <Form.Card>


### PR DESCRIPTION
Removes ReferenceError: Tools is not defined in https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/more-fields/Upload/demos/#session-storage-support