### PR TITLE
fix(Field.Upload): prevent `fileHandler` to run when it is validation errors 

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
@@ -180,7 +180,9 @@ function UploadComponent(props: Props) {
         const updatedFiles = [
           ...filesRef.current.slice(0, indexOfFirstNewFile),
           ...newFilesLoading,
-          ...filesRef.current.slice(indexOfFirstNewFile + newFiles.length),
+          ...filesRef.current.slice(
+            indexOfFirstNewFile + newFilesLoading.length
+          ),
         ]
 
         // Set error, if any

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -1210,6 +1210,49 @@ describe('Field.Upload', () => {
       })
     })
 
+    it('should not execute fileHandler function when new files are not valid', async () => {
+      const newFile1 = createMockFile(
+        'fileName-new-1.png',
+        2000000,
+        'image/png'
+      )
+
+      const asyncValidatorResolving = () =>
+        new Promise<UploadValue>((resolve) =>
+          setTimeout(() => resolve([]), 1)
+        )
+
+      const asyncFileHandlerFn = jest.fn(asyncValidatorResolving)
+
+      render(
+        <Field.Upload fileMaxSize={1} fileHandler={asyncFileHandlerFn} />
+      )
+
+      const element = getRootElement()
+
+      await waitFor(() => {
+        fireEvent.drop(element, {
+          dataTransfer: {
+            files: [newFile1],
+          },
+        })
+
+        expect(asyncFileHandlerFn).not.toHaveBeenCalled()
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        expect(
+          document.querySelectorAll('.dnb-upload__file-cell').length
+        ).toBe(1)
+
+        expect(
+          screen.queryByText('fileName-new-1.png')
+        ).toBeInTheDocument()
+      })
+    })
+
     it('should add new files from fileHandler with async function with multiple actions', async () => {
       const newFile = (fileId) => {
         return createMockFile(`${fileId}.png`, 100, 'image/png')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/stories/Upload.stories.tsx
@@ -253,3 +253,32 @@ export function SessionStorage() {
     </Form.Handler>
   )
 }
+
+export function FileSizeErrorWithFileHandler() {
+  const delay = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms))
+
+  async function uploadFilesWithMockError(newFiles: UploadValue) {
+    const updatedFiles: UploadValue = []
+    for (const [, file] of Object.entries(newFiles)) {
+      await delay(2000)
+      updatedFiles.push({
+        ...file,
+        id: crypto.randomUUID(), // id generated on server
+      })
+    }
+    return updatedFiles
+  }
+
+  return (
+    <Form.Handler
+      defaultData={{
+        documents: [],
+      }}
+    >
+      <Flex.Stack>
+        <Field.Upload fileHandler={uploadFilesWithMockError} />
+      </Flex.Stack>
+    </Form.Handler>
+  )
+}


### PR DESCRIPTION
fixes https://github.com/dnbexperience/eufemia/issues/4495

[CSB](https://codesandbox.io/p/sandbox/fileupload-validation-on-async-upload-forked-r2r4kd?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)