### PR TITLE
feat(Field.Date): show error messages on invalid date

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
@@ -114,3 +114,39 @@ export const DatePickerDateLimitValidation = () => {
     </Provider>
   )
 }
+
+export const ValidationExtendValidator = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const myDateValidator = (value: string) => {
+          if (value === '2025-01-01') {
+            return new Error('My custom message')
+          }
+
+          if (value === '2025-01-03') {
+            return [
+              new Error('My custom message 1'),
+              new Error('My custom message 2'),
+            ]
+          }
+        }
+
+        const myOnBlurValidator = (value: string, { validators }) => {
+          const { dateValidator } = validators
+
+          return [myDateValidator, dateValidator]
+        }
+
+        return (
+          <Field.Date
+            value="2025-01-01"
+            minDate="2024-12-31"
+            maxDate="2025-01-31"
+            onBlurValidator={myOnBlurValidator}
+          />
+        )
+      }}
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
@@ -47,3 +47,9 @@ The Date field will automatically display an error message if the selected date 
 ### Validation - Required
 
 <Examples.ValidationRequired />
+
+### Extend validation with custom validation function
+
+You can [extend the existing validation](/uilib/extensions/forms/create-component/useFieldProps/info/#validators) (`dateValidator`) with your own validation function.
+
+<Examples.ValidationExtendValidator />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/info.mdx
@@ -12,3 +12,10 @@ render(<Field.Date />)
 ```
 
 There is a corresponding [Value.Date](/uilib/extensions/forms/Value/Date) component.
+
+## Validators
+
+### Internal validators exposed
+
+`Field.Date` exposes the `dateValidator` validator through its `onBlurValidator` property, take a look at [this demo](/uilib/extensions/forms/feature-fields/Date/demos/#extend-validation-with-custom-validation-function).
+The `dateValidator` validator, validates invalid dates, and dates agianst the `minDate` and `maxDate` properties.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/properties.mdx
@@ -15,7 +15,7 @@ import { DateProperties } from '@dnb/eufemia/src/extensions/forms/Field/Date/Dat
 
 ### General properties
 
-<PropertiesTable props={FieldProperties} />
+<PropertiesTable props={FieldProperties} omit={'onBlurValidator'} />
 
 ## Translations
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -143,10 +143,12 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       const returnFormat = correctV1Format(returnFormatProp)
       const startDateIsValid = Boolean(startDate && isValid(startDate))
       const endDateIsValid = Boolean(endDate && isValid(endDate))
+      const hasMinOrMaxDates = minDate || maxDate
 
       const returnObject: ReturnObject<E> = {
         event,
         attributes: attributes || {},
+        partialStartDate,
       }
 
       // Handle range props
@@ -162,16 +164,17 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
             : null,
           end_date: endDateIsValid ? format(endDate, returnFormat) : null,
           is_valid_start_date:
+            hasMinOrMaxDates &&
             startDateIsValid &&
             isDisabled(startDate, dates.minDate, dates.maxDate)
               ? false
               : startDateIsValid,
           is_valid_end_date:
+            hasMinOrMaxDates &&
             endDateIsValid &&
             isDisabled(endDate, dates.minDate, dates.maxDate)
               ? false
               : endDateIsValid,
-          partialStartDate,
           partialEndDate,
           invalidStartDate,
           invalidEndDate,
@@ -193,7 +196,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
             : startDateIsValid,
       }
     },
-    [dates, views, attributes, range, returnFormatProp]
+    [dates, views, attributes, maxDate, minDate, range, returnFormatProp]
   )
 
   const callOnChangeHandler = useCallback(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -143,7 +143,6 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       const returnFormat = correctV1Format(returnFormatProp)
       const startDateIsValid = Boolean(startDate && isValid(startDate))
       const endDateIsValid = Boolean(endDate && isValid(endDate))
-      const hasMinOrMaxDates = minDate || maxDate
 
       const returnObject: ReturnObject<E> = {
         event,
@@ -163,13 +162,11 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
             : null,
           end_date: endDateIsValid ? format(endDate, returnFormat) : null,
           is_valid_start_date:
-            hasMinOrMaxDates &&
             startDateIsValid &&
             isDisabled(startDate, dates.minDate, dates.maxDate)
               ? false
               : startDateIsValid,
           is_valid_end_date:
-            hasMinOrMaxDates &&
             endDateIsValid &&
             isDisabled(endDate, dates.minDate, dates.maxDate)
               ? false
@@ -190,14 +187,13 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         partialStartDate,
         invalidDate: invalidStartDate,
         is_valid:
-          hasMinOrMaxDates &&
           startDateIsValid &&
           isDisabled(startDate, dates.minDate, dates.maxDate)
             ? false
             : startDateIsValid,
       }
     },
-    [dates, views, attributes, maxDate, minDate, range, returnFormatProp]
+    [dates, views, attributes, range, returnFormatProp]
   )
 
   const callOnChangeHandler = useCallback(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -190,6 +190,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         partialStartDate,
         invalidDate: invalidStartDate,
         is_valid:
+          hasMinOrMaxDates &&
           startDateIsValid &&
           isDisabled(startDate, dates.minDate, dates.maxDate)
             ? false

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -174,6 +174,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
             isDisabled(endDate, dates.minDate, dates.maxDate)
               ? false
               : endDateIsValid,
+          partialStartDate,
           partialEndDate,
           invalidStartDate,
           invalidEndDate,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -148,7 +148,6 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       const returnObject: ReturnObject<E> = {
         event,
         attributes: attributes || {},
-        partialStartDate,
       }
 
       // Handle range props

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -136,7 +136,7 @@ function DateComponent(props: DateProps) {
         return invalidDateErrors
       }
 
-      const dateOutsideOfLimitErrors = validateDateLimit({
+      const dateLimitErrors = validateDateLimit({
         value,
         locale,
         minDate: props.minDate,
@@ -144,7 +144,7 @@ function DateComponent(props: DateProps) {
         isRange: props.range,
       })
 
-      return [...invalidDateErrors, ...dateOutsideOfLimitErrors]
+      return [...invalidDateErrors, ...dateLimitErrors]
     },
     [props.maxDate, props.minDate, props.range, locale]
   )
@@ -303,7 +303,6 @@ function parseRangeValue(value: DateProps['value']) {
 }
 
 // Validators
-
 function validateDateLimit({
   value,
   isRange,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -177,12 +177,7 @@ function DateComponent(props: DateProps) {
         invalidEndDate,
       }
 
-      return props.range
-        ? // Set startDate and endDate to invalid dates, to properly trigger error messages when typing in a range input,
-          // (undefined|undefined) does not trigger change or new error messages, even though onBlurValidator returns a new value
-          // Not an issue in non range inputs
-          `${start_date ?? invalidStartDate}|${end_date ?? invalidEndDate}`
-        : date
+      return props.range ? `${start_date}|${end_date}` : date
     },
     [props.range]
   )
@@ -238,16 +233,8 @@ function DateComponent(props: DateProps) {
 
     return {
       value: undefined,
-      // Set invalid date values to undefined, as invalid dates are not accepted by the DatePicker component
-      // Should be fixed when we remove the input control from the DatePicker component
-      startDate:
-        startDate === invalidDatesRef.current.invalidStartDate
-          ? undefined
-          : startDate,
-      endDate:
-        endDate === invalidDatesRef.current.invalidEndDate
-          ? undefined
-          : endDate,
+      startDate,
+      endDate,
     }
   }, [range, valueProp])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useRef } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import { DatePicker } from '../../../../components'
 import { useFieldProps } from '../../hooks'
 import type {
@@ -22,6 +22,7 @@ import { ProviderProps } from '../../../../shared/Provider'
 import { FormError } from '../../utils'
 import startOfDay from 'date-fns/startOfDay'
 import { InvalidDates } from '../../../../components/date-picker/DatePickerInput'
+import useInvalidDates from './hooks/useInvalidDates'
 
 // `range`, `showInput`, `showCancelButton` and `showResetButton` are not picked from the `DatePickerProps`
 // Since they require `Field.Date` specific comments, due to them having different default values
@@ -95,7 +96,7 @@ function DateComponent(props: DateProps) {
   const { errorRequired, label: defaultLabel } = useTranslation().Date
   const { locale } = useContext(SharedContext)
 
-  const invalidDatesRef = useRef<InvalidDates>({})
+  const { invalidDatesRef, setInvalidDates } = useInvalidDates()
 
   const errorMessages = useMemo(() => {
     return {
@@ -146,7 +147,7 @@ function DateComponent(props: DateProps) {
 
       return [...invalidDateErrors, ...dateLimitErrors]
     },
-    [props.maxDate, props.minDate, props.range, locale]
+    [props.maxDate, props.minDate, props.range, invalidDatesRef, locale]
   )
 
   const onBlurValidator = useMemo(() => {
@@ -171,15 +172,15 @@ function DateComponent(props: DateProps) {
       invalidEndDate,
     }: DatePickerEvent<React.ChangeEvent<HTMLInputElement>>) => {
       // Add to ref, for use in onBlurValidator, would be better if there was a way to add this to additional args
-      invalidDatesRef.current = {
+      setInvalidDates({
         invalidDate,
         invalidStartDate,
         invalidEndDate,
-      }
+      })
 
       return props.range ? `${start_date}|${end_date}` : date
     },
-    [props.range]
+    [props.range, setInvalidDates]
   )
 
   const preparedProps = {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -128,9 +128,7 @@ function DateComponent(props: DateProps) {
 
   const dateValidator = useCallback(
     (value: string) => {
-      const invalidDateErrors = getInvalidDateError(
-        invalidDatesRef.current
-      )
+      const invalidDateErrors = validateDate(invalidDatesRef.current)
 
       // No need to validate min/max date if they are not provided
       if (!props.minDate && !props.maxDate) {
@@ -392,7 +390,7 @@ function validateDateLimit({
   return messages
 }
 
-function getInvalidDateError({
+function validateDate({
   invalidDate,
   invalidStartDate,
   invalidEndDate,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -131,6 +131,7 @@ function DateComponent(props: DateProps) {
         invalidDatesRef.current
       )
 
+      // No need to validate min/max date if they are not provided
       if (!props.minDate && !props.maxDate) {
         return invalidDateErrors
       }
@@ -300,6 +301,8 @@ function parseRangeValue(value: DateProps['value']) {
       .map((value) => (/(undefined|null)/.test(value) ? null : value))
   )
 }
+
+// Validators
 
 function validateDateLimit({
   value,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
@@ -59,7 +59,7 @@ export const DateProperties: PropertiesTableProps = {
   },
   ...datePickerProperties,
   onBlurValidator: {
-    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }. Defaults to validating the date against `minDate` and `maxDate`, using `dateLimitValidator`. Can be disabled using `false`.',
+    doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }. Defaults to validating invalid dates, and dates against `minDate` and `maxDate`, using `dateValidator`. Can be disabled using `false`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -154,48 +154,390 @@ describe('Field.Date', () => {
     expect(endYear).toHaveValue('2024')
   })
 
-  describe('error handling', () => {
-    describe('with validateInitially', () => {
-      it('should show error message initially', async () => {
-        render(<Field.Date required validateInitially />)
-        await waitFor(() => {
-          expect(
-            document.querySelector('.dnb-form-status--error')
-          ).toBeInTheDocument()
-        })
-      })
+  it('should support keyboard interactions in range mode when id includes start or end', async () => {
+    const onChange = jest.fn()
+
+    render(
+      <Field.Date
+        id="id-end-start-something"
+        value="2025-01-01|2025-01-31"
+        range
+        onChange={onChange}
+      />
+    )
+
+    const [startMonth, endMonth] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input--month')
+    ) as Array<HTMLInputElement>
+
+    await userEvent.type(startMonth, '{ArrowDown}')
+    await userEvent.type(endMonth, '{ArrowUp}')
+    await userEvent.click(document.body)
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenNthCalledWith(
+      1,
+      '2024-12-01|2025-01-31',
+      expect.anything()
+    )
+    expect(onChange).toHaveBeenNthCalledWith(
+      2,
+      '2024-12-01|2025-02-28',
+      expect.anything()
+    )
+  })
+
+  describe('validation', () => {
+    it('should display error on first form submit', async () => {
+      render(
+        <Form.Handler>
+          <Field.Date minDate="2025-01-01" required />
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(nb.Date.errorRequired)
     })
 
-    describe('with validateUnchanged', () => {
-      it('should show error message when blurring without any changes', async () => {
-        // Because of the invalid date
-        const log = jest.spyOn(console, 'log').mockImplementation()
+    it('should display date limit error messages based on locale', async () => {
+      const minDate = '2025-01-01'
+      const maxDate = '2025-01-31'
 
-        render(
+      render(
+        <Form.Handler locale="en-GB">
           <Field.Date
-            value="2023-12-0"
-            schema={{ type: 'string', minLength: 10 }}
-            validateUnchanged
+            value={minDate}
+            minDate={minDate}
+            maxDate={maxDate}
           />
+        </Form.Handler>
+      )
+
+      const [day, month] = Array.from(
+        document.querySelectorAll('.dnb-date-picker__input')
+      )
+
+      await userEvent.click(day)
+      await userEvent.keyboard('{ArrowDown}')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
+        en.Date.errorMinDate.replace(
+          /\{date\}/,
+          formatDate(minDate, formatOptions.en)
         )
+      )
 
-        const input = document.querySelector('input')
+      await userEvent.click(month)
+      await userEvent.keyboard('{ArrowUp>2}')
+      await userEvent.click(document.body)
 
-        expect(
-          document.querySelector('.dnb-form-status')
-        ).not.toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
+        en.Date.errorMaxDate.replace(
+          /\{date\}/,
+          formatDate(maxDate, formatOptions.en)
+        )
+      )
+    })
 
-        input.focus()
-        fireEvent.blur(input)
+    it('should display date limit error messages based on locale when in `range` mode', async () => {
+      const minDate = '2025-01-01'
+      const maxDate = '2025-01-31'
 
-        await waitFor(() => {
-          expect(
-            document.querySelector('.dnb-form-status--error')
-          ).toBeInTheDocument()
-        })
+      const getMessages = () =>
+        Array.from(
+          document.querySelectorAll('.dnb-form-status .dnb-li')
+        ) as Array<HTMLLIElement>
 
-        log.mockRestore()
-      })
+      render(
+        <Form.Handler locale="en-GB">
+          <Field.Date
+            value={`${minDate}|${maxDate}`}
+            minDate={minDate}
+            maxDate={maxDate}
+            range
+          />
+        </Form.Handler>
+      )
+
+      const [startMonth, endMonth] = Array.from(
+        document.querySelectorAll('.dnb-date-picker__input--month')
+      ) as Array<HTMLInputElement>
+
+      await userEvent.click(startMonth)
+      await userEvent.keyboard('{ArrowDown}')
+      await userEvent.click(endMonth)
+      await userEvent.keyboard('{ArrowUp}')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(en.Field.errorSummary)
+
+      expect(getMessages().at(0)).toHaveTextContent(
+        en.Date.errorStartDateMinDate.replace(
+          /\{date\}/,
+          formatDate(minDate, formatOptions.en)
+        )
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        en.Date.errorEndDateMaxDate.replace(
+          /\{date\}/,
+          formatDate(maxDate, formatOptions.en)
+        )
+      )
+
+      await userEvent.click(startMonth)
+      await userEvent.keyboard('{ArrowUp>2}')
+      await userEvent.click(document.body)
+
+      expect(getMessages().at(0)).toHaveTextContent(
+        en.Date.errorStartDateMaxDate.replace(
+          /\{date\}/,
+          formatDate(maxDate, formatOptions.en)
+        )
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        en.Date.errorEndDateMaxDate.replace(
+          /\{date\}/,
+          formatDate(maxDate, formatOptions.en)
+        )
+      )
+
+      await userEvent.click(endMonth)
+      await userEvent.keyboard('{ArrowDown>2}')
+      await userEvent.click(document.body)
+
+      expect(getMessages().at(0)).toHaveTextContent(
+        en.Date.errorStartDateMaxDate.replace(
+          /\{date\}/,
+          formatDate(maxDate, formatOptions.en)
+        )
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        en.Date.errorEndDateMinDate.replace(
+          /\{date\}/,
+          formatDate(minDate, formatOptions.en)
+        )
+      )
+
+      await userEvent.click(startMonth)
+      await userEvent.keyboard('{ArrowDown>2}')
+      await userEvent.click(document.body)
+
+      expect(getMessages().at(0)).toHaveTextContent(
+        en.Date.errorStartDateMinDate.replace(
+          /\{date\}/,
+          formatDate(minDate, formatOptions.en)
+        )
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        en.Date.errorEndDateMinDate.replace(
+          /\{date\}/,
+          formatDate(minDate, formatOptions.en)
+        )
+      )
+    })
+
+    it('should display error if date is invalid', async () => {
+      render(<Field.Date />)
+
+      const dayInput = document.querySelector(
+        '.dnb-date-picker__input--day'
+      )
+
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('39192025')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(nb.Date.errorInvalidDate)
+
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('11122025')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display error if start date or end date is invalid', async () => {
+      render(<Field.Date range />)
+
+      const dayInput = document.querySelector(
+        '.dnb-date-picker__input--day'
+      )
+
+      const getMessages = () =>
+        Array.from(
+          document.querySelectorAll('.dnb-form-status .dnb-li')
+        ) as Array<HTMLLIElement>
+
+      // Type start date
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('39192025')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(nb.Date.errorInvalidStartDate)
+
+      // Type end date
+      await userEvent.keyboard('39192026')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(getMessages().at(0)).toHaveTextContent(
+        nb.Date.errorInvalidStartDate
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        nb.Date.errorInvalidEndDate
+      )
+
+      // Type valid start date
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('11122025')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(nb.Date.errorInvalidEndDate)
+
+      // Type valid end date
+      await userEvent.keyboard('11122026')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display invalid date error message based on locale', async () => {
+      render(
+        <Form.Handler locale="en-GB">
+          <Field.Date />
+        </Form.Handler>
+      )
+
+      const dayInput = document.querySelector(
+        '.dnb-date-picker__input--day'
+      )
+
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('39192025')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(en.Date.errorInvalidDate)
+
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('11122025')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display invalid date error message based on locale when in `range` mode', async () => {
+      render(
+        <Form.Handler locale="en-GB">
+          <Field.Date range />
+        </Form.Handler>
+      )
+
+      const dayInput = document.querySelector(
+        '.dnb-date-picker__input--day'
+      )
+
+      const getMessages = () =>
+        Array.from(
+          document.querySelectorAll('.dnb-form-status .dnb-li')
+        ) as Array<HTMLLIElement>
+
+      // Type start date
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('39192025')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(en.Date.errorInvalidStartDate)
+
+      // Type end date
+      await userEvent.keyboard('39192026')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(getMessages().at(0)).toHaveTextContent(
+        en.Date.errorInvalidStartDate
+      )
+      expect(getMessages().at(1)).toHaveTextContent(
+        en.Date.errorInvalidEndDate
+      )
+
+      // Type valid start date
+      await userEvent.click(dayInput)
+      await userEvent.keyboard('11122025')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent(en.Date.errorInvalidEndDate)
+
+      // Type valid end date
+      await userEvent.keyboard('11122026')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -277,6 +619,841 @@ describe('Field.Date', () => {
 
   // TODO: Add test for month, sync and hideLastWeek prop when it's working again
 
+  it('should be able to correct invalid dates', async () => {
+    render(
+      <Field.Date
+        value="2024-10-07"
+        minDate="2024-10-07"
+        maxDate="2024-10-25"
+        correctInvalidDate
+      />
+    )
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(day)
+    await userEvent.keyboard('{ArrowRight>2}{Backspace>2}')
+    await userEvent.keyboard('06')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(month)
+    await userEvent.keyboard('{ArrowRight>2}{Backspace>2}')
+    await userEvent.keyboard('12')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(year)
+    await userEvent.keyboard('{ArrowRight>4}{Backspace>2}')
+    await userEvent.keyboard('2026')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(day)
+    await userEvent.keyboard('{ArrowDown>4}')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(month)
+    await userEvent.keyboard('{ArrowDown>3}')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.keyboard('{ArrowUp>3}')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.dblClick(year)
+    await userEvent.keyboard('{ArrowDown>3}')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.keyboard('{ArrowUp>3}')
+
+    expect(day).toHaveValue('07')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+  })
+
+  it('should parse dates in specified format', async () => {
+    render(<Field.Date value="01/10/2024" dateFormat="dd/MM/yyyy" />)
+
+    const [startDay, startMonth, startYear]: Array<HTMLInputElement> =
+      Array.from(document.querySelectorAll('.dnb-date-picker__input'))
+
+    expect(startDay).toHaveValue('01')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(
+      screen.getByLabelText('tirsdag 1. oktober 2024')
+    ).toHaveAttribute('aria-current', 'date')
+  })
+
+  it('should return dates in specifed return format', async () => {
+    const onChange = jest.fn()
+
+    render(
+      <Field.Date
+        value="01/10/2024"
+        dateFormat="dd/MM/yyyy"
+        returnFormat="dd/MM/yyyy"
+        onChange={onChange}
+      />
+    )
+
+    const [startDay, startMonth, startYear]: Array<HTMLInputElement> =
+      Array.from(document.querySelectorAll('.dnb-date-picker__input'))
+
+    expect(startDay).toHaveValue('01')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(
+      screen.getByLabelText('tirsdag 1. oktober 2024')
+    ).toHaveAttribute('aria-current', 'date')
+
+    await userEvent.click(
+      screen.getByLabelText('torsdag 31. oktober 2024')
+    )
+
+    expect(onChange).toHaveBeenCalledWith('31/10/2024', expect.anything())
+    expect(startDay).toHaveValue('31')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+    expect(
+      screen.getByLabelText('torsdag 31. oktober 2024')
+    ).toHaveAttribute('aria-current', 'date')
+  })
+
+  it('should display input by default', () => {
+    render(<Field.Date />)
+
+    expect(
+      document.querySelector('.dnb-date-picker__input__wrapper')
+    ).toBeInTheDocument()
+  })
+
+  it('should be able to hide input', () => {
+    render(<Field.Date showInput={false} />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day).toHaveAttribute('hidden')
+    expect(month).toHaveAttribute('hidden')
+    expect(year).toHaveAttribute('hidden')
+  })
+
+  it('should support custom mask order', () => {
+    render(<Field.Date value="2024-10-26" maskOrder="mm/dd/yyyy" />)
+
+    const [month, day, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(month).toHaveValue('10')
+    expect(day).toHaveValue('26')
+    expect(year).toHaveValue('2024')
+  })
+
+  it('should support having the picker be open by default', () => {
+    render(<Field.Date opened />)
+
+    expect(
+      document.querySelector('.dnb-date-picker__calendar')
+    ).toBeInTheDocument()
+  })
+
+  it('should show custom mask placeholder', () => {
+    render(<Field.Date maskPlaceholder="aa/bb/cccc" />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day.value).toBe('aa')
+    expect(month.value).toBe('bb')
+    expect(year.value).toBe('cccc')
+  })
+
+  it('should be able to hide navigation arrows', async () => {
+    render(<Field.Date hideNavigation />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(
+      document.querySelector('.dnb-date-picker__prev')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-date-picker__next')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should be able to hide week days', async () => {
+    render(<Field.Date hideDays />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(
+      document.querySelector('.dnb-date-picker__labels')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display cancel and reset buttons by default', async () => {
+    render(<Field.Date />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [resetButton, cancelButton] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__footer button')
+    )
+
+    expect(resetButton).toBeInTheDocument()
+    expect(resetButton).toHaveAttribute('data-testid', 'reset')
+
+    expect(cancelButton).toBeInTheDocument()
+    expect(cancelButton).toHaveAttribute('data-testid', 'cancel')
+  })
+
+  it('should be able to hide and show submit, cancel and reset buttons', async () => {
+    const { rerender } = render(
+      <Field.Date showSubmitButton showCancelButton showResetButton />
+    )
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [submitButton, resetButton, cancelButton] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__footer button')
+    )
+
+    expect(submitButton).toBeInTheDocument()
+    expect(submitButton).toHaveAttribute('data-testid', 'submit')
+    expect(resetButton).toBeInTheDocument()
+    expect(resetButton).toHaveAttribute('data-testid', 'reset')
+    expect(cancelButton).toBeInTheDocument()
+    expect(cancelButton).toHaveAttribute('data-testid', 'cancel')
+
+    rerender(
+      <Field.Date
+        showSubmitButton={false}
+        showCancelButton={false}
+        showResetButton={false}
+      />
+    )
+
+    expect(submitButton).not.toBeInTheDocument()
+    expect(resetButton).not.toBeInTheDocument()
+    expect(cancelButton).not.toBeInTheDocument()
+  })
+
+  it('should support custom submit, cancel and reset button texts', async () => {
+    render(
+      <Field.Date
+        showSubmitButton
+        submitButtonText="Custom Submit"
+        cancelButtonText="Custom Cancel"
+        resetButtonText="Custom Reset"
+      />
+    )
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [submitButton, resetButton, cancelButton] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__footer button')
+    )
+
+    expect(submitButton).toHaveTextContent('Custom Submit')
+    expect(resetButton).toHaveTextContent('Custom Reset')
+    expect(cancelButton).toHaveTextContent('Custom Cancel')
+  })
+
+  it('should support linked calendars', async () => {
+    render(<Field.Date value="2024-11-01|2024-12-01" range link />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [rightCalendar, leftCalendar] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__calendar')
+    )
+
+    // TODO: Update to use left picker nav buttons when bug is fixed in DatePicker
+    const rightNext = rightCalendar.querySelector('.dnb-date-picker__next')
+    const leftPrev = rightCalendar.querySelector('.dnb-date-picker__prev')
+
+    expect(
+      rightCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('november 2024')
+    expect(
+      leftCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('desember 2024')
+
+    await userEvent.click(rightNext)
+    await userEvent.click(rightNext)
+
+    expect(
+      rightCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('januar 2025')
+    expect(
+      leftCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('februar 2025')
+
+    await userEvent.click(leftPrev)
+    await userEvent.click(leftPrev)
+    await userEvent.click(leftPrev)
+    await userEvent.click(leftPrev)
+
+    expect(
+      rightCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('september 2024')
+    expect(
+      leftCalendar.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('oktober 2024')
+  })
+
+  it('should be able to define the first day of the week', async () => {
+    render(<Field.Date firstDay="tuesday" />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [firstDay] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__labels__day')
+    )
+
+    expect(firstDay).toHaveTextContent('ti')
+    expect(firstDay).toHaveAttribute('aria-label', 'tirsdag')
+  })
+
+  it('should be able to set picker alignment', async () => {
+    const { rerender } = render(<Field.Date alignPicker="auto" />)
+
+    const datePicker = document.querySelector('.dnb-date-picker')
+
+    expect(datePicker).toHaveClass('dnb-date-picker--auto')
+
+    rerender(<Field.Date alignPicker="right" />)
+    expect(datePicker).toHaveClass('dnb-date-picker--right')
+
+    rerender(<Field.Date alignPicker="left" />)
+    expect(datePicker).toHaveClass('dnb-date-picker--left')
+  })
+
+  it('should be able to only show the month in calendar', async () => {
+    render(<Field.Date onlyMonth />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const calendar = document.querySelector('.dnb-date-picker__calendar')
+
+    expect(
+      calendar.querySelector('.dnb-date-picker__header')
+    ).not.toBeInTheDocument()
+    expect(
+      calendar.querySelector('.dnb-date-picker__labels')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should be able to hide calendar weeks from the previous month', () => {
+    render(<Field.Date hideLastWeek />)
+
+    expect(
+      document.querySelector('.dnb-date-picker__calendar__week--last')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should support custom date shortcuts', async () => {
+    render(
+      <Field.Date
+        range
+        shortcuts={[
+          {
+            title: 'First of October',
+            date: '2024-10-01',
+          },
+          {
+            title: 'Second week of October',
+            start_date: '2024-10-07',
+            end_date: '2024-10-13',
+          },
+          {
+            title: 'Whole month of October',
+            start_date: '2024-10-01',
+            end_date: '2024-10-31',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [
+      startDay,
+      startMonth,
+      startYear,
+      endDay,
+      endMonth,
+      endYear,
+    ]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    const [dayShortcut, weekShortcut, monthShortcut] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__addon button')
+    )
+
+    expect(startDay).toHaveValue('dd')
+    expect(startMonth).toHaveValue('mm')
+    expect(startYear).toHaveValue('åååå')
+    expect(endDay).toHaveValue('dd')
+    expect(endMonth).toHaveValue('mm')
+    expect(endYear).toHaveValue('åååå')
+
+    expect(dayShortcut).toHaveTextContent('First of October')
+    expect(weekShortcut).toHaveTextContent('Second week of October')
+    expect(monthShortcut).toHaveTextContent('Whole month of October')
+
+    await userEvent.click(dayShortcut)
+
+    expect(startDay).toHaveValue('01')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+    expect(endDay).toHaveValue('01')
+    expect(endMonth).toHaveValue('10')
+    expect(endYear).toHaveValue('2024')
+
+    await userEvent.click(weekShortcut)
+
+    expect(startDay).toHaveValue('07')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+    expect(endDay).toHaveValue('13')
+    expect(endMonth).toHaveValue('10')
+    expect(endYear).toHaveValue('2024')
+
+    await userEvent.click(monthShortcut)
+
+    expect(startDay).toHaveValue('01')
+    expect(startMonth).toHaveValue('10')
+    expect(startYear).toHaveValue('2024')
+    expect(endDay).toHaveValue('31')
+    expect(endMonth).toHaveValue('10')
+    expect(endYear).toHaveValue('2024')
+  })
+
+  it('should support custom addon elements', async () => {
+    const DateWithAddon = () => {
+      const [date, setDate] = useState('2024-10-01')
+
+      return (
+        <Field.Date
+          value={date}
+          addonElement={
+            <button id="date-addon" onClick={() => setDate('2024-10-31')}>
+              Custom Date Addon
+            </button>
+          }
+        />
+      )
+    }
+
+    render(<DateWithAddon />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day).toHaveValue('01')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const addonElement = document.querySelector(
+      '.dnb-date-picker__addon button'
+    )
+
+    expect(addonElement).toHaveTextContent('Custom Date Addon')
+    expect(addonElement).toHaveAttribute('id', 'date-addon')
+    expect(addonElement.nodeName).toBe('BUTTON')
+
+    await userEvent.click(addonElement)
+
+    expect(day).toHaveValue('31')
+    expect(month).toHaveValue('10')
+    expect(year).toHaveValue('2024')
+  })
+
+  it('should be able to disable autofocus', async () => {
+    render(<Field.Date disableAutofocus />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const monthTable = document.querySelector(
+      '.dnb-date-picker__calendar table'
+    )
+
+    expect(monthTable).toHaveClass('dnb-no-focus')
+    expect(document.activeElement).not.toBe(monthTable)
+
+    await userEvent.keyboard('{ArrowRight>5}')
+
+    expect(day).toHaveValue('dd')
+    expect(month).toHaveValue('mm')
+    expect(year).toHaveValue('åååå')
+  })
+
+  it('should support onType event', async () => {
+    const onType = jest.fn()
+
+    render(<Field.Date onType={onType} />)
+
+    const dayInput = document.querySelector('.dnb-date-picker__input')
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('01102024')
+
+    expect(onType).toHaveBeenCalledTimes(8)
+    expect(onType).toHaveBeenLastCalledWith(
+      expect.objectContaining({ date: '2024-10-01' })
+    )
+  })
+
+  it('should support onSubmit event', async () => {
+    const onSubmit = jest.fn()
+
+    render(
+      <Field.Date
+        value="2024-10-31"
+        showSubmitButton
+        onSubmit={onSubmit}
+      />
+    )
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const submitButton = document.querySelector(
+      '.dnb-date-picker__footer button[data-testid="submit"]'
+    )
+
+    await userEvent.click(submitButton)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ date: '2024-10-31' })
+    )
+  })
+
+  it('should support onCancel event', async () => {
+    const onCancel = jest.fn()
+
+    render(<Field.Date value="2024-10-31" onCancel={onCancel} />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const cancelButton = document.querySelector(
+      '.dnb-date-picker__footer button[data-testid="cancel"]'
+    )
+
+    await userEvent.click(cancelButton)
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ date: '2024-10-31' })
+    )
+  })
+
+  it('should support onReset event', async () => {
+    const onReset = jest.fn()
+
+    render(<Field.Date value="2024-10-31" onReset={onReset} />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const resetButton = document.querySelector(
+      '.dnb-date-picker__footer button[data-testid="reset"]'
+    )
+
+    await userEvent.click(resetButton)
+
+    expect(onReset).toHaveBeenCalledTimes(1)
+    expect(onReset).toHaveBeenLastCalledWith(expect.anything())
+  })
+
+  it('should support onShow event', async () => {
+    const onShow = jest.fn()
+
+    render(<Field.Date value="2024-10-31" onShow={onShow} />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(onShow).toHaveBeenCalledTimes(1)
+    expect(onShow).toHaveBeenLastCalledWith(
+      expect.objectContaining({ date: '2024-10-31' })
+    )
+  })
+
+  it('should support onHide event', async () => {
+    const onHide = jest.fn()
+
+    render(<Field.Date value="2024-10-31" onHide={onHide} />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+    await waitFor(() =>
+      expect(
+        document.querySelector('.dnb-date-picker__portal')
+      ).not.toBeInTheDocument()
+    )
+
+    expect(onHide).toHaveBeenCalledTimes(1)
+    expect(onHide).toHaveBeenLastCalledWith(
+      expect.objectContaining({ date: '2024-10-31' })
+    )
+  })
+
+  it('should support onDaysRender event', async () => {
+    const onDaysRender = jest.fn()
+
+    render(<Field.Date value="2024-10-01" onDaysRender={onDaysRender} />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    expect(onDaysRender).toHaveBeenCalledTimes(1)
+    expect(onDaysRender.mock.calls[0][0].length).toBe(42)
+    expect(onDaysRender.mock.calls[0][0][0]).toEqual(
+      expect.objectContaining({
+        date: expect.any(Date),
+        isDisabled: null,
+        isEndDate: false,
+        isInactive: true,
+        isLastMonth: false,
+        isNextMonth: true,
+        isPreview: false,
+        isSelectable: false,
+        isStartDate: false,
+        isToday: false,
+        isWithinSelection: false,
+      })
+    )
+  })
+
+  it('should support `skipPortal`', async () => {
+    render(<Field.Date skipPortal />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    // dnb-date-picker__container is a direct descendant of dnb-date-picker__shell when portal is skipped
+    expect(
+      document.querySelector(
+        '.dnb-date-picker__shell > .dnb-date-picker__container'
+      )
+    ).toBeInTheDocument()
+    expect(
+      document.body.querySelector('.dnb-date-picker__portal')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should export `dateValidator`', async () => {
+    const myOnBlurValidator = (value: string) => {
+      if (value === '2025-01-01') {
+        return new Error('My custom message')
+      }
+
+      if (value === '2025-01-03') {
+        return [
+          new Error('My custom message 1'),
+          new Error('My custom message 2'),
+        ]
+      }
+    }
+
+    const onBlurValidator = (value: string, { validators }) => {
+      const { dateValidator } = validators
+
+      return [myOnBlurValidator, dateValidator]
+    }
+
+    const minDate = '2025-01-01'
+    const maxDate = '2025-01-31'
+
+    render(
+      <Field.Date
+        value="2025-01-02"
+        minDate={minDate}
+        maxDate={maxDate}
+        onBlurValidator={onBlurValidator}
+      />
+    )
+
+    const [day, month]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    // Test myOnBlurValidator
+    await userEvent.click(day)
+    await userEvent.keyboard('{ArrowDown}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'My custom message'
+    )
+
+    await userEvent.click(day)
+    await userEvent.keyboard('{ArrowUp>2}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).toBeInTheDocument()
+
+    const [firstMessage, secondMessage] = Array.from(
+      document.querySelectorAll('.dnb-li')
+    )
+
+    expect(firstMessage).toHaveTextContent('My custom message 1')
+    expect(secondMessage).toHaveTextContent('My custom message 2')
+
+    // Test date limit (min|max) validator
+    await userEvent.click(month)
+    await userEvent.keyboard('{ArrowUp}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).toBeInTheDocument()
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent(
+      nb.Date.errorMaxDate.replace(
+        /\{date\}/,
+        formatDate(maxDate, formatOptions.no)
+      )
+    )
+
+    await userEvent.click(month)
+    await userEvent.keyboard('{ArrowDown>2}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).toBeInTheDocument()
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent(
+      nb.Date.errorMinDate.replace(
+        /\{date\}/,
+        formatDate(minDate, formatOptions.no)
+      )
+    )
+
+    await userEvent.click(month)
+    await userEvent.keyboard('{ArrowUp}')
+    await userEvent.click(day)
+    await userEvent.keyboard('{ArrowDown}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).not.toBeInTheDocument()
+
+    // Test invalid date validator
+    await userEvent.click(day)
+    await userEvent.keyboard('99999999')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent(nb.Date.errorInvalidDate)
+
+    await userEvent.click(day)
+    await userEvent.keyboard('10012025')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should disable `dateValidator` if `onBlurValidation` is set to `false`', async () => {
+    const minDate = '2025-01-01'
+    const maxDate = '2025-01-31'
+
+    render(
+      <Field.Date
+        value="2025-01-01"
+        minDate={minDate}
+        maxDate={maxDate}
+        onBlurValidator={false}
+      />
+    )
+
+    const [dayInput, monthInput]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('{ArrowDown}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(monthInput)
+    await userEvent.keyboard('{ArrowUp>2}')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('99999999')
+    await userEvent.click(document.body)
+
+    expect(
+      document.querySelector('.dnb-form-status--error')
+    ).not.toBeInTheDocument()
+  })
+
   describe('startMonth and endMonth', () => {
     it('should display correct start and end month on opening the date picker', async () => {
       render(
@@ -295,7 +1472,7 @@ describe('Field.Date', () => {
   })
 
   describe('minDate and maxDate', () => {
-    it('should have functioning min and max date', async () => {
+    it('should have functioning `minDate` and `maxDate`', async () => {
       render(
         <Field.Date
           value="2024-10-01|2024-10-31"
@@ -378,7 +1555,7 @@ describe('Field.Date', () => {
       ).toHaveAttribute('aria-disabled', 'true')
     })
 
-    it('should support min and max dates as date objects', async () => {
+    it('should support `minDate` and `maxDate` as date objects', async () => {
       render(
         <Form.Handler>
           <Wizard.Container>
@@ -428,7 +1605,7 @@ describe('Field.Date', () => {
       ).toHaveAttribute('disabled')
     })
 
-    it('should support min and max dates as ISO strings', async () => {
+    it('should support `minDate` and `maxDate` as ISO strings', async () => {
       render(
         <Form.Handler>
           <Wizard.Container>
@@ -478,702 +1655,7 @@ describe('Field.Date', () => {
       ).toHaveAttribute('disabled')
     })
 
-    it('should be able to correct invalid dates', async () => {
-      render(
-        <Field.Date
-          value="2024-10-07"
-          minDate="2024-10-07"
-          maxDate="2024-10-25"
-          correctInvalidDate
-        />
-      )
-
-      const [day, month, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(day)
-      await userEvent.keyboard('{ArrowRight>2}{Backspace>2}')
-      await userEvent.keyboard('06')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(month)
-      await userEvent.keyboard('{ArrowRight>2}{Backspace>2}')
-      await userEvent.keyboard('12')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(year)
-      await userEvent.keyboard('{ArrowRight>4}{Backspace>2}')
-      await userEvent.keyboard('2026')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(day)
-      await userEvent.keyboard('{ArrowDown>4}')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(month)
-      await userEvent.keyboard('{ArrowDown>3}')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.keyboard('{ArrowUp>3}')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.dblClick(year)
-      await userEvent.keyboard('{ArrowDown>3}')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.keyboard('{ArrowUp>3}')
-
-      expect(day).toHaveValue('07')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-    })
-
-    it('should parse dates in specified format', async () => {
-      render(<Field.Date value="01/10/2024" dateFormat="dd/MM/yyyy" />)
-
-      const [startDay, startMonth, startYear]: Array<HTMLInputElement> =
-        Array.from(document.querySelectorAll('.dnb-date-picker__input'))
-
-      expect(startDay).toHaveValue('01')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(
-        screen.getByLabelText('tirsdag 1. oktober 2024')
-      ).toHaveAttribute('aria-current', 'date')
-    })
-
-    it('should return dates in specifed return format', async () => {
-      const onChange = jest.fn()
-
-      render(
-        <Field.Date
-          value="01/10/2024"
-          dateFormat="dd/MM/yyyy"
-          returnFormat="dd/MM/yyyy"
-          onChange={onChange}
-        />
-      )
-
-      const [startDay, startMonth, startYear]: Array<HTMLInputElement> =
-        Array.from(document.querySelectorAll('.dnb-date-picker__input'))
-
-      expect(startDay).toHaveValue('01')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(
-        screen.getByLabelText('tirsdag 1. oktober 2024')
-      ).toHaveAttribute('aria-current', 'date')
-
-      await userEvent.click(
-        screen.getByLabelText('torsdag 31. oktober 2024')
-      )
-
-      expect(onChange).toHaveBeenCalledWith(
-        '31/10/2024',
-        expect.anything()
-      )
-      expect(startDay).toHaveValue('31')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-      expect(
-        screen.getByLabelText('torsdag 31. oktober 2024')
-      ).toHaveAttribute('aria-current', 'date')
-    })
-
-    it('should display input by default', () => {
-      render(<Field.Date />)
-
-      expect(
-        document.querySelector('.dnb-date-picker__input__wrapper')
-      ).toBeInTheDocument()
-    })
-
-    it('should be able to hide input', () => {
-      render(<Field.Date showInput={false} />)
-
-      const [day, month, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      expect(day).toHaveAttribute('hidden')
-      expect(month).toHaveAttribute('hidden')
-      expect(year).toHaveAttribute('hidden')
-    })
-
-    it('should support custom mask order', () => {
-      render(<Field.Date value="2024-10-26" maskOrder="mm/dd/yyyy" />)
-
-      const [month, day, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      expect(month).toHaveValue('10')
-      expect(day).toHaveValue('26')
-      expect(year).toHaveValue('2024')
-    })
-
-    it('should support having the picker be open by default', () => {
-      render(<Field.Date opened />)
-
-      expect(
-        document.querySelector('.dnb-date-picker__calendar')
-      ).toBeInTheDocument()
-    })
-
-    it('should show custom mask placeholder', () => {
-      render(<Field.Date maskPlaceholder="aa/bb/cccc" />)
-
-      const [day, month, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      expect(day.value).toBe('aa')
-      expect(month.value).toBe('bb')
-      expect(year.value).toBe('cccc')
-    })
-
-    it('should be able to hide navigation arrows', async () => {
-      render(<Field.Date hideNavigation />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(
-        document.querySelector('.dnb-date-picker__prev')
-      ).not.toBeInTheDocument()
-      expect(
-        document.querySelector('.dnb-date-picker__next')
-      ).not.toBeInTheDocument()
-    })
-
-    it('should be able to hide week days', async () => {
-      render(<Field.Date hideDays />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(
-        document.querySelector('.dnb-date-picker__labels')
-      ).not.toBeInTheDocument()
-    })
-
-    it('should display cancel and reset buttons by default', async () => {
-      render(<Field.Date />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [resetButton, cancelButton] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__footer button')
-      )
-
-      expect(resetButton).toBeInTheDocument()
-      expect(resetButton).toHaveAttribute('data-testid', 'reset')
-
-      expect(cancelButton).toBeInTheDocument()
-      expect(cancelButton).toHaveAttribute('data-testid', 'cancel')
-    })
-
-    it('should be able to hide and show submit, cancel and reset buttons', async () => {
-      const { rerender } = render(
-        <Field.Date showSubmitButton showCancelButton showResetButton />
-      )
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [submitButton, resetButton, cancelButton] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__footer button')
-      )
-
-      expect(submitButton).toBeInTheDocument()
-      expect(submitButton).toHaveAttribute('data-testid', 'submit')
-      expect(resetButton).toBeInTheDocument()
-      expect(resetButton).toHaveAttribute('data-testid', 'reset')
-      expect(cancelButton).toBeInTheDocument()
-      expect(cancelButton).toHaveAttribute('data-testid', 'cancel')
-
-      rerender(
-        <Field.Date
-          showSubmitButton={false}
-          showCancelButton={false}
-          showResetButton={false}
-        />
-      )
-
-      expect(submitButton).not.toBeInTheDocument()
-      expect(resetButton).not.toBeInTheDocument()
-      expect(cancelButton).not.toBeInTheDocument()
-    })
-
-    it('should support custom submit, cancel and reset button texts', async () => {
-      render(
-        <Field.Date
-          showSubmitButton
-          submitButtonText="Custom Submit"
-          cancelButtonText="Custom Cancel"
-          resetButtonText="Custom Reset"
-        />
-      )
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [submitButton, resetButton, cancelButton] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__footer button')
-      )
-
-      expect(submitButton).toHaveTextContent('Custom Submit')
-      expect(resetButton).toHaveTextContent('Custom Reset')
-      expect(cancelButton).toHaveTextContent('Custom Cancel')
-    })
-
-    it('should support linked calendars', async () => {
-      render(<Field.Date value="2024-11-01|2024-12-01" range link />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [rightCalendar, leftCalendar] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__calendar')
-      )
-
-      // TODO: Update to use left picker nav buttons when bug is fixed in DatePicker
-      const rightNext = rightCalendar.querySelector(
-        '.dnb-date-picker__next'
-      )
-      const leftPrev = rightCalendar.querySelector(
-        '.dnb-date-picker__prev'
-      )
-
-      expect(
-        rightCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('november 2024')
-      expect(
-        leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('desember 2024')
-
-      await userEvent.click(rightNext)
-      await userEvent.click(rightNext)
-
-      expect(
-        rightCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('januar 2025')
-      expect(
-        leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('februar 2025')
-
-      await userEvent.click(leftPrev)
-      await userEvent.click(leftPrev)
-      await userEvent.click(leftPrev)
-      await userEvent.click(leftPrev)
-
-      expect(
-        rightCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('september 2024')
-      expect(
-        leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('oktober 2024')
-    })
-
-    it('should be able to define the first day of the week', async () => {
-      render(<Field.Date firstDay="tuesday" />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [firstDay] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__labels__day')
-      )
-
-      expect(firstDay).toHaveTextContent('ti')
-      expect(firstDay).toHaveAttribute('aria-label', 'tirsdag')
-    })
-
-    it('should be able to set picker alignment', async () => {
-      const { rerender } = render(<Field.Date alignPicker="auto" />)
-
-      const datePicker = document.querySelector('.dnb-date-picker')
-
-      expect(datePicker).toHaveClass('dnb-date-picker--auto')
-
-      rerender(<Field.Date alignPicker="right" />)
-      expect(datePicker).toHaveClass('dnb-date-picker--right')
-
-      rerender(<Field.Date alignPicker="left" />)
-      expect(datePicker).toHaveClass('dnb-date-picker--left')
-    })
-
-    it('should be able to only show the month in calendar', async () => {
-      render(<Field.Date onlyMonth />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const calendar = document.querySelector('.dnb-date-picker__calendar')
-
-      expect(
-        calendar.querySelector('.dnb-date-picker__header')
-      ).not.toBeInTheDocument()
-      expect(
-        calendar.querySelector('.dnb-date-picker__labels')
-      ).not.toBeInTheDocument()
-    })
-
-    it('should be able to hide calendar weeks from the previous month', () => {
-      render(<Field.Date hideLastWeek />)
-
-      expect(
-        document.querySelector('.dnb-date-picker__calendar__week--last')
-      ).not.toBeInTheDocument()
-    })
-
-    it('should support custom date shortcuts', async () => {
-      render(
-        <Field.Date
-          range
-          shortcuts={[
-            {
-              title: 'First of October',
-              date: '2024-10-01',
-            },
-            {
-              title: 'Second week of October',
-              start_date: '2024-10-07',
-              end_date: '2024-10-13',
-            },
-            {
-              title: 'Whole month of October',
-              start_date: '2024-10-01',
-              end_date: '2024-10-31',
-            },
-          ]}
-        />
-      )
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const [
-        startDay,
-        startMonth,
-        startYear,
-        endDay,
-        endMonth,
-        endYear,
-      ]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      const [dayShortcut, weekShortcut, monthShortcut] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__addon button')
-      )
-
-      expect(startDay).toHaveValue('dd')
-      expect(startMonth).toHaveValue('mm')
-      expect(startYear).toHaveValue('åååå')
-      expect(endDay).toHaveValue('dd')
-      expect(endMonth).toHaveValue('mm')
-      expect(endYear).toHaveValue('åååå')
-
-      expect(dayShortcut).toHaveTextContent('First of October')
-      expect(weekShortcut).toHaveTextContent('Second week of October')
-      expect(monthShortcut).toHaveTextContent('Whole month of October')
-
-      await userEvent.click(dayShortcut)
-
-      expect(startDay).toHaveValue('01')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-      expect(endDay).toHaveValue('01')
-      expect(endMonth).toHaveValue('10')
-      expect(endYear).toHaveValue('2024')
-
-      await userEvent.click(weekShortcut)
-
-      expect(startDay).toHaveValue('07')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-      expect(endDay).toHaveValue('13')
-      expect(endMonth).toHaveValue('10')
-      expect(endYear).toHaveValue('2024')
-
-      await userEvent.click(monthShortcut)
-
-      expect(startDay).toHaveValue('01')
-      expect(startMonth).toHaveValue('10')
-      expect(startYear).toHaveValue('2024')
-      expect(endDay).toHaveValue('31')
-      expect(endMonth).toHaveValue('10')
-      expect(endYear).toHaveValue('2024')
-    })
-
-    it('should support custom addon elements', async () => {
-      const DateWithAddon = () => {
-        const [date, setDate] = useState('2024-10-01')
-
-        return (
-          <Field.Date
-            value={date}
-            addonElement={
-              <button
-                id="date-addon"
-                onClick={() => setDate('2024-10-31')}
-              >
-                Custom Date Addon
-              </button>
-            }
-          />
-        )
-      }
-
-      render(<DateWithAddon />)
-
-      const [day, month, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      expect(day).toHaveValue('01')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const addonElement = document.querySelector(
-        '.dnb-date-picker__addon button'
-      )
-
-      expect(addonElement).toHaveTextContent('Custom Date Addon')
-      expect(addonElement).toHaveAttribute('id', 'date-addon')
-      expect(addonElement.nodeName).toBe('BUTTON')
-
-      await userEvent.click(addonElement)
-
-      expect(day).toHaveValue('31')
-      expect(month).toHaveValue('10')
-      expect(year).toHaveValue('2024')
-    })
-
-    it('should be able to disable autofocus', async () => {
-      render(<Field.Date disableAutofocus />)
-
-      const [day, month, year]: Array<HTMLInputElement> = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
-      )
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const monthTable = document.querySelector(
-        '.dnb-date-picker__calendar table'
-      )
-
-      expect(monthTable).toHaveClass('dnb-no-focus')
-      expect(document.activeElement).not.toBe(monthTable)
-
-      await userEvent.keyboard('{ArrowRight>5}')
-
-      expect(day).toHaveValue('dd')
-      expect(month).toHaveValue('mm')
-      expect(year).toHaveValue('åååå')
-    })
-
-    it('should support onType event', async () => {
-      const onType = jest.fn()
-
-      render(<Field.Date onType={onType} />)
-
-      const dayInput = document.querySelector('.dnb-date-picker__input')
-
-      await userEvent.click(dayInput)
-      await userEvent.keyboard('01102024')
-
-      expect(onType).toHaveBeenCalledTimes(8)
-      expect(onType).toHaveBeenLastCalledWith(
-        expect.objectContaining({ date: '2024-10-01' })
-      )
-    })
-
-    it('should support onSubmit event', async () => {
-      const onSubmit = jest.fn()
-
-      render(
-        <Field.Date
-          value="2024-10-31"
-          showSubmitButton
-          onSubmit={onSubmit}
-        />
-      )
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const submitButton = document.querySelector(
-        '.dnb-date-picker__footer button[data-testid="submit"]'
-      )
-
-      await userEvent.click(submitButton)
-
-      expect(onSubmit).toHaveBeenCalledTimes(1)
-      expect(onSubmit).toHaveBeenLastCalledWith(
-        expect.objectContaining({ date: '2024-10-31' })
-      )
-    })
-
-    it('should support onCancel event', async () => {
-      const onCancel = jest.fn()
-
-      render(<Field.Date value="2024-10-31" onCancel={onCancel} />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const cancelButton = document.querySelector(
-        '.dnb-date-picker__footer button[data-testid="cancel"]'
-      )
-
-      await userEvent.click(cancelButton)
-
-      expect(onCancel).toHaveBeenCalledTimes(1)
-      expect(onCancel).toHaveBeenLastCalledWith(
-        expect.objectContaining({ date: '2024-10-31' })
-      )
-    })
-
-    it('should support onReset event', async () => {
-      const onReset = jest.fn()
-
-      render(<Field.Date value="2024-10-31" onReset={onReset} />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      const resetButton = document.querySelector(
-        '.dnb-date-picker__footer button[data-testid="reset"]'
-      )
-
-      await userEvent.click(resetButton)
-
-      expect(onReset).toHaveBeenCalledTimes(1)
-      expect(onReset).toHaveBeenLastCalledWith(expect.anything())
-    })
-
-    it('should support onShow event', async () => {
-      const onShow = jest.fn()
-
-      render(<Field.Date value="2024-10-31" onShow={onShow} />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(onShow).toHaveBeenCalledTimes(1)
-      expect(onShow).toHaveBeenLastCalledWith(
-        expect.objectContaining({ date: '2024-10-31' })
-      )
-    })
-
-    it('should support onHide event', async () => {
-      const onHide = jest.fn()
-
-      render(<Field.Date value="2024-10-31" onHide={onHide} />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-      await waitFor(() =>
-        expect(
-          document.querySelector('.dnb-date-picker__portal')
-        ).not.toBeInTheDocument()
-      )
-
-      expect(onHide).toHaveBeenCalledTimes(1)
-      expect(onHide).toHaveBeenLastCalledWith(
-        expect.objectContaining({ date: '2024-10-31' })
-      )
-    })
-
-    it('should support onDaysRender event', async () => {
-      const onDaysRender = jest.fn()
-
-      render(<Field.Date value="2024-10-01" onDaysRender={onDaysRender} />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      expect(onDaysRender).toHaveBeenCalledTimes(1)
-      expect(onDaysRender.mock.calls[0][0].length).toBe(42)
-      expect(onDaysRender.mock.calls[0][0][0]).toEqual(
-        expect.objectContaining({
-          date: expect.any(Date),
-          isDisabled: null,
-          isEndDate: false,
-          isInactive: true,
-          isLastMonth: false,
-          isNextMonth: true,
-          isPreview: false,
-          isSelectable: false,
-          isStartDate: false,
-          isToday: false,
-          isWithinSelection: false,
-        })
-      )
-    })
-
-    it('should support `skipPortal`', async () => {
-      render(<Field.Date skipPortal />)
-
-      await userEvent.click(screen.getByLabelText('åpne datovelger'))
-
-      // dnb-date-picker__container is a direct descendant of dnb-date-picker__shell when portal is skipped
-      expect(
-        document.querySelector(
-          '.dnb-date-picker__shell > .dnb-date-picker__container'
-        )
-      ).toBeInTheDocument()
-      expect(
-        document.body.querySelector('.dnb-date-picker__portal')
-      ).not.toBeInTheDocument()
-    })
-
     describe('validation', () => {
-      it('should display error on first form submit', async () => {
-        render(
-          <Form.Handler>
-            <Field.Date minDate="2025-01-01" required />
-          </Form.Handler>
-        )
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).not.toBeInTheDocument()
-
-        fireEvent.submit(document.querySelector('form'))
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toHaveTextContent(nb.Date.errorRequired)
-      })
-
       it('should display error message if `value` is before `minDate`', async () => {
         const minDate = '2025-01-01'
 
@@ -1384,7 +1866,7 @@ describe('Field.Date', () => {
         )
       })
 
-      it('should display error messages if start date and end date is outside of limits in `range` mode', async () => {
+      it('should display error messages if start date and end date is outside of `minDate` and `maxDate` in `range` mode', async () => {
         const minDate = '2025-01-01'
         const maxDate = '2025-01-31'
 
@@ -1574,7 +2056,7 @@ describe('Field.Date', () => {
         ).not.toBeInTheDocument()
       })
 
-      it('should validate date limits based on `value` prop in `range` mode', async () => {
+      it('should validate `minDate` and `maxDate` based on `value` prop in `range` mode', async () => {
         const minDate = '2025-01-01'
         const maxDate = '2025-01-31'
 
@@ -1623,294 +2105,6 @@ describe('Field.Date', () => {
           document.querySelector('.dnb-form-status--error')
         ).not.toBeInTheDocument()
       })
-
-      it('should export `dateLimitValidator`', async () => {
-        const myOnBlurValidator = (value: string) => {
-          if (value === '2025-01-01') {
-            return new Error('My custom message')
-          }
-
-          if (value === '2025-01-03') {
-            return [
-              new Error('My custom message 1'),
-              new Error('My custom message 2'),
-            ]
-          }
-        }
-
-        const onBlurValidator = (value: string, { validators }) => {
-          const { dateLimitValidator } = validators
-
-          return [myOnBlurValidator, dateLimitValidator]
-        }
-
-        const minDate = '2025-01-01'
-        const maxDate = '2025-01-31'
-
-        render(
-          <Field.Date
-            value="2025-01-02"
-            minDate={minDate}
-            maxDate={maxDate}
-            onBlurValidator={onBlurValidator}
-          />
-        )
-
-        const [day, month]: Array<HTMLInputElement> = Array.from(
-          document.querySelectorAll('.dnb-date-picker__input')
-        )
-
-        await userEvent.click(day)
-        await userEvent.keyboard('{ArrowDown}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-
-        expect(screen.getByRole('alert')).toHaveTextContent(
-          'My custom message'
-        )
-
-        await userEvent.click(day)
-        await userEvent.keyboard('{ArrowUp>2}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-
-        const [firstMessage, secondMessage] = Array.from(
-          document.querySelectorAll('.dnb-li')
-        )
-
-        expect(firstMessage).toHaveTextContent('My custom message 1')
-        expect(secondMessage).toHaveTextContent('My custom message 2')
-
-        await userEvent.click(month)
-        await userEvent.keyboard('{ArrowUp}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-
-        expect(screen.getByRole('alert')).toHaveTextContent(
-          nb.Date.errorMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.no)
-          )
-        )
-
-        await userEvent.click(month)
-        await userEvent.keyboard('{ArrowDown>2}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-
-        expect(screen.getByRole('alert')).toHaveTextContent(
-          nb.Date.errorMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.no)
-          )
-        )
-
-        await userEvent.click(month)
-        await userEvent.keyboard('{ArrowUp}')
-        await userEvent.click(day)
-        await userEvent.keyboard('{ArrowDown}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).not.toBeInTheDocument()
-      })
-
-      it('should disabled `dateLimitValidator` if `onBlurValidation` is set to `false`', async () => {
-        const minDate = '2025-01-01'
-        const maxDate = '2025-01-31'
-
-        render(
-          <Field.Date
-            value="2025-01-01"
-            minDate={minDate}
-            maxDate={maxDate}
-            onBlurValidator={false}
-          />
-        )
-
-        const [day, month]: Array<HTMLInputElement> = Array.from(
-          document.querySelectorAll('.dnb-date-picker__input')
-        )
-
-        await userEvent.click(day)
-        await userEvent.keyboard('{ArrowDown}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).not.toBeInTheDocument()
-
-        await userEvent.click(month)
-        await userEvent.keyboard('{ArrowUp>2}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).not.toBeInTheDocument()
-      })
-
-      it('should display date limit error messages based on locale', async () => {
-        const minDate = '2025-01-01'
-        const maxDate = '2025-01-31'
-
-        render(
-          <Form.Handler locale="en-GB">
-            <Field.Date
-              value={minDate}
-              minDate={minDate}
-              maxDate={maxDate}
-            />
-          </Form.Handler>
-        )
-
-        const [day, month] = Array.from(
-          document.querySelectorAll('.dnb-date-picker__input')
-        )
-
-        await userEvent.click(day)
-        await userEvent.keyboard('{ArrowDown}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toHaveTextContent(
-          en.Date.errorMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.en)
-          )
-        )
-
-        await userEvent.click(month)
-        await userEvent.keyboard('{ArrowUp>2}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toHaveTextContent(
-          en.Date.errorMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.en)
-          )
-        )
-      })
-
-      it('should display date limit error messages based on locale when in `range` mode', async () => {
-        const minDate = '2025-01-01'
-        const maxDate = '2025-01-31'
-
-        const getMessages = () =>
-          Array.from(
-            document.querySelectorAll('.dnb-form-status .dnb-li')
-          ) as Array<HTMLLIElement>
-
-        render(
-          <Form.Handler locale="en-GB">
-            <Field.Date
-              value={`${minDate}|${maxDate}`}
-              minDate={minDate}
-              maxDate={maxDate}
-              range
-            />
-          </Form.Handler>
-        )
-
-        const [startMonth, endMonth] = Array.from(
-          document.querySelectorAll('.dnb-date-picker__input--month')
-        ) as Array<HTMLInputElement>
-
-        await userEvent.click(startMonth)
-        await userEvent.keyboard('{ArrowDown}')
-        await userEvent.click(endMonth)
-        await userEvent.keyboard('{ArrowUp}')
-        await userEvent.click(document.body)
-
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toBeInTheDocument()
-        expect(
-          document.querySelector('.dnb-form-status--error')
-        ).toHaveTextContent(en.Field.errorSummary)
-
-        expect(getMessages().at(0)).toHaveTextContent(
-          en.Date.errorStartDateMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.en)
-          )
-        )
-        expect(getMessages().at(1)).toHaveTextContent(
-          en.Date.errorEndDateMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.en)
-          )
-        )
-
-        await userEvent.click(startMonth)
-        await userEvent.keyboard('{ArrowUp>2}')
-        await userEvent.click(document.body)
-
-        expect(getMessages().at(0)).toHaveTextContent(
-          en.Date.errorStartDateMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.en)
-          )
-        )
-        expect(getMessages().at(1)).toHaveTextContent(
-          en.Date.errorEndDateMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.en)
-          )
-        )
-
-        await userEvent.click(endMonth)
-        await userEvent.keyboard('{ArrowDown>2}')
-        await userEvent.click(document.body)
-
-        expect(getMessages().at(0)).toHaveTextContent(
-          en.Date.errorStartDateMaxDate.replace(
-            /\{date\}/,
-            formatDate(maxDate, formatOptions.en)
-          )
-        )
-        expect(getMessages().at(1)).toHaveTextContent(
-          en.Date.errorEndDateMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.en)
-          )
-        )
-
-        await userEvent.click(startMonth)
-        await userEvent.keyboard('{ArrowDown>2}')
-        await userEvent.click(document.body)
-
-        expect(getMessages().at(0)).toHaveTextContent(
-          en.Date.errorStartDateMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.en)
-          )
-        )
-        expect(getMessages().at(1)).toHaveTextContent(
-          en.Date.errorEndDateMinDate.replace(
-            /\{date\}/,
-            formatDate(minDate, formatOptions.en)
-          )
-        )
-      })
     })
   })
 
@@ -1938,57 +2132,69 @@ describe('Field.Date', () => {
     })
   })
 
-  it('renders error', () => {
-    render(<Field.Date error={new Error('Error message')} />)
+  describe('error handling', () => {
+    it('renders error', () => {
+      render(<Field.Date error={new Error('Error message')} />)
 
-    const element = document.querySelector('.dnb-form-status')
-    expect(element).toHaveTextContent('Error message')
+      const element = document.querySelector('.dnb-form-status')
+      expect(element).toHaveTextContent('Error message')
 
-    const input = document.querySelector('.dnb-date-picker')
-    expect(input).toHaveClass('dnb-date-picker__status--error')
-  })
+      const input = document.querySelector('.dnb-date-picker')
+      expect(input).toHaveClass('dnb-date-picker__status--error')
+    })
 
-  it('shows error style in FieldBlock', () => {
-    render(
-      <FieldBlock>
-        <Field.Date error={new Error('Error message')} />
-      </FieldBlock>
-    )
+    it('shows error style in FieldBlock', () => {
+      render(
+        <FieldBlock>
+          <Field.Date error={new Error('Error message')} />
+        </FieldBlock>
+      )
 
-    const input = document.querySelector('.dnb-date-picker')
-    expect(input).toHaveClass('dnb-date-picker__status--error')
-  })
+      const input = document.querySelector('.dnb-date-picker')
+      expect(input).toHaveClass('dnb-date-picker__status--error')
+    })
 
-  it('should support keyboard interactions in range mode when id includes start or end', async () => {
-    const onChange = jest.fn()
+    describe('with validateInitially', () => {
+      it('should show error message initially', async () => {
+        render(<Field.Date required validateInitially />)
+        await waitFor(() => {
+          expect(
+            document.querySelector('.dnb-form-status--error')
+          ).toBeInTheDocument()
+        })
+      })
+    })
 
-    render(
-      <Field.Date
-        id="id-end-start-something"
-        value="2025-01-01|2025-01-31"
-        range
-        onChange={onChange}
-      />
-    )
+    describe('with validateUnchanged', () => {
+      it('should show error message when blurring without any changes', async () => {
+        // Because of the invalid date
+        const log = jest.spyOn(console, 'log').mockImplementation()
 
-    const [startMonth, endMonth] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__input--month')
-    ) as Array<HTMLInputElement>
+        render(
+          <Field.Date
+            value="2023-12-0"
+            schema={{ type: 'string', minLength: 10 }}
+            validateUnchanged
+          />
+        )
 
-    await userEvent.type(startMonth, '{ArrowDown}')
-    await userEvent.type(endMonth, '{ArrowUp}')
-    await userEvent.click(document.body)
+        const input = document.querySelector('input')
 
-    expect(onChange).toHaveBeenCalledTimes(2)
-    expect(onChange).toHaveBeenNthCalledWith(
-      1,
-      '2024-12-01|2025-01-31',
-      expect.anything()
-    )
-    expect(onChange).toHaveBeenNthCalledWith(
-      2,
-      '2024-12-01|2025-02-28',
-      expect.anything()
-    )
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+
+        input.focus()
+        fireEvent.blur(input)
+
+        await waitFor(() => {
+          expect(
+            document.querySelector('.dnb-form-status--error')
+          ).toBeInTheDocument()
+        })
+
+        log.mockRestore()
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+import { InvalidDates } from '../../../../../components/date-picker/DatePickerInput'
+
+export default function useInvalidDates() {
+  const invalidDatesRef = useRef<InvalidDates>({})
+
+  function setInvalidDates(invalidDates: InvalidDates) {
+    invalidDatesRef.current = {
+      ...invalidDatesRef.current,
+      ...invalidDates,
+    }
+  }
+
+  return { invalidDatesRef, setInvalidDates }
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
@@ -1,15 +1,15 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { InvalidDates } from '../../../../../components/date-picker/DatePickerInput'
 
 export default function useInvalidDates() {
   const invalidDatesRef = useRef<InvalidDates>({})
 
-  function setInvalidDates(invalidDates: InvalidDates) {
+  const setInvalidDates = useCallback((invalidDates: InvalidDates) => {
     invalidDatesRef.current = {
       ...invalidDatesRef.current,
       ...invalidDates,
     }
-  }
+  }, [])
 
   return { invalidDatesRef, setInvalidDates }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -125,6 +125,9 @@ export default {
       errorStartDateMaxDate: 'Start date cannot be after {date}.',
       errorEndDateMinDate: 'End date cannot be before {date}.',
       errorEndDateMaxDate: 'End date cannot be after {date}.',
+      errorInvalidDate: '{date} is not a valid date.',
+      errorInvalidStartDate: '{date} is not a valid start date.',
+      errorInvalidEndDate: '{date} is not a valid end date.',
     },
     Expiry: {
       label: 'Expiry date',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -125,9 +125,9 @@ export default {
       errorStartDateMaxDate: 'Start date cannot be after {date}.',
       errorEndDateMinDate: 'End date cannot be before {date}.',
       errorEndDateMaxDate: 'End date cannot be after {date}.',
-      errorInvalidDate: '{date} is not a valid date.',
-      errorInvalidStartDate: '{date} is not a valid start date.',
-      errorInvalidEndDate: '{date} is not a valid end date.',
+      errorInvalidDate: 'Invalid date.',
+      errorInvalidStartDate: 'Invalid start date.',
+      errorInvalidEndDate: 'Invalid end date.',
     },
     Expiry: {
       label: 'Expiry date',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -122,9 +122,9 @@ export default {
       errorStartDateMaxDate: 'Startdato kan ikke være etter {date}.',
       errorEndDateMinDate: 'Sluttdato kan ikke være før {date}.',
       errorEndDateMaxDate: 'Sluttdato kan ikke være etter {date}.',
-      errorInvalidDate: '{date} er ikke en gyldig dato.',
-      errorInvalidStartDate: '{date} er ikke en gyldig startdato.',
-      errorInvalidEndDate: '{date} er ikke en gyldig sluttdato.',
+      errorInvalidDate: 'Ugyldig dato.',
+      errorInvalidStartDate: 'Uyldig startdato.',
+      errorInvalidEndDate: 'Ugyldig sluttdato.',
     },
     Expiry: {
       label: 'Utløpsdato',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -122,6 +122,9 @@ export default {
       errorStartDateMaxDate: 'Startdato kan ikke være etter {date}.',
       errorEndDateMinDate: 'Sluttdato kan ikke være før {date}.',
       errorEndDateMaxDate: 'Sluttdato kan ikke være etter {date}.',
+      errorInvalidDate: '{date} er ikke en gyldig dato.',
+      errorInvalidStartDate: '{date} er ikke en gyldig startdato.',
+      errorInvalidEndDate: '{date} er ikke en gyldig sluttdato.',
     },
     Expiry: {
       label: 'Utløpsdato',


### PR DESCRIPTION
We have decided to go for removing the strict input control (will be done in a separate pr), and allow for user to input invalid dates, and extending the `returnObject` to contain the invalid dates, so we can allow for error messaging when an invalid date is given. This is to make the component less confusing for users, and it will remove code complexity on our side. `Field.Date` will be updated to show error messages by default when an invalid date is given, and invalid dates will be corrected to closes valid date, only when `correctInvalidDates` is enabled.

relies on groundwork from https://github.com/dnbexperience/eufemia/pull/4469
also relies on invalid date properties from https://github.com/dnbexperience/eufemia/pull/4637
now also relies on https://github.com/dnbexperience/eufemia/pull/4690

### TODO

- [x] Add date validation to `Field.Date`
- [x] Add translations
- [x] Update exportValidators docs
- [x] Add tests
- [x] Add docs
- [x] Remove hacky value solution fixed by https://github.com/dnbexperience/eufemia/pull/4690#pullrequestreview-2666525133
