### PR TITLE
chore(Field.Option): remove unused code

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Option/Option.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Option/Option.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import classnames from 'classnames'
 import type { FieldProps } from '../../types'
 
 export type Props = FieldProps<number | string> & {
@@ -9,20 +8,6 @@ export type Props = FieldProps<number | string> & {
   style?: React.CSSProperties
 }
 
-export default function Option({
-  className,
-  title,
-  text,
-  children,
-}: Props) {
-  return (
-    <span
-      className={classnames('dnb-forms-field-option', className)}
-      // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-      role="option"
-    >
-      {title ?? children}
-      {text}
-    </span>
-  )
+export default function Option(_props: Props) {
+  return null
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Option/__tests__/Option.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Option/__tests__/Option.test.tsx
@@ -8,9 +8,8 @@ describe('Field.Option', () => {
   const props: Props = {}
 
   it('should render with props', () => {
-    render(<Field.Option {...props} />)
-    const option = document.querySelector('[role="option"]')
-    expect(option).toBeInTheDocument()
+    const { container } = render(<Field.Option {...props} />)
+    expect(container).toBeEmptyDOMElement()
   })
 
   describe('ARIA', () => {


### PR DESCRIPTION
I don't see that the `Field.Option` code is actually used at all 🤔 

It's only the types that's used, as the actual JSX code that `Field.Option` had before this PR would never be ran, it would just be overridden in `Field.Selection` and `Field.ArraySelection`. And as it says in [docs](https://eufemia.dnb.no/uilib/extensions/forms/base-fields/Option/#description): _Field.Option is a pseudo-component that is used by parent components to configure options. It has no use on its own._