### PR TITLE
fix(Dialog): prevent `onClose` event from firing in StrictMode when opening a new dialog

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/event-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/event-table.mdx
@@ -1,5 +1,15 @@
 | Events                                | Description                                                                                                                                                                                                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `onOpen` / `on_open`                  | _(optional)_ This event gets triggered once the modal shows up. Returns the modal id: `{ id }`.                                                                                                                                                                                      |
-| `onClose` / `on_close`                | _(optional)_ this event gets triggered once the modal gets closed. Returns the modal id: `{ id, event, triggeredBy }`.                                                                                                                                                               |
+| `onClose` / `on_close`                | _(optional)_ this event gets triggered once the modal gets closed. Returns the modal id: `{ id, event, triggeredBy }`. More info about the `triggeredBy` down below.                                                                                                                 |
 | `onClosePrevent` / `on_close_prevent` | _(optional)_ this event gets triggered once the user tries to close the modal, but `prevent_close` is set to **true**. Returns a callback `close` you can call to trigger the close mechanism. More details below. Returns the modal id: `{ id, event, close: Method, triggeredBy }` |
+
+## `triggeredBy`
+
+The `triggeredBy` property is given when the `onClose` or the `onClosePrevent` event is triggered. It can contain one of the following values:
+
+- `button`: The close button that triggered the event.
+- `handler`: The `close` handler given by the function (as the content/children).
+- `keyboard`: The escape key that triggered the event.
+- `overlay`: The overlay element that triggered the event.
+- `unmount`: The unmount event that triggered the `openState` prop change.

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -23,6 +23,23 @@ beforeEach(() => {
   window.__modalStack = undefined
 })
 
+const log = global.console.log
+beforeEach(() => {
+  global.console.log = jest.fn((...args) => {
+    if (
+      !String(args[1]).includes(
+        'A Dialog or Drawer needs a h1 as its first element!'
+      )
+    ) {
+      log(...args)
+    }
+  })
+})
+afterEach(() => {
+  global.console.log = log
+  jest.resetAllMocks()
+})
+
 describe('Dialog', () => {
   it('will run bodyScrollLock with disableBodyScroll', () => {
     render(

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -22,6 +22,23 @@ beforeEach(() => {
   window.__modalStack = undefined
 })
 
+const log = global.console.log
+beforeEach(() => {
+  global.console.log = jest.fn((...args) => {
+    if (
+      !String(args[1]).includes(
+        'A Dialog or Drawer needs a h1 as its first element!'
+      )
+    ) {
+      log(...args)
+    }
+  })
+})
+afterEach(() => {
+  global.console.log = log
+  jest.resetAllMocks()
+})
+
 describe('Drawer', () => {
   it('will run bodyScrollLock with disableBodyScroll', () => {
     render(

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -75,6 +75,7 @@ class Modal extends React.PureComponent<
   _tryToOpenTimeout: NodeJS.Timeout
   activeElement: Element
   isInTransition: boolean
+  modalContentCloseRef: React.RefObject<any>
 
   state = {
     hide: false,
@@ -170,6 +171,7 @@ class Modal extends React.PureComponent<
     this._id = props.id || makeUniqueId('modal-')
 
     this._triggerRef = React.createRef()
+    this.modalContentCloseRef = React.createRef()
 
     this._onUnmount = []
   }
@@ -350,8 +352,12 @@ class Modal extends React.PureComponent<
 
   close = (
     event: Event,
-    { ifIsLatest, triggeredBy = null } = { ifIsLatest: true }
+    { ifIsLatest, triggeredBy = 'handler' } = {
+      ifIsLatest: true,
+    }
   ) => {
+    this.modalContentCloseRef.current?.(event, { triggeredBy })
+
     const { prevent_close = false } = this.props
 
     if (isTrue(prevent_close)) {
@@ -448,7 +454,6 @@ class Modal extends React.PureComponent<
       vertical_alignment = 'center',
 
       id, // eslint-disable-line
-      open_state, // eslint-disable-line
       open_delay, // eslint-disable-line
 
       omit_trigger_button = false,
@@ -534,6 +539,7 @@ class Modal extends React.PureComponent<
               close={this.close}
               hide={hide}
               title={rest.title || fallbackTitle}
+              modalContentCloseRef={this.modalContentCloseRef}
             />
           )}
         </>

--- a/packages/dnb-eufemia/src/components/modal/ModalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalRoot.tsx
@@ -22,6 +22,9 @@ export interface ModalRootProps extends ModalContentProps {
    * The content which will appear when triggering the modal/drawer.
    */
   children?: ReactChildType
+
+  /** For internal use only */
+  modalContentCloseRef?: React.RefObject<any>
 }
 
 interface ModalRootState {

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -18,6 +18,18 @@ export type ModalTriggerIconPosition = 'left' | 'right'
 export type ModalContentMinWidth = string | number
 export type ModalContentMaxWidth = string | number
 
+export type TriggeredBy =
+  | 'handler'
+  | 'button'
+  | 'overlay'
+  | 'keyboard'
+  | 'unmount'
+export type CloseHandlerParams = {
+  triggeredBy: TriggeredBy
+  triggeredByEvent?: Event
+}
+export type CloseHandler = (params?: CloseHandlerParams) => void
+
 export interface ModalProps extends ModalRootProps {
   /**
    * The id used internal in the modal/drawer root element. Defaults to `root`, so the element id will be `dnb-modal-root`.
@@ -94,21 +106,21 @@ export interface ModalProps extends ModalRootProps {
     id?: string
     event?: Event
     triggeredBy?: string
-    close?: (...args: any[]) => any
+    close?: CloseHandler
   }) => void
 
   /**
    * Set a function to call the callback function, once the modal/drawer should open: `open_modal={(open) => open()}`
    */
-  open_modal?: (open?: (e: Event) => void, elem?: any) => () => void | void
+  open_modal?: (
+    open?: (e: Event) => void,
+    instance?: any
+  ) => () => void | void
 
   /**
    * Set a function to call the callback function, once the modal/drawer should close: `close_modal={(close) => close()}`
    */
-  close_modal?: (
-    close?: (...args: any[]) => void,
-    elem?: any
-  ) => () => void | void
+  close_modal?: (close?: CloseHandler, instance?: any) => () => void | void
 
   /**
    * Provide a custom trigger component. Like trigger={<Anchor href="/" />}. It will set the focus on it when the modal/drawer gets closed.
@@ -306,6 +318,8 @@ export interface ModalContentProps {
   dialog_role?: 'dialog' | 'alertdialog' | 'region'
   content_ref?: React.RefObject<HTMLElement>
   scroll_ref?: React.RefObject<HTMLElement>
+  open_state?: ModalOpenState
+  modalContentCloseRef?: React.MutableRefObject<any>
 }
 
 export type TriggerAttributes = ButtonProps


### PR DESCRIPTION
- Also add `handler` to `triggeredBy` when the `close` method is called.
- Improve the documentation of the `triggeredBy` property.
- More [info](https://dnb-it.slack.com/archives/CMXABCHEY/p1738574258572699?thread_ts=1738072824.587899&cid=CMXABCHEY) about the approach.
- Thank you Ahmet for the [good reprod](https://codesandbox.io/p/sandbox/connectwithpath-forked-h2wr7p). 🫶

