### PR TITLE
fix(Forms): ensure `transformData` contains `displayValue` from fields inside Iterate

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/Examples.tsx
@@ -408,7 +408,9 @@ export const TransformData = () => {
             const transformedData = transformData(
               data,
               ({ value, displayValue, label }) => {
-                return { value, displayValue, label }
+                if (!Array.isArray(value)) {
+                  return { value, displayValue, label }
+                }
               },
             )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -339,3 +339,35 @@ The callback function receives the following arguments as an object:
 Most of the fields will return the `displayValue` as a string. But there are some exceptions:
 
 - [ArraySelection](/uilib/extensions/forms/base-fields/ArraySelection/) will return the displayed/active options content as an array that contains a string (or React.ReactNode).
+
+##### `displayValue` from fields inside Iterate.Array
+
+When using the `Iterate.Array` component, you may check if the current entry is an array. This way you ensure you never transform the array itself, but only the values from the fields inside the array.
+
+```jsx
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+const MyForm = () => {
+  return (
+    <Form.Handler
+      onSubmit={(data, { transformData }) => {
+        const transformedData = transformData(
+          data,
+          ({ value, displayValue, label }) => {
+            if (!Array.isArray(value)) {
+              return { value, displayValue, label }
+            }
+          },
+        )
+      }}
+    >
+      <Form.Card>
+        <Iterate.Array path="/myArray">
+          <Field.String itemPath="/" label="My label" />
+        </Iterate.Array>
+      </Form.Card>
+      <Form.SubmitButton />
+    </Form.Handler>
+  )
+}
+```


### PR DESCRIPTION
- This is kind of a following up on #4510
- More info [here](https://dnb-it.slack.com/archives/CMXABCHEY/p1738314903619959?thread_ts=1736345187.215229&cid=CMXABCHEY).

**Note:**

When using `transformData` with Iterate.Array, then it is important to exclude the entry from being transformed, because that is probably not what you want. You can do it with a type check or with a `path` !== 'myArray':

<img width="441" alt="Screenshot 2025-02-03 at 13 46 08" src="https://github.com/user-attachments/assets/83e969c8-73f0-4214-8c3c-97ceccdef9be" />
