### PR TITLE
fix(Forms): ensure `setFieldStatus` by useValidation does not throw when used without id

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useValidation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/useValidation.tsx
@@ -75,7 +75,7 @@ function useConnections(id: SharedStateId = undefined) {
     const connections =
       attachments?.fieldConnectionsRef || (!id && fieldConnectionsRef)
 
-    return connections.current
+    return connections?.current
   }, [fieldConnectionsRef, get, id])
 
   return useMemo(() => ({ getFieldConnections }), [getFieldConnections])


### PR DESCRIPTION
More [info](https://dnb-it.slack.com/archives/CMXABCHEY/p1738590820694909).