### PR TITLE
feat(Forms): add `valueDefined` to Form.useVisibility

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -74,6 +74,8 @@ export type Props = {
   pathTrue?: Path
   /** Given data context path must be false to show children */
   pathFalse?: Path
+  /** Given data context path must have a value other than "undefined" to show children */
+  valueDefined?: Path
   /** Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the excepted value in order to show children. The first parameter is the value of the path. */
   visibleWhen?: VisibleWhen
   /** Same as `visibleWhen`, but with inverted logic. */
@@ -117,6 +119,7 @@ function Visibility(props: Props) {
     pathFalse,
     pathValue,
     whenValue,
+    valueDefined,
     visibleWhen,
     visibleWhenNot,
     inferData,
@@ -148,6 +151,7 @@ function Visibility(props: Props) {
     pathTrue,
     pathFalse,
     pathValue,
+    valueDefined,
     whenValue,
     visibleWhen,
     visibleWhenNot,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -42,6 +42,11 @@ export const VisibilityProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  valueDefined: {
+    doc: 'Given data context path must have a value other than "undefined" to show children.',
+    type: 'string',
+    status: 'optional',
+  },
   inferData: {
     doc: 'Will be called to decide by external logic, and show/hide contents based on the return value.',
     type: 'function',

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -630,12 +630,12 @@ describe('useVisibility', () => {
     it('does not render children when target path does not have a value other than "undefined"', () => {
       const { result } = renderHook(useVisibility, {
         wrapper: ({ children }) => (
-          <Provider data={{ isDefined: 'foo' }}>{children}</Provider>
+          <Provider data={{ isUndefined: undefined }}>{children}</Provider>
         ),
       })
       expect(
         result.current.check({
-          valueDefined: '/notDefined',
+          valueDefined: '/isUndefined',
         })
       ).toBe(false)
     })
@@ -877,6 +877,52 @@ describe('useVisibility', () => {
             pathFalsy: '/isTruthy',
           })
         ).toBe(false)
+      })
+    })
+
+    describe('valueDefined', () => {
+      it('renders children when target path is defined', () => {
+        const { result } = renderHook(
+          () =>
+            useVisibility({
+              withinIterate: true,
+              valueDefined: '/isDefined',
+            }),
+          {
+            wrapper: ({ children }) => (
+              <Provider
+                data={{
+                  myList: [{ isDefined: 'foo' }],
+                }}
+              >
+                <Iterate.Array path="/myList">{children}</Iterate.Array>
+              </Provider>
+            ),
+          }
+        )
+        expect(result.current.check()).toBe(true)
+      })
+
+      it('does not render children when target path is not defined', () => {
+        const { result } = renderHook(
+          () =>
+            useVisibility({
+              withinIterate: true,
+              valueDefined: '/isUndefined',
+            }),
+          {
+            wrapper: ({ children }) => (
+              <Provider
+                data={{
+                  myList: [{ isUndefined: undefined }],
+                }}
+              >
+                <Iterate.Array path="/myList">{children}</Iterate.Array>
+              </Provider>
+            ),
+          }
+        )
+        expect(result.current.check()).toBe(false)
       })
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/useVisibility.test.tsx
@@ -611,6 +611,36 @@ describe('useVisibility', () => {
     })
   })
 
+  describe('valueDefined', () => {
+    it('renders children when target path has a value other than "undefined"', () => {
+      const { result } = renderHook(
+        () =>
+          useVisibility({
+            valueDefined: '/isDefined',
+          }),
+        {
+          wrapper: ({ children }) => (
+            <Provider data={{ isDefined: 'foo' }}>{children}</Provider>
+          ),
+        }
+      )
+      expect(result.current.check()).toBe(true)
+    })
+
+    it('does not render children when target path does not have a value other than "undefined"', () => {
+      const { result } = renderHook(useVisibility, {
+        wrapper: ({ children }) => (
+          <Provider data={{ isDefined: 'foo' }}>{children}</Provider>
+        ),
+      })
+      expect(
+        result.current.check({
+          valueDefined: '/notDefined',
+        })
+      ).toBe(false)
+    })
+  })
+
   describe('withinIterate', () => {
     describe('visibility', () => {
       it('renders children when target path is falsy, but visible prop is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -61,9 +61,9 @@ export default function useVisibility(props?: Partial<Props>) {
         originalData
 
       if (valueDefined) {
-        const hasPath = pointer.has(data, valueDefined)
+        const hasPath = pointer.has(data, makeLocalPath(valueDefined))
         if (hasPath) {
-          const value = pointer.get(data, valueDefined)
+          const value = pointer.get(data, makeLocalPath(valueDefined))
           if (value !== undefined) {
             return true
           }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -39,6 +39,7 @@ export default function useVisibility(props?: Partial<Props>) {
         visible,
         visibleWhen,
         visibleWhenNot,
+        valueDefined,
         pathDefined,
         pathUndefined,
         pathTruthy,
@@ -58,6 +59,17 @@ export default function useVisibility(props?: Partial<Props>) {
       const data =
         (filterData && filterDataHandler?.(originalData, filterData)) ||
         originalData
+
+      if (valueDefined) {
+        const hasPath = pointer.has(data, valueDefined)
+        if (hasPath) {
+          const value = pointer.get(data, valueDefined)
+          if (value !== undefined) {
+            return true
+          }
+        }
+        return false
+      }
 
       if (visibleWhen || visibleWhenNot) {
         if (visibleWhenNot) {


### PR DESCRIPTION
Instead of:

```tsx
<Form.Visibility
  visibleWhen={{
    path: '/county',
    hasValue: (value) => value !== undefined,
  }}
  animate
>
```

It could now be written like so:

```tsx
<Form.Visibility
  valueDefined="/county"
  animate
>
```