### PR TITLE
fix(Forms): only execute `transformData` from fields with a path and not Iterate

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/Examples.tsx
@@ -408,9 +408,7 @@ export const TransformData = () => {
             const transformedData = transformData(
               data,
               ({ value, displayValue, label }) => {
-                if (!Array.isArray(value)) {
-                  return { value, displayValue, label }
-                }
+                return { value, displayValue, label }
               },
             )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -275,7 +275,7 @@ The `onSubmit` event returns additional functions you can call:
 
 - `filterData` Filters the given/internal data set.
 - `reduceToVisibleFields` Reduces the given data set to only contain the visible fields (mounted fields).
-- `transformData` Will call the given function for each data path. The returned `value` will replace each data entry. It's up to you to define the shape of the value.
+- `transformData` Will call your given function for each `Field.*` that contains a path (not `Iterate.Array`). It's up to you to define the shape of the value.
 - `resetForm` Deletes `sessionStorage` and browser stored autocomplete data.
 - `clearData` Empties the given/internal data set.
 
@@ -323,9 +323,9 @@ const MyForm = () => {
 
 #### `transformData`
 
-The `transformData` function will call the given function for each data path. The returned `value` will replace each data entry. It's up to you to define the shape of the value.
+The `transformData` handler will call your given function for each `Field.*` that contains a path (not `Iterate.Array`). The returned value will be used instead of the given `value` and returned as a new data object. It's up to you to define the shape of the returned value.
 
-The callback function receives the following arguments as an object:
+The callback function receives the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.
@@ -354,9 +354,7 @@ const MyForm = () => {
         const transformedData = transformData(
           data,
           ({ value, displayValue, label }) => {
-            if (!Array.isArray(value)) {
-              return { value, displayValue, label }
-            }
+            return { value, displayValue, label }
           },
         )
       }}

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -176,7 +176,7 @@ export interface ContextState {
     Array<(showAllErrors: boolean) => void>
   >
   fieldDisplayValueRef?: React.MutableRefObject<
-    Record<Path, React.ReactNode>
+    Record<Path, { type: 'field'; value?: React.ReactNode }>
   >
   fieldInternalsRef?: React.MutableRefObject<FieldInternalsRef>
   valueInternalsRef?: React.MutableRefObject<ValueInternalsRef>

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -4838,7 +4838,7 @@ describe('DataContext.Provider', () => {
     )
   })
 
-  it('should transform data with "transformData"', async () => {
+  it('should transform submit data with "transformData"', async () => {
     let transformedData = undefined
     const onSubmit = jest.fn((data, { transformData }) => {
       transformedData = transformData(
@@ -4897,9 +4897,9 @@ describe('DataContext.Provider', () => {
         displayValue: 'Foo Value',
       },
       arraySelectionField: {
-        displayValue: ['Foo Value'],
-        label: 'ArraySelection label',
         value: ['foo'],
+        label: 'ArraySelection label',
+        displayValue: ['Foo Value'],
       },
     })
 
@@ -4922,9 +4922,9 @@ describe('DataContext.Provider', () => {
         displayValue: 'Bar Value',
       },
       arraySelectionField: {
-        displayValue: ['Foo Value'],
-        label: 'ArraySelection label',
         value: ['foo'],
+        label: 'ArraySelection label',
+        displayValue: ['Foo Value'],
       },
     })
 
@@ -4947,22 +4947,20 @@ describe('DataContext.Provider', () => {
         displayValue: 'Bar Value',
       },
       arraySelectionField: {
-        displayValue: ['Foo Value', 'Bar Value'],
-        label: 'ArraySelection label',
         value: ['foo', 'bar'],
+        label: 'ArraySelection label',
+        displayValue: ['Foo Value', 'Bar Value'],
       },
     })
   })
 
-  it('should transform data with "transformData" from fields inside Iterate', async () => {
+  it('should transform submit data with "transformData" from fields inside Iterate', async () => {
     let transformedData = undefined
     const onSubmit = jest.fn((data, { transformData }) => {
       transformedData = transformData(
         data,
         ({ value, displayValue, label }) => {
-          if (!Array.isArray(value)) {
-            return { value, displayValue, label }
-          }
+          return { value, displayValue, label }
         }
       )
     })
@@ -4976,7 +4974,7 @@ describe('DataContext.Provider', () => {
       >
         <Iterate.Array path="/accounts">
           <Field.String
-            label="Bar label"
+            label="Foo label"
             itemPath="/fooPath"
             defaultValue="foo value"
           />
@@ -4992,7 +4990,7 @@ describe('DataContext.Provider', () => {
         {
           fooPath: {
             displayValue: 'foo value',
-            label: 'Bar label',
+            label: 'Foo label',
             value: 'foo value',
           },
         },
@@ -5010,7 +5008,7 @@ describe('DataContext.Provider', () => {
         {
           fooPath: {
             displayValue: 'bar value',
-            label: 'Bar label',
+            label: 'Foo label',
             value: 'bar value',
           },
         },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import DataContext from '../../../DataContext/Context'
-import { Field, FieldBlock, Form } from '../../..'
+import { Field, FieldBlock, Form, Iterate } from '../../..'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -366,29 +366,19 @@ describe('ArraySelection', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': undefined,
+        '/mySelection': {
+          type: 'field',
+        },
       })
 
       await userEvent.tab()
       await userEvent.keyboard('{Enter}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': ['Foo!'],
-      })
-
-      await userEvent.tab()
-      await userEvent.tab()
-      await userEvent.keyboard('{Enter}')
-
-      expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': ['Foo!', 'Bar!'],
-      })
-
-      await userEvent.tab()
-      await userEvent.keyboard('{Enter}')
-
-      expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': ['Bar!'],
+        '/mySelection': {
+          type: 'field',
+          value: ['Foo!'],
+        },
       })
 
       await userEvent.tab()
@@ -396,7 +386,30 @@ describe('ArraySelection', () => {
       await userEvent.keyboard('{Enter}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': undefined,
+        '/mySelection': {
+          type: 'field',
+          value: ['Foo!', 'Bar!'],
+        },
+      })
+
+      await userEvent.tab()
+      await userEvent.keyboard('{Enter}')
+
+      expect(dataContext.fieldDisplayValueRef.current).toEqual({
+        '/mySelection': {
+          type: 'field',
+          value: ['Bar!'],
+        },
+      })
+
+      await userEvent.tab()
+      await userEvent.tab()
+      await userEvent.keyboard('{Enter}')
+
+      expect(dataContext.fieldDisplayValueRef.current).toEqual({
+        '/mySelection': {
+          type: 'field',
+        },
       })
     })
 
@@ -808,29 +821,19 @@ describe('ArraySelection', () => {
         )
 
         expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': undefined,
+          '/mySelection': {
+            type: 'field',
+          },
         })
 
         await userEvent.tab()
         await userEvent.keyboard('{Enter}')
 
         expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': ['Foo!'],
-        })
-
-        await userEvent.tab()
-        await userEvent.tab()
-        await userEvent.keyboard('{Enter}')
-
-        expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': ['Foo!', 'Bar!'],
-        })
-
-        await userEvent.tab()
-        await userEvent.keyboard('{Enter}')
-
-        expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': ['Bar!'],
+          '/mySelection': {
+            type: 'field',
+            value: ['Foo!'],
+          },
         })
 
         await userEvent.tab()
@@ -838,7 +841,124 @@ describe('ArraySelection', () => {
         await userEvent.keyboard('{Enter}')
 
         expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': undefined,
+          '/mySelection': {
+            type: 'field',
+            value: ['Foo!', 'Bar!'],
+          },
+        })
+
+        await userEvent.tab()
+        await userEvent.keyboard('{Enter}')
+
+        expect(dataContext.fieldDisplayValueRef.current).toEqual({
+          '/mySelection': {
+            type: 'field',
+            value: ['Bar!'],
+          },
+        })
+
+        await userEvent.tab()
+        await userEvent.tab()
+        await userEvent.keyboard('{Enter}')
+
+        expect(dataContext.fieldDisplayValueRef.current).toEqual({
+          '/mySelection': {
+            type: 'field',
+          },
+        })
+      })
+
+      it('should transform submit data with "transformData" when inside Iterate', async () => {
+        let transformedData = undefined
+        const onSubmit = jest.fn((data, { transformData }) => {
+          transformedData = transformData(
+            data,
+            ({ value, displayValue, label }) => {
+              return { value, displayValue, label }
+            }
+          )
+        })
+
+        render(
+          <Form.Handler
+            onSubmit={onSubmit}
+            defaultData={{
+              accounts: [
+                {
+                  arraySelection: ['bar'],
+                },
+              ],
+            }}
+          >
+            <Iterate.Array path="/accounts">
+              <Field.ArraySelection
+                label="Foo and Bar label"
+                variant={testVariant}
+                itemPath="/arraySelection"
+                data={[
+                  {
+                    value: 'foo',
+                    title: 'Foo!',
+                  },
+                  {
+                    value: 'bar',
+                    title: 'Bar!',
+                  },
+                ]}
+              />
+            </Iterate.Array>
+          </Form.Handler>
+        )
+
+        fireEvent.submit(document.querySelector('form'))
+
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(transformedData).toEqual({
+          accounts: [
+            {
+              arraySelection: {
+                displayValue: ['Bar!'],
+                label: 'Foo and Bar label',
+                value: ['bar'],
+              },
+            },
+          ],
+        })
+
+        await userEvent.tab()
+        await userEvent.keyboard('{Enter}')
+
+        fireEvent.submit(document.querySelector('form'))
+
+        expect(onSubmit).toHaveBeenCalledTimes(2)
+        expect(transformedData).toEqual({
+          accounts: [
+            {
+              arraySelection: {
+                displayValue: ['Foo!', 'Bar!'],
+                label: 'Foo and Bar label',
+                value: ['bar', 'foo'],
+              },
+            },
+          ],
+        })
+
+        await userEvent.tab()
+        await userEvent.keyboard('{Enter}')
+
+        fireEvent.submit(document.querySelector('form'))
+
+        expect(onSubmit).toHaveBeenCalledTimes(3)
+        expect(transformedData).toEqual({
+          accounts: [
+            {
+              arraySelection: {
+                displayValue: ['Bar!'],
+                label: 'Foo and Bar label',
+                value: ['bar'],
+              },
+            },
+          ],
         })
       })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -150,14 +150,20 @@ describe('Field.Boolean', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Ja',
+        '/mySelection': {
+          type: 'field',
+          value: 'Ja',
+        },
       })
 
       await userEvent.tab()
       await userEvent.keyboard('{Enter}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Nei',
+        '/mySelection': {
+          type: 'field',
+          value: 'Nei',
+        },
       })
     })
 
@@ -188,16 +194,28 @@ describe('Field.Boolean', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/myArray/0/mySelection': 'Ja',
-        '/myArray/1/mySelection': 'Ja',
+        '/myArray/0/mySelection': {
+          type: 'field',
+          value: 'Ja',
+        },
+        '/myArray/1/mySelection': {
+          type: 'field',
+          value: 'Ja',
+        },
       })
 
       await userEvent.tab()
       await userEvent.keyboard('{Enter}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/myArray/0/mySelection': 'Nei',
-        '/myArray/1/mySelection': 'Ja',
+        '/myArray/0/mySelection': {
+          type: 'field',
+          value: 'Nei',
+        },
+        '/myArray/1/mySelection': {
+          type: 'field',
+          value: 'Ja',
+        },
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -160,19 +160,27 @@ describe('Field.Currency', () => {
     const input = document.querySelector('input')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '123 kr',
+      '/myValue': {
+        type: 'field',
+        value: '123 kr',
+      },
     })
 
     await userEvent.type(input, '4')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '1 234 kr',
+      '/myValue': {
+        type: 'field',
+        value: '1 234 kr',
+      },
     })
 
     await userEvent.type(input, '{Backspace>5}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': undefined,
+      '/myValue': {
+        type: 'field',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -173,7 +173,10 @@ describe('Field.Date', () => {
     )
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '01.10.2023',
+      '/myValue': {
+        type: 'field',
+        value: '01.10.2023',
+      },
     })
 
     fireEvent.focus(day)
@@ -181,7 +184,10 @@ describe('Field.Date', () => {
     await userEvent.type(year, '2024')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '02.11.2024',
+      '/myValue': {
+        type: 'field',
+        value: '02.11.2024',
+      },
     })
   })
 
@@ -205,7 +211,10 @@ describe('Field.Date', () => {
     )
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '10/01/2023',
+      '/myValue': {
+        type: 'field',
+        value: '10/01/2023',
+      },
     })
 
     fireEvent.focus(day)
@@ -213,7 +222,10 @@ describe('Field.Date', () => {
     await userEvent.type(year, '2024')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '11/02/2024',
+      '/myValue': {
+        type: 'field',
+        value: '11/02/2024',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -322,14 +322,20 @@ describe('Field.Expiry', () => {
     )
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '08/35',
+      '/myValue': {
+        type: 'field',
+        value: '08/35',
+      },
     })
 
     await userEvent.tab()
     await userEvent.keyboard('1236')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '12/36',
+      '/myValue': {
+        type: 'field',
+        value: '12/36',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -1235,19 +1235,27 @@ describe('Field.Number', () => {
     const input = document.querySelector('input')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '123',
+      '/myValue': {
+        type: 'field',
+        value: '123',
+      },
     })
 
     await userEvent.type(input, '{Backspace>2}4')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '14',
+      '/myValue': {
+        type: 'field',
+        value: '14',
+      },
     })
 
     await userEvent.type(input, '{Backspace>5}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': undefined,
+      '/myValue': {
+        type: 'field',
+      },
     })
   })
 
@@ -1274,22 +1282,39 @@ describe('Field.Number', () => {
     const input = document.querySelector('input')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': '123',
-      '/myArray/1/myValue': '456',
+      '/myArray/0/myValue': {
+        type: 'field',
+        value: '123',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456',
+      },
     })
 
     await userEvent.type(input, '{Backspace>2}4')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': '14',
-      '/myArray/1/myValue': '456',
+      '/myArray/0/myValue': {
+        type: 'field',
+        value: '14',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456',
+      },
     })
 
     await userEvent.type(input, '{Backspace>5}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': undefined,
-      '/myArray/1/myValue': '456',
+      '/myArray/0/myValue': {
+        type: 'field',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456',
+      },
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -1137,26 +1137,38 @@ describe('Field.PhoneNumber', () => {
     )
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '+47 99 99 ​​ ​​',
+      '/myValue': {
+        type: 'field',
+        value: '+47 99 99 ​​ ​​',
+      },
     })
 
     fireEvent.focus(input)
     await userEvent.type(input, '{ArrowRight>6} 8888')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '+47 99 99 88 88',
+      '/myValue': {
+        type: 'field',
+        value: '+47 99 99 88 88',
+      },
     })
 
     await userEvent.type(input, '{Backspace>12}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': undefined,
+      '/myValue': {
+        type: 'field',
+        value: undefined,
+      },
     })
 
     await userEvent.type(input, '123')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '+47 12 3​ ​​ ​​',
+      '/myValue': {
+        type: 'field',
+        value: '+47 12 3​ ​​ ​​',
+      },
     })
 
     // Open like user would do, but without a delay
@@ -1166,7 +1178,10 @@ describe('Field.PhoneNumber', () => {
     DrawerListProvider['blurDelay'] = 201
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '+45 123​​​​​​​​​',
+      '/myValue': {
+        type: 'field',
+        value: '+45 123​​​​​​​​​',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -633,7 +633,10 @@ describe('Field.SelectCountry', () => {
     )
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/country': 'Norway',
+      '/country': {
+        type: 'field',
+        value: 'Norway',
+      },
     })
 
     // Open like user would do, but without a delay
@@ -644,7 +647,10 @@ describe('Field.SelectCountry', () => {
     DrawerListProvider['blurDelay'] = 201
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/country': 'Denmark',
+      '/country': {
+        type: 'field',
+        value: 'Denmark',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -541,14 +541,20 @@ describe('variants', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Foo!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Foo!',
+        },
       })
 
       await userEvent.tab()
       await userEvent.keyboard('{ArrowDown}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Bar!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Bar!',
+        },
       })
     })
 
@@ -915,7 +921,10 @@ describe('variants', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Foo!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Foo!',
+        },
       })
 
       await userEvent.tab()
@@ -923,7 +932,10 @@ describe('variants', () => {
       await userEvent.click(document.activeElement)
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Bar!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Bar!',
+        },
       })
     })
 
@@ -1326,7 +1338,10 @@ describe('variants', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Foo!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Foo!',
+        },
       })
 
       // Open like user would do, but without a delay
@@ -1338,7 +1353,10 @@ describe('variants', () => {
       DrawerListProvider['blurDelay'] = 201
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Bar!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Bar!',
+        },
       })
     })
 
@@ -1729,7 +1747,10 @@ describe('variants', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Foo!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Foo!',
+        },
       })
 
       // Open like user would do, but without a delay
@@ -1741,7 +1762,10 @@ describe('variants', () => {
       DrawerListProvider['blurDelay'] = 201
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/mySelection': 'Bar!',
+        '/mySelection': {
+          type: 'field',
+          value: 'Bar!',
+        },
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/__tests__/Slider.test.tsx
@@ -108,14 +108,20 @@ describe('Field.Slider', () => {
       )
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/myValue': '400,00 €',
+        '/myValue': {
+          type: 'field',
+          value: '400,00 €',
+        },
       })
 
       await userEvent.keyboard('{Tab>3}')
       await userEvent.type(document.activeElement, '{ArrowRight}')
 
       expect(dataContext.fieldDisplayValueRef.current).toEqual({
-        '/myValue': '401,00 €',
+        '/myValue': {
+          type: 'field',
+          value: '401,00 €',
+        },
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -1444,19 +1444,89 @@ describe('Field.String', () => {
     const input = document.querySelector('input')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '123 kr',
+      '/myValue': {
+        type: 'field',
+        value: '123 kr',
+      },
     })
 
     await userEvent.type(input, '{Backspace>2}4')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': '124 kr',
+      '/myValue': {
+        type: 'field',
+        value: '124 kr',
+      },
     })
 
     await userEvent.type(input, '{Backspace>5}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myValue': undefined,
+      '/myValue': {
+        type: 'field',
+      },
+    })
+  })
+
+  it('should transform submit data with "transformData"', async () => {
+    let transformedData = undefined
+    const onSubmit = jest.fn((data, { transformData }) => {
+      transformedData = transformData(
+        data,
+        ({ value, displayValue, label }) => {
+          return { value, displayValue, label }
+        }
+      )
+    })
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String
+          label="String label"
+          path="/stringField"
+          defaultValue="foo"
+        />
+      </Form.Handler>
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(transformedData).toEqual({
+      stringField: {
+        value: 'foo',
+        label: 'String label',
+        displayValue: 'foo',
+      },
+    })
+
+    await userEvent.type(
+      document.querySelector('input'),
+      '{Backspace>3}bar'
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(2)
+    expect(transformedData).toEqual({
+      stringField: {
+        value: 'bar',
+        label: 'String label',
+        displayValue: 'bar',
+      },
+    })
+
+    await userEvent.type(document.querySelector('input'), '{Backspace>3}')
+
+    fireEvent.submit(document.querySelector('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(3)
+    expect(transformedData).toEqual({
+      stringField: {
+        value: undefined,
+        label: 'String label',
+        displayValue: undefined,
+      },
     })
   })
 
@@ -1487,22 +1557,39 @@ describe('Field.String', () => {
     const input = document.querySelector('input')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': '123 kr',
-      '/myArray/1/myValue': '456 kr',
+      '/myArray/0/myValue': {
+        type: 'field',
+        value: '123 kr',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456 kr',
+      },
     })
 
     await userEvent.type(input, '{Backspace>2}4')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': '124 kr',
-      '/myArray/1/myValue': '456 kr',
+      '/myArray/0/myValue': {
+        type: 'field',
+        value: '124 kr',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456 kr',
+      },
     })
 
     await userEvent.type(input, '{Backspace>5}')
 
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
-      '/myArray/0/myValue': undefined,
-      '/myArray/1/myValue': '456 kr',
+      '/myArray/0/myValue': {
+        type: 'field',
+      },
+      '/myArray/1/myValue': {
+        type: 'field',
+        value: '456 kr',
+      },
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -136,14 +136,20 @@ describe('Field.Toggle', () => {
         )
 
         expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': 'On!',
+          '/mySelection': {
+            type: 'field',
+            value: 'On!',
+          },
         })
 
         await userEvent.tab()
         await userEvent.keyboard('{Enter}')
 
         expect(dataContext.fieldDisplayValueRef.current).toEqual({
-          '/mySelection': 'Off!',
+          '/mySelection': {
+            type: 'field',
+            value: 'Off!',
+          },
         })
       })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1681,15 +1681,19 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
   const setDisplayValue: ReturnAdditional<Value>['setDisplayValue'] =
     useCallback(
-      (content, fieldPath = itemPath ? identifier : path) => {
+      (value, options) => {
+        const {
+          path: fieldPath = itemPath ? identifier : path,
+          type = 'field',
+        } = options || {}
         if (!fieldPath || !fieldDisplayValueRef?.current) {
           return // stop here
         }
 
         fieldDisplayValueRef.current[fieldPath] =
           valueRef.current === (emptyValue as unknown as Value)
-            ? undefined
-            : content
+            ? { type }
+            : { value, type }
       },
       [identifier, emptyValue, fieldDisplayValueRef, itemPath, path]
     )
@@ -2476,7 +2480,10 @@ export interface ReturnAdditional<Value> {
   ) => void
   updateValue: (value: Value) => void
   setChanged: (state: boolean) => void
-  setDisplayValue: (value: React.ReactNode, path?: Identifier) => void
+  setDisplayValue: (
+    value: React.ReactNode,
+    { path, type }?: { path?: Identifier; type?: 'field' }
+  ) => void
   forceUpdate: () => void
   hasError?: boolean
 


### PR DESCRIPTION
More [info](https://dnb-it.slack.com/archives/CMXABCHEY/p1738852150610279?thread_ts=1736345187.215229&cid=CMXABCHEY).
A following up on #4526