### PR TITLE
feat(Forms): provide `{ props }` to the second `onChange`, `onFocus` and `onBlur` event parameter

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -228,6 +228,8 @@ const { error, hasError } = useFieldProps({
 handleChange(value, (additionalArgs = null))
 ```
 
+When `additionalArgs` is provided, it will be passed to the `onChange`, `onFocus` or `onBlur` events as the second argument. It will be merged with the internal `additionalArgs`, which includes `props`, including all of the given properties.
+
 - `updateValue(value)` to update/change the internal value, without calling any events.
 
 - `forceUpdate()` to re-render the React Hook along with the outer component.

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -1699,7 +1699,10 @@ describe('DataContext.Provider', () => {
       })
       await waitFor(() => {
         expect(onChangeField).toHaveBeenCalled()
-        expect(onChangeField).toHaveBeenLastCalledWith('valid')
+        expect(onChangeField).toHaveBeenLastCalledWith(
+          'valid',
+          expect.anything()
+        )
       })
     })
   })
@@ -4238,7 +4241,7 @@ describe('DataContext.Provider', () => {
 
       await waitFor(() => {
         expect(onChange).toHaveBeenCalledTimes(1)
-        expect(onChange).toHaveBeenLastCalledWith(123)
+        expect(onChange).toHaveBeenLastCalledWith(123, expect.anything())
 
         expect(onChangeValidator).toHaveBeenCalledTimes(2)
         expect(onChangeValidator).toHaveBeenLastCalledWith(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -65,13 +65,22 @@ describe('ArraySelection', () => {
       )
 
       fireEvent.click(screen.getByText('Option 1'))
-      expect(handleChange).toHaveBeenLastCalledWith(['option1'])
+      expect(handleChange).toHaveBeenLastCalledWith(
+        ['option1'],
+        expect.anything()
+      )
 
       fireEvent.click(screen.getByText('Option 2'))
-      expect(handleChange).toHaveBeenLastCalledWith(['option1', 'option2'])
+      expect(handleChange).toHaveBeenLastCalledWith(
+        ['option1', 'option2'],
+        expect.anything()
+      )
 
       fireEvent.click(screen.getByText('Option 1'))
-      expect(handleChange).toHaveBeenLastCalledWith(['option2'])
+      expect(handleChange).toHaveBeenLastCalledWith(
+        ['option2'],
+        expect.anything()
+      )
     })
 
     it('handles emptyValue correctly', () => {
@@ -85,7 +94,7 @@ describe('ArraySelection', () => {
 
       fireEvent.click(screen.getByText('Option 1'))
       fireEvent.click(screen.getByText('Option 1'))
-      expect(handleChange).toHaveBeenLastCalledWith([])
+      expect(handleChange).toHaveBeenLastCalledWith([], expect.anything())
     })
 
     it('displays error message when error prop is provided', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -447,7 +447,7 @@ describe('Field.Date', () => {
       screen.getByLabelText('torsdag 31. oktober 2024')
     )
 
-    expect(onChange).toHaveBeenCalledWith('31/10/2024')
+    expect(onChange).toHaveBeenCalledWith('31/10/2024', expect.anything())
     expect(startDay).toHaveValue('31')
     expect(startMonth).toHaveValue('10')
     expect(startYear).toHaveValue('2024')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -101,7 +101,7 @@ describe('Field.Expiry', () => {
     await userEvent.keyboard('1235')
 
     expect(onChange).toHaveBeenCalledTimes(4)
-    expect(onChange).toHaveBeenLastCalledWith('1235')
+    expect(onChange).toHaveBeenLastCalledWith('1235', expect.anything())
   })
 
   it('should have autofill attributes', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Name/__tests__/Name.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Name/__tests__/Name.test.tsx
@@ -129,12 +129,18 @@ describe('Field.Name', () => {
     await userEvent.type(input, ' second')
     expect(input).toHaveValue('First Name Second')
 
-    expect(onChange).toHaveBeenLastCalledWith('First Name Second')
+    expect(onChange).toHaveBeenLastCalledWith(
+      'First Name Second',
+      expect.anything()
+    )
 
     await userEvent.type(input, '-NAME')
     expect(input).toHaveValue('First Name Second-Name')
 
-    expect(onChange).toHaveBeenLastCalledWith('First Name Second-Name')
+    expect(onChange).toHaveBeenLastCalledWith(
+      'First Name Second-Name',
+      expect.anything()
+    )
 
     await userEvent.type(input, '{Backspace>22}')
     expect(input).toHaveValue('')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -149,30 +149,42 @@ describe('Field.PhoneNumber', () => {
     )
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith(undefined, {
-      countryCode: '+47',
-      phoneNumber: undefined,
-    })
+    expect(onFocus).toHaveBeenLastCalledWith(
+      undefined,
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: undefined,
+      })
+    )
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith(undefined, {
-      countryCode: '+47',
-      phoneNumber: undefined,
-    })
+    expect(onBlur).toHaveBeenLastCalledWith(
+      undefined,
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: undefined,
+      })
+    )
 
     await userEvent.type(phoneElement, '99999999')
 
     fireEvent.focus(phoneElement)
-    expect(onFocus).toHaveBeenLastCalledWith('+47 99999999', {
-      countryCode: '+47',
-      phoneNumber: '99999999',
-    })
+    expect(onFocus).toHaveBeenLastCalledWith(
+      '+47 99999999',
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: '99999999',
+      })
+    )
 
     fireEvent.blur(phoneElement)
-    expect(onBlur).toHaveBeenLastCalledWith('+47 99999999', {
-      countryCode: '+47',
-      phoneNumber: '99999999',
-    })
+    expect(onBlur).toHaveBeenLastCalledWith(
+      '+47 99999999',
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: '99999999',
+      })
+    )
   })
 
   it('should have selected correct item', async () => {
@@ -351,10 +363,13 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '99999999')
 
-    expect(onChange).toHaveBeenLastCalledWith('+47 99999999', {
-      countryCode: '+47',
-      phoneNumber: '99999999',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '+47 99999999',
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: '99999999',
+      })
+    )
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('99 99 99 99')
 
@@ -383,19 +398,25 @@ describe('Field.PhoneNumber', () => {
 
     expect(onCountryCodeChange).toHaveBeenCalledTimes(1)
     expect(onCountryCodeChange).toHaveBeenLastCalledWith('+41')
-    expect(onChange).toHaveBeenLastCalledWith('+41 99999999', {
-      countryCode: '+41',
-      phoneNumber: '99999999',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '+41 99999999',
+      expect.objectContaining({
+        countryCode: '+41',
+        phoneNumber: '99999999',
+      })
+    )
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('99999999​​​​')
 
     await userEvent.type(phoneElement, '{Backspace>12}')
 
-    expect(onChange).toHaveBeenLastCalledWith(undefined, {
-      countryCode: '+41',
-      phoneNumber: undefined,
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      undefined,
+      expect.objectContaining({
+        countryCode: '+41',
+        phoneNumber: undefined,
+      })
+    )
   })
 
   it('should return correct value onChange event in data context', async () => {
@@ -443,17 +464,23 @@ describe('Field.PhoneNumber', () => {
 
     fireEvent.change(phoneElement, { target: { value: '1' } })
 
-    expect(onChange).toHaveBeenLastCalledWith('+47 1', {
-      countryCode: '+47',
-      phoneNumber: '1',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '+47 1',
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: '1',
+      })
+    )
 
     fireEvent.change(phoneElement, { target: { value: '' } })
 
-    expect(onChange).toHaveBeenLastCalledWith(undefined, {
-      countryCode: '+47',
-      phoneNumber: undefined,
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      undefined,
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: undefined,
+      })
+    )
     expect(codeElement.value).toEqual('NO (+47)')
     expect(phoneElement.value).toEqual('')
 
@@ -473,10 +500,13 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '456')
 
-    expect(onChange).toHaveBeenLastCalledWith('+41 456', {
-      countryCode: '+41',
-      phoneNumber: '456',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '+41 456',
+      expect.objectContaining({
+        countryCode: '+41',
+        phoneNumber: '456',
+      })
+    )
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('456​​​​​​​​​')
   })
@@ -518,10 +548,13 @@ describe('Field.PhoneNumber', () => {
 
     await userEvent.type(phoneElement, '456')
 
-    expect(onChange).toHaveBeenLastCalledWith('+41 456', {
-      countryCode: '+41',
-      phoneNumber: '456',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '+41 456',
+      expect.objectContaining({
+        countryCode: '+41',
+        phoneNumber: '456',
+      })
+    )
     expect(codeElement.value).toEqual('CH (+41)')
     expect(phoneElement.value).toEqual('456​​​​​​​​​')
   })
@@ -564,14 +597,22 @@ describe('Field.PhoneNumber', () => {
     })
 
     expect(onChange).toHaveBeenCalledTimes(2)
-    expect(onChange).toHaveBeenNthCalledWith(1, '+47 999', {
-      countryCode: '+47',
-      phoneNumber: '999',
-    })
-    expect(onChange).toHaveBeenNthCalledWith(2, '+41 999', {
-      countryCode: '+41',
-      phoneNumber: '999',
-    })
+    expect(onChange).toHaveBeenNthCalledWith(
+      1,
+      '+47 999',
+      expect.objectContaining({
+        countryCode: '+47',
+        phoneNumber: '999',
+      })
+    )
+    expect(onChange).toHaveBeenNthCalledWith(
+      2,
+      '+41 999',
+      expect.objectContaining({
+        countryCode: '+41',
+        phoneNumber: '999',
+      })
+    )
 
     // Because of requestAnimationFrame
     await wait(2)
@@ -857,10 +898,12 @@ describe('Field.PhoneNumber', () => {
     await userEvent.type(numberElement, '123')
 
     expect(numberElement.value).toBe('12 3​ ​​ ​​')
-    expect(onChange).toHaveBeenLastCalledWith('123', {
-      countryCode: undefined,
-      phoneNumber: '123',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '123',
+      expect.objectContaining({
+        phoneNumber: '123',
+      })
+    )
 
     rerender(
       <Field.PhoneNumber
@@ -875,16 +918,24 @@ describe('Field.PhoneNumber', () => {
     await userEvent.type(numberElement, '{Backspace>8}8888')
 
     expect(numberElement.value).toBe('88 88 ​​ ​​')
-    expect(onChange).toHaveBeenLastCalledWith('8888', {
-      phoneNumber: '8888',
-    })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '8888',
+      expect.objectContaining({
+        phoneNumber: '8888',
+      })
+    )
 
     await userEvent.type(numberElement, '{Backspace>6}+4')
 
-    expect(numberElement.value).toBe('88 4​ ​​ ​​')
-    expect(onChange).toHaveBeenLastCalledWith('884', {
-      phoneNumber: '884',
+    await waitFor(() => {
+      expect(numberElement.value).toBe('88 4​ ​​ ​​')
     })
+    expect(onChange).toHaveBeenLastCalledWith(
+      '884',
+      expect.objectContaining({
+        phoneNumber: '884',
+      })
+    )
     expect(
       Object.prototype.hasOwnProperty.call(
         onChange.mock.calls[17][1],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -364,7 +364,7 @@ describe('variants', () => {
       expect(option2.querySelector('input')).toBeChecked()
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      expect(onChange).toHaveBeenLastCalledWith('bar')
+      expect(onChange).toHaveBeenLastCalledWith('bar', expect.anything())
     })
 
     it('should support "dataPath"', () => {
@@ -848,7 +848,7 @@ describe('variants', () => {
       }
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      expect(onChange).toHaveBeenLastCalledWith('bar')
+      expect(onChange).toHaveBeenLastCalledWith('bar', expect.anything())
     })
 
     it('should support "dataPath"', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/__tests__/Slider.test.tsx
@@ -166,7 +166,10 @@ describe('Field.Slider', () => {
       simulateMouseMove({ pageX: 80, width: 100, height: 10 })
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      expect(onChange).toHaveBeenLastCalledWith([40, 80])
+      expect(onChange).toHaveBeenLastCalledWith(
+        [40, 80],
+        expect.anything()
+      )
 
       resetMouseSimulation()
 
@@ -174,7 +177,10 @@ describe('Field.Slider', () => {
       simulateMouseMove({ pageX: 20, width: 100, height: 10 })
 
       expect(onChange).toHaveBeenCalledTimes(2)
-      expect(onChange).toHaveBeenLastCalledWith([20, 40])
+      expect(onChange).toHaveBeenLastCalledWith(
+        [20, 40],
+        expect.anything()
+      )
     })
 
     it('with "paths"', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -227,12 +227,18 @@ describe('Field.String', () => {
       await userEvent.type(input, ' second')
       expect(input).toHaveValue('First Word Second')
 
-      expect(onChange).toHaveBeenLastCalledWith('First Word Second')
+      expect(onChange).toHaveBeenLastCalledWith(
+        'First Word Second',
+        expect.anything()
+      )
 
       await userEvent.type(input, ' WORD')
       expect(input).toHaveValue('First Word Second Word')
 
-      expect(onChange).toHaveBeenLastCalledWith('First Word Second Word')
+      expect(onChange).toHaveBeenLastCalledWith(
+        'First Word Second Word',
+        expect.anything()
+      )
 
       await userEvent.type(input, '{Backspace>22}')
       expect(input).toHaveValue('')
@@ -283,14 +289,20 @@ describe('Field.String', () => {
       expect(transformIn).toHaveBeenCalledTimes(9)
       expect(transformIn).toHaveBeenLastCalledWith('abc')
       expect(transformOut).toHaveBeenCalledTimes(13)
-      expect(transformOut).toHaveBeenLastCalledWith('ABc', undefined)
+      expect(transformOut).toHaveBeenLastCalledWith(
+        'ABc',
+        expect.anything()
+      )
       expect(onChangeProvider).toHaveBeenCalledTimes(6)
       expect(onChangeProvider).toHaveBeenLastCalledWith(
         { myField: 'abc' },
         expect.anything()
       )
       expect(onChangeField).toHaveBeenCalledTimes(6)
-      expect(onChangeField).toHaveBeenLastCalledWith('abc')
+      expect(onChangeField).toHaveBeenLastCalledWith(
+        'abc',
+        expect.anything()
+      )
 
       await userEvent.type(input, '{Backspace>3}EfG')
 
@@ -298,14 +310,20 @@ describe('Field.String', () => {
       expect(transformIn).toHaveBeenCalledTimes(16)
       expect(transformIn).toHaveBeenLastCalledWith('efg')
       expect(transformOut).toHaveBeenCalledTimes(25)
-      expect(transformOut).toHaveBeenLastCalledWith('EFG', undefined)
+      expect(transformOut).toHaveBeenLastCalledWith(
+        'EFG',
+        expect.anything()
+      )
       expect(onChangeProvider).toHaveBeenCalledTimes(12)
       expect(onChangeProvider).toHaveBeenLastCalledWith(
         { myField: 'efg' },
         expect.anything()
       )
       expect(onChangeField).toHaveBeenCalledTimes(12)
-      expect(onChangeField).toHaveBeenLastCalledWith('efg')
+      expect(onChangeField).toHaveBeenLastCalledWith(
+        'efg',
+        expect.anything()
+      )
     })
 
     it('should support "transformIn" and "transformOut"', async () => {
@@ -395,19 +413,31 @@ describe('Field.String', () => {
       expect(valueTransformIn).toHaveBeenCalledTimes(6)
 
       expect(transformOut).toHaveBeenNthCalledWith(1, 'A', undefined)
-      expect(transformOut).toHaveBeenNthCalledWith(2, 'A', undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(
+        2,
+        'A',
+        expect.anything()
+      )
       expect(transformOut).toHaveBeenNthCalledWith(
         3,
         undefined,
         expect.anything()
       )
-      expect(transformOut).toHaveBeenNthCalledWith(4, undefined, undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(
+        4,
+        undefined,
+        expect.anything()
+      )
       expect(transformOut).toHaveBeenNthCalledWith(
         5,
         'B',
         expect.anything()
       )
-      expect(transformOut).toHaveBeenNthCalledWith(6, 'B', undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(
+        6,
+        'B',
+        expect.anything()
+      )
 
       expect(transformIn).toHaveBeenNthCalledWith(1, 'A')
       expect(transformIn).toHaveBeenNthCalledWith(2, 'A')
@@ -474,23 +504,32 @@ describe('Field.String', () => {
 
       await userEvent.type(input, ' second ')
 
-      expect(onChange).toHaveBeenLastCalledWith(' first second ')
+      expect(onChange).toHaveBeenLastCalledWith(
+        ' first second ',
+        expect.anything()
+      )
 
       fireEvent.blur(input)
 
       expect(input).toHaveValue('first second')
-      expect(onBlur).toHaveBeenLastCalledWith('first second')
-      expect(onChange).toHaveBeenLastCalledWith('first second')
+      expect(onBlur).toHaveBeenLastCalledWith(
+        'first second',
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenLastCalledWith(
+        'first second',
+        expect.anything()
+      )
 
       await userEvent.type(input, '{Backspace>12}third')
 
-      expect(onChange).toHaveBeenLastCalledWith('third')
+      expect(onChange).toHaveBeenLastCalledWith('third', expect.anything())
 
       fireEvent.blur(input)
 
       expect(input).toHaveValue('third')
-      expect(onBlur).toHaveBeenLastCalledWith('third')
-      expect(onChange).toHaveBeenLastCalledWith('third')
+      expect(onBlur).toHaveBeenLastCalledWith('third', expect.anything())
+      expect(onChange).toHaveBeenLastCalledWith('third', expect.anything())
     })
 
     it('input is connected to label', () => {
@@ -663,9 +702,21 @@ describe('Field.String', () => {
       const input = document.querySelector('input')
       await userEvent.type(input, 'def')
       expect(onChange).toHaveBeenCalledTimes(3)
-      expect(onChange).toHaveBeenNthCalledWith(1, 'abcd')
-      expect(onChange).toHaveBeenNthCalledWith(2, 'abcde')
-      expect(onChange).toHaveBeenNthCalledWith(3, 'abcdef')
+      expect(onChange).toHaveBeenNthCalledWith(
+        1,
+        'abcd',
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        2,
+        'abcde',
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        3,
+        'abcdef',
+        expect.anything()
+      )
     })
 
     it('calls onFocus with current value', () => {
@@ -676,7 +727,7 @@ describe('Field.String', () => {
         input.focus()
       })
       expect(onFocus).toHaveBeenCalledTimes(1)
-      expect(onFocus).toHaveBeenNthCalledWith(1, 'blah')
+      expect(onFocus).toHaveBeenNthCalledWith(1, 'blah', expect.anything())
     })
 
     it('calls onBlur with current value', async () => {
@@ -687,11 +738,15 @@ describe('Field.String', () => {
       fireEvent.blur(input)
       await wait(0)
       expect(onBlur).toHaveBeenCalledTimes(1)
-      expect(onBlur).toHaveBeenNthCalledWith(1, 'song2')
+      expect(onBlur).toHaveBeenNthCalledWith(1, 'song2', expect.anything())
       await userEvent.type(input, '345')
       fireEvent.blur(input)
       expect(onBlur).toHaveBeenCalledTimes(2)
-      expect(onBlur).toHaveBeenNthCalledWith(2, 'song2345')
+      expect(onBlur).toHaveBeenNthCalledWith(
+        2,
+        'song2345',
+        expect.anything()
+      )
     })
 
     it('should show submit indicator on async onChange', async () => {
@@ -1324,8 +1379,16 @@ describe('Field.String', () => {
       await userEvent.type(input, 'O!')
 
       await waitFor(() => {
-        expect(inputOnChange).toHaveBeenNthCalledWith(1, 'FOOO')
-        expect(inputOnChange).toHaveBeenNthCalledWith(2, 'FOOO!')
+        expect(inputOnChange).toHaveBeenNthCalledWith(
+          1,
+          'FOOO',
+          expect.anything()
+        )
+        expect(inputOnChange).toHaveBeenNthCalledWith(
+          2,
+          'FOOO!',
+          expect.anything()
+        )
 
         expect(dataContextOnChange).toHaveBeenNthCalledWith(
           1,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -103,13 +103,13 @@ describe('Field.Toggle', () => {
 
         expect(element).toHaveAttribute('aria-pressed', 'false')
         expect(onChange).toHaveBeenCalledTimes(1)
-        expect(onChange).toHaveBeenLastCalledWith('off')
+        expect(onChange).toHaveBeenLastCalledWith('off', expect.anything())
 
         fireEvent.click(element)
 
         expect(element).toHaveAttribute('aria-pressed', 'true')
         expect(onChange).toHaveBeenCalledTimes(2)
-        expect(onChange).toHaveBeenLastCalledWith('on')
+        expect(onChange).toHaveBeenLastCalledWith('on', expect.anything())
       })
 
       it('should store "displayValue" in data context', async () => {
@@ -309,14 +309,14 @@ describe('Field.Toggle', () => {
         expect(yesElement).toHaveAttribute('aria-pressed', 'false')
         expect(noElement).toHaveAttribute('aria-pressed', 'true')
         expect(onChange).toHaveBeenCalledTimes(1)
-        expect(onChange).toHaveBeenLastCalledWith('off')
+        expect(onChange).toHaveBeenLastCalledWith('off', expect.anything())
 
         fireEvent.click(yesElement)
 
         expect(yesElement).toHaveAttribute('aria-pressed', 'true')
         expect(noElement).toHaveAttribute('aria-pressed', 'false')
         expect(onChange).toHaveBeenCalledTimes(2)
-        expect(onChange).toHaveBeenLastCalledWith('on')
+        expect(onChange).toHaveBeenLastCalledWith('on', expect.anything())
       })
 
       it('should reset both buttons when value is "undefined"', () => {
@@ -521,13 +521,13 @@ describe('Field.Toggle', () => {
 
         expect(element).toHaveAttribute('data-checked', 'false')
         expect(onChange).toHaveBeenCalledTimes(1)
-        expect(onChange).toHaveBeenLastCalledWith('off')
+        expect(onChange).toHaveBeenLastCalledWith('off', expect.anything())
 
         fireEvent.click(element)
 
         expect(element).toHaveAttribute('data-checked', 'true')
         expect(onChange).toHaveBeenCalledTimes(2)
-        expect(onChange).toHaveBeenLastCalledWith('on')
+        expect(onChange).toHaveBeenLastCalledWith('on', expect.anything())
       })
 
       describe('ARIA', () => {
@@ -687,13 +687,13 @@ describe('Field.Toggle', () => {
 
         expect(element).not.toBeChecked()
         expect(onChange).toHaveBeenCalledTimes(1)
-        expect(onChange).toHaveBeenLastCalledWith('off')
+        expect(onChange).toHaveBeenLastCalledWith('off', expect.anything())
 
         fireEvent.click(element)
 
         expect(element).toBeChecked()
         expect(onChange).toHaveBeenCalledTimes(2)
-        expect(onChange).toHaveBeenLastCalledWith('on')
+        expect(onChange).toHaveBeenLastCalledWith('on', expect.anything())
       })
 
       describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -275,24 +275,27 @@ describe('Field.Upload', () => {
         expect.anything()
       )
       expect(onChangeField).toHaveBeenCalledTimes(1)
-      expect(onChangeField).toHaveBeenLastCalledWith([
-        {
-          file: file1,
-          exists: false,
-          id: expect.anything(),
-          name: 'fileName-1.png',
-        },
-        {
-          errorMessage: nbShared.Upload.errorLargeFile.replace(
-            '%size',
-            '5'
-          ),
-          file: file2,
-          exists: false,
-          id: expect.anything(),
-          name: 'fileName-2.png',
-        },
-      ])
+      expect(onChangeField).toHaveBeenLastCalledWith(
+        [
+          {
+            file: file1,
+            exists: false,
+            id: expect.anything(),
+            name: 'fileName-1.png',
+          },
+          {
+            errorMessage: nbShared.Upload.errorLargeFile.replace(
+              '%size',
+              '5'
+            ),
+            file: file2,
+            exists: false,
+            id: expect.anything(),
+            name: 'fileName-2.png',
+          },
+        ],
+        expect.anything()
+      )
 
       fireEvent.submit(document.querySelector('form'))
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -513,7 +513,7 @@ describe('Form.Section', () => {
       expect(onChange).toHaveBeenCalledTimes(0)
 
       fireEvent.change(last, { target: { value: 'bar' } })
-      expect(onChange).toHaveBeenLastCalledWith('bar')
+      expect(onChange).toHaveBeenLastCalledWith('bar', expect.anything())
     })
 
     it('should overwrite "required"', () => {
@@ -738,7 +738,7 @@ describe('Form.Section', () => {
         expect(onChange).toHaveBeenCalledTimes(0)
 
         fireEvent.change(last, { target: { value: 'bar' } })
-        expect(onChange).toHaveBeenLastCalledWith('bar')
+        expect(onChange).toHaveBeenLastCalledWith('bar', expect.anything())
       })
 
       it('should overwrite "required"', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -36,32 +36,36 @@ describe('Iterate.Array', () => {
       expect(fieldThree).toHaveDisplayValue('threethree')
 
       expect(onChange).toHaveBeenCalledTimes(6)
-      expect(onChange).toHaveBeenNthCalledWith(1, ['one1', 'two', 'three'])
-      expect(onChange).toHaveBeenNthCalledWith(2, [
-        'one1',
-        'two',
-        'threet',
-      ])
-      expect(onChange).toHaveBeenNthCalledWith(3, [
-        'one1',
-        'two',
-        'threeth',
-      ])
-      expect(onChange).toHaveBeenNthCalledWith(4, [
-        'one1',
-        'two',
-        'threethr',
-      ])
-      expect(onChange).toHaveBeenNthCalledWith(5, [
-        'one1',
-        'two',
-        'threethre',
-      ])
-      expect(onChange).toHaveBeenNthCalledWith(6, [
-        'one1',
-        'two',
-        'threethree',
-      ])
+      expect(onChange).toHaveBeenNthCalledWith(
+        1,
+        ['one1', 'two', 'three'],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        2,
+        ['one1', 'two', 'threet'],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        3,
+        ['one1', 'two', 'threeth'],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        4,
+        ['one1', 'two', 'threethr'],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        5,
+        ['one1', 'two', 'threethre'],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        6,
+        ['one1', 'two', 'threethree'],
+        expect.anything()
+      )
     })
 
     it('should support a function callback as the children prop', async () => {
@@ -284,16 +288,24 @@ describe('Iterate.Array', () => {
       expect(object2FieldFoo).toHaveDisplayValue('foo 2c')
 
       expect(onChange).toHaveBeenCalledTimes(2)
-      expect(onChange).toHaveBeenNthCalledWith(1, [
-        { foo: 'foo 0', bar: 'bar 0a' },
-        { foo: 'foo 1', bar: 'bar 1' },
-        { foo: 'foo 2', bar: 'bar 2' },
-      ])
-      expect(onChange).toHaveBeenNthCalledWith(2, [
-        { foo: 'foo 0', bar: 'bar 0a' },
-        { foo: 'foo 1', bar: 'bar 1' },
-        { foo: 'foo 2c', bar: 'bar 2' },
-      ])
+      expect(onChange).toHaveBeenNthCalledWith(
+        1,
+        [
+          { foo: 'foo 0', bar: 'bar 0a' },
+          { foo: 'foo 1', bar: 'bar 1' },
+          { foo: 'foo 2', bar: 'bar 2' },
+        ],
+        expect.anything()
+      )
+      expect(onChange).toHaveBeenNthCalledWith(
+        2,
+        [
+          { foo: 'foo 0', bar: 'bar 0a' },
+          { foo: 'foo 1', bar: 'bar 1' },
+          { foo: 'foo 2c', bar: 'bar 2' },
+        ],
+        expect.anything()
+      )
     })
 
     it('should render array elements defined in the root data context', () => {
@@ -1231,34 +1243,41 @@ describe('Iterate.Array', () => {
 
           expect(iterateOnChange).toHaveBeenCalledTimes(7)
 
-          expect(iterateOnChange).toHaveBeenNthCalledWith(1, [
-            'fool',
-            'bar',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(2, [
-            'fools',
-            'bar',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(3, [
-            'fools',
-            'bar ',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(4, [
-            'fools',
-            'bar c',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(5, [
-            'fools',
-            'bar co',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(6, [
-            'fools',
-            'bar cod',
-          ])
-          expect(iterateOnChange).toHaveBeenNthCalledWith(7, [
-            'fools',
-            'bar code',
-          ])
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            1,
+            ['fool', 'bar'],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            2,
+            ['fools', 'bar'],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            3,
+            ['fools', 'bar '],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            4,
+            ['fools', 'bar c'],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            5,
+            ['fools', 'bar co'],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            6,
+            ['fools', 'bar cod'],
+            expect.anything()
+          )
+          expect(iterateOnChange).toHaveBeenNthCalledWith(
+            7,
+            ['fools', 'bar code'],
+            expect.anything()
+          )
 
           expect(dataContextOnChange).toHaveBeenCalledTimes(8)
           expect(dataContextOnChange).toHaveBeenNthCalledWith(

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueWritePropsDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/DataValueWritePropsDocs.ts
@@ -100,17 +100,17 @@ export const DataValueWritePropsProperties: PropertiesTableProps = {
 
 export const DataValueWritePropsEvents: PropertiesTableProps = {
   onChange: {
-    doc: "Will be called on value changes made by the user, with the new value as argument. When an `async` function is used, the corresponding [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) will show an indicator on the field label. You can return `{ success: 'saved' } as const` to show a success symbol, or an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const`.",
+    doc: "Will be called on value changes made by the user, with the new value as argument. When an `async` function is used, the corresponding [FieldBlock](/uilib/extensions/forms/create-component/FieldBlock/) will show an indicator on the field label. You can return `{ success: 'saved' } as const` to show a success symbol, or an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const`. The second parameter is an object that e.g. contains `props` (all given `Field.*` properties).",
     type: '(value) => void',
     status: 'optional',
   },
   onFocus: {
-    doc: 'Will be called when the component gets into focus. Like clicking inside a text input or opening a dropdown. Called with active value as argument.',
+    doc: 'Will be called when the component gets into focus. Like clicking inside a text input or opening a dropdown. Called with active value as argument. The second parameter is an object that e.g. contains `props` (all given `Field.*` properties).',
     type: '(value) => void',
     status: 'optional',
   },
   onBlur: {
-    doc: 'Will be called when the component stop being in focus. Like when going to next field, or closing a dropdown. Called with active value as argument.',
+    doc: 'Will be called when the component stop being in focus. Like when going to next field, or closing a dropdown. Called with active value as argument. The second parameter is an object that e.g. contains `props` (all given `Field.*` properties).',
     type: '(value) => void',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -43,7 +43,11 @@ describe('useFieldProps', () => {
       handleChange('new-value')
     })
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenNthCalledWith(1, 'new-value')
+    expect(onChange).toHaveBeenNthCalledWith(
+      1,
+      'new-value',
+      expect.anything()
+    )
   })
 
   it('should update data context with initially given "value"', () => {
@@ -814,6 +818,98 @@ describe('useFieldProps', () => {
 
         expect(result.current.error).toBeUndefined()
       })
+    })
+  })
+
+  describe('onBlur', () => {
+    it('should provide "additionalArgs" to onBlur', () => {
+      const onBlur: OnChange<unknown> = jest.fn()
+
+      const { result } = renderHook(useFieldProps, {
+        initialProps: {
+          onBlur,
+          value: '',
+          foo: 'bar',
+        },
+      })
+
+      const { handleChange, handleBlur } = result.current
+
+      expect(onBlur).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange('123')
+        handleBlur()
+      })
+
+      expect(onBlur).toHaveBeenCalledTimes(1)
+      expect(onBlur).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          props: expect.objectContaining({ foo: 'bar' }),
+        })
+      )
+    })
+  })
+
+  describe('onFocus', () => {
+    it('should provide "additionalArgs" to onFocus', () => {
+      const onFocus: OnChange<unknown> = jest.fn()
+
+      const { result } = renderHook(useFieldProps, {
+        initialProps: {
+          onFocus,
+          value: '',
+          foo: 'bar',
+        },
+      })
+
+      const { handleChange, handleFocus } = result.current
+
+      expect(onFocus).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange('123')
+        handleFocus()
+      })
+
+      expect(onFocus).toHaveBeenCalledTimes(1)
+      expect(onFocus).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          props: expect.objectContaining({ foo: 'bar' }),
+        })
+      )
+    })
+  })
+
+  describe('with sync onChange', () => {
+    it('should provide "additionalArgs" to onChange', () => {
+      const onChange: OnChange<unknown> = jest.fn()
+
+      const { result } = renderHook(useFieldProps, {
+        initialProps: {
+          onChange,
+          value: '',
+          foo: 'bar',
+        },
+      })
+
+      const { handleChange } = result.current
+
+      expect(onChange).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange('456')
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(
+        '456',
+        expect.objectContaining({
+          props: expect.objectContaining({ foo: 'bar' }),
+        })
+      )
     })
   })
 
@@ -1748,6 +1844,38 @@ describe('useFieldProps', () => {
         )
       })
     })
+
+    it('should provide "additionalArgs" to onChange', async () => {
+      const onChange: OnChange<unknown> = jest.fn(async () => {
+        return null
+      })
+
+      const { result } = renderHook(useFieldProps, {
+        initialProps: {
+          onChange,
+          value: '',
+          foo: 'bar',
+        },
+      })
+
+      const { handleChange } = result.current
+
+      expect(onChange).toHaveBeenCalledTimes(0)
+
+      act(() => {
+        handleChange('456')
+      })
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledTimes(1)
+      })
+      expect(onChange).toHaveBeenCalledWith(
+        '456',
+        expect.objectContaining({
+          props: expect.objectContaining({ foo: 'bar' }),
+        })
+      )
+    })
   })
 
   describe('htmlAttributes', () => {
@@ -1997,7 +2125,7 @@ describe('useFieldProps', () => {
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(2)
       expect(transformOut).toHaveBeenNthCalledWith(1, 2, expect.anything())
-      expect(transformOut).toHaveBeenNthCalledWith(2, 2, undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(2, 2, expect.anything())
 
       act(() => {
         handleChange(4)
@@ -2007,7 +2135,7 @@ describe('useFieldProps', () => {
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(4)
       expect(transformOut).toHaveBeenNthCalledWith(3, 4, expect.anything())
-      expect(transformOut).toHaveBeenNthCalledWith(4, 4, undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(4, 4, expect.anything())
     })
 
     it('should call "transformOut" initially when path is given', () => {
@@ -2102,7 +2230,7 @@ describe('useFieldProps', () => {
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(2)
       expect(transformOut).toHaveBeenNthCalledWith(1, 3, expect.anything())
-      expect(transformOut).toHaveBeenNthCalledWith(2, 3, undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(2, 3, expect.anything())
 
       act(() => {
         handleChange(4)
@@ -2112,7 +2240,7 @@ describe('useFieldProps', () => {
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(4)
       expect(transformOut).toHaveBeenNthCalledWith(3, 5, expect.anything())
-      expect(transformOut).toHaveBeenNthCalledWith(4, 5, undefined)
+      expect(transformOut).toHaveBeenNthCalledWith(4, 5, expect.anything())
     })
 
     it('should call "fromInput" and "toInput"', () => {
@@ -2187,11 +2315,11 @@ describe('useFieldProps', () => {
       expect(toEvent).toHaveBeenLastCalledWith(2, 'onBlur')
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      expect(onChange).toHaveBeenLastCalledWith(3)
+      expect(onChange).toHaveBeenLastCalledWith(3, expect.anything())
       expect(onFocus).toHaveBeenCalledTimes(1)
-      expect(onFocus).toHaveBeenLastCalledWith(2)
+      expect(onFocus).toHaveBeenLastCalledWith(2, expect.anything())
       expect(onBlur).toHaveBeenCalledTimes(1)
-      expect(onBlur).toHaveBeenLastCalledWith(3)
+      expect(onBlur).toHaveBeenLastCalledWith(3, expect.anything())
 
       act(() => {
         handleFocus()
@@ -2203,11 +2331,11 @@ describe('useFieldProps', () => {
       expect(toEvent).toHaveBeenLastCalledWith(4, 'onBlur')
 
       expect(onChange).toHaveBeenCalledTimes(2)
-      expect(onChange).toHaveBeenLastCalledWith(5)
+      expect(onChange).toHaveBeenLastCalledWith(5, expect.anything())
       expect(onFocus).toHaveBeenCalledTimes(2)
-      expect(onFocus).toHaveBeenLastCalledWith(3)
+      expect(onFocus).toHaveBeenLastCalledWith(3, expect.anything())
       expect(onBlur).toHaveBeenCalledTimes(2)
-      expect(onBlur).toHaveBeenLastCalledWith(5)
+      expect(onBlur).toHaveBeenLastCalledWith(5, expect.anything())
     })
 
     it('should call "fromExternal"', () => {
@@ -2241,9 +2369,9 @@ describe('useFieldProps', () => {
       expect(fromExternal).toHaveBeenLastCalledWith(1)
 
       expect(onFocus).toHaveBeenCalledTimes(1)
-      expect(onFocus).toHaveBeenLastCalledWith(2)
+      expect(onFocus).toHaveBeenLastCalledWith(2, expect.anything())
       expect(onBlur).toHaveBeenCalledTimes(1)
-      expect(onBlur).toHaveBeenLastCalledWith(2)
+      expect(onBlur).toHaveBeenLastCalledWith(2, expect.anything())
 
       act(() => {
         handleFocus()
@@ -2255,9 +2383,9 @@ describe('useFieldProps', () => {
       expect(fromExternal).toHaveBeenLastCalledWith(1)
 
       expect(onFocus).toHaveBeenCalledTimes(2)
-      expect(onFocus).toHaveBeenLastCalledWith(2)
+      expect(onFocus).toHaveBeenLastCalledWith(2, expect.anything())
       expect(onBlur).toHaveBeenCalledTimes(2)
-      expect(onBlur).toHaveBeenLastCalledWith(4)
+      expect(onBlur).toHaveBeenLastCalledWith(4, expect.anything())
 
       expect(onChange).toHaveBeenCalledTimes(1)
     })
@@ -2435,8 +2563,8 @@ describe('useFieldProps', () => {
         updateValue('')
       })
 
-      expect(onFocus).toHaveBeenLastCalledWith('foo')
-      expect(onBlur).toHaveBeenLastCalledWith('foo')
+      expect(onFocus).toHaveBeenLastCalledWith('foo', expect.anything())
+      expect(onBlur).toHaveBeenLastCalledWith('foo', expect.anything())
 
       act(() => {
         handleFocus()
@@ -2444,8 +2572,8 @@ describe('useFieldProps', () => {
         handleBlur()
       })
 
-      expect(onFocus).toHaveBeenLastCalledWith('')
-      expect(onBlur).toHaveBeenLastCalledWith('a')
+      expect(onFocus).toHaveBeenLastCalledWith('', expect.anything())
+      expect(onBlur).toHaveBeenLastCalledWith('a', expect.anything())
 
       expect(onChange).toHaveBeenCalledTimes(0)
       expect(onFocus).toHaveBeenCalledTimes(2)
@@ -2528,8 +2656,8 @@ describe('useFieldProps', () => {
         updateValue('')
       })
 
-      expect(onFocus).toHaveBeenLastCalledWith('foo')
-      expect(onBlur).toHaveBeenLastCalledWith('foo')
+      expect(onFocus).toHaveBeenLastCalledWith('foo', expect.anything())
+      expect(onBlur).toHaveBeenLastCalledWith('foo', expect.anything())
 
       await waitFor(() => {
         expect(result.current.error).toBeInstanceOf(Error)
@@ -2545,8 +2673,8 @@ describe('useFieldProps', () => {
         expect(result.current.error).toBeUndefined()
       })
 
-      expect(onFocus).toHaveBeenLastCalledWith('')
-      expect(onBlur).toHaveBeenLastCalledWith('a')
+      expect(onFocus).toHaveBeenLastCalledWith('', expect.anything())
+      expect(onBlur).toHaveBeenLastCalledWith('a', expect.anything())
 
       expect(onChange).toHaveBeenCalledTimes(0)
       expect(onFocus).toHaveBeenCalledTimes(2)

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -18,11 +18,11 @@ import {
 } from '../utils'
 import {
   FieldPropsGeneric,
-  AdditionalEventArgs,
+  ProvideAdditionalEventArgs,
   SubmitState,
   EventReturnWithStateObjectAndSuccess,
   EventStateObjectWithSuccess,
-  ValidatorAdditionalArgs,
+  ReceiveAdditionalEventArgs,
   Validator,
   Identifier,
   MessageProp,
@@ -149,7 +149,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     transformValue = (value: Value) => value,
     provideAdditionalArgs = (
       value: Value,
-      additionalArgs: AdditionalEventArgs
+      additionalArgs: ProvideAdditionalEventArgs
     ) => additionalArgs,
     fromExternal = (value: Value) => value,
     validateRequired = (value, { emptyValue, required, error }) => {
@@ -750,15 +750,19 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     [getValueByPath, setFieldEventListener]
   )
 
-  const exportValidatorsRef = useRef(exportValidators)
-  exportValidatorsRef.current = exportValidators
+  const additionalArgsRef = useRef({
+    validators: exportValidators,
+    props,
+  })
+  additionalArgsRef.current.validators = exportValidators
+  additionalArgsRef.current.props = props
   const additionalArgs = useMemo(() => {
-    const args: ValidatorAdditionalArgs<Value> = {
+    const args: ReceiveAdditionalEventArgs<Value> = {
       /** Deprecated – can be removed in v11 */
       ...combinedErrorMessages,
 
       errorMessages: combinedErrorMessages,
-      validators: exportValidatorsRef.current,
+      ...additionalArgsRef.current,
       connectWithPath: (path) => {
         return handleConnectWithPath(path)
       },
@@ -1357,7 +1361,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       eventName,
       additionalArgs,
       overrideValue = undefined,
-    }): [Value] | [Value, AdditionalEventArgs] => {
+    }): [Value] | [Value, ProvideAdditionalEventArgs] => {
       const value = transformers.current.toEvent(
         overrideValue ?? valueRef.current,
         eventName
@@ -1384,12 +1388,14 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     async (
       hasFocus: boolean,
       overrideValue?: Value,
-      additionalArgs?: AdditionalEventArgs
+      localAdditionalArgs?: ProvideAdditionalEventArgs
     ) => {
       const args = getEventArgs({
         eventName: hasFocus ? 'onFocus' : 'onBlur',
         overrideValue,
-        additionalArgs,
+        additionalArgs: localAdditionalArgs
+          ? { ...additionalArgs, ...localAdditionalArgs }
+          : additionalArgs,
       })
 
       if (hasFocus) {
@@ -1428,6 +1434,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     },
     [
       getEventArgs,
+      additionalArgs,
       onFocus,
       setMountedFieldStateDataContext,
       identifier,
@@ -1701,7 +1708,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const handleChange = useCallback(
     async (
       argFromInput: Value | unknown,
-      additionalArgs: AdditionalEventArgs = undefined
+      localAdditionalArgs: ProvideAdditionalEventArgs = undefined
     ) => {
       const currentValue = valueRef.current
       const fromInput = transformers.current.fromInput(argFromInput)
@@ -1728,7 +1735,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
           async () => {
             const args = getEventArgs({
               eventName: 'onChange',
-              additionalArgs,
+              additionalArgs: localAdditionalArgs
+                ? { ...additionalArgs, ...localAdditionalArgs }
+                : additionalArgs,
             })
 
             await yieldAsyncProcess({
@@ -1767,7 +1776,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       } else {
         const args = getEventArgs({
           eventName: 'onChange',
-          additionalArgs,
+          additionalArgs: localAdditionalArgs
+            ? { ...additionalArgs, ...localAdditionalArgs }
+            : additionalArgs,
         })
 
         setEventResult(onChange?.apply(this, args))
@@ -1777,6 +1788,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     },
     [
       addToPool,
+      additionalArgs,
       asyncBehaviorIsEnabled,
       defineAsyncProcess,
       getEventArgs,
@@ -2470,13 +2482,13 @@ export interface ReturnAdditional<Value> {
   setHasFocus: (
     hasFocus: boolean,
     overrideValue?: Value,
-    additionalArgs?: AdditionalEventArgs
+    additionalArgs?: ProvideAdditionalEventArgs
   ) => void
   handleFocus: () => void
   handleBlur: () => void
   handleChange: (
     value: Value | unknown,
-    additionalArgs?: AdditionalEventArgs
+    additionalArgs?: ProvideAdditionalEventArgs
   ) => void
   updateValue: (value: Value) => void
   setChanged: (state: boolean) => void


### PR DESCRIPTION
With this change, these evens can receive the given field properties as `{ props }`. This is needed in an upcoming PR in relation to #4344.