### PR TITLE
fix(DatePicker): compare `date` and `maxDate` at same time of day so `is_valid_end_date` is `true` when `date` and `maxDate` are the same date

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
@@ -193,10 +193,11 @@ function isWithinSelectionCalc(
 
 // date is before minDate or after maxDate
 function isDisabledCalc(date: Date, minDate: Date, maxDate: Date) {
-  // isBefore and isAfter return false if comparison date is undefined, which is useful here in case minDate and maxDate aren't supplied
+  // isBefore and isAfter return false if comparison date is undefined, which is useful here in case minDate and maxDate aren't provided
+
   return (
-    (minDate && isBefore(date, startOfDay(minDate))) ||
-    (maxDate && isAfter(date, startOfDay(maxDate)))
+    (minDate && isBefore(startOfDay(date), startOfDay(minDate))) ||
+    (maxDate && isAfter(startOfDay(date), startOfDay(maxDate)))
   )
 }
 export { isDisabledCalc as isDisabled }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2475,6 +2475,90 @@ describe('DatePicker calc', () => {
     })
   })
 
+  describe('isDisabledCalc', () => {
+    it('should correctly determine `date` is before `minDate`', async () => {
+      const date = new Date('2025-02-12')
+      const onChange = jest.fn()
+
+      render(
+        <DatePicker
+          date={date}
+          minDate={date}
+          onChange={onChange}
+          shortcuts={[
+            {
+              title: 'Correct',
+              start_date: new Date('2025-02-12'),
+              end_date: new Date('2025-02-28'),
+            },
+            {
+              title: 'Wrong',
+              start_date: new Date('2025-02-11'),
+              end_date: new Date('2025-02-28'),
+            },
+          ]}
+          range
+        />
+      )
+
+      await userEvent.click(screen.getByLabelText('åpne datovelger'))
+      await userEvent.click(screen.getByText('Correct'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ is_valid_start_date: true })
+      )
+
+      await userEvent.click(screen.getByText('Wrong'))
+
+      expect(onChange).toHaveBeenCalledTimes(2)
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ is_valid_start_date: false })
+      )
+    })
+
+    it('should correctly determine `date` is after `maxDate`', async () => {
+      const date = new Date('2025-02-12')
+      const onChange = jest.fn()
+
+      render(
+        <DatePicker
+          date={date}
+          maxDate={date}
+          onChange={onChange}
+          shortcuts={[
+            {
+              title: 'Correct',
+              start_date: new Date('2025-02-01'),
+              end_date: new Date('2025-02-12'),
+            },
+            {
+              title: 'Wrong',
+              start_date: new Date('2025-02-01'),
+              end_date: new Date('2025-02-13'),
+            },
+          ]}
+          range
+        />
+      )
+
+      await userEvent.click(screen.getByLabelText('åpne datovelger'))
+      await userEvent.click(screen.getByText('Correct'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ is_valid_end_date: true })
+      )
+
+      await userEvent.click(screen.getByText('Wrong'))
+
+      expect(onChange).toHaveBeenCalledTimes(2)
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ is_valid_end_date: false })
+      )
+    })
+  })
+
   it('should support spacing props', () => {
     render(<DatePicker top="2rem" showInput />)
 


### PR DESCRIPTION
Fixes [this bug](https://dnb-it.slack.com/archives/CMXABCHEY/p1738399061145199)