### PR TITLE
chore: postcode -> postal code

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'PostalCodeAndCity'
-description: '`Field.PostalCodeAndCity` is a wrapper component for input of two separate values with user experience tailored for postcode and city values.'
+description: '`Field.PostalCodeAndCity` is a wrapper component for input of two separate values with user experience tailored for postal code and city values.'
 showTabs: true
 theme: 'sbanken'
 tabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -197,7 +197,7 @@ export const NonNorwegianPostalCode = () => {
           },
           'en-GB': {
             'PostalCode.errorPattern':
-              'This is not a valid postcode (five-digits).',
+              'This is not a valid postal code (five-digits).',
           },
         }}
       >

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/info.mdx
@@ -4,10 +4,10 @@ showTabs: true
 
 ## Description
 
-`Field.PostalCodeAndCity` is a wrapper component for input of two separate [input of strings](/uilib/extensions/forms/base-fields/String) with user experience tailored for postcode and city values.
+`Field.PostalCodeAndCity` is a wrapper component for input of two separate [input of strings](/uilib/extensions/forms/base-fields/String) with user experience tailored for postal code and city values.
 
-These fields is meant for Norwegian postcodes and cities. The postcode input takes a 4-digit string as values, since it's meant for Norwegian postcodes. A Norwegian postcode can have a leading zero, which is why the value is a string and not a number.
-More info about postcodes can be found at [Posten](https://www.bring.no/tjenester/adressetjenester/postnummer).
+These fields is meant for Norwegian postal codes and cities. The postal code input takes a 4-digit string as values, since it's meant for Norwegian postal codes. A Norwegian postal code can have a leading zero, which is why the value is a string and not a number.
+More info about postal codes can be found at [Posten](https://www.bring.no/tjenester/adressetjenester/postnummer).
 
 ```jsx
 import { Field } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -12,7 +12,7 @@ export const PostalCodeAndCityProperties: PropertiesTableProps = {
     status: 'optional',
   },
   postalCode: {
-    doc: 'Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postcode.',
+    doc: 'Properties for the [Field.String](/uilib/extensions/forms/base-fields/String/) component for postal code.',
     type: 'object',
     status: 'required',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/PostalCodeAndCity/PostalCodeAndCityDocs.ts
@@ -2,7 +2,7 @@ import { PropertiesTableProps } from '../../../../shared/types'
 
 export const PostalCodeAndCityProperties: PropertiesTableProps = {
   postalCode: {
-    doc: 'Properties such as `value` and `path` for the [Value.String](/uilib/extensions/forms/Value/String) component for postcode.',
+    doc: 'Properties such as `value` and `path` for the [Value.String](/uilib/extensions/forms/Value/String) component for postal code.',
     type: 'object',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -167,12 +167,12 @@ export default {
         'You have not entered a mobile number. You can still use this number if it is correct.',
     },
     PostalCodeAndCity: {
-      label: 'Postcode and city',
+      label: 'Postal code and city',
     },
     PostalCode: {
       label: 'Postc.',
-      errorRequired: 'You must enter a postcode.',
-      errorPattern: 'This is not a valid postcode (four-digits).',
+      errorRequired: 'You must enter a postal code.',
+      errorPattern: 'This is not a valid postal code (four-digits).',
     },
     City: {
       label: 'City',


### PR DESCRIPTION
Motivation is just to continue using postal code instead of postcode.
We already have most occurrences of postal code, hence continuing that trend...