### PR TITLE
fix(Forms): reveal error only when onChangeValidator is actually the initiator

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -980,8 +980,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         ) {
           // Because we first need to throw the error to be able to display it, we delay the showError call
           window.requestAnimationFrame(() => {
-            revealError()
-            forceUpdate()
+            if (localErrorInitiatorRef.current === 'onChangeValidator') {
+              revealError()
+              forceUpdate()
+            }
           })
         }
       }


### PR DESCRIPTION
And not when schema / pattern is the initiator, but has a `onChangeValidator` that did not throw.

