### PR TITLE
feat(Field.Expiry): add month and year validation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -45,7 +45,7 @@ function Expiry(props: ExpiryProps) {
   const preparedProps: ExpiryProps = {
     ...props,
     errorMessages,
-    fromInput: toExpiryString,
+    fromInput: (value: ExpiryValue) => Object.values(value).join(''),
     validateRequired,
   }
 
@@ -69,7 +69,7 @@ function Expiry(props: ExpiryProps) {
 
   const expiry: ExpiryValue = useMemo(() => {
     return {
-      month: value?.substring(0, 2),
+      month: value?.substring(0, 2) ?? '',
       year: value?.substring(2, 4) ?? '',
     }
   }, [value])
@@ -135,7 +135,3 @@ function Expiry(props: ExpiryProps) {
 
 Expiry._supportsEufemiaSpacingProps = true
 export default Expiry
-
-function toExpiryString(values: ExpiryValue) {
-  return Object.values(values).join('')
-}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -79,7 +79,7 @@ function Expiry(props: ExpiryProps) {
 
   const valueProp = useMemo(() => {
     const { month, year } = stringToExpiryValue(
-      props.defaultValue ?? props.value
+      props.value ?? props.defaultValue
     )
     const monthString = expiryValueToString(month, placeholders.month)
     const yearString = expiryValueToString(year, placeholders.year)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -69,7 +69,7 @@ function Expiry(props: ExpiryProps) {
 
   const expiry: ExpiryValue = useMemo(() => {
     return {
-      month: ensureValidMonth(value?.substring(0, 2)),
+      month: value?.substring(0, 2),
       year: value?.substring(2, 4) ?? '',
     }
   }, [value])
@@ -114,7 +114,7 @@ function Expiry(props: ExpiryProps) {
           {
             id: 'month',
             label: monthLabel,
-            mask: getMonthMask(expiry?.month),
+            mask: [/[0-9]/, /[0-9]/],
             placeholderCharacter: placeholders['month'],
             autoComplete: 'cc-exp-month',
             ...htmlAttributes,
@@ -138,41 +138,4 @@ export default Expiry
 
 function toExpiryString(values: ExpiryValue) {
   return Object.values(values).join('')
-}
-
-function ensureValidMonth(month: string) {
-  // Return empty value if no month is given
-  if (!month) {
-    return ''
-  }
-
-  const [firstMask, secondMask] = getMonthMask(month)
-
-  const firstDigit = month?.charAt(0)
-  const isFirstDigitValid = firstMask.test(firstDigit)
-
-  if (firstDigit && !isFirstDigitValid) {
-    // Return empty value if the first digit is invalid
-    return ''
-  }
-
-  const secondDigit = month?.charAt(1)
-  const isSecondDigitValid = secondMask.test(secondDigit)
-
-  if (secondDigit && !isSecondDigitValid) {
-    // Return empty value if the second digit is invalid
-    return ''
-  }
-
-  // Return given month of month value is valid
-  return month
-}
-
-function getMonthMask(month: string) {
-  const firstDigit = month?.charAt(0)
-
-  return [
-    /[0-1]/,
-    firstDigit === '0' || firstDigit === '' ? /[1-9]/ : /[0-2]/,
-  ]
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { act, render } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DataContext, Field, FieldBlock, Form } from '../../..'
+
+import nbNO from '../../../constants/locales/nb-NO'
+import enGB from '../../../constants/locales/en-GB'
+import FormHandler from '../../../Form/Handler/Handler'
+
+const no = nbNO['nb-NO'].Expiry
+const en = enGB['en-GB'].Expiry
 
 describe('Field.Expiry', () => {
   beforeEach(() => {
@@ -43,48 +50,6 @@ describe('Field.Expiry', () => {
 
     expect(monthInput.value).toBe('mm')
     expect(yearInput.value).toBe('åå')
-  })
-
-  describe('should handle non existing values for month', () => {
-    it('when month is 90', () => {
-      render(<Field.Expiry value="9022" />)
-
-      const monthInput = document.querySelectorAll('input')[0]
-      const yearInput = document.querySelectorAll('input')[1]
-
-      expect(monthInput.value).toBe('mm')
-      expect(yearInput.value).toBe('22')
-    })
-
-    it('when month is 23', () => {
-      render(<Field.Expiry value="2335" />)
-
-      const monthInput = document.querySelectorAll('input')[0]
-      const yearInput = document.querySelectorAll('input')[1]
-
-      expect(monthInput.value).toBe('mm')
-      expect(yearInput.value).toBe('35')
-    })
-
-    it('when month is 13', () => {
-      render(<Field.Expiry value="1312" />)
-
-      const monthInput = document.querySelectorAll('input')[0]
-      const yearInput = document.querySelectorAll('input')[1]
-
-      expect(monthInput.value).toBe('mm')
-      expect(yearInput.value).toBe('12')
-    })
-
-    it('when month is 00', () => {
-      render(<Field.Expiry value="0000" />)
-
-      const monthInput = document.querySelectorAll('input')[0]
-      const yearInput = document.querySelectorAll('input')[1]
-
-      expect(monthInput.value).toBe('mm')
-      expect(yearInput.value).toBe('00')
-    })
   })
 
   it('should return month and year values as a concatenated string', async () => {
@@ -285,9 +250,10 @@ describe('Field.Expiry', () => {
       expect(
         document.querySelector('.dnb-form-status__text')
       ).not.toBeInTheDocument()
-
+      console.log('input.value', input.value)
       await userEvent.keyboard('{Backspace}')
       await userEvent.click(document.body)
+      console.log('input.value', input.value)
 
       const formStatusText = document.querySelector(
         '.dnb-form-status__text'
@@ -303,6 +269,138 @@ describe('Field.Expiry', () => {
         'dnb-input__status--error'
       )
       expect(formStatusText).not.toBeInTheDocument()
+    })
+
+    it('should validate month and year', async () => {
+      render(<Field.Expiry value="324" />)
+
+      const [firstMessage, secondMessage] = Array.from(
+        document.querySelectorAll('.dnb-li')
+      )
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(firstMessage).toHaveTextContent(
+        no.errorMonth.replace(/\{month\}/g, '32')
+      )
+
+      expect(secondMessage).toHaveTextContent(
+        no.errorYear.replace(/\{year\}/g, '4å')
+      )
+
+      await userEvent.click(document.querySelector('input'))
+      await userEvent.keyboard('0125')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should validate month', async () => {
+      render(<Field.Expiry />)
+
+      const monthInput = document.querySelector('input')
+
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('1325')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        no.errorMonth.replace(/\{month\}/, '13')
+      )
+
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('99')
+      await userEvent.click(document.body)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        no.errorMonth.replace(/\{month\}/, '99')
+      )
+
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('0025')
+      await userEvent.click(document.body)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        no.errorMonth.replace(/\{month\}/, '00')
+      )
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('1')
+      await userEvent.click(document.body)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        no.errorMonth.replace(/\{month\}/, '1m')
+      )
+
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('09')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should validate year', async () => {
+      render(<Field.Expiry />)
+
+      const [monthInput, yearInput] = Array.from(
+        document.querySelectorAll('input')
+      )
+
+      await userEvent.click(monthInput)
+      await userEvent.keyboard('092')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        no.errorYear.replace(/\{year\}/, '2å')
+      )
+
+      await userEvent.click(yearInput)
+      await userEvent.keyboard('25')
+      await userEvent.click(document.body)
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display month and year messages based on locale', async () => {
+      render(
+        <FormHandler locale="en-GB">
+          <Field.Expiry value="324" />
+        </FormHandler>
+      )
+
+      const [firstMessage, secondMessage] = Array.from(
+        document.querySelectorAll('.dnb-li')
+      )
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+
+      expect(firstMessage).toHaveTextContent(
+        en.errorMonth.replace(/\{month\}/g, '32')
+      )
+
+      expect(secondMessage).toHaveTextContent(
+        en.errorYear.replace(/\{year\}/g, '4y')
+      )
+
+      await userEvent.click(document.querySelector('input'))
+      await userEvent.keyboard('0125')
+
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -121,6 +121,8 @@ export default {
     },
     Expiry: {
       label: 'Expiry date',
+      errorMonth: '{month} is not a valid month.',
+      errorYear: '{year} is not a valid year.',
     },
     Email: {
       label: 'Email address',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -118,6 +118,8 @@ export default {
     },
     Expiry: {
       label: 'Utløpsdato',
+      errorMonth: '{month} er ikke en gyldig måned.',
+      errorYear: '{year} er ikke et gyldig år.',
     },
     Email: {
       label: 'E-postadresse',


### PR DESCRIPTION
This PR removes the the strict input control behaviour from the month field, and adds validation and built in error messaging, to make the component be in line with the [new](https://github.com/dnbexperience/eufemia/pull/4508) `Field.Date` behaviour.

### TODO

- [x] Remove input control from month field
- [x] Add month and year validation
- [x] Add error messages for month and year validation
- [x] Update tests 
