### PR TITLE
fix(DatePicker): portal will properly unmount when 'onShow' and 'onHide' callbacks are used to set a state

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -645,13 +645,13 @@ function DatePicker(externalProps: DatePickerAllProps) {
       setOpened(false)
 
       // Double check and compare return
-      onHide?.({
-        ...getReturnObject.current(args),
-      })
 
       hideTimeout.current = setTimeout(
         () => {
           setHidden(true)
+          onHide?.({
+            ...getReturnObject.current(args),
+          })
           if (args?.['focusOnHide']) {
             try {
               submitButtonRef.current.focus({

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -644,8 +644,6 @@ function DatePicker(externalProps: DatePickerAllProps) {
 
       setOpened(false)
 
-      // Double check and compare return
-
       hideTimeout.current = setTimeout(
         () => {
           setHidden(true)

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2793,6 +2793,47 @@ describe('DatePickerPortal', () => {
       document.body.querySelector('.dnb-date-picker__portal')
     ).not.toBeInTheDocument()
   })
+
+  it('should unmount portal when `onShow` and `onHide` callbacks are setting a state', async () => {
+    const onHide = jest.fn()
+    const onShow = jest.fn()
+
+    const DatePickerComponent = () => {
+      const [, setShow] = React.useState(false)
+
+      return (
+        <DatePicker
+          date="2025-02-19"
+          onShow={() => {
+            onShow()
+            setShow(true)
+          }}
+          onHide={() => {
+            onHide()
+            setShow(false)
+          }}
+        />
+      )
+    }
+
+    render(<DatePickerComponent />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+    expect(onShow).toHaveBeenCalledTimes(1)
+    expect(onHide).toHaveBeenCalledTimes(0)
+    expect(
+      document.querySelector('.dnb-date-picker__portal')
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText('fredag 14. februar 2025'))
+    await waitFor(() =>
+      expect(
+        document.querySelector('.dnb-date-picker__portal')
+      ).not.toBeInTheDocument()
+    )
+    expect(onShow).toHaveBeenCalledTimes(1)
+    expect(onHide).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('DatePicker ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -934,6 +934,11 @@ describe('Field.Date', () => {
 
     await userEvent.click(screen.getByLabelText('åpne datovelger'))
     await userEvent.click(screen.getByLabelText('åpne datovelger'))
+    await waitFor(() =>
+      expect(
+        document.querySelector('.dnb-date-picker__portal')
+      ).not.toBeInTheDocument()
+    )
 
     expect(onHide).toHaveBeenCalledTimes(1)
     expect(onHide).toHaveBeenLastCalledWith(


### PR DESCRIPTION
Fixes this [issue](https://dnb-it.slack.com/archives/CMXABCHEY/p1739954634005029?thread_ts=1738679460.852019&cid=CMXABCHEY)