### PR TITLE
fix(DatePicker): `opened` prop listener `useEffect` no longer removes on outside click detector

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -736,12 +736,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     if (openedProp) {
       showPicker()
     }
-
-    return () => {
-      clearTimeout(hideTimeout.current)
-      removeOutsideClickHandler()
-    }
-  }, [openedProp, removeOutsideClickHandler, showPicker])
+  }, [openedProp, showPicker])
 
   const onPickerChange = useCallback(
     ({

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -115,6 +115,58 @@ describe('DatePicker component', () => {
     ).not.toContain('dnb-date-picker--opened')
   })
 
+  it.only('will close the picker on click outside when when `onShow` callback set a state', async () => {
+    const onShow = jest.fn()
+
+    const Component = () => {
+      const [opened, setOpened] = useState(true)
+      return (
+        <DatePicker
+          date="2025-02-21"
+          showInput
+          showSubmitButton
+          onShow={() => {
+            onShow()
+            setOpened(!opened)
+          }}
+        />
+      )
+    }
+
+    render(<Component />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+    expect(onShow).toHaveBeenCalledTimes(1)
+
+    expect(
+      document
+        .querySelector('button.dnb-input__submit-button__button')
+
+        .getAttribute('aria-expanded')
+    ).toBe('true')
+
+    expect(
+      document
+        .querySelector('.dnb-date-picker')
+
+        .getAttribute('class')
+    ).toContain('dnb-date-picker--opened')
+
+    await userEvent.click(screen.getByLabelText('lørdag 22. februar 2025'))
+    await userEvent.click(document.body)
+    expect(onShow).toHaveBeenCalledTimes(1)
+
+    expect(
+      document
+        .querySelector('button.dnb-input__submit-button__button')
+        .getAttribute('aria-expanded')
+    ).toBe('false')
+
+    expect(
+      document.querySelector('.dnb-date-picker').getAttribute('class')
+    ).not.toContain('dnb-date-picker--opened')
+  })
+
   it('will close the picker after selection', () => {
     const onChange = jest.fn()
     const { rerender } = render(

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -111,7 +111,7 @@ describe('DatePicker component', () => {
     ).not.toContain('dnb-date-picker--opened')
   })
 
-  it('will close the picker on click outside when when `onShow` callback set a state', async () => {
+  it('will close the picker on click outside when `onShow` callback sets a state', async () => {
     const onShow = jest.fn()
 
     const Component = () => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -142,9 +142,7 @@ describe('DatePicker component', () => {
     ).toBe('true')
 
     expect(
-      document
-        .querySelector('.dnb-date-picker')
-        .getAttribute('class')
+      document.querySelector('.dnb-date-picker').getAttribute('class')
     ).toContain('dnb-date-picker--opened')
 
     await userEvent.click(screen.getByLabelText('lørdag 22. februar 2025'))

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -148,7 +148,6 @@ describe('DatePicker component', () => {
     expect(
       document
         .querySelector('.dnb-date-picker')
-
         .getAttribute('class')
     ).toContain('dnb-date-picker--opened')
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -91,15 +91,11 @@ describe('DatePicker component', () => {
     expect(
       document
         .querySelector('button.dnb-input__submit-button__button')
-
         .getAttribute('aria-expanded')
     ).toBe('true')
 
     expect(
-      document
-        .querySelector('.dnb-date-picker')
-
-        .getAttribute('class')
+      document.querySelector('.dnb-date-picker').getAttribute('class')
     ).toContain('dnb-date-picker--opened')
 
     await userEvent.click(document.body)

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -115,7 +115,7 @@ describe('DatePicker component', () => {
     ).not.toContain('dnb-date-picker--opened')
   })
 
-  it.only('will close the picker on click outside when when `onShow` callback set a state', async () => {
+  it('will close the picker on click outside when when `onShow` callback set a state', async () => {
     const onShow = jest.fn()
 
     const Component = () => {


### PR DESCRIPTION
Fixes this [issue](https://dnb-it.slack.com/archives/CMXABCHEY/p1740128157820069).

Removes redundant `removeOutsideClickHandler` from `useEffect` since `hidePicker`already handles that.