### PR TITLE
chore(DatePicker): fix failing tests

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -477,7 +477,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
         const isInRange = target
           .getAttribute('id')
-          .match(/-([start|end]+)-/)[1]
+          .match(/-(start|end)-/)[1]
 
         let date = isInRange === 'start' ? startDate : endDate
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -473,11 +473,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       try {
         const isDate = target
           .getAttribute('class')
-          .match(/__input--([day|month|year]+)($|\s)/)[1]
+          .match(/__input--(day|month|year)($|\s)/)[1]
 
         const isInRange = target
           .getAttribute('id')
-          .match(/-(start|end)-/)[1]
+          .match(/-(start|end)-(day|month|year)/)[1]
 
         let date = isInRange === 'start' ? startDate : endDate
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -81,16 +81,16 @@ export type DateProps = FieldProps<string, undefined | string> & {
   >
 
 function DateComponent(props: DateProps) {
-  const translations = useTranslation().Date
+  const { errorRequired, label: defaultLabel } = useTranslation().Date
   const { locale } = useContext(SharedContext)
 
   const errorMessages = useMemo(() => {
     return {
-      'Field.errorRequired': translations.errorRequired,
-      'Field.errorPattern': translations.errorRequired,
+      'Field.errorRequired': errorRequired,
+      'Field.errorPattern': errorRequired,
       ...props.errorMessages,
     }
-  }, [props.errorMessages, translations.errorRequired])
+  }, [props.errorMessages, errorRequired])
 
   const schema = useMemo<AllJSONSchemaVersions>(
     () =>
@@ -114,27 +114,22 @@ function DateComponent(props: DateProps) {
 
   const dateLimitValidator = useCallback(
     (value: string) => {
-      return validateDateLimit({
+      const res = validateDateLimit({
         value,
         locale,
         minDate: props.minDate,
         maxDate: props.maxDate,
         isRange: props.range,
       })
+
+      return res
     },
     [props.maxDate, props.minDate, props.range, locale]
   )
 
   const hasDateLimitAndValue = useMemo(() => {
-    return (props.minDate || props.maxDate) && props.value
+    return (props.minDate || props.maxDate) && Boolean(props.value)
   }, [props.minDate, props.maxDate, props.value])
-
-  const validateInitially = useMemo(() => {
-    if (hasDateLimitAndValue && !props.validateInitially) {
-      return true
-    }
-    return props.validateInitially
-  }, [props.validateInitially, hasDateLimitAndValue])
 
   const preparedProps: DateProps = {
     ...props,
@@ -148,7 +143,7 @@ function DateComponent(props: DateProps) {
       return range ? `${start_date}|${end_date}` : date
     },
     validateRequired,
-    validateInitially,
+    validateInitially: props.validateInitially ?? hasDateLimitAndValue,
     onBlurValidator: props.onBlurValidator ?? dateLimitValidator,
   }
 
@@ -191,7 +186,7 @@ function DateComponent(props: DateProps) {
     const [startDate, endDate] = parseRangeValue(valueProp)
 
     return {
-      date: undefined,
+      value: undefined,
       startDate,
       endDate,
     }
@@ -205,7 +200,7 @@ function DateComponent(props: DateProps) {
 
   const fieldBlockProps: FieldBlockProps = {
     forId: id,
-    label: label ?? translations.label,
+    label: label ?? defaultLabel,
     className: classnames('dnb-forms-field-string', className),
     ...pickSpacingProps(props),
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -1651,4 +1651,37 @@ describe('Field.Date', () => {
       )
     })
   })
+
+  it('should support keyboard interactions in range mode when id includes start or end', async () => {
+    const onChange = jest.fn()
+
+    render(
+      <Field.Date
+        id="id-end-start-something"
+        value="2025-01-01|2025-01-31"
+        range
+        onChange={onChange}
+      />
+    )
+
+    const [startMonth, endMonth] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input--month')
+    ) as Array<HTMLInputElement>
+
+    await userEvent.type(startMonth, '{ArrowDown}')
+    await userEvent.type(endMonth, '{ArrowUp}')
+    await userEvent.click(document.body)
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenNthCalledWith(
+      1,
+      '2024-12-01|2025-01-31',
+      expect.anything()
+    )
+    expect(onChange).toHaveBeenNthCalledWith(
+      2,
+      '2024-12-01|2025-02-28',
+      expect.anything()
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -61,17 +61,21 @@ describe('Field.Date', () => {
       datePicker.querySelector('.dnb-form-status__text')
     ).not.toBeInTheDocument()
 
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
 
     fireEvent.focus(year)
     await userEvent.type(year, '{Backspace>2}')
     fireEvent.blur(year)
 
-    expect(screen.queryByRole('alert')).toBeInTheDocument()
+    expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
 
     await userEvent.keyboard('20231207')
 
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
 
     await userEvent.click(
       document.querySelector('.dnb-input__submit-button__button')
@@ -83,7 +87,7 @@ describe('Field.Date', () => {
         .querySelectorAll('.dnb-button--tertiary ')[0]
     )
 
-    expect(screen.queryByRole('alert')).toBeInTheDocument()
+    expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
   })
 
   it('should support date range', () => {
@@ -155,7 +159,9 @@ describe('Field.Date', () => {
       it('should show error message initially', async () => {
         render(<Field.Date required validateInitially />)
         await waitFor(() => {
-          expect(screen.getByRole('alert')).toBeInTheDocument()
+          expect(
+            document.querySelector('.dnb-form-status--error')
+          ).toBeInTheDocument()
         })
       })
     })
@@ -175,13 +181,17 @@ describe('Field.Date', () => {
 
         const input = document.querySelector('input')
 
-        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
 
         input.focus()
         fireEvent.blur(input)
 
         await waitFor(() => {
-          expect(screen.getByRole('alert')).toBeInTheDocument()
+          expect(
+            document.querySelector('.dnb-form-status--error')
+          ).toBeInTheDocument()
         })
 
         log.mockRestore()
@@ -1075,7 +1085,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1104,7 +1116,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1139,7 +1153,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorStartDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1174,7 +1190,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorStartDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1209,7 +1227,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorEndDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1244,7 +1264,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorEndDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1255,6 +1277,11 @@ describe('Field.Date', () => {
     it('should display error messages if start date and end date is outside of limits in `range` mode', async () => {
       const minDate = '2025-01-01'
       const maxDate = '2025-01-31'
+
+      const getMessages = () =>
+        Array.from(
+          document.querySelectorAll('.dnb-form-status .dnb-li')
+        ) as Array<HTMLLIElement>
 
       render(
         <Field.Date
@@ -1285,20 +1312,16 @@ describe('Field.Date', () => {
       ).toBeInTheDocument()
 
       const statusText = document.querySelector('.dnb-form-status__text')
-      const messages = () =>
-        Array.from(
-          document.querySelectorAll('.dnb-li')
-        ) as Array<HTMLLIElement>
 
       expect(statusText).toHaveTextContent(nb.Field.errorSummary)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         nb.Date.errorStartDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         nb.Date.errorEndDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1309,13 +1332,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowUp>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         nb.Date.errorStartDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         nb.Date.errorEndDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1326,13 +1349,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowDown>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         nb.Date.errorStartDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         nb.Date.errorEndDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1343,13 +1366,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowDown>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         nb.Date.errorStartDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         nb.Date.errorEndDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1380,7 +1403,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.no)
@@ -1409,7 +1434,9 @@ describe('Field.Date', () => {
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         nb.Date.errorMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.no)
@@ -1499,7 +1526,9 @@ describe('Field.Date', () => {
       expect(
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         en.Date.errorMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.en)
@@ -1510,7 +1539,9 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowUp>2}')
       await userEvent.click(document.body)
 
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(
         en.Date.errorMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.en)
@@ -1521,6 +1552,11 @@ describe('Field.Date', () => {
     it('should display date limit error messages based on locale when in `range` mode', async () => {
       const minDate = '2025-01-01'
       const maxDate = '2025-01-31'
+
+      const getMessages = () =>
+        Array.from(
+          document.querySelectorAll('.dnb-form-status .dnb-li')
+        ) as Array<HTMLLIElement>
 
       render(
         <Form.Handler locale="en-GB">
@@ -1533,8 +1569,8 @@ describe('Field.Date', () => {
         </Form.Handler>
       )
 
-      const [, startMonth, , , endMonth] = Array.from(
-        document.querySelectorAll('.dnb-date-picker__input')
+      const [startMonth, endMonth] = Array.from(
+        document.querySelectorAll('.dnb-date-picker__input--month')
       ) as Array<HTMLInputElement>
 
       await userEvent.click(startMonth)
@@ -1546,23 +1582,17 @@ describe('Field.Date', () => {
       expect(
         document.querySelector('.dnb-form-status--error')
       ).toBeInTheDocument()
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toHaveTextContent(en.Field.errorSummary)
 
-      const messages = () =>
-        Array.from(
-          document.querySelectorAll('.dnb-form-status--error .dnb-li')
-        ) as Array<HTMLLIElement>
-
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        en.Field.errorSummary
-      )
-
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         en.Date.errorStartDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.en)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         en.Date.errorEndDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.en)
@@ -1573,13 +1603,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowUp>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         en.Date.errorStartDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.en)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         en.Date.errorEndDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.en)
@@ -1590,13 +1620,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowDown>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         en.Date.errorStartDateMaxDate.replace(
           /\{date\}/,
           formatDate(maxDate, formatOptions.en)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         en.Date.errorEndDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.en)
@@ -1607,13 +1637,13 @@ describe('Field.Date', () => {
       await userEvent.keyboard('{ArrowDown>2}')
       await userEvent.click(document.body)
 
-      expect(messages()[0]).toHaveTextContent(
+      expect(getMessages().at(0)).toHaveTextContent(
         en.Date.errorStartDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.en)
         )
       )
-      expect(messages()[1]).toHaveTextContent(
+      expect(getMessages().at(1)).toHaveTextContent(
         en.Date.errorEndDateMinDate.replace(
           /\{date\}/,
           formatDate(minDate, formatOptions.en)


### PR DESCRIPTION

The regular expression extracted `"raa"` instead of `"start"` from the ID `"id-raa-start-month"`. This only happened when a certain number of tests were run, likely because React dynamically generated the ID in those cases. All other IDs worked as expected.  

Debugging this took a few hours, during which I refactored some code. I believe the changes make it more readable now.  
