### PR TITLE
feat(Forms): return existing errors in `onSubmitRequest` before Form.Handler submit or Wizard step change

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -146,6 +146,7 @@ The `InputPassword` component has been moved to `Field.Password`, and is now a p
 ## Eufemia Forms
 
 - replace `useError` with `useValidation`.
+- replace `internal.error` with `error`.
 - replace Form.Iterate label variable `{itemNr}` with `{itemNo}`.
 - replace `Form.FieldProps` with `Field.Provider`.
 - replace `<Card stack>...</Card>` with `<Form.Card>...</Form.Card>`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -252,10 +252,14 @@ render(
 
 You can use the `filterData` function to filter your `onSubmit` data. It might be useful, for example, to **exclude disabled fields** or filter out empty fields. The callback function receives the following arguments:
 
-1. `path` as the first argument.
-2. `value` as the second argument.
-3. The field `properties` (props) as the third argument.
-4. The fourth argument is an object with the internal state of the field, like the error state.
+The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
+
+- `path` The path of the field.
+- `value` The value of the field.
+- `displayValue` The displayed value of the field.
+- `label` The label of the field.
+- `props` The given field properties.
+- `error` The error of the field. Is `undefined` if there is no error.
 
 The callback function should return a `boolean` or `undefined`. Return `false` to exclude an entry.
 
@@ -308,7 +312,7 @@ const MyForm = () => {
         const myData = reduceToVisibleFields(filteredData)
         const transformed = transformData(
           myData,
-          ({ path, value, displayValue, label, props, internal }) => {
+          ({ path, value, displayValue, label, props, error }) => {
             return 'new value'
           },
         )
@@ -325,14 +329,14 @@ const MyForm = () => {
 
 The `transformData` handler will call your given function for each `Field.*` that contains a path (not `Iterate.Array`). The returned value will be used instead of the given `value` and returned as a new data object. It's up to you to define the shape of the returned value.
 
-The callback function receives the following properties in an object:
+The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
 
 - `path` The path of the field.
 - `value` The value of the field.
 - `displayValue` The displayed value of the field.
 - `label` The label of the field.
 - `props` The given field properties.
-- `internal` The `internal` parameter contains `{ error: Error | undefined }` you can utilize if needed.
+- `error` The error of the field. Is `undefined` if there is no error.
 
 **displayValue** can be `undefined` if a field does not support it, or it's value is not set (`emptyValue`).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Handler/info.mdx
@@ -252,7 +252,7 @@ render(
 
 You can use the `filterData` function to filter your `onSubmit` data. It might be useful, for example, to **exclude disabled fields** or filter out empty fields. The callback function receives the following arguments:
 
-The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
+The callback function receives the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.
@@ -329,7 +329,7 @@ const MyForm = () => {
 
 The `transformData` handler will call your given function for each `Field.*` that contains a path (not `Iterate.Array`). The returned value will be used instead of the given `value` and returned as a new data object. It's up to you to define the shape of the returned value.
 
-The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
+The callback function receives the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/info.mdx
@@ -69,7 +69,7 @@ You can use the `filterData` function to filter your data.
 
 You simply give it the [same kind of filter](/uilib/extensions/forms/Form/Handler/demos/#filter-your-data) as you would within the `onSubmit` event callback.
 
-The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
+The callback function receives the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/info.mdx
@@ -69,12 +69,14 @@ You can use the `filterData` function to filter your data.
 
 You simply give it the [same kind of filter](/uilib/extensions/forms/Form/Handler/demos/#filter-your-data) as you would within the `onSubmit` event callback.
 
-The callback function receives the following arguments:
+The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
 
-1. `path` as the first argument.
-2. `value` as the second argument.
-3. The field `properties` (props) as the third argument.
-4. The fourth argument is an object with the internal state of the field, like the error state.
+- `path` The path of the field.
+- `value` The value of the field.
+- `displayValue` The displayed value of the field.
+- `label` The label of the field.
+- `props` The given field properties.
+- `error` The error of the field. Is `undefined` if there is no error.
 
 The callback function should return a `boolean` or `undefined`. Return `false` to exclude an entry.
 
@@ -91,7 +93,7 @@ const MyForm = () => {
   )
 }
 
-const filterDataHandler = ({ path, value, data, props, internal }) => {
+const filterDataHandler = ({ path, value, data, props, error }) => {
   if (props.disabled === true) {
     return false
   }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
@@ -201,12 +201,14 @@ You can use the `filterData` function to filter your data. Check out [the exampl
 
 You simply give it the [same kind of filter](/uilib/extensions/forms/Form/Handler/demos/#filter-your-data) as you would within the `onSubmit` event callback.
 
-The callback function receives the following arguments:
+The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
 
-1. `path` as the first argument.
-2. `value` as the second argument.
-3. The field `properties` (props) as the third argument.
-4. The fourth argument is an object with the internal state of the field, like the error state.
+- `path` The path of the field.
+- `value` The value of the field.
+- `displayValue` The displayed value of the field.
+- `label` The label of the field.
+- `props` The given field properties.
+- `error` The error of the field. Is `undefined` if there is no error.
 
 The callback function should return a `boolean` or `undefined`. Return `false` to exclude an entry.
 
@@ -215,7 +217,7 @@ It returns the filtered form data.
 **Tip:** Depending on your use case – and instead of `disabled` – you may rather use a `data-*` attribute on your field (e.g. `data-exclude-field`) to filter the field out of the data set.
 
 ```tsx
-const filterDataHandler = ({ path, value, data, props, internal }) => {
+const filterDataHandler = ({ path, value, data, props, error }) => {
   if (props['data-exclude-field']) {
     return false
   }
@@ -235,11 +237,9 @@ const MyForm = () => {
 }
 ```
 
-The `internal` parameter contains `{ error: Error | undefined }` you can utilize if needed.
-
 ```tsx
-const filterDataHandler = ({ path, value, data, props, internal }) => {
-  return !(internal.error instanceof Error)
+const filterDataHandler = ({ path, value, data, props, error }) => {
+  return !(error instanceof Error)
 }
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
@@ -201,7 +201,7 @@ You can use the `filterData` function to filter your data. Check out [the exampl
 
 You simply give it the [same kind of filter](/uilib/extensions/forms/Form/Handler/demos/#filter-your-data) as you would within the `onSubmit` event callback.
 
-The callback function receives the following properties in an object with the type `DataPathHandlerParameters`:
+The callback function receives the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
@@ -251,3 +251,43 @@ export const WithStatusMessage = () => {
     </ComponentBox>
   )
 }
+
+export const OnSubmitRequest = () => {
+  return (
+    <ComponentBox>
+      <Form.Handler
+        onSubmitRequest={({ errors }) => {
+          errors.forEach(({ path, error, props }) => {
+            console.log(props.label, error.message)
+          })
+        }}
+      >
+        <Wizard.Container mode="loose" variant="drawer">
+          <Wizard.Step title="Step 1">
+            <Form.Card>
+              <Field.String
+                path="/foo"
+                label="Foo"
+                defaultValue="With default value"
+                required
+              />
+              <Field.String path="/bar" label="Bar" required />
+            </Form.Card>
+
+            <Wizard.Buttons />
+          </Wizard.Step>
+
+          <Wizard.Step title="Step 2">
+            <Form.Card>
+              <Field.String path="/baz" label="Baz" required />
+            </Form.Card>
+
+            <Wizard.Buttons />
+
+            <Form.SubmitButton />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
@@ -257,8 +257,8 @@ export const OnSubmitRequest = () => {
     <ComponentBox>
       <Form.Handler
         onSubmitRequest={({ errors }) => {
-          errors.forEach(({ path, error, props }) => {
-            console.log(props.label, error.message)
+          errors.forEach(({ label, error }) => {
+            console.log(label, error.message)
           })
         }}
       >

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
@@ -22,7 +22,7 @@ import * as Examples from './Examples'
 
 You can use the `onSubmitRequest` property on the [Form.Handler](/uilib/extensions/forms/Form/Handler/) to get visible errors before the form is submitted.
 
-Each item in the error array contains the following properties in an object with the type `DataPathHandlerParameters`:
+Each item in the error array contains the following properties in an object:
 
 - `path` The path of the field.
 - `value` The value of the field.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
@@ -18,15 +18,24 @@ import * as Examples from './Examples'
 
 <Examples.WithStatusMessage />
 
-### OnSubmitRequest
+### Get errors before submit or step change
 
-You can use the `onSubmitRequest` prop on the [Form.Handler](/uilib/extensions/forms/Form/Handler/) to get visible errors before the form is submitted.
+You can use the `onSubmitRequest` property on the [Form.Handler](/uilib/extensions/forms/Form/Handler/) to get visible errors before the form is submitted.
+
+Each item in the error array contains the following properties in an object with the type `DataPathHandlerParameters`:
+
+- `path` The path of the field.
+- `value` The value of the field.
+- `displayValue` The displayed value of the field.
+- `label` The label of the field.
+- `props` The given field properties.
+- `error` The error of the field.
 
 ```tsx
 const onSubmitRequest: OnSubmitRequest = ({ errors }) => {
-  errors.forEach(({ path, error, props }) => {
+  errors.forEach(({ path, value, displayValue, label, props, error }) => {
     // Do something with the error
-    console.log(props.label, error.message)
+    console.log(label, error.message)
   })
 }
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
@@ -17,3 +17,18 @@ import * as Examples from './Examples'
 ### With StatusMessage
 
 <Examples.WithStatusMessage />
+
+### OnSubmitRequest
+
+You can use the `onSubmitRequest` prop on the [Form.Handler](/uilib/extensions/forms/Form/Handler/) to get visible errors before the form is submitted.
+
+```tsx
+const onSubmitRequest: OnSubmitRequest = ({ errors }) => {
+  errors.forEach(({ path, error, props }) => {
+    // Do something with the error
+    console.log(props.label, error.message)
+  })
+}
+```
+
+<Examples.OnSubmitRequest />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -226,7 +226,7 @@ Here is an example of how to filter data outlining the different ways to filter 
 ```tsx
 // 1. Method – by using paths (JSON Pointer)
 const filterDataPaths = {
-  '/foo': ({ value, data, props, internal }) => value !== 'bar',
+  '/foo': ({ value, data, props, error }) => value !== 'bar',
   '/foo': false, // Will exclude the field with the path "/foo"
   '/array/0': false, // Will exclude the first item of the array
   '/array/*/objectKey': false, // Will exclude all objects inside the array with a key of "objectKey"
@@ -234,7 +234,7 @@ const filterDataPaths = {
 
 // 2. Method – by using a handler.
 // It will iterate over all fields regardless what path they have.
-const filterDataHandler = ({ path, value, data, props, internal }) =>
+const filterDataHandler = ({ path, value, data, props, error }) =>
   value !== 'bar'
 
 const MyComponent = () => {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -49,26 +49,33 @@ export type FilterDataHandler<Data> = (
 export type FilterDataHandlerCallback<R> = (
   parameters: FilterDataHandlerParameters
 ) => R
-export type FilterDataHandlerParameters =
-  FilterDataPathConditionParameters & {
-    path: Path
-  }
-export type FilterDataPathCondition<Data = unknown> = (
-  parameters: FilterDataPathConditionParameters<Data>
+export type FilterDataHandlerParameters = DataPathHandlerParameters & {
+  path: Path
+}
+export type DataPathHandler<Data = unknown> = (
+  parameters: DataPathHandlerParameters<Data>
 ) => boolean | undefined
-export type FilterDataPathConditionParameters<Data = unknown> = {
+export type DataPathHandlerParameters<Data = unknown> = {
+  path: Path
   value: unknown
   displayValue: undefined | React.ReactNode | Array<React.ReactNode>
   label: React.ReactNode
   props: FieldProps
+  error: Error | undefined
+
+  /**
+   * Used in the "filterData" given by the "useData" hook.
+   */
   data: Data
+
+  /** @deprecated – can be removed in v11 */
   internal: {
     error: Error | undefined
   }
 }
 export type FilterDataPathObject<Data> = Record<
   Path,
-  FilterDataPathCondition<Data> | boolean | undefined
+  DataPathHandler<Data> | boolean | undefined
 >
 export type FilterData<Data = unknown> =
   | FilterDataPathObject<Data>

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -26,6 +26,7 @@ import {
   ValueProps,
   OnSubmitParams,
   OnSubmitReturn,
+  OnSubmitRequest,
 } from '../../types'
 import type { IsolationProviderProps } from '../../Form/Isolation/Isolation'
 import { debounce } from '../../../../shared/helpers'
@@ -147,7 +148,7 @@ export type Props<Data extends JsonObject> =
     /**
      * Submit was requested, but data was invalid
      */
-    onSubmitRequest?: () => void
+    onSubmitRequest?: OnSubmitRequest
     /**
      * Will be called when the onSubmit is finished and had not errors
      */
@@ -1076,9 +1077,19 @@ export default function Provider<Data extends JsonObject>(
           }
         }
 
-        onSubmitRequest?.()
-
         setShowAllErrors(true)
+
+        onSubmitRequest?.({
+          errors: Object.entries(fieldErrorRef.current)
+            .map(([path, error]) => {
+              return {
+                path,
+                error,
+                props: fieldInternalsRef.current[path]?.props,
+              }
+            })
+            .filter(({ error }) => error),
+        })
       }
 
       return result

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -105,7 +105,7 @@ export const ProviderEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onSubmitRequest: {
-    doc: 'Will be called when the user tries to submit, but errors stop the data from being submitted.',
+    doc: 'Will be called when the user tries to submit, but errors stop the data from being submitted. The first parameter is an object containing the `errors` array. Each error object contains the `path`, `error` and `props` of the field. You can use this to log the errors before the form is submitted.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -27,11 +27,7 @@ import {
 } from '../../../'
 import { isCI } from 'repo-utils'
 import { Props as StringFieldProps } from '../../../Field/String'
-import {
-  ContextState,
-  FilterData,
-  FilterDataPathCondition,
-} from '../../Context'
+import { ContextState, FilterData, DataPathHandler } from '../../Context'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -455,20 +451,16 @@ describe('DataContext.Provider', () => {
 
     describe('filterData', () => {
       it('should filter data based on the given filterData paths', () => {
-        const fooHandler: FilterDataPathCondition = jest.fn(
-          ({ props }) => {
-            if (props.disabled === true) {
-              return false
-            }
+        const fooHandler: DataPathHandler = jest.fn(({ props }) => {
+          if (props.disabled === true) {
+            return false
           }
-        )
-        const barHandler: FilterDataPathCondition = jest.fn(
-          ({ props }) => {
-            if (props.disabled === true) {
-              return false
-            }
+        })
+        const barHandler: DataPathHandler = jest.fn(({ props }) => {
+          if (props.disabled === true) {
+            return false
           }
-        )
+        })
 
         const filterDataPaths: FilterData = {
           '/foo': fooHandler,
@@ -506,15 +498,22 @@ describe('DataContext.Provider', () => {
         expect(barHandler).toHaveBeenCalledTimes(1)
 
         expect(fooHandler).toHaveBeenLastCalledWith({
+          path: '/foo',
           value: 'Include this value',
+          displayValue: 'Include this value',
+          label: undefined,
           props: expect.objectContaining({}),
           data: { bar: 'bar', foo: 'Include this value' },
+          error: undefined,
           internal: { error: undefined },
         })
         expect(barHandler).toHaveBeenLastCalledWith({
+          path: '/bar',
           value: 'bar',
+          displayValue: 'bar',
           props: expect.objectContaining({}),
           data: { bar: 'bar', foo: 'Include this value' },
+          error: undefined,
           internal: { error: undefined },
         })
 
@@ -546,15 +545,23 @@ describe('DataContext.Provider', () => {
         expect(barHandler).toHaveBeenCalledTimes(2)
 
         expect(fooHandler).toHaveBeenLastCalledWith({
+          path: '/foo',
           value: 'Skip this value',
+          displayValue: 'Skip this value',
+          label: undefined,
           props: expect.objectContaining({}),
           data: { bar: 'bar value', foo: 'Skip this value' },
+          error: undefined,
           internal: { error: undefined },
         })
         expect(barHandler).toHaveBeenLastCalledWith({
+          path: '/bar',
           value: 'bar value',
+          displayValue: 'bar value',
+          label: undefined,
           props: expect.objectContaining({}),
           data: { bar: 'bar value', foo: 'Skip this value' },
+          error: undefined,
           internal: { error: undefined },
         })
 
@@ -608,6 +615,7 @@ describe('DataContext.Provider', () => {
           props: expect.objectContaining({
             value: 'Include this value',
           }),
+          error: undefined,
           internal: {
             error: undefined,
           },
@@ -624,6 +632,7 @@ describe('DataContext.Provider', () => {
           props: expect.objectContaining({
             value: 'bar',
           }),
+          error: undefined,
           internal: {
             error: undefined,
           },
@@ -666,6 +675,7 @@ describe('DataContext.Provider', () => {
           props: expect.objectContaining({
             value: 'Skip this value',
           }),
+          error: undefined,
           internal: {
             error: undefined,
           },
@@ -682,6 +692,7 @@ describe('DataContext.Provider', () => {
           props: expect.objectContaining({
             value: 'bar value',
           }),
+          error: undefined,
           internal: {
             error: undefined,
           },
@@ -2925,10 +2936,20 @@ describe('DataContext.Provider', () => {
             errors: [
               {
                 path: '/bar',
-                error: new Error(nb.Field.errorRequired),
+                value: undefined,
+                displayValue: undefined,
+                label: 'Bar',
                 props: expect.objectContaining({
                   label: 'Bar',
                 }),
+                data: {
+                  bar: undefined,
+                  foo: 'foo',
+                },
+                error: new Error(nb.Field.errorRequired),
+                internal: {
+                  error: new Error(nb.Field.errorRequired),
+                },
               },
             ],
           })
@@ -2946,17 +2967,35 @@ describe('DataContext.Provider', () => {
             errors: [
               {
                 path: '/bar',
-                error: new Error(nb.Field.errorRequired),
+                value: undefined,
+                displayValue: undefined,
+                label: 'Bar',
                 props: expect.objectContaining({
                   label: 'Bar',
                 }),
+                data: {
+                  bar: undefined,
+                },
+                error: new Error(nb.Field.errorRequired),
+                internal: {
+                  error: new Error(nb.Field.errorRequired),
+                },
               },
               {
                 path: '/foo',
-                error: new Error(nb.Field.errorRequired),
+                value: undefined,
+                displayValue: undefined,
+                label: 'Foo',
                 props: expect.objectContaining({
                   label: 'Foo',
                 }),
+                data: {
+                  foo: undefined,
+                },
+                error: new Error(nb.Field.errorRequired),
+                internal: {
+                  error: new Error(nb.Field.errorRequired),
+                },
               },
             ],
           })
@@ -2971,10 +3010,20 @@ describe('DataContext.Provider', () => {
             errors: [
               {
                 path: '/bar',
-                error: new Error(nb.Field.errorRequired),
+                value: undefined,
+                displayValue: undefined,
+                label: 'Bar',
                 props: expect.objectContaining({
                   label: 'Bar',
                 }),
+                data: {
+                  bar: undefined,
+                  foo: 'foo',
+                },
+                error: new Error(nb.Field.errorRequired),
+                internal: {
+                  error: new Error(nb.Field.errorRequired),
+                },
               },
             ],
           })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -2925,10 +2925,19 @@ describe('Wizard.Container', () => {
         errors: [
           {
             path: '/bar',
-            error: new Error(nb.Field.errorRequired),
+            value: undefined,
+            displayValue: undefined,
+            label: 'Bar',
             props: expect.objectContaining({
               label: 'Bar',
             }),
+            data: {
+              bar: undefined,
+            },
+            error: new Error(nb.Field.errorRequired),
+            internal: {
+              error: new Error(nb.Field.errorRequired),
+            },
           },
         ],
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -2896,4 +2896,42 @@ describe('Wizard.Container', () => {
       expect(document.querySelector('input')).toHaveValue('1234')
     })
   })
+
+  it('should call onSubmitRequest on step change', async () => {
+    const onSubmitRequest = jest.fn()
+
+    render(
+      <Form.Handler onSubmitRequest={onSubmitRequest}>
+        <Wizard.Container mode="loose">
+          <Wizard.Step title="Step 1">
+            <Form.Card>
+              <Field.String path="/bar" label="Bar" required />
+            </Form.Card>
+            <Wizard.Buttons />
+          </Wizard.Step>
+
+          <Wizard.Step title="Step 2">
+            <Wizard.Buttons />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
+    )
+
+    await userEvent.click(nextButton())
+
+    expect(onSubmitRequest).toHaveBeenCalledTimes(1)
+    expect(onSubmitRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        errors: [
+          {
+            path: '/bar',
+            error: new Error(nb.Field.errorRequired),
+            props: expect.objectContaining({
+              label: 'Bar',
+            }),
+          },
+        ],
+      })
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -2,6 +2,7 @@ import type { AriaAttributes } from 'react'
 import type { SpacingProps } from '../../components/space/types'
 import type {
   ContextState,
+  DataPathHandlerParameters,
   EventListenerCall,
   FilterData,
   TransformData,
@@ -676,7 +677,7 @@ export type OnSubmit<Data = JsonObject> = (
 export type OnSubmitRequest = ({
   errors,
 }: {
-  errors: Array<{ path: Path; error: Error; props: FieldProps }>
+  errors: Array<DataPathHandlerParameters>
 }) => void
 
 export type OnCommit<Data = JsonObject> = (

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -673,6 +673,11 @@ export type OnSubmit<Data = JsonObject> = (
     clearData,
   }: OnSubmitParams
 ) => OnSubmitReturn
+export type OnSubmitRequest = ({
+  errors,
+}: {
+  errors: Array<{ path: Path; error: Error; props: FieldProps }>
+}) => void
 
 export type OnCommit<Data = JsonObject> = (
   data: Data,


### PR DESCRIPTION



> You can use the `onSubmitRequest` prop on the [Form.Handler](/uilib/extensions/forms/Form/Handler/) to get visible errors before the form is submitted.



```tsx
const onSubmitRequest: OnSubmitRequest = ({ errors }) => {
  errors.forEach(({ path, value, label, error }) => {
    // Do something with the error
    console.log(label, error.message)
  })
}
```