### PR TITLE
chore: fix test warning: Unknown event handler property. It will be ignored.

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js
@@ -582,15 +582,21 @@ function DrawerListOptionItem({
   )
 }
 
-DrawerList.HorizontalItem = ({ className = null, ...props }) => (
-  <DrawerListOptionItem
-    className={classnames([
-      'dnb-drawer-list__option__item--horizontal',
-      className,
-    ])}
-    {...props}
-  />
-)
+DrawerList.HorizontalItem = ({
+  className = null,
+  on_click = null, // eslint-disable-line
+  ...props
+}) => {
+  return (
+    <DrawerListOptionItem
+      className={classnames([
+        'dnb-drawer-list__option__item--horizontal',
+        className,
+      ])}
+      {...props}
+    />
+  )
+}
 
 DrawerList.HorizontalItem.propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
Fixes following test warning when running tests for DrawerList:

  ```
console.error
    Warning: Unknown event handler property `on_click`. It will be ignored.
        at span
        at children (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js:571:3)
        at className (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js:585:32)
        at ul
        at children (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js:412:7)
        at span
        at span
        at span
        at span
        at DrawerListInstance (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js:88:5)
        at DrawerListProvider (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.js:68:5)
        at DrawerList (/Users/anderslangseth/dev/eufemia/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.js:58:5)
```