### PR TITLE
chore: return `getErrors` function in `onSubmitRequest` instead of errors

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/Examples.tsx
@@ -256,8 +256,8 @@ export const OnSubmitRequest = () => {
   return (
     <ComponentBox>
       <Form.Handler
-        onSubmitRequest={({ errors }) => {
-          errors.forEach(({ label, error }) => {
+        onSubmitRequest={({ getErrors }) => {
+          getErrors().forEach(({ label, error }) => {
             console.log(label, error.message)
           })
         }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/Container/demos.mdx
@@ -32,11 +32,13 @@ Each item in the error array contains the following properties in an object:
 - `error` The error of the field.
 
 ```tsx
-const onSubmitRequest: OnSubmitRequest = ({ errors }) => {
-  errors.forEach(({ path, value, displayValue, label, props, error }) => {
-    // Do something with the error
-    console.log(label, error.message)
-  })
+const onSubmitRequest: OnSubmitRequest = ({ getErrors }) => {
+  getErrors().forEach(
+    ({ path, value, displayValue, label, props, error }) => {
+      // Do something with the error
+      console.log(label, error.message)
+    },
+  )
 }
 ```
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1090,11 +1090,12 @@ export default function Provider<Data extends JsonObject>(
         setShowAllErrors(true)
 
         onSubmitRequest?.({
-          errors: Object.keys(fieldErrorRef.current)
-            .map((path) => {
-              return getDataPathHandlerParameters(path)
-            })
-            .filter(({ error }) => error),
+          getErrors: () =>
+            Object.keys(fieldErrorRef.current)
+              .map((path) => {
+                return getDataPathHandlerParameters(path)
+              })
+              .filter(({ error }) => error),
         })
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -105,7 +105,7 @@ export const ProviderEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onSubmitRequest: {
-    doc: 'Will be called when the user tries to submit, but errors stop the data from being submitted. The first parameter is an object containing the `errors` array. Each error object contains the `path`, `error` and `props` of the field. You can use this to log the errors before the form is submitted.',
+    doc: 'Will be called when the user tries to submit, but errors stop the data from being submitted. The first parameter is aa object containing the `getErrors` method, returning an array with field errors. Each error object contains the `path`, `error` and `props` of the field. You can use this to log the errors before the form is submitted.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -24,6 +24,7 @@ import {
   DataValueWriteProps,
   OnSubmit,
   Iterate,
+  OnSubmitRequest,
 } from '../../../'
 import { isCI } from 'repo-utils'
 import { Props as StringFieldProps } from '../../../Field/String'
@@ -2913,7 +2914,13 @@ describe('DataContext.Provider', () => {
       })
 
       it('should return errors in first parameter', async () => {
-        const onSubmitRequest = jest.fn()
+        let receivedErrors = null
+
+        const onSubmitRequest: OnSubmitRequest = jest.fn(
+          ({ getErrors }) => {
+            receivedErrors = getErrors()
+          }
+        )
 
         render(
           <DataContext.Provider onSubmitRequest={onSubmitRequest}>
@@ -2933,27 +2940,28 @@ describe('DataContext.Provider', () => {
         expect(onSubmitRequest).toHaveBeenCalledTimes(1)
         expect(onSubmitRequest).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            errors: [
-              {
-                path: '/bar',
-                value: undefined,
-                displayValue: undefined,
-                label: 'Bar',
-                props: expect.objectContaining({
-                  label: 'Bar',
-                }),
-                data: {
-                  bar: undefined,
-                  foo: 'foo',
-                },
-                error: new Error(nb.Field.errorRequired),
-                internal: {
-                  error: new Error(nb.Field.errorRequired),
-                },
-              },
-            ],
+            getErrors: expect.any(Function),
           })
         )
+        expect(receivedErrors).toEqual([
+          {
+            path: '/bar',
+            value: undefined,
+            displayValue: undefined,
+            label: 'Bar',
+            props: expect.objectContaining({
+              label: 'Bar',
+            }),
+            data: {
+              bar: undefined,
+              foo: 'foo',
+            },
+            error: new Error(nb.Field.errorRequired),
+            internal: {
+              error: new Error(nb.Field.errorRequired),
+            },
+          },
+        ])
 
         await userEvent.type(
           document.querySelector('input'),
@@ -2964,42 +2972,43 @@ describe('DataContext.Provider', () => {
         expect(onSubmitRequest).toHaveBeenCalledTimes(2)
         expect(onSubmitRequest).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            errors: [
-              {
-                path: '/bar',
-                value: undefined,
-                displayValue: undefined,
-                label: 'Bar',
-                props: expect.objectContaining({
-                  label: 'Bar',
-                }),
-                data: {
-                  bar: undefined,
-                },
-                error: new Error(nb.Field.errorRequired),
-                internal: {
-                  error: new Error(nb.Field.errorRequired),
-                },
-              },
-              {
-                path: '/foo',
-                value: undefined,
-                displayValue: undefined,
-                label: 'Foo',
-                props: expect.objectContaining({
-                  label: 'Foo',
-                }),
-                data: {
-                  foo: undefined,
-                },
-                error: new Error(nb.Field.errorRequired),
-                internal: {
-                  error: new Error(nb.Field.errorRequired),
-                },
-              },
-            ],
+            getErrors: expect.any(Function),
           })
         )
+        expect(receivedErrors).toEqual([
+          {
+            path: '/bar',
+            value: undefined,
+            displayValue: undefined,
+            label: 'Bar',
+            props: expect.objectContaining({
+              label: 'Bar',
+            }),
+            data: {
+              bar: undefined,
+            },
+            error: new Error(nb.Field.errorRequired),
+            internal: {
+              error: new Error(nb.Field.errorRequired),
+            },
+          },
+          {
+            path: '/foo',
+            value: undefined,
+            displayValue: undefined,
+            label: 'Foo',
+            props: expect.objectContaining({
+              label: 'Foo',
+            }),
+            data: {
+              foo: undefined,
+            },
+            error: new Error(nb.Field.errorRequired),
+            internal: {
+              error: new Error(nb.Field.errorRequired),
+            },
+          },
+        ])
 
         await userEvent.type(document.querySelector('input'), 'foo')
         await userEvent.click(document.querySelector('button'))
@@ -3007,27 +3016,28 @@ describe('DataContext.Provider', () => {
         expect(onSubmitRequest).toHaveBeenCalledTimes(3)
         expect(onSubmitRequest).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            errors: [
-              {
-                path: '/bar',
-                value: undefined,
-                displayValue: undefined,
-                label: 'Bar',
-                props: expect.objectContaining({
-                  label: 'Bar',
-                }),
-                data: {
-                  bar: undefined,
-                  foo: 'foo',
-                },
-                error: new Error(nb.Field.errorRequired),
-                internal: {
-                  error: new Error(nb.Field.errorRequired),
-                },
-              },
-            ],
+            getErrors: expect.any(Function),
           })
         )
+        expect(receivedErrors).toEqual([
+          {
+            path: '/bar',
+            value: undefined,
+            displayValue: undefined,
+            label: 'Bar',
+            props: expect.objectContaining({
+              label: 'Bar',
+            }),
+            data: {
+              bar: undefined,
+              foo: 'foo',
+            },
+            error: new Error(nb.Field.errorRequired),
+            internal: {
+              error: new Error(nb.Field.errorRequired),
+            },
+          },
+        ])
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -2,7 +2,14 @@ import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
-import { Field, Form, Iterate, OnSubmit, Wizard } from '../../..'
+import {
+  Field,
+  Form,
+  Iterate,
+  OnSubmit,
+  OnSubmitRequest,
+  Wizard,
+} from '../../..'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -2979,7 +2986,11 @@ describe('Wizard.Container', () => {
   })
 
   it('should call onSubmitRequest on step change', async () => {
-    const onSubmitRequest = jest.fn()
+    let receivedErrors = null
+
+    const onSubmitRequest: OnSubmitRequest = jest.fn(({ getErrors }) => {
+      receivedErrors = getErrors()
+    })
 
     render(
       <Form.Handler onSubmitRequest={onSubmitRequest}>
@@ -3003,25 +3014,26 @@ describe('Wizard.Container', () => {
     expect(onSubmitRequest).toHaveBeenCalledTimes(1)
     expect(onSubmitRequest).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        errors: [
-          {
-            path: '/bar',
-            value: undefined,
-            displayValue: undefined,
-            label: 'Bar',
-            props: expect.objectContaining({
-              label: 'Bar',
-            }),
-            data: {
-              bar: undefined,
-            },
-            error: new Error(nb.Field.errorRequired),
-            internal: {
-              error: new Error(nb.Field.errorRequired),
-            },
-          },
-        ],
+        getErrors: expect.any(Function),
       })
     )
+    expect(receivedErrors).toEqual([
+      {
+        path: '/bar',
+        value: undefined,
+        displayValue: undefined,
+        label: 'Bar',
+        props: expect.objectContaining({
+          label: 'Bar',
+        }),
+        data: {
+          bar: undefined,
+        },
+        error: new Error(nb.Field.errorRequired),
+        internal: {
+          error: new Error(nb.Field.errorRequired),
+        },
+      },
+    ])
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -675,9 +675,9 @@ export type OnSubmit<Data = JsonObject> = (
   }: OnSubmitParams
 ) => OnSubmitReturn
 export type OnSubmitRequest = ({
-  errors,
+  getErrors,
 }: {
-  errors: Array<DataPathHandlerParameters>
+  getErrors: () => Array<DataPathHandlerParameters>
 }) => void
 
 export type OnCommit<Data = JsonObject> = (


### PR DESCRIPTION
This is an addition to #4625.
I don’t think we should run the code to generate the errors with all the info unless it’s really necessary. That’s why I suggest using a function. Not that it would have a big performance impact, but still.
