### PR TITLE
fix(Forms): hide `info`, `warning` or `error` prop when `undefined` is given to a Field

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -171,6 +171,23 @@ describe('Field.Number', () => {
         ).toBeInTheDocument()
       })
 
+      it('should hide error when undefined is returned by error function', () => {
+        const { rerender } = render(
+          <Field.Number
+            error={() => new Error('This is what went wrong')}
+          />
+        )
+        expect(
+          screen.getByText('This is what went wrong')
+        ).toBeInTheDocument()
+
+        rerender(<Field.Number error={() => undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
+
       it('renders error given as a function with value', () => {
         render(
           <Field.Number

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -745,7 +745,7 @@ describe('FieldBlock', () => {
         ).not.toBeInTheDocument()
       })
 
-      it('a field (with useFieldProps) should show and hide the message when info prop gets "undefined"', () => {
+      it('should show and hide the message when info prop gets "undefined" (using Field.String in order to include useFieldProps)', () => {
         const { rerender } = render(<Field.String info="message" />)
 
         expect(
@@ -801,7 +801,7 @@ describe('FieldBlock', () => {
         ).not.toBeInTheDocument()
       })
 
-      it('a field (with useFieldProps) should show and hide the message when warning prop gets "undefined"', () => {
+      it('should show and hide the message when warning prop gets "undefined" (using Field.String in order to include useFieldProps)', () => {
         const { rerender } = render(<Field.String warning="message" />)
 
         expect(
@@ -846,7 +846,7 @@ describe('FieldBlock', () => {
         ).not.toBeInTheDocument()
       })
 
-      it('a field (with useFieldProps) should show and hide the message when error prop gets "undefined"', () => {
+      it('should show and hide the message when error prop gets "undefined" (using Field.String in order to include useFieldProps)', () => {
         const { rerender } = render(
           <Field.String error={new Error('message')} />
         )

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -730,6 +730,34 @@ describe('FieldBlock', () => {
         expect(element).toHaveClass('dnb-height-animation--is-visible')
         expect(element).toHaveTextContent(blockInfo)
       })
+
+      it('should show and hide the message when info prop gets "undefined"', () => {
+        const { rerender } = render(<FieldBlock info="message" />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<FieldBlock info={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
+
+      it('a field (with useFieldProps) should show and hide the message when info prop gets "undefined"', () => {
+        const { rerender } = render(<Field.String info="message" />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<Field.String info={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
     })
 
     describe('warning prop', () => {
@@ -758,6 +786,34 @@ describe('FieldBlock', () => {
         expect(element).toHaveClass('dnb-height-animation--is-visible')
         expect(element).toHaveTextContent(blockWarning)
       })
+
+      it('should show and hide the message when warning prop gets "undefined"', () => {
+        const { rerender } = render(<FieldBlock warning="message" />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<FieldBlock warning={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
+
+      it('a field (with useFieldProps) should show and hide the message when warning prop gets "undefined"', () => {
+        const { rerender } = render(<Field.String warning="message" />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<Field.String warning={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
     })
 
     describe('error prop', () => {
@@ -772,6 +828,38 @@ describe('FieldBlock', () => {
         expect(element).toHaveClass('dnb-form-status--error')
         expect(element).toHaveClass('dnb-height-animation--is-visible')
         expect(element).toHaveTextContent(blockError)
+      })
+
+      it('should show and hide the message when error prop gets "undefined"', () => {
+        const { rerender } = render(
+          <FieldBlock error={new Error('message')} />
+        )
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<FieldBlock error={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
+
+      it('a field (with useFieldProps) should show and hide the message when error prop gets "undefined"', () => {
+        const { rerender } = render(
+          <Field.String error={new Error('message')} />
+        )
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+
+        rerender(<Field.String error={undefined} />)
+
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -292,7 +292,12 @@ describe('useFieldProps', () => {
       const { result } = renderHook(useFieldProps, {
         initialProps: {
           value: '',
-          error: new Error('Error message'),
+          onChangeValidator: () => {
+            return new Error('Error message')
+          },
+          onBlurValidator: () => {
+            return new Error('Error message')
+          },
           validateInitially: false,
         },
       })
@@ -2076,6 +2081,7 @@ describe('useFieldProps', () => {
 
       expect(result.current.htmlAttributes).toEqual({
         'aria-describedby': expect.stringMatching(/id-.*-form-status/),
+        'aria-invalid': 'true',
       })
 
       rerender({})

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -125,7 +125,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     disabled: disabledProp,
     info: infoProp,
     warning: warningProp,
-    error: errorProp,
+    error: initialErrorProp = 'initial',
     errorMessages,
     onFocus,
     onBlur,
@@ -435,7 +435,11 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     [getFieldByPath, getValueByPath]
   )
 
-  const error = executeMessage<UseFieldProps['error']>(errorProp)
+  const errorProp =
+    initialErrorProp === 'initial' ? undefined : initialErrorProp
+  const error = executeMessage<UseFieldProps['error'] | 'initial'>(
+    errorProp
+  )
   const warning = executeMessage<UseFieldProps['warning']>(warningProp)
   const info = executeMessage<UseFieldProps['info']>(infoProp)
 
@@ -713,13 +717,16 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     revealErrorRef.current = true
   }
 
-  const bufferedError = revealErrorRef.current
-    ? prepareError(error) ??
-      localErrorRef.current ??
-      contextErrorRef.current
-    : error === null
-    ? null
-    : undefined
+  const bufferedError =
+    initialErrorProp !== 'initial' && typeof errorProp !== 'function'
+      ? prepareError(errorProp)
+      : revealErrorRef.current
+      ? prepareError(error as FormError) ??
+        localErrorRef.current ??
+        contextErrorRef.current
+      : error === null
+      ? null
+      : undefined
 
   const hasVisibleError =
     Boolean(bufferedError) ||

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -2335,12 +2335,12 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
   const infoRef = useRef<UseFieldProps['info']>(info)
   const warningRef = useRef<UseFieldProps['warning']>(warning)
-  if (typeof info !== 'undefined') {
+  useMemo(() => {
     infoRef.current = info
-  }
-  if (typeof warning !== 'undefined') {
+  }, [info])
+  useMemo(() => {
     warningRef.current = warning
-  }
+  }, [warning])
 
   const connections = useMemo(() => {
     return {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -717,16 +717,24 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     revealErrorRef.current = true
   }
 
-  const bufferedError =
-    initialErrorProp !== 'initial' && typeof errorProp !== 'function'
-      ? prepareError(errorProp)
-      : revealErrorRef.current
-      ? prepareError(error as FormError) ??
+  const getBufferedError = useCallback(() => {
+    if (
+      initialErrorProp !== 'initial' &&
+      typeof errorProp !== 'function'
+    ) {
+      return prepareError(errorProp)
+    } else if (revealErrorRef.current) {
+      return (
+        prepareError(error as FormError) ??
         localErrorRef.current ??
         contextErrorRef.current
-      : error === null
-      ? null
-      : undefined
+      )
+    } else if (error === null) {
+      return null
+    }
+  }, [error, errorProp, initialErrorProp, prepareError])
+
+  const bufferedError = getBufferedError()
 
   const hasVisibleError =
     Boolean(bufferedError) ||


### PR DESCRIPTION
Fixes #4611