### PR TITLE
docs(Name): remove Field.SummaryList from example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
@@ -7,16 +7,16 @@ showTabs: true
 `Field.Name` is a wrapper component for the [input of strings](/uilib/extensions/forms/base-fields/String), with user experience tailored for first and last name and company names.
 
 ```jsx
-import { Field } from '@dnb/eufemia/extensions/forms'
+import { Field, Form } from '@dnb/eufemia/extensions/forms'
 
 function MyForm() {
   return (
-    <Field.SummaryList>
+    <Form.Handler>
       <Field.Name />
       <Field.Name.First value="Nora" />
       <Field.Name.Last value="Mørk" />
       <Field.Name.Company value="DNB" />
-    </Field.SummaryList>
+    </Form.Handler>
   )
 }
 ```


### PR DESCRIPTION
I don't think this docs/info is correct, as we don't have a field named `Field.SummaryList`, and it doesn't make sense to use `Value.SummaryList` in the example either, so changing to `Form.Handler` instead.