### PR TITLE
feat(DatePicker): add invalid dates to return object

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/events.mdx
@@ -17,12 +17,15 @@ All additional HTML attributes will be returned as well.
 
 ```js
 {
-  date: null|'like return_format', /* Gets returned if range is false */
-  start_date: null|'like return_format',
-  end_date: null|'like return_format',
+  date: null | 'date as `returnFormat` | `yyyy-MM-dd` ', /* Available if `range` is `false` */
+  start_date: null | 'date as `returnFormat` | `yyyy-MM-dd`', /* Available if `range` is `true` */
+  end_date: null | 'date as `returnFormat` | `yyyy-MM-dd`', /* Available if `range` is `true` */
+  invalidDate: null | 'date as `returnFormat` | `yyyy-MM-dd`', /* Available if `range` is `false` */
+  invalidStartDate: null | 'date as `returnFormat` | ´yyyy-MM-dd`', /* Available if `range` is `true` */
+  invalidEndDate: null | 'date as `returnFormat` | `yyyy-MM-dd`', /* Available if `range` is `true` */
   days_between: number,
   attributes: { attributes },
-  event: null|{ native event }
+  event: null | { native event }
 }
 ```
 
@@ -34,10 +37,9 @@ Additional event return object properties:
 
 ```js
 {
-  is_valid: boolean, /* Gets returned if range is false */
-  is_valid_start_date: boolean,
-  is_valid_end_date: boolean,
-  ...
+  is_valid: boolean, /* Available if `range` is `false` */
+  is_valid_start_date: boolean, /* Available if `range` is `true` */
+  is_valid_end_date: boolean, /* Available if `range` is `true` */
 }
 ```
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -348,6 +348,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           hoverDate: null,
         },
         (dates) => {
+          // Should fire if user has filled out an invalid date,
+          // or of the date was valid, but the user has pressed backsapce or removed it
           if (isDateFullyFilledOutRef.current || hasHadValidDate) {
             const { startDate, endDate, event } = {
               ...state,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -445,7 +445,12 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       const isStartDateValid = isValid(parsedStartDate)
       const isEndDateValid = isValid(parsedEndDate)
 
-      let returnObject = getReturnObject({
+      const {
+        is_valid,
+        is_valid_start_date,
+        is_valid_end_date,
+        ...returnObject
+      } = getReturnObject({
         startDate: isStartDateValid ? parsedStartDate : null,
         endDate: isEndDateValid ? parsedEndDate : null,
         event,
@@ -454,28 +459,22 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         ...invalidDatesRef.current,
       })
 
-      // Now, lets correct
-      if (
-        returnObject.is_valid === false ||
-        returnObject.is_valid_start_date === false ||
-        returnObject.is_valid_end_date === false
-      ) {
-        const { startDate, endDate } = getDates()
-
-        const typedDates = isRange
-          ? {
-              start_date: startDate,
-              end_date: endDate,
-            }
-          : { date: startDate }
-
-        returnObject = {
-          ...returnObject,
-          ...typedDates,
-        }
+      // Re-assigns dates to typed the date, instead of null returned from getReturnObject, if they are invalid
+      const typedDates = {
+        ...(!isRange && is_valid === false && { date: startDate }),
+        ...(isRange &&
+          is_valid_start_date === false && { start_date: startDate }),
+        ...(isRange &&
+          is_valid_end_date === false && { end_date: endDate }),
       }
 
-      onType?.({ ...returnObject })
+      onType?.({
+        is_valid,
+        is_valid_start_date,
+        is_valid_end_date,
+        ...returnObject,
+        ...typedDates,
+      })
     },
     [isRange, dateRefs, getReturnObject, inputDates, onType]
   )

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -153,7 +153,10 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     partialEndDate: '',
   })
 
-  const invalidDatesRef = useRef<InvalidDates>({})
+  const invalidDatesRef = useRef<InvalidDates>({
+    invalidStartDate: null,
+    invalidEndDate: null,
+  })
   const isDateFullyFilledOutRef = useRef(false)
 
   const {
@@ -391,7 +394,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           (typeof startDate !== 'undefined' && isValid(startDate)) ||
           (typeof endDate !== 'undefined' && isValid(endDate))
         ) {
-          callOnChangeHandler({ event, ...dates })
+          callOnChangeHandler({
+            event,
+            ...dates,
+            ...invalidDatesRef.current,
+          })
         }
       })
     },
@@ -695,6 +702,13 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
       // update the date
       if (isValidDate) {
+        invalidDatesRef.current = {
+          ...invalidDatesRef.current,
+          ...(mode === 'start'
+            ? { invalidStartDate: null }
+            : { invalidEndDate: null }),
+        }
+
         callOnChange({
           [`${mode}Date`]: date,
           event,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -349,7 +349,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         },
         (dates) => {
           // Should fire if user has filled out an invalid date,
-          // or of the date was valid, but the user has pressed backsapce or removed it
+          // or if the date was valid. Like if the user has pressed backspace or removed the valid date.
           if (isDateFullyFilledOutRef.current || hasHadValidDate) {
             const { startDate, endDate, event } = {
               ...state,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -459,7 +459,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         ...invalidDatesRef.current,
       })
 
-      // Re-assigns dates to typed the date, instead of null returned from getReturnObject, if they are invalid
+      // Re-assigns dates to the typed date, instead of `null` from getReturnObject, if dates are invalid
       const typedDates = {
         ...(!isRange && is_valid === false && { date: startDate }),
         ...(isRange &&

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -24,6 +24,7 @@ import useDates, { DatePickerDates } from './hooks/useDates'
 import useLastEventCallCache, {
   LastEventCallCache,
 } from './hooks/useLastEventCallCache'
+import { InvalidDates } from './DatePickerInput'
 
 type DatePickerProviderProps = DatePickerAllProps & {
   setReturnObject: (
@@ -34,18 +35,20 @@ type DatePickerProviderProps = DatePickerAllProps & {
   children: React.ReactNode
 }
 
-export type DatePickerChangeEvent<E> = DatePickerDates & {
-  nr?: number
-  hidePicker?: boolean
-  event?: E
-}
+export type DatePickerChangeEvent<E> = DatePickerDates &
+  InvalidDates & {
+    nr?: number
+    hidePicker?: boolean
+    event?: E
+  }
 
-export type GetReturnObjectParams<E> = DatePickerDates & {
-  event?: E
-}
+export type GetReturnObjectParams<E> = DatePickerDates &
+  InvalidDates & {
+    event?: E
+  }
 
 // TODO: convert properties on event handler return objects to camelCase, constitutes a breaking change
-export type ReturnObject<E> = {
+export type ReturnObject<E> = InvalidDates & {
   event?: E
   attributes?: Record<string, unknown>
   days_between?: number
@@ -123,7 +126,14 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
 
   const getReturnObject = useCallback(
     <E,>({ event = null, ...rest }: GetReturnObjectParams<E> = {}) => {
-      const { startDate, endDate, partialStartDate, partialEndDate } = {
+      const {
+        startDate,
+        endDate,
+        partialStartDate,
+        partialEndDate,
+        invalidStartDate,
+        invalidEndDate,
+      } = {
         ...views,
         ...dates,
         ...rest,
@@ -165,12 +175,15 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
               ? false
               : endDateIsValid,
           partialEndDate,
+          invalidStartDate,
+          invalidEndDate,
         }
       }
 
       return {
         ...returnObject,
         date: startDateIsValid ? format(startDate, returnFormat) : null,
+        invalidDate: invalidStartDate,
         is_valid:
           hasMinOrMaxDates &&
           startDateIsValid &&

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2456,22 +2456,22 @@ describe('DatePicker component', () => {
     const dayInput = document.querySelector('.dnb-date-picker__input--day')
 
     await userEvent.click(dayInput)
-    await userEvent.keyboard('99')
+    await userEvent.keyboard('39')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('99')
+    await userEvent.keyboard('19')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('9999')
+    await userEvent.keyboard('1111')
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ invalidDate: '9999-99-99' })
+      expect.objectContaining({ invalidDate: '1111-19-39' })
     )
 
     // Typing a valid date
     await userEvent.click(dayInput)
     await userEvent.keyboard('20112025')
-    expect(onChange).toHaveBeenCalledTimes(6)
+    expect(onChange).toHaveBeenCalledTimes(7)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ invalidDate: null })
     )
@@ -2485,48 +2485,48 @@ describe('DatePicker component', () => {
 
     // Fill out startDay
     await userEvent.click(dayInput)
-    await userEvent.keyboard('99')
+    await userEvent.keyboard('39')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('99')
+    await userEvent.keyboard('19')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('9999')
+    await userEvent.keyboard('1111')
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ invalidStartDate: '9999-99-99' })
+      expect.objectContaining({ invalidStartDate: '1111-19-39' })
     )
 
     // Fill out endDay
-    await userEvent.keyboard('88')
+    await userEvent.keyboard('39')
     expect(onChange).toHaveBeenCalledTimes(1)
 
-    await userEvent.keyboard('88')
+    await userEvent.keyboard('19')
     expect(onChange).toHaveBeenCalledTimes(1)
 
-    await userEvent.keyboard('8888')
+    await userEvent.keyboard('2222')
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        invalidStartDate: '9999-99-99',
-        invalidEndDate: '8888-88-88',
+        invalidStartDate: '1111-19-39',
+        invalidEndDate: '2222-19-39',
       })
     )
 
     // Typing a valid start date
     await userEvent.click(dayInput)
     await userEvent.keyboard('20112025')
-    expect(onChange).toHaveBeenCalledTimes(7)
+    expect(onChange).toHaveBeenCalledTimes(8)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         invalidStartDate: null,
-        invalidEndDate: '8888-88-88',
+        invalidEndDate: '2222-19-39',
       })
     )
 
     // Typing a valid end date
     await userEvent.keyboard('29112025')
-    expect(onChange).toHaveBeenCalledTimes(12)
+    expect(onChange).toHaveBeenCalledTimes(13)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         invalidStartDate: null,

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2448,6 +2448,92 @@ describe('DatePicker component', () => {
       expect(document.querySelector('#my-input')).toHaveFocus()
     })
   })
+
+  it('should trigger `onChange` with `invalidDate` when input is fully filled out with an invalid date', async () => {
+    const onChange = jest.fn()
+    render(<DatePicker onChange={onChange} showInput />)
+
+    const dayInput = document.querySelector('.dnb-date-picker__input--day')
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('99')
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.keyboard('99')
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.keyboard('9999')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ invalidDate: '9999-99-99' })
+    )
+
+    // Typing a valid date
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('20112025')
+    expect(onChange).toHaveBeenCalledTimes(6)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ invalidDate: null })
+    )
+  })
+
+  it('should trigger `onChange` with `invalidStartDate` and `invalidEndDate` when input is fully filled out with an invalid dates in `range` mode', async () => {
+    const onChange = jest.fn()
+    render(<DatePicker onChange={onChange} range showInput />)
+
+    const dayInput = document.querySelector('.dnb-date-picker__input--day')
+
+    // Fill out startDay
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('99')
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.keyboard('99')
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.keyboard('9999')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ invalidStartDate: '9999-99-99' })
+    )
+
+    // Fill out endDay
+    await userEvent.keyboard('88')
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    await userEvent.keyboard('88')
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    await userEvent.keyboard('8888')
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidStartDate: '9999-99-99',
+        invalidEndDate: '8888-88-88',
+      })
+    )
+
+    // Typing a valid start date
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('20112025')
+    expect(onChange).toHaveBeenCalledTimes(7)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidStartDate: null,
+        invalidEndDate: '8888-88-88',
+      })
+    )
+
+    // Typing a valid end date
+    await userEvent.keyboard('29112025')
+    expect(onChange).toHaveBeenCalledTimes(12)
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidStartDate: null,
+        invalidEndDate: null,
+      })
+    )
+  })
 })
 
 // for the unit calc tests

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -39,6 +39,7 @@ export type DatePickerDates = {
   maxDate?: Date
   startMonth?: Date
   endMonth?: Date
+  // TODO: Move partial dates to own types, as they are not really only used on `getReturnObject`, and not in this hook
   partialStartDate?: string
   partialEndDate?: string
   hasHadValidDate?: boolean


### PR DESCRIPTION
Adding invalid dates, typed in by user, to the return object, to make it possible to validate if the given date is invalid. As of today, the date is set to null of the date is invalid, making it impossible to tell if the date is null because the input field is empty, or if the date is invalid