### PR TITLE
chore(StepIndicator): add `triggerButtonProps` for internal Wizard use to show a state on the trigger button when in small view

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -21,6 +21,7 @@ import type {
 } from './StepIndicatorItem'
 import { stepIndicatorDefaultProps } from './StepIndicatorProps'
 import useId from '../../shared/helpers/useId'
+import { StepIndicatorTriggerButtonProps } from './StepIndicatorTriggerButton'
 
 export type StepIndicatorMode = 'static' | 'strict' | 'loose'
 export type StepIndicatorDataItem = Pick<
@@ -125,6 +126,12 @@ export type StepIndicatorProps = Omit<
       current_step,
       currentStep,
     }: StepIndicatorMouseEvent) => void
+
+    /**
+     * The props for the trigger button.
+     * Used internally to pass the props such as a status to the trigger button.
+     */
+    triggerButtonProps?: StepIndicatorTriggerButtonProps
 
     /**
      * If set to `true`, the height animation on the step items and the drawer button will be omitted. Defaults to `false`.

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorContext.tsx
@@ -23,6 +23,7 @@ import {
   StepIndicatorProps,
 } from './StepIndicator'
 import { StepIndicatorItemProps } from './StepIndicatorItem'
+import { StepIndicatorTriggerButtonProps } from './StepIndicatorTriggerButton'
 
 // We use this array to filter out unwanted properties
 const filterAttributes = Object.keys(stepIndicatorDefaultProps)
@@ -79,6 +80,7 @@ export type StepIndicatorProviderProps = Omit<
   mode?: StepIndicatorMode
   children: React.ReactNode
   isSidebar?: boolean
+  triggerButtonProps?: StepIndicatorTriggerButtonProps
 }
 
 export type StepIndicatorProviderStates = {

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -41,6 +41,7 @@ function StepIndicatorTriggerButton(
 
   const {
     data, // eslint-disable-line
+    triggerButtonProps, // eslint-disable-line
     ...contextWithoutData
   } = context
 
@@ -55,6 +56,7 @@ function StepIndicatorTriggerButton(
   } as React.HTMLProps<HTMLElement>
 
   const buttonParams = {
+    ...triggerButtonProps,
     ...props,
     className: classnames(
       'dnb-step-indicator__trigger__button',


### PR DESCRIPTION
We need this prop in order to be able to show an error status on the Wizard when the screen has a small width. Its used internally only. And may even be removed in v3 of the StepIndicator.