### PR TITLE
chore(Field.Slider): incorrect use of label `for`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
@@ -122,6 +122,7 @@ function SliderComponent(props: Props) {
   }
 
   const sliderProps: SliderProps = {
+    id,
     value,
     step,
     min,


### PR DESCRIPTION
Hopefully fixes the following error, seen in the [example](https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/more-fields/Slider/demos/): 

```
The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form and accessibility tools from working correctly.

To fix this issue, make sure the label's for attribute references the correct id of a form field.
```

Fix can be tested/validated here: https://eufemia-git-chore-incorrect-use-of-label-eufemia.vercel.app/uilib/extensions/forms/feature-fields/more-fields/Slider/