### PR TITLE
docs(Dialog): removes double properties heading

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/prop-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/prop-table.mdx
@@ -1,6 +1,4 @@
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { DialogProperties } from '@dnb/eufemia/src/components/dialog/DialogDocs'
 
-## Properties
-
 <PropertiesTable props={DialogProperties} />


### PR DESCRIPTION
As of now, we have 2x "Properties"-heading in the Dialog properties docs, https://eufemia.dnb.no/uilib/components/dialog/properties/