### PR TITLE
docs(HeightAnimation): remove properties heading from events doc

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/events.mdx
@@ -2,11 +2,9 @@
 showTabs: true
 ---
 
-## Events
-
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { HeightAnimationEvents } from '@dnb/eufemia/src/components/height-animation/HeightAnimationDocs'
 
-## Properties
+## Events
 
 <PropertiesTable props={HeightAnimationEvents} />


### PR DESCRIPTION
This is how it looks today: https://eufemia.dnb.no/uilib/components/height-animation/events/