### PR TITLE
docs(InfoCard): remove events from properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/properties.mdx
@@ -18,8 +18,6 @@ showTabs: true
 | `skeleton`                              | _(optional)_ Applies loading skeleton.                                                                                             |
 | `closeButtonText`                       | _(optional)_ The close button text.                                                                                                |
 | `closeButtonAttributes`                 | _(optional)_ define any valid Eufemia [Button properties](/uilib/components/button/properties) or HTML attribute inside an object. |
-| `onClose`                               | _(optional)_ A function called when the user clicks the close button.                                                              |
 | `acceptButtonText`                      | _(optional)_ The accept button text.                                                                                               |
 | `acceptButtonAttributes`                | _(optional)_ define any valid Eufemia [Button properties](/uilib/components/button/properties) or HTML attribute inside an object. |
-| `onAccept`                              | _(optional)_ A function called when the user clicks the accept button.                                                             |
 | [Space](/uilib/layout/space/properties) | _(optional)_ spacing properties like `top` or `bottom` are supported.                                                              |


### PR DESCRIPTION
These events are already listed under [events](https://eufemia.dnb.no/uilib/components/info-card/events/), so removing them from [properties](https://eufemia.dnb.no/uilib/components/info-card/properties/).