### PR TITLE
fix(DatePicker): remove input validation (use Field.Date for included validation)

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -821,7 +821,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
                       inputSizeClassName
                     )}
                     size={2}
-                    mask={[/[0-3]/, /[0-9]/]}
+                    mask={[/[0-9]/, /[0-9]/]}
                     inputRef={inputRefs.current[`${mode}DayRef`]}
                     onChange={dateSetters[`set_${mode}Day`]}
                     value={inputDates[`__${mode}Day`] || ''}
@@ -853,7 +853,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
                       inputSizeClassName
                     )}
                     size={2}
-                    mask={[/[0-1]/, /[0-9]/]}
+                    mask={[/[0-9]/, /[0-9]/]}
                     inputRef={inputRefs.current[`${mode}MonthRef`]}
                     onChange={dateSetters[`set_${mode}Month`]}
                     value={inputDates[`__${mode}Month`] || ''}
@@ -885,7 +885,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
                       inputSizeClassName
                     )}
                     size={4}
-                    mask={[/[1-2]/, /[0-9]/, /[0-9]/, /[0-9]/]}
+                    mask={[/[0-9]/, /[0-9]/, /[0-9]/, /[0-9]/]}
                     inputRef={inputRefs.current[`${mode}YearRef`]}
                     onChange={dateSetters[`set_${mode}Year`]}
                     value={inputDates[`__${mode}Year`] || ''}

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2532,52 +2532,58 @@ describe('DatePicker component', () => {
 
     // Fill out startDay
     await userEvent.click(dayInput)
-    await userEvent.keyboard('39')
+    await userEvent.keyboard('99')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('19')
+    await userEvent.keyboard('99')
     expect(onChange).toHaveBeenCalledTimes(0)
 
-    await userEvent.keyboard('1111')
+    await userEvent.keyboard('9999')
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ invalidStartDate: '1111-19-39' })
+      expect.objectContaining({ invalidStartDate: '9999-99-99' })
     )
 
     // Fill out endDay
-    await userEvent.keyboard('39')
+    await userEvent.keyboard('88')
     expect(onChange).toHaveBeenCalledTimes(1)
 
-    await userEvent.keyboard('19')
+    await userEvent.keyboard('88')
     expect(onChange).toHaveBeenCalledTimes(1)
 
-    await userEvent.keyboard('2222')
+    await userEvent.keyboard('8888')
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        invalidStartDate: '1111-19-39',
-        invalidEndDate: '2222-19-39',
+        invalidStartDate: '9999-99-99',
+        invalidEndDate: '8888-88-88',
+        start_date: null,
+        end_date: null,
       })
     )
 
     // Typing a valid start date
     await userEvent.click(dayInput)
     await userEvent.keyboard('20112025')
-    expect(onChange).toHaveBeenCalledTimes(8)
+    expect(onChange).toHaveBeenCalledTimes(7)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         invalidStartDate: null,
-        invalidEndDate: '2222-19-39',
+        invalidEndDate: '8888-88-88',
+        start_date: '2025-11-20',
+        end_date: null,
       })
     )
 
     // Typing a valid end date
     await userEvent.keyboard('29112025')
-    expect(onChange).toHaveBeenCalledTimes(13)
+    expect(onChange).toHaveBeenCalledTimes(12)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         invalidStartDate: null,
         invalidEndDate: null,
+        start_date: '2025-11-20',
+        end_date: '2025-11-29',
       })
     )
   })


### PR DESCRIPTION
As concluded in a team meeting, we should remove the input control, and allow users to type in whatever numbers they want, to prevent confusion, especially for vision impaired users. 

`Field.Date` will with [this PR](https://github.com/dnbexperience/eufemia/pull/4508) warn users if they have typed an invalid date