### PR TITLE
feat: use @dnb/browserslist-config for when creating the bundle

### DIFF
--- a/packages/dnb-design-system-portal/.browserslistrc
+++ b/packages/dnb-design-system-portal/.browserslistrc
@@ -1,2 +1,1 @@
-# Should reflect: https://eufemia.dnb.no/uilib/usage#supported-browsers-and-platforms
-defaults and supports es6-module
+extends @dnb/browserslist-config

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -26,7 +26,7 @@ const ignoreAsPage = [
   '**/skip-link-example.tsx',
   '**/CardProductsTable.js',
   '**/ColorTable.tsx',
-  '**/assets/*.js',
+  '**/assets/*.{js,ts,tsx}',
   '**/__utils__/*.{js,ts,tsx}',
   // '**/*.mdx',// Use when templates/mdx.tsx in createPage is used
 ]

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -59,7 +59,7 @@
     "@babel/core": "7.22.5",
     "@babel/eslint-parser": "7.22.5",
     "@babel/node": "7.22.5",
-    "@dnb/browserslist-config": "1.1.0",
+    "@dnb/browserslist-config": "1.2.0",
     "@emotion/cache": "11.11.0",
     "@playwright/test": "1.49.1",
     "@types/json-schema": "7.0.12",

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -59,6 +59,7 @@
     "@babel/core": "7.22.5",
     "@babel/eslint-parser": "7.22.5",
     "@babel/node": "7.22.5",
+    "@dnb/browserslist-config": "1.1.0",
     "@emotion/cache": "11.11.0",
     "@playwright/test": "1.49.1",
     "@types/json-schema": "7.0.12",

--- a/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
@@ -40,28 +40,6 @@ When switching over to Yarn PnP, there are some issues:
   gatsby-plugin-mdx tried to access mkdirp, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
   ```
 
-### Gatsby v4
-
-In order to ensure `defaults and supports es6-module` is not targeting IE11, we run a newer version of `browserslist`.
-
-```json
-{
-  "resolutions": {
-    "gatsby/browserslist": "4.21.4"
-  }
-}
-```
-
-Gatsby v4 uses socket.io v3 that has an [issue](https://github.com/socketio/socket.io/issues/3838) when running all visual tests in a batch locally on a development build. To mitigate it, we have installed a newer version of socket.io:
-
-```json
-{
-  "resolutions": {
-    "gatsby/socket.io": "4.6.1"
-  }
-}
-```
-
 ### svg2vectordrawable
 
 `svg2vectordrawable` uses an very old version of svgo that did not work with newer versions of Node.js.

--- a/packages/dnb-design-system-portal/src/docs/uilib/assets/SupportedBrowsers.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/assets/SupportedBrowsers.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import config from '@dnb/browserslist-config'
+import supportedBrowsers from '@dnb/browserslist-config/supportedBrowsers.mjs'
+import {
+  Table,
+  Th,
+  Tr,
+  Code,
+  CopyOnClick,
+  Space,
+  Td,
+} from '@dnb/eufemia/src'
+
+export function SupportedBrowsersConfig() {
+  return (
+    <Space element="pre">
+      <Code>
+        <Space innerSpace>
+          <CopyOnClick>
+            {config
+              .map((browser) => {
+                return browser
+              })
+              .join(',\n')}
+          </CopyOnClick>
+        </Space>
+      </Code>
+    </Space>
+  )
+}
+
+export function SupportedBrowsersTable() {
+  return (
+    <Table size="small" outline>
+      <thead>
+        <Tr>
+          <Th
+            style={{
+              width: '30%',
+            }}
+          >
+            Browser
+          </Th>
+          <Th>Minimum version</Th>
+        </Tr>
+      </thead>
+
+      <tbody>
+        {supportedBrowsers.map((browser, key) => {
+          return (
+            <Tr key={key}>
+              <Td>{browser.name}</Td>
+              <Td>
+                <Code>{browser.minimumVersion}</Code>
+              </Td>
+            </Tr>
+          )
+        })}
+      </tbody>
+    </Table>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
@@ -36,8 +36,8 @@ Read more in the [First Steps](/uilib/usage/first-steps/) section.
 
 ## Supported Browsers and Platforms
 
-Eufemia uses the following config for the bundle output, defined in `.browserslistrc`:
+Eufemia uses the [@dnb/browserslist-config](https://github.com/dnbexperience/browserslist-config) configuration for the bundle output, defined in `.browserslistrc`:
 
-- `defaults and supports es6-module`
+- `extends @dnb/browserslist-config`
 
 To see exactly which browsers this config supports, take a look [here](https://browsersl.ist/#q=defaults+and+supports+es6-module).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
@@ -48,7 +48,7 @@ Eufemia uses the [@dnb/browserslist-config](https://github.com/dnbexperience/bro
 
 - `extends @dnb/browserslist-config`
 
-It only effects the JavaScript bundle output, not the CSS bundle output.
+It only affects the JavaScript bundle output, not the CSS bundle output.
 
 To see exactly which browsers this config supports, paste the following config into the [Check compatible browsers](https://browsersl.ist/#q=defaults+and+supports+es6-module) tool:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage.mdx
@@ -5,6 +5,10 @@ order: 3
 ---
 
 import WatchingReleases from 'Docs/uilib/info/about-watching-releases.mdx'
+import {
+  SupportedBrowsersConfig,
+  SupportedBrowsersTable,
+} from 'Docs/uilib/assets/SupportedBrowsers'
 
 # Usage
 
@@ -36,8 +40,16 @@ Read more in the [First Steps](/uilib/usage/first-steps/) section.
 
 ## Supported Browsers and Platforms
 
+<SupportedBrowsersTable />
+
+### Configuration and Browserslist
+
 Eufemia uses the [@dnb/browserslist-config](https://github.com/dnbexperience/browserslist-config) configuration for the bundle output, defined in `.browserslistrc`:
 
 - `extends @dnb/browserslist-config`
 
-To see exactly which browsers this config supports, take a look [here](https://browsersl.ist/#q=defaults+and+supports+es6-module).
+It only effects the JavaScript bundle output, not the CSS bundle output.
+
+To see exactly which browsers this config supports, paste the following config into the [Check compatible browsers](https://browsersl.ist/#q=defaults+and+supports+es6-module) tool:
+
+<SupportedBrowsersConfig />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/polyfill.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/polyfill.mdx
@@ -21,7 +21,7 @@ Use [postcss-preset-env](https://github.com/csstools/postcss-preset-env). Exampl
       postcssPresetEnv({
         stage: 0,
         preserve: true,
-        browsers: ['defaults and supports es6-module'],
+        browsers: ['extends @dnb/browserslist-config'],
         importFrom: [require.resolve('@dnb/eufemia/style/themes/theme-ui/ui-theme-properties.css')]
       })
     ]

--- a/packages/dnb-eufemia/.browserslistrc
+++ b/packages/dnb-eufemia/.browserslistrc
@@ -1,1 +1,1 @@
-defaults and supports es6-module
+extends @dnb/browserslist-config

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -151,6 +151,7 @@
     "@babel/preset-react": "7.22.5",
     "@babel/preset-typescript": "7.22.5",
     "@babel/traverse": "7.23.2",
+    "@dnb/browserslist-config": "1.1.0",
     "@emotion/react": "11.11.0",
     "@emotion/styled": "11.11.0",
     "@playwright/test": "1.49.1",

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -151,7 +151,7 @@
     "@babel/preset-react": "7.22.5",
     "@babel/preset-typescript": "7.22.5",
     "@babel/traverse": "7.23.2",
-    "@dnb/browserslist-config": "1.1.0",
+    "@dnb/browserslist-config": "1.2.0",
     "@emotion/react": "11.11.0",
     "@emotion/styled": "11.11.0",
     "@playwright/test": "1.49.1",

--- a/packages/dnb-eufemia/scripts/prebuild/config/postcssConfig.js
+++ b/packages/dnb-eufemia/scripts/prebuild/config/postcssConfig.js
@@ -9,7 +9,7 @@ module.exports = (options) => {
     // preset-env processes the most of our old legacy browsers
     require('postcss-preset-env')({
       stage: 2,
-      browsers: ['defaults and supports es6-module'].filter((i) => i),
+      browsers: ['extends @dnb/browserslist-config'].filter((i) => i),
       ...options,
     }),
   ].filter((i) => i) // remove the first

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,6 +2929,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnb/browserslist-config@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@dnb/browserslist-config@npm:1.1.0"
+  checksum: 10/e0e14971f7a2cf37ec62d36d0f21c645fc8cb744fc4f66846c42ca2ddbe8746baa8fa46fd6463696ecc600fbf465a60de4111c5f7dc0ccff5b2315e7221e01bd
+  languageName: node
+  linkType: hard
+
 "@dnb/eufemia@workspace:*, @dnb/eufemia@workspace:packages/dnb-eufemia":
   version: 0.0.0-use.local
   resolution: "@dnb/eufemia@workspace:packages/dnb-eufemia"
@@ -2954,6 +2961,7 @@ __metadata:
     "@babel/preset-typescript": "npm:7.22.5"
     "@babel/runtime": "npm:7.22.5"
     "@babel/traverse": "npm:7.23.2"
+    "@dnb/browserslist-config": "npm:1.1.0"
     "@emotion/react": "npm:11.11.0"
     "@emotion/styled": "npm:11.11.0"
     "@navikt/fnrvalidator": "npm:2.1.5"
@@ -13272,6 +13280,7 @@ __metadata:
     "@babel/core": "npm:7.22.5"
     "@babel/eslint-parser": "npm:7.22.5"
     "@babel/node": "npm:7.22.5"
+    "@dnb/browserslist-config": "npm:1.1.0"
     "@dnb/eufemia": "workspace:*"
     "@emotion/cache": "npm:11.11.0"
     "@emotion/react": "npm:11.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,10 +2929,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dnb/browserslist-config@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@dnb/browserslist-config@npm:1.1.0"
-  checksum: 10/e0e14971f7a2cf37ec62d36d0f21c645fc8cb744fc4f66846c42ca2ddbe8746baa8fa46fd6463696ecc600fbf465a60de4111c5f7dc0ccff5b2315e7221e01bd
+"@dnb/browserslist-config@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@dnb/browserslist-config@npm:1.2.0"
+  checksum: 10/62641b81b2fc5ac57225ef7a32beb5e8ce4f3e1b42d401b1778ba41bf66ebd9195e65ef4603499faf75fb69dbf92f72c15e7114fab4f2738a075f5101238795b
   languageName: node
   linkType: hard
 
@@ -2961,7 +2961,7 @@ __metadata:
     "@babel/preset-typescript": "npm:7.22.5"
     "@babel/runtime": "npm:7.22.5"
     "@babel/traverse": "npm:7.23.2"
-    "@dnb/browserslist-config": "npm:1.1.0"
+    "@dnb/browserslist-config": "npm:1.2.0"
     "@emotion/react": "npm:11.11.0"
     "@emotion/styled": "npm:11.11.0"
     "@navikt/fnrvalidator": "npm:2.1.5"
@@ -13280,7 +13280,7 @@ __metadata:
     "@babel/core": "npm:7.22.5"
     "@babel/eslint-parser": "npm:7.22.5"
     "@babel/node": "npm:7.22.5"
-    "@dnb/browserslist-config": "npm:1.1.0"
+    "@dnb/browserslist-config": "npm:1.2.0"
     "@dnb/eufemia": "workspace:*"
     "@emotion/cache": "npm:11.11.0"
     "@emotion/react": "npm:11.9.3"


### PR DESCRIPTION
My research so far is:

There is a difference in the output. But its minimal. Basically, every file (over 400) have some more imports such as this:

```js
import "core-js/modules/web.dom-collections.iterator.js";
```

Also, we may add a list of the supported browsers in a human readable table/list. Here is a PR that would make that possible: https://github.com/dnbexperience/browserslist-config