### PR TITLE
fix(Input): remove value attribute (⚠️ Use element.value instead in e.g. tests)

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
@@ -3,7 +3,7 @@
  *
  */
 
-import React from 'react'
+import React, { useCallback } from 'react'
 import classnames from 'classnames'
 import {
   cleanNumber,
@@ -230,34 +230,44 @@ export const useInputElement = () => {
   // Create the actual input element
   const inputElementRef = React.useRef(<input ref={ref} />)
 
-  const InputElement = (params, innerRef) => {
-    // Set ref for Eufemia input
-    innerRef.current = ref.current
+  return useCallback(
+    (params, innerRef) => {
+      // Set ref for Eufemia input
+      innerRef.current = ref.current
 
-    return (
-      <TextMask
-        inputRef={ref}
-        inputElement={inputElementRef.current}
-        pipe={pipe}
-        mask={mask || createNumberMask()}
-        showMask={showMask}
-        guide={showGuide}
-        keepCharPositions={keepCharPositions}
-        placeholderChar={placeholderChar}
-        {...getSoftKeyboardAttributes(mask)}
-        {...params}
-        className={classnames(
-          params.className,
-          showMask &&
-            showGuide &&
-            placeholderChar &&
-            placeholderChar !== invisibleSpace &&
-            'dnb-input-masked--guide' // will use --font-family-monospace
-        )}
-      />
-    )
-  }
-  return InputElement
+      return (
+        <TextMask
+          inputRef={ref}
+          inputElement={inputElementRef.current}
+          pipe={pipe}
+          mask={mask || createNumberMask()}
+          showMask={showMask}
+          guide={showGuide}
+          keepCharPositions={keepCharPositions}
+          placeholderChar={placeholderChar}
+          {...getSoftKeyboardAttributes(mask)}
+          {...params}
+          className={classnames(
+            params.className,
+            showMask &&
+              showGuide &&
+              placeholderChar &&
+              placeholderChar !== invisibleSpace &&
+              'dnb-input-masked--guide' // will use --font-family-monospace
+          )}
+        />
+      )
+    },
+    [
+      keepCharPositions,
+      mask,
+      pipe,
+      placeholderChar,
+      ref,
+      showGuide,
+      showMask,
+    ]
+  )
 }
 
 /**

--- a/packages/dnb-eufemia/src/components/input-masked/MultiInputMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/MultiInputMask.tsx
@@ -347,10 +347,10 @@ function MultiInputMaskInput<T extends string>({
       )}
     </>
   )
+}
 
-  function removePlaceholder(value: string, placeholder: string) {
-    return value.replace(RegExp(placeholder, 'gm'), '')
-  }
+function removePlaceholder(value: string, placeholder: string) {
+  return value.replace(RegExp(placeholder, 'gm'), '')
 }
 
 export default MultiInputMask

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -261,10 +261,25 @@ export default class Input extends React.PureComponent {
   componentWillUnmount() {
     clearTimeout(this._selectallTimeout)
   }
+  componentDidMount() {
+    this.updateInputValue()
+  }
+  componentDidUpdate() {
+    this.updateInputValue()
+  }
+  updateInputValue = () => {
+    // Only update the input value if it's not a custom input_element.
+    // The custom input_element will handle the value.
+    // This is used in the InputMasked component.
+    if (this._ref.current && !this.props.input_element) {
+      const value = this.state.value
+      const hasValue = Input.hasValue(value)
+      this._ref.current.value = hasValue ? value : ''
+    }
+  }
   onFocusHandler = (event) => {
     const { value } = event.target
     this.setState({
-      // value,// why should we update the value on blur?
       inputState: 'focus',
     })
 
@@ -303,6 +318,7 @@ export default class Input extends React.PureComponent {
       event,
     })
     if (result === false) {
+      this.updateInputValue()
       return // stop here
     }
     if (typeof result === 'string') {
@@ -448,7 +464,6 @@ export default class Input extends React.PureComponent {
     const inputParams = {
       className: classnames('dnb-input__input', input_class),
       autoComplete: autocomplete,
-      value: hasValue ? value : '',
       type,
       id,
       disabled: isTrue(disabled),
@@ -496,7 +511,7 @@ export default class Input extends React.PureComponent {
     validateDOMAttributes(null, shellParams)
 
     if (InputElement && typeof InputElement === 'function') {
-      InputElement = InputElement(inputParams, this._ref)
+      InputElement = InputElement({ ...inputParams, value }, this._ref)
     } else if (!InputElement && _input_element) {
       InputElement = _input_element
     }

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react'
 import { axeComponent, loadScss, wait } from '../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import Input, { InputProps } from '../Input'
 import { format } from '../../number-format/NumberUtils'
 import { Provider } from '../../../shared'
@@ -57,9 +58,7 @@ describe('Input component', () => {
       document.querySelector('.dnb-input').getAttribute('data-has-content')
     ).toBe('true')
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      newValue
-    )
+    expect(document.querySelector('input').value).toBe(newValue)
   })
 
   it('gets valid ref element', () => {
@@ -115,7 +114,7 @@ describe('Input component', () => {
 
     render(<Controlled />)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
+    expect(document.querySelector('input').value).toBe(
       format(initialValue)
     )
 
@@ -124,9 +123,7 @@ describe('Input component', () => {
       target: { value: newValue },
     })
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      format(newValue)
-    )
+    expect(document.querySelector('input').value).toBe(format(newValue))
   })
 
   it('value can be manipulated during on_change', () => {
@@ -143,9 +140,7 @@ describe('Input component', () => {
       target: { value: newValue },
     })
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'NEW VALUE'
-    )
+    expect(document.querySelector('input').value).toBe('NEW VALUE')
   })
 
   it('value will not change when returning false on_change', () => {
@@ -162,7 +157,7 @@ describe('Input component', () => {
       target: { value: newValue },
     })
 
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
+    expect(document.querySelector('input').value).toBe('')
   })
 
   it('events gets emitted correctly: "on_change" and "onKeyDown"', () => {
@@ -272,9 +267,7 @@ describe('Input component', () => {
     expect(document.querySelector('input').value).toBe('')
 
     rerender(<Input placeholder="Placeholder" value={zeroValue} />)
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      String(zeroValue)
-    )
+    expect(document.querySelector('input').value).toBe(String(zeroValue))
   })
 
   it('uses aria-placeholder and label for when placeholder is set', () => {
@@ -377,9 +370,7 @@ describe('Input component', () => {
 
   it('uses children as the value', () => {
     render(<Input>children</Input>)
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'children'
-    )
+    expect(document.querySelector('input').value).toBe('children')
   })
 
   it('has correct size attribute (chars length) on input by int number', () => {
@@ -478,6 +469,33 @@ describe('Input component', () => {
     ).toBe('focus')
   })
 
+  it('should not expose the value as an html attribute', async () => {
+    render(<Input />)
+
+    const input = document.querySelector('input')
+
+    await userEvent.type(input, 'foo')
+    expect(input).not.toHaveAttribute('value')
+    expect(input).toHaveValue('foo')
+
+    await userEvent.type(input, ' bar')
+    expect(input).not.toHaveAttribute('value')
+    expect(input).toHaveValue('foo bar')
+  })
+
+  it('should not expose the value as an html attribute when initially provided', async () => {
+    render(<Input value="foo" />)
+
+    const input = document.querySelector('input')
+
+    expect(input).not.toHaveAttribute('foo')
+    expect(input).toHaveValue('foo')
+
+    await userEvent.type(input, ' bar')
+    expect(input).not.toHaveAttribute('foo bar')
+    expect(input).toHaveValue('foo bar')
+  })
+
   it('should call on_submit event handler', () => {
     const on_submit = jest.fn()
     render(
@@ -489,9 +507,7 @@ describe('Input component', () => {
       />
     )
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'value'
-    )
+    expect(document.querySelector('input').value).toBe('value')
 
     fireEvent.keyDown(document.querySelector('input'), {
       key: 'Enter',
@@ -511,31 +527,27 @@ describe('Input with clear button', () => {
   it('should clear the value on press', () => {
     render(<Input id="input-id" clear={true} value="value" />)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'value'
-    )
+    expect(document.querySelector('input').value).toBe('value')
 
     const clearButton = document.querySelector(
       'button#input-id-clear-button'
     )
     fireEvent.click(clearButton)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
+    expect(document.querySelector('input').value).toBe('')
   })
 
   it('should have a disabled clear button when no value is given', () => {
     render(<Input id="input-id" clear={true} value="value" />)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      'value'
-    )
+    expect(document.querySelector('input').value).toBe('value')
 
     const clearButton = document.querySelector(
       'button#input-id-clear-button'
     )
     fireEvent.click(clearButton)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
+    expect(document.querySelector('input').value).toBe('')
     expect(clearButton.getAttribute('aria-hidden')).toBe('true')
     expect(clearButton).toHaveAttribute('disabled')
   })
@@ -543,13 +555,13 @@ describe('Input with clear button', () => {
   it('should have a disabled clear button when initially empty value is given', () => {
     render(<Input id="input-id" clear={true} />)
 
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
+    expect(document.querySelector('input').value).toBe('')
 
     const clearButton = document.querySelector(
       'button#input-id-clear-button'
     )
 
-    expect(document.querySelector('input').getAttribute('value')).toBe('')
+    expect(document.querySelector('input').value).toBe('')
     expect(clearButton.getAttribute('aria-hidden')).toBe('true')
     expect(clearButton).toHaveAttribute('disabled')
   })

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -31,9 +31,7 @@ describe('Radio component', () => {
 
     const value = 'new value'
     rerender(<Radio {...props} checked value={value} />)
-    expect(document.querySelector('input').getAttribute('value')).toBe(
-      value
-    )
+    expect(document.querySelector('input').value).toBe(value)
   })
 
   it('has "on_change" event which will trigger on a input change', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -122,7 +122,6 @@ describe('Form.Section', () => {
               id="id-r1b"
               name="firstName"
               type="text"
-              value=""
             />,
           },
           "label": "Fornavn",
@@ -151,7 +150,6 @@ describe('Form.Section', () => {
               id="id-r1h"
               name="lastName"
               type="text"
-              value=""
             />,
           },
           "label": "Etternavn",

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
@@ -108,7 +108,6 @@ describe('Tools.GenerateSchema', () => {
               id="id-rm"
               name="myField"
               type="text"
-              value=""
             />,
           },
           "label": "My field",
@@ -130,7 +129,6 @@ describe('Tools.GenerateSchema', () => {
                 id="id-rs"
                 name="nested/myString"
                 type="text"
-                value="my string"
               />,
             },
             "minLength": 2,
@@ -171,7 +169,6 @@ describe('Tools.GenerateSchema', () => {
               id="id-rm"
               name="myString"
               type="text"
-              value="local value"
             />,
           },
           "label": "My field",
@@ -192,7 +189,6 @@ describe('Tools.GenerateSchema', () => {
               id="id-rm"
               name="myString"
               type="text"
-              value="local value"
             />,
           },
           "minLength": 2,

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
@@ -65,7 +65,6 @@ describe('Tools.ListAllProps', () => {
               id="id-ra"
               name="myField"
               type="text"
-              value=""
             />,
           },
           "label": "My field",
@@ -87,7 +86,6 @@ describe('Tools.ListAllProps', () => {
                 id="id-rg"
                 name="nested/myString"
                 type="text"
-                value="my string"
               />,
             },
             "minLength": 2,
@@ -128,7 +126,6 @@ describe('Tools.ListAllProps', () => {
               id="id-ra"
               name="myString"
               type="text"
-              value="local value"
             />,
           },
           "label": "My field",
@@ -149,7 +146,6 @@ describe('Tools.ListAllProps', () => {
               id="id-ra"
               name="myString"
               type="text"
-              value="local value"
             />,
           },
           "minLength": 2,
@@ -298,7 +294,6 @@ describe('Tools.ListAllProps', () => {
                 id="id-rs"
                 name="myString"
                 type="text"
-                value=""
               />,
             },
             "path": "/myString",
@@ -393,7 +388,6 @@ describe('Tools.ListAllProps', () => {
                   id="id-r1t"
                   name="myObject/withString"
                   type="text"
-                  value=""
                 />,
               },
               "maxLength": 10,
@@ -416,7 +410,6 @@ describe('Tools.ListAllProps', () => {
                 id="id-r1n"
                 name="myString"
                 type="text"
-                value=""
               />,
             },
             "maxLength": 5,
@@ -499,7 +492,6 @@ describe('Tools.ListAllProps', () => {
                   id="id-r2h"
                   name="myObject/withString"
                   type="text"
-                  value=""
                 />,
               },
               "maxLength": 10,
@@ -591,7 +583,6 @@ describe('Tools.ListAllProps', () => {
                   id="id-r34"
                   name="myObject/withString"
                   type="text"
-                  value=""
                 />,
               },
               "maxLength": 10,
@@ -615,7 +606,6 @@ describe('Tools.ListAllProps', () => {
                 id="id-r2u"
                 name="myString"
                 type="text"
-                value=""
               />,
             },
             "path": "/myString",


### PR DESCRIPTION
Removing the `value` attribute from the HTML output, as best practice nowdays is to avoid updating it dynamically.  
Getting the `value` via the attribute was **never documented**, so this should be safe to remove.