### PR TITLE
docs(Field.Date): remove `date` property

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
@@ -24,6 +24,7 @@ const {
   suffix,
   stretch,
   size,
+  date,
   '[Space](/uilib/layout/space/properties)': space,
   ...datePickerProperties
 } = DatePickerProperties


### PR DESCRIPTION
`Field.Date` does not support `date` property, but uses `value` instead.
Hence removing `date` property from the properties docs of `Field.Date` :) 