### PR TITLE
docs(Value): add help button to example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/Examples.tsx
@@ -8,7 +8,11 @@ export const SummaryList = () => {
     <ComponentBox>
       <Value.SummaryList>
         <Value.String label="Foo" value="value" />
-        <Value.Number label="Bar" value={123} />
+        <Value.Number
+          label="Bar"
+          value={123}
+          help={{ title: 'Help title', content: 'Help content' }}
+        />
       </Value.SummaryList>
     </ComponentBox>
   )


### PR DESCRIPTION
Reason for adding is that it's nice to have a help button example incorporated in the [value docs](https://eufemia.dnb.no/uilib/extensions/forms/Value/) as well.