### PR TITLE
fix(NumberFormat): render properly when `sv-SE` locale is given

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -309,7 +309,7 @@ export const format = (
     }
 
     if (value === 'invalid') {
-      aria = locales[locale].NumberFormat.not_available || 'N/A'
+      aria = locales[locale]?.NumberFormat.not_available || 'N/A'
     }
 
     // return "locale" as well value,l, since we have to "auto" option

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -116,6 +116,26 @@ describe('NumberFormat component', () => {
     )
   })
 
+  it('have support invalid locale with invalid value', () => {
+    const log = jest.spyOn(console, 'log').mockImplementation()
+
+    render(
+      <NumberFormat locale="something" decimals={2}>
+        invalid
+      </NumberFormat>
+    )
+
+    expect(document.querySelector(displaySelector).textContent).toBe(
+      'invalid'
+    )
+
+    expect(
+      document.querySelector(ariaSelector).getAttribute('data-text')
+    ).toBe('N/A')
+
+    log.mockRestore()
+  })
+
   it('have to match currency with large decimals', () => {
     render(<Component value="5000.0099" currency />)
     expect(document.querySelector(displaySelector).textContent).toBe(

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -120,6 +120,19 @@ describe('Decimals format', () => {
     expect(global.console.log).toHaveBeenCalledTimes(4)
   })
 
+  it('should render N/A when unsupported locale is given', () => {
+    expect(
+      format('invalid', { locale: 'something', returnAria: true })
+    ).toEqual({
+      aria: 'N/A',
+      cleanedValue: 'invalid',
+      locale: 'something',
+      number: 'invalid',
+      type: 'number',
+      value: 'invalid',
+    })
+  })
+
   describe('rounding', () => {
     it('omit', () => {
       expect(


### PR DESCRIPTION
Fixes #4753