### PR TITLE
docs: add link to localization docs in portal tools menu

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -75,7 +75,7 @@ export default function PortalToolsMenu({
             Read more about{' '}
             <Anchor href="/uilib/usage/customisation/localization/">
               localization
-            </Anchor>{' '}
+            </Anchor>
           </P>
         </Space>
 

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { Drawer, Space, Tooltip } from '@dnb/eufemia/src/components'
-import { H2 } from '@dnb/eufemia/src'
+import { H2, P, Anchor } from '@dnb/eufemia/src'
 import ToggleGrid from './ToggleGrid'
 import { Context } from '@dnb/eufemia/src/shared'
 import PortalSkeleton from '../../core/PortalSkeleton'
@@ -71,6 +71,12 @@ export default function PortalToolsMenu({
           <Space top>
             <ChangeLocale />
           </Space>
+          <P size="small" top="x-small">
+            Read more about{' '}
+            <Anchor href="/uilib/usage/customisation/localization/">
+              localization
+            </Anchor>{' '}
+          </P>
         </Space>
 
         <Space top="large">


### PR DESCRIPTION
Looking like:
<img width="634" alt="Screenshot 2025-03-17 at 12 38 32" src="https://github.com/user-attachments/assets/b769002c-b895-434d-85d8-5d5b47123ec5" />
