### PR TITLE
chore(Field.Currency): add autoComplete transaction-amount test

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -184,7 +184,7 @@ describe('Field.Currency', () => {
     })
   })
 
-  it('renders autoComplete', () => {
+  it('should render autoComplete when provided', () => {
     render(
       <Field.Currency value={123} autoComplete="transaction-amount" />
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -184,6 +184,15 @@ describe('Field.Currency', () => {
     })
   })
 
+  it('renders autoComplete', () => {
+    render(
+      <Field.Currency value={123} autoComplete="transaction-amount" />
+    )
+    expect(
+      document.querySelector('input').getAttribute('autocomplete')
+    ).toBe('transaction-amount')
+  })
+
   describe('ARIA', () => {
     it('should validate with ARIA rules', async () => {
       const result = render(


### PR DESCRIPTION
Not too important, but just a nice-to-have test, as I assume a lot of applications should use the autocomplete value [transaction-amount](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#transaction-amount), especially in PM, etc.

I've added docs for this `transaction-amount` in https://github.com/dnbexperience/eufemia/pull/4770