### PR TITLE
fix(Forms): don't show Wizard step error on small screens for the same step

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/DisplaySteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/DisplaySteps.tsx
@@ -17,6 +17,7 @@ export function DisplaySteps({
     activeIndexRef,
     stepsRef,
     updateTitlesRef,
+    hasErrorInOtherStepRef,
     hasInvalidStepsState,
   } = useContext(WizardContext) || {}
   updateTitlesRef.current = () => {
@@ -28,6 +29,9 @@ export function DisplaySteps({
     variant === 'drawer' && !sidebarId ? undefined : sidebarId ?? id
 
   const getTriggerStatus = useCallback(() => {
+    if (!hasErrorInOtherStepRef.current) {
+      return // stop here
+    }
     if (hasInvalidStepsState(['error'])) {
       return {
         status: translations.Step.stepHasError,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
@@ -16,7 +16,9 @@ export function IterateOverSteps({ children }) {
     stepStatusRef,
     prerenderFieldProps,
     prerenderFieldPropsRef,
+    hasErrorInOtherStepRef,
   } = useContext(WizardContext)
+  hasErrorInOtherStepRef.current = false
 
   stepsRef.current = {}
   let incrementIndex = -1
@@ -77,6 +79,10 @@ export function IterateOverSteps({ children }) {
             : undefined
         const statusState = state === 'error' ? 'error' : undefined // undefined shows 'warn' by default
         const key = `${index}-${activeIndexRef.current}`
+
+        if (status) {
+          hasErrorInOtherStepRef.current = true
+        }
 
         stepsRef.current[index] = {
           id,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -143,7 +143,8 @@ function WizardContainer(props: Props) {
   const activeIndexRef = useRef<StepIndex>(initialActiveIndex)
   const totalStepsRef = useRef<number>(NaN)
   const stepStatusRef = useRef<InternalStepStatuses>({})
-  const fieldErrorRef = useRef<InternalFieldError>({})
+  const hasVisibleErrorRef = useRef<InternalFieldError>({})
+  const hasErrorInOtherStepRef = useRef<boolean>(false)
   const visitedStepsRef = useRef<InternalVisitedSteps>({})
   const elementRef = useRef<HTMLElement>()
   const stepElementRef = useRef<HTMLElement>()
@@ -177,7 +178,7 @@ function WizardContainer(props: Props) {
     []
   )
   const hasFieldErrorInStep = useCallback((index: StepIndex) => {
-    return Object.values(fieldErrorRef.current).some(
+    return Object.values(hasVisibleErrorRef.current).some(
       ({ index: i, hasError }) => {
         return i === index && hasError
       }
@@ -185,7 +186,7 @@ function WizardContainer(props: Props) {
   }, [])
   const revealError: WizardContextState['revealError'] = useCallback(
     (index, path, hasError) => {
-      fieldErrorRef.current[path] = { index, hasError }
+      hasVisibleErrorRef.current[path] = { index, hasError }
 
       if (hasFieldErrorInStep(index)) {
         setStepState(index, 'error')
@@ -454,6 +455,7 @@ function WizardContainer(props: Props) {
       stepStatusRef,
       prerenderFieldProps,
       prerenderFieldPropsRef,
+      hasErrorInOtherStepRef,
       keepInDOM,
       check,
       setActiveIndex,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -3015,7 +3015,7 @@ describe('Wizard.Container', () => {
           )
         ).toHaveLength(0)
 
-        // To to Step 2
+        // Go to Step 2
         await userEvent.click(secondStep.querySelector('.dnb-button'))
 
         expect(output()).toHaveTextContent('Step 2')
@@ -3195,7 +3195,7 @@ describe('Wizard.Container', () => {
           )
         ).toHaveLength(0)
 
-        // To to Step 2
+        // Go to Step 2
         await userEvent.click(secondStep.querySelector('.dnb-button'))
 
         expect(output()).toHaveTextContent('Step 2')
@@ -3264,9 +3264,11 @@ describe('Wizard.Container', () => {
       fireEvent.submit(document.querySelector('form'))
 
       expect(output()).toHaveTextContent('Step 1')
-      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
-        nb.Step.stepHasError
-      )
+      expect(document.querySelectorAll('.dnb-form-status')).toHaveLength(1)
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toHaveTextContent(nb.Step.stepHasError)
+
       expect(
         document.querySelectorAll(
           '.dnb-step-indicator__button__status--warn'
@@ -3277,6 +3279,21 @@ describe('Wizard.Container', () => {
           '.dnb-step-indicator__button__status--error'
         )
       ).toHaveLength(0)
+
+      // Open the drawer
+      await userEvent.click(
+        document.querySelector('.dnb-step-indicator__trigger__button')
+      )
+
+      // Go to Step 2
+      const [, secondStep] = Array.from(
+        document.querySelectorAll('.dnb-step-indicator__item')
+      )
+      await userEvent.click(secondStep.querySelector('.dnb-button'))
+
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.Step.stepHasError
+      )
     })
 
     it('should show a warning beneath the trigger button when the step status is unknown and the screen width is small', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/WizardContext.ts
@@ -23,6 +23,7 @@ export interface WizardContextState {
   prerenderFieldPropsRef?: React.MutableRefObject<
     Record<string, () => React.ReactElement>
   >
+  hasErrorInOtherStepRef?: React.MutableRefObject<boolean>
   prerenderFieldProps?: boolean
   keepInDOM?: boolean
   handlePrevious?: () => void


### PR DESCRIPTION
Same as #4751 – just to the StepIndicator trigger button – e.g. when on small screens.