### PR TITLE
fix(DatePicker): correct invalid dates if  `correctInvalidDate` is `true` and `minDate` or `maxDate` is defined

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -118,6 +118,7 @@ export type DatePickerProps = {
   maxDate?: DateType
   /**
    * Corrects the input date value to be the same as either `minDate` or `maxDate`, when the user types in a date that is either before or after one of these. Defaults to `false`.
+   * Deprecate in v11 in favor of built in validation through Field.Date
    */
   correctInvalidDate?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -39,6 +39,7 @@ import { DatePickerEventAttributes } from './DatePicker'
 import { useTranslation } from '../../shared'
 import { DatePickerInputDates } from './hooks/useDates'
 import usePartialDates from './hooks/usePartialDates'
+import useInvalidDates from './hooks/useInvalidDates'
 
 export type DatePickerInputProps = Omit<
   React.HTMLProps<HTMLInputElement>,
@@ -104,12 +105,6 @@ export type DatePickerInputProps = Omit<
   ) => void
 }
 
-export type InvalidDates = {
-  invalidDate?: string
-  invalidStartDate?: string
-  invalidEndDate?: string
-}
-
 const defaultProps: DatePickerInputProps = {
   maskOrder: 'dd/mm/yyyy',
   maskPlaceholder: 'dd/mm/åååå',
@@ -150,11 +145,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
   const [focusState, setFocusState] = useState<string>('virgin')
 
   const { partialDatesRef, setPartialDates } = usePartialDates()
+  const { invalidDatesRef, setInvalidDates } = useInvalidDates()
 
-  const invalidDatesRef = useRef<InvalidDates>({
-    invalidStartDate: null,
-    invalidEndDate: null,
-  })
   const isDateFullyFilledOutRef = useRef(false)
 
   const {
@@ -343,7 +335,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         }
       )
     },
-    [updateDates, callOnChangeHandler, hasHadValidDate]
+    [updateDates, callOnChangeHandler, hasHadValidDate, invalidDatesRef]
   )
 
   const callOnChange = useCallback(
@@ -382,7 +374,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         }
       })
     },
-    [updateDates, callOnChangeHandler, isRange]
+    [updateDates, callOnChangeHandler, isRange, invalidDatesRef]
   )
 
   const callOnType = useCallback(
@@ -452,7 +444,14 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         ...typedDates,
       })
     },
-    [isRange, dateRefs, getReturnObject, inputDates, onType]
+    [
+      isRange,
+      dateRefs,
+      getReturnObject,
+      inputDates,
+      onType,
+      invalidDatesRef,
+    ]
   )
 
   const prepareCounting = useCallback(
@@ -678,12 +677,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
       // update the date
       if (isValidDate) {
-        invalidDatesRef.current = {
-          ...invalidDatesRef.current,
+        setInvalidDates({
           ...(mode === 'start'
             ? { invalidStartDate: null }
             : { invalidEndDate: null }),
-        }
+        })
 
         callOnChange({
           [`${mode}Date`]: date,
@@ -695,12 +693,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           [`__${mode}${type}`]: value,
         })
 
-        invalidDatesRef.current = {
-          ...invalidDatesRef.current,
+        setInvalidDates({
           ...(mode === 'start'
             ? { invalidStartDate: dateString }
             : { invalidEndDate: dateString }),
-        }
+        })
 
         callOnChangeAsInvalid({
           [`${mode}Date`]: null,
@@ -718,6 +715,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       modeDate,
       dateRefs,
       temporaryDates,
+      setInvalidDates,
     ]
   )
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -313,6 +313,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       starDate?: Date
       event: React.ChangeEvent<HTMLInputElement>
     }) => {
+      // TODO: Check if we can drop the updateDates here to prevent double re-render when callOnChangeAsInvalid is called from setDate
       updateDates(
         {
           hoverDate: null,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -450,6 +450,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       getReturnObject,
       inputDates,
       onType,
+      partialDatesRef,
+      setPartialDates,
       invalidDatesRef,
     ]
   )
@@ -683,20 +685,26 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             : { invalidEndDate: null }),
         })
 
+        updateDates(invalidDatesRef.current)
+
         callOnChange({
           [`${mode}Date`]: date,
           event,
         })
       } else {
-        updateDates({
-          [`${mode}Date`]: null,
-          [`__${mode}${type}`]: value,
-        })
-
         setInvalidDates({
           ...(mode === 'start'
             ? { invalidStartDate: dateString }
             : { invalidEndDate: dateString }),
+        })
+
+        updateDates({
+          [`${mode}Date`]: null,
+          [`__${mode}${type}`]: value,
+          // Only send invalid dates to useDates if the date is fully filled out
+          ...(isDateFullyFilledOutRef.current && {
+            ...invalidDatesRef.current,
+          }),
         })
 
         callOnChangeAsInvalid({
@@ -716,6 +724,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       dateRefs,
       temporaryDates,
       setInvalidDates,
+      invalidDatesRef,
     ]
   )
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -24,7 +24,7 @@ import useDates, { DatePickerDates } from './hooks/useDates'
 import useLastEventCallCache, {
   LastEventCallCache,
 } from './hooks/useLastEventCallCache'
-import { InvalidDates } from './DatePickerInput'
+import { InvalidDates } from './hooks/useInvalidDates'
 import { PartialDates } from './hooks/usePartialDates'
 
 type DatePickerProviderProps = DatePickerAllProps & {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1515,6 +1515,149 @@ describe('DatePicker component', () => {
     expect(yearElem).toHaveValue('2024')
   })
 
+  it('should auto-correct invalid dates if `correctInvalidDate` is set to true and `minDate` is defined', async () => {
+    render(
+      <DatePicker minDate="2025-03-01" correctInvalidDate showInput />
+    )
+
+    const [dayInput, monthInput, yearInput] = Array.from(
+      document.querySelectorAll('input.dnb-date-picker__input')
+    )
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('55555555')
+
+    expect(dayInput).toHaveValue('01')
+    expect(monthInput).toHaveValue('03')
+    expect(yearInput).toHaveValue('2025')
+  })
+
+  it('should auto-correct invalid dates if `correctInvalidDate` is set to true and `maxDate` is defined', async () => {
+    render(
+      <DatePicker maxDate="2026-04-30" correctInvalidDate showInput />
+    )
+
+    const [dayInput, monthInput, yearInput] = Array.from(
+      document.querySelectorAll('input.dnb-date-picker__input')
+    )
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('55555555')
+
+    expect(dayInput).toHaveValue('30')
+    expect(monthInput).toHaveValue('04')
+    expect(yearInput).toHaveValue('2026')
+  })
+
+  it('should auto-correct invalid dates if `correctInvalidDate` is set to true and `minDate` is defined when in `range` mode', async () => {
+    render(
+      <DatePicker
+        minDate="2027-11-19"
+        correctInvalidDate
+        showInput
+        range
+      />
+    )
+
+    const [
+      startDayInput,
+      startMonthInput,
+      startYearInput,
+      endDayInput,
+      endMonthInput,
+      endYearInput,
+    ] = Array.from(
+      document.querySelectorAll('input.dnb-date-picker__input')
+    )
+
+    // startDate should be auto-corrected to `2027-11-19`
+    await userEvent.click(startDayInput)
+    await userEvent.keyboard('55555555')
+
+    expect(startDayInput).toHaveValue('19')
+    expect(startMonthInput).toHaveValue('11')
+    expect(startYearInput).toHaveValue('2027')
+
+    // endDate should be auto-corrected to `2027-11-19`
+    await userEvent.keyboard('66666666')
+    expect(endDayInput).toHaveValue('19')
+    expect(endMonthInput).toHaveValue('11')
+    expect(endYearInput).toHaveValue('2027')
+  })
+
+  it('should auto-correct invalid dates if `correctInvalidDate` is set to true and `maxDate` is defined when in `range` mode', async () => {
+    render(
+      <DatePicker
+        maxDate="2026-04-30"
+        correctInvalidDate
+        showInput
+        range
+      />
+    )
+
+    const [
+      startDayInput,
+      startMonthInput,
+      startYearInput,
+      endDayInput,
+      endMonthInput,
+      endYearInput,
+    ] = Array.from(
+      document.querySelectorAll('input.dnb-date-picker__input')
+    )
+
+    // startDate should be auto-corrected to `2026-04-30`
+    await userEvent.click(startDayInput)
+    await userEvent.keyboard('55555555')
+
+    expect(startDayInput).toHaveValue('30')
+    expect(startMonthInput).toHaveValue('04')
+    expect(startYearInput).toHaveValue('2026')
+
+    // endDate should be auto-corrected to `2026-04-30`
+    await userEvent.keyboard('66666666')
+    expect(endDayInput).toHaveValue('30')
+    expect(endMonthInput).toHaveValue('04')
+    expect(endYearInput).toHaveValue('2026')
+  })
+
+  it('should auto-correct invalid dates if `correctInvalidDate` is set to true and `minDate` and `maxDate` is defined when in `range` mode', async () => {
+    render(
+      <DatePicker
+        minDate="2025-03-01"
+        maxDate="2026-04-30"
+        correctInvalidDate
+        showInput
+        range
+      />
+    )
+
+    const [
+      startDayInput,
+      startMonthInput,
+      startYearInput,
+      endDayInput,
+      endMonthInput,
+      endYearInput,
+    ] = Array.from(
+      document.querySelectorAll('input.dnb-date-picker__input')
+    )
+
+    // startDate should be auto-corrected to `2025-03-01`
+    await userEvent.click(startDayInput)
+    await userEvent.keyboard('55555555')
+
+    expect(startDayInput).toHaveValue('01')
+    expect(startMonthInput).toHaveValue('03')
+    expect(startYearInput).toHaveValue('2025')
+
+    // endDate should be auto-corrected to `2026-04-30`
+    await userEvent.keyboard('66666666')
+    expect(endDayInput).toHaveValue('30')
+    expect(endMonthInput).toHaveValue('04')
+    expect(endYearInput).toHaveValue('2026')
+  })
+
   it('has valid on_type and onChange event calls', () => {
     const onType = jest.fn()
     const onChange = jest.fn()

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
-import { addMonths, isSameDay } from 'date-fns'
+import { addMonths, isSameDay, min } from 'date-fns'
 import { DateType } from '../DatePickerContext'
+import { InvalidDates } from './useInvalidDates'
 
 export type DatePickerDateProps = {
   date?: DateType
@@ -41,7 +42,8 @@ export type DatePickerDates = {
   endMonth?: Date
   hasHadValidDate?: boolean
   hoverDate?: Date
-} & DatePickerInputDates
+} & DatePickerInputDates &
+  InvalidDates
 
 export default function useDates(
   dateProps: DatePickerDateProps,
@@ -114,6 +116,8 @@ export default function useDates(
             endDate: newDates.endDate ?? dates.endDate,
             minDate: dates.minDate,
             maxDate: dates.maxDate,
+            invalidStartDate: newDates.invalidStartDate,
+            invalidEndDate: newDates.invalidEndDate,
             isRange,
           })
         : {}
@@ -357,15 +361,33 @@ function correctDates({
   endDate,
   minDate,
   maxDate,
+  invalidStartDate,
+  invalidEndDate,
   isRange,
 }: {
   startDate: Date
   endDate: Date
   minDate: Date
   maxDate: Date
+  invalidStartDate?: string
+  invalidEndDate?: string
   isRange: boolean
 }) {
   const correctedDates = {}
+
+  if (!isRange && invalidStartDate) {
+    correctedDates['startDate'] = minDate ?? maxDate
+  }
+
+  if (isRange) {
+    if (invalidStartDate) {
+      correctedDates['startDate'] = minDate ?? maxDate
+    }
+
+    if (invalidEndDate) {
+      correctedDates['endDate'] = maxDate ?? minDate
+    }
+  }
 
   if (isDisabled(startDate, minDate, maxDate)) {
     correctedDates['startDate'] = minDate

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -375,16 +375,16 @@ function correctDates({
 }) {
   const correctedDates = {}
 
-  if (!isRange && invalidStartDate) {
+  if (!isRange && invalidStartDate && !startDate) {
     correctedDates['startDate'] = minDate ?? maxDate
   }
 
   if (isRange) {
-    if (invalidStartDate) {
+    if (invalidStartDate && !startDate) {
       correctedDates['startDate'] = minDate ?? maxDate
     }
 
-    if (invalidEndDate) {
+    if (invalidEndDate && !endDate) {
       correctedDates['endDate'] = maxDate ?? minDate
     }
   }

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
-import { addMonths, isSameDay, min } from 'date-fns'
+import { addMonths, isSameDay } from 'date-fns'
 import { DateType } from '../DatePickerContext'
 import { InvalidDates } from './useInvalidDates'
 

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useInvalidDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useInvalidDates.ts
@@ -1,0 +1,23 @@
+import { useRef } from 'react'
+
+export type InvalidDates = {
+  invalidDate?: string
+  invalidStartDate?: string
+  invalidEndDate?: string
+}
+
+export default function useInvalidDates() {
+  const invalidDatesRef = useRef<InvalidDates>({
+    invalidStartDate: null,
+    invalidEndDate: null,
+  })
+
+  function setInvalidDates(invalidDate: InvalidDates) {
+    invalidDatesRef.current = {
+      ...invalidDatesRef.current,
+      ...invalidDate,
+    }
+  }
+
+  return { invalidDatesRef, setInvalidDates }
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -21,7 +21,7 @@ import { convertStringToDate } from '../../../../components/date-picker/DatePick
 import { ProviderProps } from '../../../../shared/Provider'
 import { FormError } from '../../utils'
 import startOfDay from 'date-fns/startOfDay'
-import { InvalidDates } from '../../../../components/date-picker/DatePickerInput'
+import { InvalidDates } from '../../../../components/date-picker/hooks/useInvalidDates'
 import useInvalidDates from './hooks/useInvalidDates'
 
 // `range`, `showInput`, `showCancelButton` and `showResetButton` are not picked from the `DatePickerProps`

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/hooks/useInvalidDates.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react'
-import { InvalidDates } from '../../../../../components/date-picker/DatePickerInput'
+import { InvalidDates } from '../../../../../components/date-picker/hooks/useInvalidDates'
 
 export default function useInvalidDates() {
   const invalidDatesRef = useRef<InvalidDates>({})


### PR DESCRIPTION
### TODO

- [x] Move `invalidDates` to own hook
- [x] Add `invalidDates` to date correction function
- [x] Add test

`TODO` comments added to the code is meant for a later pr🙏