### PR TITLE
fix(Forms): enhance typing for `FieldBlock` and `useFieldProps`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
@@ -184,6 +184,7 @@ import {
   Form,
   FieldBlock,
   useFieldProps,
+  FieldProps,
 } from '@dnb/eufemia/extensions/forms'
 
 const myFieldTranslations = {
@@ -204,7 +205,9 @@ const myFieldTranslations = {
 type Translation =
   (typeof myFieldTranslations)[keyof typeof myFieldTranslations]
 
-const MyField = (props) => {
+type MyFieldValue = string
+
+const MyField = (props: FieldProps<MyFieldValue>) => {
   const translations = Form.useTranslation<Translation>(
     myFieldTranslations,
   )
@@ -222,7 +225,7 @@ const MyField = (props) => {
     useFieldProps(preparedProps)
 
   return (
-    <FieldBlock forId={id}>
+    <FieldBlock<MyFieldValue> forId={id}>
       <input
         id={id}
         value={value}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/stories/Number.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/stories/Number.stories.tsx
@@ -163,6 +163,11 @@ export const ConditionalInfo = () => {
           labelDescription="Should be same or lower than maximum."
           path="/amount"
           required
+          error={(value) => {
+            if (value < 5) {
+              return new Error('You done messed up, A-a-ron!')
+            }
+          }}
           // defaultValue={5}
           onBlurValidator={onBlurValidator}
           // validateInitially

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -110,9 +110,9 @@ export type SharedFieldBlockProps = {
   help?: HelpProps
 }
 
-export type Props = SharedFieldBlockProps &
+export type Props<Value = unknown> = SharedFieldBlockProps &
   Pick<
-    FieldProps,
+    FieldProps<Value>,
     keyof ComponentProps | 'info' | 'warning' | 'error' | 'disabled'
   > & {
     /** The id to link a element with */
@@ -140,7 +140,7 @@ export type Props = SharedFieldBlockProps &
     children?: React.ReactNode
   } & React.HTMLAttributes<HTMLDivElement>
 
-function FieldBlock(props: Props) {
+function FieldBlock<Value = unknown>(props: Props<Value>) {
   const dataContext = useContext(DataContext)
   const fieldBlockContext = useContext(FieldBlockContext)
   const nestedFieldBlockContext = !fieldBlockContext?.disableStatusSummary

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import FieldBlock from '../FieldBlock'
 import Input from '../../../../components/Input'
 import { useFieldProps } from '../../hooks'
-import { Field, Form } from '../..'
+import { Field, FieldProps, Form } from '../..'
 import { Anchor, Flex } from '../../../../components'
 
 export default {
@@ -268,4 +268,42 @@ export const WithInlineHelp = () => {
       </Form.Card>
     </Flex.Stack>
   )
+}
+
+export function Types() {
+  type FieldPropsProps = FieldProps<string, string>
+  const MyInput = (props: FieldPropsProps) => {
+    const {
+      id,
+      value,
+      error,
+      handleChange,
+      handleFocus,
+      handleBlur,
+      htmlAttributes,
+      // We get an error which seems to be due
+      // to missing ProvideAdditionalEventArgs
+    } = useFieldProps(props)
+
+    return (
+      <FieldBlock
+        forId={id}
+        id={id}
+        // We get a `unknown is not assignable to string` type error
+        error={error}
+        space="medium"
+      >
+        <input
+          id={id}
+          value={value}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          {...htmlAttributes}
+        />
+      </FieldBlock>
+    )
+  }
+
+  return <MyInput error={Error('error')} />
 }

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
@@ -11,6 +11,16 @@ export default {
 
 export function FieldBlockLabel() {
   const fromInput = useCallback(({ value }) => value, [])
+  // const fromInput = useCallback((external: unknown) => {
+  //   if (
+  //     typeof external === 'object' &&
+  //     external !== null &&
+  //     'value' in external
+  //   ) {
+  //     return external.value
+  //   }
+  //   return ''
+  // }, [])
   const { value, handleChange, handleFocus, handleBlur } = useFieldProps({
     value: 'foo',
     fromInput,

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/stories/FieldBlock.stories.tsx
@@ -281,8 +281,7 @@ export const WithInlineHelp = () => {
 }
 
 export function Types() {
-  type FieldPropsProps = FieldProps<string, string>
-  const MyInput = (props: FieldPropsProps) => {
+  const MyInput = (props: FieldProps<string>) => {
     const {
       id,
       value,
@@ -296,7 +295,7 @@ export function Types() {
     } = useFieldProps(props)
 
     return (
-      <FieldBlock
+      <FieldBlock<string>
         forId={id}
         id={id}
         // We get a `unknown is not assignable to string` type error

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -229,7 +229,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     setFieldState: setFieldStateFieldBlock,
     showFieldError: showFieldErrorFieldBlock,
     mountedFieldsRef: mountedFieldsRefFieldBlock,
-  } = inFieldBlock ? fieldBlockContext : ({} as FieldBlockContextProps)
+  } = (inFieldBlock ? fieldBlockContext : {}) as FieldBlockContextProps
   const {
     activeIndex,
     activeIndexRef,

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -139,7 +139,10 @@ export type ErrorMessagesWithLocaleSupport = Record<
   DefaultErrorMessages
 >
 
-export type InternalErrorMessages = Record<FormsTranslationFlat, string>
+export type InternalErrorMessages = Record<
+  Exclude<FormsTranslationFlat, undefined>,
+  string
+>
 export type DefaultErrorMessages = Partial<InternalErrorMessages> &
   Partial<DotNotationErrorMessages> &
   Partial<DeprecatedErrorMessages>
@@ -222,13 +225,14 @@ export function omitDataValueReadProps<Props extends DataValueReadProps>(
 
 type EventArgs<Value, ExtraValue extends ProvideAdditionalEventArgs> = [
   value: Value,
-  additionalArgs?: ExtraValue | ReceiveAdditionalEventArgs<Value>,
+  additionalArgs?: ExtraValue & ReceiveAdditionalEventArgs<Value>,
 ]
 
 export interface DataValueWriteProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
-  ExtraValue extends ProvideAdditionalEventArgs = undefined,
+  ExtraValue extends
+    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
 > {
   emptyValue?: EmptyValue
   onFocus?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -329,7 +329,7 @@ export type MessageProp<Value, ReturnValue> =
   | ((
       value: Value,
       options: MessagePropParams<Value, ReturnValue>
-    ) => ReturnValue)
+    ) => ReturnValue | undefined)
 export type MessageTypes<Value> =
   | UseFieldProps<Value>['info']
   | UseFieldProps<Value>['warning']


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1742375173085389
Fixes https://github.com/dnbexperience/eufemia/issues/4771

CSB of the issue: https://codesandbox.io/p/sandbox/eloquent-tharp-z9pck9


For now, I've just added a stor, but not sure if that's too helpful as I don't believe the TypeScript settings in this repo is strict enough to catch/display the same errors as in the [CSB of the issue](https://codesandbox.io/p/sandbox/eloquent-tharp-z9pck9).