### PR TITLE
fix(NumberFormat): ensure -0 is displayed as 0 when formatted as currency

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -557,8 +557,8 @@ export const formatNumber = (
     ) {
       number = parseFloat(number).toLocaleString(locale, options)
     }
-    if (number === '−0') {
-      number = '0'
+    if (String(number).startsWith('−0')) {
+      number = number.replace('−0', '0')
     }
   } catch (e) {
     warn(

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -374,6 +374,34 @@ describe('NumberFormat component', () => {
     )
   })
 
+  it('should yield strict zero currency when value gets rounded to zero because of decimals=0', () => {
+    render(<NumberFormat value={-0.2} currency decimals={0} />)
+    expect(document.querySelector('.dnb-number-format').textContent).toBe(
+      '0 kr'
+    )
+  })
+
+  it('should yield strict zero currency when value gets rounded to zero because of decimals=0 and locale is en-GB', () => {
+    render(
+      <NumberFormat
+        value={-0.2}
+        currency="SEK"
+        locale="en-GB"
+        decimals={0}
+      />
+    )
+    expect(document.querySelector('.dnb-number-format').textContent).toBe(
+      '-SEK 0'
+    )
+  })
+
+  it('should yield strict zero percent when value gets rounded to zero because of decimals=0', () => {
+    render(<NumberFormat value={-0.2} percent decimals={0} />)
+    expect(document.querySelector('.dnb-number-format').textContent).toBe(
+      '0 %'
+    )
+  })
+
   it('have to match phone number', () => {
     render(<Component phone>+47 99999999</Component>)
     expect(document.querySelector(displaySelector).textContent).toBe(


### PR DESCRIPTION
Related PR #4691 and [more details](https://dnb-it.slack.com/archives/CMXABCHEY/p1742463244250749?thread_ts=1741254690.495009&cid=CMXABCHEY).