### PR TITLE
docs: add `xx-small` to the spacing table

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
@@ -1,10 +1,9 @@
-| Pixel | Type       | Rem     | Custom Property      |
-| ----- | ---------- | ------- | -------------------- |
-| 8     | `x-small`  | **0.5** | `--spacing-x-small`  |
-| 16    | `small`    | **1**   | `--spacing-small`    |
-| 24    | `medium`   | **1.5** | `--spacing-medium`   |
-| 32    | `large`    | **2**   | `--spacing-large`    |
-| 48    | `x-large`  | **3**   | `--spacing-x-large`  |
-| 56    | `xx-large` | **3.5** | `--spacing-xx-large` |
-
-**NB:** In some circumstances you may be in need of using **0.25rem** (4px) - therefore `xx-small` also exists, but as a single type. So, combining `xx-small` and `small` would not result in 0.25rem, but still remain 1rem.
+| Pixel | Type       | Rem      | Custom Property      |
+| ----- | ---------- | -------- | -------------------- |
+| 4     | `xx-small` | **0.25** | `--spacing-xx-small` |
+| 8     | `x-small`  | **0.5**  | `--spacing-x-small`  |
+| 16    | `small`    | **1**    | `--spacing-small`    |
+| 24    | `medium`   | **1.5**  | `--spacing-medium`   |
+| 32    | `large`    | **2**    | `--spacing-large`    |
+| 48    | `x-large`  | **3**    | `--spacing-x-large`  |
+| 56    | `xx-large` | **3.5**  | `--spacing-xx-large` |

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
@@ -2,13 +2,12 @@
 draft: true
 ---
 
-| Pixel | Type       | Rem     | CSS Variable         |
-| ----- | ---------- | ------- | -------------------- |
-| 8     | `x-small`  | **0.5** | `--spacing-x-small`  |
-| 16    | `small`    | **1**   | `--spacing-small`    |
-| 24    | `medium`   | **1.5** | `--spacing-medium`   |
-| 32    | `large`    | **2**   | `--spacing-large`    |
-| 48    | `x-large`  | **3**   | `--spacing-x-large`  |
-| 56    | `xx-large` | **3.5** | `--spacing-xx-large` |
-
-**NB:** In some circumstances you may be in need of using **0.25rem** (4px) - therefore `xx-small` also exists, but as a single type. So, combining `xx-small` and `small` would not result in 0.25rem, but still remain 1rem.
+| Pixel | Type       | Rem      | Custom Property      |
+| ----- | ---------- | -------- | -------------------- |
+| 4     | `xx-small` | **0.25** | `--spacing-xx-small` |
+| 8     | `x-small`  | **0.5**  | `--spacing-x-small`  |
+| 16    | `small`    | **1**    | `--spacing-small`    |
+| 24    | `medium`   | **1.5**  | `--spacing-medium`   |
+| 32    | `large`    | **2**    | `--spacing-large`    |
+| 48    | `x-large`  | **3**    | `--spacing-x-large`  |
+| 56    | `xx-large` | **3.5**  | `--spacing-xx-large` |

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
@@ -11,5 +11,3 @@ draft: true
 | 32    | `large`    | **2**    | `--spacing-large`    |
 | 48    | `x-large`  | **3**    | `--spacing-x-large`  |
 | 56    | `xx-large` | **3.5**  | `--spacing-xx-large` |
-
-**NB:** When combining sizes we only allow increments of `0.5rem`, so `xx-small` will not increment by `0.25rem` when combined with other sizes.

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -41,6 +41,7 @@ describe('translateSpace', () => {
   it('should translate and calc types', () => {
     expect(translateSpace('large')).toBe(2)
     expect(translateSpace('xx-large-x2')).toBe(7)
+    expect(translateSpace('xx-small')).toBe(0.25)
   })
 
   it('should translate and calc types -x2', () => {
@@ -87,6 +88,9 @@ describe('calc', () => {
   it('should output calc based on string types', () => {
     expect(calc('large x-small')).toEqual(
       'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+    expect(calc('small xx-small')).toEqual(
+      'calc(var(--spacing-small) + var(--spacing-xx-small))'
     )
   })
 
@@ -180,6 +184,7 @@ describe('createTypeModifiers', () => {
       'small',
       'large',
     ])
+    expect(createTypeModifiers('0.25 1')).toEqual(['xx-small', 'small'])
     expect(createTypeModifiers('2 0.5')).toEqual(['large', 'x-small'])
     expect(createTypeModifiers(1)).toEqual(['small'])
     expect(createTypeModifiers(true)).toEqual(['small'])
@@ -189,6 +194,7 @@ describe('createTypeModifiers', () => {
 
 describe('findNearestTypes', () => {
   it('should find the nearest type in correct order', () => {
+    expect(findNearestTypes(0.25)).toEqual(['xx-small'])
     expect(findNearestTypes(2.5)).toEqual(['large', 'x-small'])
     expect(findNearestTypes(5)).toEqual(['xx-large', 'medium'])
     expect(findNearestTypes(8)).toEqual(['xx-large', 'xx-large', 'small'])
@@ -211,6 +217,10 @@ describe('createSpacingClasses', () => {
     expect(createSpacingClasses({ right: 'large x-small' })).toEqual([
       'dnb-space__right--large',
       'dnb-space__right--x-small',
+    ])
+    expect(createSpacingClasses({ right: 'small xx-small' })).toEqual([
+      'dnb-space__right--small',
+      'dnb-space__right--xx-small',
     ])
   })
 

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -46,6 +46,7 @@ describe('translateSpace', () => {
   it('should translate and calc types', () => {
     expect(translateSpace('large')).toBe(2)
     expect(translateSpace('xx-large-x2')).toBe(7)
+    expect(translateSpace('xx-small')).toBe(0.25)
   })
 
   it('should translate and calc types -x2', () => {
@@ -92,6 +93,9 @@ describe('calc', () => {
   it('should output calc based on string types', () => {
     expect(calc('large x-small')).toEqual(
       'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+    expect(calc('small xx-small')).toEqual(
+      'calc(var(--spacing-small) + var(--spacing-xx-small))'
     )
   })
 
@@ -185,6 +189,7 @@ describe('createTypeModifiers', () => {
       'small',
       'large',
     ])
+    expect(createTypeModifiers('0.25 1')).toEqual(['xx-small', 'small'])
     expect(createTypeModifiers('2 0.5')).toEqual(['large', 'x-small'])
     expect(createTypeModifiers(1)).toEqual(['small'])
     expect(createTypeModifiers(true)).toEqual(['small'])
@@ -194,6 +199,7 @@ describe('createTypeModifiers', () => {
 
 describe('findNearestTypes', () => {
   it('should find the nearest type in correct order', () => {
+    expect(findNearestTypes(0.25)).toEqual(['xx-small'])
     expect(findNearestTypes(2.5)).toEqual(['large', 'x-small'])
     expect(findNearestTypes(5)).toEqual(['xx-large', 'medium'])
     expect(findNearestTypes(8)).toEqual(['xx-large', 'xx-large', 'small'])
@@ -216,6 +222,10 @@ describe('createSpacing', () => {
     expect(createSpacing({ right: 'large x-small' }).className).toEqual([
       'dnb-space__right--large',
       'dnb-space__right--x-small',
+    ])
+    expect(createSpacingClasses({ right: 'small xx-small' })).toEqual([
+      'dnb-space__right--small',
+      'dnb-space__right--xx-small',
     ])
   })
 

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -47,6 +47,7 @@ describe('translateSpace', () => {
   it('should translate and calc types', () => {
     expect(translateSpace('large')).toBe(2)
     expect(translateSpace('xx-large-x2')).toBe(7)
+    expect(translateSpace('xx-small')).toBe(0.25)
   })
 
   it('should translate and calc types -x2', () => {
@@ -93,6 +94,9 @@ describe('calc', () => {
   it('should output calc based on string types', () => {
     expect(calc('large x-small')).toEqual(
       'calc(var(--spacing-large) + var(--spacing-x-small))'
+    )
+    expect(calc('small xx-small')).toEqual(
+      'calc(var(--spacing-small) + var(--spacing-xx-small))'
     )
   })
 
@@ -186,6 +190,7 @@ describe('createTypeModifiers', () => {
       'small',
       'large',
     ])
+    expect(createTypeModifiers('0.25 1')).toEqual(['xx-small', 'small'])
     expect(createTypeModifiers('2 0.5')).toEqual(['large', 'x-small'])
     expect(createTypeModifiers(1)).toEqual(['small'])
     expect(createTypeModifiers(true)).toEqual(['small'])
@@ -195,6 +200,7 @@ describe('createTypeModifiers', () => {
 
 describe('findNearestTypes', () => {
   it('should find the nearest type in correct order', () => {
+    expect(findNearestTypes(0.25)).toEqual(['xx-small'])
     expect(findNearestTypes(2.5)).toEqual(['large', 'x-small'])
     expect(findNearestTypes(5)).toEqual(['xx-large', 'medium'])
     expect(findNearestTypes(8)).toEqual(['xx-large', 'xx-large', 'small'])
@@ -217,6 +223,10 @@ describe('createSpacing', () => {
     expect(createSpacing({ right: 'large x-small' }).className).toEqual([
       'dnb-space__right--large',
       'dnb-space__right--x-small',
+    ])
+    expect(createSpacing({ right: 'small xx-small' }).className).toEqual([
+      'dnb-space__right--small',
+      'dnb-space__right--xx-small',
     ])
   })
 


### PR DESCRIPTION
This is a draft PR. Looks like we support it in JavaScript, but not in CSS. So we would need to change the setup in CSS to make it actually work:

<img width="802" alt="Screenshot 2025-03-20 at 14 17 55" src="https://github.com/user-attachments/assets/cced0645-d7bc-4003-b261-19d81ef5bc54" />

