### PR TITLE
feat(Currency.Selector): add property `displayFormat`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs.ts
@@ -8,6 +8,11 @@ export const SelectCurrencyProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  displayFormat: {
+    doc: 'Sets the format for displaying the currency. `IsoCode`(NOK (Norsk krone)) or `CurrencyName`(Norsk krone (NOK)). Defaults to `CurrencyName`.',
+    type: 'string',
+    status: 'optional',
+  },
   filterCurrencies: {
     doc: 'Use this prop to filter out certain currencies. The function receives the currency object and should return a boolean. Returning `false` will omit the currency.',
     type: 'function',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.screenshot.test.ts
@@ -13,7 +13,7 @@ describe('Field.SelectCurrency', () => {
     url: '/uilib/extensions/forms/feature-fields/SelectCurrency/demos/',
   })
 
-  it.skip('match vertical layout', async () => {
+  it('match vertical layout', async () => {
     const screenshot = await makeScreenshot({
       selector: '[data-visual-test="select-currency-vertical-layout"]',
     })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -753,6 +753,62 @@ describe('Field.SelectCurrency', () => {
     ).toBe('transaction-currency')
   })
 
+  describe('displayFormat IsoCode', () => {
+    it('should format selected item correctly', () => {
+      render(<Field.SelectCurrency displayFormat="IsoCode" value="NOK" />)
+
+      const inputElement: HTMLInputElement = document.querySelector(
+        '.dnb-forms-field-select-currency input'
+      )
+
+      expect(inputElement).toHaveValue('NOK (Norsk krone)')
+    })
+
+    it('should format list elements correctly', () => {
+      render(<Field.SelectCurrency displayFormat="IsoCode" />)
+
+      const inputElement: HTMLInputElement = document.querySelector(
+        '.dnb-forms-field-select-currency input'
+      )
+
+      // open
+      fireEvent.focus(inputElement)
+
+      const liElements = document.querySelectorAll('li:not([aria-hidden])')
+      expect(liElements.length).toBeGreaterThan(176)
+      expect(liElements[0].textContent).toBe('NOKNorsk krone')
+      expect(liElements[1].textContent).toBe('SEKSvensk krone')
+      expect(liElements[2].textContent).toBe('DKKDansk krone')
+      expect(liElements[3].textContent).toBe('EUREuro')
+      expect(liElements[4].textContent).toBe('USDAmerikansk dollar')
+      expect(liElements[5].textContent).toBe('AEDEmiratarabisk dirham')
+    })
+
+    it('should sort "ZMW" as last', () => {
+      render(
+        <Form.Handler>
+          <Field.SelectCurrency displayFormat="IsoCode" />
+        </Form.Handler>
+      )
+
+      const inputElement: HTMLInputElement = document.querySelector(
+        '.dnb-forms-field-select-currency input'
+      )
+
+      // open
+      fireEvent.focus(inputElement)
+
+      {
+        const liElements = document.querySelectorAll(
+          'li:not([aria-hidden])'
+        )
+        expect(liElements[liElements.length - 1].textContent).toBe(
+          'ZMWZambisk kwacha'
+        )
+      }
+    })
+  })
+
   describe('ARIA', () => {
     it('should validate with ARIA rules', async () => {
       const result = render(


### PR DESCRIPTION
Not requested by anyone yet, so perhaps not worth including.
But just having it here for now, as I spent the short amount of time to make it, as I thought it would make sense to have.