### PR TITLE
chore(Anchor): swallow deprecated scrollToHashHandler test logs

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/AnchorScroll.test.tsx
@@ -33,8 +33,12 @@ describe('Anchor with scrollToHash', () => {
   })
 })
 
+/**
+ * @deprecated – can be removed in v11
+ */
 describe('Anchor with scrollToHashHandler', () => {
   let location: Location
+  jest.spyOn(console, 'log').mockImplementation()
 
   beforeEach(() => {
     location = window.location


### PR DESCRIPTION
Swallowing these logs:
 ```
PASS  src/components/anchor/__tests__/AnchorScroll.test.tsx (6.433 s)
  ● Console

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)

    console.log
      Eufemia "scrollToHashHandler" is deprecated.

      at log (src/shared/helpers.js:407:15)
```