### PR TITLE
chore: Cannot decrease to heading level 1

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/info.mdx
@@ -5,7 +5,7 @@ hideInMenu: true
 
 import { SummaryList, Composition } from './Examples'
 
-# Description
+## Description
 
 On many screens, data from the dataset is summarized statically, such as on a final review screen where users can confirm their entered data before submitting it to the bank. To streamline the display of such data, Eufemia Forms has Value components. These components operate similarly to [field components](/uilib/extensions/forms/all-fields/), meaning they're data-driven, can accept value properties, and can be connected to a surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler) by specifying the relevant value with a `path` property.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -2,7 +2,7 @@
 draft: true
 ---
 
-# Description
+## Description
 
 The `useFieldProps` hook standardize handling of the value flow for a single consumer component representing one data point. It holds error state, hides it while the field is in focus, connects to surrounding `DataContext` (if present) and other things that all field or value components needs to do. By implementing custom field or value components and passing the received properties through `useFieldProps`, all these features work the same way as other field or value components, and you only need to implement the specific unique features of that component.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useValueProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useValueProps/info.mdx
@@ -2,7 +2,7 @@
 draft: true
 ---
 
-# Description
+## Description
 
 The `useValueProps` hook standardize handling of the value flow for a single consumer component representing one data point.
 


### PR DESCRIPTION
Improves the warning:

```
Eufemia Cannot decrease to heading level 1! Had before 2 - The new level is 2 
NB: This warning was triggered by:  #Description
```