### PR TITLE
chore: Eufemia TypeError: Cannot use 'in' operator to search for 'current' in undefined

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -181,6 +181,25 @@ describe('"detectOutsideClick" should', () => {
     await userEvent.click(wrapperElementRef.current)
     expect(onSuccess).toHaveBeenCalledTimes(2)
   })
+
+  it('should not throw an error when "ignoreElementRef" is undefined', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation()
+
+    window.PointerEvent = undefined
+    const ignoreElementRef = undefined
+
+    const MockComponent = () => {
+      detectOutsideClick(ignoreElementRef)
+      return null
+    }
+
+    render(<MockComponent />)
+
+    await userEvent.click(document.body)
+
+    expect(log).toHaveBeenCalledTimes(0)
+    log.mockRestore()
+  })
 })
 
 describe('"checkIfHasScrollbar" should', () => {

--- a/packages/dnb-eufemia/src/shared/component-helper.js
+++ b/packages/dnb-eufemia/src/shared/component-helper.js
@@ -555,8 +555,9 @@ export class DetectOutsideClickClass {
       for (let i = 0, elem, l = ignoreElements.length; i < l; ++i) {
         // Allow for comparing ref elements that are rendered conditionally,
         // That might be `null` or ´undefined` during the construction stage of this class
+
         const ignoreElement =
-          'current' in ignoreElements[i]
+          ignoreElements[i] && 'current' in ignoreElements[i]
             ? ignoreElements[i].current
             : ignoreElements[i]
 


### PR DESCRIPTION
I get the following error:

```
Eufemia TypeError: Cannot use 'in' operator to search for 'current' in undefined
    at DetectOutsideClickClass.checkOutsideClick (component-helper.js:558:1)
    at DetectOutsideClickClass.handleClickOutside
```
    
 when visiting https://eufemia.dnb.no/uilib/components/fragments/scroll-view/ locally http://localhost:8000/uilib/components/fragments/scroll-view/