### PR TITLE
docs(Field.SelectCurrency): add link to list of currencies

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/info.mdx
@@ -5,6 +5,7 @@ showTabs: true
 ## Description
 
 `Field.SelectCurrency` is a wrapper component for the [selection component](/uilib/extensions/forms/base-fields/Selection), with options built in for selecting a currency.
+[The list of available currencies to select](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/constants/allCurrencies.ts#L1659) is carefully curated to meet the demands we know today.
 When selecting a currency, the value returned is the selected currency's [ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217) (currency code) like `NOK` for Norwegian krone.
 
 ```jsx


### PR DESCRIPTION
Perhaps we should also render the actual list of currencies in a table format as well?