### PR TITLE
docs(Field.SelectCurrency): display list of available currencies

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/AvailableCurrenciesTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/AvailableCurrenciesTable.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Table, Th, Tr, Td } from '@dnb/eufemia/src'
+import currencies from '@dnb/eufemia/src/extensions/forms/constants/currencies'
+import { FormattedCode } from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+
+export function AvailableCurrenciesTable() {
+  return (
+    <Table.ScrollView>
+      <Table>
+        <thead>
+          <Tr>
+            <Th>ISO 4217 code</Th>
+            {Object.entries(currencies[0].i18n).map(([key]) => {
+              return <Th key={key}>{key}</Th>
+            })}
+          </Tr>
+        </thead>
+        <tbody>
+          {Object.entries(currencies).map(([key, values]) => {
+            return (
+              <Tr key={key}>
+                <Td>
+                  <FormattedCode variant="prop">
+                    {values.iso}
+                  </FormattedCode>
+                </Td>
+                {Object.entries(values.i18n).map(([locale, value], i) => {
+                  return <Td key={i + locale}>{value}</Td>
+                })}
+              </Tr>
+            )
+          })}
+        </tbody>
+      </Table>
+    </Table.ScrollView>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/AvailableCurrenciesTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/AvailableCurrenciesTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Table, Th, Tr, Td } from '@dnb/eufemia/src'
 import currencies from '@dnb/eufemia/src/extensions/forms/constants/currencies'
-import { FormattedCode } from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { FormattedCode } from '../../../../../.../../../shared/parts/PropertiesTable'
 
 export function AvailableCurrenciesTable() {
   return (

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/assets/AvailableCurrenciesTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/assets/AvailableCurrenciesTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Table, Th, Tr, Td } from '@dnb/eufemia/src'
 import currencies from '@dnb/eufemia/src/extensions/forms/constants/currencies'
-import { FormattedCode } from '../../../../../.../../../shared/parts/PropertiesTable'
+import { FormattedCode } from '../../../../../../../shared/parts/PropertiesTable'
 
 export function AvailableCurrenciesTable() {
   return (

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/info.mdx
@@ -5,7 +5,7 @@ showTabs: true
 ## Description
 
 `Field.SelectCurrency` is a wrapper component for the [selection component](/uilib/extensions/forms/base-fields/Selection), with options built in for selecting a currency.
-[The list of available currencies to select](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/constants/allCurrencies.ts#L1659) is carefully curated to meet the demands we know today.
+[The list of available currencies to select](/uilib/extensions/forms/feature-fields/SelectCurrency/properties/#list-of-available-currencies) is carefully curated to meet the demands we know today.
 When selecting a currency, the value returned is the selected currency's [ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217) (currency code) like `NOK` for Norwegian krone.
 
 ```jsx

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
@@ -6,6 +6,7 @@ import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/Transla
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { FieldProperties } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
 import { SelectCurrencyProperties } from '@dnb/eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs'
+import { AvailableCurrenciesTable } from './AvailableCurrenciesTable'
 
 ### Field-specific properties
 
@@ -18,3 +19,11 @@ import { SelectCurrencyProperties } from '@dnb/eufemia/src/extensions/forms/Fiel
 ## Translations
 
 <TranslationsTable localeKey={['SelectCurrency', 'Field']} />
+
+## List of available currencies
+
+[Link to the code of the available currencies](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/constants/currencies.ts#L21).
+
+NOTE: This list does not say anything about the order in which they will appear in component `Field.SelectCurrency`. And is only meant to easily find which countries that's supported and available to use.
+
+<AvailableCurrenciesTable />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
@@ -24,6 +24,6 @@ import { AvailableCurrenciesTable } from './AvailableCurrenciesTable'
 
 [Link to the code of the available currencies](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/constants/currencies.ts#L21).
 
-NOTE: This list does not say anything about the order in which they will appear in component `Field.SelectCurrency`. And is only meant to easily find which countries that's supported and available to use.
+NOTE: This list does not say anything about the order in which they will appear in component `Field.SelectCurrency`. And is only meant to easily find which currencies that's supported and available to use.
 
 <AvailableCurrenciesTable />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency/properties.mdx
@@ -6,7 +6,7 @@ import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/Transla
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { FieldProperties } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
 import { SelectCurrencyProperties } from '@dnb/eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs'
-import { AvailableCurrenciesTable } from './AvailableCurrenciesTable'
+import { AvailableCurrenciesTable } from './assets/AvailableCurrenciesTable'
 
 ### Field-specific properties
 


### PR DESCRIPTION
Can be demoed here: https://eufemia-git-docs-add-list-of-currencies-in-props-eufemia.vercel.app/uilib/extensions/forms/feature-fields/SelectCurrency/properties/#list-of-available-currencies