### PR TITLE
chore(Forms): refactor object to use maps

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -189,7 +189,7 @@ export interface ContextState {
   fieldInternalsRef?: React.MutableRefObject<FieldInternalsRef>
   valueInternalsRef?: React.MutableRefObject<ValueInternalsRef>
   fieldConnectionsRef?: React.RefObject<Record<Path, FieldConnections>>
-  mountedFieldsRef?: React.MutableRefObject<Record<Path, MountState>>
+  mountedFieldsRef?: React.MutableRefObject<Map<Path, MountState>>
   snapshotsRef?: React.MutableRefObject<
     Map<SnapshotName, Map<Path, unknown>>
   >

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/FieldBoundaryProvider.tsx
@@ -34,12 +34,12 @@ export default function FieldBoundaryProvider(props: Props) {
     onPathErrorRef.current?.(path, error)
   }, [])
 
-  const hasVisibleErrorRef = useRef<Record<Path, boolean>>({})
+  const hasVisibleErrorRef = useRef<Map<Path, boolean>>(new Map())
   const revealError = useCallback((path: Path, hasError: boolean) => {
     if (hasError) {
-      hasVisibleErrorRef.current[path] = hasError
+      hasVisibleErrorRef.current.set(path, hasError)
     } else {
-      delete hasVisibleErrorRef.current[path]
+      hasVisibleErrorRef.current.delete(path)
     }
     forceUpdate()
   }, [])
@@ -55,7 +55,7 @@ export default function FieldBoundaryProvider(props: Props) {
   const context: FieldBoundaryContextState = {
     hasError,
     hasSubmitError,
-    hasVisibleError: Object.keys(hasVisibleErrorRef.current).length > 0,
+    hasVisibleError: hasVisibleErrorRef.current.size > 0,
     errorsRef,
     showBoundaryErrors: showBoundaryErrorsRef.current,
     setShowBoundaryErrors,

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -276,7 +276,7 @@ export default function Provider<Data extends JsonObject>(
   )
 
   // - Errors from provider validation (the whole data set)
-  const hasVisibleErrorRef = useRef<Record<Path, boolean>>({})
+  const hasVisibleErrorRef = useRef<Map<Path, boolean>>(new Map())
   const errorsRef = useRef<Record<Path, FormError> | undefined>()
   const addSetShowAllErrorsRef = useRef<
     Array<(showAllErrors: boolean) => void>
@@ -289,9 +289,9 @@ export default function Provider<Data extends JsonObject>(
   }, [])
   const revealError = useCallback((path: Path, hasError: boolean) => {
     if (hasError) {
-      hasVisibleErrorRef.current[path] = hasError
+      hasVisibleErrorRef.current.set(path, hasError)
     } else {
-      delete hasVisibleErrorRef.current[path]
+      hasVisibleErrorRef.current.delete(path)
     }
     forceUpdate() // Will rerender the whole form initially
   }, [])
@@ -1439,7 +1439,7 @@ export default function Provider<Data extends JsonObject>(
     hasContext: true,
     errors: errorsRef.current,
     showAllErrors: showAllErrorsRef.current,
-    hasVisibleError: Object.keys(hasVisibleErrorRef.current).length > 0,
+    hasVisibleError: hasVisibleErrorRef.current.size > 0,
     addSetShowAllErrorsRef,
     fieldConnectionsRef,
     fieldDisplayValueRef,

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -187,7 +187,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
 
   const blockId = useId(props.id)
   const [salt, forceUpdate] = useReducer(() => ({}), {})
-  const mountedFieldsRef = useRef<MountedFieldsRef>({})
+  const mountedFieldsRef = useRef<MountedFieldsRef>(new Map())
   const fieldStateRef = useRef<SubmitState>(null)
   const stateRecordRef = useRef<StateRecord>({})
   const fieldStateIdsRef = useRef<FieldErrorIdsRef>(null)
@@ -436,7 +436,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
 
   useEffect(
     () => () => {
-      mountedFieldsRef.current = {}
+      mountedFieldsRef.current = new Map()
       stateRecordRef.current = {}
     },
     []

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockContext.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import type { FieldProps, Identifier, SubmitState } from '../types'
 
 export type FieldErrorIdsRef = Record<StateTypes, string>
-export type MountedFieldsRef = Record<Identifier, boolean>
+export type MountedFieldsRef = Map<Identifier, boolean>
 export type StateTypes = 'error' | 'warning' | 'info'
 export type StateContent =
   | FieldProps<unknown>['error']

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -133,12 +133,13 @@ function IsolationProvider<Data extends JsonObject>(
 
   const getMountedData = useCallback((data: Data) => {
     const mounterData = {} as Data
-    for (const path in dataContextRef.current?.mountedFieldsRef.current) {
-      const field = dataContextRef.current.mountedFieldsRef.current[path]
-      if (field.isMounted && pointer.has(data, path)) {
-        pointer.set(mounterData, path, pointer.get(data, path))
+    dataContextRef.current?.mountedFieldsRef.current.forEach(
+      (field, path) => {
+        if (field.isMounted && pointer.has(data, path)) {
+          pointer.set(mounterData, path, pointer.get(data, path))
+        }
       }
-    }
+    )
     return mounterData
   }, [])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/useVisibility.tsx
@@ -70,7 +70,7 @@ export default function useVisibility(props?: Partial<Props>) {
             : makePath(visibleWhen.path)
 
         if ('isValid' in visibleWhen) {
-          const item = mountedFieldsRef.current[path]
+          const item = mountedFieldsRef.current.get(path)
           if (!item || item.isMounted !== true) {
             return visibleWhenNot ? true : false
           }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/useCollectStepsData.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/useCollectStepsData.tsx
@@ -22,7 +22,7 @@ export function useCollectStepsData() {
       const stringifiedTitle =
         title !== undefined ? convertJsxToString(title) : 'Title missing'
 
-      const state = stepStatusRef.current[index]
+      const state = stepStatusRef.current.get(index)
       const status =
         index !== activeIndexRef.current
           ? state === 'error'

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Context/types.ts
@@ -44,9 +44,9 @@ export type SetActiveIndexOptions = {
 }
 
 export type InternalStepStatus = 'error' | 'valid' | 'unknown' | undefined
-export type InternalStepStatuses = Record<StepIndex, InternalStepStatus>
-export type InternalVisitedSteps = Record<StepIndex, boolean>
-export type InternalFieldError = Record<
+export type InternalStepStatuses = Map<StepIndex, InternalStepStatus>
+export type InternalVisitedSteps = Map<StepIndex, boolean>
+export type InternalFieldError = Map<
   Path,
   {
     index: StepIndex

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -2339,7 +2339,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         // Unmount procedure
         if (mountedFieldsRefFieldBlock) {
           // eslint-disable-next-line react-hooks/exhaustive-deps
-          mountedFieldsRefFieldBlock.current[identifier] = true
+          mountedFieldsRefFieldBlock.current.set(identifier, true)
         }
       }
     }
@@ -2392,7 +2392,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   if (inFieldBlock) {
     // Mount the field in the field block context
     if (mountedFieldsRefFieldBlock) {
-      mountedFieldsRefFieldBlock.current[identifier] = true
+      mountedFieldsRefFieldBlock.current.set(identifier, true)
     }
 
     // Check if there are any state IDs to be added to the aria-describedby attribute

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useValueProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useValueProps.ts
@@ -74,7 +74,7 @@ export default function useValueProps<
 
   const shouldBeVisible = useCallback(
     (path: Path): boolean => {
-      const item = mountedFieldsRef?.current?.[path]
+      const item = mountedFieldsRef?.current?.get(path)
 
       if (!item || !inheritVisibility) {
         return true


### PR DESCRIPTION
We use maps a couple of places in Eufemia Forms. Maps in general can be faster, but are mostly less memory hungry. So I think some of our internals can and should be rewritten. 