### PR TITLE
fix(Field.Upload): async removal of file with same file name as other file

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
@@ -45,11 +45,11 @@ function UploadFileList() {
       const idIsSame =
         fileListElement.id && fileListElement.id === fileToBeUpdated.id
 
-      const fileNameIsSame =
-        fileListElement?.file?.name &&
-        fileListElement?.file?.name === fileToBeUpdated?.file?.name
+      const fileIsSame =
+        fileListElement.file &&
+        fileListElement.file === fileToBeUpdated.file
 
-      return idIsSame || fileNameIsSame
+      return idIsSame || fileIsSame
         ? {
             ...fileListElement,
             ...props,

--- a/packages/dnb-eufemia/src/components/upload/__tests__/testHelpers.ts
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/testHelpers.ts
@@ -1,5 +1,10 @@
-export function createMockFile(name: string, size: number, type: string) {
-  const file = new File([], name, { type })
+export function createMockFile(
+  name: string,
+  size: number,
+  type: string,
+  lastModified?: number
+) {
+  const file = new File([], name, { type, lastModified })
   Object.defineProperty(file, 'size', {
     get() {
       return size

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -1587,6 +1587,91 @@ describe('Field.Upload', () => {
     ).toBe(1)
   })
 
+  it.only('should remove correct file when file names are the same', async () => {
+    const fileName = 'fileName-1.png'
+    const asyncOnFileDelete = jest.fn(async () => {
+      await wait(1)
+    })
+
+    const existingFile = createMockFile(
+      fileName,
+      100,
+      'image/png',
+      1730801854755
+    )
+    const newFile = createMockFile(
+      fileName,
+      100,
+      'image/png',
+      1730801854752
+    )
+
+    render(
+      <Form.Handler
+        data={{
+          myFiles: [
+            {
+              file: existingFile,
+            },
+          ],
+        }}
+      >
+        <Field.Upload path="/myFiles" onFileDelete={asyncOnFileDelete} />
+      </Form.Handler>
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-upload__file-cell').length
+    ).toBe(1)
+
+    const element = getRootElement()
+
+    await waitFor(() =>
+      fireEvent.drop(element, {
+        dataTransfer: {
+          files: [newFile],
+        },
+      })
+    )
+
+    // it should allow uploading two files with the same file name, as they are not identical files
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.dnb-upload__file-cell').length
+      ).toBe(2)
+    })
+
+    await waitFor(() => {
+      // delete the second file
+      fireEvent.click(
+        document
+          .querySelectorAll('.dnb-upload__file-cell')[1]
+          .querySelector('button')
+      )
+    })
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.dnb-upload__file-cell').length
+      ).toBe(1)
+    })
+
+    await waitFor(() => {
+      // delete the first file
+      fireEvent.click(
+        document
+          .querySelectorAll('.dnb-upload__file-cell')[0]
+          .querySelector('button')
+      )
+    })
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.dnb-upload__file-cell').length
+      ).toBe(0)
+    })
+  })
+
   describe('transformIn and transformOut', () => {
     type DocumentMetadata = {
       id: string

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -1587,7 +1587,7 @@ describe('Field.Upload', () => {
     ).toBe(1)
   })
 
-  it.only('should remove correct file when file names are the same', async () => {
+  it('should remove correct file when file names are the same', async () => {
     const fileName = 'fileName-1.png'
     const asyncOnFileDelete = jest.fn(async () => {
       await wait(1)


### PR DESCRIPTION
When async removing a file that has the same file name as an other file, both files displays as loading/removing, and only 1 file is removed. 

The expected result when clicking remove for file x is that only file x is loading/removing and only file x is removed.

CSB of the problem: https://codesandbox.io/p/devbox/exciting-pike-td395f

Video of the problem:

https://github.com/user-attachments/assets/549bccac-d856-4b48-a924-6104d592e666

CSB with the fix in this PR: https://codesandbox.io/p/devbox/sad-antonelli-dkdmtp?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE


Sidenote: As of today, it's allowed with files of the same file name, that's not in our code classified as an "existing file".
These are the conditions that needs to be met for it to be an "existing file": https://github.com/dnbexperience/eufemia/blob/efbf145a25ef7c8274bd06df7b3c2dc695cbb4cd/packages/dnb-eufemia/src/components/upload/useUpload.ts#L49-L51
