### PR TITLE
fix(DatePicker): update calendar views based on input value when `range` is `true`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.tsx
@@ -28,7 +28,6 @@ export type DatePickerAddonProps = React.HTMLProps<HTMLElement> & {
 function DatePickerAddon(props: DatePickerAddonProps) {
   const {
     updateDates,
-    forceViewMonthChange,
     callOnChangeHandler,
     hidePicker,
     startDate,
@@ -57,14 +56,14 @@ function DatePickerAddon(props: DatePickerAddonProps) {
       event?: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
     } = {}) => {
       updateDates({ startDate, endDate })
-      forceViewMonthChange()
+
       callOnChangeHandler({
         startDate,
         endDate: endDate || startDate,
         event,
       })
     },
-    [updateDates, callOnChangeHandler, forceViewMonthChange]
+    [updateDates, callOnChangeHandler]
   )
 
   const setDate = useCallback(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -44,13 +44,14 @@ import {
   getCalendar,
 } from './DatePickerCalc'
 import Button, { ButtonProps } from '../button/Button'
-import DatePickerContext from './DatePickerContext'
+import DatePickerContext, {
+  DatePickerContextValues,
+} from './DatePickerContext'
 import { useTranslation } from '../../shared'
 import { InternalLocale } from '../../shared/Context'
 import { DatePickerChangeEvent } from './DatePickerProvider'
 import { DatePickerDates } from './hooks/useDates'
 import { LOCALE } from '../../shared/defaults'
-import { ClickedCalendarDays } from './hooks/useViews'
 
 export type CalendarDay = {
   date: Date
@@ -166,7 +167,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
   const {
     updateDates,
-    setClickedCalendarDays,
+    setHasClickedCalendarDay,
     startDate,
     endDate,
     hoverDate,
@@ -679,7 +680,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                   endDate,
                                   resetDate,
                                   event,
-                                  setClickedCalendarDays,
+                                  setHasClickedCalendarDay,
                                   onSelect: (state) => {
                                     updateDates(state, (dates) =>
                                       callOnSelect({
@@ -774,7 +775,10 @@ function CalendarButton({
   )
 }
 
-type SelectRangeEvent = {
+type SelectRangeEvent = Pick<
+  DatePickerContextValues,
+  'setHasClickedCalendarDay'
+> & {
   day: DayObject
   event?: React.MouseEvent<HTMLButtonElement>
   startDate?: Date
@@ -782,7 +786,6 @@ type SelectRangeEvent = {
   resetDate?: boolean
   isRange?: boolean
   onSelect?: DatePickerCalendarProps['onSelect']
-  setClickedCalendarDays: (days: ClickedCalendarDays) => void
 }
 
 function onSelectRange({
@@ -793,13 +796,11 @@ function onSelectRange({
   onSelect,
   resetDate,
   event,
-  setClickedCalendarDays,
+  setHasClickedCalendarDay,
 }: SelectRangeEvent) {
   event.persist()
 
   if (!isRange) {
-    setClickedCalendarDays({ start: day.date })
-
     // set only date
     return onSelect({
       startDate: startOfDay(day.date),
@@ -810,11 +811,10 @@ function onSelectRange({
     // for setting date new on every selection, do this here
   }
 
+  // Set to true to stop calendar views from changing in range mode when clicking a day
+  setHasClickedCalendarDay(true)
+
   if (!startDate || (resetDate && startDate && endDate)) {
-    setClickedCalendarDays({
-      start: day.date,
-      end: undefined,
-    })
     // set startDate
     // user is selecting startDate
     return onSelect({
@@ -838,11 +838,6 @@ function onSelectRange({
       : startDate,
     day.date
   )
-
-  setClickedCalendarDays({
-    start: range.startDate,
-    end: range.endDate,
-  })
 
   return onSelect({
     startDate: startOfDay(range.startDate),

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -50,7 +50,7 @@ import { InternalLocale } from '../../shared/Context'
 import { DatePickerChangeEvent } from './DatePickerProvider'
 import { DatePickerDates } from './hooks/useDates'
 import { LOCALE } from '../../shared/defaults'
-import { ClickedViewDays } from './hooks/useViews'
+import { ClickedCalendarDays } from './hooks/useViews'
 
 export type CalendarDay = {
   date: Date
@@ -166,7 +166,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
   const {
     updateDates,
-    setClickedDays,
+    setClickedCalendarDays,
     startDate,
     endDate,
     hoverDate,
@@ -679,7 +679,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                   endDate,
                                   resetDate,
                                   event,
-                                  setClickedDays,
+                                  setClickedCalendarDays,
                                   onSelect: (state) => {
                                     updateDates(state, (dates) =>
                                       callOnSelect({
@@ -782,7 +782,7 @@ type SelectRangeEvent = {
   resetDate?: boolean
   isRange?: boolean
   onSelect?: DatePickerCalendarProps['onSelect']
-  setClickedDays: (days: ClickedViewDays) => void
+  setClickedCalendarDays: (days: ClickedCalendarDays) => void
 }
 
 function onSelectRange({
@@ -793,12 +793,12 @@ function onSelectRange({
   onSelect,
   resetDate,
   event,
-  setClickedDays,
+  setClickedCalendarDays,
 }: SelectRangeEvent) {
   event.persist()
 
   if (!isRange) {
-    setClickedDays({ startDay: startOfDay(day.date) })
+    setClickedCalendarDays({ start: startOfDay(day.date) })
 
     // set only date
     return onSelect({
@@ -811,7 +811,10 @@ function onSelectRange({
   }
 
   if (!startDate || (resetDate && startDate && endDate)) {
-    setClickedDays({ startDay: startOfDay(day.date), endDay: undefined })
+    setClickedCalendarDays({
+      start: startOfDay(day.date),
+      end: undefined,
+    })
     // set startDate
     // user is selecting startDate
     return onSelect({
@@ -836,7 +839,10 @@ function onSelectRange({
     day.date
   )
 
-  setClickedDays({ startDay: range.startDate, endDay: range.endDate })
+  setClickedCalendarDays({
+    start: range.startDate,
+    end: range.endDate,
+  })
 
   return onSelect({
     startDate: startOfDay(range.startDate),

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -50,6 +50,7 @@ import { InternalLocale } from '../../shared/Context'
 import { DatePickerChangeEvent } from './DatePickerProvider'
 import { DatePickerDates } from './hooks/useDates'
 import { LOCALE } from '../../shared/defaults'
+import { ClickedViewDays } from './hooks/useViews'
 
 export type CalendarDay = {
   date: Date
@@ -166,6 +167,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   const {
     updateDates,
     forceViewMonthChange,
+    setClickedDays,
     startDate,
     endDate,
     hoverDate,
@@ -681,6 +683,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                   endDate,
                                   resetDate,
                                   event,
+                                  setClickedDays,
                                   onSelect: (state) => {
                                     updateDates(state, (dates) =>
                                       callOnSelect({
@@ -693,11 +696,13 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                   },
                                 })
                         }
+                        // TODO: See if this can be replaced with css, to prevent massive amount of re-renders
                         onMouseOver={
                           handleAsDisabled
                             ? undefined
                             : () => onHoverDay({ day, hoverDate, onHover })
                         }
+                        // TODO: See if this can be replaced with css, to prevent massive amount of re-renders
                         onFocus={
                           handleAsDisabled
                             ? undefined
@@ -781,6 +786,7 @@ type SelectRangeEvent = {
   resetDate?: boolean
   isRange?: boolean
   onSelect?: DatePickerCalendarProps['onSelect']
+  setClickedDays: (days: ClickedViewDays) => void
 }
 
 function onSelectRange({
@@ -791,10 +797,13 @@ function onSelectRange({
   onSelect,
   resetDate,
   event,
+  setClickedDays,
 }: SelectRangeEvent) {
   event.persist()
 
   if (!isRange) {
+    setClickedDays({ startDay: startOfDay(day.date) })
+
     // set only date
     return onSelect({
       startDate: startOfDay(day.date),
@@ -806,6 +815,7 @@ function onSelectRange({
   }
 
   if (!startDate || (resetDate && startDate && endDate)) {
+    setClickedDays({ startDay: startOfDay(day.date), endDay: undefined })
     // set startDate
     // user is selecting startDate
     return onSelect({
@@ -829,6 +839,8 @@ function onSelectRange({
       : startDate,
     day.date
   )
+
+  setClickedDays({ startDay: range.startDate, endDay: range.endDate })
 
   return onSelect({
     startDate: startOfDay(range.startDate),

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -166,7 +166,6 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
   const {
     updateDates,
-    forceViewMonthChange,
     setClickedDays,
     startDate,
     endDate,
@@ -448,8 +447,6 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         })
       })
 
-      forceViewMonthChange()
-
       // and set the focus back again
       if (listRef && listRef.current) {
         listRef.current.focus({ preventScroll: true })
@@ -470,7 +467,6 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
       onlyMonth,
       endMonth,
       startMonth,
-      forceViewMonthChange,
     ]
   )
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -798,7 +798,7 @@ function onSelectRange({
   event.persist()
 
   if (!isRange) {
-    setClickedCalendarDays({ start: startOfDay(day.date) })
+    setClickedCalendarDays({ start: day.date })
 
     // set only date
     return onSelect({
@@ -812,7 +812,7 @@ function onSelectRange({
 
   if (!startDate || (resetDate && startDate && endDate)) {
     setClickedCalendarDays({
-      start: startOfDay(day.date),
+      start: day.date,
       end: undefined,
     })
     // set startDate

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -13,7 +13,7 @@ import {
   ReturnObject,
 } from './DatePickerProvider'
 import { DatePickerDateProps, DatePickerDates } from './hooks/useDates'
-import { CalendarView, ClickedViewDays } from './hooks/useViews'
+import { CalendarView, ClickedCalendarDays } from './hooks/useViews'
 
 export type DateType = Date | string
 
@@ -30,7 +30,7 @@ export type DatePickerContextValues = ContextProps &
     ) => void
     setState?: (state: DatePickerProviderState) => void
     setViews: (views: Array<CalendarView>, callback?: () => void) => void
-    setClickedDays: (days: ClickedViewDays) => void
+    setClickedCalendarDays: (days: ClickedCalendarDays) => void
     callOnChangeHandler: <E>(event: DatePickerChangeEvent<E>) => void
     hidePicker: (event: DisplayPickerEvent) => void
     getReturnObject: <E>(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -13,7 +13,7 @@ import {
   ReturnObject,
 } from './DatePickerProvider'
 import { DatePickerDateProps, DatePickerDates } from './hooks/useDates'
-import { CalendarView } from './hooks/useViews'
+import { CalendarView, ClickedViewDays } from './hooks/useViews'
 
 export type DateType = Date | string
 
@@ -30,6 +30,7 @@ export type DatePickerContextValues = ContextProps &
     ) => void
     setState?: (state: DatePickerProviderState) => void
     setViews: (views: Array<CalendarView>, callback?: () => void) => void
+    setClickedDays: (days: ClickedViewDays) => void
     forceViewMonthChange: () => void
     callOnChangeHandler: <E>(event: DatePickerChangeEvent<E>) => void
     hidePicker: (event: DisplayPickerEvent) => void

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -13,7 +13,7 @@ import {
   ReturnObject,
 } from './DatePickerProvider'
 import { DatePickerDateProps, DatePickerDates } from './hooks/useDates'
-import { CalendarView, ClickedCalendarDays } from './hooks/useViews'
+import { CalendarView } from './hooks/useViews'
 
 export type DateType = Date | string
 
@@ -30,7 +30,7 @@ export type DatePickerContextValues = ContextProps &
     ) => void
     setState?: (state: DatePickerProviderState) => void
     setViews: (views: Array<CalendarView>, callback?: () => void) => void
-    setClickedCalendarDays: (days: ClickedCalendarDays) => void
+    setHasClickedCalendarDay: (hasClicked: boolean) => void
     callOnChangeHandler: <E>(event: DatePickerChangeEvent<E>) => void
     hidePicker: (event: DisplayPickerEvent) => void
     getReturnObject: <E>(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -31,7 +31,6 @@ export type DatePickerContextValues = ContextProps &
     setState?: (state: DatePickerProviderState) => void
     setViews: (views: Array<CalendarView>, callback?: () => void) => void
     setClickedDays: (days: ClickedViewDays) => void
-    forceViewMonthChange: () => void
     callOnChangeHandler: <E>(event: DatePickerChangeEvent<E>) => void
     hidePicker: (event: DisplayPickerEvent) => void
     getReturnObject: <E>(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -113,7 +113,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       }
     )
 
-  const { views, setViews, setClickedDays } = useViews({
+  const { views, setViews, setClickedCalendarDays } = useViews({
     startMonth: dates.startMonth,
     endMonth: dates.endMonth,
     isRange: range,
@@ -248,7 +248,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         hasHadValidDate,
         views,
         setViews,
-        setClickedDays,
+        setClickedCalendarDays,
       }}
     >
       {children}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -113,11 +113,12 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       }
     )
 
-  const { views, setViews, forceViewMonthChange } = useViews({
-    startMonth: dates.startMonth,
-    endMonth: dates.endMonth,
-    isRange: range,
-  })
+  const { views, setViews, setClickedDays, forceViewMonthChange } =
+    useViews({
+      startMonth: dates.startMonth,
+      endMonth: dates.endMonth,
+      isRange: range,
+    })
 
   const [lastEventCallCache, setLastEventCallCache] =
     useLastEventCallCache({
@@ -248,6 +249,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         hasHadValidDate,
         views,
         setViews,
+        setClickedDays,
         forceViewMonthChange,
       }}
     >

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -113,7 +113,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       }
     )
 
-  const { views, setViews, setClickedCalendarDays } = useViews({
+  const { views, setViews, setHasClickedCalendarDay } = useViews({
     startMonth: dates.startMonth,
     endMonth: dates.endMonth,
     isRange: range,
@@ -248,7 +248,7 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         hasHadValidDate,
         views,
         setViews,
-        setClickedCalendarDays,
+        setHasClickedCalendarDay,
       }}
     >
       {children}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -113,12 +113,11 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       }
     )
 
-  const { views, setViews, setClickedDays, forceViewMonthChange } =
-    useViews({
-      startMonth: dates.startMonth,
-      endMonth: dates.endMonth,
-      isRange: range,
-    })
+  const { views, setViews, setClickedDays } = useViews({
+    startMonth: dates.startMonth,
+    endMonth: dates.endMonth,
+    isRange: range,
+  })
 
   const [lastEventCallCache, setLastEventCallCache] =
     useLastEventCallCache({
@@ -250,7 +249,6 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         views,
         setViews,
         setClickedDays,
-        forceViewMonthChange,
       }}
     >
       {children}

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2216,6 +2216,58 @@ describe('DatePicker component', () => {
     expect(endMonth).toHaveTextContent('desember 2024')
   })
 
+  it('should display month based on input value when opening picker', async () => {
+    render(<DatePicker showInput />)
+
+    const dayInput = document.querySelector('.dnb-date-picker__input--day')
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('10022001')
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const startMonth = document.querySelector(
+      '.dnb-date-picker__header__title'
+    )
+    const selectedMonth = document.querySelector('[aria-current="date"]')
+
+    expect(startMonth).toHaveTextContent('februar 2001')
+    expect(selectedMonth).toHaveAttribute(
+      'aria-label',
+      'lørdag 10. februar 2001'
+    )
+  })
+
+  it('should display correct months in calendar view based on input value when opening the picker in range mode', async () => {
+    render(
+      <DatePicker startMonth="2024-01-01" endMonth="2024-12-31" range />
+    )
+
+    const dayInput = document.querySelector('.dnb-date-picker__input--day')
+
+    await userEvent.click(dayInput)
+    await userEvent.keyboard('0103200106042003')
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    const [startMonth, endMonth] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__header__title')
+    )
+
+    const [selectedStartMonth, selectedEndMonth] = Array.from(
+      document.querySelectorAll('[aria-current="date"]')
+    )
+
+    expect(startMonth).toHaveTextContent('mars 2001')
+    expect(endMonth).toHaveTextContent('april 2003')
+    expect(selectedStartMonth).toHaveAttribute(
+      'aria-label',
+      'torsdag 1. mars 2001'
+    )
+    expect(selectedEndMonth).toHaveAttribute(
+      'aria-label',
+      'søndag 6. april 2003'
+    )
+  })
+
   describe('size', () => {
     it('has correct small size', () => {
       render(<DatePicker {...defaultProps} size="small" />)

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -952,6 +952,28 @@ describe('DatePicker component', () => {
 
     await userEvent.click(screen.getByLabelText('torsdag 18. juli 2024'))
     await userEvent.click(screen.getByLabelText('onsdag 1. januar 2025'))
+
+    await userEvent.click(leftPrev)
+    await userEvent.click(screen.getByLabelText('tirsdag 4. juni 2024'))
+    await userEvent.click(screen.getByLabelText('tirsdag 11. juni 2024'))
+
+    expect(
+      leftPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('juni 2024')
+    expect(
+      rightPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('januar 2025')
+
+    await userEvent.click(leftPrev)
+    await userEvent.click(screen.getByLabelText('fredag 10. mai 2024'))
+    await userEvent.click(screen.getByLabelText('fredag 17. mai 2024'))
+
+    expect(
+      leftPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('mai 2024')
+    expect(
+      rightPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('januar 2025')
   })
 
   it('should set correct month based date selected with keyboard navigation', async () => {

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -35,20 +35,19 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
   )
 
   if (hasDateChanges) {
-    if (!hasClickedCalendarDay.current) {
-      const updatedViews = getViews({
-        ...dates,
-        isRange,
-      })
-
-      setViews(updatedViews)
-    }
-
-    if (hasClickedCalendarDay.current) {
-      setHasClickedCalendarDay(false)
-    }
-
     setPreviousDates(dates)
+
+    // Stop here if the user has clicked a date in the calendar, as we don't want to update the views then
+    if (hasClickedCalendarDay.current) {
+      return setHasClickedCalendarDay(false)
+    }
+
+    const updatedViews = getViews({
+      ...dates,
+      isRange,
+    })
+
+    setViews(updatedViews)
   }
 
   function updateViews(

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -26,7 +26,6 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     startDay: undefined,
     endDay: undefined,
   })
-  const forceViewChange = useRef(false)
 
   const hasDateChanges = useMemo(
     () =>
@@ -38,18 +37,15 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
 
   if (hasDateChanges) {
     // Maintain range views unless forced to change by shortcut or keyboard navigation
-    if (forceViewChange.current || !isRange) {
-      setViews(
-        getViews({
-          ...dates,
-          isRange,
-          views,
-          clickedDays: clickedDays.current,
-        })
-      )
-      forceViewChange.current = false
-    }
 
+    const updatedViews = getViews({
+      ...dates,
+      isRange,
+      views,
+      clickedDays: clickedDays.current,
+    })
+
+    setViews(updatedViews)
     setClickedDays({ startDay: undefined, endDay: undefined })
     setPreviousDates(dates)
   }
@@ -62,10 +58,6 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     cb?.()
   }
 
-  function forceViewMonthChange() {
-    forceViewChange.current = true
-  }
-
   function setClickedDays(days: ClickedViewDays) {
     clickedDays.current = { ...clickedDays.current, ...days }
   }
@@ -74,7 +66,6 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     views,
     setViews: updateViews,
     setClickedDays,
-    forceViewMonthChange,
   } as const
 }
 

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -16,7 +16,12 @@ export type UseViewsParams = ViewDates & {
 export default function useViews({ isRange, ...dates }: UseViewsParams) {
   const [previousDates, setPreviousDates] = useState(dates)
   const [views, setViews] = useState<Array<CalendarView>>(
-    getViews({ views: undefined, ...dates, isRange })
+    isRange
+      ? [
+          { nr: 0, month: dates.startMonth },
+          { nr: 1, month: dates.endMonth },
+        ]
+      : [{ nr: 0, month: dates.startMonth }]
   )
 
   const forceViewChange = useRef(false)

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -10,7 +10,7 @@ export type ViewDates = {
   endMonth?: DatePickerDates['endMonth']
 }
 
-export type ClickedViewDays = { startDay?: Date; endDay?: Date }
+export type ClickedCalendarDays = { start?: Date; end?: Date }
 
 export type UseViewsParams = ViewDates & {
   isRange?: boolean
@@ -22,9 +22,9 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     getViews({ ...dates, isRange, views: undefined })
   )
 
-  const clickedDays = useRef<ClickedViewDays>({
-    startDay: undefined,
-    endDay: undefined,
+  const clickedCalendarDays = useRef<ClickedCalendarDays>({
+    start: undefined,
+    end: undefined,
   })
 
   const hasDateChanges = useMemo(
@@ -42,11 +42,11 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
       ...dates,
       isRange,
       views,
-      clickedDays: clickedDays.current,
+      clickedCalendarDays: clickedCalendarDays.current,
     })
 
     setViews(updatedViews)
-    setClickedDays({ startDay: undefined, endDay: undefined })
+    setClickedCalendarDays({ start: undefined, end: undefined })
     setPreviousDates(dates)
   }
 
@@ -58,26 +58,29 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     cb?.()
   }
 
-  function setClickedDays(days: ClickedViewDays) {
-    clickedDays.current = { ...clickedDays.current, ...days }
+  function setClickedCalendarDays(days: ClickedCalendarDays) {
+    clickedCalendarDays.current = {
+      ...clickedCalendarDays.current,
+      ...days,
+    }
   }
 
   return {
     views,
     setViews: updateViews,
-    setClickedDays,
+    setClickedCalendarDays,
   } as const
 }
 
 export function getViews({
   isRange,
   views,
-  clickedDays,
+  clickedCalendarDays,
   ...dates
 }: ViewDates &
   UseViewsParams & {
     views: Array<CalendarView>
-    clickedDays?: ClickedViewDays
+    clickedCalendarDays?: ClickedCalendarDays
   }): Array<CalendarView> {
   // Handle non-range views
   if (!isRange) {
@@ -86,10 +89,10 @@ export function getViews({
 
   // Do not change views if the clicked start or end day is in one of the currently displayed month views
   if (
-    (clickedDays?.startDay &&
-      isSameMonth(clickedDays.startDay, views[1].month)) ||
-    (clickedDays?.endDay &&
-      isSameMonth(clickedDays.endDay, views[0].month))
+    (clickedCalendarDays?.start &&
+      isSameMonth(clickedCalendarDays.start, views[1].month)) ||
+    (clickedCalendarDays?.end &&
+      isSameMonth(clickedCalendarDays.end, views[0].month))
   ) {
     return views
   }

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -35,15 +35,9 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
   )
 
   if (hasDateChanges) {
-    const currentViews = Array.isArray(views)
-      ? views.length > 1
-        ? views
-        : views[0]
-      : views
-
     // Maintain range views unless forced to change by shortcut or keyboard navigation
     if (forceViewChange.current || !isRange) {
-      setViews(getViews({ ...dates, views: currentViews, isRange }))
+      setViews(getViews({ ...dates, isRange }))
       forceViewChange.current = false
     }
 
@@ -70,26 +64,17 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
 }
 
 export function getViews({
-  views,
   isRange,
   ...dates
-}: ViewDates &
-  UseViewsParams & {
-    views?: CalendarView | Array<CalendarView>
-  }): Array<CalendarView> {
-  // fill the views with the calendar data getMonth()
-  return (
-    Array.isArray(views)
-      ? views
-      : Array(
-          isRange
-            ? 2 // set default range calendars
-            : views
-        ).fill(1)
-  ).map((view, nr) => ({
-    month: getMonthView({ ...dates }, nr),
-    nr,
-  }))
+}: ViewDates & UseViewsParams): Array<CalendarView> {
+  if (!isRange) {
+    return [{ nr: 0, month: getMonthView({ ...dates }, 0) }]
+  }
+
+  return [
+    { nr: 0, month: getMonthView({ ...dates }, 0) },
+    { nr: 1, month: getMonthView({ ...dates }, 1) },
+  ]
 }
 
 function getMonthView(

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -37,7 +37,7 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
   if (hasDateChanges) {
     setPreviousDates(dates)
 
-    // Stop here if the user has clicked a date in the calendar, as we don't want to update
+    // Stop here if the user has clicked a day in the calendar, as we don't want update the views then
     if (hasClickedCalendarDay.current) {
       setHasClickedCalendarDay(false)
     } else {

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -1,6 +1,7 @@
 import addMonths from 'date-fns/addMonths'
 import { useMemo, useRef, useState } from 'react'
 import { DatePickerDates } from './useDates'
+import { isSameMonth } from 'date-fns'
 
 export type CalendarView = { nr: number; month?: Date }
 
@@ -9,6 +10,8 @@ export type ViewDates = {
   endMonth?: DatePickerDates['endMonth']
 }
 
+export type ClickedViewDays = { startDay?: Date; endDay?: Date }
+
 export type UseViewsParams = ViewDates & {
   isRange?: boolean
 }
@@ -16,9 +19,13 @@ export type UseViewsParams = ViewDates & {
 export default function useViews({ isRange, ...dates }: UseViewsParams) {
   const [previousDates, setPreviousDates] = useState(dates)
   const [views, setViews] = useState<Array<CalendarView>>(
-    getViews({ ...dates, isRange })
+    getViews({ ...dates, isRange, views: undefined })
   )
 
+  const clickedDays = useRef<ClickedViewDays>({
+    startDay: undefined,
+    endDay: undefined,
+  })
   const forceViewChange = useRef(false)
 
   const hasDateChanges = useMemo(
@@ -32,10 +39,18 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
   if (hasDateChanges) {
     // Maintain range views unless forced to change by shortcut or keyboard navigation
     if (forceViewChange.current || !isRange) {
-      setViews(getViews({ ...dates, isRange }))
+      setViews(
+        getViews({
+          ...dates,
+          isRange,
+          views,
+          clickedDays: clickedDays.current,
+        })
+      )
       forceViewChange.current = false
     }
 
+    setClickedDays({ startDay: undefined, endDay: undefined })
     setPreviousDates(dates)
   }
 
@@ -51,27 +66,52 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
     forceViewChange.current = true
   }
 
+  function setClickedDays(days: ClickedViewDays) {
+    clickedDays.current = { ...clickedDays.current, ...days }
+  }
+
   return {
     views,
     setViews: updateViews,
+    setClickedDays,
     forceViewMonthChange,
   } as const
 }
 
 export function getViews({
   isRange,
+  views,
+  clickedDays,
   ...dates
-}: ViewDates & UseViewsParams): Array<CalendarView> {
+}: ViewDates &
+  UseViewsParams & {
+    views: Array<CalendarView>
+    clickedDays?: ClickedViewDays
+  }): Array<CalendarView> {
+  // Handle non-range views
+  if (!isRange) {
+    return [{ nr: 0, month: getMonthView({ months: dates, nr: 0 }) }]
+  }
+
+  // Do not change views if the clicked start or end day is in one of the currently displayed month views
+  if (
+    (clickedDays?.startDay &&
+      isSameMonth(clickedDays.startDay, views[1].month)) ||
+    (clickedDays?.endDay &&
+      isSameMonth(clickedDays.endDay, views[0].month))
+  ) {
+    return views
+  }
+
   return [
-    { nr: 0, month: getMonthView({ ...dates }, 0) },
-    isRange && { nr: 1, month: getMonthView({ ...dates }, 1) },
-  ].filter(Boolean)
+    { nr: 0, month: getMonthView({ months: dates, nr: 0 }) },
+    { nr: 1, month: getMonthView({ months: dates, nr: 1 }) },
+  ]
 }
 
-function getMonthView(
-  { startMonth, endMonth }: ViewDates,
-  nr: CalendarView['nr']
-) {
+function getMonthView({ months, nr }: { months: ViewDates; nr: number }) {
+  const { startMonth, endMonth } = months
+
   if (startMonth && nr === 0) {
     return startMonth
   }

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -16,12 +16,10 @@ export type UseViewsParams = ViewDates & {
 export default function useViews({ isRange, ...dates }: UseViewsParams) {
   const [previousDates, setPreviousDates] = useState(dates)
   const [views, setViews] = useState<Array<CalendarView>>(
-    isRange
-      ? [
-          { nr: 0, month: dates.startMonth },
-          { nr: 1, month: dates.endMonth },
-        ]
-      : [{ nr: 0, month: dates.startMonth }]
+    [
+      { nr: 0, month: dates.startMonth },
+      isRange && { nr: 1, month: dates.endMonth },
+    ].filter(Boolean)
   )
 
   const forceViewChange = useRef(false)
@@ -67,14 +65,10 @@ export function getViews({
   isRange,
   ...dates
 }: ViewDates & UseViewsParams): Array<CalendarView> {
-  if (!isRange) {
-    return [{ nr: 0, month: getMonthView({ ...dates }, 0) }]
-  }
-
   return [
     { nr: 0, month: getMonthView({ ...dates }, 0) },
-    { nr: 1, month: getMonthView({ ...dates }, 1) },
-  ]
+    isRange && { nr: 1, month: getMonthView({ ...dates }, 1) },
+  ].filter(Boolean)
 }
 
 function getMonthView(

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -9,8 +9,6 @@ export type ViewDates = {
   endMonth?: DatePickerDates['endMonth']
 }
 
-export type ClickedCalendarDays = { start?: Date; end?: Date }
-
 export type UseViewsParams = ViewDates & {
   isRange?: boolean
 }

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -37,17 +37,17 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
   if (hasDateChanges) {
     setPreviousDates(dates)
 
-    // Stop here if the user has clicked a date in the calendar, as we don't want to update the views then
+    // Stop here if the user has clicked a date in the calendar, as we don't want to update
     if (hasClickedCalendarDay.current) {
-      return setHasClickedCalendarDay(false)
+      setHasClickedCalendarDay(false)
+    } else {
+      const updatedViews = getViews({
+        ...dates,
+        isRange,
+      })
+
+      setViews(updatedViews)
     }
-
-    const updatedViews = getViews({
-      ...dates,
-      isRange,
-    })
-
-    setViews(updatedViews)
   }
 
   function updateViews(
@@ -69,6 +69,8 @@ export function getViews({
   isRange,
   ...dates
 }: ViewDates & UseViewsParams): Array<CalendarView> {
+  // Handle non-range views
+
   return isRange
     ? [
         { nr: 0, month: getMonthView({ months: dates, nr: 0 }) },

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -69,8 +69,6 @@ export function getViews({
   isRange,
   ...dates
 }: ViewDates & UseViewsParams): Array<CalendarView> {
-  // Handle non-range views
-
   return isRange
     ? [
         { nr: 0, month: getMonthView({ months: dates, nr: 0 }) },

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -16,10 +16,7 @@ export type UseViewsParams = ViewDates & {
 export default function useViews({ isRange, ...dates }: UseViewsParams) {
   const [previousDates, setPreviousDates] = useState(dates)
   const [views, setViews] = useState<Array<CalendarView>>(
-    [
-      { nr: 0, month: dates.startMonth },
-      isRange && { nr: 1, month: dates.endMonth },
-    ].filter(Boolean)
+    getViews({ ...dates, isRange })
   )
 
   const forceViewChange = useRef(false)


### PR DESCRIPTION
Fixes  [this issue](https://dnb.enterprise.slack.com/archives/CMXABCHEY/p1742391247076779?thread_ts=1742391247.076779&cid=CMXABCHEY)

### TODO

- [x] Refactor view setting logic in `useView`
- [x] Remove `forceViewMonthChange`
- [x] Add tests