### PR TITLE
chore(Field.Date): improve localization in docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
@@ -102,16 +102,14 @@ export const AutoClose = () => {
 
 export const DatePickerDateLimitValidation = () => {
   return (
-    <Provider locale="en-GB">
-      <ComponentBox>
-        <Field.Date
-          value="2024-12-31|2025-02-01"
-          minDate="2025-01-01"
-          maxDate="2025-01-31"
-          range
-        />
-      </ComponentBox>
-    </Provider>
+    <ComponentBox>
+      <Field.Date
+        value="2024-12-31|2025-02-01"
+        minDate="2025-01-01"
+        maxDate="2025-01-31"
+        range
+      />
+    </ComponentBox>
   )
 }
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
@@ -1,4 +1,3 @@
-import Provider from '@dnb/eufemia/src/shared/Provider'
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/demos.mdx
@@ -4,7 +4,15 @@ showTabs: true
 
 import * as Examples from './Examples'
 
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
+
 ## Demos
+
+<ChangeLocale
+  bottom
+  label="Locale used in the demos:"
+  listUSLocale={true}
+/>
 
 ### Label and value
 


### PR DESCRIPTION
This PR now just adds the `ChangeLocale` dropdown in the `Field.Date` docs.

TODO:
- [x]  Actually fix that localization does not work for `Field.Date` in our docs. Is it a real problem with the component or just for the docs in our portal? It seems like it updates the label based on the locale, but not the formatting of the date.

Here's a video from main branch when changing locale in DatePicker (expected behavior):

https://github.com/user-attachments/assets/c9fa9398-3a3f-4da6-abf6-889ab43dd72a


Here's a video from main branch when changing locale in Field.Date (unexpected behavior):


https://github.com/user-attachments/assets/7f1ddabd-4269-4aa0-b3b1-9cf40480c554


