### PR TITLE
chore(Upload): improve  example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
@@ -126,7 +126,7 @@ export const UploadRemoveFile = () => (
 
               reader.readAsDataURL(file)
             })
-          }, [files, images])
+          }, [files])
 
           return (
             <Section aria-label="List of chosen images">


### PR DESCRIPTION
Improves so that we don't render the uploaded file/image infinitely many times, demo [here](https://eufemia.dnb.no/uilib/components/upload/demos/#useupload-react-hook):



https://github.com/user-attachments/assets/292f3046-7841-4e3e-a476-c9a7a18c7c08

Should only display the image once, and not infinitely many times.