### PR TITLE
fix(Avatar.Group): forward `size`, `variant`, `color`, `backgroundColor` to single child

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -104,6 +104,8 @@ const Avatar = (localProps: AvatarProps & SpacingProps) => {
     avatarGroupContext
   )
 
+  console.log(avatarGroupContext)
+
   const {
     alt,
     className,

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -128,7 +128,7 @@ const AvatarGroup = (localProps: AvatarGroupProps & SpacingProps) => {
   } = validateDOMAttributes({}, props)
 
   return (
-    <AvatarGroupContext.Provider value={props}>
+    <AvatarGroupContext.Provider value={{ ...props, variant, size }}>
       <span
         className={classnames(
           'dnb-avatar__group',


### PR DESCRIPTION
Fixes so setting `size`, `variant`, `color`, `backgroundColor` when single Avatar as child should work