### PR TITLE
fix(Heading): warning when increasing heading to be `h2` when previous sibling is `h1`

### DIFF
--- a/packages/dnb-eufemia/src/components/heading/HeadingHelpers.ts
+++ b/packages/dnb-eufemia/src/components/heading/HeadingHelpers.ts
@@ -85,11 +85,16 @@ export const correctInternalHeadingLevel = ({
       }
     }
 
+    const counterWasCorrectedToLevel2 =
+      globalHeadingCounter?.current?.hasCorrection() &&
+      globalSyncCounter?.current?.level === 1 &&
+      counter?.getLevel() === 2
+
     if (level >= 1) {
       counter.setLevel(level)
     } else if (decrease) {
       counter.decrement()
-    } else if (increase) {
+    } else if (increase && !counterWasCorrectedToLevel2) {
       counter.increment()
     }
 

--- a/packages/dnb-eufemia/src/components/heading/HeadingHelpers.ts
+++ b/packages/dnb-eufemia/src/components/heading/HeadingHelpers.ts
@@ -67,6 +67,14 @@ export const correctInternalHeadingLevel = ({
     counter.enableBypassChecks()
   }
 
+  const hasCounterWasCorrectedToLevel2 = () => {
+    return (
+      globalSyncCounter?.current?.level === 1 &&
+      globalHeadingCounter?.current?.hasCorrection() &&
+      counter?.getLevel() === 2
+    )
+  }
+
   const update = (level: InternalHeadingLevel) => {
     if (!isRerender) {
       counter.makeMeReady({ level })
@@ -85,16 +93,11 @@ export const correctInternalHeadingLevel = ({
       }
     }
 
-    const counterWasCorrectedToLevel2 =
-      globalHeadingCounter?.current?.hasCorrection() &&
-      globalSyncCounter?.current?.level === 1 &&
-      counter?.getLevel() === 2
-
     if (level >= 1) {
       counter.setLevel(level)
     } else if (decrease) {
       counter.decrement()
-    } else if (increase && !counterWasCorrectedToLevel2) {
+    } else if (increase && !hasCounterWasCorrectedToLevel2()) {
       counter.increment()
     }
 

--- a/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
+++ b/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
@@ -317,6 +317,26 @@ describe('Heading component', () => {
     )
   })
 
+  it('have to not warn when setting h2 by increasing Header', () => {
+    const debugWarning = jest.fn()
+    render(
+      <>
+        <Heading debug={debugWarning}>Heading #1</Heading>
+        <Heading debug={debugWarning} increase>
+          Heading #2
+        </Heading>
+      </>
+    )
+
+    expect(document.querySelectorAll('.dnb-heading')[0].textContent).toBe(
+      '[h1] Heading #1'
+    )
+    expect(document.querySelectorAll('.dnb-heading')[1].textContent).toBe(
+      '[h2] Heading #2'
+    )
+    expect(debugWarning).not.toHaveBeenCalled()
+  })
+
   it('have to have correct size class', () => {
     render(
       <Heading debug={warn} size="x-large" reset={1}>


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1743769418111539
CSB: https://codesandbox.io/p/devbox/value-padding-forked-5lrp2k

I do not think we should warn about this, as I believe:
```
<Heading>heading</Heading>
<Heading increase>subheading</Heading>
``` 
should result in h1 and h2 which it does, but without warnings.

I do think the reason why we log the warning today, is because we automatically change the second heading to be a h2 in the snippet:
```
<Heading>heading</Heading>
<Heading>subheading</Heading>
``` 
So hence, our code tries/thinks the following code will increase the heading level to h3 of the second heading which is already made into a h3:

```
<Heading>heading</Heading>
<Heading increase>subheading</Heading>
``` 


I think the code perhaps could be simplified or made a tiny bit easier to read.