### PR TITLE
fix(DatePicker): display correct dates when props are updated with `useLayoutEffect`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3228,6 +3228,46 @@ describe('DatePicker component', () => {
       rightPicker.querySelector('.dnb-date-picker__header__title')
     ).toHaveTextContent('november 2024')
   })
+
+  it('should use correct dates based on props updated through useLayoutEffect', async () => {
+    const Component = () => {
+      const [date, setDate] = React.useState(new Date('2025-04-12'))
+      const [minDate, setMinDate] = React.useState(new Date('2025-04-10'))
+      const [maxDate, setMaxDate] = React.useState(new Date('2025-04-20'))
+
+      React.useLayoutEffect(() => {
+        setDate(new Date('2025-04-15'))
+        setMinDate(new Date('2025-04-05'))
+        setMaxDate(new Date('2025-04-25'))
+      }, [])
+
+      return <DatePicker date={date} minDate={minDate} maxDate={maxDate} />
+    }
+
+    render(<Component />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    // Check date
+    expect(
+      screen.getByLabelText('lørdag 12. april 2025')
+    ).not.toHaveAttribute('aria-current', 'date')
+    expect(
+      screen.getByLabelText('tirsdag 15. april 2025')
+    ).toHaveAttribute('aria-current', 'date')
+
+    // Check minDate
+    expect(
+      screen.getByLabelText('onsdag 9. april 2025')
+    ).not.toBeDisabled()
+    expect(screen.getByLabelText('fredag 4. april 2025')).toBeDisabled()
+
+    // Check maxDate
+    expect(
+      screen.getByLabelText('mandag 21. april 2025')
+    ).not.toBeDisabled()
+    expect(screen.getByLabelText('lørdag 26. april 2025')).toBeDisabled()
+  })
 })
 
 // for the unit calc tests

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,9 +1,13 @@
-import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
 import { addMonths, isSameDay } from 'date-fns'
 import { DateType } from '../DatePickerContext'
+
+// SSR warning fix: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+const useLayoutEffect =
+  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
 
 export type DatePickerDateProps = {
   date?: DateType

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'
@@ -142,7 +142,7 @@ export default function useDates(
 
   // Updated input dates based on start and end dates, move to DatePickerInput
   // TODO: Move to DatePickerInput
-  useEffect(() => {
+  useLayoutEffect(() => {
     const startDates = updateInputDates('start', dates.startDate)
     const endDates = updateInputDates('end', dates.endDate)
 


### PR DESCRIPTION
Fixes [this issue](https://dnb-it.slack.com/archives/CMXABCHEY/p1744105593951939)

### TODO

- [x] Replace input dates `useEffect` with `useLayoutEffect`
- [x] Add tests