### PR TITLE
chore(DatePicker): move `hasHadValidDate` to `DatePickerInput`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -22,7 +22,6 @@ export type DatePickerContextValues = ContextProps &
     props: DatePickerAllProps
     translation: ContextProps['translation']
     views: Array<CalendarView>
-    hasHadValidDate: boolean
     previousDateProps: DatePickerDateProps
     updateDates: (
       dates: DatePickerDates,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -179,10 +179,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
   const translation = useTranslation().DatePicker
 
-  const hasHadValidDate = useMemo(
-    () => isValid(startDate) || isValid(endDate),
-    [startDate, endDate]
-  )
+  const hasHadValidDate = isValid(startDate) || isValid(endDate)
 
   const modeDate = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -165,7 +165,6 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
   const {
     updateDates,
     callOnChangeHandler,
-    hasHadValidDate,
     getReturnObject,
     __startDay,
     __startMonth,
@@ -179,6 +178,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
   } = useContext(DatePickerContext)
 
   const translation = useTranslation().DatePicker
+
+  const hasHadValidDate = useMemo(
+    () => isValid(startDate) || isValid(endDate),
+    [startDate, endDate]
+  )
 
   const modeDate = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -95,23 +95,22 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
 
   const sharedContext = useContext(SharedContext)
 
-  const { dates, updateDates, hasHadValidDate, previousDateProps } =
-    useDates(
-      {
-        date,
-        startDate,
-        endDate,
-        startMonth,
-        endMonth,
-        minDate,
-        maxDate,
-      },
-      {
-        dateFormat: dateFormat,
-        isRange: range,
-        shouldCorrectDate: correctInvalidDate,
-      }
-    )
+  const { dates, updateDates, previousDateProps } = useDates(
+    {
+      date,
+      startDate,
+      endDate,
+      startMonth,
+      endMonth,
+      minDate,
+      maxDate,
+    },
+    {
+      dateFormat: dateFormat,
+      isRange: range,
+      shouldCorrectDate: correctInvalidDate,
+    }
+  )
 
   const { views, setViews, setHasClickedCalendarDay } = useViews({
     startMonth: dates.startMonth,
@@ -245,7 +244,6 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         props,
         ...dates,
         previousDateProps,
-        hasHadValidDate,
         views,
         setViews,
         setHasClickedCalendarDay,

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
 import isValid from 'date-fns/isValid'
 import format from 'date-fns/format'

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -39,7 +39,6 @@ export type DatePickerDates = {
   maxDate?: Date
   startMonth?: Date
   endMonth?: Date
-  hasHadValidDate?: boolean
   hoverDate?: Date
 } & DatePickerInputDates
 
@@ -100,8 +99,6 @@ export default function useDates(
     setPreviousDateProps(dateProps)
   }
 
-  const hasHadValidDate = useRef<boolean>(false)
-
   const updateDates = useCallback(
     (
       newDates: DatePickerDates,
@@ -149,9 +146,6 @@ export default function useDates(
     const startDates = updateInputDates('start', dates.startDate)
     const endDates = updateInputDates('end', dates.endDate)
 
-    hasHadValidDate.current =
-      isValid(dates.startDate) || isValid(dates.endDate)
-
     setDates((currentDates) => ({
       ...currentDates,
       ...startDates,
@@ -163,7 +157,6 @@ export default function useDates(
   return {
     dates,
     updateDates,
-    hasHadValidDate: hasHadValidDate.current,
     previousDateProps,
   } as const
 }


### PR DESCRIPTION
Moves the value `hasHadValidDate` variable to `DatePickerInput` since it's the only component that actually uses it. No need for it to live in the context and `useDates` hook