### PR TITLE
fix(InputMasked): ensure correct cursor position when suffix changes during typing

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.js
@@ -100,13 +100,13 @@ export const useLocalValue = () => {
   const maskParams = useNumberMaskParams() || {}
   const locale = useTranslation()
 
-  const [localValue, setLocalValue] = React.useState(() =>
-    correctNumberValue({
+  const [localValue, setLocalValue] = React.useState(() => {
+    return correctNumberValue({
       locale,
       props,
       maskParams,
     })
-  )
+  })
 
   /**
    * Use an effect here, just;
@@ -306,8 +306,10 @@ export const useEventMapping = ({ setLocalValue }) => {
  * @returns event handler function
  */
 const useCallEvent = ({ setLocalValue }) => {
+  const maskParamsRef = React.useRef()
+  maskParamsRef.current = useMaskParams()
+
   const { props } = React.useContext(InputMaskedContext)
-  const maskParams = useMaskParams()
   const isNumberMask = useNumberMask()
 
   // Source: https://en.wikipedia.org/wiki/Decimal_separator
@@ -315,6 +317,7 @@ const useCallEvent = ({ setLocalValue }) => {
   let isUnidentified = false
 
   const callEvent = ({ event, value }, name) => {
+    const maskParams = maskParamsRef.current
     value = value || event.target.value
     const selStart = event.target.selectionStart
     let keyCode = keycode(event)
@@ -444,7 +447,7 @@ const useCallEvent = ({ setLocalValue }) => {
       case 'on_mouse_down':
       case 'on_mouse_up':
         event.target.runCorrectCaretPosition = () =>
-          correctCaretPosition(event.target, maskParams, props)
+          correctCaretPosition(event.target, maskParamsRef, props)
         if (!event.target.__getCorrectCaretPosition) {
           event.target.runCorrectCaretPosition()
         }

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.js
@@ -187,9 +187,11 @@ export const correctNumberValue = ({
  * @param {Element} element Input Element
  * @param {Object} maskParams Mask parameters, containing eventually suffix or prefix
  */
-export const correctCaretPosition = (element, maskParams, props) => {
+export const correctCaretPosition = (element, maskParamsRef, props) => {
   const correction = () => {
     try {
+      const maskParams = maskParamsRef?.current
+
       const suffix = maskParams?.suffix
       const prefix = maskParams?.prefix
 

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMaskedUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMaskedUtils.test.ts
@@ -180,9 +180,11 @@ describe('correctCaretPosition', () => {
     element.setSelectionRange = jest.fn()
 
     const maskParams = {
-      suffix: 'suffix',
-      prefix: 'prefix',
-      placeholderChar: '_',
+      current: {
+        suffix: 'suffix',
+        prefix: 'prefix',
+        placeholderChar: '_',
+      },
     }
 
     correctCaretPosition(element, maskParams, {})
@@ -198,9 +200,11 @@ describe('correctCaretPosition', () => {
     element.setSelectionRange = jest.fn()
 
     const maskParams = {
-      suffix: 'suffix',
-      prefix: 'prefix',
-      placeholderChar: '_',
+      current: {
+        suffix: 'suffix',
+        prefix: 'prefix',
+        placeholderChar: '_',
+      },
     }
 
     correctCaretPosition(element, maskParams, {})
@@ -216,9 +220,11 @@ describe('correctCaretPosition', () => {
     element.setSelectionRange = jest.fn()
 
     const maskParams = {
-      suffix: 'suffix',
-      prefix: 'prefix',
-      placeholderChar: '_',
+      current: {
+        suffix: 'suffix',
+        prefix: 'prefix',
+        placeholderChar: '_',
+      },
     }
 
     correctCaretPosition(element, maskParams, {})
@@ -234,9 +240,11 @@ describe('correctCaretPosition', () => {
     element.setSelectionRange = jest.fn()
 
     const maskParams = {
-      suffix: 'suffix',
-      prefix: '',
-      placeholderChar: '_',
+      current: {
+        suffix: 'suffix',
+        prefix: '',
+        placeholderChar: '_',
+      },
     }
 
     correctCaretPosition(element, maskParams, {})

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -27,82 +27,6 @@ describe('Field.Currency', () => {
     expect(input).toHaveValue('123 NOK')
   })
 
-  it('placeholder should use correct currency format', () => {
-    const { rerender } = render(
-      <Provider>
-        <Field.Currency />
-      </Provider>
-    )
-
-    expect(
-      document.querySelector('.dnb-input__placeholder').textContent
-    ).toBe('kr')
-
-    rerender(
-      <Provider locale="en-GB">
-        <Field.Currency />
-      </Provider>
-    )
-
-    expect(
-      document.querySelector('.dnb-input__placeholder').textContent
-    ).toBe('NOK')
-
-    rerender(<Field.Currency currencyDisplay="name" />)
-
-    expect(
-      document.querySelector('.dnb-input__placeholder').textContent
-    ).toBe('kroner')
-  })
-
-  it('should support "currencyDisplay"', () => {
-    const { rerender } = render(
-      <Provider>
-        <Field.Currency value={1234} currencyDisplay="name" />
-      </Provider>
-    )
-
-    const input = document.querySelector('input')
-
-    expect(input).toHaveValue('1 234 kroner')
-
-    rerender(
-      <Provider>
-        <Field.Currency value={1} currencyDisplay="name" />
-      </Provider>
-    )
-
-    expect(input).toHaveValue('1 krone')
-
-    rerender(
-      <Provider locale="en-GB">
-        <Field.Currency value={1234} currencyDisplay="name" />
-      </Provider>
-    )
-
-    expect(input).toHaveValue('1 234 kroner')
-
-    rerender(
-      <Provider locale="de-CH">
-        <Field.Currency value={1234} currencyDisplay="name" />
-      </Provider>
-    )
-
-    expect(input).toHaveValue('1’234 Kronen')
-
-    rerender(
-      <Provider>
-        <Field.Currency
-          value={1234}
-          currency="SEK"
-          currencyDisplay="name"
-        />
-      </Provider>
-    )
-
-    expect(input).toHaveValue('1 234 svenske kroner')
-  })
-
   it('should align input correctly', () => {
     render(
       <>
@@ -247,6 +171,106 @@ describe('Field.Currency', () => {
     )
 
     log.mockRestore()
+  })
+
+  describe('currencyDisplay', () => {
+    it('placeholder should use correct currency format', () => {
+      const { rerender } = render(
+        <Provider>
+          <Field.Currency />
+        </Provider>
+      )
+
+      expect(
+        document.querySelector('.dnb-input__placeholder').textContent
+      ).toBe('kr')
+
+      rerender(
+        <Provider locale="en-GB">
+          <Field.Currency />
+        </Provider>
+      )
+
+      expect(
+        document.querySelector('.dnb-input__placeholder').textContent
+      ).toBe('NOK')
+
+      rerender(<Field.Currency currencyDisplay="name" />)
+
+      expect(
+        document.querySelector('.dnb-input__placeholder').textContent
+      ).toBe('kroner')
+    })
+
+    it('should support "currencyDisplay"', () => {
+      const { rerender } = render(
+        <Provider>
+          <Field.Currency value={1234} currencyDisplay="name" />
+        </Provider>
+      )
+
+      const input = document.querySelector('input')
+
+      expect(input).toHaveValue('1 234 kroner')
+
+      rerender(
+        <Provider>
+          <Field.Currency value={1} currencyDisplay="name" />
+        </Provider>
+      )
+
+      expect(input).toHaveValue('1 krone')
+
+      rerender(
+        <Provider locale="en-GB">
+          <Field.Currency value={1234} currencyDisplay="name" />
+        </Provider>
+      )
+
+      expect(input).toHaveValue('1 234 kroner')
+
+      rerender(
+        <Provider locale="de-CH">
+          <Field.Currency value={1234} currencyDisplay="name" />
+        </Provider>
+      )
+
+      expect(input).toHaveValue('1’234 Kronen')
+
+      rerender(
+        <Provider>
+          <Field.Currency
+            value={1234}
+            currency="SEK"
+            currencyDisplay="name"
+          />
+        </Provider>
+      )
+
+      expect(input).toHaveValue('1 234 svenske kroner')
+    })
+
+    it('should support dynamic suffix and cursor position correction', async () => {
+      render(<Field.Currency currencyDisplay="name" />)
+
+      const input = document.querySelector('input')
+
+      expect(input).toHaveValue('')
+      expect(input).toHaveAttribute('aria-placeholder', 'kroner')
+
+      await userEvent.type(input, '1')
+      expect(input).toHaveValue('1 krone')
+      expect(input.selectionStart).toBe(1)
+      expect(input.selectionEnd).toBe(1)
+
+      await userEvent.keyboard('{Backspace}')
+      expect(input).toHaveValue('')
+
+      await userEvent.type(input, '2')
+      expect(input).toHaveValue('2 kroner')
+      expect(input.selectionStart).toBe(1)
+      expect(input.selectionEnd).toBe(1)
+    })
   })
 
   describe('ARIA', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/stories/Currency.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/stories/Currency.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Field } from '../../..'
+
+export default {
+  title: 'Eufemia/Extensions/Forms/Currency',
+}
+
+export function Currency() {
+  return (
+    <Field.Currency
+      label="Amount"
+      currencyDisplay="name"
+      onChange={(value) => console.log('onChange', value)}
+    />
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -342,17 +342,17 @@ function NumberComponent(props: Props) {
     placeholder,
     value,
     align: showStepControls ? 'center' : align,
-    ...maskProps,
     onKeyDown: onKeyDownHandler,
     onFocus: handleFocus,
     onBlur: handleBlur,
     onChange: handleChange,
     disabled,
-    ...htmlAttributes,
     status: hasError ? 'error' : undefined,
     stretch: Boolean(width),
+    ...maskProps,
+    ...htmlAttributes,
+    ...(ariaParams as any),
   }
-  Object.assign(inputProps, ariaParams)
 
   if (showStepControls) {
     return (


### PR DESCRIPTION
This issue only occurred when the suffix changed while typing. In that case, the cursor was placed at the end because the lengths no longer matched the initially provided value.
We now send in the current/latest suffix, and the cursor position is set correctly.

In this video; the issue is shown all the way at the end of the video, where the cursor gets placed at the end.

https://github.com/user-attachments/assets/aee4df3c-3394-4b40-a653-0083b13e1ca1

