### PR TITLE
fix(DatePicker): display correct dates when props are updated with `useLayoutEffect` in `React.StrictMode` 

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
@@ -8,7 +8,7 @@ import Button from '../button/Button'
 import DatePickerContext from './DatePickerContext'
 import { convertStringToDate } from './DatePickerCalc'
 import { useTranslation } from '../../shared'
-import { DatePickerInputDates } from './hooks/useDates'
+import { DatePickerInputDates } from './hooks/useInputDates'
 
 type DatePickerFooterEvent = React.MouseEvent<HTMLButtonElement> &
   DatePickerInputDates & {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -39,8 +39,8 @@ import type { SkeletonShow } from '../Skeleton'
 import { ReturnObject } from './DatePickerProvider'
 import { DatePickerEventAttributes } from './DatePicker'
 import { useTranslation } from '../../shared'
-import { DatePickerInputDates } from './hooks/useDates'
 import usePartialDates from './hooks/usePartialDates'
+import useInputDates, { DatePickerInputDates } from './hooks/useInputDates'
 
 export type DatePickerInputProps = Omit<
   React.HTMLProps<HTMLInputElement>,
@@ -163,16 +163,15 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     updateDates,
     callOnChangeHandler,
     getReturnObject,
-    __startDay,
-    __startMonth,
-    __startYear,
-    __endDay,
-    __endMonth,
-    __endYear,
     startDate,
     endDate,
     props: { onType, label, correctInvalidDate },
   } = useContext(DatePickerContext)
+
+  const { inputDates, updateInputDates } = useInputDates({
+    startDate,
+    endDate,
+  })
 
   const translation = useTranslation().DatePicker
 
@@ -184,25 +183,6 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       endDate,
     }),
     [startDate, endDate]
-  )
-
-  const inputDates = useMemo(
-    () => ({
-      __startDay,
-      __startMonth,
-      __startYear,
-      __endDay,
-      __endMonth,
-      __endYear,
-    }),
-    [
-      __startDay,
-      __startMonth,
-      __startYear,
-      __endDay,
-      __endMonth,
-      __endYear,
-    ]
   )
 
   const inputRefs = useRef<
@@ -530,8 +510,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       } else {
         updateDates({
           [`${mode}Date`]: null,
-          [`__${mode}${type}`]: value,
         })
+        updateInputDates({ [`__${mode}${type}`]: value })
 
         invalidDatesRef.current = {
           ...invalidDatesRef.current,
@@ -556,6 +536,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       modeDate,
       dateRefs,
       temporaryDates,
+      updateInputDates,
     ]
   )
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React, { useState } from 'react'
+import React, { StrictMode, useState } from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import userEvent from '@testing-library/user-event'
 import * as helpers from '../../../shared/helpers'
@@ -3225,6 +3225,50 @@ describe('DatePicker component', () => {
     }
 
     render(<Component />)
+
+    await userEvent.click(screen.getByLabelText('åpne datovelger'))
+
+    // Check date
+    expect(
+      screen.getByLabelText('lørdag 12. april 2025')
+    ).not.toHaveAttribute('aria-current', 'date')
+    expect(
+      screen.getByLabelText('tirsdag 15. april 2025')
+    ).toHaveAttribute('aria-current', 'date')
+
+    // Check minDate
+    expect(
+      screen.getByLabelText('onsdag 9. april 2025')
+    ).not.toBeDisabled()
+    expect(screen.getByLabelText('fredag 4. april 2025')).toBeDisabled()
+
+    // Check maxDate
+    expect(
+      screen.getByLabelText('mandag 21. april 2025')
+    ).not.toBeDisabled()
+    expect(screen.getByLabelText('lørdag 26. april 2025')).toBeDisabled()
+  })
+
+  it('should use correct dates based on props updated through useLayoutEffect in StrictMode', async () => {
+    const Component = () => {
+      const [date, setDate] = React.useState(new Date('2025-04-12'))
+      const [minDate, setMinDate] = React.useState(new Date('2025-04-10'))
+      const [maxDate, setMaxDate] = React.useState(new Date('2025-04-20'))
+
+      React.useLayoutEffect(() => {
+        setDate(new Date('2025-04-15'))
+        setMinDate(new Date('2025-04-05'))
+        setMaxDate(new Date('2025-04-25'))
+      }, [])
+
+      return <DatePicker date={date} minDate={minDate} maxDate={maxDate} />
+    }
+
+    render(
+      <StrictMode>
+        <Component />
+      </StrictMode>
+    )
 
     await userEvent.click(screen.getByLabelText('åpne datovelger'))
 

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,13 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { convertStringToDate, isDisabled } from '../DatePickerCalc'
-import isValid from 'date-fns/isValid'
-import format from 'date-fns/format'
 import { addMonths, isSameDay } from 'date-fns'
 import { DateType } from '../DatePickerContext'
-
-// SSR warning fix: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
-const useLayoutEffect =
-  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
 
 export type DatePickerDateProps = {
   date?: DateType
@@ -25,15 +19,6 @@ type UseDatesOptions = {
   isRange: boolean
   shouldCorrectDate: boolean
 }
-// TODO: Move to DatePickerInput
-export type DatePickerInputDates = {
-  __startDay?: string
-  __startMonth?: string
-  __startYear?: string
-  __endDay?: string
-  __endMonth?: string
-  __endYear?: string
-}
 
 export type DatePickerDates = {
   date?: DateType
@@ -44,7 +29,7 @@ export type DatePickerDates = {
   startMonth?: Date
   endMonth?: Date
   hoverDate?: Date
-} & DatePickerInputDates
+}
 
 export default function useDates(
   dateProps: DatePickerDateProps,
@@ -144,42 +129,11 @@ export default function useDates(
     [dates, shouldCorrectDate, isRange]
   )
 
-  // Updated input dates based on start and end dates, move to DatePickerInput
-  // TODO: Move to DatePickerInput
-  useLayoutEffect(() => {
-    const startDates = updateInputDates('start', dates.startDate)
-    const endDates = updateInputDates('end', dates.endDate)
-
-    setDates((currentDates) => ({
-      ...currentDates,
-      ...startDates,
-      ...endDates,
-    }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dates.startDate, dates.endDate])
-
   return {
     dates,
     updateDates,
     previousDateProps,
   } as const
-}
-
-// TODO: Move to DatePickerInput
-function updateInputDates(type: 'start' | 'end', date: Date | undefined) {
-  const updatedDates = {}
-
-  if (isValid(date)) {
-    updatedDates[`__${type}Day`] = pad(format(date, 'dd'), 2)
-    updatedDates[`__${type}Month`] = pad(format(date, 'MM'), 2)
-    updatedDates[`__${type}Year`] = format(date, 'yyyy')
-  } else if (date === undefined) {
-    updatedDates[`__${type}Day`] = null
-    updatedDates[`__${type}Month`] = null
-    updatedDates[`__${type}Year`] = null
-  }
-
-  return updatedDates
 }
 
 function mapDates(
@@ -241,25 +195,8 @@ function mapDates(
     ...correctedDates,
   }
 
-  const hasValidStartDate = isValid(dates.startDate)
-  const hasValidEndDate = isValid(dates.endDate)
-
   return {
     ...dates,
-    __startDay: hasValidStartDate
-      ? pad(format(dates.startDate, 'dd'), 2)
-      : null,
-    __startMonth: hasValidStartDate
-      ? pad(format(dates.startDate, 'MM'), 2)
-      : null,
-    __startYear: hasValidStartDate
-      ? format(dates.startDate, 'yyyy')
-      : null,
-    __endDay: hasValidEndDate ? pad(format(dates.endDate, 'dd'), 2) : null,
-    __endMonth: hasValidEndDate
-      ? pad(format(dates.endDate, 'MM'), 2)
-      : null,
-    __endYear: hasValidEndDate ? format(dates.endDate, 'yyyy') : null,
   }
 }
 

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -364,9 +364,3 @@ function getStartDate(
 
   return undefined
 }
-
-export function pad(date: string, size: number) {
-  const dateWithPadding = '000000000' + date
-
-  return dateWithPadding.substring(dateWithPadding.length - size)
-}

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
@@ -1,6 +1,6 @@
 import { format, isValid } from 'date-fns'
 import { DatePickerDates } from './useDates'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export type DatePickerInputDates = {
   __startDay?: string
@@ -36,9 +36,9 @@ export default function useInputDates({
     setPreviousDates({ startDate, endDate })
   }
 
-  function updateInputDates(dates: DatePickerInputDates) {
+  const updateInputDates = useCallback((dates: DatePickerInputDates) => {
     setInputDates((current) => ({ ...current, ...dates }))
-  }
+  }, [])
 
   return {
     inputDates,

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
@@ -1,0 +1,88 @@
+import { format, isValid } from 'date-fns'
+import { DatePickerDates } from './useDates'
+import { useState } from 'react'
+
+export type DatePickerInputDates = {
+  __startDay?: string
+  __startMonth?: string
+  __startYear?: string
+  __endDay?: string
+  __endMonth?: string
+  __endYear?: string
+}
+
+export default function useInputDates({
+  startDate,
+  endDate,
+}: Pick<DatePickerDates, 'startDate' | 'endDate'>) {
+  const [previousDates, setPreviousDates] = useState<
+    Pick<DatePickerDates, 'startDate' | 'endDate'>
+  >({ startDate, endDate })
+  const [inputDates, setInputDates] = useState<DatePickerInputDates>(
+    initializeInputDates({ startDate, endDate })
+  )
+
+  // Update input dates if startDate or endDate changes
+  if (
+    startDate !== previousDates.startDate ||
+    endDate !== previousDates.endDate
+  ) {
+    setInputDates((currentInputDates) => ({
+      ...currentInputDates,
+      ...getInputDates('start', startDate),
+      ...getInputDates('end', endDate),
+    }))
+
+    setPreviousDates({ startDate, endDate })
+  }
+
+  function updateInputDates(dates: DatePickerInputDates) {
+    setInputDates((current) => ({ ...current, ...dates }))
+  }
+
+  return {
+    inputDates,
+    updateInputDates,
+  }
+}
+
+function initializeInputDates({
+  startDate,
+  endDate,
+}: Pick<DatePickerDates, 'startDate' | 'endDate'>): DatePickerInputDates {
+  const hasValidStartDate = isValid(startDate)
+  const hasValidEndDate = isValid(endDate)
+
+  return {
+    __startDay: hasValidStartDate ? pad(format(startDate, 'dd'), 2) : null,
+    __startMonth: hasValidStartDate
+      ? pad(format(startDate, 'MM'), 2)
+      : null,
+    __startYear: hasValidStartDate ? format(startDate, 'yyyy') : null,
+    __endDay: hasValidEndDate ? pad(format(endDate, 'dd'), 2) : null,
+    __endMonth: hasValidEndDate ? pad(format(endDate, 'MM'), 2) : null,
+    __endYear: hasValidEndDate ? format(endDate, 'yyyy') : null,
+  }
+}
+
+function getInputDates(type: 'start' | 'end', date: Date | undefined) {
+  const updatedDates = {}
+
+  if (isValid(date)) {
+    updatedDates[`__${type}Day`] = pad(format(date, 'dd'), 2)
+    updatedDates[`__${type}Month`] = pad(format(date, 'MM'), 2)
+    updatedDates[`__${type}Year`] = format(date, 'yyyy')
+  } else if (date === undefined) {
+    updatedDates[`__${type}Day`] = null
+    updatedDates[`__${type}Month`] = null
+    updatedDates[`__${type}Year`] = null
+  }
+
+  return updatedDates
+}
+
+export function pad(date: string, size: number) {
+  const dateWithPadding = '000000000' + date
+
+  return dateWithPadding.substring(dateWithPadding.length - size)
+}


### PR DESCRIPTION
Fixes this [issue](https://dnb-it.slack.com/archives/CMXABCHEY/p1744105593951939) by removing the `useEffect`/`useLayoutEffect` that updates the input date values

Related to https://github.com/dnbexperience/eufemia/pull/4945 and https://github.com/dnbexperience/eufemia/pull/4937

[CSB reprod ](https://codesandbox.io/p/sandbox/inspiring-water-cqtxc8)with the original issue, using this build