### PR TITLE
fix(StepIndicator): font size of step items

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -299,12 +299,7 @@ function StepIndicatorItem({
             </span>
           )}
           <div className="dnb-step-indicator__item-content__wrapper">
-            <StepItemButton
-              {...buttonParams}
-              className="dnb-step-indicator__item-content__text"
-            >
-              {element}
-            </StepItemButton>
+            <StepItemButton {...buttonParams}>{element}</StepItemButton>
             <FormStatus
               shellSpace={{ top: '1rem' }}
               no_animation={no_animation}

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -661,11 +661,9 @@ button.dnb-button::-moz-focus-inner {
   margin-right: 0.5rem;
 }
 .dnb-step-indicator__item-content__wrapper {
+  font-size: var(--font-size-basis);
   display: flex;
   flex-direction: column;
-}
-.dnb-step-indicator__item-content__text {
-  font-size: var(--font-size-basis);
 }
 .dnb-step-indicator__item__icon {
   opacity: 1;

--- a/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
@@ -56,7 +56,7 @@
         top: 0.25rem;
         left: 0.71875rem;
 
-        width: 0.0625rem;        
+        width: 0.0625rem;
         height: 100%;
 
         background-color: var(--color-black-20);
@@ -114,12 +114,9 @@
       }
 
       &__wrapper {
+        font-size: var(--font-size-basis);
         display: flex;
         flex-direction: column;
-      }
-
-      &__text {
-        font-size: var(--font-size-basis);
       }
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -2660,7 +2660,7 @@ describe('Wizard.Container', () => {
     expandStepIndicator()
 
     expect(
-      document.querySelector('.dnb-step-indicator__item-content__text')
+      document.querySelector('.dnb-step-indicator__button')
     ).toHaveTextContent('Title missing')
   })
 


### PR DESCRIPTION
[CSB of the issue](https://codesandbox.io/p/devbox/frosty-hertz-vnxfsp?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE):

<img width="273" alt="image" src="https://github.com/user-attachments/assets/7eeca005-b73e-41ad-bb5a-b9171e684f54" />


[How it should look](https://codesandbox.io/p/sandbox/laughing-darkness-788lz8)

[CSB of the fix](https://codesandbox.io/p/devbox/smoosh-worker-rs5ncc?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE):
<img width="252" alt="image" src="https://github.com/user-attachments/assets/a9d4b042-c302-4ec4-bf04-d7f7f94dd4ac" />

