### PR TITLE
feat(StepIndicator): animate chevron on expand/collapse

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -9,7 +9,6 @@ import Button, { ButtonProps } from '../button/Button'
 import Section from '../section/Section'
 import HeightAnimation from '../height-animation/HeightAnimation'
 import chevron_down from '../../icons/chevron_down'
-import chevron_up from '../../icons/chevron_up'
 import {
   validateDOMAttributes,
   combineDescribedBy,
@@ -125,7 +124,7 @@ function StepIndicatorTriggerButton({
             id={id}
             wrap
             variant="tertiary"
-            icon={openState ? chevron_up : chevron_down}
+            icon={chevron_down}
             icon_position="right"
           >
             {(typeof item === 'string' ? item : item && item.title) || ''}

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -601,6 +601,10 @@ button.dnb-button::-moz-focus-inner {
 }
 .dnb-step-indicator__trigger__button .dnb-button__icon {
   --button-icon-margin-top: 0.25rem;
+  transition: transform 400ms var(--easing-default);
+}
+.dnb-step-indicator__trigger__button--expanded .dnb-button__icon {
+  transform: rotate(180deg);
 }
 .dnb-step-indicator__item__wrapper {
   display: flex;

--- a/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
@@ -39,6 +39,10 @@
     }
     .dnb-button__icon {
       --button-icon-margin-top: 0.25rem;
+      transition: transform 400ms var(--easing-default);
+    }
+    &--expanded .dnb-button__icon {
+      transform: rotate(180deg);
     }
   }
 


### PR DESCRIPTION
Example: https://eufemia-git-feat-step-indicator-chevron-transition-eufemia.vercel.app/uilib/components/step-indicator/demos/#stepindicator-in-static-mode

Before:

https://github.com/user-attachments/assets/20ae29aa-33ce-4e1d-a4a2-efcafcf48dab




After:


https://github.com/user-attachments/assets/d2df8875-6b9d-4d55-b794-2d4f8cf8912a




