### PR TITLE
fix(Value.SelectCountry): handle invalid iso code values

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCountry` will render the selected country name by `value`'s ISO code ([ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). It displays the country name in the current locale.
+`Value.SelectCountry` will render the selected country name by `value`'s ISO code ([ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). It displays the country name in the current locale. If the value is not a valid/supported ISO code, it renders the value provided.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCountry` will render the selected country name by `value`'s ISO code ([ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). It displays the country name in the current locale. If the value provided is not a valid/supported ISO code, it renders the value.
+`Value.SelectCountry` will render the selected country name by `value`'s ISO code ([ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). It displays the country name in the current locale. If the value provided is not a valid/supported ISO code, it displays the value.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCountry/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCountry` will render the selected country.
+`Value.SelectCountry` will render the selected country name by `value`'s ISO code ([ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). It displays the country name in the current locale.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/SelectCountry.tsx
@@ -25,7 +25,7 @@ function SelectCountry(props: Props) {
       className={classnames('dnb-forms-value-select-country', className)}
       {...rest}
     >
-      {getCountryNameByIso(value)}
+      {getCountryNameByIso(value) ?? value}
     </ValueBlock>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -14,40 +14,45 @@ describe('Value.SelectCountry', () => {
     ).toHaveTextContent('Norge')
   })
 
-  it('renders invalid values', () => {
+  it('supports invalid values', () => {
     const { rerender } = render(
-      <Value.SelectCountry value={'NotValidISOCode' as CountryISO} />
+      <Value.SelectCountry
+        value={'NotValidISOCode' as CountryISO}
+        showEmpty
+      />
     )
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
 
-    rerender(<Value.SelectCountry value={0 as unknown as CountryISO} />)
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-
-    rerender(<Value.SelectCountry value={null} />)
+    rerender(
+      <Value.SelectCountry value={0 as unknown as CountryISO} showEmpty />
+    )
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
 
-    rerender(<Value.SelectCountry value={undefined} />)
+    rerender(<Value.SelectCountry value={null} showEmpty />)
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
+
+    rerender(<Value.SelectCountry value={undefined} showEmpty />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('renders label when showEmpty is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -16,10 +16,7 @@ describe('Value.SelectCountry', () => {
 
   it('supports invalid values', () => {
     const { rerender } = render(
-      <Value.SelectCountry
-        value={'NotValidISOCode' as CountryISO}
-        showEmpty
-      />
+      <Value.SelectCountry value={'NotValidISOCode' as CountryISO} />
     )
 
     expect(

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -26,7 +26,7 @@ describe('Value.SelectCountry', () => {
       document.querySelector(
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
-    ).not.toBeInTheDocument()
+    ).toHaveTextContent('NotValidISOCode')
 
     rerender(
       <Value.SelectCountry value={0 as unknown as CountryISO} showEmpty />

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -15,13 +15,39 @@ describe('Value.SelectCountry', () => {
   })
 
   it('renders invalid values', () => {
-    render(<Value.SelectCountry value={'NotValidISOCode' as CountryISO} />)
+    const { rerender } = render(
+      <Value.SelectCountry value={'NotValidISOCode' as CountryISO} />
+    )
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('')
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={0 as unknown as CountryISO} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={null} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={undefined} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
   })
 
   it('renders label when showEmpty is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { Value, Form } from '../../..'
+import { CountryISO } from '../../../constants/countries'
 
 describe('Value.SelectCountry', () => {
   it('renders string values', () => {
@@ -11,6 +12,16 @@ describe('Value.SelectCountry', () => {
         '.dnb-forms-value-select-country .dnb-forms-value-block__content'
       )
     ).toHaveTextContent('Norge')
+  })
+
+  it('renders even though value is not a valid ISO code ', () => {
+    render(<Value.SelectCountry value={'NotValidISOCode' as CountryISO} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('')
   })
 
   it('renders label when showEmpty is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -14,7 +14,7 @@ describe('Value.SelectCountry', () => {
     ).toHaveTextContent('Norge')
   })
 
-  it('renders even though value is not a valid ISO code ', () => {
+  it('renders invalid values', () => {
     render(<Value.SelectCountry value={'NotValidISOCode' as CountryISO} />)
 
     expect(

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/useCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/useCountry.test.tsx
@@ -41,10 +41,33 @@ describe('useCountry', () => {
     expect(getCountryNameByIso('')).toBeNull()
   })
 
-  it('should return undefined if ISO code is not valid', () => {
+  it('should return undefined if ISO code is not found', () => {
+    const mock = getCountryData as jest.Mock
+    mock.mockReturnValue(undefined)
     const { result } = renderHook(() => useCountry(), { wrapper })
     const { getCountryNameByIso } = result.current
 
     expect(getCountryNameByIso('NotValidISOCode')).toBeUndefined()
+  })
+
+  it('should return null if ISO code is 0', () => {
+    const { result } = renderHook(() => useCountry(), { wrapper })
+    const { getCountryNameByIso } = result.current
+
+    expect(getCountryNameByIso(0 as unknown as string)).toBeNull()
+  })
+
+  it('should return null if ISO code is null', () => {
+    const { result } = renderHook(() => useCountry(), { wrapper })
+    const { getCountryNameByIso } = result.current
+
+    expect(getCountryNameByIso(null)).toBeNull()
+  })
+
+  it('should return null if ISO code is undefined', () => {
+    const { result } = renderHook(() => useCountry(), { wrapper })
+    const { getCountryNameByIso } = result.current
+
+    expect(getCountryNameByIso(undefined)).toBeNull()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/useCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/useCountry.test.tsx
@@ -40,4 +40,11 @@ describe('useCountry', () => {
 
     expect(getCountryNameByIso('')).toBeNull()
   })
+
+  it('should return undefined if ISO code is not valid', () => {
+    const { result } = renderHook(() => useCountry(), { wrapper })
+    const { getCountryNameByIso } = result.current
+
+    expect(getCountryNameByIso('NotValidISOCode')).toBeUndefined()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/useCountry.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/useCountry.ts
@@ -18,7 +18,7 @@ export default function useCountry() {
         filter: (country) => {
           return country.iso === iso
         },
-      }).at(0)?.content
+      })?.at(0)?.content
     },
     [locale]
   )


### PR DESCRIPTION
When providing a not valid/supported iso code as `value`, the provided value will be displayed instead of the component breaking/failing.

fixes https://github.com/dnbexperience/eufemia/issues/4991