### PR TITLE
fix(Value.SelectCurrency): handle invalid iso code values

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCurrency` will render the selected currency display name by the `value`'s ISO code ([ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)). It displays the currency name in the current locale, together with the currency ISO code, like `Norwegian krone (NOK)`.
+`Value.SelectCurrency` will render the selected currency display name by the `value`'s ISO code ([ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)). It displays the currency name in the current locale, together with the currency ISO code, like `Norwegian krone (NOK)`. If the value is not a valid/supported ISO code, it renders the value provided.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCurrency` will render the selected currency.
+`Value.SelectCurrency` will render the selected currency display name by the `value`'s ISO code ([ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)). It displays the currency name in the current locale, together with the currency ISO code, like `Norwegian krone (NOK)`.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SelectCurrency/info.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 ## Description
 
-`Value.SelectCurrency` will render the selected currency display name by the `value`'s ISO code ([ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)). It displays the currency name in the current locale, together with the currency ISO code, like `Norwegian krone (NOK)`. If the value is not a valid/supported ISO code, it renders the value provided.
+`Value.SelectCurrency` will render the selected currency display name by the `value`'s ISO code ([ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)). It displays the currency name in the current locale, together with the currency ISO code, like `Norwegian krone (NOK)`. If the value provided is not a valid/supported ISO code, it displays the value.
 
 ```jsx
 import { Value } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -1,47 +1,10 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { Value, Form } from '../../..'
-import { CountryISO } from '../../../constants/countries'
 
 describe('Value.SelectCountry', () => {
   it('renders string values', () => {
     render(<Value.SelectCountry value="NO" />)
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-  })
-
-  it('renders invalid values', () => {
-    const { rerender } = render(
-      <Value.SelectCountry value={'NotValidISOCode' as CountryISO} />
-    )
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-
-    rerender(<Value.SelectCountry value={0 as unknown as CountryISO} />)
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-
-    rerender(<Value.SelectCountry value={null} />)
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-
-    rerender(<Value.SelectCountry value={undefined} />)
 
     expect(
       document.querySelector(

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -1,10 +1,47 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { Value, Form } from '../../..'
+import { CountryISO } from '../../../constants/countries'
 
 describe('Value.SelectCountry', () => {
   it('renders string values', () => {
     render(<Value.SelectCountry value="NO" />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+  })
+
+  it('renders invalid values', () => {
+    const { rerender } = render(
+      <Value.SelectCountry value={'NotValidISOCode' as CountryISO} />
+    )
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={0 as unknown as CountryISO} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={null} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-country .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCountry value={undefined} />)
 
     expect(
       document.querySelector(

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/SelectCurrency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/SelectCurrency.tsx
@@ -25,7 +25,7 @@ function SelectCurrency(props: Props) {
       className={classnames('dnb-forms-value-select-currency', className)}
       {...rest}
     >
-      {getCurrencyDisplayNameByIso(value)}
+      {getCurrencyDisplayNameByIso(value) ?? value}
     </ValueBlock>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -14,40 +14,48 @@ describe('Value.SelectCurrency', () => {
     ).toHaveTextContent('Norsk krone (NOK)')
   })
 
-  it('renders invalid values', () => {
+  it('supports invalid values', () => {
     const { rerender } = render(
-      <Value.SelectCurrency value={'NotValidISOCode' as CurrencyISO} />
+      <Value.SelectCurrency
+        value={'NotValidISOCode' as CurrencyISO}
+        showEmpty
+      />
     )
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
 
-    rerender(<Value.SelectCurrency value={0 as unknown as CurrencyISO} />)
-
-    expect(
-      document.querySelector(
-        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
-      )
-    ).toHaveTextContent('Norge')
-
-    rerender(<Value.SelectCurrency value={null} />)
+    rerender(
+      <Value.SelectCurrency
+        value={0 as unknown as CurrencyISO}
+        showEmpty
+      />
+    )
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
 
-    rerender(<Value.SelectCurrency value={undefined} />)
+    rerender(<Value.SelectCurrency value={null} showEmpty />)
 
     expect(
       document.querySelector(
         '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
       )
-    ).toHaveTextContent('Norge')
+    ).not.toBeInTheDocument()
+
+    rerender(<Value.SelectCurrency value={undefined} showEmpty />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('renders label when showEmpty is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
 import { Value, Form } from '../../..'
+import { CurrencyISO } from '../../../constants/currencies'
 
 describe('Value.SelectCurrency', () => {
   it('renders string values', () => {
@@ -11,6 +12,42 @@ describe('Value.SelectCurrency', () => {
         '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
       )
     ).toHaveTextContent('Norsk krone (NOK)')
+  })
+
+  it('renders invalid values', () => {
+    const { rerender } = render(
+      <Value.SelectCurrency value={'NotValidISOCode' as CurrencyISO} />
+    )
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCurrency value={0 as unknown as CurrencyISO} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCurrency value={null} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
+
+    rerender(<Value.SelectCurrency value={undefined} />)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
+      )
+    ).toHaveTextContent('Norge')
   })
 
   it('renders label when showEmpty is true', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -16,10 +16,7 @@ describe('Value.SelectCurrency', () => {
 
   it('supports invalid values', () => {
     const { rerender } = render(
-      <Value.SelectCurrency
-        value={'NotValidISOCode' as CurrencyISO}
-        showEmpty
-      />
+      <Value.SelectCurrency value={'NotValidISOCode' as CurrencyISO} />
     )
 
     expect(

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -26,7 +26,7 @@ describe('Value.SelectCurrency', () => {
       document.querySelector(
         '.dnb-forms-value-select-currency .dnb-forms-value-block__content'
       )
-    ).not.toBeInTheDocument()
+    ).toHaveTextContent('NotValidISOCode')
 
     rerender(
       <Value.SelectCurrency

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/useCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/__tests__/useCurrency.test.tsx
@@ -48,4 +48,34 @@ describe('useCurrency', () => {
 
     expect(getCurrencyDisplayNameByIso('')).toBeNull()
   })
+
+  it('should return undefined if ISO code is not found', () => {
+    const mock = getCurrencyData as jest.Mock
+    mock.mockReturnValue(undefined)
+    const { result } = renderHook(() => useCurrency(), { wrapper })
+    const { getCurrencyDisplayNameByIso } = result.current
+
+    expect(getCurrencyDisplayNameByIso('NotValidISOCode')).toBeUndefined()
+  })
+
+  it('should return null if ISO code is 0', () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper })
+    const { getCurrencyDisplayNameByIso } = result.current
+
+    expect(getCurrencyDisplayNameByIso(0 as unknown as string)).toBeNull()
+  })
+
+  it('should return null if ISO code is null', () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper })
+    const { getCurrencyDisplayNameByIso } = result.current
+
+    expect(getCurrencyDisplayNameByIso(null)).toBeNull()
+  })
+
+  it('should return null if ISO code is undefined', () => {
+    const { result } = renderHook(() => useCurrency(), { wrapper })
+    const { getCurrencyDisplayNameByIso } = result.current
+
+    expect(getCurrencyDisplayNameByIso(undefined)).toBeNull()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/useCurrency.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SelectCurrency/useCurrency.ts
@@ -18,7 +18,7 @@ export default function useCurrency() {
         filter: (currency) => {
           return currency.iso === iso
         },
-      }).at(0).selected_value
+      })?.at(0)?.selected_value
     },
     [locale]
   )


### PR DESCRIPTION
When providing a not valid/supported iso code as `value`, the provided value will be displayed instead of the component breaking/failing.