### PR TITLE
fix(DatePicker): prevent selection of invalid dates when navigating the calendar with arrow keys

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -475,7 +475,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     // Cache the result, just because we then avoid at least double calc because of reconciliation,
     // but we do not avoid calculating every day during hover or select
 
-    if (cacheKey in cache.current) {
+    if (cache.current[cacheKey]) {
       return cache.current[cacheKey]
     }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -278,18 +278,14 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
   const findValid = useCallback(
     (date: Date, keyCode: string) => {
-      if (!onDaysRender) {
-        return date
-      }
-
-      if (!days.current) {
+      if (!onDaysRender || !days.current) {
         return date
       }
 
       const month = format(date, 'yyyy-MM')
 
+      // re-render with new month
       if (!days.current[month]) {
-        // re-render with new month
         getDays(date)
       }
 
@@ -305,7 +301,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
             foundDate.isInactive)
         ) {
           const nextDate = keyNavCalc(foundDate.date, keyCode)
-          foundDate.date = findValid(nextDate, keyCode)
+          return findValid(nextDate, keyCode)
         }
 
         if (foundDate?.date) {
@@ -479,23 +475,26 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     // Cache the result, just because we then avoid at least double calc because of reconciliation,
     // but we do not avoid calculating every day during hover or select
 
-    if (cache.current[cacheKey]) {
+    if (cacheKey in cache.current) {
       return cache.current[cacheKey]
     }
 
     let count = 0
 
-    return (cache.current[cacheKey] = Object.values(
-      getDays(month).reduce((acc, cur, i) => {
-        // Normalize the data for table consumption
-        acc[count] = acc[count] || []
-        acc[count].push(cur)
-        if (i % 7 === 6) {
-          count++
-        }
-        return acc
-      }, {})
-    ))
+    const days = getDays(month).reduce((acc, cur, i) => {
+      // Normalize the data for table consumption
+      acc[count] = acc[count] || []
+      acc[count].push(cur)
+      if (i % 7 === 6) {
+        count++
+      }
+
+      return acc
+    }, {})
+
+    cache.current[cacheKey] = Object.values(days)
+
+    return cache.current[cacheKey]
   }, [cacheKey, getDays, month])
 
   return (

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3292,6 +3292,67 @@ describe('DatePicker component', () => {
     ).not.toBeDisabled()
     expect(screen.getByLabelText('lørdag 26. april 2025')).toBeDisabled()
   })
+
+  it('should not select invalid dates when navigating the calendar using the arrow keys', async () => {
+    render(
+      <DatePicker
+        date="2025-04-25"
+        showInput
+        onDaysRender={(days) => {
+          return days.map((dayObject) => {
+            if (isWeekend(dayObject.date)) {
+              dayObject.isInactive = true
+              dayObject.className = 'dnb-date-picker__day--weekend' // custom css
+            }
+
+            return dayObject
+          })
+        }}
+      />
+    )
+
+    await userEvent.click(screen.getByLabelText('Åpne datovelger'))
+
+    const [day, month, year] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    ) as Array<HTMLInputElement>
+
+    await userEvent.keyboard('{ArrowRight}')
+
+    expect(screen.getByLabelText('mandag 28. april 2025')).toHaveAttribute(
+      'aria-current',
+      'date'
+    )
+
+    expect(day.value).toBe('28')
+    expect(month.value).toBe('04')
+    expect(year.value).toBe('2025')
+
+    expect(
+      screen.getByLabelText('lørdag 26. april 2025')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('søndag 27. april 2025')
+    ).toBeInTheDocument()
+
+    await userEvent.keyboard('{ArrowLeft}')
+
+    expect(screen.getByLabelText('fredag 25. april 2025')).toHaveAttribute(
+      'aria-current',
+      'date'
+    )
+
+    expect(day.value).toBe('25')
+    expect(month.value).toBe('04')
+    expect(year.value).toBe('2025')
+
+    expect(
+      screen.getByLabelText('lørdag 26. april 2025')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('søndag 27. april 2025')
+    ).toBeInTheDocument()
+  })
 })
 
 // for the unit calc tests


### PR DESCRIPTION
Fixes [this](https://dnb-asa.atlassian.net/jira/software/c/projects/EDS/boards/734?assignee=712020%3A11a274b8-3b2a-4c7f-9968-07cf788ff7dd&selectedIssue=EDS-730) and [this](https://dnb-asa.atlassian.net/jira/software/c/projects/EDS/boards/734?assignee=712020%3A11a274b8-3b2a-4c7f-9968-07cf788ff7dd&selectedIssue=EDS-279).

Line 308 caused the date object to mutate to the previous valid date, when navigating backwards with the keyboard.

### TODO

- [x] Add fix
- [x] Add tests

### Before

https://github.com/user-attachments/assets/b533c424-81c6-4fce-b8a8-a92f7c859e92



### After

https://github.com/user-attachments/assets/4821f4ad-3053-4da3-9e4f-dafd94b7690e

