### PR TITLE
fix(CopyOnClick): copy `textContent` when given children is empty

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/Examples.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
-import { CopyOnClick, P } from '@dnb/eufemia/src'
+import { CopyOnClick, NumberFormat, P } from '@dnb/eufemia/src'
 
 export const Default = () => {
   return (
@@ -43,6 +43,18 @@ export const CopyContent = () => {
       <P>
         <CopyOnClick copyContent="content to copy">
           content to display
+        </CopyOnClick>
+      </P>
+    </ComponentBox>
+  )
+}
+
+export const CopyTextContent = () => {
+  return (
+    <ComponentBox>
+      <P>
+        <CopyOnClick>
+          <NumberFormat value={1234567.89} currency="NOK" />
         </CopyOnClick>
       </P>
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/demos.mdx
@@ -16,6 +16,12 @@ import * as Examples from './Examples'
 
 ### Copy content
 
-Used when the copied value should differ from the visually shown value(`children`).
+Used when the copied value should differ from the visually shown value (`children`).
 
 <Examples.CopyContent />
+
+### Copy text content
+
+If `children` is a React element that cannot be directly converted to a string, the component will copy the rendered text content instead.
+
+<Examples.CopyTextContent />

--- a/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
@@ -44,7 +44,9 @@ const CopyOnClick = ({
   const onClickHandler = useCallback(() => {
     if (!hasSelectedText()) {
       try {
-        const str = convertJsxToString(copyContent || children)
+        const str =
+          convertJsxToString(copyContent || children) ||
+          ref.current.textContent
 
         if (str) {
           const selection = window.getSelection()

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -103,7 +103,7 @@ describe('CopyOnClick', () => {
     expect(screen.getByText('CopyOnClick')).toBeInTheDocument()
   })
 
-  it('should support spacing props', async () => {
+  it('should support spacing props', () => {
     render(<CopyOnClick top="large">CopyOnClick text</CopyOnClick>)
     const element = document.querySelector('.dnb-copy-on-click')
     expect(element).toHaveClass('dnb-space__top--large')

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -11,7 +11,7 @@ describe('CopyOnClick', () => {
     mockClipboard()
   })
 
-  it('renders with default props', async () => {
+  it('renders with default props', () => {
     render(<CopyOnClick>CopyOnClick text</CopyOnClick>)
 
     expect(screen.getByText('CopyOnClick text')).toBeInTheDocument()

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import CopyOnClick from '../CopyOnClick'
 import { mockClipboard } from '../../../core/jest/jestSetup'
 import { copyWithEffect } from '../../../components/number-format/NumberUtils'
+import NumberFormat from '../../NumberFormat'
+import userEvent from '@testing-library/user-event'
 
 describe('CopyOnClick', () => {
   beforeAll(() => {
@@ -12,9 +14,7 @@ describe('CopyOnClick', () => {
   it('renders with default props', async () => {
     render(<CopyOnClick>CopyOnClick text</CopyOnClick>)
 
-    await waitFor(() =>
-      expect(screen.getByText('CopyOnClick text')).toBeInTheDocument()
-    )
+    expect(screen.getByText('CopyOnClick text')).toBeInTheDocument()
 
     const element = document.querySelector('.dnb-copy-on-click')
 
@@ -38,15 +38,11 @@ describe('CopyOnClick', () => {
   it('updates when children changes', async () => {
     const { rerender } = render(<CopyOnClick>First copy text</CopyOnClick>)
 
-    await waitFor(() =>
-      expect(screen.getByText('First copy text')).toBeInTheDocument()
-    )
+    expect(screen.getByText('First copy text')).toBeInTheDocument()
 
     rerender(<CopyOnClick>Second copy text</CopyOnClick>)
 
-    await waitFor(() =>
-      expect(screen.getByText('Second copy text')).toBeInTheDocument()
-    )
+    expect(screen.getByText('Second copy text')).toBeInTheDocument()
   })
 
   it('renders with a paragraph element', async () => {
@@ -56,9 +52,7 @@ describe('CopyOnClick', () => {
       </CopyOnClick>
     )
 
-    await waitFor(() =>
-      expect(screen.getByText('CopyOnClick text')).toBeInTheDocument()
-    )
+    expect(screen.getByText('CopyOnClick text')).toBeInTheDocument()
   })
 
   it('should set any given HTML attribute on the element', () => {
@@ -106,14 +100,52 @@ describe('CopyOnClick', () => {
       <CopyOnClick copyContent="copyContent">CopyOnClick</CopyOnClick>
     )
 
-    await waitFor(() =>
-      expect(screen.getByText('CopyOnClick')).toBeInTheDocument()
-    )
+    expect(screen.getByText('CopyOnClick')).toBeInTheDocument()
   })
 
   it('should support spacing props', async () => {
     render(<CopyOnClick top="large">CopyOnClick text</CopyOnClick>)
     const element = document.querySelector('.dnb-copy-on-click')
     expect(element).toHaveClass('dnb-space__top--large')
+  })
+
+  it('should copy children to clipboard', async () => {
+    window.getSelection()?.removeAllRanges()
+
+    render(<CopyOnClick>CopyOnClick</CopyOnClick>)
+
+    expect(screen.getByText('CopyOnClick')).toBeInTheDocument()
+
+    await userEvent.click(document.querySelector('.dnb-copy-on-click'))
+
+    expect(await navigator.clipboard.readText()).toBe('CopyOnClick')
+  })
+
+  it('should copy copyContent to clipboard', async () => {
+    window.getSelection()?.removeAllRanges()
+
+    render(
+      <CopyOnClick copyContent="copyContent">CopyOnClick</CopyOnClick>
+    )
+
+    expect(screen.getByText('CopyOnClick')).toBeInTheDocument()
+
+    await userEvent.click(document.querySelector('.dnb-copy-on-click'))
+
+    expect(await navigator.clipboard.readText()).toBe('copyContent')
+  })
+
+  it('should copy textContent to clipboard when children is empty', async () => {
+    window.getSelection()?.removeAllRanges()
+
+    render(
+      <CopyOnClick>
+        <NumberFormat value={1234567.89} currency="NOK" />
+      </CopyOnClick>
+    )
+
+    await userEvent.click(document.querySelector('.dnb-copy-on-click'))
+
+    expect(await navigator.clipboard.readText()).toBe('1 234 567,89 kr')
   })
 })

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -35,7 +35,7 @@ describe('CopyOnClick', () => {
     ])
   })
 
-  it('updates when children changes', async () => {
+  it('updates when children changes', () => {
     const { rerender } = render(<CopyOnClick>First copy text</CopyOnClick>)
 
     expect(screen.getByText('First copy text')).toBeInTheDocument()

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -45,7 +45,7 @@ describe('CopyOnClick', () => {
     expect(screen.getByText('Second copy text')).toBeInTheDocument()
   })
 
-  it('renders with a paragraph element', async () => {
+  it('renders with a paragraph element', () => {
     render(
       <CopyOnClick>
         <p>CopyOnClick text</p>

--- a/packages/dnb-eufemia/src/components/copy-on-click/style/dnb-copy-on-click.scss
+++ b/packages/dnb-eufemia/src/components/copy-on-click/style/dnb-copy-on-click.scss
@@ -4,6 +4,7 @@
 */
 
 .dnb-copy-on-click {
+  &--cursor,
   &--cursor * {
     cursor: copy;
   }

--- a/packages/dnb-eufemia/src/core/jest/jestSetup.js
+++ b/packages/dnb-eufemia/src/core/jest/jestSetup.js
@@ -43,18 +43,18 @@ export const loadScss = (file, options = {}) => {
 }
 
 export const mockClipboard = () => {
-  let memory
+  let memory = ''
+  const clipboardMock = {
+    writeText: jest.fn().mockImplementation((v) => {
+      memory = v
+      return Promise.resolve(v)
+    }),
+    readText: jest.fn().mockImplementation(() => Promise.resolve(memory)),
+  }
+
   Object.defineProperty(window.navigator, 'clipboard', {
     configurable: true,
-    value: {
-      writeText: jest.fn().mockImplementation((v) => {
-        memory = v
-        return Promise.resolve(v)
-      }),
-      readText: jest
-        .fn()
-        .mockImplementation(() => Promise.resolve(memory)),
-    },
+    value: clipboardMock,
   })
 
   const mockRange = new (class Range {


### PR DESCRIPTION
- Feature nr. 1 of [this post](https://dnb-it.slack.com/archives/CMXABCHEY/p1745580508874319?thread_ts=1745578322.405229&cid=CMXABCHEY).
- PR [Preview](https://eufemia-git-fix-copyonclick-textcontent-eufemia.vercel.app/uilib/components/copy-on-click/demos/#copy-text-content).
- We could almost always just relay on using `.textContent` instead of trying to get the content of children. Any thoughts?