### PR TITLE
fix(Selection): support `undefined` value from data context

### DIFF
--- a/packages/dnb-eufemia/src/components/radio/Radio.js
+++ b/packages/dnb-eufemia/src/components/radio/Radio.js
@@ -180,10 +180,7 @@ export default class Radio extends React.PureComponent {
           if (value !== null && typeof value !== 'undefined') {
             event.preventDefault()
           }
-          if (key === 'enter') {
-            const checked = !this.state.checked
-            this.setState({ checked, _listenForPropChanges: false })
-          }
+          this.onChangeHandler(event)
           break
         }
       }
@@ -213,9 +210,9 @@ export default class Radio extends React.PureComponent {
       // in case we have a false "hasContext" but a "group"
       // then we have to use a delay, to overwrite the uncontrolled state
       setTimeout(() => {
-        this.setState({ checked, _listenForPropChanges: false }, () =>
+        this.setState({ checked, _listenForPropChanges: false }, () => {
           this.callOnChange({ value, checked, event })
-        )
+        })
       }, 1)
     } else {
       this.setState({ checked, _listenForPropChanges: false })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -258,7 +258,7 @@ function Selection(props: Props) {
             }
             disabled={disabled}
             on_change={onChangeHandler}
-            value={String(value ?? '') || undefined}
+            value={String(value ?? '')}
           >
             {items}
           </Component.Group>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -549,6 +549,29 @@ describe('variants', () => {
       expect(radioButtons[2]).not.toBeChecked()
     })
 
+    it('should support selecting first option by space key, using keyboard navigation', async () => {
+      render(
+        <Field.Selection variant="radio">
+          <Field.Option value="foo">Foo</Field.Option>
+          <Field.Option value="bar">Bar</Field.Option>
+          <Field.Option value="baz">Baz</Field.Option>
+        </Field.Selection>
+      )
+
+      const radioButtons = screen.queryAllByRole('radio')
+
+      expect(radioButtons.length).toEqual(3)
+      expect(radioButtons[0]).not.toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+
+      await userEvent.tab()
+      await userEvent.keyboard('{Space}')
+      expect(radioButtons[0]).toBeChecked()
+      expect(radioButtons[1]).not.toBeChecked()
+      expect(radioButtons[2]).not.toBeChecked()
+    })
+
     it('should store "displayValue" in data context', async () => {
       let dataContext = null
 


### PR DESCRIPTION
This fix has a relation to #4584

