### PR TITLE
fix(HeightAnimation): always end animation properly when animation has finished

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import HeightAnimation from '../HeightAnimation'
 import HeightAnimationInstance from '../HeightAnimationInstance'
 import {
@@ -10,7 +10,6 @@ import {
   runAnimation,
   simulateAnimationEnd,
 } from './HeightAnimationUtils'
-import { wait } from '../../../core/jest/jestSetup'
 
 describe('HeightAnimation', () => {
   initializeTestSetup()
@@ -377,89 +376,6 @@ describe('HeightAnimation', () => {
     expect(element).not.toHaveClass('dnb-height-animation--animating')
 
     globalThis.IS_TEST = false
-  })
-})
-
-describe('stopOuterAnimations', () => {
-  it('should stop outer height animation by adding the --stop className', async () => {
-    globalThis.readjustTime = 1
-
-    const { rerender } = render(
-      <HeightAnimation className="outer">
-        <HeightAnimation className="inner">123</HeightAnimation>
-      </HeightAnimation>
-    )
-
-    expect(
-      document.querySelectorAll('.dnb-height-animation')
-    ).toHaveLength(2)
-
-    const innerElement = document.querySelector(
-      '.dnb-height-animation .dnb-height-animation'
-    )
-
-    mockHeight(100, innerElement)
-    mockHeight(200, innerElement)
-
-    // To ensure the "dnb-height-animation--stop" className is set after rerender
-    await wait(10)
-
-    rerender(
-      <HeightAnimation className="outer">
-        <HeightAnimation className="inner">456</HeightAnimation>
-      </HeightAnimation>
-    )
-
-    expect(
-      document.querySelector('.dnb-height-animation--stop')
-    ).toHaveClass('outer')
-
-    runAnimation()
-
-    await waitFor(() => {
-      expect(
-        document.querySelector('.dnb-height-animation--stop')
-      ).not.toBeInTheDocument()
-    })
-  })
-
-  it('should not animate when outer height animation has --stop className', async () => {
-    globalThis.readjustTime = 1
-
-    const { rerender } = render(
-      <HeightAnimation open={false}>123</HeightAnimation>
-    )
-
-    expect(
-      document.querySelector('.dnb-height-animation')
-    ).not.toBeInTheDocument()
-
-    rerender(<HeightAnimation open>123</HeightAnimation>)
-
-    runAnimation()
-
-    expect(getElement()).toBeInTheDocument()
-    expect(getElement()).toHaveAttribute('style', '')
-
-    mockHeight(100)
-    mockHeight(200)
-
-    rerender(<HeightAnimation open>456</HeightAnimation>)
-
-    rerender(
-      <HeightAnimation open className="dnb-height-animation--stop">
-        789
-      </HeightAnimation>
-    )
-
-    nextAnimationFrame()
-    expect(getElement()).toHaveAttribute('style', '')
-
-    nextAnimationFrame()
-    expect(getElement()).toHaveAttribute('style', '')
-
-    simulateAnimationEnd()
-    expect(getElement()).toHaveAttribute('style', '')
   })
 })
 


### PR DESCRIPTION
This PR reverts the fix introduced here #4493 

With this we ensure it always "end" animations properly. I have seen too often that this causes issues. 

In future we rather can and should use only CSS solutions like [`interpolate-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size) with [`calc-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc-size).



