### PR TITLE
chore(DatePicker): separate `onHoverDay` from `useDate` to prevent unnecessary date updates

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -74,16 +74,15 @@ export type DatePickerCalendarProps = Omit<
    * To display what month should be shown in the first calendar by default. Defaults to the `date` respective `startDate`.
    */
   month?: Date
+  hoverDate?: Date
   prevBtn?: boolean
   nextBtn?: boolean
-
   firstDayOfWeek?: string
   hideNav?: boolean
   hideDays?: boolean
   onlyMonth?: boolean
   hideNextMonthWeek?: boolean
   noAutoFocus?: boolean
-  onHover?: (day: Date) => void
   onSelect?: (
     event: DatePickerChangeEvent<
       | React.MouseEvent<HTMLSpanElement>
@@ -150,11 +149,12 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     setHasClickedCalendarDay,
     startDate,
     endDate,
-    hoverDate,
     maxDate,
     minDate,
     startMonth,
     endMonth,
+    hoverDate,
+    setHoverDate,
     translation: {
       DatePicker: { selectedMonth },
     },
@@ -174,7 +174,6 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     onPrev,
     onNext,
     onSelect,
-    onHover,
     onKeyDown,
     resetDate,
     prevBtn,
@@ -198,10 +197,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   }, [noAutoFocus, nr])
 
   const onMouseLeaveHandler = useCallback(() => {
-    updateDates({
-      hoverDate: null,
-    })
-  }, [updateDates])
+    setHoverDate(undefined)
+  }, [setHoverDate])
 
   const callOnSelect = useCallback(
     (
@@ -668,17 +665,25 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                   },
                                 })
                         }
-                        // TODO: See if this can be replaced with css, to prevent massive amount of re-renders
                         onMouseOver={
                           handleAsDisabled
                             ? undefined
-                            : () => onHoverDay({ day, hoverDate, onHover })
+                            : () =>
+                                onHoverDay({
+                                  day,
+                                  hoverDate,
+                                  setHoverDate,
+                                })
                         }
-                        // TODO: See if this can be replaced with css, to prevent massive amount of re-renders
                         onFocus={
                           handleAsDisabled
                             ? undefined
-                            : () => onHoverDay({ day, hoverDate, onHover })
+                            : () =>
+                                onHoverDay({
+                                  day,
+                                  hoverDate,
+                                  setHoverDate,
+                                })
                         }
                       />
                     </td>
@@ -828,14 +833,14 @@ function onSelectRange({
 function onHoverDay({
   day,
   hoverDate,
-  onHover,
+  setHoverDate,
 }: {
   day: CalendarDay
   hoverDate?: Date
-  onHover: DatePickerCalendarProps['onHover']
+  setHoverDate: (date: Date) => void
 }) {
-  if (!isSameDay(day.date, hoverDate) && onHover) {
-    onHover(day.date)
+  if (!isSameDay(day.date, hoverDate)) {
+    setHoverDate?.(day.date)
   }
 }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerContext.ts
@@ -30,6 +30,8 @@ export type DatePickerContextValues = ContextProps &
     setState?: (state: DatePickerProviderState) => void
     setViews: (views: Array<CalendarView>, callback?: () => void) => void
     setHasClickedCalendarDay: (hasClicked: boolean) => void
+    hoverDate?: Date
+    setHoverDate: (date: Date) => void
     callOnChangeHandler: <E>(event: DatePickerChangeEvent<E>) => void
     hidePicker: (event: DisplayPickerEvent) => void
     getReturnObject: <E>(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -304,29 +304,27 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       starDate?: Date
       event: React.ChangeEvent<HTMLInputElement>
     }) => {
-      updateDates(
-        {
-          hoverDate: null,
-        },
-        (dates) => {
-          // Should fire if user has filled out an invalid date,
-          // or if the date was valid. Like if the user has pressed backspace or removed the valid date.
-          if (isDateFullyFilledOutRef.current || hasHadValidDate) {
-            const { startDate, endDate, event } = {
-              ...state,
-              ...dates,
-            }
-            callOnChangeHandler({
-              startDate,
-              endDate,
-              event,
-              ...invalidDatesRef.current,
-            })
-          }
+      if (isDateFullyFilledOutRef.current || hasHadValidDate) {
+        const datesFromContext = { startDate, endDate }
+
+        const {
+          startDate: derivedStartDate,
+          endDate: derivedEndDate,
+          event,
+        } = {
+          ...state,
+          ...datesFromContext,
         }
-      )
+
+        callOnChangeHandler({
+          startDate: derivedStartDate,
+          endDate: derivedEndDate,
+          event,
+          ...invalidDatesRef.current,
+        })
+      }
     },
-    [updateDates, callOnChangeHandler, hasHadValidDate]
+    [callOnChangeHandler, hasHadValidDate, startDate, endDate]
   )
 
   const callOnChange = useCallback(

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -304,6 +304,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       starDate?: Date
       event: React.ChangeEvent<HTMLInputElement>
     }) => {
+      // Should fire if user has filled out an invalid date,
+      // or if the date was valid. Like if the user has pressed backspace or removed the valid date.
       if (isDateFullyFilledOutRef.current || hasHadValidDate) {
         const datesFromContext = { startDate, endDate }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -26,6 +26,7 @@ import useLastEventCallCache, {
 } from './hooks/useLastEventCallCache'
 import { InvalidDates } from './DatePickerInput'
 import { PartialDates } from './hooks/usePartialDates'
+import useHoverDate from './hooks/useHoverDate'
 
 type DatePickerProviderProps = DatePickerAllProps & {
   setReturnObject: (
@@ -123,6 +124,8 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
       startDate: dates.startDate,
       endDate: dates.endDate,
     })
+
+  const { hoverDate, setHoverDate } = useHoverDate()
 
   const getReturnObject = useCallback(
     <E,>({ event = null, ...rest }: GetReturnObjectParams<E> = {}) => {
@@ -247,6 +250,8 @@ function DatePickerProvider(externalProps: DatePickerProviderProps) {
         views,
         setViews,
         setHasClickedCalendarDay,
+        hoverDate,
+        setHoverDate,
       }}
     >
       {children}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.tsx
@@ -51,7 +51,7 @@ const monthHandlers: {
 function DatePickerRange(props: DatePickerRangeProps) {
   // Destructured to prevent useCallback from updating on all prop or context changes
   const { onChange, isRange, isLink } = props
-  const { views, setViews, updateDates, callOnChangeHandler } =
+  const { views, setViews, callOnChangeHandler } =
     useContext(DatePickerContext)
 
   const onNav = useCallback(
@@ -90,13 +90,6 @@ function DatePickerRange(props: DatePickerRangeProps) {
     [isRange, onChange, callOnChangeHandler]
   )
 
-  const onHover = useCallback(
-    (hoverDate: DatePickerDates['hoverDate']) => {
-      updateDates({ hoverDate })
-    },
-    [updateDates]
-  )
-
   return (
     <div className="dnb-date-picker__views">
       {views.map((calendar, i) => (
@@ -106,7 +99,6 @@ function DatePickerRange(props: DatePickerRangeProps) {
           {...props}
           id={`${props.id}-${i}-`}
           onSelect={onSelect}
-          onHover={onHover}
           onPrev={onNav}
           onNext={onNav}
         />

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -11,7 +11,6 @@ export type DatePickerDateProps = {
   endMonth?: DateType
   minDate?: DateType
   maxDate?: DateType
-  hoverDate?: DateType | null
 }
 
 type UseDatesOptions = {
@@ -28,7 +27,6 @@ export type DatePickerDates = {
   maxDate?: Date
   startMonth?: Date
   endMonth?: Date
-  hoverDate?: Date
 }
 
 export default function useDates(

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useHoverDate.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useHoverDate.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react'
+
+export default function useHoverDate() {
+  const [hoverDate, setHoverDate] = useState<Date>(null)
+
+  return { hoverDate, setHoverDate }
+}


### PR DESCRIPTION
Motivated by https://github.com/dnbexperience/eufemia/pull/5021 as the `onHoverDay` keeps updating the other dates, making it impossible to keep track of the previous selected dates without adding a lot of extra code.