### PR TITLE
fix(Forms): ensure fields do not overflow in width on a certain screen size

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
@@ -96,7 +96,7 @@
     }
 
     &--has-controls.dnb-forms-field-block__contents--width-small {
-      width: calc(
+      --field-block-content-width: calc(
         var(--forms-field-width--small) +
           var(--forms-field-block--number-control-buttons-width--small)
       );
@@ -106,7 +106,7 @@
       }
     }
     &--has-controls.dnb-forms-field-block__contents--width-medium {
-      width: calc(
+      --field-block-content-width: calc(
         var(--forms-field-width--medium) +
           var(--forms-field-block--number-control-buttons-width--medium)
       );
@@ -116,7 +116,7 @@
       }
     }
     &--has-controls.dnb-forms-field-block__contents--width-large {
-      width: calc(
+      --field-block-content-width: calc(
         var(--forms-field-width--large) +
           var(--forms-field-block--number-control-buttons-width--large)
       );

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -198,18 +198,36 @@ fieldset.dnb-forms-field-block {
       &-stretch {
         width: 100%;
       }
+      &-custom {
+        --field-block-content-width: calc(
+          var(--dnb-forms-field-block-content-width)
+        );
+      }
+      &-small {
+        --field-block-content-width: var(--forms-field-width--small);
+      }
+      &-medium {
+        --field-block-content-width: var(--forms-field-width--medium);
+      }
+      &-large {
+        --field-block-content-width: var(--forms-field-width--large);
+      }
+
       @include allAbove(x-small) {
-        &-custom {
-          width: calc(var(--dnb-forms-field-block-content-width));
-        }
-        &-small {
-          width: var(--forms-field-width--small);
-        }
-        &-medium {
-          width: var(--forms-field-width--medium);
-        }
+        &-custom,
+        &-small,
+        &-medium,
         &-large {
-          width: var(--forms-field-width--large);
+          max-width: var(--field-block-content-width, none);
+        }
+      }
+
+      @include allAbove(small) {
+        &-custom,
+        &-small,
+        &-medium,
+        &-large {
+          width: var(--field-block-content-width, max-content);
         }
       }
     }


### PR DESCRIPTION
On a certain screen width, a large FieldBlock will overflow. It "can" and probably will cut over Field.String in the default width.

With the issue:
<img width="436" alt="Screenshot 2025-04-30 at 15 31 44" src="https://github.com/user-attachments/assets/639bc1e7-9dbd-49d5-ac78-995ec11232e1" />

With this PR, the large size will adjust it to a lower width, so it will not overflow:
<img width="451" alt="Screenshot 2025-04-30 at 16 13 16" src="https://github.com/user-attachments/assets/b6faee3d-d129-4d92-8a48-aaf6383101db" />
