### PR TITLE
feat(DatePicker): copy whole formatted date when coping from input field

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalc.ts
@@ -251,6 +251,20 @@ export function correctV1Format(date: string) {
   return date
 }
 
+function parseHumanDate(
+  input: string,
+  humanDateFormats = ['dd.MM.yyyy', 'dd/MM/yyyy', 'yyyy-MM-dd']
+) {
+  for (const format of humanDateFormats) {
+    const parsed = parse(input, format, new Date())
+    if (isValid(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
 export function convertStringToDate(
   date: string | Date,
   { dateFormat = null }: { dateFormat?: string | null } = {}
@@ -260,12 +274,20 @@ export function convertStringToDate(
   }
 
   let dateObject: Date
-  dateObject = typeof date === 'string' ? parseISO(date) : toDate(date)
 
-  // check one more time if we can generate a valid date
-  if (typeof date === 'string' && dateFormat && !isValid(dateObject)) {
-    dateFormat = correctV1Format(dateFormat)
-    dateObject = parse(date, dateFormat, new Date())
+  if (typeof date === 'string') {
+    dateObject = parseISO(date)
+
+    if (!isValid(dateObject)) {
+      dateObject = parseHumanDate(date)
+    }
+
+    // Check one more time if we can generate a valid date
+    if (dateFormat && !isValid(dateObject)) {
+      dateObject = parseHumanDate(date, [correctV1Format(dateFormat)])
+    }
+  } else {
+    dateObject = toDate(date)
   }
 
   // rather return null than an invalid date

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -27,7 +27,7 @@ import {
   toCapitalized,
 } from '../../shared/component-helper'
 import { IS_ANDROID, IS_IOS } from '../../shared/helpers'
-import { convertStringToDate } from './DatePickerCalc'
+import { convertStringToDate, formatDate } from './DatePickerCalc'
 import DatePickerContext from './DatePickerContext'
 
 import type {
@@ -38,7 +38,7 @@ import type {
 import type { SkeletonShow } from '../Skeleton'
 import { ReturnObject } from './DatePickerProvider'
 import { DatePickerEventAttributes } from './DatePicker'
-import { useTranslation } from '../../shared'
+import { Context, useTranslation } from '../../shared'
 import usePartialDates from './hooks/usePartialDates'
 import useInputDates, { DatePickerInputDates } from './hooks/useInputDates'
 
@@ -174,6 +174,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
   })
 
   const translation = useTranslation().DatePicker
+  const { locale } = useContext(Context)
 
   const hasHadValidDate = isValid(startDate) || isValid(endDate)
 
@@ -238,6 +239,21 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       }, [])
   }, [maskOrder, separatorRegExp])
 
+  const copyHandler = useCallback(
+    (
+      event: React.ClipboardEvent<HTMLInputElement>,
+      mode: DatePickerEventAttributes['mode']
+    ) => {
+      const date = mode === 'end' ? endDate : startDate
+      if (isValid(date)) {
+        event.preventDefault()
+        const valueToCopy = formatDate(date, { locale })
+        event.clipboardData.setData('text/plain', valueToCopy)
+      }
+    },
+    [endDate, locale, startDate]
+  )
+
   const pasteHandler = useCallback(
     async (event: React.ClipboardEvent<HTMLInputElement>) => {
       if (!focusMode.current) {
@@ -247,7 +263,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       const success = (
         event.clipboardData ||
         (typeof window !== 'undefined' && window['clipboardData'])
-      ).getData('text')
+      ).getData('text/plain')
 
       if (!success) {
         return // Stop here
@@ -747,12 +763,15 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
               ...element,
               onInput: onInputHandler,
               onKeyDown: onKeyDownHandler,
-              onPaste: pasteHandler,
               onFocus: (e) => {
                 focusMode.current = mode
                 onFocusHandler(e)
               },
               onBlur: onBlurHandler,
+              onPaste: pasteHandler,
+              onCopy: (event) => {
+                copyHandler(event, mode)
+              },
               placeholderChar,
             }
           }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3622,6 +3622,84 @@ describe('Custom text for buttons', () => {
       ).toBeInTheDocument()
     })
   })
+
+  describe('copy & paste', () => {
+    it('should copy the whole date when copied from input field', async () => {
+      const { rerender } = render(
+        <DatePicker showInput date="2025-04-01" />
+      )
+
+      const [day, month, year]: Array<HTMLInputElement> = Array.from(
+        document.querySelectorAll('input.dnb-input__input')
+      )
+
+      const setData = jest.fn()
+      const clipboardData = { setData }
+
+      day.focus()
+      day.select()
+      fireEvent.copy(day, {
+        clipboardData,
+      })
+      expect(setData).toHaveBeenLastCalledWith('text/plain', '01.04.2025')
+
+      rerender(<DatePicker showInput date="2025-04-02" />)
+      month.focus()
+      month.select()
+      fireEvent.copy(month, {
+        clipboardData,
+      })
+      expect(setData).toHaveBeenLastCalledWith('text/plain', '02.04.2025')
+
+      rerender(<DatePicker showInput date="2025-04-03" />)
+      year.focus()
+      year.select()
+      fireEvent.copy(year, {
+        clipboardData,
+      })
+      expect(setData).toHaveBeenLastCalledWith('text/plain', '03.04.2025')
+    })
+
+    it('should paste the whole date as the value of the input field', async () => {
+      render(<DatePicker showInput />)
+
+      const [day, month, year]: Array<HTMLInputElement> = Array.from(
+        document.querySelectorAll('input.dnb-input__input')
+      )
+
+      let date = null
+
+      const getData = jest.fn(() => date)
+      const clipboardData = { getData }
+
+      date = '01.04.2025'
+      day.focus()
+      day.select()
+      fireEvent.paste(day, { clipboardData })
+      expect(getData).toHaveBeenCalledWith('text/plain')
+      expect(day).toHaveValue('01')
+      expect(month).toHaveValue('04')
+      expect(year).toHaveValue('2025')
+
+      date = '02.05.2025'
+      month.focus()
+      month.select()
+      fireEvent.paste(month, { clipboardData })
+      expect(getData).toHaveBeenCalledWith('text/plain')
+      expect(day).toHaveValue('02')
+      expect(month).toHaveValue('05')
+      expect(year).toHaveValue('2025')
+
+      date = '03.05.2026'
+      year.focus()
+      year.select()
+      fireEvent.paste(year, { clipboardData })
+      expect(getData).toHaveBeenCalledWith('text/plain')
+      expect(day).toHaveValue('03')
+      expect(month).toHaveValue('05')
+      expect(year).toHaveValue('2026')
+    })
+  })
 })
 
 describe('DatePickerPortal', () => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePickerCalc.test.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePickerCalc.test.ts
@@ -1,0 +1,62 @@
+import { convertStringToDate } from '../DatePickerCalc'
+
+describe('convertStringToDate', () => {
+  it('returns null for falsy input', () => {
+    expect(convertStringToDate(null)).toBeNull()
+    expect(convertStringToDate(undefined as any)).toBeNull()
+    expect(convertStringToDate('')).toBeNull()
+  })
+
+  it('parses ISO string', () => {
+    const date = convertStringToDate('2023-12-25')
+    expect(date).toBeInstanceOf(Date)
+    expect(date?.getFullYear()).toBe(2023)
+    expect(date?.getMonth()).toBe(11) // December is 11
+    expect(date?.getDate()).toBe(25)
+  })
+
+  it('parses human date formats', () => {
+    const date1 = convertStringToDate('25.12.2023')
+    expect(date1).toBeInstanceOf(Date)
+    expect(date1?.getFullYear()).toBe(2023)
+    expect(date1?.getMonth()).toBe(11)
+    expect(date1?.getDate()).toBe(25)
+
+    const date2 = convertStringToDate('25/12/2023')
+    expect(date2).toBeInstanceOf(Date)
+    expect(date2?.getFullYear()).toBe(2023)
+    expect(date2?.getMonth()).toBe(11)
+    expect(date2?.getDate()).toBe(25)
+  })
+
+  it('parses with custom dateFormat', () => {
+    const date = convertStringToDate('31-12-2023', {
+      dateFormat: 'dd-MM-yyyy',
+    })
+    expect(date).toBeInstanceOf(Date)
+    expect(date?.getFullYear()).toBe(2023)
+    expect(date?.getMonth()).toBe(11)
+    expect(date?.getDate()).toBe(31)
+  })
+
+  it('returns null for invalid date', () => {
+    const log = jest.fn()
+    const mock = jest.spyOn(console, 'log').mockImplementation(log)
+
+    expect(convertStringToDate('not-a-date')).toBeNull()
+    expect(log).toHaveBeenCalledWith(
+      expect.any(String),
+      'convertStringToDate got invalid date:',
+      'not-a-date'
+    )
+
+    mock.mockRestore()
+  })
+
+  it('returns a Date when given a Date', () => {
+    const now = new Date(2022, 5, 10)
+    const result = convertStringToDate(now)
+    expect(result).toBeInstanceOf(Date)
+    expect(result?.getTime()).toBe(now.getTime())
+  })
+})


### PR DESCRIPTION
Relates to #4886

You can test it here: https://eufemia-git-feat-date-picker-copy-eufemia.vercel.app/uilib/extensions/forms/feature-fields/Date/ by copy&pasting from one field to another.