### PR TITLE
fix(Forms): support `required` in Field.Selection with `button` variant

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
@@ -129,6 +129,7 @@ export default class ToggleButton extends React.PureComponent {
     globalStatus: null,
     suffix: null,
     value: '',
+    role: undefined,
     icon: null,
     icon_position: 'right',
     icon_size: null,
@@ -316,6 +317,7 @@ export default class ToggleButton extends React.PureComponent {
             icon_size,
             icon_position,
             value: propValue,
+            role,
 
             id: _id, // eslint-disable-line
             // group: _group, // eslint-disable-line
@@ -379,7 +381,10 @@ export default class ToggleButton extends React.PureComponent {
             icon,
             icon_size,
             icon_position,
-            'aria-pressed': String(checked || false),
+            [`aria-${role === 'radio' ? 'checked' : 'pressed'}`]: String(
+              checked || false
+            ),
+            role,
             ...rest,
           }
 

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
@@ -230,6 +230,39 @@ describe('ToggleButton component', () => {
     expect(document.querySelector('button[disabled]')).toBeInTheDocument()
   })
 
+  it('should set aria-checked when role is radio', () => {
+    render(<ToggleButton role="radio" />)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('role')
+    ).toBe('radio')
+
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-pressed')
+    ).toBe(null)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-checked')
+    ).toBe('false')
+
+    fireEvent.click(document.querySelector('button'))
+
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-pressed')
+    ).toBe(null)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-checked')
+    ).toBe('true')
+  })
+
   it('should support enter key', () => {
     const onChange = jest.fn()
     render(<ToggleButton on_change={onChange} />)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -257,6 +257,7 @@ function Selection(props: Props) {
       return (
         <FieldBlock {...fieldBlockProps} {...additionalFieldBlockProps}>
           <Component.Group
+            role="radiogroup"
             size={size}
             className={cn}
             layout_direction={
@@ -413,6 +414,7 @@ function renderRadioItems({
             : undefined
         }
         text={variant === 'button' ? label : undefined}
+        role="radio"
         value={String(value ?? valueProp) || undefined}
         status={
           (hasError || checkForError([error, info, warning])) && 'error'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -775,8 +775,28 @@ describe('variants', () => {
 
       const buttons = document.querySelectorAll('button')
       expect(buttons.length).toEqual(2)
-      expect(buttons[0].getAttribute('aria-pressed')).toBe('false')
-      expect(buttons[1].getAttribute('aria-pressed')).toBe('false')
+      expect(buttons[0].getAttribute('aria-checked')).toBe('false')
+      expect(buttons[1].getAttribute('aria-checked')).toBe('false')
+    })
+
+    it('has radio roles', () => {
+      render(
+        <Field.Selection variant="button">
+          <Field.Option value="foo">Foo</Field.Option>
+        </Field.Selection>
+      )
+
+      expect(
+        document
+          .querySelector('.dnb-toggle-button-group__shell')
+          .getAttribute('role')
+      ).toBe('radiogroup')
+
+      expect(
+        document
+          .querySelector('button.dnb-toggle-button__button')
+          .getAttribute('role')
+      ).toBe('radio')
     })
 
     it('renders help', () => {
@@ -832,8 +852,8 @@ describe('variants', () => {
 
       const buttons = document.querySelectorAll('button')
       expect(buttons.length).toEqual(2)
-      expect(buttons[0].getAttribute('aria-pressed')).toBe('false')
-      expect(buttons[1].getAttribute('aria-pressed')).toBe('true')
+      expect(buttons[0].getAttribute('aria-checked')).toBe('false')
+      expect(buttons[1].getAttribute('aria-checked')).toBe('true')
     })
 
     it('should render options in nested elements', () => {
@@ -920,8 +940,8 @@ describe('variants', () => {
 
       const buttons = document.querySelectorAll('button')
       expect(buttons.length).toEqual(2)
-      expect(buttons[0].getAttribute('aria-pressed')).toBe('true')
-      expect(buttons[1].getAttribute('aria-pressed')).toBe('false')
+      expect(buttons[0].getAttribute('aria-checked')).toBe('true')
+      expect(buttons[1].getAttribute('aria-checked')).toBe('false')
     })
 
     it('should support selected value from "path"', async () => {
@@ -960,8 +980,8 @@ describe('variants', () => {
       expect(option1).toHaveTextContent('Foo!')
       expect(option2).toHaveTextContent('Bar!')
 
-      expect(option1).toHaveAttribute('aria-pressed', 'true')
-      expect(option2).toHaveAttribute('aria-pressed', 'false')
+      expect(option1).toHaveAttribute('aria-checked', 'true')
+      expect(option2).toHaveAttribute('aria-checked', 'false')
 
       await userEvent.click(option2)
 
@@ -969,8 +989,8 @@ describe('variants', () => {
         const [option1, option2] = Array.from(
           document.querySelectorAll('button')
         )
-        expect(option1).toHaveAttribute('aria-pressed', 'false')
-        expect(option2).toHaveAttribute('aria-pressed', 'true')
+        expect(option1).toHaveAttribute('aria-checked', 'false')
+        expect(option2).toHaveAttribute('aria-checked', 'true')
       }
 
       expect(onChange).toHaveBeenCalledTimes(1)
@@ -1008,9 +1028,9 @@ describe('variants', () => {
       expect(option2).toHaveTextContent('Bar!')
       expect(option3).toHaveTextContent('Baz!')
 
-      expect(option1).toHaveAttribute('aria-pressed', 'false')
-      expect(option2).toHaveAttribute('aria-pressed', 'false')
-      expect(option3).toHaveAttribute('aria-pressed', 'false')
+      expect(option1).toHaveAttribute('aria-checked', 'false')
+      expect(option2).toHaveAttribute('aria-checked', 'false')
+      expect(option3).toHaveAttribute('aria-checked', 'false')
     })
 
     it('should store "displayValue" in data context', async () => {
@@ -1110,14 +1130,7 @@ describe('variants', () => {
           </Field.Selection>
         )
 
-        expect(
-          await axeComponent(result, {
-            rules: {
-              // Because of aria-required is not allowed on buttons – but VO still reads it
-              'aria-allowed-attr': { enabled: false },
-            },
-          })
-        ).toHaveNoViolations()
+        expect(await axeComponent(result)).toHaveNoViolations()
       })
 
       it('should have aria-required', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
@@ -259,3 +259,17 @@ export function SelectionAutocompleteAriaRequired() {
     </Field.Selection>
   )
 }
+
+export function SelectionButtonsAriaRequired() {
+  return (
+    <Field.Selection
+      required
+      variant="button"
+      label="Label text"
+      onChange={(value) => console.log('onChange', value)}
+    >
+      <Field.Option value="foo" title="Foo!" />
+      <Field.Option value="bar" title="Baar!" />
+    </Field.Selection>
+  )
+}


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1746520226276669

The fix does so [Field.Selection variant button](https://eufemia.dnb.no/uilib/extensions/forms/base-fields/Selection/demos/#toggle-buttons):
- ToggleButton has `role="radio"`
- ToggleButton.Group has`role="radiogroup"`
- ToggleButton component when role radio sets `aria-checked` instead of `aria-pressed`


I think role radio is correct as one can only select one of these toggle buttons / items, read https://www.w3.org/TR/wai-aria/#radio

Fixes https://github.com/dnbexperience/eufemia/issues/3241