### PR TITLE
fix(Forms): support `required` in Field.ArraySelection with `button` & `checkbox-button` variant

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -241,6 +241,7 @@ export function useCheckboxOrToggleOptions({
             (hasError || checkForError([error, info, warning])) && 'error'
           }
           suffix={suffix}
+          role="checkbox"
           on_change={handleSelect}
           {...htmlAttributes}
           {...rest}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -777,19 +777,19 @@ describe('ArraySelection', () => {
         expect(option3).toHaveTextContent('Baz!')
 
         expect(option1.querySelector('button')).toHaveAttribute(
-          'aria-pressed',
+          'aria-checked',
           'false'
         )
         expect(option1).not.toHaveClass('dnb-toggle-button--checked')
 
         expect(option2.querySelector('button')).toHaveAttribute(
-          'aria-pressed',
+          'aria-checked',
           'true'
         )
         expect(option2).toHaveClass('dnb-toggle-button--checked')
 
         expect(option3.querySelector('button')).toHaveAttribute(
-          'aria-pressed',
+          'aria-checked',
           'false'
         )
         expect(option3).not.toHaveClass('dnb-toggle-button--checked')
@@ -1038,14 +1038,7 @@ describe('ArraySelection', () => {
             </Field.ArraySelection>
           )
 
-          expect(
-            await axeComponent(result, {
-              rules: {
-                // Because of aria-required is not allowed on buttons – but VO still reads it
-                'aria-allowed-attr': { enabled: false },
-              },
-            })
-          ).toHaveNoViolations()
+          expect(await axeComponent(result)).toHaveNoViolations()
         })
 
         it('should have aria-required', () => {


### PR DESCRIPTION
Builds on top of https://github.com/dnbexperience/eufemia/pull/5104

Variant [button](https://eufemia-git-fix-array-selection-a11y-issues-eufemia.vercel.app/uilib/extensions/forms/base-fields/ArraySelection/demos/#button-variant) and [checkbox-button](https://eufemia-git-fix-array-selection-a11y-issues-eufemia.vercel.app/uilib/extensions/forms/base-fields/ArraySelection/demos/#button-with-checkbox-variant) behaves like checboxes, hence setting role to `checkbox`
