### PR TITLE
docs(Modal): `closeTitle`, `hideCloseButton`, `spacing` is not deprecated

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
+++ b/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
@@ -156,17 +156,17 @@ export const ModalProperties: PropertiesTableProps = {
   spacing: {
     doc: 'if set to `false` then the modal content will be shown without any spacing. Defaults to `true`.',
     type: 'boolean',
-    status: 'deprecated',
+    status: 'optional',
   },
   closeTitle: {
     doc: 'the title of the close button. Defaults to _Lukk_.',
     type: 'string',
-    status: 'deprecated',
+    status: 'optional',
   },
   hideCloseButton: {
     doc: 'if true, the close button will not be shown.',
     type: 'boolean',
-    status: 'deprecated',
+    status: 'optional',
   },
   class: {
     doc: 'give the inner content wrapper a class name (maps to `dnb-modal__content__inner`).',


### PR DESCRIPTION
I don't think it was done with purpose to deprecate these props in this PR https://github.com/dnbexperience/eufemia/pull/1190, and commit 
https://github.com/dnbexperience/eufemia/commit/ebe8e6a597c87885c081fcdfd76339780e90befc#diff-f1c94bc3bf35a0cb7181e56dab45c760dfa612539ab3fcd8c903e3c76b6b9f6e

It's been over 3 years since the docs was set to `deprecated/optional`, and the props have not been deprecated since.
There's also no comments in the actual code about deprecation of these props, or that these props should be deprecated.

Props written in snake_case(`close_title`, `hide_close_button`, `spacing`) is also not deprecated here https://github.com/dnbexperience/eufemia/blob/0c4ef059e5ff9af51ad7393290aaa7184c0da1c0/packages/dnb-eufemia/src/components/modal/types.ts