### PR TITLE
fix(Forms): support `required` in Field.Toggle with `button` & `checkbox-button` variant

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.js
@@ -381,9 +381,11 @@ export default class ToggleButton extends React.PureComponent {
             icon,
             icon_size,
             icon_position,
-            [`aria-${role === 'radio' ? 'checked' : 'pressed'}`]: String(
-              checked || false
-            ),
+            [`aria-${
+              role === 'radio' || role === 'checkbox'
+                ? 'checked'
+                : 'pressed'
+            }`]: String(checked || false),
             role,
             ...rest,
           }

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
@@ -263,6 +263,39 @@ describe('ToggleButton component', () => {
     ).toBe('true')
   })
 
+  it('should set aria-checked when role is checkbox', () => {
+    render(<ToggleButton role="checkbox" />)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('role')
+    ).toBe('checkbox')
+
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-pressed')
+    ).toBe(null)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-checked')
+    ).toBe('false')
+
+    fireEvent.click(document.querySelector('button'))
+
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-pressed')
+    ).toBe(null)
+    expect(
+      document
+        .querySelector('button.dnb-toggle-button__button')
+        .getAttribute('aria-checked')
+    ).toBe('true')
+  })
+
   it('should support enter key', () => {
     const onChange = jest.fn()
     render(<ToggleButton on_change={onChange} />)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -413,14 +413,7 @@ describe('Field.Boolean', () => {
           />
         )
 
-        expect(
-          await axeComponent(result, {
-            rules: {
-              // Because of aria-required is not allowed on buttons – but VO still reads it
-              'aria-allowed-attr': { enabled: false },
-            },
-          })
-        ).toHaveNoViolations()
+        expect(await axeComponent(result)).toHaveNoViolations()
       })
 
       it('should have aria-required', () => {
@@ -593,14 +586,7 @@ describe('Field.Boolean', () => {
           />
         )
 
-        expect(
-          await axeComponent(result, {
-            rules: {
-              // Because of aria-required is not allowed on buttons – but VO still reads it
-              'aria-allowed-attr': { enabled: false },
-            },
-          })
-        ).toHaveNoViolations()
+        expect(await axeComponent(result)).toHaveNoViolations()
       })
 
       it('should have aria-required', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -127,6 +127,7 @@ function Toggle(props: Props) {
             value={value ? 'true' : 'false'}
             size={size}
             on_change={handleCheckboxChange}
+            role="checkbox"
             {...htmlAttributes}
           />
         </FieldBlock>
@@ -175,6 +176,7 @@ function Toggle(props: Props) {
             value={value ? 'true' : 'false'}
             size={size}
             on_change={handleCheckboxChange}
+            role="checkbox"
             {...htmlAttributes}
           />
         </FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -189,14 +189,7 @@ describe('Field.Toggle', () => {
             />
           )
 
-          expect(
-            await axeComponent(result, {
-              rules: {
-                // Because of aria-required is not allowed on buttons – but VO still reads it
-                'aria-allowed-attr': { enabled: false },
-              },
-            })
-          ).toHaveNoViolations()
+          expect(await axeComponent(result)).toHaveNoViolations()
         })
 
         it('should have aria-required', () => {
@@ -622,14 +615,7 @@ describe('Field.Toggle', () => {
             />
           )
 
-          expect(
-            await axeComponent(result, {
-              rules: {
-                // Because of aria-required is not allowed on buttons – but VO still reads it
-                'aria-allowed-attr': { enabled: false },
-              },
-            })
-          ).toHaveNoViolations()
+          expect(await axeComponent(result)).toHaveNoViolations()
         })
 
         it('should have aria-required', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -120,17 +120,17 @@ describe('Field.Toggle', () => {
         )
 
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('aria-pressed', 'true')
+        expect(element).toHaveAttribute('aria-checked', 'true')
 
         fireEvent.click(element)
 
-        expect(element).toHaveAttribute('aria-pressed', 'false')
+        expect(element).toHaveAttribute('aria-checked', 'false')
         expect(onChange).toHaveBeenCalledTimes(1)
         expect(onChange).toHaveBeenLastCalledWith('off', expect.anything())
 
         fireEvent.click(element)
 
-        expect(element).toHaveAttribute('aria-pressed', 'true')
+        expect(element).toHaveAttribute('aria-checked', 'true')
         expect(onChange).toHaveBeenCalledTimes(2)
         expect(onChange).toHaveBeenLastCalledWith('on', expect.anything())
       })


### PR DESCRIPTION
Here's demo for variant [button](https://eufemia-git-fix-toggle-a11y-issues-variant-buttons-eufemia.vercel.app/uilib/extensions/forms/base-fields/Toggle/demos/#buttons) and variant [checkbox-button](https://eufemia-git-fix-toggle-a11y-issues-eufemia.vercel.app/uilib/extensions/forms/base-fields/Toggle/demos/#checkbox-button). They behave like checkboxes, therefore I've set the role to `checkbox`.