### PR TITLE
fix(Forms): ensure support for `labelSrOnly` in Field.Toggle

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -81,7 +81,7 @@ function Toggle(props: Props) {
     }
   }, [isOn, setDisplayValue, textOff, textOn])
 
-  const { label, labelSuffix, required } = props
+  const { label, labelSuffix, required, labelSrOnly } = props
   const labelWithItemNo = useIterateItemNo({
     label,
     labelSuffix,
@@ -102,6 +102,7 @@ function Toggle(props: Props) {
                 ? textOn ?? translations.yes
                 : textOff ?? translations.no)
             }
+            labelSrOnly={labelSrOnly}
             checked={isOn}
             disabled={disabled}
             size={size !== 'small' ? size : undefined}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -741,6 +741,27 @@ describe('Field.Toggle', () => {
         expect(screen.getByLabelText('Toggle label')).toBeInTheDocument()
       })
 
+      it('should set correct class when labelSrOnly is true', () => {
+        render(
+          <Field.Toggle
+            valueOn="on"
+            valueOff="off"
+            variant="checkbox"
+            label="Toggle label"
+          />
+        )
+
+        it('should set correct class when labelSrOnly is true', () => {
+          render(<Field.String label="Toggle label" labelSrOnly />)
+
+          const element = document.querySelector('.dnb-form-label')
+
+          expect(element).toHaveTextContent('Toggle label')
+          expect(element).toHaveClass('dnb-sr-only')
+          expect(element).not.toHaveClass('dnb-form-label--interactive')
+        })
+      })
+
       it('renders help', () => {
         render(
           <Field.Toggle


### PR DESCRIPTION
As Field.Boolean uses Field.Toggle under the hood, this fixes it in Both Field.Toggle and Field.Boolean