### PR TITLE
fix(Field.Toggle, Field.Boolean): add support for `preventDefault` in onClick for `checkbox` variant

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
@@ -64,6 +64,21 @@ export const CheckboxDisabled = () => {
   )
 }
 
+export const CheckboxPreventDefault = () => {
+  return (
+    <ComponentBox>
+      <Field.Boolean
+        variant="checkbox"
+        label="I will never change the state"
+        onClick={(value, { event }) => {
+          event.preventDefault()
+        }}
+        onChange={(value) => console.log('onChange', value)}
+      />
+    </ComponentBox>
+  )
+}
+
 export const CheckboxError = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
@@ -28,6 +28,12 @@ import * as Examples from './Examples'
 
 <Examples.CheckboxDisabled />
 
+### Checkbox - prevent changing the state of the checkbox
+
+You can prevent the state of the checkbox from changing by calling `preventDefault` on the `onClick` event.
+
+<Examples.CheckboxPreventDefault />
+
 #### Checkbox - Error
 
 <Examples.CheckboxError />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/events.mdx
@@ -4,7 +4,14 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { FieldEvents } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
+import { BooleanEvents } from '@dnb/eufemia/src/extensions/forms/Field/Boolean/BooleanDocs'
 
 ## Events
+
+### Field-specific events
+
+<PropertiesTable props={BooleanEvents} />
+
+### General events
 
 <PropertiesTable props={FieldEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle/events.mdx
@@ -4,7 +4,14 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { FieldEvents } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
+import { ToggleEvents } from '@dnb/eufemia/src/extensions/forms/Field/Toggle/ToggleDocs'
 
 ## Events
+
+### Field-specific events
+
+<PropertiesTable props={ToggleEvents} />
+
+### General events
 
 <PropertiesTable props={FieldEvents} />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -8,6 +8,7 @@ type BooleanProps = {
   falseText?: string
   variant?: ToggleFieldProps['variant']
   size?: ToggleFieldProps['size']
+  onClick?: ToggleFieldProps['onClick']
   dependencePaths?: never
 }
 type NeverBooleanProps = {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/BooleanDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/BooleanDocs.tsx
@@ -19,3 +19,11 @@ export const BooleanProperties: PropertiesTableProps = {
   },
   size: ToggleProperties.size,
 }
+
+export const BooleanEvents: PropertiesTableProps = {
+  onClick: {
+    doc: 'Will be called on click.',
+    type: '(value: unknown, { event: ClickEvent, preventDefault: () => void }) => void',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -240,6 +240,45 @@ describe('Field.Boolean', () => {
       })
     })
 
+    it('should not change the state when calling preventDefault on the onClick event', async () => {
+      const onClick = jest.fn((value, { preventDefault }) => {
+        preventDefault()
+      })
+
+      render(
+        <Field.Boolean
+          label="Label {itemNo}"
+          variant="checkbox"
+          onClick={onClick}
+        />
+      )
+
+      const checkbox = document.querySelector('input')
+      expect(checkbox.checked).toBe(false)
+
+      await userEvent.click(checkbox)
+
+      expect(checkbox.checked).toBe(false)
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(onClick).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({
+          checked: false,
+        })
+      )
+
+      await userEvent.click(checkbox)
+
+      expect(checkbox.checked).toBe(false)
+      expect(onClick).toHaveBeenCalledTimes(2)
+      expect(onClick).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({
+          checked: false,
+        })
+      )
+    })
+
     describe('ARIA', () => {
       it('should validate with ARIA rules', async () => {
         const result = render(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/ToggleDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/ToggleDocs.tsx
@@ -32,3 +32,11 @@ export const ToggleProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
+
+export const ToggleEvents: PropertiesTableProps = {
+  onClick: {
+    doc: 'Will be called on click.',
+    type: '(value: unknown, { event: ClickEvent, preventDefault: () => void }) => void',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -929,6 +929,89 @@ describe('Field.Toggle', () => {
         expect(screen.getByText('Label 1')).toBeInTheDocument()
         expect(screen.getByText('Label 2')).toBeInTheDocument()
       })
+
+      it('should not change the state when calling preventDefault on the onClick event', async () => {
+        const onClick = jest.fn((value, { preventDefault }) => {
+          preventDefault()
+        })
+
+        render(
+          <Field.Toggle
+            label="Label {itemNo}"
+            valueOn="on"
+            valueOff="off"
+            variant="checkbox"
+            onClick={onClick}
+          />
+        )
+
+        const checkbox = document.querySelector('input')
+        expect(checkbox.checked).toBe(false)
+
+        await userEvent.click(checkbox)
+
+        expect(checkbox.checked).toBe(false)
+        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(onClick).toHaveBeenLastCalledWith(
+          'off',
+          expect.objectContaining({
+            checked: false,
+          })
+        )
+
+        await userEvent.click(checkbox)
+
+        expect(checkbox.checked).toBe(false)
+        expect(onClick).toHaveBeenCalledTimes(2)
+        expect(onClick).toHaveBeenLastCalledWith(
+          'off',
+          expect.objectContaining({
+            checked: false,
+          })
+        )
+      })
+
+      it('should not change the state when calling preventDefault on the onClick event when default value is true', async () => {
+        const onClick = jest.fn((value, { preventDefault }) => {
+          preventDefault()
+        })
+
+        render(
+          <Field.Toggle
+            label="Label {itemNo}"
+            value="on"
+            valueOn="on"
+            valueOff="off"
+            variant="checkbox"
+            onClick={onClick}
+          />
+        )
+
+        const checkbox = document.querySelector('input')
+        expect(checkbox.checked).toBe(true)
+
+        await userEvent.click(checkbox)
+
+        expect(checkbox.checked).toBe(true)
+        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(onClick).toHaveBeenLastCalledWith(
+          'on',
+          expect.objectContaining({
+            checked: true,
+          })
+        )
+
+        await userEvent.click(checkbox)
+
+        expect(checkbox.checked).toBe(true)
+        expect(onClick).toHaveBeenCalledTimes(2)
+        expect(onClick).toHaveBeenLastCalledWith(
+          'on',
+          expect.objectContaining({
+            checked: true,
+          })
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
Based on #4768