### PR TITLE
fix(Dropdown): fix `React.ReactNode` support for `title` prop

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -483,7 +483,10 @@ class DropdownInstance extends React.PureComponent {
 
     const handleAsMenu =
       isTrue(action_menu) || isTrue(more_menu) || isTrue(prevent_selection)
-    const isPopupMenu = isTrue(more_menu) || !(_title && _title.length > 0)
+
+    const title = this.getTitle(_title)
+    const isPopupMenu = isTrue(more_menu) || !title
+
     if (isPopupMenu) {
       icon = icon || (isTrue(more_menu) ? 'more' : 'chevron_down')
     }
@@ -496,7 +499,6 @@ class DropdownInstance extends React.PureComponent {
 
     const { selected_item, direction, opened } = this.context.drawerList
     const showStatus = getStatusState(status)
-    const title = this.getTitle(_title)
 
     // make it possible to grab the rest attributes and return it with all events
     Object.assign(

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -1142,6 +1142,42 @@ describe('Dropdown component', () => {
     ).toBe(title)
   })
 
+  it('should support title as `React.Node`', () => {
+    const TitleAsChildren = ({ children }) => {
+      return <span id="title-as-children">{children}</span>
+    }
+
+    const TitleAsProp = ({ title }) => {
+      return <span id="title-as-prop">{title}</span>
+    }
+
+    const { rerender } = render(
+      <Dropdown
+        data={['A', 'B', 'C']}
+        title={<TitleAsChildren>Title as children</TitleAsChildren>}
+      />
+    )
+
+    expect(
+      document.querySelector('#title-as-children')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-dropdown__text__inner')
+    ).toHaveTextContent('Title as children')
+
+    rerender(
+      <Dropdown
+        data={['A', 'B', 'C']}
+        title={<TitleAsProp title="Title as prop" />}
+      />
+    )
+
+    expect(document.querySelector('#title-as-prop')).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-dropdown__text__inner')
+    ).toHaveTextContent('Title as prop')
+  })
+
   it('should support inline styling', () => {
     render(<Dropdown data={mockData} style={{ color: 'red' }} />)
 


### PR DESCRIPTION
fixes this [issue](https://dnb-it.slack.com/archives/CMXABCHEY/p1747217419048679)