### PR TITLE
chore(Form.useSnapshot): add safeguard when using hook

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useSnapshot.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useSnapshot.tsx
@@ -15,8 +15,8 @@ export default function useSnapshot(id?: SharedStateId) {
   const { getContext } = useDataContext(id)
   const { set: setData, update: updateData } = useData(id)
 
-  const { internalDataRef, snapshotsRef } = getContext()
-  const internalData = internalDataRef.current // Ensure the createSnapshot dependency gets updated
+  const { internalDataRef, snapshotsRef } = getContext() || {}
+  const internalData = internalDataRef?.current // Ensure the createSnapshot dependency gets updated
   const createSnapshot = useCallback(
     (
       id: SnapshotId = makeUniqueId(),


### PR DESCRIPTION
It looks like #5129 did introduce a issue during portal build.

<img width="528" alt="Screenshot 2025-05-15 at 10 56 38" src="https://github.com/user-attachments/assets/a5c29719-1581-457d-b257-97387cf9308e" />
