### PR TITLE
chore(Form.Isolation): errorIsPresent -> uncommitedChangePrevented

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/Examples.tsx
@@ -253,7 +253,7 @@ export const PreventUncommitedChanges = () => {
 
               <Flex.Horizontal>
                 <Form.Isolation.CommitButton />
-                <Form.Isolation.ResetButton showWhen="errorIsPresent" />
+                <Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />
               </Flex.Horizontal>
             </Flex.Stack>
           </Form.Isolation>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
@@ -226,11 +226,11 @@ function MyForm() {
       <Form.Isolation preventUncommitedChanges resetDataAfterCommit>
         <Field.String path="/isolated" />
         <Form.Isolation.CommitButton />
-        <Form.Isolation.ResetButton showWhen="errorIsPresent" />
+        <Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />
       </Form.Isolation>
     </Form.Handler>
   )
 }
 ```
 
-The `showWhen="errorIsPresent"` property ensures that the reset button is displayed only when the "prevent uncommited changes" error is visible. This helps prevent users from resetting the form unnecessarily.
+The `showWhen="uncommitedChangePrevented"` property ensures that the reset button is displayed only when the "prevent uncommited changes" error is visible. This helps prevent users from resetting the form unnecessarily.

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationResetButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationResetButton.tsx
@@ -14,7 +14,7 @@ import IsolationContext from './IsolationContext'
 
 type Props = ButtonProps & {
   showConfirmDialog?: boolean
-  showWhen?: 'errorIsPresent'
+  showWhen?: 'uncommitedChangePrevented'
 }
 
 export default function IsolationResetButton(props: Props) {
@@ -79,7 +79,9 @@ export default function IsolationResetButton(props: Props) {
       ref={buttonWrapperRef}
       className="dnb-no-focus"
       hidden={
-        !(showWhen === 'errorIsPresent' ? Boolean(showCommitStatus) : true)
+        !(showWhen === 'uncommitedChangePrevented'
+          ? Boolean(showCommitStatus)
+          : true)
       }
     >
       {showConfirmDialog ? (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -2824,13 +2824,13 @@ describe('Form.Isolation', () => {
       expect(onCommit).toHaveBeenCalledTimes(1)
     })
 
-    it('should hide and show reset button when showWhen="errorIsPresent" is set', async () => {
+    it('should hide and show reset button when showWhen="uncommitedChangePrevented" is set', async () => {
       render(
         <Form.Handler>
           <Form.Isolation preventUncommitedChanges resetDataAfterCommit>
             <Field.String path="/name" emptyValue="The empty value" />
             <Form.Isolation.CommitButton />
-            <Form.Isolation.ResetButton showWhen="errorIsPresent" />
+            <Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />
           </Form.Isolation>
         </Form.Handler>
       )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/stories/Isolation.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/stories/Isolation.stories.tsx
@@ -192,7 +192,7 @@ export function preventUncommitedChanges() {
 
             <Flex.Horizontal>
               <Form.Isolation.CommitButton />
-              <Form.Isolation.ResetButton showWhen="errorIsPresent" />
+              <Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />
             </Flex.Horizontal>
           </Flex.Stack>
         </Form.Isolation>


### PR DESCRIPTION
My motivation is that when reading the following code:
```
    <Form.Handler>
      <Form.Isolation preventUncommitedChanges resetDataAfterCommit>
        <Field.String path="/isolated" />
        <Form.Isolation.CommitButton />
        <Form.Isolation.ResetButton showWhen="errorIsPresent" />
      </Form.Isolation>
    </Form.Handler>
```

I don't fully understand that there's a relation between`<Form.Isolation.ResetButton showWhen="errorIsPresent" />` and  `<Form.Isolation preventUncommitedChanges>`. Further, I feel like ` <Form.Isolation.ResetButton showWhen="errorIsPresent" />` is very generic. If the reset button should be showed when error is present, why does it not show if the required error is present, but only when the uncommited changes error is displayed?

From:
`<Form.Isolation.ResetButton showWhen="errorIsPresent" />`

To:
`<Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />`

Now looking like:
```
    <Form.Handler>
      <Form.Isolation preventUncommitedChanges resetDataAfterCommit>
        <Field.String path="/isolated" />
        <Form.Isolation.CommitButton />
        <Form.Isolation.ResetButton showWhen="uncommitedChangePrevented" />
      </Form.Isolation>
    </Form.Handler>
```

I'm open to other naming suggestions that could help solve the issues described above.