### PR TITLE
fix(Field.Indeterminate): add support for `required` property

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/Indeterminate.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/Indeterminate.tsx
@@ -41,10 +41,11 @@ export default function Indeterminate(props: Props) {
   )
 
   const value = useMemo(() => {
-    if (typeof valueProp !== 'undefined') {
-      return valueProp
+    if (typeof internalValue !== 'undefined') {
+      return internalValue ? valueOn : valueOff
     }
-    return internalValue ? valueOn : valueOff
+
+    return valueProp
   }, [valueProp, internalValue, valueOn, valueOff])
 
   return (

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
@@ -831,4 +831,88 @@ describe('Indeterminate', () => {
       )
     })
   })
+
+  it('should support required property', async () => {
+    const onSubmit = jest.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.Indeterminate
+          dependencePaths={['/child1', '/child2']}
+          propagateIndeterminateState="auto"
+          valueOn="what-ever"
+          valueOff="you-name-it"
+          path="/parent"
+          required
+        />
+        <Field.Boolean path="/child1" />
+        <Field.Toggle
+          path="/child2"
+          valueOn="custom-on"
+          valueOff="custom-off"
+        />
+      </Form.Handler>
+    )
+
+    const form = document.querySelector('form')
+    const [parent, child1] = Array.from(document.querySelectorAll('input'))
+
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(child1)
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(parent)
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('should change internal required state when indeterminate state changes', async () => {
+    const onSubmit = jest.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.Indeterminate
+          dependencePaths={['/child1', '/child2']}
+          propagateIndeterminateState="auto"
+          valueOn="what-ever"
+          valueOff="you-name-it"
+          path="/parent"
+          required
+        />
+        <Field.Boolean path="/child1" />
+        <Field.Toggle
+          path="/child2"
+          valueOn="custom-on"
+          valueOff="custom-off"
+        />
+      </Form.Handler>
+    )
+
+    const form = document.querySelector('form')
+    const [, child1, child2] = Array.from(
+      document.querySelectorAll('input')
+    )
+
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(child1)
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(child2)
+    fireEvent.submit(form)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Field, Form } from '../../..'
-import { axeComponent } from '../../../../../core/jest/jestSetup'
 
 describe('Indeterminate', () => {
   describe('with propagateIndeterminateState="true"', () => {
@@ -41,7 +40,7 @@ describe('Indeterminate', () => {
           child1: undefined,
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -62,7 +61,7 @@ describe('Indeterminate', () => {
           child1: 'checked',
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -317,7 +316,7 @@ describe('Indeterminate', () => {
           child1: undefined,
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -338,7 +337,7 @@ describe('Indeterminate', () => {
           child1: 'checked',
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -593,7 +592,7 @@ describe('Indeterminate', () => {
           child1: undefined,
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -614,7 +613,7 @@ describe('Indeterminate', () => {
           child1: 'checked',
           child2: undefined,
           child3: undefined,
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -641,7 +640,7 @@ describe('Indeterminate', () => {
           child1: 'checked',
           child2: 'checked',
           child3: 'checked',
-          parent: false,
+          parent: undefined,
         }),
         expect.anything()
       )
@@ -830,101 +829,6 @@ describe('Indeterminate', () => {
         }),
         expect.anything()
       )
-    })
-  })
-
-  describe('ARIA', () => {
-    it('should validate with ARIA rules', async () => {
-      const result = render(
-        <Form.Handler>
-          <Field.Indeterminate
-            label="Indeterminate"
-            dependencePaths={['/child1', '/child2', '/child3']}
-            required
-          />
-
-          <Field.Toggle
-            label="Checkbox 1"
-            path="/child1"
-            valueOn="what-ever"
-            valueOff="you-name-it"
-          />
-
-          <Field.Boolean label="Checkbox 2" path="/child2" />
-
-          <Field.Toggle
-            label="Checkbox 3"
-            path="/child3"
-            valueOn="on"
-            valueOff="off"
-          />
-        </Form.Handler>
-      )
-
-      expect(await axeComponent(result)).toHaveNoViolations()
-    })
-
-    it('should have aria-required', () => {
-      render(
-        <Form.Handler>
-          <Field.Indeterminate
-            label="Indeterminate"
-            dependencePaths={['/child1', '/child2', '/child3']}
-            required
-          />
-
-          <Field.Toggle
-            label="Checkbox 1"
-            path="/child1"
-            valueOn="what-ever"
-            valueOff="you-name-it"
-          />
-
-          <Field.Boolean label="Checkbox 2" path="/child2" />
-
-          <Field.Toggle
-            label="Checkbox 3"
-            path="/child3"
-            valueOn="on"
-            valueOff="off"
-          />
-        </Form.Handler>
-      )
-
-      const input = document.querySelector('input')
-      expect(input).toHaveAttribute('aria-required', 'true')
-    })
-
-    it('should have aria-invalid', () => {
-      render(
-        <Form.Handler>
-          <Field.Indeterminate
-            label="Indeterminate"
-            dependencePaths={['/child1', '/child2', '/child3']}
-            validateInitially
-            required
-          />
-
-          <Field.Toggle
-            label="Checkbox 1"
-            path="/child1"
-            valueOn="what-ever"
-            valueOff="you-name-it"
-          />
-
-          <Field.Boolean label="Checkbox 2" path="/child2" />
-
-          <Field.Toggle
-            label="Checkbox 3"
-            path="/child3"
-            valueOn="on"
-            valueOff="off"
-          />
-        </Form.Handler>
-      )
-
-      const input = document.querySelector('input')
-      expect(input).toHaveAttribute('aria-invalid', 'true')
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/__tests__/Indeterminate.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Field, Form } from '../../..'
+import { axeComponent } from '../../../../../core/jest/jestSetup'
 
 describe('Indeterminate', () => {
   describe('with propagateIndeterminateState="true"', () => {
@@ -829,6 +830,101 @@ describe('Indeterminate', () => {
         }),
         expect.anything()
       )
+    })
+  })
+
+  describe('ARIA', () => {
+    it('should validate with ARIA rules', async () => {
+      const result = render(
+        <Form.Handler>
+          <Field.Indeterminate
+            label="Indeterminate"
+            dependencePaths={['/child1', '/child2', '/child3']}
+            required
+          />
+
+          <Field.Toggle
+            label="Checkbox 1"
+            path="/child1"
+            valueOn="what-ever"
+            valueOff="you-name-it"
+          />
+
+          <Field.Boolean label="Checkbox 2" path="/child2" />
+
+          <Field.Toggle
+            label="Checkbox 3"
+            path="/child3"
+            valueOn="on"
+            valueOff="off"
+          />
+        </Form.Handler>
+      )
+
+      expect(await axeComponent(result)).toHaveNoViolations()
+    })
+
+    it('should have aria-required', () => {
+      render(
+        <Form.Handler>
+          <Field.Indeterminate
+            label="Indeterminate"
+            dependencePaths={['/child1', '/child2', '/child3']}
+            required
+          />
+
+          <Field.Toggle
+            label="Checkbox 1"
+            path="/child1"
+            valueOn="what-ever"
+            valueOff="you-name-it"
+          />
+
+          <Field.Boolean label="Checkbox 2" path="/child2" />
+
+          <Field.Toggle
+            label="Checkbox 3"
+            path="/child3"
+            valueOn="on"
+            valueOff="off"
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveAttribute('aria-required', 'true')
+    })
+
+    it('should have aria-invalid', () => {
+      render(
+        <Form.Handler>
+          <Field.Indeterminate
+            label="Indeterminate"
+            dependencePaths={['/child1', '/child2', '/child3']}
+            validateInitially
+            required
+          />
+
+          <Field.Toggle
+            label="Checkbox 1"
+            path="/child1"
+            valueOn="what-ever"
+            valueOff="you-name-it"
+          />
+
+          <Field.Boolean label="Checkbox 2" path="/child2" />
+
+          <Field.Toggle
+            label="Checkbox 3"
+            path="/child3"
+            valueOn="on"
+            valueOff="off"
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveAttribute('aria-invalid', 'true')
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/stories/Indeterminate.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/stories/Indeterminate.stories.tsx
@@ -36,3 +36,20 @@ export function WithToggle() {
     </Form.Handler>
   )
 }
+
+export function Required() {
+  return (
+    <Form.Handler onSubmit={console.log}>
+      <Form.Card>
+        <Field.Indeterminate
+          dependencePaths={['/checkbox1', '/checkbox2', '/checkbox3']}
+          label="Indeterminate"
+          required
+          validateInitially
+        />
+      </Form.Card>
+
+      <Form.SubmitButton />
+    </Form.Handler>
+  )
+}


### PR DESCRIPTION
Deploy preview: https://eufemia-git-chore-add-axe-tests-to-fields-eufemia.vercel.app/uilib/extensions/forms/base-fields/Indeterminate/demos/