### PR TITLE
chore(Field.Boolean): remove Indeterminate props

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ToggleField, { Props as ToggleFieldProps } from '../Toggle'
 import useTranslation from '../../hooks/useTranslation'
-import { FieldProps, Path } from '../../types'
+import { FieldProps } from '../../types'
 
 type BooleanProps = {
   trueText?: string
@@ -9,22 +9,16 @@ type BooleanProps = {
   variant?: ToggleFieldProps['variant']
   size?: ToggleFieldProps['size']
   onClick?: ToggleFieldProps['onClick']
-  dependencePaths?: never
 }
-type NeverBooleanProps = {
-  // eslint-disable-next-line no-unused-vars
-  [K in keyof Partial<Omit<BooleanProps, 'dependencePaths'>>]: never
-}
+
 type SharedFieldProps = Omit<
   FieldProps<unknown>,
   'layout' | 'layoutOptions'
 >
-export type IndeterminateProps = SharedFieldProps & {
-  dependencePaths: Array<Path>
-} & NeverBooleanProps
+
 export type Props = SharedFieldProps & BooleanProps
 
-function BooleanComponent(props: Props | IndeterminateProps) {
+function BooleanComponent(props: Props) {
   const { trueText, falseText, ...restProps } = props
   const translations = useTranslation().BooleanField
 


### PR DESCRIPTION
Seems like these props was introduced in https://github.com/dnbexperience/eufemia/pull/3513/files#diff-de62b4ab2ab5f16d0a602679528ed1dff658f08f79dcab55310c59b0d70a6abd

I don't fully understand why `Field.Boolean` has to have props related to `Field.Indeterminate`. Hence suggesting to remove it, or at least discuss it 😅 