### PR TITLE
docs(CountryFlag): list available countries

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { CountryFlagProperties } from '@dnb/eufemia/src/components/country-flag/CountryFlagDocs'
-import { AvailableCountriesTable } from '@dnb/eufemia/src/extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
+import { AvailableCountriesTable } from './../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { CountryFlagProperties } from '@dnb/eufemia/src/components/country-flag/CountryFlagDocs'
-import { AvailableCountriesTable } from './../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
+import { AvailableCountriesTable } from 'dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { CountryFlagProperties } from '@dnb/eufemia/src/components/country-flag/CountryFlagDocs'
-import { AvailableCountriesTable } from './../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
+import { AvailableCountriesTable } from './../../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
@@ -4,7 +4,7 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { CountryFlagProperties } from '@dnb/eufemia/src/components/country-flag/CountryFlagDocs'
-import { AvailableCountriesTable } from './../../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
+import { AvailableCountriesTable } from './../../extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/properties.mdx
@@ -4,7 +4,14 @@ showTabs: true
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { CountryFlagProperties } from '@dnb/eufemia/src/components/country-flag/CountryFlagDocs'
+import { AvailableCountriesTable } from '@dnb/eufemia/src/extensions/forms/feature-fields/SelectCountry/assets/AvailableCountriesTable'
 
 ## Properties
 
 <PropertiesTable props={CountryFlagProperties} />
+
+## List of available countries
+
+[Link to the code of the available countries](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/constants/countries.ts#L46).
+
+<AvailableCountriesTable />


### PR DESCRIPTION
When thinking about it, it's sort of misleading as the list of available/supported countries is not actually determined from `import countries from '../../extensions/forms/constants/countries'` but rather all the ISO codes listed here: packages/dnb-eufemia/assets/flags/1x1