### PR TITLE
chore(useTranslation): add typing tests for using an identifier

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -180,8 +180,10 @@ const myTranslations = {
   },
 }
 
+type Translation = (typeof myTranslations)[keyof typeof myTranslations]
+
 const MyComponent = () => {
-  const t = useTranslation<typeof myTranslations>()
+  const t = useTranslation<Translation>()
 
   // Internal translations
   const existingString = t.Dropdown.title
@@ -238,8 +240,7 @@ const myTranslations = {
 }
 
 // Infer the type of the translations
-type MyLocales = keyof typeof myTranslations
-type MyTranslation = (typeof myTranslations)[MyLocales]
+type Translation = (typeof myTranslations)[keyof typeof myTranslations]
 ```
 
 ## How to combine with other tools
@@ -296,6 +297,7 @@ import nb from './nb.json'
 import en from './en.json'
 
 const MyComponent = () => {
+  // Note: no TypeScript support when using an identifier.
   const str = useTranslation('my.string', {
     foo: 'bar',
   })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -266,4 +266,17 @@ describe('Form.useTranslation', () => {
     // @ts-expect-error
     expect(result.current.my.foo).toBeUndefined()
   })
+
+  it('should not support an identifier', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const { result } = renderHook(() => useTranslation('Email.label'))
+
+    const nb = {}
+    extendDeep(nb, forms_nbNO['nb-NO'], global_nbNO['nb-NO'])
+    nb['formatMessage'] = expect.any(Function)
+    nb['renderMessage'] = expect.any(Function)
+
+    expect(result.current).toEqual(expect.objectContaining(nb))
+  })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -573,4 +573,15 @@ describe('useTranslation with an ID', () => {
       ])
     })
   })
+
+  it('should return translation with an identifier', () => {
+    const { result } = renderHook(
+      () => useTranslation('Modal.close_title'),
+      {
+        wrapper: ({ children }) => <Provider>{children}</Provider>,
+      }
+    )
+
+    expect(result.current).toEqual(nbNO['nb-NO'].Modal.close_title)
+  })
 })


### PR DESCRIPTION
This PR adds some tests and enhances the tests with some info about typing.

Thank you @andlbrei 

Motivation: https://github.com/dnbexperience/eufemia/pull/5148#discussion_r2103103453