### PR TITLE
chore: remove beta from Swedish

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ChangeLocale.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeLocale.tsx
@@ -5,7 +5,7 @@ import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const languageDisplayNames = {
   'nb-NO': { label: 'Norsk' },
-  'sv-SE': { label: 'Svenska (beta)', status: 'beta' },
+  'sv-SE': { label: 'Svenska' },
   'en-GB': { label: 'English (GB)' },
   'en-US': { label: 'English (US)' },
 }


### PR DESCRIPTION
Pretty sure we removed all other occurrences of "beta" for Swedish in our docs in a PR not many weeks ago.