### PR TITLE
fix(Accordion): fix Accordion toggle behavior when not used inside an `Accordion.Group`

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -461,7 +461,8 @@ export type GroupProps = AccordionProps & {
 }
 
 const Group = ({
-  expandBehaviour = undefined,
+  // expandBehaviour can be removed in v11
+  expandBehaviour,
   expandBehavior = 'single',
   ...props
 }: GroupProps) => {
@@ -532,6 +533,7 @@ const Group = ({
       onInit={onInit}
       {...props}
       group={group}
+      // expandBehaviour can be removed in v11
       expandBehavior={expandBehaviour || expandBehavior}
       expanded_id={expandedId || props.expanded_id}
     />

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -461,7 +461,7 @@ export type GroupProps = AccordionProps & {
 }
 
 const Group = ({
-  expandBehaviour = 'single',
+  expandBehaviour = undefined,
   expandBehavior = 'single',
   ...props
 }: GroupProps) => {
@@ -532,8 +532,7 @@ const Group = ({
       onInit={onInit}
       {...props}
       group={group}
-      expandBehaviour={expandBehaviour}
-      expandBehavior={expandBehavior}
+      expandBehavior={expandBehaviour || expandBehavior}
       expanded_id={expandedId || props.expanded_id}
     />
   )

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContext.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContext.ts
@@ -11,10 +11,6 @@ import { AccordionGroupProps } from './AccordionGroup'
 export type AccordionContextProps = AccordionProps &
   SkeletonContextProps & {
     allow_close_all?: boolean
-    /**
-     * @deprecated – Replaced with expandBehavior, expandBehaviour can be removed in v11
-     */
-    expandBehaviour: AccordionGroupProps['expandBehaviour']
     expandBehavior: AccordionGroupProps['expandBehavior']
     callOnChange?: (parameters: {
       id: string

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -71,7 +71,6 @@ const AccordionGroup = (props: AccordionGroupProps) => {
     id: _id, // eslint-disable-line
     children, // eslint-disable-line
     collapseAllHandleRef,
-    expandBehaviour,
     expandBehavior,
 
     ...restOfExtendedProps
@@ -113,7 +112,6 @@ const AccordionGroup = (props: AccordionGroupProps) => {
     onChange: onChangeHandler,
     collapseAllHandleRef,
     collapseAccordionCallbacks,
-    expandBehaviour, // Deprecated – expandBehaviour is replaced with expandBehavior - can be removed in v11
     expandBehavior,
   }
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
@@ -17,7 +17,6 @@ type AccordionGroupContextProps = {
   onInit?: (...args: any[]) => any
   collapseAccordionCallbacks?: React.MutableRefObject<(() => void)[]>
   collapseAllHandleRef?: React.MutableRefObject<() => void>
-
   expandBehavior?: AccordionGroupProps['expandBehavior']
 }
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
@@ -17,14 +17,14 @@ type AccordionGroupContextProps = {
   onInit?: (...args: any[]) => any
   collapseAccordionCallbacks?: React.MutableRefObject<(() => void)[]>
   collapseAllHandleRef?: React.MutableRefObject<() => void>
-  /**
-   * @deprecated – Replaced with expandBehavior, expandBehaviour can be removed in v11
-   */
-  expandBehaviour?: AccordionGroupProps['expandBehaviour']
+
   expandBehavior?: AccordionGroupProps['expandBehavior']
 }
 
 const AccordionGroupContext =
-  React.createContext<AccordionGroupContextProps>({})
+  React.createContext<AccordionGroupContextProps>({
+    // Make sure the AccordionStore gets the correct expandBehavior default value when AccordionGroup is not used.
+    expandBehavior: 'single',
+  })
 
 export default AccordionGroupContext

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
@@ -23,7 +23,7 @@ type AccordionGroupContextProps = {
 
 const AccordionGroupContext =
   React.createContext<AccordionGroupContextProps>({
-    // Make sure the AccordionStore gets the correct expandBehavior default value when AccordionGroup is not used.
+    // Make sure the AccordionStore gets the correct `expandBehavior` default value, for when grouped `Accordions` are used outside of an `AccordionGroup`.
     expandBehavior: 'single',
   })
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
@@ -15,11 +15,7 @@ export class AccordionStore {
   }
   onChange({ id }: { id: string }) {
     this._instances.forEach((inst) => {
-      // Deprecated – expandBehaviour is replaced with expandBehavior - can be removed in v11
-      const closeAccordion =
-        inst.context.expandBehaviour === 'single' &&
-        inst.context.expandBehavior === 'single'
-      if (closeAccordion && inst._id !== id) {
+      if (inst.context.expandBehavior === 'single' && inst._id !== id) {
         inst.close()
       }
     })


### PR DESCRIPTION
Fixes [this issue](https://dnb-asa.atlassian.net/jira/software/c/projects/EDS/boards/734?assignee=712020%3A11a274b8-3b2a-4c7f-9968-07cf788ff7dd&selectedIssue=EDS-789) by consolidating the `expandBehaviour` and `expandBehavior` and adding a default value to the `expandBehavior` used in context, for grouped accordions used outside of an `Accordion.Group`

## Testing

[Deploy Preview](https://eufemia-git-fix-accordion-unable-to-collapse-group-bug-eufemia.vercel.app/uilib/components/accordion/#customized-accordion)

[Current Docs](https://eufemia.dnb.no/uilib/components/accordion/#customized-accordion)