### PR TITLE
fix(PaymentCard): export `formatCardNumber` from PaymentCard

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
@@ -11,7 +11,8 @@ Will by default limit the number of characters in the card number to be of 8 cha
 Can be specified by using the `digits` param.
 
 ```js
-import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'
+import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'
+import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card/PaymentCard'
 
 formatCardNumber(cardNumber: string, digits*: number) // returns string
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
@@ -12,7 +12,7 @@ Can be specified by using the `digits` param.
 
 ```js
 import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'
-import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card/PaymentCard'
+// or import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card/PaymentCard'
 
 formatCardNumber(cardNumber: string, digits*: number) // returns string
 

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
@@ -32,6 +32,8 @@ import cardProducts from './utils/cardProducts'
 
 export { Designs, ProductType, CardType, BankAxeptType }
 
+export { formatCardNumber }
+
 const translationDefaultPropsProps = {
   text_blocked: null,
   text_expired: null,


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1748941526894089

[Link to the docs saying how to import](https://eufemia.dnb.no/uilib/extensions/payment-card/helpers/#formatcardnumber):  `import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'`. 
But this is actually never been a valid path or import statement (take a look at this [CSB](https://codesandbox.io/p/devbox/intelligent-bas-sz6n52?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE) from where the [docs was added](https://github.com/dnbexperience/eufemia/pull/2702), it's not working), but should have been either: 
`import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card/PaymentCard'`
or: `import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'`.

So this PR updates the docs for the correct imports, but also adds the export from which we not by purpose removed here https://github.com/dnbexperience/eufemia/pull/5085/files#diff-cd973396bf87032377f68be76ef20ff81ea8a3c68086b9de38bb4f490f49b820L191

[CSB of the problem](https://codesandbox.io/p/devbox/agitated-snowflake-pz5znw?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)
[CSB with the fix `import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card/PaymentCard'`](https://codesandbox.io/p/devbox/damp-snowflake-96k9lz?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)
[CSB with the fix `import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'`](https://codesandbox.io/p/devbox/async-sky-q78trv?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)