### PR TITLE
feat(PaymentCard): deprecate `formatCardNumber` in PaymentCard

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -94,6 +94,7 @@ The `InputPassword` component has been moved to `Field.Password`, and is now a p
 ## PaymentCard
 
 - remove translation `text_card_number` as it's not supported anymore.
+- replace `import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'` with import { formatCardNumber } from `'@dnb/eufemia/extensions/payment-card'`.
 
 ## Hr-line (Divider)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/helpers.mdx
@@ -11,7 +11,7 @@ Will by default limit the number of characters in the card number to be of 8 cha
 Can be specified by using the `digits` param.
 
 ```js
-import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'
+import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'
 
 formatCardNumber(cardNumber: string, digits*: number) // returns string
 

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
@@ -32,6 +32,8 @@ import cardProducts from './utils/cardProducts'
 
 export { Designs, ProductType, CardType, BankAxeptType }
 
+export { formatCardNumber }
+
 const translationDefaultPropsProps = {
   text_blocked: null,
   text_expired: null,

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.js
@@ -32,6 +32,8 @@ import cardProducts from './utils/cardProducts'
 
 export { Designs, ProductType, CardType, BankAxeptType }
 
+// Deprecated – can be removed in v11
+// Replaced with import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'
 export { formatCardNumber }
 
 const translationDefaultPropsProps = {


### PR DESCRIPTION
Builds on top of https://github.com/dnbexperience/eufemia/pull/5227

Reason for deprecating it is because I do think it better fits under `payment-card,` and not `PaymentCard`?

So rather having `import { formatCardNumber } from '@dnb/eufemia/extensions/payment-card'`.
Instead of how it is today: `import { formatCardNumber } from '@dnb/eufemia/extensions/PaymentCard'`