### PR TITLE
fix(Field.Date): required validation with date ranges

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -318,9 +318,9 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
   )
 
   const callOnChangeAsInvalid = useCallback(
-    (state: {
+    (params: {
       endDate?: Date
-      starDate?: Date
+      startDate?: Date
       event: React.ChangeEvent<HTMLInputElement>
     }) => {
       // Should fire if user has filled out an invalid date,
@@ -333,8 +333,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           endDate: derivedEndDate,
           event,
         } = {
-          ...state,
           ...datesFromContext,
+          ...params,
         }
 
         callOnChangeHandler({

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -131,7 +131,6 @@ function DateComponent(props: DateProps) {
           return new FormError('Date.errorRequiredRange')
         }
 
-        return undefined
       }
 
       return !value || !isValid(parseISO(value)) ? error : undefined

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -130,7 +130,6 @@ function DateComponent(props: DateProps) {
         if (!startDate && !endDate) {
           return new FormError('Date.errorRequiredRange')
         }
-
       }
 
       return !value || !isValid(parseISO(value)) ? error : undefined

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -120,13 +120,23 @@ function DateComponent(props: DateProps) {
 
   const validateRequired = useCallback(
     (value: string, { required, error }) => {
-      if (required && (!value || !isValid(parseISO(value)))) {
-        return error
+      if (!required) {
+        return undefined
       }
 
-      return undefined
+      if (props.range) {
+        const [startDate, endDate] = parseRangeValue(value)
+
+        if (!startDate && !endDate) {
+          return new FormError('Date.errorRequiredRange')
+        }
+
+        return undefined
+      }
+
+      return !value || !isValid(parseISO(value)) ? error : undefined
     },
-    []
+    [props.range]
   )
 
   const dateValidator = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -89,6 +89,43 @@ describe('Field.Date', () => {
     expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
   })
 
+  it('should show required warning in range mode', async () => {
+    render(<Field.Date value="2023-12-07|2023-12-14" range required />)
+
+    const datePicker = document.querySelector('.dnb-date-picker')
+    const startDayInput = datePicker.querySelector(
+      '.dnb-date-picker__input--day'
+    )
+    const endDateYear = datePicker.querySelectorAll(
+      '.dnb-date-picker__input--year'
+    )[1]
+
+    expect(datePicker.classList).not.toContain(
+      'dnb-date-picker__status--error'
+    )
+    expect(
+      datePicker.querySelector('.dnb-form-status__text')
+    ).not.toBeInTheDocument()
+
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+
+    await userEvent.type(endDateYear, '{Backspace>16}')
+    await userEvent.click(document.body)
+
+    expect(document.querySelector('.dnb-form-status')).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent(nb.Date.errorRequiredRange)
+
+    await userEvent.type(startDayInput, '0102202304052026')
+
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+  })
+
   it('should support date range', () => {
     const { rerender } = render(
       <Field.Date range value="2024-09-01|2024-09-30" />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -8,6 +8,7 @@ import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
 import FormHandler from '../../../Form/Handler/Handler'
 
+const noDate = nbNO['nb-NO'].Date
 const no = nbNO['nb-NO'].Expiry
 const en = enGB['en-GB'].Expiry
 
@@ -275,7 +276,7 @@ describe('Field.Expiry', () => {
 
       expect(inputWrapper.classList).toContain('dnb-input__status--error')
       expect(formStatusText).toBeInTheDocument()
-      expect(formStatusText).toHaveTextContent('Du må angi en gyldig dato')
+      expect(formStatusText).toHaveTextContent(noDate.errorRequired)
 
       await userEvent.type(input, '12')
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -126,7 +126,7 @@ export default {
     },
     Date: {
       label: 'Date',
-      errorRequired: 'You must provide a valid date.',
+      errorRequired: 'You must enter a date.',
       errorRequiredRange: 'You must enter a date range.',
       errorMinDate: 'Chosen date cannot be before {date}.',
       errorMaxDate: 'Chosen date cannot be after {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -127,6 +127,7 @@ export default {
     Date: {
       label: 'Date',
       errorRequired: 'You must provide a valid date.',
+      errorRequiredRange: 'You must provide a valid date range.',
       errorMinDate: 'Chosen date cannot be before {date}.',
       errorMaxDate: 'Chosen date cannot be after {date}.',
       errorStartDateMinDate: 'Start date cannot be before {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -127,7 +127,7 @@ export default {
     Date: {
       label: 'Date',
       errorRequired: 'You must provide a valid date.',
-      errorRequiredRange: 'You must provide a valid date range.',
+      errorRequiredRange: 'You must enter a date range.',
       errorMinDate: 'Chosen date cannot be before {date}.',
       errorMaxDate: 'Chosen date cannot be after {date}.',
       errorStartDateMinDate: 'Start date cannot be before {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -124,6 +124,7 @@ export default {
     Date: {
       label: 'Dato',
       errorRequired: 'Du må angi en gyldig dato.',
+      errorRequiredRange: 'Du må angi en gyldig datoperiode.',
       errorMinDate: 'Valgt dato kan ikke være før {date}.',
       errorMaxDate: 'Valgt dato kan ikke være etter {date}.',
       errorStartDateMinDate: 'Startdato kan ikke være før {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -124,7 +124,7 @@ export default {
     Date: {
       label: 'Dato',
       errorRequired: 'Du må fylle inn en dato.',
-      errorRequiredRange: 'Du må angi en gyldig datoperiode.',
+      errorRequiredRange: 'Du må fylle inn en datoperiode.',
       errorMinDate: 'Valgt dato kan ikke være før {date}.',
       errorMaxDate: 'Valgt dato kan ikke være etter {date}.',
       errorStartDateMinDate: 'Startdato kan ikke være før {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -123,7 +123,7 @@ export default {
     },
     Date: {
       label: 'Dato',
-      errorRequired: 'Du må angi en gyldig dato.',
+      errorRequired: 'Du må fylle inn en dato.',
       errorRequiredRange: 'Du må angi en gyldig datoperiode.',
       errorMinDate: 'Valgt dato kan ikke være før {date}.',
       errorMaxDate: 'Valgt dato kan ikke være etter {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -125,6 +125,7 @@ export default {
     Date: {
       label: 'Datum',
       errorRequired: 'Du måste ange ett giltigt datum.',
+      errorRequiredRange: 'Du måste ange en giltig datumintervall.',
       errorMinDate: 'Valt datum kan inte vara före {date}.',
       errorMaxDate: 'Valt datum kan inte vara efter {date}.',
       errorStartDateMinDate: 'Startdatum kan inte vara före {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -125,7 +125,7 @@ export default {
     Date: {
       label: 'Datum',
       errorRequired: 'Du måste fylla i en datum.',
-      errorRequiredRange: 'Du måste ange en giltig datumintervall.',
+      errorRequiredRange: 'Du måste fylla i en datumintervall.',
       errorMinDate: 'Valt datum kan inte vara före {date}.',
       errorMaxDate: 'Valt datum kan inte vara efter {date}.',
       errorStartDateMinDate: 'Startdatum kan inte vara före {date}.',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -124,7 +124,7 @@ export default {
     },
     Date: {
       label: 'Datum',
-      errorRequired: 'Du måste ange ett giltigt datum.',
+      errorRequired: 'Du måste fylla i en datum.',
       errorRequiredRange: 'Du måste ange en giltig datumintervall.',
       errorMinDate: 'Valt datum kan inte vara före {date}.',
       errorMaxDate: 'Valt datum kan inte vara efter {date}.',


### PR DESCRIPTION
[Fixes](https://dnb-it.slack.com/archives/CMXABCHEY/p1748958017935249) 🙏

You should now be able to select dates in range mode, without triggering the required error message. An error message for invalid date range will also now trigger of both start date and end date inputs are empty.

## Testing

[Oirginal CSB](https://codesandbox.io/p/devbox/quizzical-ritchie-td7q84?workspaceId=ws_E5ciTFghWDp59nAiN8Yqpd)

[CSB With Fix](https://codesandbox.io/p/sandbox/white-wave-sj4x3c?file=%2Fpackage.json%3A17%2C101)