### PR TITLE
chore: add `Eufemia.versions` support

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -3,6 +3,7 @@
  *
  */
 
+import { execSync } from 'child_process'
 import fs from 'fs-extra'
 import { isCI } from 'repo-utils'
 import getBranchName from 'current-git-branch'
@@ -33,13 +34,20 @@ export async function makeReleaseVersion() {
     }
   }
 
+  const sha = execSync('git rev-parse --short HEAD')?.toString().trim()
+  const replace = (content: string) => {
+    return content
+      .replace(/__SHA__/g, sha)
+      .replace(/__VERSION__/g, version)
+  }
+
   // JS – for handling Eufemia.version
   {
     const file = require.resolve('@dnb/eufemia/src/shared/Eufemia.ts')
     const fileContent = await fs.readFile(file, 'utf-8')
 
     // Update the extracted version of package.json with the build version
-    await fs.writeFile(file, fileContent.replace(/__VERSION__/g, version))
+    await fs.writeFile(file, replace(fileContent))
   }
 
   // CSS – for handling --eufemia-version
@@ -48,7 +56,7 @@ export async function makeReleaseVersion() {
     const fileContent = await fs.readFile(file, 'utf-8')
 
     // Update the extracted version of package.json with the build version
-    await fs.writeFile(file, fileContent.replace(/__VERSION__/g, version))
+    await fs.writeFile(file, replace(fileContent))
   }
 
   log.succeed(`Success on write version to CSS and JS sources: ${version}`)

--- a/packages/dnb-eufemia/src/shared/Eufemia.ts
+++ b/packages/dnb-eufemia/src/shared/Eufemia.ts
@@ -1,10 +1,56 @@
+/**
+ * This file will be transformed by makeReleaseVersion.ts
+ */
+
 export const version = '__VERSION__'
+export const sha = '__SHA__'
+
+declare global {
+  interface Window {
+    Eufemia?: {
+      version?: string
+      versions?: string[]
+      sha?: string
+      shas?: string[]
+    }
+    __eufemiaVersions?: string[]
+    __eufemiaSHAs?: string[]
+  }
+}
 
 export function init() {
   if (typeof window !== 'undefined') {
     class Eufemia {
+      constructor() {
+        if (!window.__eufemiaVersions) {
+          window.__eufemiaVersions = []
+        }
+        if (!window.__eufemiaVersions.includes(this.version)) {
+          window.__eufemiaVersions.push(this.version)
+        }
+
+        if (!window.__eufemiaSHAs) {
+          window.__eufemiaSHAs = []
+        }
+        if (!window.__eufemiaSHAs.includes(this.sha)) {
+          window.__eufemiaSHAs.push(this.sha)
+        }
+      }
+
       get version() {
-        return '__VERSION__'
+        return version
+      }
+
+      get versions(): string[] {
+        return window.__eufemiaVersions
+      }
+
+      get sha() {
+        return sha
+      }
+
+      get shas(): string[] {
+        return window.__eufemiaSHAs
       }
     }
 

--- a/packages/dnb-eufemia/src/shared/__tests__/Eufemia.test.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/Eufemia.test.ts
@@ -1,0 +1,122 @@
+import * as EufemiaImport from '../Eufemia'
+import '../component-helper'
+
+const { version, sha, init } = EufemiaImport
+
+jest.mock('../Eufemia', () => {
+  const actual = jest.requireActual('../Eufemia')
+  return {
+    ...actual,
+    init: jest.fn(actual.init),
+  }
+})
+
+describe('Eufemia', () => {
+  beforeEach(() => {
+    delete window.Eufemia
+    delete window.__eufemiaVersions
+    delete window.__eufemiaSHAs
+  })
+
+  describe('component-helper', () => {
+    it('should call init on component-helper', () => {
+      expect(init).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('version and sha', () => {
+    it('should export version and sha constants', () => {
+      expect(version).toBeDefined()
+      expect(sha).toBeDefined()
+    })
+  })
+
+  describe('init', () => {
+    it('should initialize Eufemia on window object', () => {
+      init()
+      expect(window.Eufemia).toBeDefined()
+    })
+
+    it('should not initialize Eufemia when window is undefined', () => {
+      const originalWindow = global.window
+      delete global.window
+
+      init()
+      expect(global.window).toBeUndefined()
+
+      global.window = originalWindow
+    })
+  })
+
+  describe('Eufemia instance', () => {
+    beforeEach(() => {
+      init()
+    })
+
+    it('should have version getter', () => {
+      expect(window.Eufemia?.version).toBe(version)
+    })
+
+    it('should have sha getter', () => {
+      expect(window.Eufemia?.sha).toBe(sha)
+    })
+
+    it('should initialize versions array on first access', () => {
+      expect(window.__eufemiaVersions).toEqual(['__VERSION__'])
+      const versions = window.Eufemia?.versions
+      expect(versions).toEqual([version])
+      expect(window.__eufemiaVersions).toEqual([version])
+    })
+
+    it('should initialize shas array on first access', () => {
+      expect(window.__eufemiaSHAs).toEqual(['__SHA__'])
+      const shas = window.Eufemia?.shas
+      expect(shas).toEqual([sha])
+      expect(window.__eufemiaSHAs).toEqual([sha])
+    })
+
+    it('should not add duplicate versions', () => {
+      const versions1 = window.Eufemia?.versions
+      const versions2 = window.Eufemia?.versions
+      expect(versions1).toEqual([version])
+      expect(versions2).toEqual([version])
+      expect(window.__eufemiaVersions?.length).toBe(1)
+    })
+
+    it('should not add duplicate shas', () => {
+      const shas1 = window.Eufemia?.shas
+      const shas2 = window.Eufemia?.shas
+      expect(shas1).toEqual([sha])
+      expect(shas2).toEqual([sha])
+      expect(window.__eufemiaSHAs?.length).toBe(1)
+    })
+  })
+
+  describe('Eufemia versions and "shas"', () => {
+    it('should handle multiple different versions', () => {
+      {
+        init()
+        expect(window.__eufemiaVersions).toEqual(['__VERSION__'])
+        window.__eufemiaVersions = ['1.0.0'] // Do this as we are not able to mock the correct value when the class constructor gets called
+      }
+
+      {
+        init()
+        expect(window.__eufemiaVersions).toEqual(['1.0.0', '__VERSION__'])
+      }
+    })
+
+    it('should handle multiple different "shas"', () => {
+      {
+        init()
+        expect(window.__eufemiaSHAs).toEqual(['__SHA__'])
+        window.__eufemiaSHAs = ['abc123'] // Do this as we are not able to mock the correct value when the class constructor gets called
+      }
+
+      {
+        init()
+        expect(window.__eufemiaSHAs).toEqual(['abc123', '__SHA__'])
+      }
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/runCssVersionMismatchWarning.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/runCssVersionMismatchWarning.ts
@@ -1,11 +1,3 @@
-declare global {
-  interface Window {
-    Eufemia?: {
-      version: string
-    }
-  }
-}
-
 export function runCssVersionMismatchWarning() {
   try {
     if (


### PR DESCRIPTION
Also, it should with that be possible to get a short sha. We may document that as a feature if we see that it works.

Here is a test setup: https://stackblitz.com/edit/dsuwq5hy

<img width="208" alt="Screenshot 2025-06-05 at 14 00 40" src="https://github.com/user-attachments/assets/37e8e7db-2f43-468b-80a3-36dfc5b83ca9" />

