### PR TITLE
chore: refactor version handling during build

### DIFF
--- a/packages/dnb-eufemia/.gitignore
+++ b/packages/dnb-eufemia/.gitignore
@@ -17,6 +17,7 @@
 @dnb/eufemia*.tgz
 
 # misc
+BuildInfo.js
 package-lock.json
 completions.json
 *snapshot.json

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -97,8 +97,8 @@ describe('makeReleaseVersion', () => {
     // JS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('src/shared/BuildInfo.cjs'),
-      expect.stringContaining(`exports.version = 'some-branch'`)
+      expect.stringContaining('src/shared/BuildInfo.js'),
+      expect.stringContaining(`some-branch`)
     )
 
     // CSS
@@ -109,7 +109,7 @@ describe('makeReleaseVersion', () => {
     )
   })
 
-  it('write version in Eufemia file', async () => {
+  it('write version in file', async () => {
     jest
       .spyOn(getBranchName, 'default')
       .mockImplementationOnce(() => 'release')
@@ -124,8 +124,8 @@ describe('makeReleaseVersion', () => {
     // JS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('src/shared/BuildInfo.cjs'),
-      expect.stringContaining(`exports.version = '123456789'`)
+      expect.stringContaining('src/shared/BuildInfo.js'),
+      expect.stringContaining(`123456789`)
     )
 
     // CSS
@@ -136,7 +136,7 @@ describe('makeReleaseVersion', () => {
     )
   })
 
-  it('write branch in Eufemia file', async () => {
+  it('write branch in file', async () => {
     jest
       .spyOn(getBranchName, 'default')
       .mockImplementationOnce(() => 'release')
@@ -151,13 +151,8 @@ describe('makeReleaseVersion', () => {
     // JS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('src/shared/BuildInfo.cjs'),
-      expect.stringContaining(`exports.version = 'release'`)
-    )
-    expect(fs.writeFile).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('src/shared/BuildInfo.cjs'),
-      expect.stringContaining(`exports.version = 'release'`)
+      expect.stringContaining('src/shared/BuildInfo.js'),
+      expect.stringContaining(`release`)
     )
 
     // CSS
@@ -168,7 +163,7 @@ describe('makeReleaseVersion', () => {
     )
   })
 
-  it('write sha in Eufemia file', async () => {
+  it('write sha in file', async () => {
     jest
       .spyOn(getBranchName, 'default')
       .mockImplementationOnce(() => 'release')
@@ -183,8 +178,8 @@ describe('makeReleaseVersion', () => {
     // JS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('src/shared/BuildInfo.cjs'),
-      expect.stringContaining(`exports.sha = 'test-sha'`)
+      expect.stringContaining('src/shared/BuildInfo.js'),
+      expect.stringContaining(`test-sha`)
     )
 
     // CSS

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -21,29 +21,29 @@ export async function makeReleaseVersion() {
   }
 
   let version = null
+  let sha = null
 
   if (releaseBranches.includes(branchName)) {
     version = await getNextReleaseVersion()
   }
 
-  if (!version) {
-    if (isCI) {
-      version = branchName
-    } else {
-      version = '__VERSION__'
-    }
+  if (!version && isCI) {
+    version = branchName
   }
 
-  const sha = execSync('git rev-parse --short HEAD')?.toString().trim()
+  if (isCI) {
+    sha = execSync('git rev-parse --short HEAD')?.toString().trim()
+  }
+
   const replace = (content: string) => {
     return content
-      .replace(/__SHA__/g, sha)
-      .replace(/__VERSION__/g, version)
+      .replace(/__SHA__/g, sha || '__SHA__')
+      .replace(/__VERSION__/g, version || '__VERSION__')
   }
 
   // JS – for handling Eufemia.version
   {
-    const file = require.resolve('@dnb/eufemia/src/shared/BuildInfo.cjs')
+    const file = require.resolve('@dnb/eufemia/src/shared/BuildInfo.js')
     const fileContent = await fs.readFile(file, 'utf-8')
 
     // Update the extracted version of package.json with the build version

--- a/packages/dnb-eufemia/src/shared/BuildInfo.cjs
+++ b/packages/dnb-eufemia/src/shared/BuildInfo.cjs
@@ -2,5 +2,21 @@
  * This file will be transformed by makeReleaseVersion.ts
  */
 
-exports.version = '__VERSION__'
-exports.sha = '__SHA__'
+const getInfo = () => {
+  try {
+    delete require.cache[require.resolve('./BuildInfo.js')]
+  } catch (error) {
+    //
+  }
+  return require('./BuildInfo.js')
+}
+
+const getVersion = () => {
+  return getInfo().version
+}
+const getSha = () => {
+  return getInfo().sha
+}
+
+exports.getVersion = getVersion
+exports.getSha = getSha

--- a/packages/dnb-eufemia/src/shared/BuildInfo.js
+++ b/packages/dnb-eufemia/src/shared/BuildInfo.js
@@ -1,0 +1,5 @@
+const version = '__VERSION__'
+const sha = '__SHA__'
+
+exports.version = version
+exports.sha = sha

--- a/packages/dnb-eufemia/src/shared/Eufemia.ts
+++ b/packages/dnb-eufemia/src/shared/Eufemia.ts
@@ -1,7 +1,7 @@
-import * as BuildInfo from './BuildInfo.cjs'
+import { getVersion, getSha } from './BuildInfo.cjs'
 
-export const version = BuildInfo.version
-export const sha = BuildInfo.sha
+export const version = getVersion()
+export const sha = getSha()
 
 declare global {
   interface Window {

--- a/packages/dnb-eufemia/src/shared/__tests__/BuildInfo.test.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/BuildInfo.test.ts
@@ -1,0 +1,15 @@
+import * as BuildInfo from '../BuildInfo.cjs'
+
+describe('BuildInfo', () => {
+  describe('version and sha', () => {
+    it('should export version and sha functions', () => {
+      expect(typeof BuildInfo.getVersion).toBe('function')
+      expect(typeof BuildInfo.getSha).toBe('function')
+    })
+
+    it('should return version and sha from info', () => {
+      expect(BuildInfo.getVersion()).toBe('__VERSION__')
+      expect(BuildInfo.getSha()).toBe('__SHA__')
+    })
+  })
+})


### PR DESCRIPTION
This makes it possible to use the version or sha earlier and during build. Because modules gets cached.

It still works as it should:

<img width="250" alt="Screenshot 2025-06-06 at 17 33 42" src="https://github.com/user-attachments/assets/89b58ace-8a38-4ce9-aa0d-6dd112a5d512" />

