### PR TITLE
fix(DrawerList): add & export DrawerListSize-type

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -73,7 +73,12 @@ export type DrawerListDataArrayItem =
 export type DrawerListDataArray = DrawerListDataArrayItem[]
 export type DrawerListDataRecord = Record<string, DrawerListContent>
 export type DrawerListDataAll = DrawerListDataRecord | DrawerListDataArray
-export type DrawerListSize = 'default' | 'small' | 'medium' | 'large' | number
+export type DrawerListSize =
+  | 'default'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | number
 
 export type DrawerListOptionsRender = ({
   data,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -73,6 +73,7 @@ export type DrawerListDataArrayItem =
 export type DrawerListDataArray = DrawerListDataArrayItem[]
 export type DrawerListDataRecord = Record<string, DrawerListContent>
 export type DrawerListDataAll = DrawerListDataRecord | DrawerListDataArray
+export type DrawerListSize = 'default' | 'small' | 'medium' | 'large' | number
 
 export type DrawerListOptionsRender = ({
   data,
@@ -114,7 +115,7 @@ export interface DrawerListProps {
    * Defines the direction of how the drawer-list shows the options list. Can be 'bottom' or 'top'. Defaults to 'auto'.
    */
   direction?: 'auto' | 'top' | 'bottom'
-  size?: 'default' | 'small' | 'medium' | 'large' | number
+  size?: DrawerListSize
   /**
    * Defines the minimum height (in `rem`) of the options list.
    */


### PR DESCRIPTION
Add & exported `DrawerListSize`-type. This was available before 10.74.0, but removed after for some reason