### PR TITLE
chore(CI): fix failing tests on main

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -104,6 +104,11 @@ describe('babel build', () => {
       'BuildInfo.cjs',
       'BuildInfoData.cjs',
       'dnb-ui-lib.min.mjs',
+      'dnb-ui-basis.min.mjs',
+      'dnb-ui-components.min.mjs',
+      'dnb-ui-elements.min.mjs',
+      'dnb-ui-extensions.min.mjs',
+      'dnb-ui-icons.min.mjs',
     ]
 
     const invalidExtensions = files.filter(


### PR DESCRIPTION
A test that should verify that no files with .mjs or .cjs extensions are used, does fail.
On main we build more packages, so there it failed only on main. This will replaced #5249.