### PR TITLE
docs(Upload): support `children`

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
@@ -6,6 +6,11 @@ export const UploadProperties: PropertiesTableProps = {
     type: ['string', 'Function', 'Object', 'React.Context'],
     status: 'optional',
   },
+  children: {
+    doc: 'Content to display below the `title` and `text`. Can be used to add custom content.',
+    type: ['React.ReactNode'],
+    status: 'optional',
+  },
   acceptedFileTypes: {
     doc: 'List of accepted file types. Either as string or [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype). When providing a list of [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype), the accepted file types will be presented in a table(see [example](/uilib/components/upload/demos/#upload-with-file-max-size-based-on-file-type)).',
     type: ['Array<string>', 'Array<AcceptedFileType>'],

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -43,6 +43,12 @@ describe('Upload', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders custom content using children', () => {
+    render(<Upload {...defaultProps}>My custom content</Upload>)
+
+    expect(screen.getByText('My custom content')).toBeInTheDocument()
+  })
+
   describe('Text', () => {
     it('renders the title', () => {
       render(<Upload {...defaultProps} />)


### PR DESCRIPTION
`Upload` already support `children` prop today, but it's not documented. Hence documenting it.