### PR TITLE
chore(Forms): correct link to bring address api

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/info.mdx
@@ -191,7 +191,7 @@ function MyForm() {
 
 ### Supported countries
 
-The Bring API for Address supports the [following countries](https://developer.bring.com/api/address/#supported-countries), by its country codes:
+The Bring API for Address supports the [following countries](https://developer.bring.com/api/address/), by its country codes:
 
 {address_supportedCountryCodes.join(', ')}
 


### PR DESCRIPTION
Not too important, but the url with `#supported-countries` doesn't exist.