### PR TITLE
chore(Field.Number): fix custom mask docs example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -33,7 +33,7 @@ export const WithCustomMask = () => {
       <Field.Number
         label="Label text"
         defaultValue={1234}
-        mask={Array(4).fill(/\d/)}
+        mask={Array(4).fill(/\\d/)}
         onChange={(value) => console.log('onChange', value)}
       />
     </ComponentBox>


### PR DESCRIPTION
The code box seems to remove the `\` from the regex masks used in the example.

Before: 
<img width="1161" height="358" alt="Screenshot 2025-07-14 at 11 13 50" src="https://github.com/user-attachments/assets/216f2fe6-b27f-4b87-852a-af851c9e6a5b" />

After:
<img width="1170" height="349" alt="Screenshot 2025-07-14 at 11 14 03" src="https://github.com/user-attachments/assets/3dbf80fd-8493-4331-b790-35a57cde3dbd" />
