### PR TITLE
docs(Field.String): add demo example using `TextCounter` together with `maxLength` property

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/Examples.tsx
@@ -6,6 +6,8 @@ import {
   Tools,
   Value,
 } from '@dnb/eufemia/src/extensions/forms'
+import { TextCounter } from '@dnb/eufemia/src/fragments'
+import React from 'react'
 
 export const Placeholder = () => {
   return (
@@ -593,6 +595,31 @@ export const OnInput = () => {
             <Form.SubmitButton />
           </Form.Handler>
         )
+      }}
+    </ComponentBox>
+  )
+}
+
+export const MaximumLengthWithTextCounter = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const MyFieldStringWithTextCounter = () => {
+          const [text, setText] = React.useState('')
+
+          return (
+            <Flex.Vertical gap="x-small">
+              <Field.String
+                label="Label text (maximum 8 characters)"
+                maxLength={8}
+                onChange={setText}
+              />
+              <TextCounter variant="down" text={text} max={8} />
+            </Flex.Vertical>
+          )
+        }
+
+        return <MyFieldStringWithTextCounter />
       }}
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/demos.mdx
@@ -64,6 +64,10 @@ This example demonstrates how the status message width adjusts according to the 
 
 <Examples.ValidateMaximumLengthCustomError />
 
+### Validation - Maximum length with [TextCounter](/uilib/components/fragments/text-counter/)
+
+<Examples.MaximumLengthWithTextCounter />
+
 ### Validation - Pattern
 
 <Examples.ValidatePattern />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
@@ -45,4 +45,4 @@ A demo of how to use the `TextCounter` with `Field.String` can be found [here](/
 
 This way, the user receives visual feedback on the number of characters entered and the maximum allowed, without being limited in their workflow.
 
-You still can still set the requirement of your desired maximum amount of characters by setting the `maxLength` property in Eufemia Forms.
+You can still set the desired maximum number of characters by using the `maxLength` property in Eufemia Forms.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
@@ -39,7 +39,7 @@ The `path` property will be used to set the `name` attribute.
 
 ## Accessibility
 
-Please avoid using the maxlength attribute whenever possible, as it is not accessible. Use [TextCounter](/uilib/components/fragments/text-counter/) together with `Field.String` instead.
+Avoid using the `maxlength` attribute when possible, as it is not accessible. Instead, use [TextCounter](/uilib/components/fragments/text-counter/) together with `Field.String`.
 
 A demo of how to use the `TextCounter` with `Field.String` can be found [here](/uilib/extensions/forms/base-fields/String/#validation---maximum-length-with-textcounter).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
@@ -43,6 +43,6 @@ Please avoid using the maxlength attribute whenever possible, as it is not acces
 
 A demo of how to use the `TextCounter` with `Field.String` can be found [here](/uilib/extensions/forms/base-fields/String/#validation---maximum-length-with-textcounter).
 
-This way the user gets a visual feedback of the number of characters entered and the maximum number of characters allowed. And it will not limit the user in their workflow.
+This way, the user receives visual feedback on the number of characters entered and the maximum allowed, without being limited in their workflow.
 
 You still can still set the requirement of your desired maximum amount of characters by setting the `maxLength` property in Eufemia Forms.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
@@ -36,3 +36,13 @@ The string component does support HTML `autocomplete` [attributes](https://devel
 ```
 
 The `path` property will be used to set the `name` attribute.
+
+## Accessibility
+
+Please avoid using the maxlength attribute whenever possible, as it is not accessible. Use [TextCounter](/uilib/components/fragments/text-counter/) together with `Field.String` instead.
+
+A demo of how to use the `TextCounter` with `Field.String` can be found [here](/uilib/extensions/forms/base-fields/String/#validation---maximum-length-with-textcounter).
+
+This way the user gets a visual feedback of the number of characters entered and the maximum number of characters allowed. And it will not limit the user in their workflow.
+
+You still can still set the requirement of your desired maximum amount of characters by setting the `maxLength` property in Eufemia Forms.


### PR DESCRIPTION
Adds documentation based on the answers in [this thread](https://dnb-it.slack.com/archives/CMXABCHEY/p1753096647186049)