### PR TITLE
fix(Table): allow expanding by chevron when text is selected

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/style/dnb-number-format.scss
+++ b/packages/dnb-eufemia/src/components/number-format/style/dnb-number-format.scss
@@ -49,7 +49,7 @@
 
     opacity: 0;
 
-    user-select: none; // important, so this number not gets copied if only marked/selected
+    user-select: none; // important, so this number does not get copied if only marked/selected
   }
 
   &--selected &__selection {

--- a/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
@@ -146,16 +146,16 @@ export function TableClickableButtonTd(props: {
       : 'medium'
 
   return (
-    <Td className="dnb-table__td__button-icon">
-      <span
-        className="dnb-table__button"
-        onClick={() => {
-          // Empty the selected text, so that the user can always expand/close accordion.
-          // The selected text is not automatically cleared because we have
-          // CSS property `user-select: none` to prevent selection on double-click.
-          emptySelectedText()
-        }}
-      >
+    <Td
+      className="dnb-table__td__button-icon"
+      onClick={() => {
+        // Empty the selected text, so that the user can always expand/close accordion.
+        // The selected text is not automatically cleared because we have
+        // CSS property `user-select: none` to prevent selection on double-click.
+        emptySelectedText()
+      }}
+    >
+      <span className="dnb-table__button">
         <IconPrimary icon={icon} size={iconSize} />
         <Button
           className="dnb-sr-only"

--- a/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 import keycode from '../../shared/keycode'
 import useId from '../../shared/helpers/useId'
-import { hasSelectedText } from '../../shared/helpers'
+import { emptySelectedText, hasSelectedText } from '../../shared/helpers'
 import Button from '../button/Button'
 import IconPrimary from '../icon/IconPrimary'
 import Th from './TableTh'
@@ -147,7 +147,15 @@ export function TableClickableButtonTd(props: {
 
   return (
     <Td className="dnb-table__td__button-icon">
-      <span className="dnb-table__button">
+      <span
+        className="dnb-table__button"
+        onClick={() => {
+          // Empty the selected text, so that the user can always expand/close accordion.
+          // The selected text is not automatically cleared because we have
+          // CSS property `user-select: none` to prevent selection on double-click.
+          emptySelectedText()
+        }}
+      >
         <IconPrimary icon={icon} size={iconSize} />
         <Button
           className="dnb-sr-only"

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
@@ -516,6 +516,43 @@ describe('Table using mode="accordion" prop', () => {
     )
   })
 
+  it('tr should clear selected text on toggle button click', () => {
+    const emptyFn = jest.fn()
+    render(
+      <Table mode="accordion">
+        <tbody>
+          <Tr>
+            <Td>Nothing</Td>
+            <Td.AccordionContent>accordion content</Td.AccordionContent>
+          </Tr>
+        </tbody>
+      </Table>
+    )
+
+    const trElement = document.querySelector('tr')
+    const toggleButtonElem = trElement.querySelector(
+      '.dnb-table__button button'
+    )
+
+    const getSelection = jest.fn(() => ({
+      toString: () => '',
+      empty: emptyFn,
+    })) as jest.Mock
+    jest.spyOn(window, 'getSelection').mockImplementation(getSelection)
+
+    jest
+      .spyOn(document, 'activeElement', 'get')
+      .mockReturnValue(toggleButtonElem)
+
+    fireEvent.click(toggleButtonElem)
+
+    expect(emptyFn).toHaveBeenCalledTimes(1)
+
+    expect(Array.from(trElement.classList)).toContain(
+      'dnb-table__tr--expanded'
+    )
+  })
+
   it('chevron placement class should be set with accordionChevronPlacement', () => {
     const { rerender } = render(
       <Table mode="accordion">

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -266,6 +266,17 @@ export function getSelectedText() {
   return ''
 }
 
+export function emptySelectedText() {
+  try {
+    if (window.getSelection && window.getSelection().empty) {
+      window.getSelection().empty()
+    }
+  } catch (e) {
+    //
+  }
+  return ''
+}
+
 export function hasSelectedText() {
   return getSelectedText().length > 0
 }

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -263,7 +263,6 @@ export function getSelectedText() {
   } catch (e) {
     //
   }
-  return ''
 }
 
 export function emptySelectedText() {
@@ -274,7 +273,6 @@ export function emptySelectedText() {
   } catch (e) {
     //
   }
-  return ''
 }
 
 export function hasSelectedText() {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1753777131358149

By clicking the "button" which is not a button, but just an icon in the most left cell, we should always be able to expand or close the accordion.