### PR TITLE
fix: ensure media queries with `xx-small` max-width do work

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -2,13 +2,6 @@
 @import '../../../../style/core/utilities.scss';
 @import '../../Field/style/field-sizes.scss';
 
-$breakpoints: map.merge(
-  $breakpoints,
-  (
-    'xx-small': 15em,
-  )
-);
-
 fieldset.dnb-forms-field-block {
   @include fieldsetReset();
 }

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -280,6 +280,7 @@
 }
 
 $breakpoints: (
+  'xx-small': 15em /* not documented yet */,
   'x-small': 25em /* not documented yet */,
   'small': 40em,
   'medium': 60em,


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1754467136253299

Before:

<img width="481" height="85" alt="Screenshot 2025-08-07 at 11 31 52" src="https://github.com/user-attachments/assets/ed4abbf9-162f-420c-88aa-55fbab552efa" />

After:

<img width="480" height="119" alt="Screenshot 2025-08-07 at 11 32 35" src="https://github.com/user-attachments/assets/67edb1c8-b442-411f-915e-6ca256823980" />
