### PR TITLE
fix: remove unused CSS reset `input-placeholder`

### DIFF
--- a/packages/dnb-eufemia/src/style/core/reset.scss
+++ b/packages/dnb-eufemia/src/style/core/reset.scss
@@ -334,16 +334,6 @@
   }
 
   /**
-   * Correct the text style of placeholders in Chrome, Edge, and Safari.
-   */
-
-  // stylelint-disable-next-line
-  ::input-placeholder {
-    color: inherit;
-    opacity: 0.54;
-  }
-
-  /**
    * Remove the inner padding in Chrome and Safari on macOS.
    */
 


### PR DESCRIPTION
This PR removes an unused/invalid selector introduced in this [PR](https://github.com/dnbexperience/eufemia/commit/b4ca07c12653294ad8695f33eb4d07c11eb6dd62#diff-a1e4292214065861fccb00c2b14b6649f9c1852fb8ab5f070dd471d9312bd24fL347)

<img width="394" height="209" alt="Screenshot 2025-08-08 at 11 15 12" src="https://github.com/user-attachments/assets/67724249-af01-4519-8207-3f5692ad136d" />

`::input-placeholder` is not a valid selector. But because no body did miss it in two years, I think we can remove it for now.