### PR TITLE
chore(Portal): vertically stretch the home page background

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
@@ -14,7 +14,7 @@
 }
 
 .home-background {
-  height: 100vh;
+  min-height: 100dvh;
   background-color: var(--color-emerald-green);
 }
 


### PR DESCRIPTION
Related to #5367

This fixes a new arising issue on smaller screens by using `min-height` instead of just height:

<img width="1008" height="820" alt="Screenshot 2025-08-08 at 11 23 46" src="https://github.com/user-attachments/assets/609dd88b-f07d-4b82-86f5-5cff501bfa55" />

`dvh` is useful here because on mobile browsers (like Safari or Chrome on iOS/Android) the classic vh unit can be misleading — it includes the space taken up by the browser’s address bar and navigation controls, even when they’re visible.