### PR TITLE
chore(AriaLive): improve additions demo

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live/Examples.tsx
@@ -31,7 +31,10 @@ export const AriaLivePlayground = () => (
         return (
           <Form.Handler id="aria-live-playground">
             <Flex.Stack>
-              <Field.Boolean label="Enabled" path="/enabled" />
+              <Field.Boolean
+                label="Announcement enabled"
+                path="/enabled"
+              />
               <Field.Selection
                 variant="button"
                 optionsLayout="horizontal"
@@ -93,7 +96,7 @@ export const AriaLiveAdditions = () => (
     {() => {
       const defaultData = {
         enabled: false,
-        content: [<P key="one">Line 1</P>],
+        content: ['Line 1'],
       }
 
       function AriaLiveExample() {
@@ -105,7 +108,10 @@ export const AriaLiveAdditions = () => (
         return (
           <Form.Handler id="aria-live-additions">
             <Flex.Stack>
-              <Field.Boolean label="Enabled" path="/enabled" />
+              <Field.Boolean
+                label="Announcement enabled"
+                path="/enabled"
+              />
 
               <FieldBlock label="Content">
                 <Form.ButtonRow>
@@ -117,8 +123,8 @@ export const AriaLiveAdditions = () => (
                     on_click={() => {
                       update('/content', (content) => {
                         const c = content.length + 1
-                        content.push(<P key={c}>Line {c}</P>)
-                        return content
+                        content.push(`Line ${c}`)
+                        return [...content]
                       })
                     }}
                   />
@@ -130,7 +136,7 @@ export const AriaLiveAdditions = () => (
                     on_click={() => {
                       update('/content', (content) => {
                         content.pop()
-                        return content
+                        return [...content]
                       })
                     }}
                   />
@@ -140,7 +146,10 @@ export const AriaLiveAdditions = () => (
               <Flex.Item>
                 Output:{' '}
                 <AriaLive variant="content" disabled={!data.enabled}>
-                  Message: {data.content}
+                  Message:{' '}
+                  {data.content.map((line, i) => {
+                    return <P key={i}>{line}</P>
+                  })}
                 </AriaLive>
               </Flex.Item>
             </Flex.Stack>

--- a/packages/dnb-eufemia/src/components/aria-live/stories/AriaLive.stories.tsx
+++ b/packages/dnb-eufemia/src/components/aria-live/stories/AriaLive.stories.tsx
@@ -90,7 +90,7 @@ export function AriaLiveAdditions() {
   const defaultData = React.useMemo(
     () => ({
       enabled: true,
-      content: [<P key="one">Line 1</P>],
+      content: ['Line 1'],
     }),
     []
   )
@@ -99,7 +99,7 @@ export function AriaLiveAdditions() {
   return (
     <Form.Handler id="aria-live-additions">
       <Flex.Stack>
-        <Field.Boolean label="Enabled" path="/enabled" />
+        <Field.Boolean label="Announcement enabled" path="/enabled" />
 
         <FieldBlock label="Content">
           <Form.ButtonRow>
@@ -111,8 +111,8 @@ export function AriaLiveAdditions() {
               on_click={() => {
                 update('/content', (content) => {
                   const c = content.length + 1
-                  content.push(<P key={c}>Line {c}</P>)
-                  return content
+                  content.push(`Line ${c}`)
+                  return [...content]
                 })
               }}
             />
@@ -124,7 +124,7 @@ export function AriaLiveAdditions() {
               on_click={() => {
                 update('/content', (content) => {
                   content.pop()
-                  return content
+                  return [...content]
                 })
               }}
             />
@@ -138,7 +138,9 @@ export function AriaLiveAdditions() {
             disabled={!data.enabled}
             relevant="all"
           >
-            {data.content}
+            {data.content.map((line, i) => {
+              return <P key={i}>{line}</P>
+            })}
           </AriaLive>
         </Flex.Item>
       </Flex.Stack>


### PR DESCRIPTION
Fixes the broken ["additions demo/example"](https://eufemia.dnb.no/uilib/components/aria-live/demos/#additions):
```
react-dom.production.min.js:106 Uncaught DataCloneError: Failed to execute 'structuredClone' on 'Window': Symbol(react.element) could not be cloned.
    at index.js:20:46
    at useData.tsx:115:12
    at useData.tsx:135:28
    at Object.on_click (eval at si (evalCode.ts:3:7), <anonymous>:22:17)
    at _ (component-helper.ts:249:34)
    at Button.js:86:26
    at Object.Fe (react-dom.production.min.js:54:317)
    at $e (react-dom.production.min.js:54:471)
    at react-dom.production.min.js:55:35
    at Ir (react-dom.production.min.js:105:68)
```
