### PR TITLE
fix(Autocomplete): highlight letters inside words when filter is disabled with `disable_filter`

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -309,7 +309,7 @@ export default class Autocomplete extends React.PureComponent {
     align_autocomplete: null,
     options_render: null,
     data: null,
-    search_in_word_index: 3,
+    search_in_word_index: null,
     search_numbers: null,
     default_value: null,
     value: 'initval',
@@ -1323,7 +1323,9 @@ class AutocompleteInstance extends React.PureComponent {
       data = null, // rawData
       searchIndex = this.state.searchIndex,
       searchNumbers = isTrue(this.props.search_numbers),
-      inWordIndex = (parseFloat(this.props.search_in_word_index) || 3) - 2,
+      inWordIndex = parseFloat(
+        this.props.search_in_word_index ?? (this.skipFilter ? 1 : 3)
+      ) - 1,
       disableHighlighting = false,
       skipFilter = false,
       skipReorder = false,
@@ -1367,7 +1369,7 @@ class AutocompleteInstance extends React.PureComponent {
 
           // if the uses reached word 3, then we go inside words as well
           const regexWord = new RegExp(
-            wordIndex > inWordIndex ? `${word}` : `(${wordCond})${word}`,
+            wordIndex >= inWordIndex ? `${word}` : `(${wordCond})${word}`,
             'i'
           )
 
@@ -1483,7 +1485,7 @@ class AutocompleteInstance extends React.PureComponent {
                   }
                 })
               } else {
-                if (wordIndex > inWordIndex) {
+                if (wordIndex >= inWordIndex) {
                   segment = segment.replace(
                     new RegExp(`(${word})`, 'gi'),
                     `${strS}$1${strE}`

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -881,26 +881,72 @@ describe('Autocomplete component', () => {
     expect(elem.getAttribute('aria-selected')).toBe('true')
   })
 
-  it('has correct options after filter if filter is disabled', () => {
-    render(
-      <Autocomplete
-        disable_filter
-        data={mockData}
-        show_submit_button
-        {...mockProps}
-      />
-    )
+  describe('disable_filter', () => {
+    it('has correct options after filter if filter is disabled', () => {
+      render(
+        <Autocomplete
+          disable_filter
+          data={mockData}
+          show_submit_button
+          {...mockProps}
+        />
+      )
 
-    toggle()
+      toggle()
 
-    fireEvent.change(document.querySelector('.dnb-input__input'), {
-      target: { value: 'aa' },
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aa' },
+      })
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        ).length
+      ).toBe(3)
     })
-    expect(
-      document.querySelectorAll(
-        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
-      ).length
-    ).toBe(3)
+
+    it('should still highlight when disabled', () => {
+      render(
+        <Autocomplete
+          disable_filter
+          data={mockData}
+          show_submit_button
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'c' },
+      })
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        ).length
+      ).toBe(3)
+
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        )[0].innerHTML
+      ).toBe(
+        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>AA <span class="dnb-drawer-list__option__item--highlight">c</span></span></span></span>'
+      )
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        )[1].innerHTML
+      ).toBe(
+        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>BB <span class="dnb-drawer-list__option__item--highlight">cc</span> zethx</span></span></span>'
+      )
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        )[2].innerHTML
+      ).toBe(
+        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item item-nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item item-nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
+      )
+    })
   })
 
   it('has correct "aria-expanded"', () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1684241747908289?thread_ts=1684227771.026529&cid=CMXABCHEY

After:
<img width="325" height="307" alt="Screenshot 2025-08-13 at 11 34 20" src="https://github.com/user-attachments/assets/6e77b364-1e42-4f58-bf4a-bbc91bebed66" />

Before:
<img width="456" height="455" alt="Screenshot 2025-08-13 at 11 36 37" src="https://github.com/user-attachments/assets/e76ec560-858c-471a-a347-1aaed6646323" />

