### PR TITLE
chore: remove non-visible label in example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -55,10 +55,7 @@ export const ValueComposition = () => {
             },
           ]}
         >
-          <Value.String
-            label={<Value.String itemPath="/label" />}
-            itemPath="/value"
-          />
+          <Value.String itemPath="/value" />
         </Iterate.Array>
       </Value.Composition>
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -46,11 +46,9 @@ export const ValueComposition = () => {
         <Iterate.Array
           defaultValue={[
             {
-              label: 'Label A',
               value: 'value 1',
             },
             {
-              label: 'Label B',
               value: 'value 2',
             },
           ]}


### PR DESCRIPTION
Suggesting to remove this, as it doesn't work to provide a `Value` to a `label` of a `Value` or `Field`:

`label={<Value.String itemPath="/label" />}`

Or should it actually work?

```
          <Value.String
            label={<Value.String itemPath="/label" />}
            itemPath="/value"
          />
```

I see that the reporter expects it to work in https://github.com/dnbexperience/eufemia/issues/4194

The example can be viewed/demoed here: https://eufemia.dnb.no/uilib/extensions/forms/Iterate/Array/#value-composition