### PR TITLE
fix(Forms): ensure labels from `Value.*` components can be served from a `Value.*` component itself

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -99,14 +99,19 @@ function ValueBlock(localProps: Props) {
 
     let label = labelProp
 
-    if (iterateIndex !== undefined) {
+    const canRenderToString = React.isValidElement(labelProp)
+      ? typeof labelProp.type === 'string' // Not just a span or div
+      : true
+    if (iterateIndex !== undefined && canRenderToString) {
       label = convertJsxToString(labelProp).replace(
         '{itemNo}',
         String(iterateIndex + 1)
       )
     }
 
-    return transformLabel(label, transformLabelParameters)
+    return canRenderToString
+      ? transformLabel(label, transformLabelParameters)
+      : label
   }, [inline, iterateIndex, labelProp, transformLabel])
 
   const hide =

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../core/jest/jestSetup'
 import { render, fireEvent } from '@testing-library/react'
 import ValueBlock from '../ValueBlock'
-import { Form, Iterate, Value } from '../..'
+import { Field, Form, Iterate, Value } from '../..'
 import userEvent from '@testing-library/user-event'
 
 describe('ValueBlock', () => {
@@ -672,6 +672,45 @@ describe('ValueBlock', () => {
     expect(
       document.querySelector('.dnb-forms-value-block')
     ).toHaveTextContent('The label')
+  })
+
+  describe('inheritLabel', () => {
+    it('renders label from field with same path', () => {
+      render(
+        <Form.Handler
+          data={{
+            myPath: 'A value',
+          }}
+        >
+          <Field.String path="/myPath" label="The label" />
+          <Value.String path="/myPath" inheritLabel />
+        </Form.Handler>
+      )
+      expect(
+        document.querySelector('.dnb-forms-field-string')
+      ).toHaveTextContent('The label')
+      expect(
+        document.querySelector('.dnb-forms-value-string')
+      ).toHaveTextContent('The label')
+    })
+
+    it('renders label from field with same path given as a ValueBlock', () => {
+      render(
+        <Form.Handler data={{ label: 'The label' }}>
+          <Field.String
+            path="/myPath"
+            label={<Value.String path="/label" />}
+          />
+          <Value.String path="/myPath" inheritLabel />
+        </Form.Handler>
+      )
+      expect(
+        document.querySelector('.dnb-forms-field-string')
+      ).toHaveTextContent('The label')
+      expect(
+        document.querySelector('.dnb-forms-value-string')
+      ).toHaveTextContent('The label')
+    })
   })
 
   describe('help', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { axeComponent } from '../../../../core/jest/jestSetup'
 import { render, fireEvent } from '@testing-library/react'
 import ValueBlock from '../ValueBlock'
-import { Form, Value } from '../..'
+import { Form, Iterate, Value } from '../..'
 import userEvent from '@testing-library/user-event'
 
 describe('ValueBlock', () => {
@@ -240,6 +240,113 @@ describe('ValueBlock', () => {
       expect(
         document.querySelector('.dnb-forms-value-block__label strong')
       ).toBeInTheDocument()
+    })
+
+    it('renders Composition value from Iterate.Array', () => {
+      render(
+        <Value.Composition>
+          <Iterate.Array
+            defaultValue={[
+              {
+                value: 'value 1',
+              },
+              {
+                value: 'value 2',
+              },
+            ]}
+          >
+            <Value.String label="Label {itemNo}" itemPath="/value" />
+          </Iterate.Array>
+        </Value.Composition>
+      )
+
+      expect(
+        document.querySelectorAll(
+          '.dnb-forms-value-block__composition--horizontal'
+        )
+      ).toHaveLength(1)
+      expect(
+        document.querySelectorAll(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block'
+        )
+      ).toHaveLength(2)
+
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block > .dnb-forms-value-block__label'
+        )
+      ).toHaveTextContent('Label 1')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block > .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('value 1')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block:last-child > .dnb-forms-value-block__label'
+        )
+      ).toHaveTextContent('Label 2')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block:last-child > .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('value 2')
+    })
+
+    it('renders label given as a ValueBlock', () => {
+      render(
+        <Value.Composition>
+          <Iterate.Array
+            defaultValue={[
+              {
+                label: 'Label A',
+                value: 'value 1',
+              },
+              {
+                label: 'Label B',
+                value: 'value 2',
+              },
+            ]}
+          >
+            <Value.String
+              label={<Value.String itemPath="/label" />}
+              itemPath="/value"
+            />
+          </Iterate.Array>
+        </Value.Composition>
+      )
+
+      expect(
+        document.querySelectorAll(
+          '.dnb-forms-value-block__composition--horizontal'
+        )
+      ).toHaveLength(1)
+      expect(
+        document.querySelectorAll(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block'
+        )
+      ).toHaveLength(2)
+
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block > .dnb-forms-value-block__label'
+        )
+      ).toHaveTextContent('Label A')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block > .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('value 1')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block:last-child > .dnb-forms-value-block__label'
+        )
+      ).toHaveTextContent('Label B')
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-block__content > .dnb-forms-value-block:last-child > .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('value 2')
     })
 
     describe('with Visibility', () => {
@@ -536,6 +643,35 @@ describe('ValueBlock', () => {
         expect.anything()
       )
     })
+
+    it('should not transform a label when label is given as a ValueBlock', () => {
+      const transformLabel = jest.fn((label) => label.toUpperCase())
+      render(
+        <Form.Handler data={{ label: 'The label' }}>
+          <Value.String
+            label={<Value.String path="/label" />}
+            transformLabel={transformLabel}
+            showEmpty
+          />
+        </Form.Handler>
+      )
+
+      expect(
+        document.querySelector('.dnb-forms-value-block')
+      ).toHaveTextContent('The label')
+    })
+  })
+
+  it('should allow a label to be served from a ValueBlock', () => {
+    render(
+      <Form.Handler data={{ label: 'The label' }}>
+        <Value.String label={<Value.String path="/label" />} showEmpty />
+      </Form.Handler>
+    )
+
+    expect(
+      document.querySelector('.dnb-forms-value-block')
+    ).toHaveTextContent('The label')
   })
 
   describe('help', () => {


### PR DESCRIPTION
In regards to #4194 and [this comment](https://github.com/dnbexperience/eufemia/issues/4194#issuecomment-3188760960).