### PR TITLE
docs(Avatar): remove `size="auto"`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
@@ -80,7 +80,7 @@ See more examples below.
 
 #### Auto-size
 
-An icon will automatically be given the correct size (`size="auto"`) unless the icon's `size` prop is set.
+An icon will automatically be given the correct size unless the icon's `size` prop is set.
 
 <AvatarIconSize />
 


### PR DESCRIPTION
Motivation:
After I read the docs, I expected the following two Avatar's to be of the same size, but they are not:
```
<Avatar icon={Bank} size="auto" />
<Avatar icon={Bank} />
```

There's also not documented that `auto` is a valid value for [the size property](https://eufemia.dnb.no/uilib/components/avatar/properties/).