### PR TITLE
fix(Input): ensure error, focus, and hover states work with autofilled content

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Autocomplete scss has to match style dependencies css 1`] = `
 "/*
@@ -1029,6 +1029,13 @@ button .dnb-form-status__text {
   --b-width: var(--input-border-width--hover);
   --b-inset: var(--input-border-inset--hover);
 }
+.dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color);
+  --b-inset: var(--input-border-inset--active);
+}
+.dnb-input__status--error .dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color__error);
+}
 .dnb-input__status--error .dnb-input__border {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error);
@@ -1039,7 +1046,7 @@ button .dnb-form-status__text {
   --b-inset: var(--input-border-inset--active);
   --b-radius: var(--input-border-radius--active);
 }
-.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border.hover {
+.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border:hover:has(.dnb-input__input:autofill), .dnb-input__status--error .dnb-input__border.hover {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error--hover);
   --b-inset: var(--input-border-inset--hover);
@@ -1093,7 +1100,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   font-family: var(--font-family-monospace);
 }
 .dnb-input__input:autofill {
-  box-shadow: 0 0 0 var(--input-border-width) var(--input-border-color) var(--autofill-inset, inset), 0 0 0 10em var(--input-background-color) inset;
+  box-shadow: 0 0 0 10em var(--input-background-color) inset;
 }
 .dnb-input__suffix {
   color: inherit;

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1317,9 +1317,6 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 html[data-visual-test] .dnb-input__input {
   caret-color: var(--color-white);
 }
-.dnb-input[data-has-content=false] .dnb-input__input:focus:autofill {
-  --autofill-inset: none;
-}
 .dnb-input[data-input-state=focus] .dnb-input__placeholder {
   display: none;
 }

--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
@@ -1004,7 +1004,7 @@ describe('DateFormat', () => {
       // The output depends on the current date and locale, so we'll check for a relative time pattern
       // This should match patterns like "in X days", "for X uker siden", "om X dager", etc.
       expect(dateFormat.textContent).toMatch(
-        /^(?:in |for |om )?\d+ (?:days?|dager?|uker?|weeks?|months?|years?)(?:\s+(?:siden|ago))?$/
+        /^(?:in |for |om )?\d+ (?:days?|dager?|dag|uker?|uke|weeks?|months?|måned(er)?|years?|år)(?:\s+(?:siden|ago))?$/
       )
     })
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1029,6 +1029,13 @@ button .dnb-form-status__text {
   --b-width: var(--input-border-width--hover);
   --b-inset: var(--input-border-inset--hover);
 }
+.dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color);
+  --b-inset: var(--input-border-inset--active);
+}
+.dnb-input__status--error .dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color__error);
+}
 .dnb-input__status--error .dnb-input__border {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error);
@@ -1039,7 +1046,7 @@ button .dnb-form-status__text {
   --b-inset: var(--input-border-inset--active);
   --b-radius: var(--input-border-radius--active);
 }
-.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border.hover {
+.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border:hover:has(.dnb-input__input:autofill), .dnb-input__status--error .dnb-input__border.hover {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error--hover);
   --b-inset: var(--input-border-inset--hover);
@@ -1093,7 +1100,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   font-family: var(--font-family-monospace);
 }
 .dnb-input__input:autofill {
-  box-shadow: 0 0 0 var(--input-border-width) var(--input-border-color) var(--autofill-inset, inset), 0 0 0 10em var(--input-background-color) inset;
+  box-shadow: 0 0 0 10em var(--input-background-color) inset;
 }
 .dnb-input__suffix {
   color: inherit;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1317,9 +1317,6 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 html[data-visual-test] .dnb-input__input {
   caret-color: var(--color-white);
 }
-.dnb-input[data-has-content=false] .dnb-input__input:focus:autofill {
-  --autofill-inset: none;
-}
 .dnb-input[data-input-state=focus] .dnb-input__placeholder {
   display: none;
 }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1317,9 +1317,6 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 html[data-visual-test] .dnb-input__input {
   caret-color: var(--color-white);
 }
-.dnb-input[data-has-content=false] .dnb-input__input:focus:autofill {
-  --autofill-inset: none;
-}
 .dnb-input[data-input-state=focus] .dnb-input__placeholder {
   display: none;
 }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`InputMasked scss has to match style dependencies css 1`] = `
 "/*
@@ -1029,6 +1029,13 @@ button .dnb-form-status__text {
   --b-width: var(--input-border-width--hover);
   --b-inset: var(--input-border-inset--hover);
 }
+.dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color);
+  --b-inset: var(--input-border-inset--active);
+}
+.dnb-input__status--error .dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color__error);
+}
 .dnb-input__status--error .dnb-input__border {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error);
@@ -1039,7 +1046,7 @@ button .dnb-form-status__text {
   --b-inset: var(--input-border-inset--active);
   --b-radius: var(--input-border-radius--active);
 }
-.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border.hover {
+.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border:hover:has(.dnb-input__input:autofill), .dnb-input__status--error .dnb-input__border.hover {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error--hover);
   --b-inset: var(--input-border-inset--hover);
@@ -1093,7 +1100,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   font-family: var(--font-family-monospace);
 }
 .dnb-input__input:autofill {
-  box-shadow: 0 0 0 var(--input-border-width) var(--input-border-color) var(--autofill-inset, inset), 0 0 0 10em var(--input-background-color) inset;
+  box-shadow: 0 0 0 10em var(--input-background-color) inset;
 }
 .dnb-input__suffix {
   color: inherit;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Input scss has to match style dependencies css 1`] = `
 "/*
@@ -1022,6 +1022,13 @@ button .dnb-form-status__text {
   --b-width: var(--input-border-width--hover);
   --b-inset: var(--input-border-inset--hover);
 }
+.dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color);
+  --b-inset: var(--input-border-inset--active);
+}
+.dnb-input__status--error .dnb-input__border:has(.dnb-input__input:autofill) {
+  --b-color: var(--input-border-color__error);
+}
 .dnb-input__status--error .dnb-input__border {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error);
@@ -1032,7 +1039,7 @@ button .dnb-form-status__text {
   --b-inset: var(--input-border-inset--active);
   --b-radius: var(--input-border-radius--active);
 }
-.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border.hover {
+.dnb-input__status--error .dnb-input__border:hover, .dnb-input__status--error .dnb-input__border:hover:has(.dnb-input__input:autofill), .dnb-input__status--error .dnb-input__border.hover {
   --b-color: var(--input-border-color__error);
   --b-width: var(--input-border-width__error--hover);
   --b-inset: var(--input-border-inset--hover);
@@ -1086,7 +1093,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   font-family: var(--font-family-monospace);
 }
 .dnb-input__input:autofill {
-  box-shadow: 0 0 0 var(--input-border-width) var(--input-border-color) var(--autofill-inset, inset), 0 0 0 10em var(--input-background-color) inset;
+  box-shadow: 0 0 0 10em var(--input-background-color) inset;
 }
 .dnb-input__suffix {
   color: inherit;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1310,9 +1310,6 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 html[data-visual-test] .dnb-input__input {
   caret-color: var(--color-white);
 }
-.dnb-input[data-has-content=false] .dnb-input__input:focus:autofill {
-  --autofill-inset: none;
-}
 .dnb-input[data-input-state=focus] .dnb-input__placeholder {
   display: none;
 }

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -535,10 +535,6 @@
     caret-color: var(--color-white);
   }
 
-  &[data-has-content='false'] &__input:focus:autofill {
-    --autofill-inset: none;
-  }
-
   &[data-input-state='focus'] &__placeholder {
     display: none;
   }

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -141,6 +141,15 @@
     --b-width: var(--input-border-width--hover);
     --b-inset: var(--input-border-inset--hover);
   }
+
+  &__border:has(#{&}__input:autofill) {
+    --b-color: var(--input-border-color);
+    --b-inset: var(--input-border-inset--active);
+  }
+  &__status--error &__border:has(#{&}__input:autofill) {
+    --b-color: var(--input-border-color__error);
+  }
+
   &__status--error &__border {
     --b-color: var(--input-border-color__error);
     --b-width: var(--input-border-width__error);
@@ -152,6 +161,7 @@
     --b-radius: var(--input-border-radius--active);
   }
   &__status--error &__border:hover,
+  &__status--error &__border:hover:has(#{&}__input:autofill),
   &__status--error &__border.hover {
     --b-color: var(--input-border-color__error);
     --b-width: var(--input-border-width__error--hover);
@@ -227,13 +237,12 @@
     font-family: var(--font-family-monospace);
   }
 
-  // change the autocomplete appearance once filled out
+  // Set the background color to the default background color.
+  // Some browsers change the background color so users can see the difference between "autofill" and "user input".
+  // Which can be a bit jarring in DNBs design. We may consider to change this to a custom color in the future.
+  // NB: There are more than this ":autofill" in the theme file.
   &__input:autofill {
-    // set the border and the background
-    box-shadow:
-      0 0 0 var(--input-border-width) var(--input-border-color)
-        var(--autofill-inset, inset),
-      0 0 0 10em var(--input-background-color) inset;
+    box-shadow: 0 0 0 10em var(--input-background-color) inset;
   }
 
   &__suffix {

--- a/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
@@ -131,9 +131,10 @@
     }
   }
 
-  // change the autocomplete appearance once filled out
+  // Set the background color to the default background color.
+  // Some browsers change the background color so users can see the difference between "autofill" and "user input".
+  // Which can be a bit jarring in DNBs design. We may consider to change this to a custom color in the future.
   &__input:autofill {
-    // set the border and the background
     box-shadow:
       0 0 0 var(--border-width) var(--border-color),
       0 0 0 10em var(--textarea-background-color) inset;


### PR DESCRIPTION
Fixes #5217

I also tried adding a visual test for these styles. There is a way to do this via Chromium and its DevTools, but it would require a significant refactoring.
Another option would be to use a "simulation" class, but I think this approach is too fragile from a maintenance perspective and could negatively impact CSS specificity in certain cases. 