### PR TITLE
fix(Tooltip): remove click event to make screen reader not read out "clickable"

### DIFF
--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -90,11 +90,9 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   const addEvents = (element: HTMLElement) => {
     try {
-      element.addEventListener('click', onMouseLeave)
       element.addEventListener('focus', onFocus)
       element.addEventListener('blur', onMouseLeave)
       element.addEventListener('mouseenter', onMouseEnter)
-      element.addEventListener('mousedown', onMouseEnter)
       element.addEventListener('mouseleave', onMouseLeave)
       element.addEventListener('touchstart', onMouseEnter)
       element.addEventListener('touchend', onMouseLeave)
@@ -106,7 +104,6 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
   const removeEvents = (element: HTMLElement) => {
     if (!element) return
     try {
-      element.removeEventListener('click', onMouseLeave)
       element.removeEventListener('focus', onFocus)
       element.removeEventListener('blur', onMouseLeave)
       element.removeEventListener('mouseenter', onMouseEnter)

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -351,6 +351,45 @@ describe('Tooltip', () => {
       )
     })
 
+    it('should not register click or mousedown on the target', () => {
+      const originalAdd = HTMLElement.prototype.addEventListener
+      const calls: Array<{
+        self: EventTarget
+        type: string
+      }> = []
+
+      const spy = jest
+        .spyOn(HTMLElement.prototype as any, 'addEventListener')
+        .mockImplementation(function (
+          this: EventTarget,
+          type: string,
+          listener: any,
+          options?: any
+        ) {
+          calls.push({ self: this, type })
+          return originalAdd.call(
+            this as any,
+            type,
+            listener,
+            options as any
+          )
+        })
+
+      try {
+        render(<Tooltip />)
+
+        const button = document.querySelector('button')
+        const targetCalls = calls.filter((c) => c.self === button)
+        const hasClickOrMouseDown = targetCalls.some(
+          (c) => c.type === 'click' || c.type === 'mousedown'
+        )
+
+        expect(hasClickOrMouseDown).toBe(false)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
     it('should validate with ARIA rules as a tooltip', async () => {
       const Component = render(<Tooltip active />)
       expect(await axeComponent(Component)).toHaveNoViolations()


### PR DESCRIPTION
I'm not 100% sure why we have had these events. Also, no tests are failing when removing it. The most important once for such as hover, touchstart and focus we have tests. So I think its fine for now.

Here are the PR docs in case of a need: https://aa466ee5.eufemia-e25.pages.dev/uilib/components/tooltip/