### PR TITLE
fix(DrawerList): swap aria-selected and aria-current

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -455,7 +455,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
     )
 
     // First result direction
@@ -475,7 +475,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
     )
 
     // With three matches, we prioritize the second one to be on the first place
@@ -671,7 +671,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">2223</span> <span class="dnb-drawer-list__option__item--highlight">33</span> <span class="dnb-drawer-list__option__item--highlight">4442</span>5</span></span></span></li>`
+      /* html */ `<li class="first-of-type dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">2223</span> <span class="dnb-drawer-list__option__item--highlight">33</span> <span class="dnb-drawer-list__option__item--highlight">4442</span>5</span></span></span></li>`
     )
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
@@ -864,12 +864,12 @@ describe('Autocomplete component', () => {
     expect(
       document
         .querySelectorAll('li.dnb-drawer-list__option')[1]
-        .getAttribute('aria-selected')
+        .getAttribute('aria-current')
     ).toBe('true')
 
     let elem = optionElements()[1]
     expect(elem.textContent).toBe(mockData[1])
-    expect(elem.getAttribute('aria-selected')).toBe('true')
+    expect(elem.getAttribute('aria-current')).toBe('true')
 
     // remove selection and reset the order and open again
     // aria-selected should now be on place 1
@@ -878,7 +878,7 @@ describe('Autocomplete component', () => {
 
     elem = optionElements()[1]
     expect(elem.textContent).toBe(mockData[1])
-    expect(elem.getAttribute('aria-selected')).toBe('true')
+    expect(elem.getAttribute('aria-current')).toBe('true')
   })
 
   describe('disable_filter', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -1204,6 +1204,9 @@ describe('variants', () => {
         expect(options.length).toEqual(2)
         expect(options[0].getAttribute('aria-selected')).toBe('false')
         expect(options[1].getAttribute('aria-selected')).toBe('false')
+
+        expect(options[0].getAttribute('aria-current')).toBe(null)
+        expect(options[1].getAttribute('aria-current')).toBe(null)
       })
     })
 
@@ -1295,6 +1298,9 @@ describe('variants', () => {
       expect(options.length).toEqual(2)
       expect(options[0].getAttribute('aria-selected')).toBe('false')
       expect(options[1].getAttribute('aria-selected')).toBe('true')
+
+      expect(options[0].getAttribute('aria-current')).toBe(null)
+      expect(options[1].getAttribute('aria-current')).toBe('true')
     })
 
     it('renders update selected option based on external value change', async () => {
@@ -1318,6 +1324,9 @@ describe('variants', () => {
       expect(options.length).toEqual(2)
       expect(options[0].getAttribute('aria-selected')).toBe('true')
       expect(options[1].getAttribute('aria-selected')).toBe('false')
+
+      expect(options[0].getAttribute('aria-current')).toBe('true')
+      expect(options[1].getAttribute('aria-current')).toBe(null)
     })
 
     it('renders only options with a value', async () => {
@@ -1401,6 +1410,9 @@ describe('variants', () => {
 
       expect(option1).toHaveAttribute('aria-selected', 'true')
       expect(option2).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).toHaveAttribute('aria-current', 'true')
+      expect(option2).not.toHaveAttribute('aria-current')
     })
 
     it('should support selected value from "path"', async () => {
@@ -1442,6 +1454,9 @@ describe('variants', () => {
 
       expect(option1).toHaveAttribute('aria-selected', 'true')
       expect(option2).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).toHaveAttribute('aria-current', 'true')
+      expect(option2).not.toHaveAttribute('aria-current')
     })
 
     it('should support "dataPath"', async () => {
@@ -1483,6 +1498,10 @@ describe('variants', () => {
       expect(option1).toHaveAttribute('aria-selected', 'false')
       expect(option2).toHaveAttribute('aria-selected', 'false')
       expect(option3).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).not.toHaveAttribute('aria-current')
+      expect(option2).not.toHaveAttribute('aria-current')
+      expect(option3).not.toHaveAttribute('aria-current')
     })
 
     it('should store "displayValue" in data context', async () => {
@@ -1693,6 +1712,9 @@ describe('variants', () => {
         expect(options.length).toEqual(2)
         expect(options[0].getAttribute('aria-selected')).toBe('false')
         expect(options[1].getAttribute('aria-selected')).toBe('false')
+
+        expect(options[0].getAttribute('aria-current')).toBe(null)
+        expect(options[1].getAttribute('aria-current')).toBe(null)
       })
     })
 
@@ -1970,6 +1992,9 @@ describe('variants', () => {
         expect(options.length).toEqual(2)
         expect(options[0].getAttribute('aria-selected')).toBe('false')
         expect(options[1].getAttribute('aria-selected')).toBe('true')
+
+        expect(options[0].getAttribute('aria-current')).toBe(null)
+        expect(options[1].getAttribute('aria-current')).toBe('true')
       })
     })
 
@@ -1995,6 +2020,9 @@ describe('variants', () => {
         expect(options.length).toEqual(2)
         expect(options[0].getAttribute('aria-selected')).toBe('true')
         expect(options[1].getAttribute('aria-selected')).toBe('false')
+
+        expect(options[0].getAttribute('aria-current')).toBe('true')
+        expect(options[1].getAttribute('aria-current')).toBe(null)
       })
     })
 
@@ -2089,6 +2117,9 @@ describe('variants', () => {
 
       expect(option1).toHaveAttribute('aria-selected', 'true')
       expect(option2).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).toHaveAttribute('aria-current', 'true')
+      expect(option2).not.toHaveAttribute('aria-current')
     })
 
     it('should support selected value from "path"', async () => {
@@ -2133,6 +2164,9 @@ describe('variants', () => {
 
       expect(option1).toHaveAttribute('aria-selected', 'true')
       expect(option2).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).toHaveAttribute('aria-current', 'true')
+      expect(option2).not.toHaveAttribute('aria-current')
     })
 
     it('should support "dataPath"', async () => {
@@ -2177,6 +2211,10 @@ describe('variants', () => {
       expect(option1).toHaveAttribute('aria-selected', 'false')
       expect(option2).toHaveAttribute('aria-selected', 'false')
       expect(option3).toHaveAttribute('aria-selected', 'false')
+
+      expect(option1).not.toHaveAttribute('aria-current')
+      expect(option2).not.toHaveAttribute('aria-current')
+      expect(option3).not.toHaveAttribute('aria-current')
     })
 
     it('should store "displayValue" in data context', async () => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
@@ -53,11 +53,11 @@ export const DrawerListItem = forwardRef(function DrawerListItem(
     role,
     tabIndex: selected ? 0 : -1,
     disabled,
-    'aria-selected': active,
+    'aria-selected': !!selected,
     'aria-disabled': disabled,
   }
-  if (selected) {
-    params['aria-current'] = true // has best support on NVDA
+  if (active) {
+    params['aria-current'] = true
   }
 
   if (on_click && !rest.onClick) {


### PR DESCRIPTION
Reverse of `aria-current` and `aria-selected` to be correct with accessibility rules.

- `aria-selected` is `true` for the selected option (the input value) and `false` for the other options.
- `aria-current` is true for the focused option (when navigating), and is removed from other option.

The use of `aria-current` is not needed by WAI-ARIA specs, but added by us for screen reader compatibility.