### PR TITLE
chore: remove `copyWithEffect`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -3,11 +3,10 @@
  *
  */
 
-import React from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
-import { useMedia } from '@dnb/eufemia/src/shared'
-import { useCopyWithNotice } from '@dnb/eufemia/src/components/number-format/NumberUtils'
+import { useMedia, useTranslation } from '@dnb/eufemia/src/shared'
 import {
   H2,
   P,
@@ -19,6 +18,7 @@ import {
   Card,
   Flex,
   Badge,
+  Tooltip,
 } from '@dnb/eufemia/src'
 import {
   stop as stopIcon,
@@ -38,6 +38,35 @@ import Td from '@dnb/eufemia/src/components/table/TableTd'
 import Tr from '@dnb/eufemia/src/components/table/TableTr'
 import TableContainer from '@dnb/eufemia/src/components/table/TableContainer'
 import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
+import { copyToClipboard } from '@dnb/eufemia/src/shared/helpers'
+
+function useCopyWithNotice() {
+  const [active, setActive] = useState(false)
+  const { NumberFormat } = useTranslation()
+  const timeoutRef = useRef<NodeJS.Timeout>()
+
+  const CopyTooltip = useCallback(
+    ({ target }) => {
+      return (
+        <Tooltip active={active} targetElement={target}>
+          {NumberFormat.clipboard_copy}
+        </Tooltip>
+      )
+    },
+    [NumberFormat.clipboard_copy, active],
+  )
+
+  const copy = useCallback((str: string) => {
+    copyToClipboard(str)
+    setActive(true)
+    clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => {
+      setActive(false)
+    }, 1500)
+  }, [])
+
+  return { copy, CopyTooltip }
+}
 
 export const VariantBasic = () => (
   <ComponentBox
@@ -715,12 +744,12 @@ export const Accordion = () => (
         }
         const Content = ({ shareId }) => {
           const ref = React.useRef()
-          const { copy } = useCopyWithNotice()
+          const { copy, CopyTooltip } = useCopyWithNotice()
 
           const shareHandler = () => {
             const url = new URL(location.href)
             url.hash = '#' + shareId
-            copy(url.toString(), ref.current)
+            copy(url.toString())
           }
 
           return (
@@ -748,6 +777,8 @@ export const Accordion = () => (
               >
                 Copy link to this row
               </Button>
+
+              <CopyTooltip target={ref.current} />
             </>
           )
         }
@@ -832,12 +863,12 @@ export const AccordionMixed = () => (
         }
         const Content = ({ shareId }) => {
           const ref = React.useRef()
-          const { copy } = useCopyWithNotice()
+          const { copy, CopyTooltip } = useCopyWithNotice()
 
           const shareHandler = () => {
             const url = new URL(location.href)
             url.hash = '#' + shareId
-            copy(url.toString(), ref.current)
+            copy(url.toString())
           }
 
           return (
@@ -865,6 +896,8 @@ export const AccordionMixed = () => (
               >
                 Copy link to this row
               </Button>
+
+              <CopyTooltip target={ref.current} />
             </>
           )
         }

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.d.ts
@@ -114,12 +114,6 @@ export const cleanNumber: (
   options?: cleanNumberOptions
 ) => number | string;
 
-export const copyWithEffect: (
-  value: number | string,
-  label?: React.ReactNode,
-  positionElement?: HTMLElement
-) => boolean;
-
 export const getFallbackCurrencyDisplay: (
   locale?: InternalLocale,
   currency_display?: string
@@ -141,11 +135,6 @@ export const countDecimals: (
 ) => number;
 
 type copy = (content: string, HTMLElement) => void;
-
-/**
- * Only for internal use as of now. So it's not documented.
- */
-export const useCopyWithNotice: () => { copy: copy };
 
 /**
  * Only for internal use as of now. So it's not documented.

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.js
@@ -1,6 +1,3 @@
-import React from 'react'
-import Context from '../../shared/Context'
-
 /**
  * Web NumberFormat Helpers
  *
@@ -17,7 +14,6 @@ import {
   getOffsetTop,
   getOffsetLeft,
   getSelectedElement,
-  copyToClipboard,
   IS_MAC,
   IS_WIN,
 } from '../../shared/helpers'
@@ -919,41 +915,6 @@ export function runIOSSelectionFix() {
 }
 
 /**
- * A function that tries to copy to the clipboard
- * at the same time it shows the copy result in a tooltip
- *
- * NB: This function is not documented.
- * It should not be used!
- *
- * @param {string} value any number
- * @param {*} label
- * @param {*} positionElement
- * @returns
- */
-export async function copyWithEffect(
-  value,
-  label,
-  positionElement = null
-) {
-  let success = null
-
-  if (value) {
-    try {
-      const fx = showSelectionNotice({ value, label })
-      success = await copyToClipboard(value)
-      if (success === true) {
-        fx.run(positionElement)
-      }
-    } catch (e) {
-      warn(e)
-      success = e
-    }
-  }
-
-  return success
-}
-
-/**
  * This function add a tooltip looking
  *
  * @type {object} object with property
@@ -1047,26 +1008,6 @@ export function showSelectionNotice({ value, label, timeout = 3e3 }) {
       }
     }
   })()
-}
-
-/**
- * React Hook
- * It returns "copyWithEffect" but with a translated string
- *
- * @returns copyWithEffect function inside object { copy }
- */
-export function useCopyWithNotice() {
-  const {
-    translation: {
-      NumberFormat: { clipboard_copy },
-    },
-  } = React.useContext(Context)
-
-  const copy = (value, positionElement) => {
-    copyWithEffect(value, clipboard_copy, positionElement)
-  }
-
-  return { copy }
 }
 
 /**

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -13,7 +13,6 @@ import * as helpers from '../../../shared/helpers'
 import {
   format,
   cleanNumber,
-  copyWithEffect,
   getFallbackCurrencyDisplay,
   getDecimalSeparator,
   getThousandsSeparator,
@@ -918,13 +917,6 @@ describe('NumberFormat cleanNumber', () => {
     expect(cleanNumber("prefix -1.234.567'891 suffix")).toBe(
       '-1234567.891'
     )
-  })
-})
-
-describe('copyWithEffect should', () => {
-  it('make valid clipboard copy', async () => {
-    copyWithEffect('1234.56')
-    expect(await navigator.clipboard.readText()).toBe('1234.56')
   })
 })
 


### PR DESCRIPTION
After #5449, we no longer use `copyWithEffect` in any components. So I think it’s safe to remove it. It only needs a replacement for it in two Table examples.