### PR TITLE
fix(Button): remove `disabled` attribute when disabled with `href`

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -239,6 +239,7 @@ export default class Button extends React.PureComponent {
       }
       params.tabIndex = -1
       params['aria-disabled'] = true
+      delete params.disabled
 
       // Remove href when disabled to avoid navigation via URL bar/status
       if (params.href) {

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -277,6 +277,17 @@ describe('Button component', () => {
         expect(anchor).toHaveAttribute('tabindex', '-1')
       })
 
+      it('should not render disabled attribute when', async () => {
+        render(
+          <Button href="https://url" disabled>
+            Go to example
+          </Button>
+        )
+
+        const anchor = document.querySelector('a')
+        expect(anchor).not.toHaveAttribute('disabled')
+      })
+
       it('removes href from anchor when disabled', () => {
         render(
           <Button href="https://example.com" disabled>


### PR DESCRIPTION
Related to #5447