### PR TITLE
fix(Field.Number): ensure the field reacts on `locale` without currency variant

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/demos.mdx
@@ -2,9 +2,16 @@
 showTabs: true
 ---
 
+import ChangeLocale from 'dnb-design-system-portal/src/core/ChangeLocale'
 import * as Examples from './Examples'
 
 ## Demos
+
+<ChangeLocale
+  bottom
+  label="Locale used in the demos:"
+  listUSLocale={true}
+/>
 
 ### Label and value
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -405,6 +405,7 @@ function NumberComponent(props: Props) {
     // Custom mask based on props
     return {
       mask,
+      as_number: mask ? undefined : true,
       number_mask: mask ? undefined : mask_options,
     }
   }, [

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -95,6 +95,24 @@ describe('Field.Number', () => {
       expect(document.querySelector('input')).toHaveValue('1234')
     })
 
+    it('should format according to en-GB locale (no currency)', () => {
+      render(
+        <Provider locale="en-GB">
+          <Field.Number value={1234.56789} decimalLimit={2} />
+        </Provider>
+      )
+      expect(document.querySelector('input')).toHaveValue('1,234.56')
+    })
+
+    it('should format according to de-DE locale (no currency)', () => {
+      render(
+        <Provider locale="de-DE">
+          <Field.Number value={1234.56789} decimalLimit={2} />
+        </Provider>
+      )
+      expect(document.querySelector('input')).toHaveValue('1.234,56')
+    })
+
     it('shows error when minimum exceeded', () => {
       render(<Field.Number value={Number.MIN_SAFE_INTEGER} />)
 


### PR DESCRIPTION
Will be used to format numbers in error messages that renders a number, that now can get formatted based on the app locale.