### PR TITLE
fix: use `en-GB` translation strings when `en-US` is given

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -1,4 +1,4 @@
-import nb from './nb-NO'
+import type nb from './nb-NO'
 export default {
   'da-DK': {
     /**

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -1,4 +1,4 @@
-import nb from './nb-NO'
+import type nb from './nb-NO'
 export default {
   'en-GB': {
     /**

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-US.ts
@@ -12,5 +12,5 @@ export default {
       errorOrgNoLength:
         'Invalid organization number. Enter a valid organization number with 9 digits.',
     },
-  },
+  } satisfies typeof enGB,
 }

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -1,4 +1,4 @@
-import nb from './nb-NO'
+import type nb from './nb-NO'
 export default {
   'sv-SE': {
     /**

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -279,4 +279,49 @@ describe('Form.useTranslation', () => {
 
     expect(result.current).toEqual(expect.objectContaining(nb))
   })
+
+  it('should fallback to en-GB when en-US is requested but not available', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-US">{children}</Provider>
+      ),
+    })
+
+    const gb = {}
+    extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
+    gb['formatMessage'] = expect.any(Function)
+    gb['renderMessage'] = expect.any(Function)
+
+    expect(result.current).toEqual(gb)
+  })
+
+  it('should fallback to en-GB when en-CA is requested but not available', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-CA">{children}</Provider>
+      ),
+    })
+
+    const gb = {}
+    extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
+    gb['formatMessage'] = expect.any(Function)
+    gb['renderMessage'] = expect.any(Function)
+
+    expect(result.current).toEqual(gb)
+  })
+
+  it('should not fallback when en-GB is explicitly requested', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-GB">{children}</Provider>
+      ),
+    })
+
+    const gb = {}
+    extendDeep(gb, forms_enGB['en-GB'], global_enGB['en-GB'])
+    gb['formatMessage'] = expect.any(Function)
+    gb['renderMessage'] = expect.any(Function)
+
+    expect(result.current).toEqual(gb)
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.tsx
@@ -42,9 +42,20 @@ export default function useTranslation<T = FormsTranslation>(
   return useMemo<
     TranslationFlatToObject<T> & AdditionalReturnUtils
   >(() => {
+    // Handle translation fallback logic
+    let translationLocale = locale
+
+    // If e.g. en-US translations don't exist, fallback to en-GB
+    if (
+      locale.startsWith('en-') &&
+      !Object.keys(formsLocales).some((l) => l === locale)
+    ) {
+      translationLocale = 'en-GB'
+    }
+
     const translation = extendDeep(
       {},
-      formsLocales[locale] || formsLocales[LOCALE],
+      formsLocales[translationLocale] || formsLocales[LOCALE],
       globalTranslation
     )
 

--- a/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTranslation.test.tsx
@@ -584,4 +584,49 @@ describe('useTranslation with an ID', () => {
 
     expect(result.current).toEqual(nbNO['nb-NO'].Modal.close_title)
   })
+
+  it('should fallback to en-GB when en-US is requested but not available', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-US">{children}</Provider>
+      ),
+    })
+
+    expect(result.current).toEqual(
+      Object.assign({}, enGB['en-GB'], {
+        formatMessage: expect.any(Function),
+        renderMessage: expect.any(Function),
+      })
+    )
+  })
+
+  it('should fallback to en-GB when en-CA is requested but not available', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-CA">{children}</Provider>
+      ),
+    })
+
+    expect(result.current).toEqual(
+      Object.assign({}, enGB['en-GB'], {
+        formatMessage: expect.any(Function),
+        renderMessage: expect.any(Function),
+      })
+    )
+  })
+
+  it('should not fallback when en-GB is explicitly requested', () => {
+    const { result } = renderHook(useTranslation, {
+      wrapper: ({ children }) => (
+        <Provider locale="en-GB">{children}</Provider>
+      ),
+    })
+
+    expect(result.current).toEqual(
+      Object.assign({}, enGB['en-GB'], {
+        formatMessage: expect.any(Function),
+        renderMessage: expect.any(Function),
+      })
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -40,11 +40,22 @@ export default function useTranslation<T = Translation>(
       return formatMessage(id, args, translation)
     }
 
+    // Handle translation fallback logic
+    let translationLocale = locale
+
+    // If e.g. en-US translations don't exist, fallback to en-GB
+    if (
+      locale.startsWith('en-') &&
+      !Object.keys(defaultLocales).some((l) => l === locale)
+    ) {
+      translationLocale = 'en-GB'
+    }
+
     return assignUtils(
       combineWithExternalTranslations({
         translation,
         messages,
-        locale,
+        locale: translationLocale,
       })
     )
   }, [messages, translation, locale, assignUtils, args])


### PR DESCRIPTION
When `en-US` is given but does not exist, we currently render the translation strings for `nb-NO`.