### PR TITLE
chore(CI): run macos-26

### DIFF
--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -21,7 +21,7 @@ jobs:
   process-icons:
     name: Fetch and Build Icons
 
-    runs-on: macos-15
+    runs-on: macos-26
 
     timeout-minutes: 60
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -43,7 +43,7 @@ jobs:
   visual-regression:
     name: Run visual-regression tests
 
-    runs-on: macos-15
+    runs-on: macos-26
 
     timeout-minutes: 40
 


### PR DESCRIPTION
https://github.blog/changelog/2025-09-11-actions-macos-26-image-now-in-public-preview/