### PR TITLE
fix(Field.Number): show formatted numbers in error messages

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
@@ -52,7 +52,7 @@ export const LabelAndValue = () => {
 export const ExclusiveMinMax = () => {
   return (
     <ComponentBox>
-      <Field.Number
+      <Field.Currency
         value={1000}
         label="Label text"
         allowNegative={false}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react'
 import { InputMasked, Button } from '../../../../components'
 import { InputMaskedProps } from '../../../../components/InputMasked'
+import { format } from '../../../../components/number-format/NumberUtils'
 import type {
   InputAlign,
   InputProps,
@@ -62,6 +63,7 @@ function NumberComponent(props: Props) {
   const dataContext = useContext(DataContext)
   const fieldBlockContext = useContext(FieldBlockContext)
   const sharedContext = useContext(SharedContext)
+  const locale = sharedContext?.locale
 
   const validateContinuouslyRef = useRef(props?.validateContinuously)
 
@@ -102,7 +104,11 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: true,
                 message: 'NumberField.errorMinimum',
+                messageValues: {
+                  minimum: format(defaultMinimum, { locale }),
+                },
                 origin: 'number',
+                locale,
               })
             }
 
@@ -113,7 +119,11 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: true,
                 message: 'NumberField.errorMaximum',
+                messageValues: {
+                  maximum: format(defaultMaximum, { locale }),
+                },
                 origin: 'number',
+                locale,
               })
             }
 
@@ -125,7 +135,11 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: true,
                 message: 'NumberField.errorMinimum',
+                messageValues: {
+                  minimum: format(p.minimum, { locale }),
+                },
                 origin: 'number',
+                locale,
               })
             }
 
@@ -137,7 +151,11 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: true,
                 message: 'NumberField.errorMaximum',
+                messageValues: {
+                  maximum: format(p.maximum, { locale }),
+                },
                 origin: 'number',
+                locale,
               })
             }
 
@@ -152,8 +170,12 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: false,
                 message: 'NumberField.errorExclusiveMinimum',
+                messageValues: {
+                  exclusiveMinimum: format(p.exclusiveMinimum, { locale }),
+                },
                 origin: 'number',
                 exclusiveMinimum: p.exclusiveMinimum,
+                locale,
               })
             }
 
@@ -168,8 +190,12 @@ function NumberComponent(props: Props) {
                 type: 'number',
                 inclusive: false,
                 message: 'NumberField.errorExclusiveMaximum',
+                messageValues: {
+                  exclusiveMaximum: format(p.exclusiveMaximum, { locale }),
+                },
                 origin: 'number',
                 exclusiveMaximum: p.exclusiveMaximum,
+                locale,
               })
             }
 
@@ -178,8 +204,12 @@ function NumberComponent(props: Props) {
               ctx.addIssue({
                 code: 'custom',
                 message: 'NumberField.errorMultipleOf',
+                messageValues: {
+                  multipleOf: format(p.multipleOf, { locale }),
+                },
                 origin: 'number',
                 multipleOf: p.multipleOf,
+                locale,
               })
             }
           })
@@ -194,6 +224,7 @@ function NumberComponent(props: Props) {
     props.exclusiveMinimum,
     props.exclusiveMaximum,
     props.multipleOf,
+    locale,
   ])
 
   const toInput = useCallback((external: number | undefined | unknown) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -88,6 +88,17 @@ function NumberComponent(props: Props) {
       // in sync with dynamic prop changes and avoids stale closures.
       props.schema ??
       ((p: Props) => {
+        // Helper function to format validation values with currency/percent suffix
+        const formatValidationValue = (value: number) => {
+          if (p.currency) {
+            return format(value, { locale, currency: p.currency })
+          }
+          if (p.percent) {
+            return format(value, { locale, percent: true })
+          }
+          return format(value, { locale })
+        }
+
         return z
           .number()
           .nullish()
@@ -105,7 +116,7 @@ function NumberComponent(props: Props) {
                 inclusive: true,
                 message: 'NumberField.errorMinimum',
                 messageValues: {
-                  minimum: format(defaultMinimum, { locale }),
+                  minimum: formatValidationValue(defaultMinimum),
                 },
                 origin: 'number',
                 locale,
@@ -120,7 +131,7 @@ function NumberComponent(props: Props) {
                 inclusive: true,
                 message: 'NumberField.errorMaximum',
                 messageValues: {
-                  maximum: format(defaultMaximum, { locale }),
+                  maximum: formatValidationValue(defaultMaximum),
                 },
                 origin: 'number',
                 locale,
@@ -136,7 +147,7 @@ function NumberComponent(props: Props) {
                 inclusive: true,
                 message: 'NumberField.errorMinimum',
                 messageValues: {
-                  minimum: format(p.minimum, { locale }),
+                  minimum: formatValidationValue(p.minimum),
                 },
                 origin: 'number',
                 locale,
@@ -152,7 +163,7 @@ function NumberComponent(props: Props) {
                 inclusive: true,
                 message: 'NumberField.errorMaximum',
                 messageValues: {
-                  maximum: format(p.maximum, { locale }),
+                  maximum: formatValidationValue(p.maximum),
                 },
                 origin: 'number',
                 locale,
@@ -171,7 +182,9 @@ function NumberComponent(props: Props) {
                 inclusive: false,
                 message: 'NumberField.errorExclusiveMinimum',
                 messageValues: {
-                  exclusiveMinimum: format(p.exclusiveMinimum, { locale }),
+                  exclusiveMinimum: formatValidationValue(
+                    p.exclusiveMinimum
+                  ),
                 },
                 origin: 'number',
                 exclusiveMinimum: p.exclusiveMinimum,
@@ -191,7 +204,9 @@ function NumberComponent(props: Props) {
                 inclusive: false,
                 message: 'NumberField.errorExclusiveMaximum',
                 messageValues: {
-                  exclusiveMaximum: format(p.exclusiveMaximum, { locale }),
+                  exclusiveMaximum: formatValidationValue(
+                    p.exclusiveMaximum
+                  ),
                 },
                 origin: 'number',
                 exclusiveMaximum: p.exclusiveMaximum,
@@ -205,7 +220,7 @@ function NumberComponent(props: Props) {
                 code: 'custom',
                 message: 'NumberField.errorMultipleOf',
                 messageValues: {
-                  multipleOf: format(p.multipleOf, { locale }),
+                  multipleOf: formatValidationValue(p.multipleOf),
                 },
                 origin: 'number',
                 multipleOf: p.multipleOf,
@@ -224,6 +239,8 @@ function NumberComponent(props: Props) {
     props.exclusiveMinimum,
     props.exclusiveMaximum,
     props.multipleOf,
+    props.currency,
+    props.percent,
     locale,
   ])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -7,7 +7,10 @@ import React, {
 } from 'react'
 import { InputMasked, Button } from '../../../../components'
 import { InputMaskedProps } from '../../../../components/InputMasked'
-import { format } from '../../../../components/number-format/NumberUtils'
+import {
+  format,
+  formatOptionParams,
+} from '../../../../components/number-format/NumberUtils'
 import type {
   InputAlign,
   InputProps,
@@ -90,13 +93,19 @@ function NumberComponent(props: Props) {
       ((p: Props) => {
         // Helper function to format validation values with currency/percent suffix
         const formatValidationValue = (value: number) => {
+          const formatOptions: Partial<formatOptionParams> = { locale }
+
           if (p.currency) {
-            return format(value, { locale, currency: p.currency })
+            formatOptions.currency = p.currency
           }
           if (p.percent) {
-            return format(value, { locale, percent: true })
+            formatOptions.percent = true
           }
-          return format(value, { locale })
+          if (p.decimalLimit !== undefined) {
+            formatOptions.decimals = p.decimalLimit
+          }
+
+          return format(value, formatOptions)
         }
 
         return z
@@ -241,6 +250,7 @@ function NumberComponent(props: Props) {
     props.multipleOf,
     props.currency,
     props.percent,
+    props.decimalLimit,
     locale,
   ])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -1219,7 +1219,11 @@ describe('Field.Number', () => {
           const expected = nb.NumberField.errorExclusiveMinimum.replace(
             '{exclusiveMinimum}',
             String(
-              format(10.123456, { locale: 'nb-NO', percent: true, decimals: 1 })
+              format(10.123456, {
+                locale: 'nb-NO',
+                percent: true,
+                decimals: 1,
+              })
             )
           )
           // Use regex to handle both regular and non-breaking spaces

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -907,6 +907,267 @@ describe('Field.Number', () => {
         expect(screen.getByRole('alert')).toHaveTextContent(expected)
       })
     })
+
+    describe('currency', () => {
+      it('should show currency-specific message for exclusiveMinimum', async () => {
+        render(
+          <Field.Number
+            value={10}
+            exclusiveMinimum={20}
+            validateInitially
+            currency
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMinimum.replace(
+            '{exclusiveMinimum}',
+            String(format(20, { locale: 'nb-NO', currency: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show currency-specific message for exclusiveMaximum', async () => {
+        render(
+          <Field.Number
+            value={100}
+            exclusiveMaximum={100}
+            validateInitially
+            currency
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMaximum.replace(
+            '{exclusiveMaximum}',
+            String(format(100, { locale: 'nb-NO', currency: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show currency-specific message for minimum', async () => {
+        render(
+          <Field.Number
+            value={30}
+            minimum={50}
+            validateInitially
+            currency
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMinimum.replace(
+            '{minimum}',
+            String(format(50, { locale: 'nb-NO', currency: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show currency-specific message for maximum', async () => {
+        render(
+          <Field.Number
+            value={1500}
+            maximum={1000}
+            validateInitially
+            currency
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMaximum.replace(
+            '{maximum}',
+            String(format(1000, { locale: 'nb-NO', currency: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show currency-specific message for multipleOf', async () => {
+        render(
+          <Field.Number
+            value={7}
+            multipleOf={5}
+            validateInitially
+            currency
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMultipleOf.replace(
+            '{multipleOf}',
+            String(format(5, { locale: 'nb-NO', currency: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+    })
+
+    describe('percent', () => {
+      it('should show percent-specific message for exclusiveMinimum', async () => {
+        render(
+          <Field.Number
+            percent
+            value={5}
+            exclusiveMinimum={10}
+            validateInitially
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMinimum.replace(
+            '{exclusiveMinimum}',
+            String(format(10, { locale: 'nb-NO', percent: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show percent-specific message for exclusiveMaximum', async () => {
+        render(
+          <Field.Number
+            percent
+            value={90}
+            exclusiveMaximum={90}
+            validateInitially
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMaximum.replace(
+            '{exclusiveMaximum}',
+            String(format(90, { locale: 'nb-NO', percent: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show percent-specific message for minimum', async () => {
+        render(
+          <Field.Number percent value={2} minimum={5} validateInitially />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMinimum.replace(
+            '{minimum}',
+            String(format(5, { locale: 'nb-NO', percent: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show percent-specific message for maximum', async () => {
+        render(
+          <Field.Number
+            percent
+            value={150}
+            maximum={100}
+            validateInitially
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMaximum.replace(
+            '{maximum}',
+            String(format(100, { locale: 'nb-NO', percent: true }))
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show percent-specific message for multipleOf', async () => {
+        render(
+          <Field.Number
+            percent
+            value={3}
+            multipleOf={2.5}
+            validateInitially
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorMultipleOf.replace(
+            '{multipleOf}',
+            String(
+              format(2.5, { locale: 'nb-NO', percent: true, decimals: 1 })
+            )
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+    })
   })
 
   describe('should gracefully handle empty value', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -810,7 +810,9 @@ describe('Field.Number', () => {
 
         // Check that the message contains the Norwegian text and the formatted number
         const alertText = alertElement.textContent
-        expect(alertText).toContain('Verdien må være maksimalt')
+        expect(alertText).toContain(
+          nb.NumberField.errorMaximum.split('{maximum}')[0]
+        )
         expect(alertText).toMatch(/1\s000/) // The number should be formatted with space separator (regular or non-breaking)
         expect(alertText).toContain('.') // Should end with a period
       })
@@ -878,9 +880,16 @@ describe('Field.Number', () => {
         target: { value: '1' },
       })
 
+      const expected = nb.NumberField.errorMultipleOf.replace(
+        '{multipleOf}',
+        String(format(3000, { locale: 'nb-NO' }))
+      )
+      // Use regex to handle both regular and non-breaking spaces
+      const expectedRegex = expected.replace(/\s/g, '\\s')
+
       await waitFor(() => {
         expect(screen.getByRole('alert')).toHaveTextContent(
-          'Verdien må være et multiplum av 3 000.'
+          new RegExp(expectedRegex)
         )
       })
     })
@@ -2171,8 +2180,14 @@ describe('Field.Number', () => {
       input.blur()
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
+        const expected = nb.NumberField.errorMaximum.replace(
+          '{maximum}',
+          String(format(1000, { locale: 'nb-NO' }))
+        )
+        // Use regex to handle both regular and non-breaking spaces
+        const expectedRegex = expected.replace(/\s/g, '\\s')
         expect(screen.getByRole('alert')).toHaveTextContent(
-          'Verdien må være maksimalt 1 000.'
+          new RegExp(expectedRegex)
         )
       })
     })
@@ -2213,8 +2228,14 @@ describe('Field.Number', () => {
       input.blur()
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
+        const expected = nb.NumberField.errorMaximum.replace(
+          '{maximum}',
+          String(format(1000, { locale: 'nb-NO' }))
+        )
+        // Use regex to handle both regular and non-breaking spaces
+        const expectedRegex = expected.replace(/\s/g, '\\s')
         expect(screen.getByRole('alert')).toHaveTextContent(
-          'Verdien må være maksimalt 1 000.'
+          new RegExp(expectedRegex)
         )
       })
     })
@@ -2233,8 +2254,14 @@ describe('Field.Number', () => {
       input.blur()
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
+        const expected = nb.NumberField.errorExclusiveMaximum.replace(
+          '{exclusiveMaximum}',
+          String(format(1000, { locale: 'nb-NO' }))
+        )
+        // Use regex to handle both regular and non-breaking spaces
+        const expectedRegex = expected.replace(/\s/g, '\\s')
         expect(screen.getByRole('alert')).toHaveTextContent(
-          'Verdien må være mindre enn 1 000.'
+          new RegExp(expectedRegex)
         )
       })
     })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -1038,6 +1038,39 @@ describe('Field.Number', () => {
           )
         })
       })
+
+      it('should show currency-specific message with decimalLimit', async () => {
+        render(
+          <Field.Number
+            value={10.5}
+            exclusiveMinimum={20.123456}
+            validateInitially
+            currency
+            decimalLimit={2}
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMinimum.replace(
+            '{exclusiveMinimum}',
+            String(
+              format(20.123456, {
+                locale: 'nb-NO',
+                currency: true,
+                decimals: 2,
+              })
+            )
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
     })
 
     describe('percent', () => {
@@ -1158,6 +1191,35 @@ describe('Field.Number', () => {
             '{multipleOf}',
             String(
               format(2.5, { locale: 'nb-NO', percent: true, decimals: 1 })
+            )
+          )
+          // Use regex to handle both regular and non-breaking spaces
+          const expectedRegex = expected.replace(/\s/g, '\\s')
+          expect(alertElement.textContent).toMatch(
+            new RegExp(expectedRegex)
+          )
+        })
+      })
+
+      it('should show percent-specific message with decimalLimit', async () => {
+        render(
+          <Field.Number
+            percent
+            value={5.25}
+            exclusiveMinimum={10.123456}
+            validateInitially
+            decimalLimit={1}
+          />
+        )
+
+        await waitFor(() => {
+          const alertElement = screen.getByRole('alert')
+          expect(alertElement).toBeInTheDocument()
+
+          const expected = nb.NumberField.errorExclusiveMinimum.replace(
+            '{exclusiveMinimum}',
+            String(
+              format(10.123456, { locale: 'nb-NO', percent: true, decimals: 1 })
             )
           )
           // Use regex to handle both regular and non-breaking spaces

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -89,6 +89,9 @@ function StringComponent(props: Props) {
               inclusive: true,
               origin: 'string',
               message: 'StringField.errorMinLength',
+              messageValues: {
+                minLength: String(p.minLength),
+              },
             })
           }
           if (p.maxLength !== undefined && val.length > p.maxLength) {
@@ -99,6 +102,9 @@ function StringComponent(props: Props) {
               inclusive: true,
               origin: 'string',
               message: 'StringField.errorMaxLength',
+              messageValues: {
+                maxLength: String(p.maxLength),
+              },
             })
           }
           if (p.pattern && !new RegExp(p.pattern, 'u').test(val)) {
@@ -107,6 +113,9 @@ function StringComponent(props: Props) {
               validation: 'regex',
               format: 'regex',
               message: 'Field.errorPattern',
+              messageValues: {
+                pattern: p.pattern,
+              },
             })
           }
         })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -893,7 +893,7 @@ describe('Iterate.Array', () => {
       )
 
       expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
-        nb.IterateArray.errorMinItems.replace('{minItems}', '1')
+        nb.IterateArray.errorMinItems
       )
     })
   })
@@ -909,7 +909,7 @@ describe('Iterate.Array', () => {
       )
 
       expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
-        nb.IterateArray.errorMaxItems.replace('{maxItems}', '1')
+        nb.IterateArray.errorMaxItems
       )
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -752,7 +752,9 @@ describe('EditContainer and ViewContainer', () => {
       // Remove the element
       await userEvent.click(removeButton)
 
-      expect(onChange).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledTimes(1)
+      })
       expect(onChange).toHaveBeenLastCalledWith(
         {
           myList: ['bar'],

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
@@ -12,6 +12,7 @@ import ChildrenWithAge from '../ChildrenWithAge'
 import { translations } from '../ChildrenWithAgeTranslations'
 import { GenerateRef } from '../../../Tools/ListAllProps'
 import nbNO from '../../../constants/locales/nb-NO'
+import { format } from '../../../../../components/number-format/NumberUtils'
 
 describe('ChildrenWithAge', () => {
   const translationsNO = translations['nb-NO']
@@ -162,8 +163,14 @@ describe('ChildrenWithAge', () => {
 
     fireEvent.blur(numOfChildrenInput)
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      nbNO['nb-NO'].NumberField.errorMaximum.replace('{maximum}', '9')
+    const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
+      '{maximum}',
+      String(format(9, { locale: 'nb-NO' }))
+    )
+    // Use regex to handle both regular and non-breaking spaces
+    const expectedRegex = expectedText.replace(/\s/g, '\\s')
+    expect(screen.getByRole('alert').textContent).toMatch(
+      new RegExp(expectedRegex)
     )
   })
 
@@ -210,8 +217,14 @@ describe('ChildrenWithAge', () => {
 
     fireEvent.blur(input)
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      nbNO['nb-NO'].NumberField.errorMaximum.replace('{maximum}', '17')
+    const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
+      '{maximum}',
+      String(format(17, { locale: 'nb-NO' }))
+    )
+    // Use regex to handle both regular and non-breaking spaces
+    const expectedRegex = expectedText.replace(/\s/g, '\\s')
+    expect(screen.getByRole('alert').textContent).toMatch(
+      new RegExp(expectedRegex)
     )
   })
 
@@ -252,11 +265,14 @@ describe('ChildrenWithAge', () => {
 
     fireEvent.blur(input)
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      nbNO['nb-NO'].NumberField.errorMaximum.replace(
-        '{maximum}',
-        '1000000'
-      )
+    const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
+      '{maximum}',
+      String(format(1000000, { locale: 'nb-NO' }))
+    )
+    // Use regex to handle both regular and non-breaking spaces
+    const expectedRegex = expectedText.replace(/\s/g, '\\s')
+    expect(screen.getByRole('alert').textContent).toMatch(
+      new RegExp(expectedRegex)
     )
   })
 
@@ -271,18 +287,14 @@ describe('ChildrenWithAge', () => {
 
     fireEvent.blur(input)
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      nbNO['nb-NO'].NumberField.errorMaximum.replace(
-        '{maximum}',
-        '1000000'
-      )
+    const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
+      '{maximum}',
+      String(format(1000000, { locale: 'nb-NO' }))
     )
-
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      nbNO['nb-NO'].NumberField.errorMaximum.replace(
-        '{maximum}',
-        '1000000'
-      )
+    // Use regex to handle both regular and non-breaking spaces
+    const expectedRegex = expectedText.replace(/\s/g, '\\s')
+    expect(screen.getByRole('alert').textContent).toMatch(
+      new RegExp(expectedRegex)
     )
   })
 
@@ -303,7 +315,7 @@ describe('ChildrenWithAge', () => {
     expect(document.querySelectorAll('input')).toHaveLength(0)
     const dlDDs = Array.from(document.querySelectorAll('dl dd'))
     expect(dlDDs).toHaveLength(1)
-    expect(dlDDs.at(0)).toHaveTextContent('Nei')
+    expect(dlDDs.at(0)).toHaveTextContent(nbNO['nb-NO'].BooleanField.no)
 
     await userEvent.click(yesButton)
     expect(document.querySelector('.dnb-input__input')).toHaveValue('1')
@@ -311,7 +323,7 @@ describe('ChildrenWithAge', () => {
     await waitFor(() => {
       const dlDDs = Array.from(document.querySelectorAll('dl dd'))
       expect(dlDDs).toHaveLength(3)
-      expect(dlDDs.at(0)).toHaveTextContent('Ja')
+      expect(dlDDs.at(0)).toHaveTextContent(nbNO['nb-NO'].BooleanField.yes)
     })
 
     await userEvent.click(noButton)
@@ -323,7 +335,7 @@ describe('ChildrenWithAge', () => {
     {
       const dlDDs = Array.from(document.querySelectorAll('dl dd'))
       expect(dlDDs).toHaveLength(1)
-      expect(dlDDs.at(0)).toHaveTextContent('Nei')
+      expect(dlDDs.at(0)).toHaveTextContent(nbNO['nb-NO'].BooleanField.no)
     }
 
     await userEvent.click(yesButton)
@@ -332,7 +344,7 @@ describe('ChildrenWithAge', () => {
     {
       const dlDDs = Array.from(document.querySelectorAll('dl dd'))
       expect(dlDDs).toHaveLength(3)
-      expect(dlDDs.at(0)).toHaveTextContent('Ja')
+      expect(dlDDs.at(0)).toHaveTextContent(nbNO['nb-NO'].BooleanField.yes)
     }
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1476,7 +1476,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
           if (hasZodSchema) {
             // Zod validation failed - validationResult is a ZodError
             const zodError = validationResult as z.ZodError<any>
-            error = zodErrorsToOneFormError(zodError.issues, value)
+            error = zodErrorsToOneFormError(zodError.issues)
           } else {
             // AJV validation failed - validationResult is false
             error = ajvErrorsToOneFormError(


### PR DESCRIPTION
From:
<img width="443" height="56" alt="Screenshot 2025-09-23 at 13 23 23" src="https://github.com/user-attachments/assets/c7910a95-1915-41ea-848e-b320b044aed1" />


To:
<img width="485" height="104" alt="Screenshot 2025-09-23 at 14 16 56" src="https://github.com/user-attachments/assets/ff8b1b40-64f4-4b68-b977-1be78883dd09" />

