### PR TITLE
chore: ensure no ViewTransition is enabled during visual tests

### DIFF
--- a/packages/dnb-design-system-portal/gatsby-node.js
+++ b/packages/dnb-design-system-portal/gatsby-node.js
@@ -271,6 +271,11 @@ exports.onCreateWebpackConfig = ({
       // Webpack 4 to 5 migration
       plugins.provide({ process: 'process/browser' }),
 
+      // Setup
+      plugins.define({
+        'process.env.isCI': JSON.stringify(isCI),
+      }),
+
       // Algolia info
       plugins.define({
         'process.env.ALGOLIA_INDEX_NAME': JSON.stringify(

--- a/packages/dnb-design-system-portal/src/shared/tags/Transition.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/Transition.ts
@@ -3,7 +3,7 @@ export function startPageTransition() {
     typeof document !== 'undefined' &&
     typeof document.startViewTransition !== 'undefined' &&
     !globalThis.IS_TEST &&
-    !window.location.href.includes('data-visual-test')
+    !process.env.isCI
   ) {
     document.startViewTransition()
   }

--- a/packages/dnb-design-system-portal/src/shared/tags/Transition.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/Transition.ts
@@ -1,7 +1,9 @@
 export function startPageTransition() {
   if (
+    typeof document !== 'undefined' &&
+    typeof document.startViewTransition !== 'undefined' &&
     !globalThis.IS_TEST &&
-    typeof document.startViewTransition !== 'undefined'
+    !window.location.href.includes('data-visual-test')
   ) {
     document.startViewTransition()
   }


### PR DESCRIPTION
It may be the cause of such wired snapshots:
<img width="434" height="96" alt="Screenshot 2025-09-24 at 14 40 04" src="https://github.com/user-attachments/assets/ec1aacf9-e3f7-42bd-8435-2bde32220fb2" />

Like when ViewTransition runs – even it theoretical should not:
<img width="569" height="505" alt="Screenshot 2025-09-24 at 15 09 45" src="https://github.com/user-attachments/assets/55bacac1-11ce-4dc2-a9e5-e4a1093a8041" />


Or maybe a transition to fullscreen. Even I can't find it to happen.
<img width="1944" height="232" alt="Screenshot 2025-09-24 at 14 59 37" src="https://github.com/user-attachments/assets/411bb22c-e41e-4fbf-aa79-76a43bbd247c" />

