### PR TITLE
chore: correct wrong link to JavaScript properties file

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -152,7 +152,7 @@ import '@dnb/eufemia/style/themes/theme-ui/ui-theme-basis.min.css'
 
 ## A list of all CSS properties (variables)
 
-Beside the portal documentation with related tables and additional information, you may have a look at the [CSS file](https://unpkg.com/browse/@dnb/eufemia@latest/style/themes/theme-ui/ui-theme-properties.css), containing the custom properties (CSS variables), as well as a[ JavaScript file](https://unpkg.com/browse/@dnb/eufemia@latest/style/properties.js), which is auto generated from the CSS data.
+Beside the portal documentation with related tables and additional information, you may have a look at the [CSS file](https://unpkg.com/browse/@dnb/eufemia@latest/style/themes/theme-ui/ui-theme-properties.css), containing the custom properties (CSS variables), as well as a[ JavaScript file](https://unpkg.com/browse/@dnb/eufemia@latest/style/themes/theme-ui/properties.js), which is auto generated from the CSS data.
 
 ### Access CSS properties (variables) in JavaScript
 


### PR DESCRIPTION
Here are the current docs with the wrong link: https://eufemia.dnb.no/uilib/usage/customisation/styling/#a-list-of-all-css-properties-variables