### PR TITLE
chore(Tabs.Content): remove propType `key`

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.tsx
@@ -28,7 +28,6 @@ export default class CustomContent extends React.PureComponent {
     hash: PropTypes.string, // eslint-disable-line
     selected: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]), // eslint-disable-line
     id: PropTypes.string, // eslint-disable-line
-    key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]), // eslint-disable-line
     disabled: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]), // eslint-disable-line
 
     ...spacingPropTypes,


### PR DESCRIPTION
Fixes the following error from our tests:

```
  console.error
    Warning: CustomContent: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
```