### PR TITLE
chore: swallow logs from tests

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -3616,6 +3616,9 @@ describe('Autocomplete component', () => {
   })
 
   describe('groups', () => {
+    beforeEach(() => {
+      global.console.log = jest.fn()
+    })
     const dataProp: DrawerListDataArray = [
       { groupIndex: 0, content: 'Item 0.1' },
       { groupIndex: 0, content: 'Item 0.2' },
@@ -3719,6 +3722,12 @@ describe('Autocomplete component', () => {
 
       expect(groupsUL[3].textContent).toBe(nbNO.missingGroup + ' 4')
       expect(groupsUL[3].classList).not.toContain('dnb-sr-only')
+
+      expect(global.console.log).toHaveBeenCalledTimes(10)
+      expect(global.console.log).toHaveBeenLastCalledWith(
+        expect.stringContaining('Eufemia'),
+        `Missing group title for groupIndex: 3`
+      )
     })
 
     it('adds group for items without group index', async () => {

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -1799,6 +1799,10 @@ describe('Dropdown component', () => {
   })
 
   describe('groups', () => {
+    beforeEach(() => {
+      global.console.log = jest.fn()
+    })
+
     const dataProp: DrawerListDataArray = [
       { groupIndex: 0, content: 'Item 0.1' },
       { groupIndex: 0, content: 'Item 0.2' },
@@ -1898,6 +1902,12 @@ describe('Dropdown component', () => {
 
       expect(groupsUL[3].textContent).toBe(nbNO.missingGroup + ' 4')
       expect(groupsUL[3].classList).not.toContain('dnb-sr-only')
+
+      expect(global.console.log).toHaveBeenCalledTimes(8)
+      expect(global.console.log).toHaveBeenLastCalledWith(
+        expect.stringContaining('Eufemia'),
+        `Missing group title for groupIndex: 3`
+      )
     })
 
     it('adds group for items without group index', async () => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -810,6 +810,10 @@ describe('DrawerList component', () => {
   })
 
   describe('groups', () => {
+    beforeEach(() => {
+      global.console.log = jest.fn()
+    })
+
     const dataProp: DrawerListDataArray = [
       { groupIndex: 0, content: 'Item 0.1' },
       { groupIndex: 0, content: 'Item 0.2' },
@@ -905,6 +909,12 @@ describe('DrawerList component', () => {
 
       expect(groupsUL[3].textContent).toBe(nbNO.missingGroup + ' 4')
       expect(groupsUL[3].classList).not.toContain('dnb-sr-only')
+
+      expect(global.console.log).toHaveBeenCalledTimes(6)
+      expect(global.console.log).toHaveBeenLastCalledWith(
+        expect.stringContaining('Eufemia'),
+        `Missing group title for groupIndex: 3`
+      )
     })
 
     it('adds group for items without group index', () => {


### PR DESCRIPTION
Swalling logs like this:
```

  ● Console

    console.log
      Eufemia Missing group title for groupIndex: 1

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)

    console.log
      Eufemia Missing group title for groupIndex: 3

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)

    console.log
      Eufemia Missing group title for groupIndex: 1

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)

    console.log
      Eufemia Missing group title for groupIndex: 3

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)

    console.log
      Eufemia Missing group title for groupIndex: 1

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)

    console.log
      Eufemia Missing group title for groupIndex: 3

      at log (src/shared/helpers.js:416:15)
          at Array.forEach (<anonymous>)
```