### PR TITLE
chore(Dropdown, Autocomplete, DrawerList): `group` to `groups`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -98,6 +98,6 @@ const data = [
 
 ### Groups
 
-If an item has a `groupIndex` property it will use the groups in the `group` property. Only the first group can be without title, all other groups must have a title.
+If an item has a `groupIndex` property, it will use the groups in the `groups` property. Only the first group can be without title, all other groups must have a title.
 
 <AutocompleteGroups />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
@@ -119,6 +119,6 @@ Only to visualize and used for visual testing
 
 ### Groups
 
-If an item has a `groupIndex` property it will use the groups in the `group` property. Only the first group can be without title, all other groups must have a title.
+If an item has a `groupIndex` property, it will use the groups in the `groups` property. Only the first group can be without title, all other groups must have a title.
 
 <DropdownGroups />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/demos.mdx
@@ -52,6 +52,6 @@ import {
 
 ### Groups
 
-If an item has a `groupIndex` property it will use the groups in the `group` property. Only the first group can be without title, all other groups must have a title.
+If an item has a `groupIndex` property, it will use the groups in the `groups` property. Only the first group can be without title, all other groups must have a title.
 
 <DrawerListGroups />


### PR DESCRIPTION
@snorrekim, does these changes make sense?

I just saw the docs was referencing a `group` property, which doesn't exist, so I changes to `groups`.