### PR TITLE
docs(DateFormat): document `formatDate` helper function

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
@@ -47,3 +47,19 @@ The following formats are supported as date values for conversion:
 - `dd.MM.yyyy`
 - `dd/MM/yyyy`
 - `Date` object
+
+### `formatDate` helper function
+
+If you really need a formatted date string without rendering the component, you can import the utility directly:
+
+```ts
+import { formatDate } from '@dnb/eufemia/components/date-format/DateFormatUtils'
+formatDate('2023-01-01')
+```
+
+#### Parameters
+
+| Name      | Type                         | Default                  | Description                                                                                                                                                       |
+| --------- | ---------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `locale`  | `AnyLocale`                  | `'nb-NO'`                | The locale to use for formatting.                                                                                                                                 |
+| `options` | `Intl.DateTimeFormatOptions` | `{ dateStyle: 'short' }` | The format options following the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API. |


### PR DESCRIPTION
Motivation: Krister did use the old import from when it was placed in the DatePicker.