### PR TITLE
fix(Field.DateOfBirth): ensure smart autofill when tabbing out of day and month

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -359,12 +359,14 @@ function DateOfBirth(props: Props) {
           ?.value
         const month = monthValue || emptyValue
         monthRef.current = month
+        forceUpdate()
         callOnChange({ month })
       } else {
         // If the value is a month name, find the corresponding value
         const monthValue = months.find((m) => m.title === value)?.value
         if (monthValue) {
           monthRef.current = monthValue
+          forceUpdate()
           callOnChange({ month: monthValue })
         }
       }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
@@ -352,6 +352,33 @@ describe('Field.DateOfBirth', () => {
         expect(first?.textContent).toBe('Ingen alternativer')
       })
     })
+
+    it('should autofill day and month name when shifting focus after typing single digit', async () => {
+      render(<Field.DateOfBirth />)
+
+      const inputs = document.querySelectorAll('input')
+      const dayInput = inputs[0]
+      const monthInput = inputs[1]
+      const yearInput = inputs[2]
+
+      // Ensure day has a value
+      await userEvent.type(dayInput, '2')
+
+      // Type a single digit in month and focus on the next input with a clicktab
+      await userEvent.click(monthInput)
+      await waitFor(() => {
+        expect(dayInput).toHaveValue('02')
+      })
+
+      // Type a single digit in month and focus on the next input with a clicktab
+      await userEvent.type(monthInput, '2')
+      await userEvent.click(yearInput)
+
+      // Expect month to be changed to the corresponding month name
+      await waitFor(() => {
+        expect(monthInput).toHaveValue('Februar')
+      })
+    })
   })
 
   describe('Year', () => {


### PR DESCRIPTION
Motivation: Thought this did work fine before. But when I now fill [here](https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/DateOfBirth/demos/#empty) 2 + tab + 2 + tab – the month is not shown.

The test does fail when the changes are not present.