### PR TITLE
docs: use `makeAjvInstance` to create an Ajv instance

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider/Examples.tsx
@@ -5,7 +5,7 @@ import {
   Field,
   Value,
   JSONSchema,
-  Ajv,
+  makeAjvInstance,
 } from '@dnb/eufemia/src/extensions/forms'
 import { Flex } from '@dnb/eufemia/src'
 
@@ -173,9 +173,7 @@ export const Default = () => {
 }
 
 export const ValidationWithJsonSchema = () => {
-  const ajv = new Ajv({
-    allErrors: true,
-  })
+  const ajv = makeAjvInstance()
   return (
     <ComponentBox
       scope={{

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Isolation/info.mdx
@@ -154,12 +154,14 @@ render(
 **Using JSON Schema (Ajv)**
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field, JSONSchema } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  JSONSchema,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const isolatedSchema: JSONSchema = {
   type: 'object',
   properties: {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/Examples.tsx
@@ -7,7 +7,7 @@ import {
   SectionProps,
   Tools,
   Value,
-  Ajv,
+  makeAjvInstance,
 } from '@dnb/eufemia/src/extensions/forms'
 
 export const WithoutDataContext = () => {
@@ -258,7 +258,7 @@ export const OverwriteProps = () => {
 
 export const AllFieldsRequired = () => {
   return (
-    <ComponentBox scope={{ Ajv }}>
+    <ComponentBox scope={{ makeAjvInstance }}>
       {() => {
         const MyNameSection = (props: SectionProps) => {
           return (
@@ -278,9 +278,7 @@ export const AllFieldsRequired = () => {
           required: ['myRequiredSection'],
         }
 
-        const ajv = new Ajv({
-          allErrors: true,
-        })
+        const ajv = makeAjvInstance()
         return (
           <Flex.Stack>
             <Form.Handler
@@ -307,7 +305,7 @@ export const AllFieldsRequired = () => {
 
 export const SchemaSupport = () => {
   return (
-    <ComponentBox scope={{ Ajv }}>
+    <ComponentBox scope={{ makeAjvInstance }}>
       {() => {
         const MyNameSection = (props: SectionProps) => {
           return (
@@ -346,9 +344,7 @@ export const SchemaSupport = () => {
           },
         }
 
-        const ajv = new Ajv({
-          allErrors: true,
-        })
+        const ajv = makeAjvInstance()
         return (
           <Form.Handler
             onSubmit={async (data) => console.log('onSubmit', data)}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/info.mdx
@@ -196,11 +196,14 @@ render(
 
 ```tsx
 import Ajv from 'ajv/dist/2020'
-import { Form, Field, JSONSchema } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  JSONSchema,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const MySection = (props) => {
   return (
     <Form.Section {...props}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
@@ -223,12 +223,13 @@ render(
 **Using JSON Schema (Ajv)**
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const schema = {
   type: 'string',
   pattern: '^([a-z]+)$',
@@ -270,9 +271,7 @@ render(
 **Using JSON Schema (Ajv)**
 
 ```tsx
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const schema = {
   type: 'object',
   properties: {
@@ -316,12 +315,13 @@ render(
 **Using JSON Schema (Ajv)**
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const schema = {
   type: 'object',
   properties: {
@@ -357,12 +357,13 @@ The levels are prioritized in the order above, so the field level error message 
 Here is an example of how to do expose a custom error message for the `Field.errorRequired` validation rule on all levels:
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field,  } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-    allErrors: true,
-  })
+const ajv = makeAjvInstance()
 
 render(
   <Form.Handler
@@ -382,7 +383,6 @@ render(
         // Level 3
         'Field.errorRequired': 'Or on a single Field itself',
       }}
-      ...
     />
   </Form.Handler>,
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/Examples.tsx
@@ -4,14 +4,12 @@ import {
   Form,
   Field,
   Iterate,
-  Ajv,
+  makeAjvInstance,
 } from '@dnb/eufemia/src/extensions/forms'
 import { trash as TrashIcon } from '@dnb/eufemia/src/icons'
 
 export const SingleFieldSchema = () => {
-  const ajv = new Ajv({
-    allErrors: true,
-  })
+  const ajv = makeAjvInstance()
   return (
     <ComponentBox scope={{ ajv }}>
       <Form.Handler ajvInstance={ajv}>
@@ -22,9 +20,7 @@ export const SingleFieldSchema = () => {
 }
 
 export const DataSetSchema = () => {
-  const ajv = new Ajv({
-    allErrors: true,
-  })
+  const ajv = makeAjvInstance()
   return (
     <ComponentBox scope={{ ajv }}>
       <Form.Handler
@@ -54,9 +50,7 @@ export const DataSetSchema = () => {
 }
 
 export const IfRuleSchema = () => {
-  const ajv = new Ajv({
-    allErrors: true,
-  })
+  const ajv = makeAjvInstance()
   return (
     <ComponentBox scope={{ ajv }}>
       <Form.Handler
@@ -101,9 +95,7 @@ export const IfRuleSchema = () => {
 }
 
 export const DependantListSchema = () => {
-  const ajv = new Ajv({
-    allErrors: true,
-  })
+  const ajv = makeAjvInstance()
   return (
     <ComponentBox scope={{ TrashIcon, ajv }}>
       <Form.Handler

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
@@ -86,7 +86,7 @@ These two examples will result in the same validation for the user:
 vs.
 
 ```tsx
-import { Form, Field, z } from '@dnb/eufemia/extensions/forms'
+import { Form, Field, z, makeAjvInstance } from '@dnb/eufemia/extensions/forms'
 
 const schema = z.object({
   name: z.string().min(3),
@@ -107,9 +107,7 @@ const schema = z.object({
 import Ajv from 'ajv/dist/2020'
 import { JSONSchema,  } from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-    allErrors: true,
-  })
+const ajv = makeAjvInstance()
 const schema: JSONSchema = {
   properties: {
     name: { minLength: 3 },
@@ -208,12 +206,15 @@ You can provide your custom `validate` function with your own keywords to your s
 First, you need to create your won instance of Ajv:
 
 ```ts
+import { makeAjvInstance } from '@dnb/eufemia/extensions/forms'
 import Ajv from 'ajv/dist/2020'
 
-const ajv = new Ajv({
-  strict: true,
-  allErrors: true,
-})
+const ajv = makeAjvInstance(
+  new Ajv({
+    strict: true,
+    allErrors: true,
+  }),
+)
 ```
 
 Then you add your custom keyword to the Ajv instance:
@@ -246,10 +247,14 @@ And finally add the Ajv instance to your form:
 
 ```tsx
 import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
 render(
-  <Form.Handler schema={schema} ajvInstance={new Ajv({ allErrors: true })}>
+  <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
     <Field.String path="/myKey" value="1" validateInitially />
   </Form.Handler>,
 )
@@ -260,10 +265,13 @@ render(
 Here is another example of a custom keyword, used in one field only:
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
+const ajv = makeAjvInstance({
   strict: true,
   allErrors: true,
 })

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/Examples.tsx
@@ -9,7 +9,7 @@ import {
   Wizard,
   ValueBlock,
   FieldBlock,
-  Ajv,
+  makeAjvInstance,
 } from '@dnb/eufemia/src/extensions/forms'
 export { Default as AnimatedContainer } from '../AnimatedContainer/Examples'
 
@@ -424,11 +424,9 @@ export const InitiallyOpen = () => {
 
 export const MinItems = () => {
   return (
-    <ComponentBox hideCode scope={{ Ajv }}>
+    <ComponentBox hideCode scope={{ makeAjvInstance }}>
       {() => {
-        const ajv = new Ajv({
-          allErrors: true,
-        })
+        const ajv = makeAjvInstance()
         const schema = {
           type: 'object',
           properties: {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/info.mdx
@@ -52,12 +52,13 @@ render(
 **Using JSON Schema (Ajv)**
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-  allErrors: true,
-})
+const ajv = makeAjvInstance()
 const schema = {
   type: 'object',
   properties: {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -28,8 +28,6 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 - Added support for [Zod](https://zod.dev/) schemas (along with Ajv).
 - When using JSON Schema (Ajv) it is recommended to explicitly providing an `ajvInstance` to `Form.Handler`:
-  - Import Ajv from `ajv`: `import Ajv from 'ajv/dist/2020'`
-  - Pass an instance to your form: `<Form.Handler ajvInstance={new Ajv({ allErrors: true })}>`
 
 ## v10.81.0
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/Examples.tsx
@@ -5,8 +5,8 @@ import {
   FieldBlock,
   Form,
   useFieldProps,
-  Ajv,
   z,
+  makeAjvInstance,
 } from '@dnb/eufemia/src/extensions/forms'
 import { Flex, Slider } from '@dnb/eufemia/src'
 
@@ -215,7 +215,7 @@ export const CustomComponentWithZodSchemaExample = () => {
 
 export const CustomComponentWithJsonSchema = () => {
   return (
-    <ComponentBox scope={{ useFieldProps, Ajv }}>
+    <ComponentBox scope={{ useFieldProps, makeAjvInstance }}>
       {() => {
         const MySliderComponent = (props) => {
           const fromInput = React.useCallback(
@@ -296,9 +296,7 @@ export const CustomComponentWithJsonSchema = () => {
         }
 
         // Note: When using JSON Schema, you must provide ajvInstance to Form.Handler
-        const ajv = new Ajv({
-          allErrors: true,
-        })
+        const ajv = makeAjvInstance()
         return (
           <Form.Handler data={{ sliderValue: 50 }} ajvInstance={ajv}>
             <MySliderComponent

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -620,19 +620,22 @@ const schema = z.string().min(5)
 **NB:** An `Ajv` instance is required on the `Form.Handler`.
 
 ```tsx
-import Ajv from 'ajv/dist/2020'
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
+import {
+  Form,
+  Field,
+  makeAjvInstance,
+} from '@dnb/eufemia/extensions/forms'
 
-const ajv = new Ajv({
-    allErrors: true,
-  })
+const ajv = makeAjvInstance()
 const schema = {
   /* Ajv Schema */
 }
 
-<Form.Handler ajvInstance={ajv}>
-  <Field.PhoneNumber schema={schema} />
-</Form.Handler>
+render(
+  <Form.Handler ajvInstance={ajv}>
+    <Field.PhoneNumber schema={schema} />
+  </Form.Handler>,
+)
 ```
 
 ### onBlurValidator and onChangeValidator

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -210,7 +210,7 @@ export interface ContextState {
   showAllErrors: boolean | number
   hasVisibleError: boolean
   formState: SubmitState
-  getAjvInstance?: (instance?: Ajv) => Ajv
+  getAjvInstance?: () => Ajv
   contextErrorMessages: GlobalErrorMessagesWithPaths
   schema: Schema
   path?: Path

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -33,8 +33,7 @@ import {
   Schema,
 } from '../../types'
 import type { IsolationProviderProps } from '../../Form/Isolation/Isolation'
-import { debounce } from '../../../../shared/helpers'
-import { warn } from '../../../../shared/helpers'
+import { debounce, warn } from '../../../../shared/helpers'
 import FieldPropsProvider from '../../Field/Provider'
 import useUpdateEffect from '../../../../shared/helpers/useUpdateEffect'
 import { isAsync } from '../../../../shared/helpers/isAsync'
@@ -286,7 +285,7 @@ export default function Provider<Data extends JsonObject>(
   useEffect(() => {
     if (schema && !isZodSchema(schema) && !ajvInstance) {
       warn(
-        'Form.Handler received a JSON Schema but no ajvInstance. Provide ajvInstance={new Ajv({ allErrors: true })} to enable schema validation.'
+        'Form.Handler received a JSON Schema but no ajvInstance. Provide ajvInstance={makeAjvInstance()} to enable schema validation.'
       )
     }
   }, [schema, ajvInstance])

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -47,7 +47,7 @@ export const ProviderProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ajvInstance: {
-    doc: 'REQUIRED when using JSON Schema validation. Provide your own custom Ajv instance: import Ajv from "@dnb/eufemia/extensions/forms" and pass ajvInstance={new Ajv({ allErrors: true })}. This ensures your bundle only includes AJV when you actually need it. More info in the [Schema validation](/uilib/extensions/forms/Form/schema-validation/#custom-ajv-instance-and-keywords) section.',
+    doc: 'REQUIRED when using JSON Schema validation. Provide your own custom Ajv instance: import Ajv from "@dnb/eufemia/extensions/forms" and pass ajvInstance={makeAjvInstance()}. This ensures your bundle only includes AJV when you actually need it. More info in the [Schema validation](/uilib/extensions/forms/Form/schema-validation/#custom-ajv-instance-and-keywords) section.',
     type: 'ajv',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -26,6 +26,7 @@ import {
   Iterate,
   OnSubmitRequest,
   Wizard,
+  makeAjvInstance,
 } from '../../../'
 import { isCI } from 'repo-utils'
 import { Props as StringFieldProps } from '../../../Field/String'
@@ -2629,7 +2630,7 @@ describe('DataContext.Provider', () => {
         render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{
               myField: 'invalid',
             }}
@@ -2665,7 +2666,7 @@ describe('DataContext.Provider', () => {
         const { rerender } = render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={undefined}
           >
             <TestField path="/myKey" />
@@ -2679,7 +2680,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'correct' }}
           >
             <TestField path="/myKey" />
@@ -2690,7 +2691,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{}}
           >
             <TestField path="/myKey" />
@@ -2704,7 +2705,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'wrong' }}
           >
             <TestField path="/myKey" />
@@ -2718,7 +2719,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'correct' }}
           >
             <TestField path="/myKey" />
@@ -2740,7 +2741,7 @@ describe('DataContext.Provider', () => {
         const { rerender } = render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'one' }}
           >
             <TestField path="/myKey" />
@@ -2752,7 +2753,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'fooooooooo' }}
           >
             <TestField path="/myKey" maxLength={5} />
@@ -2764,7 +2765,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'fooo' }}
           >
             <TestField path="/myKey" maxLength={5} />
@@ -2776,7 +2777,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'three' }}
           >
             <TestField path="/myKey" maxLength={1} />
@@ -2788,7 +2789,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ myKey: 'three' }}
           >
             <TestField path="/myKey" maxLength={5} />
@@ -2811,7 +2812,7 @@ describe('DataContext.Provider', () => {
         render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ val: 'abc' }}
           >
             <TestField
@@ -2842,7 +2843,7 @@ describe('DataContext.Provider', () => {
         render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={{ val: 'abc' }}
           >
             <TestField path="/val" />
@@ -2870,7 +2871,7 @@ describe('DataContext.Provider', () => {
           <DataContext.Provider
             data={{ foo: 'original' }}
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <Field.Number path="/foo" />
             <Form.SubmitButton />
@@ -2889,7 +2890,7 @@ describe('DataContext.Provider', () => {
           <DataContext.Provider
             data={{ foo: 'changed' }}
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <Field.Number path="/fooBar" required />
             <Form.SubmitButton />
@@ -2935,7 +2936,7 @@ describe('DataContext.Provider', () => {
         const { rerender } = render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <TestField path="/myField" />
           </DataContext.Provider>
@@ -2946,7 +2947,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <TestField path="/myField" disabled />
           </DataContext.Provider>
@@ -2974,7 +2975,7 @@ describe('DataContext.Provider', () => {
         const { rerender } = render(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <TestField path="/myField" />
           </DataContext.Provider>
@@ -2985,7 +2986,7 @@ describe('DataContext.Provider', () => {
         rerender(
           <DataContext.Provider
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <TestField path="/myField" readOnly />
           </DataContext.Provider>
@@ -3160,7 +3161,7 @@ describe('DataContext.Provider', () => {
             data={{ foo: 'original' }}
             onSubmitRequest={onSubmitRequest}
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <Field.Number path="/foo" />
             <Form.SubmitButton />
@@ -3183,7 +3184,7 @@ describe('DataContext.Provider', () => {
             data={{ foo: 'changed' }}
             onSubmitRequest={onSubmitRequest}
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
           >
             <Field.Number path="/fooBar" required />
             <Form.SubmitButton />
@@ -3450,7 +3451,7 @@ describe('DataContext.Provider', () => {
       const { rerender } = render(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={validData}
         >
           <Field.String
@@ -3465,7 +3466,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={invalidData}
         >
           <Field.String
@@ -3481,7 +3482,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={validData}
         >
           <Field.String
@@ -3522,7 +3523,7 @@ describe('DataContext.Provider', () => {
       const { rerender } = render(
         <DataContext.Provider
           schema={schema1}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3540,7 +3541,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema2}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3556,7 +3557,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema1}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3592,7 +3593,7 @@ describe('DataContext.Provider', () => {
       const { rerender } = render(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={validData}
         >
           <Field.String
@@ -3607,7 +3608,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={invalidData}
         >
           <Field.String
@@ -3623,7 +3624,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={validData}
         >
           <Field.String
@@ -3664,7 +3665,7 @@ describe('DataContext.Provider', () => {
       const { rerender } = render(
         <DataContext.Provider
           schema={schema1}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3682,7 +3683,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema2}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3698,7 +3699,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={schema1}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={data}
         >
           <Field.String
@@ -3715,10 +3716,12 @@ describe('DataContext.Provider', () => {
     })
 
     it('should accept custom ajv instance', async () => {
-      const ajv = new Ajv({
-        strict: true,
-        allErrors: true,
-      })
+      const ajv = makeAjvInstance(
+        new Ajv({
+          strict: true,
+          allErrors: true,
+        })
+      )
 
       ajv.addKeyword({
         keyword: 'isEven',
@@ -3765,7 +3768,7 @@ describe('DataContext.Provider', () => {
       } as const
 
       const { rerender } = render(
-        <DataContext.Provider ajvInstance={new Ajv({ allErrors: true })}>
+        <DataContext.Provider ajvInstance={makeAjvInstance()}>
           <Field.String
             schema={fieldSchema}
             path="/myKey"
@@ -3793,7 +3796,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={providerSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
         >
           <Field.String path="/myKey" value="" validateInitially />
         </DataContext.Provider>
@@ -3821,7 +3824,7 @@ describe('DataContext.Provider', () => {
       rerender(
         <DataContext.Provider
           schema={providerSharedSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
         >
           <Field.String path="/myKey" value="" />
         </DataContext.Provider>
@@ -3845,10 +3848,12 @@ describe('DataContext.Provider', () => {
     })
 
     it('should accept custom ajv instance with custom error messages', () => {
-      const ajv = new Ajv({
-        strict: true,
-        allErrors: true,
-      })
+      const ajv = makeAjvInstance(
+        new Ajv({
+          strict: true,
+          allErrors: true,
+        })
+      )
 
       ajv.addKeyword({
         keyword: 'notEmpty',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -2,7 +2,14 @@ import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { screen, render, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { DataContext, Field, Form, Iterate, Ajv, z } from '../../..'
+import {
+  DataContext,
+  Field,
+  Form,
+  Iterate,
+  makeAjvInstance,
+  z,
+} from '../../..'
 import nbNO from '../../../constants/locales/nb-NO'
 
 const nb = nbNO['nb-NO']
@@ -1708,7 +1715,7 @@ describe('Field.Boolean', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={{ myField: false }}
         >
           <Field.Boolean path="/myField" validateInitially />
@@ -1734,7 +1741,7 @@ describe('Field.Boolean', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={{ myField: undefined }}
         >
           <Field.Boolean required path="/myField" />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field, Form, JSONSchema, Ajv } from '../../..'
+import { Field, Form, JSONSchema, makeAjvInstance } from '../../..'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
 
 import nbNO from '../../../constants/locales/nb-NO'
@@ -591,10 +591,7 @@ describe('Field.Composition', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Composition>
             <Field.Name.First path="/first" />
             <Field.Name.Last path="/last" />
@@ -629,10 +626,7 @@ describe('Field.Composition', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Composition>
             <Field.Name.First path="/first" validateInitially />
             <Field.Name.Last path="/last" validateInitially />
@@ -666,10 +660,7 @@ describe('Field.Composition', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Composition>
             <Field.String path="/first" value="f" validateInitially />
             <Field.String path="/last" value="l" validateInitially />
@@ -703,10 +694,7 @@ describe('Field.Composition', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Composition>
             <Field.String
               path="/first"
@@ -787,10 +775,7 @@ describe('Field.Composition', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Composition>
             <Field.String
               path="/first"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -7,8 +7,8 @@ import {
   Field,
   FieldBlock,
   Form,
+  makeAjvInstance,
   Wizard,
-  Ajv,
 } from '../../..'
 import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
@@ -2515,7 +2515,7 @@ describe('Field.Date', () => {
         const log = jest.spyOn(console, 'log').mockImplementation()
 
         render(
-          <Form.Handler ajvInstance={new Ajv({ allErrors: true })}>
+          <Form.Handler ajvInstance={makeAjvInstance()}>
             <Field.Date
               value="2023-12-0"
               schema={{ type: 'string', minLength: 10 }}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -15,7 +15,7 @@ import {
   Form,
   Iterate,
   JSONSchema,
-  Ajv,
+  makeAjvInstance,
   z,
 } from '../../..'
 import { format } from '../../../../../components/number-format/NumberUtils'
@@ -1371,7 +1371,7 @@ describe('Field.Number', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={data}
           >
             <Field.Number path="/myFieldWithUndefined" />
@@ -1389,7 +1389,7 @@ describe('Field.Number', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={data}
           >
             <Field.Number path="/myFieldWithZero" />
@@ -1407,7 +1407,7 @@ describe('Field.Number', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={data}
           >
             <Field.Number path="/myFieldWithNull" />
@@ -1427,7 +1427,7 @@ describe('Field.Number', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             data={data}
           >
             <Field.Number
@@ -1474,10 +1474,7 @@ describe('Field.Number', () => {
           }
 
           render(
-            <Form.Handler
-              schema={schema}
-              ajvInstance={new Ajv({ allErrors: true })}
-            >
+            <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
               <Field.Number path="/amount" />
             </Form.Handler>
           )
@@ -2378,10 +2375,7 @@ describe('Field.Number', () => {
       const schema = z.object({ amount: z.number().max(10) })
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Number path="/amount" />
         </Form.Handler>
       )
@@ -2436,10 +2430,7 @@ describe('Field.Number', () => {
       })
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <Field.Number path="/amount" />
         </Form.Handler>
       )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -10,8 +10,8 @@ import {
   JSONSchema,
   JSONSchemaType,
   OnSubmit,
+  makeAjvInstance,
 } from '../../..'
-import { Ajv } from '../../..'
 import type { Props as StringFieldProps } from '../../../Field/String'
 import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
@@ -1142,10 +1142,7 @@ describe('Form.Handler', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           content
         </Form.Handler>
       )
@@ -1164,10 +1161,7 @@ describe('Form.Handler', () => {
       } as const
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           content
         </Form.Handler>
       )
@@ -1190,10 +1184,7 @@ describe('Form.Handler', () => {
 
       expect(() => {
         render(
-          <Form.Handler
-            schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
-          >
+          <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
             content
           </Form.Handler>
         )
@@ -1211,10 +1202,7 @@ describe('Form.Handler', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           content
         </Form.Handler>
       )
@@ -1235,10 +1223,7 @@ describe('Form.Handler', () => {
 
       expect(() => {
         render(
-          <Form.Handler
-            schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
-          >
+          <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
             content
           </Form.Handler>
         )
@@ -1262,10 +1247,7 @@ describe('Form.Handler', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           content
         </Form.Handler>
       )

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -8,7 +8,15 @@ import {
   waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Ajv, Field, Form, Iterate, JSONSchema, Wizard, z } from '../../..'
+import {
+  Field,
+  Form,
+  Iterate,
+  JSONSchema,
+  makeAjvInstance,
+  Wizard,
+  z,
+} from '../../..'
 import DataContext from '../../../DataContext/Context'
 import setData from '../../data-context/setData'
 import useReportError from '../useReportError'
@@ -790,7 +798,7 @@ describe('Form.Isolation', () => {
       <Form.Handler>
         <Form.Isolation
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           data={{
             myKey: 'valid',
           }}
@@ -3485,7 +3493,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{
               user: {
                 foo: 'foo', // This should fail validation (minLength: 4)
@@ -3560,7 +3568,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{
               firstSubPath: {
                 secondSubPath: {
@@ -3625,7 +3633,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{
               foo: 'foo',
             }}
@@ -3684,7 +3692,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{ foo: 'foo' }}
           >
             {/* No schema/ajv passed to Isolation. It should inherit from Form.Handler */}
@@ -3742,7 +3750,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{
               foo: 'foo',
             }}
@@ -3811,7 +3819,7 @@ describe('Form.Isolation', () => {
         render(
           <Form.Handler
             schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
+            ajvInstance={makeAjvInstance()}
             defaultData={{ foo: 'foo' }}
           >
             <Form.Isolation

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -2,7 +2,14 @@
 import React from 'react'
 import { spyOnEufemiaWarn } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render } from '@testing-library/react'
-import { Field, Form, JSONSchema, Tools, Value, Ajv } from '../../..'
+import {
+  Field,
+  Form,
+  JSONSchema,
+  makeAjvInstance,
+  Tools,
+  Value,
+} from '../../..'
 import { SectionProps } from '../Section'
 import { Props as FieldNameProps } from '../../../Field/Name'
 import FieldPropsProvider from '../../../Field/Provider'
@@ -983,10 +990,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/mySection" />
         </Form.Handler>
       )
@@ -1006,10 +1010,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/mySection" />
         </Form.Handler>
       )
@@ -1039,10 +1040,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/mySection" />
         </Form.Handler>
       )
@@ -1077,10 +1075,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/myObject/mySection" />
         </Form.Handler>
       )
@@ -1110,10 +1105,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/firstName" />
         </Form.Handler>
       )
@@ -1138,10 +1130,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection path="/firstName" />
         </Form.Handler>
       )
@@ -1171,10 +1160,7 @@ describe('Form.Section', () => {
       }
 
       render(
-        <Form.Handler
-          schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
           <MySection
             path="/mySection"
             overwriteProps={{

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -9,11 +9,11 @@ import {
   FieldBlock,
   Form,
   JSONSchema,
+  makeAjvInstance,
   Value,
   ValueBlock,
   Wizard,
 } from '../../..'
-import { Ajv } from '../../..'
 import * as z from 'zod'
 import { ContextState, FilterData } from '../../../DataContext'
 
@@ -2678,7 +2678,7 @@ describe('Iterate.Array', () => {
       }
 
       const { rerender } = render(
-        <Form.Handler ajvInstance={new Ajv({ allErrors: true })}>
+        <Form.Handler ajvInstance={makeAjvInstance()}>
           <Iterate.Array
             path="/items"
             schema={schema}
@@ -2697,7 +2697,7 @@ describe('Iterate.Array', () => {
       rerender(
         <Form.Handler
           data={{ items: ['one', 'two', 'three'] }}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
         >
           <Iterate.Array
             path="/items"
@@ -2732,7 +2732,7 @@ describe('Iterate.Array', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={{ myList: [{ foo }] }}
         >
           <Iterate.Array path="/myList" errorMessages={{ minItems }}>
@@ -2848,7 +2848,7 @@ describe('Iterate.Array', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           defaultData={{
             mySection: {
               myList: [{ foo }],

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -7,9 +7,9 @@ import {
   Form,
   Iterate,
   JSONSchema,
+  makeAjvInstance,
   Value,
   Wizard,
-  Ajv,
   z,
 } from '../../..'
 import { Div } from '../../../../../elements'
@@ -2104,10 +2104,7 @@ describe('PushContainer', () => {
         const schema: JSONSchema = { type: 'object', properties: {} }
 
         render(
-          <Form.Handler
-            schema={schema}
-            ajvInstance={new Ajv({ allErrors: true })}
-          >
+          <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
             <Wizard.Container>
               <Wizard.Step title="Step 1">
                 <output>Step 1</output>
@@ -2660,7 +2657,7 @@ describe('PushContainer', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           onChange={onChange}
         >
           <Iterate.Array path="/entries">...</Iterate.Array>

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Errors.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Errors.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Field, Form, JSONSchema, Tools, Ajv } from '../../'
+import { Field, Form, JSONSchema, Tools, makeAjvInstance } from '../../'
 
 describe('Tools.Errors', () => {
   it('should render empty log when no errors are present', () => {
@@ -72,7 +72,7 @@ describe('Tools.Errors', () => {
       required: ['foo'],
     }
 
-    const ajv = new Ajv({ allErrors: true })
+    const ajv = makeAjvInstance()
 
     const { rerender } = render(
       <Form.Handler schema={schema1} ajvInstance={ajv}>

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { Ajv, Field, Form, Value, Tools } from '../../'
+import { Field, Form, Value, Tools, makeAjvInstance } from '../../'
 import { GenerateRef } from '../GenerateSchema'
 
 describe('Tools.GenerateSchema', () => {
@@ -541,7 +541,7 @@ describe('Tools.GenerateSchema', () => {
       }
     `)
 
-    const ajv = new Ajv()
+    const ajv = makeAjvInstance()
     const validate = ajv.compile(schema)
     const valid = validate(data)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -11,8 +11,8 @@ import {
   OnSubmit,
   OnSubmitRequest,
   Wizard,
+  makeAjvInstance,
 } from '../../..'
-import { Ajv } from '../../..'
 import WizardContext from '../../Context'
 
 import nbNO from '../../../constants/locales/nb-NO'
@@ -2683,10 +2683,7 @@ describe('Wizard.Container', () => {
     } as const
 
     render(
-      <Form.Handler
-        schema={schema}
-        ajvInstance={new Ajv({ allErrors: true })}
-      >
+      <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
         <Wizard.Container>
           <Wizard.Step title="Step 1">
             <output>Step 1</output>
@@ -3405,7 +3402,7 @@ describe('Wizard.Container', () => {
       render(
         <Form.Handler
           schema={schema}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
           onSubmit={onSubmit}
         >
           <Wizard.Container initialActiveIndex={1}>
@@ -5322,7 +5319,7 @@ describe('Wizard.Container', () => {
               },
             },
           }}
-          ajvInstance={new Ajv({ allErrors: true })}
+          ajvInstance={makeAjvInstance()}
         >
           <Wizard.Container expandedInitially>
             <Wizard.Step title="Step 1">

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -27,7 +27,7 @@ import Field, {
   SubmitState,
   UseFieldProps,
   Wizard,
-  Ajv,
+  makeAjvInstance,
 } from '../../Forms'
 import SectionContext, {
   SectionContextState,
@@ -2118,7 +2118,7 @@ describe('useFieldProps', () => {
             }),
           {
             wrapper: ({ children }) => {
-              const ajv = new Ajv({ allErrors: true })
+              const ajv = makeAjvInstance()
               return (
                 <Provider schema={schema} ajvInstance={ajv}>
                   {children}
@@ -2157,7 +2157,7 @@ describe('useFieldProps', () => {
             }),
           {
             wrapper: ({ children }) => {
-              const ajv = new Ajv({ allErrors: true })
+              const ajv = makeAjvInstance()
               return (
                 <Provider schema={schema} ajvInstance={ajv}>
                   {children}
@@ -7958,10 +7958,7 @@ describe('Zod schema support', () => {
 
     const wrapper = ({ children }) => (
       <SectionContext.Provider value={{ path: '', errorPrioritization }}>
-        <Provider
-          schema={jsonSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Provider schema={jsonSchema} ajvInstance={makeAjvInstance()}>
           {children}
         </Provider>
       </SectionContext.Provider>
@@ -8059,10 +8056,7 @@ describe('Zod schema support', () => {
           errorPrioritization: ['contextSchema', 'fieldSchema'],
         }}
       >
-        <Provider
-          schema={jsonSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Provider schema={jsonSchema} ajvInstance={makeAjvInstance()}>
           {children}
         </Provider>
       </SectionContext.Provider>
@@ -8126,10 +8120,7 @@ describe('Zod schema support', () => {
 
     const wrapper = ({ children }) => (
       <SectionContext.Provider value={{ path: '', errorPrioritization }}>
-        <Provider
-          schema={mockZodSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Provider schema={mockZodSchema} ajvInstance={makeAjvInstance()}>
           {children}
         </Provider>
       </SectionContext.Provider>
@@ -8161,10 +8152,7 @@ describe('Zod schema support', () => {
     // Context Zod schema succeeds (mocked in beforeEach)
     const wrapper = ({ children }) => (
       <SectionContext.Provider value={{ path: '', errorPrioritization }}>
-        <Provider
-          schema={mockZodSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Provider schema={mockZodSchema} ajvInstance={makeAjvInstance()}>
           {children}
         </Provider>
       </SectionContext.Provider>
@@ -8205,10 +8193,7 @@ describe('Zod schema support', () => {
     // Context Zod schema succeeds (mocked in beforeEach)
     const wrapper = ({ children }) => (
       <SectionContext.Provider value={{ path: '', errorPrioritization }}>
-        <Provider
-          schema={mockZodSchema}
-          ajvInstance={new Ajv({ allErrors: true })}
-        >
+        <Provider schema={mockZodSchema} ajvInstance={makeAjvInstance()}>
           {children}
         </Provider>
       </SectionContext.Provider>

--- a/packages/dnb-eufemia/src/extensions/forms/index.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/index.ts
@@ -12,17 +12,6 @@ export * as Connectors from './Connectors'
 export { default as FieldBlock } from './FieldBlock'
 export { default as ValueBlock } from './ValueBlock'
 
-/**
- * IMPORTANT: In future AJV will not longer be imported by default in Eufemia Forms.
- *
- * If you use JSON Schema validation (AJV schemas), you MUST:
- * 1. Import AJV: import Ajv from '@dnb/eufemia/extensions/forms'
- * 2. Provide ajvInstance prop to Form.Handler: <Form.Handler ajvInstance={new Ajv({ allErrors: true })}>
- *
- * This ensures your bundle only includes AJV when you actually need it.
- */
-export { default as Ajv } from 'ajv/dist/2020.js'
-
 // Re-export Zod so consumers can `import { z } from '@dnb/eufemia/extensions/forms'`
 export * as z from 'zod'
 

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajv.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajv.test.ts
@@ -5,6 +5,7 @@ import { FormsTranslation } from '../../hooks/useTranslation'
 import { AdditionalReturnUtils } from '../../../../shared/useTranslation'
 import {
   makeAjvInstance,
+  enhanceAjvInstance,
   getInstancePath,
   getValidationRule,
   getMessageValues,
@@ -33,6 +34,36 @@ describe('makeAjvInstance', () => {
 
     expect(ajvInstance).toBeDefined()
     expect(ajvInstance).toBeInstanceOf(Ajv)
+  })
+})
+
+describe('enhanceAjvInstance', () => {
+  it('should enhance an existing Ajv instance with ajv-errors plugin', () => {
+    const ajv = new Ajv({
+      allErrors: true,
+    })
+
+    const ajvInstance = enhanceAjvInstance(ajv)
+
+    expect(ajvInstance).toBeDefined()
+    expect(ajvInstance).toBeInstanceOf(Ajv)
+    expect(ajvInstance).toBe(ajv) // Should return the same instance
+    expect(ajvInstance['__ajvErrors__']).toBe(true) // Should be enhanced
+  })
+
+  it('should not re-enhance an already enhanced Ajv instance', () => {
+    const ajv = new Ajv({
+      allErrors: true,
+    })
+
+    // First enhancement
+    const ajvInstance1 = enhanceAjvInstance(ajv)
+    expect(ajvInstance1['__ajvErrors__']).toBe(true)
+
+    // Second enhancement should not cause issues
+    const ajvInstance2 = enhanceAjvInstance(ajv)
+    expect(ajvInstance2).toBe(ajv)
+    expect(ajvInstance2['__ajvErrors__']).toBe(true)
   })
 })
 

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
@@ -42,27 +42,27 @@ const ajvErrorKeywordsTranslationTable = [
 ]
 
 /**
- * Creates an instance of Ajv (Another JSON Schema Validator) with optional custom instance.
- * If no instance is provided, a new instance of Ajv is created with the specified options.
- * The created Ajv instance is enhanced with custom error handling.
+ * Creates or enhances an Ajv instance.
+ * If no instance is provided, a new one is created with allErrors option enabled.
+ * The ajv-errors plugin is added to the instance if it hasn't been added yet.
+ */
+export function makeAjvInstance(instance?: Ajv): Ajv {
+  return enhanceAjvInstance(instance || new Ajv({ allErrors: true }))
+}
+
+/**
+ * Enhances an Ajv instance by adding the ajv-errors plugin if it hasn't been added yet.
  *
  * @param instance - Optional custom instance of Ajv.
  * @returns The created or provided instance of Ajv.
  */
-export function makeAjvInstance(instance?: Ajv): Ajv {
-  const ajv =
-    instance ||
-    new Ajv({
-      // If allErrors is off, Ajv only give you the first error it finds
-      allErrors: true,
-    })
-
-  if (!ajv['__ajvErrors__']) {
-    ajvErrors(ajv)
-    ajv['__ajvErrors__'] = true
+export function enhanceAjvInstance(instance?: Ajv): Ajv {
+  if (!instance['__ajvErrors__']) {
+    ajvErrors(instance)
+    instance['__ajvErrors__'] = true
   }
 
-  return ajv
+  return instance
 }
 
 /**


### PR DESCRIPTION
Until now, we’ve recommended using a new Ajv instance directly. However, with the upcoming v11 release in mind, I see the benefit of creating the instance through a helper method instead — this allows us to wrap it with proper error handling.

```diff
-const ajv = new Ajv({
-    allErrors: true,
-  })
+const ajv = makeAjvInstance()

```
