### PR TITLE
chore(Forms): wrap field tests with Ajv schema provider

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -2,8 +2,14 @@ import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import DataContext from '../../../DataContext/Context'
-import { Field, FieldBlock, Form, Iterate } from '../../..'
+import {
+  Field,
+  FieldBlock,
+  Form,
+  Iterate,
+  makeAjvInstance,
+  DataContext,
+} from '../../..'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -875,19 +881,21 @@ describe('ArraySelection', () => {
         ]
 
         render(
-          <Field.ArraySelection
-            label="Select cities"
-            data={data}
-            schema={{
-              type: 'array',
-              minItems: 2,
-              maxItems: 3,
-            }}
-            errorMessages={{
-              minItems: 'You must select at least two',
-              maxItems: 'You can only select up to three',
-            }}
-          />
+          <DataContext.Provider ajvInstance={makeAjvInstance()}>
+            <Field.ArraySelection
+              label="Select cities"
+              data={data}
+              schema={{
+                type: 'array',
+                minItems: 2,
+                maxItems: 3,
+              }}
+              errorMessages={{
+                minItems: 'You must select at least two',
+                maxItems: 'You can only select up to three',
+              }}
+            />
+          </DataContext.Provider>
         )
 
         // Trying to select only one item

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -1668,11 +1668,13 @@ describe('Field.Boolean', () => {
       }
 
       render(
-        <Field.Boolean
-          value={false}
-          schema={booleanSchema}
-          validateInitially
-        />
+        <DataContext.Provider ajvInstance={makeAjvInstance()}>
+          <Field.Boolean
+            value={false}
+            schema={booleanSchema}
+            validateInitially
+          />
+        </DataContext.Provider>
       )
 
       const formStatus = document.querySelector('.dnb-form-status')
@@ -1687,11 +1689,13 @@ describe('Field.Boolean', () => {
       }
 
       render(
-        <Field.Boolean
-          value={false}
-          schema={booleanSchema}
-          validateInitially
-        />
+        <DataContext.Provider ajvInstance={makeAjvInstance()}>
+          <Field.Boolean
+            value={false}
+            schema={booleanSchema}
+            validateInitially
+          />
+        </DataContext.Provider>
       )
 
       const formStatus = document.querySelector('.dnb-form-status')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -19,7 +19,7 @@ import {
   z,
 } from '../../..'
 import { format } from '../../../../../components/number-format/NumberUtils'
-import { Provider } from '../../../../../shared'
+import { Provider as SharedProvider } from '../../../../../shared'
 import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
 
@@ -100,18 +100,18 @@ describe('Field.Number', () => {
 
     it('should format according to en-GB locale (no currency)', () => {
       render(
-        <Provider locale="en-GB">
+        <SharedProvider locale="en-GB">
           <Field.Number value={1234.56789} decimalLimit={2} />
-        </Provider>
+        </SharedProvider>
       )
       expect(document.querySelector('input')).toHaveValue('1,234.56')
     })
 
     it('should format according to de-DE locale (no currency)', () => {
       render(
-        <Provider locale="de-DE">
+        <SharedProvider locale="de-DE">
           <Field.Number value={1234.56789} decimalLimit={2} />
-        </Provider>
+        </SharedProvider>
       )
       expect(document.querySelector('input')).toHaveValue('1.234,56')
     })
@@ -602,9 +602,9 @@ describe('Field.Number', () => {
 
       it('formats in different locale', () => {
         render(
-          <Provider locale="en-GB">
+          <SharedProvider locale="en-GB">
             <Field.Number value={1234.56789} currency decimalLimit={2} />
-          </Provider>
+          </SharedProvider>
         )
         expect(document.querySelector('input')).toHaveValue('1,234.56 NOK')
       })
@@ -902,9 +902,9 @@ describe('Field.Number', () => {
 
     it('formats using provided locale (en-GB)', async () => {
       render(
-        <Provider locale="en-GB">
+        <SharedProvider locale="en-GB">
           <Field.Number maximum={1000} />
-        </Provider>
+        </SharedProvider>
       )
 
       const input = document.querySelector('input')
@@ -1292,7 +1292,11 @@ describe('Field.Number', () => {
         const log = jest.spyOn(console, 'error').mockImplementation()
 
         const invalidValue = 'foo' as null
-        render(<Field.Number schema={schema} value={invalidValue} />)
+        render(
+          <DataContext.Provider ajvInstance={makeAjvInstance()}>
+            <Field.Number schema={schema} value={invalidValue} />
+          </DataContext.Provider>
+        )
 
         const input = document.querySelector('input')
         expect(input).toHaveValue('')
@@ -1319,7 +1323,11 @@ describe('Field.Number', () => {
       it('Ajv integer field schema: shows type error when typing 1.2 (decimal)', async () => {
         const schema: JSONSchema = { type: 'integer' }
 
-        render(<Field.Number schema={schema} />)
+        render(
+          <DataContext.Provider ajvInstance={makeAjvInstance()}>
+            <Field.Number schema={schema} />
+          </DataContext.Provider>
+        )
 
         const input = document.querySelector('input')
         await userEvent.type(input, '1.2')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -4,8 +4,13 @@ import { axeComponent } from '../../../../../core/jest/jestSetup'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SharedProvider from '../../../../../shared/Provider'
-import DataContext from '../../../DataContext/Context'
-import { Field, Form, JSONSchema } from '../../..'
+import {
+  Field,
+  Form,
+  JSONSchema,
+  makeAjvInstance,
+  DataContext,
+} from '../../..'
 import locales from '../../../constants/locales'
 import DrawerListProvider from '../../../../../fragments/drawer-list/DrawerListProvider'
 import { AdditionalArgs } from '../PhoneNumber'
@@ -1510,7 +1515,11 @@ describe('Field.PhoneNumber', () => {
       pattern: '^\\+47 [49]+',
     }
 
-    render(<Field.PhoneNumber schema={schema} />)
+    render(
+      <DataContext.Provider ajvInstance={makeAjvInstance()}>
+        <Field.PhoneNumber schema={schema} />
+      </DataContext.Provider>
+    )
 
     const numberElement = document.querySelector(
       '.dnb-forms-field-phone-number__number input'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -21,6 +21,7 @@ import {
   Validator,
   Value,
   z,
+  makeAjvInstance,
 } from '../../..'
 import sharedGB from '../../../../../shared/locales/en-GB'
 import nbNO from '../../../constants/locales/nb-NO'
@@ -830,10 +831,12 @@ describe('Field.String', () => {
 
         it('should show error only after changing when the value is still invalid', async () => {
           render(
-            <Field.String
-              value="abc"
-              schema={{ type: 'string', minLength: 6 }}
-            />
+            <Provider ajvInstance={makeAjvInstance()}>
+              <Field.String
+                value="abc"
+                schema={{ type: 'string', minLength: 6 }}
+              />
+            </Provider>
           )
           // Do not show error initially when validateInitially is not enabled, to avoid initial error messages all over empty forms
           expect(
@@ -884,11 +887,13 @@ describe('Field.String', () => {
       describe('with validateInitially', () => {
         it('should show error message initially', async () => {
           render(
-            <Field.String
-              value="abc"
-              schema={{ type: 'string', minLength: 6 }}
-              validateInitially
-            />
+            <Provider ajvInstance={makeAjvInstance()}>
+              <Field.String
+                value="abc"
+                schema={{ type: 'string', minLength: 6 }}
+                validateInitially
+              />
+            </Provider>
           )
           await waitFor(() => {
             expect(screen.getByRole('alert')).toBeInTheDocument()
@@ -899,11 +904,13 @@ describe('Field.String', () => {
       describe('with validateUnchanged', () => {
         it('should show error message when blurring without any changes', async () => {
           render(
-            <Field.String
-              value="abc"
-              schema={{ type: 'string', minLength: 6 }}
-              validateUnchanged
-            />
+            <Provider ajvInstance={makeAjvInstance()}>
+              <Field.String
+                value="abc"
+                schema={{ type: 'string', minLength: 6 }}
+                validateUnchanged
+              />
+            </Provider>
           )
           const input = document.querySelector('input')
           expect(
@@ -1847,11 +1854,13 @@ describe('Field.String', () => {
 
     it('should have aria-invalid', () => {
       render(
-        <Field.String
-          value="abc"
-          schema={{ type: 'string', minLength: 6 }}
-          validateInitially
-        />
+        <Provider ajvInstance={makeAjvInstance()}>
+          <Field.String
+            value="abc"
+            schema={{ type: 'string', minLength: 6 }}
+            validateInitially
+          />
+        </Provider>
       )
 
       const input = document.querySelector('input')
@@ -1881,12 +1890,14 @@ describe('Field.String', () => {
 
       it('should have aria-invalid', () => {
         render(
-          <Field.String
-            multiline
-            value="abc"
-            schema={{ type: 'string', minLength: 6 }}
-            validateInitially
-          />
+          <Provider ajvInstance={makeAjvInstance()}>
+            <Field.String
+              multiline
+              value="abc"
+              schema={{ type: 'string', minLength: 6 }}
+              validateInitially
+            />
+          </Provider>
         )
 
         const textarea = document.querySelector('textarea')

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -358,11 +358,17 @@ describe('useFieldProps', () => {
         pattern: '^(valid)$',
       }
 
-      const { result } = renderHook(() =>
-        useFieldProps({
-          value: 'valid',
-          schema,
-        })
+      const { result } = renderHook(
+        () =>
+          useFieldProps({
+            value: 'valid',
+            schema,
+          }),
+        {
+          wrapper: ({ children }) => (
+            <Provider ajvInstance={makeAjvInstance()}>{children}</Provider>
+          ),
+        }
       )
 
       const { handleChange, handleFocus } = result.current
@@ -396,11 +402,17 @@ describe('useFieldProps', () => {
         type: 'number',
       }
 
-      const { result } = renderHook(() =>
-        useFieldProps({
-          value: '',
-          schema,
-        })
+      const { result } = renderHook(
+        () =>
+          useFieldProps({
+            value: '',
+            schema,
+          }),
+        {
+          wrapper: ({ children }) => (
+            <Provider ajvInstance={makeAjvInstance()}>{children}</Provider>
+          ),
+        }
       )
 
       await waitFor(() => {
@@ -447,6 +459,9 @@ describe('useFieldProps', () => {
           value: 'invalid',
           schema,
         },
+        wrapper: ({ children }) => (
+          <Provider ajvInstance={makeAjvInstance()}>{children}</Provider>
+        ),
       })
 
       const { handleChange } = result.current
@@ -542,6 +557,9 @@ describe('useFieldProps', () => {
 
       const { result } = renderHook(useFieldProps, {
         initialProps,
+        wrapper: ({ children }) => (
+          <Provider ajvInstance={makeAjvInstance()}>{children}</Provider>
+        ),
       })
 
       // Try onBlurValidator
@@ -4471,10 +4489,12 @@ describe('useFieldProps', () => {
         }
 
         render(
-          <Field.String
-            schema={schema}
-            onChangeValidator={onChangeValidator}
-          />
+          <Provider ajvInstance={makeAjvInstance()}>
+            <Field.String
+              schema={schema}
+              onChangeValidator={onChangeValidator}
+            />
+          </Provider>
         )
 
         const input = document.querySelector('input')
@@ -6962,6 +6982,9 @@ describe('useFieldProps', () => {
           onBlurValidator,
           schema,
         },
+        wrapper: ({ children }) => (
+          <Provider ajvInstance={makeAjvInstance()}>{children}</Provider>
+        ),
       })
 
       expect(result.current.error).toBeUndefined()


### PR DESCRIPTION
Include this in `main` to keep v11 smaller and avoid unnecessary conflicts. Part of #5618.