### PR TITLE
chore(Checkbox): remove deprecated leftovers

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -129,26 +129,7 @@ export type CheckboxProps = {
   Omit<
     React.HTMLProps<HTMLInputElement>,
     'ref' | 'label' | 'size' | 'onChange' | 'onClick'
-  > &
-  DeprecatedCheckboxProps
-
-// deprecated, can be removed in v11
-type DeprecatedCheckboxProps = {
-  /** @deprecated use the `label` prop instead */
-  children?: React.ReactNode
-  /**  @deprecated use `onChange` */
-  on_change?: (args: OnChangeParams) => void
-  /**  @deprecated use `labelPosition` */
-  label_position?: CheckboxLabelPosition
-  /**  @deprecated use `labelSrOnly` */
-  label_sr_only?: boolean
-  /**  @deprecated use `statusState` */
-  status_state?: FormStatusState
-  /**  @deprecated use `statusProps` */
-  status_props?: FormStatusProps
-  /**  @deprecated use `statusNoAnimation` */
-  status_no_animation?: boolean
-}
+  >
 
 const defaultProps: CheckboxProps = {
   statusState: 'error',


### PR DESCRIPTION
This is just in case we forget to remove DeprecatedCheckboxProps