### PR TITLE
chore(DrawerList): remove `ignore_events` as deprecated

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -67,7 +67,7 @@ export type DrawerListDataArrayObjectStrict = {
   style?: React.CSSProperties
   /** classname added to the html list item */
   class_name?: string
-  /** set to true to disable mouse events selected style. Keyboard can still select @deprecated */
+  /** set to true to disable mouse events selected style. Keyboard can still select. */
   ignore_events?: boolean
   /** internal use only */
   render?: (children: React.ReactNode, id: string) => React.ReactNode


### PR DESCRIPTION
Not sure, but does not seem deprecated to me...
Here's a PR where I try to deprecate and remove it:
https://github.com/dnbexperience/eufemia/pull/5704

