### PR TITLE
fix(Form.Iterate): preserve JSX when replacing `{itemNo}` in labels

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -2064,7 +2064,7 @@ describe('Iterate.Array', () => {
       expect(log).toHaveBeenCalledWith(
         expect.any(String),
         'Value components as siblings should be wrapped inside a Value.SummaryList:',
-        { itemPath: '/', label: '', path: undefined }
+        { itemPath: '/', label: undefined, path: undefined }
       )
 
       log.mockRestore()

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/ItemNo.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/ItemNo.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { Iterate } from '../../..'
+import { renderWithFormatting } from '../../../../../shared'
 
 describe('Iterate.ItemNo', () => {
   it('should replace {itemNo} in children given as a string', () => {
@@ -22,7 +23,7 @@ describe('Iterate.ItemNo', () => {
     expect(document.body).toHaveTextContent('Item no. 2 string')
   })
 
-  it('should remove jsx and return only a string', () => {
+  it('should replace {itemNo} inside JSX children while preserving markup', () => {
     render(
       <Iterate.Array value={['foo']}>
         <Iterate.ItemNo>
@@ -30,6 +31,58 @@ describe('Iterate.ItemNo', () => {
         </Iterate.ItemNo>
       </Iterate.Array>
     )
-    expect(document.body).toHaveTextContent('Item no. 1 string')
+
+    expect(document.querySelector('b')?.textContent).toBe(
+      'Item no. 1 string'
+    )
+    expect(document.querySelector('section')).toMatchInlineSnapshot(`
+      <section
+        class="dnb-space dnb-flex-container dnb-flex-stack dnb-forms-iterate dnb-forms-section dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space"
+      >
+        <div
+          class="dnb-space dnb-space__top--zero dnb-space__bottom--zero dnb-flex-item dnb-forms-iterate__element"
+          tabindex="-1"
+        >
+          <b>
+            Item no. 1 string
+          </b>
+        </div>
+      </section>
+    `)
+  })
+
+  it('should support renderWithFormatting while preserving markup', () => {
+    const label = 'Item no. `{itemNo}` – **ready**'
+
+    render(
+      <Iterate.Array value={['foo']}>
+        <Iterate.ItemNo>{renderWithFormatting(label)}</Iterate.ItemNo>
+      </Iterate.Array>
+    )
+
+    expect(document.body).toHaveTextContent('Item no. 1 – ready')
+    expect(document.querySelector('code').textContent).toBe('1')
+    expect(document.querySelector('strong').textContent).toBe('ready')
+    expect(document.querySelector('section')).toMatchInlineSnapshot(`
+      <section
+        class="dnb-space dnb-flex-container dnb-flex-stack dnb-forms-iterate dnb-forms-section dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space"
+      >
+        <div
+          class="dnb-space dnb-space__top--zero dnb-space__bottom--zero dnb-flex-item dnb-forms-iterate__element"
+          tabindex="-1"
+        >
+          Item no. 
+          <code
+            class="dnb-code"
+          >
+            1
+          </code>
+           – 
+          <strong>
+            ready
+          </strong>
+        </div>
+      </section>
+    `)
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/useIterateItemNo.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/useIterateItemNo.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { useIterateItemNo } from '../useIterateItemNo'
 import IterateItemContext from '../../IterateItemContext'
+import { Field, Iterate } from '../../..'
+import { renderWithFormatting } from '../../../../../shared'
 
 function TestComponent(props: any) {
   const content = useIterateItemNo(props)
@@ -74,5 +76,30 @@ describe('useIterateItemNo', () => {
       </IterateItemContext.Provider>
     )
     expect(screen.getByText('Custom 4')).toBeInTheDocument()
+  })
+
+  it('should support renderWithFormatting', () => {
+    const label = 'Item no. `{itemNo}` – **ready**'
+
+    const Item = () => {
+      const str = useIterateItemNo({ label })
+      return <Field.String label={renderWithFormatting(str)} />
+    }
+
+    render(
+      <Iterate.Array value={['foo']}>
+        <Item />
+      </Iterate.Array>
+    )
+
+    expect(document.querySelector('label').textContent).toContain(
+      'Item no. 1 – ready'
+    )
+    expect(
+      document.querySelector('.dnb-forms-field-block__label__content')
+        .innerHTML
+    ).toMatchInlineSnapshot(
+      `"Item no. <code class="dnb-code">1</code> – <strong>ready</strong>"`
+    )
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/useIterateItemNo.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/useIterateItemNo.tsx
@@ -2,11 +2,12 @@ import React, { useMemo } from 'react'
 import { useItem } from '../hooks'
 import { useTranslation } from '../../hooks'
 import { convertJsxToString } from '../../../../shared/component-helper'
+import { replaceItemNo } from './ItemNo'
 
 export function useIterateItemNo({
   label: labelProp,
-  labelSuffix,
-  required,
+  labelSuffix = undefined,
+  required = undefined,
 }) {
   const { index: iterateIndex } = useItem() || {}
 
@@ -25,10 +26,7 @@ export function useIterateItemNo({
     let content = labelProp
 
     if (iterateIndex !== undefined) {
-      content = convertJsxToString(labelProp).replace(
-        '{itemNo}',
-        String(iterateIndex + 1)
-      )
+      content = replaceItemNo(labelProp, iterateIndex)
     }
 
     if (labelSuffixText) {

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -18,6 +18,7 @@ import DataContext from '../DataContext/Context'
 import { Path, ValueProps } from '../types'
 import { pickSpacingProps } from '../../../components/flex/utils'
 import IterateItemContext from '../Iterate/IterateItemContext'
+import { replaceItemNo } from '../Iterate/ItemNo'
 import { convertJsxToString } from '../../../shared/component-helper'
 import VisibilityContext from '../Form/Visibility/VisibilityContext'
 import Visibility from '../Form/Visibility/Visibility'
@@ -99,15 +100,13 @@ function ValueBlock(localProps: Props) {
 
     let label = labelProp
 
-    const canRenderToString = React.isValidElement(labelProp)
-      ? typeof labelProp.type === 'string' // Not just a span or div
-      : true
-    if (iterateIndex !== undefined && canRenderToString) {
-      label = convertJsxToString(labelProp).replace(
-        '{itemNo}',
-        String(iterateIndex + 1)
-      )
+    if (iterateIndex !== undefined) {
+      label = replaceItemNo(labelProp, iterateIndex)
     }
+
+    const canRenderToString = React.isValidElement(label)
+      ? typeof (label as any).type === 'string' // Not a custom component
+      : true
 
     return canRenderToString
       ? transformLabel(label, transformLabelParameters)

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -3,6 +3,7 @@ import { axeComponent } from '../../../../core/jest/jestSetup'
 import { render, fireEvent } from '@testing-library/react'
 import ValueBlock from '../ValueBlock'
 import { Field, Form, Iterate, Value } from '../..'
+import { renderWithFormatting } from '../../../../shared'
 import userEvent from '@testing-library/user-event'
 
 describe('ValueBlock', () => {
@@ -88,6 +89,39 @@ describe('ValueBlock', () => {
     const element = document.querySelector('.dnb-form-label')
     expect(element).toHaveClass('dnb-sr-only')
     expect(element).toHaveTextContent('Label')
+  })
+
+  it('replaces {itemNo} inside formatted JSX labels', () => {
+    const label = 'Item no. `{itemNo}` – **ready**'
+
+    render(
+      <Iterate.Array value={['foo']}>
+        <ValueBlock label={renderWithFormatting(label)} showEmpty />
+      </Iterate.Array>
+    )
+
+    expect(
+      document.querySelector('.dnb-forms-value-block__label__content')
+        .textContent
+    ).toContain('Item no. 1 – ready')
+    expect(
+      document.querySelector('.dnb-forms-value-block__label__content')
+    ).toMatchInlineSnapshot(`
+      <span
+        class="dnb-forms-value-block__label__content"
+      >
+        Item no. 
+        <code
+          class="dnb-code"
+        >
+          1
+        </code>
+         – 
+        <strong>
+          ready
+        </strong>
+      </span>
+    `)
   })
 
   it('should put children in a wrapper element "__content"', () => {


### PR DESCRIPTION
This ensures `{itemNo}` works when labels are React nodes (e.g. formatted or wrapped), aligning with e.g. Iterate containers and Field.Toggle behavior.

This makes the `{itemNo}` work with `renderWithFormatting`.

**NB:** This will create a conflict when rebasing `main` on top of `v11`.
