### PR TITLE
feat(Translation): enhance support for typing via generic `<Translation<SupportedTypes> id={(t) => t.my.string} />`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -118,19 +118,16 @@ const myTranslations = {
   'nb-NO': { 'custom.string': 'Min egendefinerte streng' },
   'en-GB': { 'custom.string': 'My custom string' },
 }
-
-// For TypeScript support
-type Tr<T> = TranslationProps<T[keyof T]>
-const Tr = (props: Tr<typeof myTranslations>) => <Translation {...props} />
+type TranslationType = (typeof myTranslations)[keyof typeof myTranslations]
 
 render(
   <Form.Handler translations={myTranslations}>
     <Form.MainHeading>
-      <Translation id="custom.string" />
+      <Translation<TranslationType> id="custom.string" />
     </Form.MainHeading>
 
     <Form.SubHeading>
-      <Tr id={(t) => t.custom.string} />
+      <Translation<TranslationType> id={(t) => t.custom.string} />
     </Form.SubHeading>
   </Form.Handler>,
 )
@@ -152,11 +149,12 @@ const myTranslations = {
     'custom.string': 'My custom string',
   },
 }
+type TranslationType = (typeof myTranslations)[keyof typeof myTranslations]
 
 render(
   <Provider translations={myTranslations}>
     <Heading>
-      <Translation id="custom.string" />
+      <Translation<TranslationType> id={(t) => t.custom.string} />
     </Heading>
 
     <Form.Handler>

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -467,16 +467,11 @@ const translations = {
   'nb-NO': { my: { string: 'streng {foo}' } },
   'en-GB': { my: { string: 'string {foo}' } },
 }
-type Translation = (typeof translations)[keyof typeof translations]
-
-// Make a wrapper, so we can use your translation types
-const MyTranslation = (props: TranslationProps<Translation>) => (
-  <Translation {...props} />
-)
+type TranslationType = (typeof translations)[keyof typeof translations]
 
 render(
   <EufemiaProvider locale="nb-NO" translations={translations}>
-    <MyTranslation id={(t) => t.my.string} foo="bar" />
+    <Translation<TranslationType> id={(t) => t.my.string} foo="bar" />
   </EufemiaProvider>,
 )
 ```

--- a/packages/dnb-eufemia/src/shared/Translation.tsx
+++ b/packages/dnb-eufemia/src/shared/Translation.tsx
@@ -15,11 +15,11 @@ export type TranslationProps<T = TranslationCustomLocales> = {
   children?: TranslationId
 } & TranslationArguments
 
-export default function Translation({
+const TranslationImpl = <T = TranslationCustomLocales,>({
   id,
   children,
   ...params
-}: TranslationProps) {
+}: TranslationProps<T>) => {
   const { translation } = useContext(SharedContext)
   const result = formatMessage(id || children, params, translation)
 
@@ -29,6 +29,28 @@ export default function Translation({
 
   return <>{result}</>
 }
+
+type TranslationFn = <T = TranslationCustomLocales>(
+  props: TranslationProps<T>
+) => JSX.Element
+
+export type TranslationComponent = TranslationFn & {
+  withTypes: <T = TranslationCustomLocales>() => (
+    props: TranslationProps<T>
+  ) => JSX.Element
+}
+
+const Translation = TranslationImpl as unknown as TranslationComponent
+
+Translation.withTypes = function withTypes<
+  T = TranslationCustomLocales,
+>() {
+  return function TypedTranslation(props: TranslationProps<T>) {
+    return <TranslationImpl {...(props as TranslationProps)} />
+  }
+}
+
+export default Translation
 
 export function mergeTranslations(
   ...translations: Array<Record<string, any>>

--- a/packages/dnb-eufemia/src/shared/__tests__/Translation.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Translation.test.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import Translation, {
-  TranslationProps,
-  mergeTranslations,
-} from '../Translation'
+import Translation, { mergeTranslations } from '../Translation'
 
 import Context from '../Context'
 import Provider from '../Provider'
@@ -149,15 +146,11 @@ describe('Translation', () => {
       'nb-NO': { my: { string: 'streng {foo}' } },
       'en-GB': { my: { string: 'string {foo}' } },
     }
-    type Translation = (typeof translations)[keyof typeof translations]
-
-    const MyTranslation = (props: TranslationProps<Translation>) => (
-      <Translation {...props} />
-    )
+    type TranslationType = (typeof translations)[keyof typeof translations]
 
     const { rerender } = render(
       <Provider translations={translations}>
-        <MyTranslation id={(t) => t.my.string} foo="bar" />
+        <Translation<TranslationType> id={(t) => t.my.string} foo="bar" />
       </Provider>
     )
 
@@ -165,7 +158,35 @@ describe('Translation', () => {
 
     rerender(
       <Provider locale="en-GB" translations={translations}>
-        <MyTranslation id={(t) => t.my.string} foo={() => 'baz'} />
+        <Translation<TranslationType>
+          id={(t) => t.my.string}
+          foo={() => 'baz'}
+        />
+      </Provider>
+    )
+
+    expect(document.body.textContent).toBe('string baz')
+  })
+
+  it('should support withTypes factory to keep types', () => {
+    const translations = {
+      'nb-NO': { my: { string: 'streng {foo}' } },
+      'en-GB': { my: { string: 'string {foo}' } },
+    }
+    type T = (typeof translations)[keyof typeof translations]
+    const TComp = Translation.withTypes<T>()
+
+    const { rerender } = render(
+      <Provider translations={translations}>
+        <TComp id={(t) => t.my.string} foo="bar" />
+      </Provider>
+    )
+
+    expect(document.body.textContent).toBe('streng bar')
+
+    rerender(
+      <Provider locale="en-GB" translations={translations}>
+        <TComp id={(t) => t.my.string} foo={() => 'baz'} />
       </Provider>
     )
 


### PR DESCRIPTION
Motivation: This way a dev does not need to create a wrapper component.