### PR TITLE
chore(CI): add support for `--skip-audit`

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -61,6 +61,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Audit dependencies
+        if: ${{ !contains(github.event.head_commit.message || '', '--skip-audit') && !(github.event.pull_request && contains(github.event.pull_request.title || '', '--skip-audit')) }}
         run: yarn workspace @dnb/eufemia audit:ci
 
       - name: Run lint

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -87,6 +87,16 @@ git commit -m "feat: implement new feature --run-all"
 
 This is particularly useful when you want to see all visual test failures at once, rather than stopping at the first one. The CI/CD pipeline automatically detects this flag and adjusts the test behavior accordingly.
 
+### Skip dependency audit in CI
+
+You can skip the dependency audit step in the Verify workflow by including `--skip-audit` in your commit message:
+
+```bash
+git commit -m "chore: update snapshots --skip-audit"
+```
+
+The CI will detect `--skip-audit` and skip the "Audit dependencies" step accordingly.
+
 **Playwright end-to-end tests:**
 
 ```bash


### PR DESCRIPTION
Motivation: Due to the downtime of `npm audit`.

<img width="269" height="161" alt="Screenshot 2025-10-20 at 12 14 30" src="https://github.com/user-attachments/assets/c0889214-bdad-4d5f-8d27-dbe5cdd35680" />

