### PR TITLE
break(DrawerListPortal): remove `include_owner_width` property

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -675,7 +675,6 @@ class DrawerListInstance extends React.Component<DrawerListAllProps> {
           id={this._id}
           rootRef={_refRoot}
           opened={hidden === false}
-          include_owner_width={alignDrawer === 'right'}
           independentWidth={isTrue(independentWidth)}
           fixedPosition={isTrue(fixedPosition)}
           className={getThemeClasses(this.context?.theme, portalClass)}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
@@ -19,7 +19,6 @@ export type DrawerListPortalProps = {
   opened: boolean
   innerRef?: React.ForwardedRef<HTMLSpanElement>
   rootRef: React.RefObject<HTMLSpanElement>
-  include_owner_width?: boolean
   independentWidth?: boolean
   fixedPosition?: boolean
   skipPortal?: boolean
@@ -31,7 +30,6 @@ function DrawerListPortal({
   id,
   opened,
   rootRef = { current: undefined },
-  include_owner_width,
   independentWidth,
   fixedPosition,
   skipPortal,
@@ -143,10 +141,7 @@ function DrawerListPortal({
         : window.pageXOffset
 
       let top = scrollY + rect.top
-      let left =
-        scrollX +
-        rect.left +
-        (include_owner_width ? parseFloat(ownerWidth || '0') : 0)
+      let left = scrollX + rect.left
 
       if (width > window.innerWidth) {
         width = window.innerWidth
@@ -170,14 +165,7 @@ function DrawerListPortal({
     } catch (e) {
       warn(e)
     }
-  }, [
-    isMounted,
-    rootRef,
-    independentWidth,
-    fixedPosition,
-    include_owner_width,
-    portalRef,
-  ])
+  }, [isMounted, rootRef, independentWidth, fixedPosition, portalRef])
 
   const addPositionObserver = useCallback(() => {
     if (setPosition.current || typeof window === 'undefined') {


### PR DESCRIPTION
Doesn't seem like it's used?

I should rather rename this one, and not remove. 