### PR TITLE
docs(Field.Upload): add example of how to validate custom file sizes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -3,6 +3,7 @@ import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
 import {
   Field,
   Form,
+  FormError,
   Tools,
   Value,
 } from '@dnb/eufemia/src/extensions/forms'
@@ -381,6 +382,71 @@ export const WithFileItemOptions = () => {
         }
 
         return <MyForm />
+      }}
+    </ComponentBox>
+  )
+}
+
+export const WithFileSizeValidation = () => {
+  return (
+    <ComponentBox scope={{ FormError }}>
+      {() => {
+        const MAX_SIZE = 500 * 1024 // 500 KB
+        const MIN_SIZE = 50 * 1024 // 50 KB
+
+        const myTranslation = {
+          'nb-NO': {
+            errorFileTooSmall: 'Filen er for liten.',
+            errorFileTooLarge: 'Filen er for stor.',
+          },
+          'en-GB': {
+            errorFileTooSmall: 'File is too small.',
+            errorFileTooLarge: 'File is too large.',
+          },
+        }
+
+        function MyField() {
+          const tr = Form.useTranslation()
+
+          const fileHandler = (newFiles: UploadValue) => {
+            return newFiles.map((item) => {
+              console.log('item:', item)
+
+              if (item.file.size < MIN_SIZE) {
+                item.errorMessage = tr['errorFileTooSmall']
+              }
+              if (item.file.size > MAX_SIZE) {
+                item.errorMessage = tr['errorFileTooLarge']
+              }
+
+              return item
+            })
+          }
+
+          return (
+            <Field.Upload
+              label="Label"
+              labelDescription="This is a Field"
+              path="/myField"
+              acceptedFileTypes={['PNG']}
+              fileMaxSize={false}
+              fileHandler={fileHandler}
+            />
+          )
+        }
+
+        return (
+          <Form.Handler
+            translations={myTranslation}
+            onSubmit={(data) => console.log('onSubmit', data)}
+          >
+            <Form.Card>
+              <MyField />
+            </Form.Card>
+
+            <Form.SubmitButton />
+          </Form.Handler>
+        )
       }}
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/demos.mdx
@@ -60,6 +60,10 @@ The `fileHandler` property supports a synchronous function, and can be used for 
 
 <Examples.WithFileItemOptions />
 
+### With file size validation
+
+<Examples.WithFileSizeValidation />
+
 <VisibleWhenVisualTest>
   <Examples.Width />
   <Examples.WithHelpWithoutLabelDescription />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/info.mdx
@@ -53,6 +53,8 @@ The `onChange` event handler will return an array with [file item objects](/uili
 
 For error handling of invalid files, you can refer to the [Upload](/uilib/components/upload/) component for more details.
 
+Here is [an example](/uilib/extensions/forms/feature-fields/more-fields/Upload/#with-file-size-validation) of how to use the `fileHandler` property to validate file sizes.
+
 ## About the `value` and `path` property
 
 The `path` property represents an array with an object described above:


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1761302527252939

Or do we have a similar/same example already?