### PR TITLE
fix(Field.Date): should reset value when pressing reset button

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -245,18 +245,32 @@ function DateComponent(props: DateProps) {
 
   const datePickerProps = pickDatePickerProps(rest)
   const handleReset = useCallback(
-    (event) => {
-      handleChange(event)
-      onReset?.(event)
+    (
+      event: DatePickerEvent<
+        React.MouseEvent<HTMLButtonElement, MouseEvent>
+      >
+    ) => {
+      const reset = {
+        date: undefined,
+        start_date: undefined,
+        end_date: undefined,
+        is_valid: false,
+      }
+      handleChange(reset)
+      setDisplayValue(undefined)
+      onReset?.({
+        ...event,
+        ...reset,
+      })
     },
-    [handleChange, onReset]
+    [handleChange, onReset, setDisplayValue]
   )
   const onFocus = useCallback(() => {
     handleFocus()
     handleError()
   }, [handleFocus, handleError])
   const onType = useCallback(
-    (event) => {
+    (event: DatePickerEvent<React.ChangeEvent<HTMLInputElement>>) => {
       const { date, start_date, end_date, ...rest } = event
 
       if (props.range) {
@@ -302,7 +316,7 @@ function DateComponent(props: DateProps) {
 
   useMemo(() => {
     if ((path || itemPath) && value) {
-      setDisplayValue(formatDate(value, { locale }), undefined)
+      setDisplayValue(formatDate(value, { locale }))
     }
   }, [itemPath, locale, path, setDisplayValue, value])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
@@ -60,6 +60,11 @@ export const DateProperties: PropertiesTableProps = {
     doc: `${size.doc} Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).`,
   },
   ...datePickerProperties,
+  onType: {
+    doc: 'Event handler that is called when the user types in the input field. The first parameter is a string, the second parameter is an object containing { date, start_date, end_date, is_valid, event }.',
+    type: 'function',
+    status: 'optional',
+  },
   onBlurValidator: {
     doc: 'Custom validator function that is triggered when the user leaves a field (e.g., blurring a text input or closing a dropdown). The function can be either asynchronous or synchronous. The first parameter is the value, and the second parameter returns an object containing { errorMessages, connectWithPath, validators }. Defaults to validating invalid dates, and dates against `minDate` and `maxDate`, using `dateValidator`. Can be disabled using `false`.',
     type: 'function',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -933,10 +933,17 @@ describe('Field.Date', () => {
         value: '01.10.2024',
       },
     })
+    expect(dataContext.fieldDisplayValueRef.current).toEqual({
+      '/date': {
+        type: 'field',
+        value: '01.10.2024',
+      },
+    })
 
-    fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+    const openButton = document.querySelector(
+      'button.dnb-input__submit-button__button'
     )
+    await userEvent.click(openButton)
 
     expect(document.querySelector('.dnb-date-picker')).toHaveClass(
       'dnb-date-picker--opened'
@@ -945,12 +952,16 @@ describe('Field.Date', () => {
     const resetButton = document.querySelector(
       'button[data-testid="reset"]'
     )
-
     await userEvent.click(resetButton)
 
     expect(onReset).toHaveBeenCalledTimes(1)
     expect(onReset).toHaveBeenCalledWith(
-      expect.objectContaining({ date: '2024-10-01' })
+      expect.objectContaining({
+        date: undefined,
+        is_valid: false,
+        start_date: undefined,
+        end_date: undefined,
+      })
     )
 
     expect(document.querySelector('.dnb-date-picker')).not.toHaveClass(
@@ -965,6 +976,9 @@ describe('Field.Date', () => {
     expect(month.value).toBe('mm')
     expect(year.value).toBe('åååå')
 
+    expect(dataContext.internalDataRef.current).toEqual({
+      '/date': undefined,
+    })
     expect(dataContext.fieldDisplayValueRef.current).toEqual({
       '/date': {
         type: 'field',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/stories/Date.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/stories/Date.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Field, Form, Value } from '../../..'
+import { Field, Form, Tools, Value } from '../../..'
 import FormHandler from '../../../Form/Handler/Handler'
 import { Card, DatePicker, Dropdown } from '../../../../../components'
 import Context from '../../../../../shared/Context'
@@ -133,8 +133,15 @@ export function Reset() {
             console.log('onReset', props)
           }}
         />
+        <Tools.Log />
       </FormHandler>
-      <DatePicker showInput showResetButton />
+      <DatePicker
+        showInput
+        showResetButton
+        onReset={(props) => {
+          console.log('onReset', props)
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1762173393020519

TODO:
- [x] The actual fix. Not sure if we should just in `Field.Date` clear/empty the date on reset "manually", or if we should try to reuse the logic of clearing/emptying from `DatePicker`