### PR TITLE
chore: refactor NPM README.md (license) file and routine

### DIFF
--- a/packages/dnb-eufemia/README
+++ b/packages/dnb-eufemia/README
@@ -1,5 +1,0 @@
-# DNB UI Library
-
-This User Interface Library is meant to use as a top layer on existing and new applications made by DNB.
-
-Read more about Eufemia and the [DNB UI Library](https://eufemia.dnb.no/uilib)

--- a/packages/dnb-eufemia/README.md
+++ b/packages/dnb-eufemia/README.md
@@ -1,3 +1,9 @@
 # DNB UI Library
 
+Eufemia is DNB's design system and UI library, providing a consistent and accessible set of components for building modern web applications. It streamlines development by offering reusable elements, design guidelines, and best practices, ensuring a unified user experience across DNB's digital products.
+
 Read more about Eufemia and the [DNB UI Library](https://eufemia.dnb.no/uilib/about-the-lib).
+
+## License
+
+You find the license here: https://github.com/dnbexperience/eufemia/blob/main/LICENSE

--- a/packages/dnb-eufemia/scripts/postbuild/copy-build-artifacts.sh
+++ b/packages/dnb-eufemia/scripts/postbuild/copy-build-artifacts.sh
@@ -7,7 +7,10 @@ echo 'Copy build artifacts ...'
 rm -rf build/**/{__tests__,cjs}
 cp -r ./assets/ ./build/assets
 cp .npmignore ./build/.npmignore
-cp README README.md LICENSE ./build
+# Copy README.md as the source of truth
+cp README.md LICENSE ./build
+# Also provide an extensionless README for compatibility
+cp README.md ./build/README
 babel-node --extensions .js,.ts,.tsx ./scripts/postbuild/copyFinaleBuild.js
 
 echo 'Copy build artifacts done!'


### PR DESCRIPTION
Motivation: Today we have two very similar README files. Both are needed in the build output. But this PR simplifies it and creates a copy. Also, adding a link to the license. Because [here](https://www.npmjs.com/package/@dnb/eufemia) its not easy to see/read the license.