### PR TITLE
fix(Form.useData): should set `data` to `defaultData` when `data` is not provided

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -4233,8 +4233,13 @@ describe('DataContext.Provider', () => {
         </DataContext.Provider>
       )
 
-      expect(nestedMockData).toHaveLength(2)
-      expect(nestedMockData).toEqual([initialData, initialData])
+      expect(nestedMockData).toHaveLength(4)
+      expect(nestedMockData).toEqual([
+        initialData,
+        initialData,
+        initialData,
+        initialData,
+      ])
 
       const inputElement = document.querySelector('input')
       expect(inputElement).toHaveValue('bar')
@@ -4271,8 +4276,12 @@ describe('DataContext.Provider', () => {
       expect(sidecarMockData).toHaveLength(2)
       expect(sidecarMockData).toEqual([undefined, initialData])
 
-      expect(nestedMockData).toHaveLength(2)
-      expect(nestedMockData).toEqual([initialData, initialData])
+      expect(nestedMockData).toHaveLength(3)
+      expect(nestedMockData).toEqual([
+        initialData,
+        initialData,
+        initialData,
+      ])
 
       const [sidecar, nested] = Array.from(
         document.querySelectorAll('input')
@@ -4366,10 +4375,12 @@ describe('DataContext.Provider', () => {
         { wrapper: StrictMode }
       )
 
-      expect(sidecarMockData).toHaveLength(4)
+      expect(sidecarMockData).toHaveLength(6)
       expect(sidecarMockData).toEqual([
         undefined,
         undefined,
+        initialData,
+        initialData,
         initialData,
         initialData,
       ])

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
@@ -114,7 +114,7 @@ describe('Field.DateOfBirth', () => {
         </Form.Handler>
       )
 
-      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenCalledTimes(3)
       expect(transformIn).toHaveBeenLastCalledWith({
         year: '1990',
         month: '05',
@@ -129,7 +129,7 @@ describe('Field.DateOfBirth', () => {
       expect(monthInput).toHaveValue('Mai')
       expect(yearInput.value).toBe('1990')
 
-      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenCalledTimes(3)
       expect(transformIn).toHaveBeenLastCalledWith({
         year: '1990',
         month: '05',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -178,7 +178,7 @@ describe('Field.Expiry', () => {
       year: '24',
       month: '12',
     })
-    expect(transformIn).toHaveBeenCalledTimes(6)
+    expect(transformIn).toHaveBeenCalledTimes(7)
     expect(transformIn).toHaveBeenLastCalledWith({
       year: '24',
       month: '12',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -633,7 +633,7 @@ describe('Field.Number', () => {
         expect(document.querySelector('input')).toHaveValue(
           'prefix 12 345 kr'
         )
-        expect(prefix).toHaveBeenCalledTimes(1)
+        expect(prefix).toHaveBeenCalledTimes(2)
         expect(prefix).toHaveBeenCalledWith(12345)
       })
 
@@ -645,7 +645,7 @@ describe('Field.Number', () => {
         expect(document.querySelector('input')).toHaveValue(
           '12 345 suffix'
         )
-        expect(suffix).toHaveBeenCalledTimes(1)
+        expect(suffix).toHaveBeenCalledTimes(2)
         expect(suffix).toHaveBeenCalledWith(12345)
       })
     })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -809,7 +809,7 @@ describe('Field.PhoneNumber', () => {
         </Form.Handler>
       )
 
-      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenCalledTimes(2)
       expect(transformIn).toHaveBeenLastCalledWith({
         countryCode: 'GB',
         phoneNumber: '9999',
@@ -826,7 +826,7 @@ describe('Field.PhoneNumber', () => {
       expect(phoneElement).toHaveValue('9999​​​​​​​​')
       expect(codeElement).toHaveValue('GB (+44)')
 
-      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenCalledTimes(2)
       expect(transformIn).toHaveBeenLastCalledWith({
         countryCode: 'GB',
         countryCodePrefix: '+44',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -572,7 +572,7 @@ describe('Field.SelectCountry', () => {
     }
 
     expect(transformOut).toHaveBeenCalledTimes(0)
-    expect(transformIn).toHaveBeenCalledTimes(1)
+    expect(transformIn).toHaveBeenCalledTimes(2)
     expect(valueTransformIn).toHaveBeenCalledTimes(1)
 
     const firstItemElement = () =>
@@ -590,7 +590,7 @@ describe('Field.SelectCountry', () => {
     )
 
     expect(transformOut).toHaveBeenCalledTimes(0)
-    expect(transformIn).toHaveBeenCalledTimes(2)
+    expect(transformIn).toHaveBeenCalledTimes(3)
     expect(valueTransformIn).toHaveBeenCalledTimes(2)
 
     expect(input).toHaveValue('Norge')
@@ -606,7 +606,7 @@ describe('Field.SelectCountry', () => {
     expect(value).toHaveTextContent('Sveits')
 
     expect(transformOut).toHaveBeenCalledTimes(3)
-    expect(transformIn).toHaveBeenCalledTimes(4)
+    expect(transformIn).toHaveBeenCalledTimes(5)
     expect(valueTransformIn).toHaveBeenCalledTimes(3)
 
     fireEvent.submit(form)
@@ -617,7 +617,7 @@ describe('Field.SelectCountry', () => {
     )
 
     expect(transformOut).toHaveBeenCalledTimes(3)
-    expect(transformIn).toHaveBeenCalledTimes(5)
+    expect(transformIn).toHaveBeenCalledTimes(6)
     expect(valueTransformIn).toHaveBeenCalledTimes(4)
 
     expect(transformOut).toHaveBeenNthCalledWith(1, 'NO', NO)
@@ -627,8 +627,9 @@ describe('Field.SelectCountry', () => {
     expect(transformIn).toHaveBeenNthCalledWith(1, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(2, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(3, 'Norge (NO)')
-    expect(transformIn).toHaveBeenNthCalledWith(4, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(4, 'Norge (NO)')
     expect(transformIn).toHaveBeenNthCalledWith(5, 'Sveits (CH)')
+    expect(transformIn).toHaveBeenNthCalledWith(6, 'Sveits (CH)')
 
     expect(valueTransformIn).toHaveBeenNthCalledWith(1, 'Norge (NO)')
     expect(valueTransformIn).toHaveBeenNthCalledWith(2, 'Norge (NO)')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -761,7 +761,7 @@ describe('Field.SelectCurrency', () => {
     }
 
     expect(transformOut).toHaveBeenCalledTimes(0)
-    expect(transformIn).toHaveBeenCalledTimes(1)
+    expect(transformIn).toHaveBeenCalledTimes(2)
     expect(valueTransformIn).toHaveBeenCalledTimes(1)
 
     const firstItemElement = () =>
@@ -779,7 +779,7 @@ describe('Field.SelectCurrency', () => {
     )
 
     expect(transformOut).toHaveBeenCalledTimes(0)
-    expect(transformIn).toHaveBeenCalledTimes(2)
+    expect(transformIn).toHaveBeenCalledTimes(3)
     expect(valueTransformIn).toHaveBeenCalledTimes(2)
 
     expect(input).toHaveValue('Norsk krone (NOK)')
@@ -795,7 +795,7 @@ describe('Field.SelectCurrency', () => {
     expect(value).toHaveTextContent('Sveitsisk franc (CHF)')
 
     expect(transformOut).toHaveBeenCalledTimes(3)
-    expect(transformIn).toHaveBeenCalledTimes(4)
+    expect(transformIn).toHaveBeenCalledTimes(5)
     expect(valueTransformIn).toHaveBeenCalledTimes(3)
 
     fireEvent.submit(form)
@@ -806,7 +806,7 @@ describe('Field.SelectCurrency', () => {
     )
 
     expect(transformOut).toHaveBeenCalledTimes(3)
-    expect(transformIn).toHaveBeenCalledTimes(5)
+    expect(transformIn).toHaveBeenCalledTimes(6)
     expect(valueTransformIn).toHaveBeenCalledTimes(4)
 
     expect(transformOut).toHaveBeenNthCalledWith(1, 'NOK', NOK)
@@ -816,8 +816,9 @@ describe('Field.SelectCurrency', () => {
     expect(transformIn).toHaveBeenNthCalledWith(1, 'Norsk krone (NOK)')
     expect(transformIn).toHaveBeenNthCalledWith(2, 'Norsk krone (NOK)')
     expect(transformIn).toHaveBeenNthCalledWith(3, 'Norsk krone (NOK)')
-    expect(transformIn).toHaveBeenNthCalledWith(4, 'Sveitsisk franc (CHF)')
+    expect(transformIn).toHaveBeenNthCalledWith(4, 'Norsk krone (NOK)')
     expect(transformIn).toHaveBeenNthCalledWith(5, 'Sveitsisk franc (CHF)')
+    expect(transformIn).toHaveBeenNthCalledWith(6, 'Sveitsisk franc (CHF)')
 
     expect(valueTransformIn).toHaveBeenNthCalledWith(
       1,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -285,7 +285,7 @@ describe('Field.String', () => {
       const input = document.querySelector('input')
 
       expect(input).toHaveValue('XYZ')
-      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenCalledTimes(2)
       expect(transformIn).toHaveBeenLastCalledWith('xYz')
       expect(transformOut).toHaveBeenCalledTimes(0)
       expect(onChangeProvider).toHaveBeenCalledTimes(0)
@@ -294,7 +294,7 @@ describe('Field.String', () => {
       await userEvent.type(input, '{Backspace>3}aBc')
 
       expect(input).toHaveValue('ABC')
-      expect(transformIn).toHaveBeenCalledTimes(9)
+      expect(transformIn).toHaveBeenCalledTimes(10)
       expect(transformIn).toHaveBeenLastCalledWith('abc')
       expect(transformOut).toHaveBeenCalledTimes(13)
       expect(transformOut).toHaveBeenLastCalledWith(
@@ -315,7 +315,7 @@ describe('Field.String', () => {
       await userEvent.type(input, '{Backspace>3}EfG')
 
       expect(input).toHaveValue('EFG')
-      expect(transformIn).toHaveBeenCalledTimes(16)
+      expect(transformIn).toHaveBeenCalledTimes(17)
       expect(transformIn).toHaveBeenLastCalledWith('efg')
       expect(transformOut).toHaveBeenCalledTimes(25)
       expect(transformOut).toHaveBeenLastCalledWith(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
@@ -1522,41 +1522,64 @@ describe('Form.useData', () => {
       expect(collectData).toEqual({ foo: 'bar' })
     })
 
-    describe('StrictMode', () => {
+    describe('Without StrictMode', () => {
       it('should return data when id is used', () => {
+        let rerendered = 0
         let collectData = null
-        const formId = 'form'
 
         const MockComponent = () => {
-          const { data } = Form.useData(formId)
+          const { data } = Form.useData(identifier)
           collectData = data
+          rerendered += 1
 
           return (
-            <Form.Handler data={{ foo: 'bar' }} id={formId}>
+            <Form.Handler data={{ foo: 'bar' }} id={identifier}>
               <Field.String path="/foo" />
             </Form.Handler>
           )
         }
 
-        render(
-          <React.StrictMode>
-            <MockComponent />
-          </React.StrictMode>
-        )
+        render(<MockComponent />)
 
         expect(collectData).toEqual({ foo: 'bar' })
+        expect(rerendered).toBe(2)
       })
 
-      it.only('should set data to be defaultData when no data is provided and id is used', () => {
+      it('should set data to be defaultData when no data is provided and id is used', () => {
+        let rerendered = 0
         let collectData = null
-        const formId = 'form'
 
         const MockComponent = () => {
-          const { data } = Form.useData(formId)
+          const { data } = Form.useData(identifier)
           collectData = data
+          rerendered += 1
 
           return (
-            <Form.Handler defaultData={{ foo: 'bar' }} id={formId}>
+            <Form.Handler defaultData={{ foo: 'bar' }} id={identifier}>
+              <Field.String path="/foo" />
+            </Form.Handler>
+          )
+        }
+
+        render(<MockComponent />)
+
+        expect(collectData).toEqual({ foo: 'bar' })
+        expect(rerendered).toBe(2)
+      })
+    })
+
+    describe('StrictMode', () => {
+      it('should return data when id is used', () => {
+        let rerendered = 0
+        let collectData = null
+
+        const MockComponent = () => {
+          const { data } = Form.useData(identifier)
+          collectData = data
+          rerendered += 1
+
+          return (
+            <Form.Handler data={{ foo: 'bar' }} id={identifier}>
               <Field.String path="/foo" />
             </Form.Handler>
           )
@@ -1569,6 +1592,33 @@ describe('Form.useData', () => {
         )
 
         expect(collectData).toEqual({ foo: 'bar' })
+        expect(rerendered).toBe(4)
+      })
+
+      it('should set data to be defaultData when no data is provided and id is used', () => {
+        let rerendered = 0
+        let collectData = null
+
+        const MockComponent = () => {
+          const { data } = Form.useData(identifier)
+          collectData = data
+          rerendered += 1
+
+          return (
+            <Form.Handler defaultData={{ foo: 'bar' }} id={identifier}>
+              <Field.String path="/foo" />
+            </Form.Handler>
+          )
+        }
+
+        render(
+          <React.StrictMode>
+            <MockComponent />
+          </React.StrictMode>
+        )
+
+        expect(collectData).toEqual({ foo: 'bar' })
+        expect(rerendered).toBe(4)
       })
     })
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
@@ -1481,5 +1481,43 @@ describe('Form.useData', () => {
         interactive: 'I am visible',
       })
     })
+
+    it('should set data to be defaultData when no data is provided', () => {
+      let collectData = null
+
+      const MockComponent = () => {
+        const { data } = Form.useData()
+        collectData = data
+        return null
+      }
+
+      render(
+        <Form.Handler defaultData={{ foo: 'bar' }}>
+          <Field.String path="/foo" />
+          <MockComponent />
+        </Form.Handler>
+      )
+
+      expect(collectData).toEqual({ foo: 'bar' })
+    })
+
+    it('should not override data when providing defaultData', () => {
+      let collectData = null
+
+      const MockComponent = () => {
+        const { data } = Form.useData()
+        collectData = data
+        return null
+      }
+
+      render(
+        <Form.Handler data={{ foo: 'bar' }} defaultData={{ foo: 'foo' }}>
+          <Field.String path="/foo" />
+          <MockComponent />
+        </Form.Handler>
+      )
+
+      expect(collectData).toEqual({ foo: 'bar' })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useData.test.tsx
@@ -1481,7 +1481,9 @@ describe('Form.useData', () => {
         interactive: 'I am visible',
       })
     })
+  })
 
+  describe('data and defaultData', () => {
     it('should set data to be defaultData when no data is provided', () => {
       let collectData = null
 
@@ -1518,6 +1520,56 @@ describe('Form.useData', () => {
       )
 
       expect(collectData).toEqual({ foo: 'bar' })
+    })
+
+    describe('StrictMode', () => {
+      it('should return data when id is used', () => {
+        let collectData = null
+        const formId = 'form'
+
+        const MockComponent = () => {
+          const { data } = Form.useData(formId)
+          collectData = data
+
+          return (
+            <Form.Handler data={{ foo: 'bar' }} id={formId}>
+              <Field.String path="/foo" />
+            </Form.Handler>
+          )
+        }
+
+        render(
+          <React.StrictMode>
+            <MockComponent />
+          </React.StrictMode>
+        )
+
+        expect(collectData).toEqual({ foo: 'bar' })
+      })
+
+      it.only('should set data to be defaultData when no data is provided and id is used', () => {
+        let collectData = null
+        const formId = 'form'
+
+        const MockComponent = () => {
+          const { data } = Form.useData(formId)
+          collectData = data
+
+          return (
+            <Form.Handler defaultData={{ foo: 'bar' }} id={formId}>
+              <Field.String path="/foo" />
+            </Form.Handler>
+          )
+        }
+
+        render(
+          <React.StrictMode>
+            <MockComponent />
+          </React.StrictMode>
+        )
+
+        expect(collectData).toEqual({ foo: 'bar' })
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -100,7 +100,7 @@ describe('Iterate.Array', () => {
       expect(fieldTwo).toHaveDisplayValue('two')
       expect(fieldThree).toHaveDisplayValue('three')
 
-      expect(callback).toHaveBeenCalledTimes(3)
+      expect(callback).toHaveBeenCalledTimes(6)
       expect(callback).toHaveBeenNthCalledWith(
         1,
         'one',
@@ -1125,7 +1125,7 @@ describe('Iterate.Array', () => {
           </Iterate.Array>
         )
 
-        expect(renderProp).toHaveBeenCalledTimes(3)
+        expect(renderProp).toHaveBeenCalledTimes(6)
         expect(renderProp).toHaveBeenNthCalledWith(
           1,
           'first',
@@ -1166,7 +1166,7 @@ describe('Iterate.Array', () => {
           </Iterate.Array>
         )
 
-        expect(renderProp1).toHaveBeenCalledTimes(4)
+        expect(renderProp1).toHaveBeenCalledTimes(8)
         expect(renderProp1).toHaveBeenNthCalledWith(
           1,
           { mem: 'A' },
@@ -1192,7 +1192,7 @@ describe('Iterate.Array', () => {
           expect.any(Array)
         )
 
-        expect(renderProp2).toHaveBeenCalledTimes(4)
+        expect(renderProp2).toHaveBeenCalledTimes(8)
         expect(renderProp2).toHaveBeenNthCalledWith(
           1,
           { mem: 'A' },

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Visibility/__tests__/Visibility.test.tsx
@@ -200,7 +200,7 @@ describe('Iterate.Visibility', () => {
         </Provider>
       )
       expect(screen.queryByText('Child')).not.toBeInTheDocument()
-      expect(inferData).toHaveBeenCalledTimes(1)
+      expect(inferData).toHaveBeenCalledTimes(2)
       expect(inferData).toHaveBeenLastCalledWith({
         myList: [{ foo: 'bar' }],
       })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2826,7 +2826,7 @@ describe('useFieldProps', () => {
 
       const { handleChange } = result.current
 
-      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenCalledTimes(2)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(0)
 
@@ -2834,7 +2834,7 @@ describe('useFieldProps', () => {
         handleChange(2)
       })
 
-      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenCalledTimes(3)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(2)
       expect(transformOut).toHaveBeenNthCalledWith(1, 2, expect.anything())
@@ -2844,7 +2844,7 @@ describe('useFieldProps', () => {
         handleChange(4)
       })
 
-      expect(transformIn).toHaveBeenCalledTimes(3)
+      expect(transformIn).toHaveBeenCalledTimes(4)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(4)
       expect(transformOut).toHaveBeenNthCalledWith(3, 4, expect.anything())
@@ -2931,7 +2931,7 @@ describe('useFieldProps', () => {
 
       const { handleChange } = result.current
 
-      expect(transformIn).toHaveBeenCalledTimes(1)
+      expect(transformIn).toHaveBeenCalledTimes(2)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(0)
 
@@ -2939,7 +2939,7 @@ describe('useFieldProps', () => {
         handleChange(2)
       })
 
-      expect(transformIn).toHaveBeenCalledTimes(2)
+      expect(transformIn).toHaveBeenCalledTimes(3)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(2)
       expect(transformOut).toHaveBeenNthCalledWith(1, 3, expect.anything())
@@ -2949,7 +2949,7 @@ describe('useFieldProps', () => {
         handleChange(4)
       })
 
-      expect(transformIn).toHaveBeenCalledTimes(3)
+      expect(transformIn).toHaveBeenCalledTimes(4)
       expect(transformIn).toHaveBeenLastCalledWith(1)
       expect(transformOut).toHaveBeenCalledTimes(4)
       expect(transformOut).toHaveBeenNthCalledWith(3, 5, expect.anything())
@@ -2973,14 +2973,14 @@ describe('useFieldProps', () => {
       const { handleChange } = result.current
 
       expect(fromInput).toHaveBeenCalledTimes(0)
-      expect(toInput).toHaveBeenCalledTimes(1)
+      expect(toInput).toHaveBeenCalledTimes(2)
 
       act(() => {
         handleChange(2)
       })
 
       expect(fromInput).toHaveBeenCalledTimes(1)
-      expect(toInput).toHaveBeenCalledTimes(2)
+      expect(toInput).toHaveBeenCalledTimes(3)
       expect(fromInput).toHaveBeenLastCalledWith(2)
       expect(toInput).toHaveBeenLastCalledWith(3)
 
@@ -2989,7 +2989,7 @@ describe('useFieldProps', () => {
       })
 
       expect(fromInput).toHaveBeenCalledTimes(2)
-      expect(toInput).toHaveBeenCalledTimes(3)
+      expect(toInput).toHaveBeenCalledTimes(4)
       expect(fromInput).toHaveBeenLastCalledWith(4)
       expect(toInput).toHaveBeenLastCalledWith(5)
 
@@ -3341,7 +3341,7 @@ describe('useFieldProps', () => {
       })
 
       expect(fromInput).toHaveBeenCalledTimes(2)
-      expect(toInput).toHaveBeenCalledTimes(5)
+      expect(toInput).toHaveBeenCalledTimes(6)
       expect(onChange).toHaveBeenCalledTimes(1)
     })
 
@@ -3528,7 +3528,7 @@ describe('useFieldProps', () => {
       },
     })
 
-    expect(setFieldInternalsDataContext).toHaveBeenCalledTimes(1)
+    expect(setFieldInternalsDataContext).toHaveBeenCalledTimes(2)
     expect(setFieldInternalsDataContext).toHaveBeenLastCalledWith(
       props.path,
       { id: expect.any(String), props }
@@ -3540,7 +3540,7 @@ describe('useFieldProps', () => {
       emptyValue: 'new empty value',
     })
 
-    expect(setFieldInternalsDataContext).toHaveBeenCalledTimes(3)
+    expect(setFieldInternalsDataContext).toHaveBeenCalledTimes(4)
     expect(setFieldInternalsDataContext).toHaveBeenLastCalledWith(
       props.path,
       {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1761828345372899

[Here's a CSB describing and showcasing the issue](https://codesandbox.io/p/devbox/gifted-boyd-8jly2c?workspaceId=ws_LbiDwJdEBdbwxH2AkyAyVE)