### PR TITLE
fix(Field.PostalCodeAndCity): TypeScript issues for spacing properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/properties.mdx
@@ -17,7 +17,7 @@ import { PostalCodeAndCityProperties } from '@dnb/eufemia/src/extensions/forms/F
 
 <PropertiesTable
   props={FieldBlockProperties}
-  omit={['value', 'layout', 'layoutOptions', 'label', 'labelDescription']}
+  pick={['width', 'help', '[Space](/uilib/layout/space/properties)']}
 />
 
 ## Translations

--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -85,12 +85,14 @@ export default function PropertiesTable({
   valueType = 'string',
   camelCase,
   omit,
+  pick,
   showDefaultValue = false,
 }: {
   props: PropertiesTableProps
   valueType?: unknown
   camelCase?: boolean
   omit?: string[]
+  pick?: string[]
   showDefaultValue: boolean
 }) {
   const keys = Object.keys(props || {})
@@ -99,6 +101,9 @@ export default function PropertiesTable({
       return null
     }
     const { type, defaultValue, doc, status } = props
+    if (pick && !pick.includes(key)) {
+      return null
+    }
     if (omit && omit.includes(key)) {
       return null
     }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -8,12 +8,17 @@ import { CountryCode, Path } from '../../types'
 import useTranslation from '../../hooks/useTranslation'
 import useDataValue from '../../hooks/useDataValue'
 import { COUNTRY as defaultCountry } from '../../../../shared/defaults'
-import { HelpProps } from '../../../../components/help-button/HelpButtonInline'
 import { SpacingProps } from '../../../../shared/types'
 
 export type Props = Pick<
   FieldBlockProps,
-  'error' | 'warning' | 'info' | 'width' | 'className' | keyof SpacingProps
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'width'
+  | 'className'
+  | 'help'
+  | keyof SpacingProps
 > &
   Partial<Record<'postalCode' | 'city', StringFieldProps>> & {
     /**
@@ -34,7 +39,6 @@ export type Props = Pick<
      * Default: `NO`
      */
     countryCode?: CountryCode
-    help?: HelpProps
   } & Pick<StringFieldProps, 'size'>
 
 function PostalCodeAndCity(props: Props) {


### PR DESCRIPTION
This PR also improves the field block properties docs that's supported for Field.PostalCodeAndCity