### PR TITLE
chore: resolve circular dependency between @dnb/eufemia and storybook-utils

### DIFF
--- a/tools/storybook-utils/package.json
+++ b/tools/storybook-utils/package.json
@@ -6,9 +6,6 @@
   "author": "DNB Team & Tobias Høegh",
   "version": "1.0.0",
   "main": "index.js",
-  "dependencies": {
-    "@dnb/eufemia": "workspace:*"
-  },
   "peerDependencies": {
     "@emotion/react": "11.9.3",
     "@emotion/styled": "11.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34843,8 +34843,6 @@ __metadata:
 "storybook-utils@workspace:*, storybook-utils@workspace:tools/storybook-utils":
   version: 0.0.0-use.local
   resolution: "storybook-utils@workspace:tools/storybook-utils"
-  dependencies:
-    "@dnb/eufemia": "workspace:*"
   peerDependencies:
     "@emotion/react": 11.9.3
     "@emotion/styled": 11.9.3


### PR DESCRIPTION
## Problem
Moving `react` and `react-dom` from dependencies to peerDependencies in `@dnb/eufemia` caused a circular dependency issue between `@dnb/eufemia` and `storybook-utils`, resulting in deeply nested `node_modules` structures and `ENAMETOOLONG` errors.

## Solution
Removed `@dnb/eufemia` from `storybook-utils`'s peerDependencies. Since `storybook-utils` is a private dev tool in the same workspace and uses direct path imports (`@dnb/eufemia/src/components`), module resolution will find `@dnb/eufemia` at the workspace root without needing to declare it as a dependency.
