### PR TITLE
chore(NumberFormat): format is not deprecated

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
@@ -136,7 +136,7 @@ const ABSENT_VALUE_FORMAT = '–'
  * @returns a formatted number as a string or as an object if "returnAria" is true
  */
 export const format = (
-  value: string | number,
+  value,
   {
     locale = null, // can be "auto"
     clean = false,


### PR DESCRIPTION
fixes the following issue, that it says that the format function is deprecated, which it is not:

<img width="668" height="360" alt="image" src="https://github.com/user-attachments/assets/a491dedb-a41a-412a-9156-4e52d0755ee5" />

I think the issue is with JSDocs, and that using `@deprecated` will mark the whole function/symbol as deprecated, and not only the given param/property.

CSB of the issue: https://codesandbox.io/p/devbox/wonderful-cray-4xqg5l
StackBlitz of the issue: https://stackblitz.com/edit/eqj2yfk1-gfrm3xne?file=package.json

StackBlitz of the fix: https://stackblitz.com/edit/eqj2yfk1-cqcawnam?file=src%2FApp.tsx

Screenshot of fix:

<img width="706" height="182" alt="image" src="https://github.com/user-attachments/assets/d1e8e174-71cf-4405-8e57-daac217a52a5" />
