### PR TITLE
fix(Tooltip,TermDefinition,DatePicker): improve handling of screen-reader focus when navigating out of content

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -606,7 +606,7 @@ export default function Popover(props: PopoverProps) {
   const overlayContent = (
     <>
       {!disableFocusTrap && (
-        <button className="dnb-sr-only" aria-hidden onFocus={close}>
+        <button className="dnb-sr-only" onFocus={close}>
           Focus trap
         </button>
       )}
@@ -632,7 +632,7 @@ export default function Popover(props: PopoverProps) {
       {closeButton}
 
       {!disableFocusTrap && (
-        <button className="dnb-sr-only" aria-hidden onFocus={close}>
+        <button className="dnb-sr-only" onFocus={close}>
           Focus trap
         </button>
       )}

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -562,7 +562,7 @@ describe('Popover', () => {
 
     // Verify the bottom focus trap button has sr-only class and aria-hidden attribute
     expect(bottomFocusTrap).toHaveClass('dnb-sr-only')
-    expect(bottomFocusTrap).toHaveAttribute('aria-hidden', 'true')
+    expect(bottomFocusTrap).not.toHaveAttribute('aria-hidden')
 
     // Actually focus the button to trigger the onFocus handler
     fireEvent.focus(bottomFocusTrap)
@@ -602,7 +602,7 @@ describe('Popover', () => {
 
     // Verify the top focus trap button has sr-only class and aria-hidden attribute
     expect(topFocusTrap).toHaveClass('dnb-sr-only')
-    expect(topFocusTrap).toHaveAttribute('aria-hidden', 'true')
+    expect(topFocusTrap).not.toHaveAttribute('aria-hidden')
 
     // Simulate Shift+Tab from the first element by focusing the top trap
     fireEvent.focus(topFocusTrap)


### PR DESCRIPTION
Motivation: I realized this might be an issue after dreaming about it last night — and it's now confirmed with VoiceOver.