### PR TITLE
fix(Field.Upload): should not display error removing file using async `fileHandler`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
@@ -164,13 +164,14 @@ function UploadComponent(props: Props) {
 
   const handleChangeAsync = useCallback(
     async (files: UploadValue) => {
+      const filesArray = files || []
       // Filter out existing files
       const existingFileIds =
         filesRef.current?.map((file) => file.id) || []
-      const existingFiles = files.filter((file) =>
+      const existingFiles = filesArray.filter((file) =>
         existingFileIds.includes(file.id)
       )
-      const newFiles = files.filter(
+      const newFiles = filesArray.filter(
         (file) => !existingFileIds.includes(file.id)
       )
       const newValidFiles = newFiles.filter((file) => !file.errorMessage)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -1251,6 +1251,19 @@ describe('Field.Upload', () => {
           document.querySelector('.dnb-form-status')
         ).toHaveTextContent('customError')
       })
+
+      // delete the file
+      fireEvent.click(
+        document
+          .querySelectorAll('.dnb-upload__file-cell')[0]
+          .querySelector('button')
+      )
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).not.toBeInTheDocument()
+      })
     })
 
     it('should handle displaying success from fileHandler with async function', async () => {


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/dnbexperience/eufemia/pull/5998, as we now have to handle `undefined` value as well. Previously it was only an empty list `[]`.


[Can be demoed here, by uploading a file, then pressing remove](https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/more-fields/Upload/demos/#with-asynchronous-file-handler)

<img width="866" height="425" alt="image" src="https://github.com/user-attachments/assets/899e4488-f0a5-4b35-b97f-8a6d8be6d3d3" />
