### PR TITLE
fix(Forms): ensure help property works in Field.Boolean when variant is `checkbox`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/Examples.tsx
@@ -92,6 +92,18 @@ export const CheckboxError = () => {
   )
 }
 
+export const VariantCheckboxWithHelp = () => {
+  return (
+    <ComponentBox>
+      <Field.Boolean
+        variant="checkbox"
+        label="Checkbox variant"
+        help={{ title: 'Help title', content: 'Help content' }}
+      />
+    </ComponentBox>
+  )
+}
+
 export const ButtonTrue = () => {
   return (
     <ComponentBox>
@@ -398,6 +410,18 @@ export const VariantRadioWithHelp = () => {
       <Field.Boolean
         variant="radio"
         label="Radio variant"
+        help={{ title: 'Help title', content: 'Help content' }}
+      />
+    </ComponentBox>
+  )
+}
+
+export const VariantSwitchWithHelp = () => {
+  return (
+    <ComponentBox>
+      <Field.Boolean
+        variant="switch"
+        label="Switch variant"
         help={{ title: 'Help title', content: 'Help content' }}
       />
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean/demos.mdx
@@ -38,6 +38,10 @@ You can prevent the state of the checkbox from changing by calling `preventDefau
 
 <Examples.CheckboxError />
 
+### Checkbox - With Help
+
+<Examples.VariantCheckboxWithHelp />
+
 ### Button
 
 #### Value true
@@ -141,3 +145,9 @@ You can prevent the state of the checkbox from changing by calling `preventDefau
 #### Radio - Error
 
 <Examples.RadioError />
+
+### Switch
+
+#### Switch - With Help
+
+<Examples.VariantSwitchWithHelp />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/__tests__/Boolean.test.tsx
@@ -57,17 +57,20 @@ describe('Field.Boolean', () => {
         />
       )
       expect(document.querySelectorAll('.dnb-help-button')).toHaveLength(1)
+      const helpButton = document.querySelector(
+        '.dnb-checkbox__suffix .dnb-help-button'
+      )
+      expect(helpButton).toBeInTheDocument()
       expect(document.querySelector('input')).toHaveAttribute(
         'aria-describedby'
       )
-      expect(
-        document.querySelector('input').getAttribute('aria-describedby')
-      ).toBe(document.querySelector('.dnb-help-button').id)
-      expect(
-        document
-          .querySelector('.dnb-help-button')
-          .getAttribute('aria-describedby')
-      ).toBe(document.querySelector('.dnb-tooltip__content').id)
+      const describedby = document
+        .querySelector('input')
+        .getAttribute('aria-describedby')
+      expect(describedby).toContain(helpButton.id)
+      expect(helpButton.getAttribute('aria-describedby')).toBe(
+        document.querySelector('.dnb-tooltip__content').id
+      )
     })
 
     it('renders error', () => {
@@ -365,17 +368,20 @@ describe('Field.Boolean', () => {
         />
       )
       expect(document.querySelectorAll('.dnb-help-button')).toHaveLength(1)
+      const helpButton = document.querySelector(
+        '.dnb-switch__suffix .dnb-help-button'
+      )
+      expect(helpButton).toBeInTheDocument()
       expect(document.querySelector('input')).toHaveAttribute(
         'aria-describedby'
       )
-      expect(
-        document.querySelector('input').getAttribute('aria-describedby')
-      ).toBe(document.querySelector('.dnb-help-button').id)
-      expect(
-        document
-          .querySelector('.dnb-help-button')
-          .getAttribute('aria-describedby')
-      ).toBe(document.querySelector('.dnb-tooltip__content').id)
+      const describedby = document
+        .querySelector('input')
+        .getAttribute('aria-describedby')
+      expect(describedby).toContain(helpButton.id)
+      expect(helpButton.getAttribute('aria-describedby')).toBe(
+        document.querySelector('.dnb-tooltip__content').id
+      )
     })
 
     it('renders error', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/stories/Boolean.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/stories/Boolean.stories.tsx
@@ -60,3 +60,58 @@ export function BooleanReset() {
     </Form.Handler>
   )
 }
+
+export function WithHelp() {
+  return (
+    <Flex.Stack>
+      <Field.Boolean
+        variant="button"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+      <Field.Boolean
+        variant="checkbox-button"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+      <Field.Boolean
+        variant="buttons"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+      <Field.Boolean
+        variant="switch"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+      <Field.Boolean
+        variant="checkbox"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+      <Field.Boolean
+        variant="radio"
+        label="Is this true?"
+        help={{
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+    </Flex.Stack>
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -21,6 +21,7 @@ import type {
 } from '../../../../components/Checkbox'
 import type { ToggleButtonProps } from '../../../../components/ToggleButton'
 import { SwitchOnChangeParams } from '../../../../components/Switch'
+import HelpButtonInline from '../../../../components/help-button/HelpButtonInline'
 
 export type ToggleProps = {
   valueOn: unknown
@@ -55,6 +56,7 @@ function Toggle(props: Props) {
     ...props,
     errorMessages: props.errorMessages,
   }
+  const { help } = props
 
   const {
     id,
@@ -72,6 +74,12 @@ function Toggle(props: Props) {
     handleChange,
     setDisplayValue,
   } = useFieldProps(preparedProps)
+
+  const helpButton =
+    help && (variant === 'checkbox' || variant === 'switch') ? (
+      <HelpButtonInline contentId={`${id}-help`} help={help} />
+    ) : undefined
+  const hideHelpButton = Boolean(helpButton)
 
   const preventChangeRef = useRef(false)
 
@@ -121,6 +129,7 @@ function Toggle(props: Props) {
     forId: id,
     className: cn,
     disabled,
+    hideHelpButton,
     ...pickSpacingProps(props),
   }
 
@@ -162,6 +171,7 @@ function Toggle(props: Props) {
             status={hasError ? 'error' : undefined}
             onChange={handleCheckboxChange}
             onClick={handleClick}
+            suffix={helpButton}
             {...htmlAttributes}
           />
         </FieldBlock>
@@ -185,6 +195,7 @@ function Toggle(props: Props) {
             status={hasError ? 'error' : undefined}
             onChange={handleSwitchChange}
             onClick={handleClick}
+            suffix={helpButton}
             {...htmlAttributes}
           />
         </FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/__tests__/Toggle.test.tsx
@@ -100,17 +100,20 @@ describe('Field.Toggle', () => {
         expect(document.querySelectorAll('.dnb-help-button')).toHaveLength(
           1
         )
+        const helpButton = document.querySelector(
+          '.dnb-switch__suffix .dnb-help-button'
+        )
+        expect(helpButton).toBeInTheDocument()
         expect(document.querySelector('input')).toHaveAttribute(
           'aria-describedby'
         )
-        expect(
-          document.querySelector('input').getAttribute('aria-describedby')
-        ).toBe(document.querySelector('.dnb-help-button').id)
-        expect(
-          document
-            .querySelector('.dnb-help-button')
-            .getAttribute('aria-describedby')
-        ).toBe(document.querySelector('.dnb-tooltip__content').id)
+        const describedby = document
+          .querySelector('input')
+          .getAttribute('aria-describedby')
+        expect(describedby).toContain(helpButton.id)
+        expect(helpButton.getAttribute('aria-describedby')).toBe(
+          document.querySelector('.dnb-tooltip__content').id
+        )
       })
 
       it('renders error', () => {
@@ -1378,17 +1381,20 @@ describe('Field.Toggle', () => {
         expect(document.querySelectorAll('.dnb-help-button')).toHaveLength(
           1
         )
+        const helpButton = document.querySelector(
+          '.dnb-checkbox__suffix .dnb-help-button'
+        )
+        expect(helpButton).toBeInTheDocument()
         expect(document.querySelector('input')).toHaveAttribute(
           'aria-describedby'
         )
-        expect(
-          document.querySelector('input').getAttribute('aria-describedby')
-        ).toBe(document.querySelector('.dnb-help-button').id)
-        expect(
-          document
-            .querySelector('.dnb-help-button')
-            .getAttribute('aria-describedby')
-        ).toBe(document.querySelector('.dnb-tooltip__content').id)
+        const describedby = document
+          .querySelector('input')
+          .getAttribute('aria-describedby')
+        expect(describedby).toContain(helpButton.id)
+        expect(helpButton.getAttribute('aria-describedby')).toBe(
+          document.querySelector('.dnb-tooltip__content').id
+        )
       })
 
       it('should render correct HTML', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -116,6 +116,10 @@ export type SharedFieldBlockProps = {
    * Provide help content for the field.
    */
   help?: HelpProps
+  /**
+   * Hide the help button that is normally rendered beside the label.
+   */
+  hideHelpButton?: boolean
 }
 
 export type Props<Value = unknown> = SharedFieldBlockProps &
@@ -169,6 +173,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
     labelSize,
     labelHeight,
     help,
+    hideHelpButton,
     asFieldset,
     required,
     info,
@@ -562,14 +567,16 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
                   </span>
                 )}
 
-                {hasHelp && !hasOnlyLabelDescription && (
-                  <span className="dnb-help-button__word-joiner">
-                    <HelpButtonInline
-                      contentId={`${id}-help`}
-                      help={help}
-                    />
-                  </span>
-                )}
+                {hasHelp &&
+                  !hasOnlyLabelDescription &&
+                  !hideHelpButton && (
+                    <span className="dnb-help-button__word-joiner">
+                      <HelpButtonInline
+                        contentId={`${id}-help`}
+                        help={help}
+                      />
+                    </span>
+                  )}
 
                 {label &&
                   hasLabelDescription &&
@@ -581,7 +588,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
                   </span>
                 )}
 
-                {hasHelp && hasOnlyLabelDescription && (
+                {hasHelp && hasOnlyLabelDescription && !hideHelpButton && (
                   <span className="dnb-help-button__word-joiner">
                     <HelpButtonInline
                       contentId={`${id}-help`}

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
@@ -31,6 +31,11 @@ export const FieldBlockSharedProperties: PropertiesTableProps = {
     type: 'object',
     status: 'optional',
   },
+  hideHelpButton: {
+    doc: 'Set `true` when you render the inline help button outside the label (e.g. inside a checkbox suffix) so FieldBlock skips drawing the default label help button.',
+    type: 'boolean',
+    status: 'optional',
+  },
   layout: {
     doc: 'Layout for the label and input. Can be `horizontal` or `vertical`.',
     type: 'string',

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -522,6 +522,30 @@ describe('FieldBlock', () => {
     expect(document.querySelectorAll('label')).toHaveLength(1)
   })
 
+  it('hides the label help button when requested', () => {
+    const help = { title: 'Help title', content: 'Help content' }
+
+    const { rerender } = render(
+      <FieldBlock label="Label" help={help}>
+        content
+      </FieldBlock>
+    )
+
+    expect(
+      document.querySelector('.dnb-form-label .dnb-help-button')
+    ).toBeInTheDocument()
+
+    rerender(
+      <FieldBlock label="Label" help={help} hideHelpButton>
+        content
+      </FieldBlock>
+    )
+
+    expect(
+      document.querySelector('.dnb-form-label .dnb-help-button')
+    ).not.toBeInTheDocument()
+  })
+
   it('should use fieldset/legend when "asFieldset" is given', () => {
     render(
       <FieldBlock label="Legend" asFieldset>


### PR DESCRIPTION
**Now**
<img width="209" height="158" alt="Screenshot 2025-12-03 at 16 50 33" src="https://github.com/user-attachments/assets/b1babb70-afe9-402e-ac10-944fb850db77" />

**All of them**
<img width="224" height="494" alt="Screenshot 2025-12-03 at 16 50 25" src="https://github.com/user-attachments/assets/b8e9a19f-2055-47ad-9650-8f114d286d17" />



**Before**
<img width="189" height="86" alt="Screenshot 2025-12-03 at 16 49 52" src="https://github.com/user-attachments/assets/4214bc04-79a2-45ab-b701-6c39cf66b281" />
