### PR TITLE
fix(Forms): improve async validator detection and behavior

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -109,6 +109,7 @@ export type FieldInternalsRefProps =
 export type FieldInternalsValue<Props = FieldInternalsRefProps> = {
   id?: Identifier
   props?: Props
+  enableAsyncMode?: boolean
 }
 export type FieldInternalsRef = Record<Path, FieldInternalsValue>
 export type ValueInternalsRef = Record<
@@ -151,6 +152,7 @@ export interface ContextState {
   hasErrors: () => boolean
   hasFieldState: (state: SubmitState) => boolean
   hasFieldError: (path: Path) => boolean
+  hasFieldWithAsyncValidator?: () => boolean
   setFieldState?: (path: Path, fieldState: SubmitState) => void
   setFieldError?: (path: Path, error: Error | FormError) => void
   setMountedFieldState: (path: Path, options: MountState) => void

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -760,14 +760,14 @@ export default function Provider<Data extends JsonObject>(
 
   const hasFieldWithAsyncValidator = useCallback(() => {
     for (const path in fieldInternalsRef.current) {
-      if (mountedFieldsRef.current.get(path)?.isMounted) {
-        const props = fieldInternalsRef.current[path]?.props
-        if (
-          isAsync(props?.onChangeValidator) ||
-          isAsync(props?.onBlurValidator)
-        ) {
-          return true
-        }
+      const fieldInternals = fieldInternalsRef.current[path] || {}
+      const { enableAsyncMode, props } = fieldInternals
+      if (
+        enableAsyncMode ||
+        isAsync(props?.onChangeValidator) ||
+        isAsync(props?.onBlurValidator)
+      ) {
+        return true
       }
     }
 
@@ -1104,7 +1104,7 @@ export default function Provider<Data extends JsonObject>(
 
       const asyncBehaviorIsEnabled =
         (skipErrorCheck
-          ? true
+          ? enableAsyncBehavior
           : // Don't enable async behavior if we have errors, but when we have a pending state
             !hasErrors() || hasFieldState('pending')) &&
         (enableAsyncBehavior || hasFieldWithAsyncValidator())
@@ -1534,6 +1534,7 @@ export default function Provider<Data extends JsonObject>(
     hasErrors,
     hasFieldError,
     hasFieldState,
+    hasFieldWithAsyncValidator,
     validateData,
     updateDataValue,
     setData,

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -6161,5 +6161,37 @@ describe('DataContext.Provider', () => {
 
       expect(currentContext?.countryCode).toBe('DK')
     })
+
+    it('should treat enableAsyncMode fields as async', async () => {
+      let contextValue: ContextState = null
+
+      const AsyncField = () => {
+        const dataContext = React.useContext(DataContext.Context)
+
+        React.useEffect(() => {
+          dataContext?.setFieldInternals?.('/async-field', {
+            enableAsyncMode: true,
+          })
+        }, [dataContext])
+
+        return null
+      }
+
+      const Reporter = () => {
+        contextValue = React.useContext(DataContext.Context)
+        return null
+      }
+
+      render(
+        <Form.Handler>
+          <AsyncField />
+          <Reporter />
+        </Form.Handler>
+      )
+
+      await waitFor(() => {
+        expect(contextValue?.hasFieldWithAsyncValidator?.()).toBeTruthy()
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -2028,6 +2028,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       additionalArgs,
       asyncBehaviorIsEnabled,
       defineAsyncProcess,
+      executeOnChangeRegardlessOfUnchangedValue,
       getEventArgs,
       hasError,
       hideError,


### PR DESCRIPTION
- Add handleAsAsync flag to FieldInternalsValue type
- Update hasFieldWithAsyncValidator to check handleAsAsync flag
- Fix async behavior logic when skipErrorCheck is true
- Add hasFieldWithAsyncValidator to ContextState interface
- Add missing dependency to useFieldProps hook

To make #6032 work.