### PR TITLE
fix(Dialog, HelpButton): reading button title twice in VoiceOver

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -12,7 +12,10 @@ import { DialogProps, DialogContentProps } from './types'
 import classnames from 'classnames'
 import Context from '../../shared/Context'
 import DialogAction from './parts/DialogAction'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  removeUndefinedProps,
+} from '../../shared/component-helper'
 
 const defaultProps = {
   variant: 'information',
@@ -94,7 +97,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
     currentFullscreen = variant === 'information' ? 'auto' : false
   }
 
-  const modalProps = {
+  const modalProps = removeUndefinedProps({
     title,
     id,
     focusSelector,
@@ -132,7 +135,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
     space,
     contentRef,
     scrollRef,
-  }
+  })
 
   const dialogProps = {
     ...props,


### PR DESCRIPTION
This does not fix the issues regarding helpbutton/dialog title when modal is opened is read twice. 

The fix is just to wrap the modal props in `removeUndefinedProps`, same as we've done in `Drawer`.

From:
<img width="922" height="804" alt="Screenshot 2025-12-08 at 09 17 10" src="https://github.com/user-attachments/assets/447e3fd2-7fea-48ea-9fca-01bdee101bac" />



To:
<img width="875" height="844" alt="Screenshot 2025-12-08 at 09 04 32" src="https://github.com/user-attachments/assets/1b307cb9-9c89-44c2-8fcd-0ec27f5c3e3b" />
