### PR TITLE
chore(Popover): add `targetRefreshKey` (internal use)

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -59,6 +59,7 @@ export default function Popover(props: PopoverProps) {
     triggerOffset,
     targetElement: externalTargetElement,
     targetSelector,
+    targetRefreshKey,
     portalRootClass,
     showDelay: showDelayProp,
     hideDelay: hideDelayProp,
@@ -685,6 +686,7 @@ export default function Popover(props: PopoverProps) {
           triggerOffset={triggerOffset}
           hideArrow={hideArrow}
           arrowEdgeOffset={arrowEdgeOffset}
+          targetRefreshKey={targetRefreshKey}
         >
           {overlayContent}
         </PopoverContainer>
@@ -711,6 +713,7 @@ export default function Popover(props: PopoverProps) {
           triggerOffset={triggerOffset}
           hideArrow={hideArrow}
           arrowEdgeOffset={arrowEdgeOffset}
+          targetRefreshKey={targetRefreshKey}
         >
           {overlayContent}
         </PopoverPortal>

--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -41,6 +41,7 @@ type PopoverContainerProps = {
   autoAlignMode?: PopoverAutoAlignMode
   hideArrow?: boolean
   arrowEdgeOffset?: number
+  targetRefreshKey?: unknown
 }
 
 const isResolvedTargetRefsObject = (
@@ -75,6 +76,7 @@ function PopoverContainer(props: PopoverContainerProps) {
     autoAlignMode = 'initial',
     hideArrow = false,
     arrowEdgeOffset,
+    targetRefreshKey,
   } = props
 
   const [style, setStyle] = useState<React.CSSProperties | null>(null)
@@ -797,6 +799,7 @@ function PopoverContainer(props: PopoverContainerProps) {
     renewStyles,
     skipPortal,
     targetElement,
+    targetRefreshKey,
     wasActive,
     arrowPositionSelector,
     resolvedPlacement,

--- a/packages/dnb-eufemia/src/components/popover/PopoverDocs.ts
+++ b/packages/dnb-eufemia/src/components/popover/PopoverDocs.ts
@@ -171,6 +171,11 @@ export const PopoverProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  targetRefreshKey: {
+    doc: 'Forces the popover to recalculate its layout whenever this value changes. Useful when the trigger moves but the DOM tree stays mounted.',
+    type: 'unknown',
+    status: 'optional',
+  },
   portalRootClass: {
     doc: 'Extra className applied to the portal wrapper (only when not using `skipPortal`).',
     type: 'string',

--- a/packages/dnb-eufemia/src/components/popover/PopoverPortal.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverPortal.tsx
@@ -50,6 +50,7 @@ type PopoverPortalProps = {
   arrowEdgeOffset?: React.ComponentProps<
     typeof PopoverContainer
   >['arrowEdgeOffset']
+  targetRefreshKey?: unknown
 }
 
 type PopoverPortalEntry = {
@@ -93,6 +94,7 @@ function PopoverPortal(props: PopoverPortalProps) {
     autoAlignMode,
     hideArrow,
     arrowEdgeOffset,
+    targetRefreshKey,
   } = props
 
   const [id] = useState(() => makeUniqueId())
@@ -144,6 +146,7 @@ function PopoverPortal(props: PopoverPortalProps) {
           autoAlignMode={autoAlignMode}
           hideArrow={hideArrow}
           arrowEdgeOffset={arrowEdgeOffset}
+          targetRefreshKey={targetRefreshKey}
         >
           {children}
         </PopoverContainer>

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Dialog } from '../../'
 import Popover from '../Popover'
+import * as PopoverContainerModule from '../PopoverContainer'
 import Provider from '../../../shared/Provider'
 import defaultLocales from '../../../shared/locales'
 import * as sharedHelpers from '../../../shared/helpers'
@@ -295,6 +296,33 @@ describe('Popover', () => {
         {contentText}
       </Popover>
     )
+
+  it('passes updated targetRefreshKey to PopoverContainer', () => {
+    const spy = jest.spyOn(PopoverContainerModule, 'default')
+    const target = createTargetElement()
+
+    const { rerender } = render(
+      <Popover open targetElement={target.element} targetRefreshKey={1}>
+        Shake
+      </Popover>
+    )
+
+    expect(spy).toHaveBeenCalled()
+    const firstCall = spy.mock.calls.pop()
+    expect(firstCall[0].targetRefreshKey).toBe(1)
+
+    rerender(
+      <Popover open targetElement={target.element} targetRefreshKey={2}>
+        Shake
+      </Popover>
+    )
+
+    expect(spy).toHaveBeenCalled()
+    const secondCall = spy.mock.calls.pop()
+    expect(secondCall[0].targetRefreshKey).toBe(2)
+
+    spy.mockRestore()
+  })
 
   it('renders provided trigger and toggles visibility', async () => {
     renderWithTrigger()

--- a/packages/dnb-eufemia/src/components/popover/types.ts
+++ b/packages/dnb-eufemia/src/components/popover/types.ts
@@ -92,6 +92,10 @@ type PopoverPropsBase = {
    * @default false
    */
   skipPortal?: boolean
+  /**
+   * Forces PopoverContainer to recalculate its layout when the value changes.
+   */
+  targetRefreshKey?: unknown
   noAnimation?: boolean
   showDelay?: number
   hideDelay?: number

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -24,6 +24,7 @@ import AriaLive from '../AriaLive'
 type TooltipWithEventsProps = {
   target: TooltipProps['targetElement']
   attributes?: React.HTMLAttributes<HTMLElement>
+  targetRefreshKey?: TooltipProps['targetRefreshKey']
 }
 
 function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
@@ -44,6 +45,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     contentRef,
     size,
     keepInDOM = false,
+    targetRefreshKey,
   } = restProps
 
   const { internalId, isControlled } = useContext(TooltipContext)
@@ -317,6 +319,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         keepInDOM={keepInDOM}
         noAnimation={noAnimation}
         triggerOffset={triggerOffset}
+        targetRefreshKey={targetRefreshKey}
         arrowPosition={arrow}
         placement={position}
         alignOnTarget={align}

--- a/packages/dnb-eufemia/src/components/tooltip/types.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/types.ts
@@ -63,6 +63,10 @@ export type TooltipProps = IncludeSnakeCase<{
    * @default 16
    */
   triggerOffset?: number
+  /**
+   * Forces the tooltip to re-evaluate the target position when the provided key changes.
+   */
+  targetRefreshKey?: unknown
 }>
 
 export type TooltipAllProps = TooltipProps &


### PR DESCRIPTION
This PR adds a feature we will use inside Tooltip, so we can fix the Slider->Tooltip issue.