### PR TITLE
chore(Field.Name): add missing test for two letter name

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Name/__tests__/Name.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Name/__tests__/Name.test.tsx
@@ -206,6 +206,7 @@ describe('Field.Name', () => {
     ]
 
     const invalidNames = [
+      'Li',
       'Ole1',
       'Hans  Christian',
       'Anne--Marie',


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1765376565418549

I'm not sure if a two letter name should be valid or not, but based on our existing code today it's not valid.

Todo:
- [ ] Update docs so that users better understand the validation. 