### PR TITLE
feat(Badge): add variant `content`

### DIFF
--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -63,7 +63,7 @@ export type BadgeProps = {
    * The variant of the component.
    * Default: information.
    */
-  variant?: 'information' | 'notification'
+  variant?: 'information' | 'notification' | 'content'
 }
 
 type BadgeAndSpacingProps = BadgeProps &
@@ -154,7 +154,7 @@ function BadgeElem(
       role="status"
       className={classnames(
         'dnb-badge',
-        `dnb-badge--variant-${variant}`,
+        variant !== 'content' && `dnb-badge--variant-${variant}`,
         horizontal && `dnb-badge--horizontal-${horizontal}`,
         vertical && `dnb-badge--vertical-${vertical}`,
         isInline && 'dnb-badge--inline',

--- a/packages/dnb-eufemia/src/components/badge/BadgeDocs.ts
+++ b/packages/dnb-eufemia/src/components/badge/BadgeDocs.ts
@@ -32,8 +32,8 @@ export const BadgeProperties: PropertiesTableProps = {
     status: 'optional',
   },
   variant: {
-    doc: 'defines the visual appearance of the badge. There are two main variants `notification` and `information`. The default variant is `information`.',
-    type: ['information', 'notification'],
+    doc: 'defines the visual appearance of the badge. There are two main variants `notification` and `information`. The `content` variant is just for placement purposes, and will require you to style the `content` all by yourself. The default variant is `information`.',
+    type: ['information', 'notification', 'content'],
     status: 'optional',
   },
   label: {

--- a/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
+++ b/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
@@ -32,6 +32,17 @@ describe('Badge', () => {
     expect(screen.queryByText(label)).toBeInTheDocument()
   })
 
+  it('supports variant content', () => {
+    render(<Badge variant="content" content="content" />)
+
+    const element = document.querySelector('.dnb-badge')
+
+    expect(Array.from(element.classList)).toEqual([
+      'dnb-badge',
+      'dnb-badge--inline',
+    ])
+  })
+
   it('renders formatted number when content is a number with notification variant', () => {
     const number = 10
     const label = 'Notifications:'
@@ -128,8 +139,8 @@ describe('Badge', () => {
     expect(attributes).toEqual(['role', 'class', 'aria-label'])
     expect(Array.from(element.classList)).toEqual([
       'dnb-badge',
-      'dnb-badge--variant-information',
       'dnb-space__top--large',
+      'dnb-badge--variant-information',
       'dnb-badge--inline',
     ])
   })
@@ -153,9 +164,9 @@ describe('Badge', () => {
 
     expect(Array.from(element.classList)).toEqual([
       'dnb-badge',
-      'dnb-badge--variant-information',
       'dnb-skeleton',
       'dnb-skeleton--shape',
+      'dnb-badge--variant-information',
       'dnb-badge--inline',
     ])
   })


### PR DESCRIPTION
Builds on top of https://github.com/dnbexperience/eufemia/pull/6071

Deploy preview: https://feat-badge-variant-content.eufemia-e25.pages.dev/uilib/components/badge/properties/

For now, I've not added any demos for the new variant content, as I'm not sure if we should document it too much.
As of now it's mostly/only used internally. But since we'll add demos for it in https://github.com/dnbexperience/eufemia/pull/6078, I think it's correct to add the type to TS and our properties docs, but probably nothing more 🙏 
