### PR TITLE
fix(Forms): automatically use `onBlurValidator` as `onChangeValidator` when `validateContinuously` is enabled

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -172,17 +172,23 @@ function DateComponent(props: DateProps) {
     [props.maxDate, props.minDate, props.range, invalidDatesRef, locale]
   )
 
+  const {
+    onBlurValidator: propOnBlurValidator,
+    onChangeValidator,
+    ...restProps
+  } = props
+
   const onBlurValidator = useMemo(() => {
-    if (props.onBlurValidator === false) {
+    if (propOnBlurValidator === false) {
       return undefined
     }
 
-    if (props.onBlurValidator) {
-      return props.onBlurValidator
+    if (propOnBlurValidator) {
+      return propOnBlurValidator
     }
 
     return dateValidator
-  }, [props.onBlurValidator, dateValidator])
+  }, [propOnBlurValidator, dateValidator])
 
   const fromInput = useCallback(
     ({
@@ -206,12 +212,13 @@ function DateComponent(props: DateProps) {
   )
 
   const preparedProps = {
-    ...props,
+    ...restProps,
     errorMessages,
     schema,
     fromInput,
     validateRequired,
     onBlurValidator,
+    onChangeValidator,
     exportValidators: { dateValidator },
     invalidDatesRef,
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -112,7 +112,13 @@ function DateOfBirth(props: Props) {
     [errorDateOfBirth, errorDateOfBirthFuture, dateFormat]
   )
 
-  const { onBlurValidator: propOnBlurValidator } = props
+  const {
+    onBlurValidator: propOnBlurValidator,
+    onChangeValidator,
+    value: propValue,
+    space,
+    ...otherProps
+  } = props
 
   const onBlurValidator = useMemo(() => {
     if (propOnBlurValidator === false) {
@@ -133,14 +139,13 @@ function DateOfBirth(props: Props) {
     return dateOfBirthValidator
   }, [propOnBlurValidator, dateOfBirthValidator])
 
-  const { value: propValue, space, ...otherProps } = props
-
   const preparedProps: Props = useMemo(
     () => ({
       ...otherProps,
       value: propValue,
       errorMessages,
       onBlurValidator,
+      onChangeValidator,
       exportValidators: { dateOfBirthValidator },
       provideAdditionalArgs,
     }),
@@ -149,7 +154,9 @@ function DateOfBirth(props: Props) {
       propValue,
       errorMessages,
       onBlurValidator,
+      onChangeValidator,
       dateOfBirthValidator,
+      provideAdditionalArgs,
     ]
   )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -47,7 +47,7 @@ function Expiry(props: ExpiryProps = {}) {
 
   const {
     onBlurValidator = expiryValidator,
-    onChangeValidator: onChangeValidatorProp,
+    onChangeValidator,
     errorMessages: propErrorMessages,
     validateInitially: validateInitiallyProp,
     validateContinuously,
@@ -55,16 +55,6 @@ function Expiry(props: ExpiryProps = {}) {
     transformIn: transformInProp,
     onStatusChange,
   } = props
-
-  // When validateContinuously is enabled, also validate on change
-  const onChangeValidator = useMemo(() => {
-    if (onChangeValidatorProp) {
-      return onChangeValidatorProp
-    }
-    if (validateContinuously) {
-      return expiryValidator
-    }
-  }, [onChangeValidatorProp, validateContinuously, expiryValidator])
 
   const errorMessages = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -677,4 +677,156 @@ describe('Field.NationalIdentityNumber', () => {
       expect(await axeComponent(result)).toHaveNoViolations()
     })
   })
+
+  it('should validate continuously when validateContinuously is enabled', async () => {
+    render(<Field.NationalIdentityNumber validateContinuously />)
+
+    const input = document.querySelector('input')
+
+    // Type invalid identity number (too short) - error should appear during typing
+    await userEvent.type(input, '123')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(document.querySelector('[role="alert"]')).toHaveTextContent(
+        nb.NationalIdentityNumber.errorFnrLength
+      )
+    })
+
+    // Type more digits to reach 11 - error should change to invalid format
+    await userEvent.type(input, '45678901')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(document.querySelector('[role="alert"]')).toHaveTextContent(
+        nb.NationalIdentityNumber.errorFnr
+      )
+    })
+
+    // Type valid identity number - error should disappear
+    await userEvent.clear(input)
+    await userEvent.type(input, '08121312590')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('should call onStatusChange when validateContinuously reveals validation errors', async () => {
+    const onStatusChange = jest.fn()
+
+    render(
+      <Field.NationalIdentityNumber
+        onStatusChange={onStatusChange}
+        validateContinuously
+        required
+      />
+    )
+
+    const input = document.querySelector('input')
+
+    // Type invalid identity number
+    await userEvent.type(input, '123')
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled()
+      expect(onStatusChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          error: expect.anything(),
+        })
+      )
+    })
+
+    // Clear mock to track new calls
+    onStatusChange.mockClear()
+
+    // Type valid identity number
+    await userEvent.clear(input)
+    await userEvent.type(input, '08121312590')
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled()
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: undefined,
+      })
+    })
+  })
+
+  it('should call onStatusChange when error prop changes without validateContinuously', async () => {
+    const onStatusChange = jest.fn()
+    const error1 = new Error('Error 1')
+    const error2 = new Error('Error 2')
+
+    const { rerender } = render(
+      <Field.NationalIdentityNumber
+        onStatusChange={onStatusChange}
+        error={undefined}
+      />
+    )
+
+    // Initially no error should be called
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(0)
+    })
+
+    // Set error prop
+    rerender(
+      <Field.NationalIdentityNumber
+        onStatusChange={onStatusChange}
+        error={error1}
+      />
+    )
+
+    // Wait for onStatusChange to be called with error
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(1)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: error1,
+      })
+    })
+
+    // Change to different error
+    rerender(
+      <Field.NationalIdentityNumber
+        onStatusChange={onStatusChange}
+        error={error2}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(2)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: error2,
+      })
+    })
+
+    // Clear error
+    rerender(
+      <Field.NationalIdentityNumber
+        onStatusChange={onStatusChange}
+        error={undefined}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(3)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: undefined,
+      })
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/__tests__/OrganizationNumber.test.tsx
@@ -610,4 +610,156 @@ describe('Field.OrganizationNumber', () => {
       expect(input).toHaveAttribute('aria-invalid', 'true')
     })
   })
+
+  it('should validate continuously when validateContinuously is enabled', async () => {
+    render(<Field.OrganizationNumber validateContinuously />)
+
+    const input = document.querySelector('input')
+
+    // Type invalid organization number (too short) - error should appear during typing
+    await userEvent.type(input, '123')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(document.querySelector('[role="alert"]')).toHaveTextContent(
+        nb.OrganizationNumber.errorOrgNoLength
+      )
+    })
+
+    // Type more digits to reach 9 - error should change to invalid checksum
+    await userEvent.type(input, '456789')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).toBeInTheDocument()
+      expect(document.querySelector('[role="alert"]')).toHaveTextContent(
+        nb.OrganizationNumber.errorOrgNo
+      )
+    })
+
+    // Type valid organization number - error should disappear
+    await userEvent.clear(input)
+    await userEvent.type(input, '724841198')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-form-status--error')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('should call onStatusChange when validateContinuously reveals validation errors', async () => {
+    const onStatusChange = jest.fn()
+
+    render(
+      <Field.OrganizationNumber
+        onStatusChange={onStatusChange}
+        validateContinuously
+        required
+      />
+    )
+
+    const input = document.querySelector('input')
+
+    // Type invalid organization number
+    await userEvent.type(input, '123')
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled()
+      expect(onStatusChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          error: expect.anything(),
+        })
+      )
+    })
+
+    // Clear mock to track new calls
+    onStatusChange.mockClear()
+
+    // Type valid organization number
+    await userEvent.clear(input)
+    await userEvent.type(input, '724841198')
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled()
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: undefined,
+      })
+    })
+  })
+
+  it('should call onStatusChange when error prop changes without validateContinuously', async () => {
+    const onStatusChange = jest.fn()
+    const error1 = new Error('Error 1')
+    const error2 = new Error('Error 2')
+
+    const { rerender } = render(
+      <Field.OrganizationNumber
+        onStatusChange={onStatusChange}
+        error={undefined}
+      />
+    )
+
+    // Initially no error should be called
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(0)
+    })
+
+    // Set error prop
+    rerender(
+      <Field.OrganizationNumber
+        onStatusChange={onStatusChange}
+        error={error1}
+      />
+    )
+
+    // Wait for onStatusChange to be called with error
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(1)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: error1,
+      })
+    })
+
+    // Change to different error
+    rerender(
+      <Field.OrganizationNumber
+        onStatusChange={onStatusChange}
+        error={error2}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(2)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: error2,
+      })
+    })
+
+    // Clear error
+    rerender(
+      <Field.OrganizationNumber
+        onStatusChange={onStatusChange}
+        error={undefined}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(3)
+      expect(onStatusChange).toHaveBeenLastCalledWith({
+        info: undefined,
+        warning: undefined,
+        error: undefined,
+      })
+    })
+  })
 })


### PR DESCRIPTION
- Centralize `validateContinuously` logic in `useFieldProps` hook
- When `validateContinuously` is enabled and no explicit `onChangeValidator` is provided, automatically use `onBlurValidator` as `onChangeValidator`
- Remove duplicate logic from field components: `Expiry`, `BankAccountNumber`, `OrganizationNumber`, `NationalIdentityNumber`, `DateOfBirth` and `Date`
- Add tests to useFieldProps for the new centralized behavior
- Add `validateContinuously` and `onStatusChange` tests to all affected field components

Fixes also: https://github.com/dnbexperience/eufemia/pull/6076#issuecomment-3642104270