### PR TITLE
fix(DatePicker, TermDefinition): add translated string to "focus trap" buttons

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -615,7 +615,7 @@ export default function Popover(props: PopoverProps) {
     <>
       {!disableFocusTrap && (
         <button className="dnb-sr-only" onFocus={close}>
-          Focus trap
+          {tr.focusTrapTitle}
         </button>
       )}
 
@@ -641,7 +641,7 @@ export default function Popover(props: PopoverProps) {
 
       {!disableFocusTrap && (
         <button className="dnb-sr-only" onFocus={close}>
-          Focus trap
+          {tr.focusTrapTitle}
         </button>
       )}
     </>

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -694,6 +694,30 @@ describe('Popover', () => {
     })
   })
 
+  it('renders focus trap buttons with the translated label', async () => {
+    renderWithTrigger()
+
+    const trigger = document.querySelector('button[aria-controls]')
+    await userEvent.click(trigger)
+
+    await waitFor(() =>
+      expect(document.querySelector('.dnb-popover')).toBeInTheDocument()
+    )
+
+    const focusTrapButtons = Array.from(
+      document.querySelectorAll(
+        '.dnb-popover .dnb-sr-only button, .dnb-popover button.dnb-sr-only'
+      )
+    )
+
+    const focusTrapTitle = defaultLocales['nb-NO'].Popover.focusTrapTitle
+
+    expect(focusTrapButtons.length).toBeGreaterThanOrEqual(2)
+    focusTrapButtons.forEach((button) => {
+      expect(button).toHaveTextContent(focusTrapTitle)
+    })
+  })
+
   it('provides default trigger aria attributes', () => {
     const baseTranslation = defaultLocales['nb-NO']
     const customTranslation = {

--- a/packages/dnb-eufemia/src/components/term-definition/stories/TermDefinition.stories.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/stories/TermDefinition.stories.tsx
@@ -10,33 +10,11 @@ export default {
 export const Basic = {
   render: () => (
     <P space="2rem">
-      <button>A</button>A text with Ullamco mollit id nulla id enim aute
-      voluptate nulla non. Ad velit elit amet laborum deserunt nostrud
-      reprehenderit exercitation. Consequat deserunt amet minim id Lorem
-      proident sunt sunt incididunt reprehenderit incididunt. Qui eu ipsum
-      minim eu tempor. Amet magna ex reprehenderit est ipsum culpa magna do
-      amet aliquip duis eiusmod sint. Do do mollit deserunt ipsum aliquip
-      adipisicing labore aliqua do. Non irure ullamco do minim esse ex
-      magna minim quis excepteur cupidatat do aliqua.{' '}
+      <button>A</button> before{' '}
       <TermDefinition content="Unusual words are words that are not commonly used or that many people might not know the meaning of.">
         unusual words
       </TermDefinition>{' '}
-      non anim mollit amet culpa ipsum ullamco irure excepteur officia
-      veniam. Et occaecat aliquip incididunt velit pariatur in.{' '}
-      <button>B</button> Id est laboris consequat Lorem tempor. Cupidatat
-      proident irure dolore voluptate dolore excepteur nulla nostrud minim
-      dolore mollit reprehenderit reprehenderit. Magna est fugiat sit
-      cupidatat sint deserunt sit culpa nostrud dolore reprehenderit
-      ullamco ex in. Dolore consequat non occaecat sunt deserunt ipsum esse
-      aliquip nostrud fugiat amet sunt fugiat. Pariatur id et Lorem
-      consectetur eiusmod. Do cillum proident magna sit. Aute adipisicing
-      labore dolore incididunt tempor sunt officia tempor magna duis quis.
-      Consequat minim deserunt amet nulla cillum occaecat duis commodo.
-      Ullamco eu ea et do dolor consectetur non consectetur esse. Nostrud
-      elit Lorem ullamco mollit voluptate eu exercitation enim nisi nulla
-      incididunt est velit anim. Mollit Lorem nulla irure nisi magna non ex
-      cillum excepteur aliqua occaecat in proident laborum. Amet occaecat
-      minim veniam nostrud veniam sit mollit consequat in consequat.
+      text. <button>B</button> after.
     </P>
   ),
 }

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -179,6 +179,7 @@ export default {
       closeButtonTitle: 'Luk',
       openTriggerTitle: 'Klik for at åbne',
       closeTriggerTitle: 'Klik for at lukke',
+      focusTrapTitle: 'Klik for at vende tilbage',
     },
     TermDefinition: {
       closeButtonTitle: 'Luk ordforklaring',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -181,6 +181,7 @@ export default {
       closeButtonTitle: 'Close',
       openTriggerTitle: 'Click to open',
       closeTriggerTitle: 'Click to close',
+      focusTrapTitle: 'Click to return',
     },
     TermDefinition: {
       closeButtonTitle: 'Close definition',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -179,6 +179,7 @@ export default {
       closeButtonTitle: 'Lukk',
       openTriggerTitle: 'Klikk for å åpne',
       closeTriggerTitle: 'Klikk for å lukke',
+      focusTrapTitle: 'Klikk for å gå tilbake',
     },
     TermDefinition: {
       closeButtonTitle: 'Lukk ordforklaring',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -180,6 +180,7 @@ export default {
       closeButtonTitle: 'Stäng',
       openTriggerTitle: 'Klicka för att öppna',
       closeTriggerTitle: 'Klicka för att stänga',
+      focusTrapTitle: 'Klicka för att återgå',
     },
     TermDefinition: {
       closeButtonTitle: 'Stäng ordförklaring',


### PR DESCRIPTION
In order to enhance NVDA UX.

Here's how its today:
<img width="812" height="524" alt="Screenshot 2025-12-12 at 09 48 58" src="https://github.com/user-attachments/assets/b22e21c5-6c89-4723-a6fd-1eab2f935e5e" />
