### PR TITLE
fix(Button): ensure tooltip is rendered when initially active

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -8,6 +8,7 @@ import * as helpers from '../../../shared/helpers'
 import { fireEvent, render, waitFor, screen } from '@testing-library/react'
 import { Form } from '../../../extensions/forms'
 import Translation from '../../../shared/Translation'
+import userEvent from '@testing-library/user-event'
 
 const props: DialogProps & DialogContentProps = {
   noAnimation: true,
@@ -157,6 +158,30 @@ describe('Dialog', () => {
     )
 
     expect(document.querySelector('.dnb-dialog__title').textContent).toBe(
+      'Dialog Window'
+    )
+  })
+
+  it('accepts a <Translation> title and renders it in the HelpButton Tooltip', async () => {
+    render(
+      <Provider value={{ locale: 'en-GB' }}>
+        <Dialog
+          noAnimation
+          openState
+          title={<Translation id="Modal.dialog_title" />}
+        />
+      </Provider>
+    )
+
+    await userEvent.hover(document.querySelector('.dnb-modal__trigger'))
+
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('.dnb-tooltip')
+      ).toBeInTheDocument()
+    })
+
+    expect(document.body.querySelector('.dnb-tooltip').textContent).toBe(
       'Dialog Window'
     )
   })

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -73,7 +73,7 @@ function Tooltip(localProps: TooltipAllProps) {
         forceActive={forceActive}
         {...props}
       >
-        {tooltip || children}
+        {children}
       </TooltipWithEvents>
     </TooltipContext.Provider>
   )
@@ -149,6 +149,8 @@ function createAttributes(
     ...attributeProps,
   }
 }
+
+Tooltip.isTooltipComponent = true
 
 export { injectTooltipSemantic }
 export default Tooltip

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -771,9 +771,9 @@ describe('Tooltip', () => {
       render(
         <NumberFormat
           tooltip={
-            <Tooltip {...defaultProps} className="custom-class">
+            <OriginalTooltip {...defaultProps} className="custom-class">
               Tooltip for this NumberFormat
-            </Tooltip>
+            </OriginalTooltip>
           }
         >
           5678


### PR DESCRIPTION
Currently, [this](https://eufemia.dnb.no/uilib/components/tooltip/demos/#button-with-active-tooltip) example renders like this: 
<img width="794" height="234" alt="Screenshot 2025-12-15 at 14 29 49" src="https://github.com/user-attachments/assets/7bf9796a-911e-43a9-9fad-45e0d69f1742" />
