### PR TITLE
chore(Field.Upload): update example to reflect its label

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload/Examples.tsx
@@ -171,7 +171,7 @@ export const WithAsyncFileHandler = () => {
         ): Promise<UploadValue> {
           const updatedFiles: UploadValue = []
 
-          for (const [, file] of Object.entries(newFiles)) {
+          for (const [index, file] of Object.entries(newFiles)) {
             const formData = new FormData()
             formData.append('file', file.file, file.file.name)
 
@@ -180,7 +180,7 @@ export const WithAsyncFileHandler = () => {
 
             try {
               const mockResponse = {
-                ok: false, // Fails virus check
+                ok: (parseFloat(index) + 2) % 2 === 0, // Every other request will fail
                 json: async () => ({
                   server_generated_id:
                     file.file.name + '_' + crypto.randomUUID(),


### PR DESCRIPTION
Label of the example says `This demo has been set up so that every other file in a batch will fail.`,  but the actual example (async fileHandler) was not doing so. Hence this PR to update the functionality it to match the label.