### PR TITLE
fix(Forms): improve type safety for custom validators for `Field.Name`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
@@ -92,14 +92,14 @@ The validation happens on blur, internally using the `onBlurValidator` [property
 You can extend the validation by providing your own `onBlurValidator` function. Access the internal validator through the `validators` parameter and combine it with your custom validation. This allows you to add additional validation rules while keeping the default validation intact.
 
 ```tsx
-import { Field } from '@dnb/eufemia/extensions/forms'
-import type { NameCompanyValidator } from '@dnb/eufemia/extensions/forms/Field/Name'
+import { Field, Validator } from '@dnb/eufemia/extensions/forms'
+import type { CompanyNameValidator } from '@dnb/eufemia/extensions/forms/Field/Name'
 
 // Extend validation to require company names to contain "Corp"
-const myValidator: NameCompanyValidator = (value, { validators }) => {
-  const { companyValidator } = validators ?? {}
+const myValidator: CompanyNameValidator = (value, { validators }) => {
+  const { companyValidator } = validators
 
-  const customValidator = (value: string) => {
+  const customValidator: Validator<string> = (value) => {
     if (value && !value.includes('Corp')) {
       return new Error('Company name must contain "Corp"')
     }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Name/Name.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Name/Name.tsx
@@ -11,7 +11,7 @@ export type NameValidator = ValidatorWithCustomValidators<
   }
 >
 
-export type NameCompanyValidator = ValidatorWithCustomValidators<
+export type CompanyNameValidator = ValidatorWithCustomValidators<
   string,
   {
     companyValidator: Validator<string>


### PR DESCRIPTION
Based on #6127 
