### PR TITLE
fix(Field.Expiry): should not display error borders when providing `info` or `warning`

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -232,7 +232,7 @@ function Expiry(props: ExpiryProps = {}) {
         stretch
         id={`${id}-input`}
         values={expiry}
-        status={status}
+        status={status === 'error'}
         statusState={disabled ? 'disabled' : undefined}
         disabled={disabled}
         size={size}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -956,6 +956,26 @@ describe('Field.Expiry', () => {
     })
   })
 
+  it('renders info', () => {
+    render(<Field.Expiry info="Info message" />)
+
+    const element = document.querySelector('.dnb-form-status')
+    expect(element).toHaveTextContent('Info message')
+
+    const input = document.querySelector('.dnb-input')
+    expect(input).not.toHaveClass('dnb-input__status--error')
+  })
+
+  it('renders warning', () => {
+    render(<Field.Expiry warning="Warning message" />)
+
+    const element = document.querySelector('.dnb-form-status')
+    expect(element).toHaveTextContent('Warning message')
+
+    const input = document.querySelector('.dnb-input')
+    expect(input).not.toHaveClass('dnb-input__status--error')
+  })
+
   it('renders error', () => {
     render(<Field.Expiry error={new Error('Error message')} />)
 


### PR DESCRIPTION
Deploy preview: https://chore-expiry.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/Expiry/

Fixes:
<img width="217" height="137" alt="Screenshot 2025-12-18 at 10 59 04" src="https://github.com/user-attachments/assets/2e6cbc4a-1a12-4e51-aeb6-741f96553c52" />
<img width="219" height="141" alt="Screenshot 2025-12-18 at 10 58 57" src="https://github.com/user-attachments/assets/2244e612-b9d1-47b0-9536-169a4405d53e" />
