### PR TITLE
feat(Form.Section.EditButton): add support for custom properties

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/EditButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/EditButton.tsx
@@ -4,8 +4,11 @@ import ToolbarContext from '../Toolbar/ToolbarContext'
 import { useTranslation } from '../../../hooks'
 import { Button } from '../../../../../components'
 import { edit } from '../../../../../icons'
+import { ButtonProps } from '../../../../../components/button/Button'
 
-export default function EditButton() {
+export type Props = ButtonProps
+
+export default function EditButton(props: Props) {
   const sectionContainerContext = useContext(SectionContainerContext)
   const { onEdit } = useContext(ToolbarContext) || {}
   const { switchContainerMode, disableEditing } =
@@ -28,6 +31,7 @@ export default function EditButton() {
       icon={edit}
       icon_position="left"
       on_click={editHandler}
+      {...props}
     >
       {translation.editButton}
     </Button>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/EditButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/EditButton.test.tsx
@@ -48,4 +48,19 @@ describe('EditButton', () => {
 
     expect(document.querySelector('button')).not.toBeInTheDocument()
   })
+
+  it('supports custom properties', () => {
+    render(
+      <Toolbar>
+        <EditButton
+          className="custom-class"
+          aria-label="Custom edit label"
+        />
+      </Toolbar>
+    )
+
+    const button = document.querySelector('button')
+    expect(button).toHaveClass('custom-class')
+    expect(button).toHaveAttribute('aria-label', 'Custom edit label')
+  })
 })


### PR DESCRIPTION
Motivation: Make `Form.Selection` more flexible to use for various use-cases.