### PR TITLE
chore: replace substr as it's deprecated

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/addons/createNumberMask.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/addons/createNumberMask.ts
@@ -79,7 +79,7 @@ export default function createNumberMask({
     const isNegative = rawValue[0] === minus && allowNegative
     // If negative remove "-" sign
     if (isNegative) {
-      rawValue = rawValue.toString().substr(1)
+      rawValue = rawValue.toString().substring(1)
     }
 
     const indexOfLastDecimal = rawValue.lastIndexOf(decimalSymbol)

--- a/packages/dnb-eufemia/src/components/input-masked/addons/emailPipe.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/addons/emailPipe.ts
@@ -46,7 +46,7 @@ export default function emailPipe(conformedValue, config) {
 
   if (
     (domainPart.match(allDotsRegExp) || emptyArray).length > 1 &&
-    value.substr(-1) === dot &&
+    value.substring(-1) === dot &&
     currentCaretPosition !== rawValue.length
   ) {
     value = value.slice(0, value.length - 1)

--- a/packages/dnb-eufemia/src/components/input-masked/text-mask/adjustCaretPosition.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/text-mask/adjustCaretPosition.ts
@@ -82,7 +82,7 @@ export default function adjustCaretPosition({
 
     // Then we take all characters that come before where the caret currently is.
     const leftHalfChars = normalizedRawValue
-      .substr(0, currentCaretPosition)
+      .substring(0, currentCaretPosition)
       .split(emptyString)
 
     // Now we find all the characters in the left half that exist in the conformed input
@@ -98,14 +98,14 @@ export default function adjustCaretPosition({
     // Calculate the number of mask characters in the previous placeholder
     // from the start of the string up to the place where the caret is
     const previousLeftMaskChars = previousPlaceholder
-      .substr(0, intersection.length)
+      .substring(0, intersection.length)
       .split(emptyString)
       .filter((char) => char !== placeholderChar).length
 
     // Calculate the number of mask characters in the current placeholder
     // from the start of the string up to the place where the caret is
     const leftMaskChars = placeholder
-      .substr(0, intersection.length)
+      .substring(0, intersection.length)
       .split(emptyString)
       .filter((char) => char !== placeholderChar).length
 
@@ -161,7 +161,7 @@ export default function adjustCaretPosition({
     // We need to know if the placeholder contains characters that look like
     // our `targetChar`, so we don't select one of those by mistake.
     const countTargetCharInPlaceholder = placeholder
-      .substr(0, placeholder.indexOf(placeholderChar))
+      .substring(0, placeholder.indexOf(placeholderChar))
       .split(emptyString)
       .filter(
         (char, index) =>

--- a/packages/dnb-eufemia/src/components/input-masked/text-mask/conformToMask.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/text-mask/conformToMask.ts
@@ -238,7 +238,7 @@ export default function conformToMask(
       //
       // That is, for mask `(111)` and user input `2`, we want to return `(2`, not `(2__)`.
       if (suppressGuide === false) {
-        conformedValue += placeholder.substr(i, placeholderLength)
+        conformedValue += placeholder.substring(i, placeholderLength)
       }
 
       // And we break
@@ -269,7 +269,7 @@ export default function conformToMask(
 
     if (indexOfLastFilledPlaceholderChar !== null) {
       // We substring from the beginning until the position after the last filled placeholder char.
-      conformedValue = conformedValue.substr(
+      conformedValue = conformedValue.substring(
         0,
         indexOfLastFilledPlaceholderChar + 1
       )

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -336,7 +336,7 @@ export function toCapitalized(str) {
 export const makeUniqueId = (prefix = 'id-', length = 8) =>
   prefix +
   String(
-    Math.random().toString(36).substr(2, length) + idIncrement++
+    Math.random().toString(36).substring(2, length) + idIncrement++
   ).slice(-length)
 let idIncrement = 0
 


### PR DESCRIPTION
Motivation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr