### PR TITLE
chore(CopyOnClick, NumberFormat): iOS v13 workaround is no longer needed

### DIFF
--- a/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
@@ -2,14 +2,12 @@
  * Web CopyOnClick Component
  */
 
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import classnames from 'classnames'
 import type { CopyOnClickAllProps } from './types'
-import { runIOSSelectionFix } from '../number-format/NumberUtils'
 import {
   copyToClipboard,
   hasSelectedText,
-  IS_IOS,
   warn,
 } from '../../shared/helpers'
 import { convertJsxToString } from '../../shared/component-helper'
@@ -29,12 +27,6 @@ const CopyOnClick = ({
   const ref = useRef<HTMLSpanElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout>()
   const [active, setActive] = React.useState(false)
-
-  useEffect(() => {
-    if (IS_IOS) {
-      runIOSSelectionFix()
-    }
-  }, [])
 
   const {
     CopyOnClick: { clipboard_copy },

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
@@ -22,7 +22,7 @@ import {
   detectOutsideClick,
   isTouchDevice,
 } from '../../shared/component-helper'
-import { hasSelectedText, IS_IOS } from '../../shared/helpers'
+import { hasSelectedText } from '../../shared/helpers'
 import {
   spacingPropTypes,
   createSpacingClasses,

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
@@ -32,7 +32,7 @@ import {
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
 import Tooltip, { injectTooltipSemantic } from '../tooltip/Tooltip'
-import { format, runIOSSelectionFix } from './NumberUtils'
+import { format } from './NumberUtils'
 import { SpacingProps } from '../space/types'
 
 // TypeScript types
@@ -235,15 +235,6 @@ export default class NumberFormat extends React.PureComponent<NumberFormatAllPro
       hover: false,
       copyTooltipActive: false,
       copyTooltipText: null,
-    }
-  }
-
-  componentDidMount() {
-    // NB: This hack may be removed in future iOS versions
-    // in order that iOS v13 can select something on the first try, we run this add range trick
-    if (IS_IOS && !hasiOSFix) {
-      hasiOSFix = true
-      runIOSSelectionFix()
     }
   }
 
@@ -598,7 +589,5 @@ export default class NumberFormat extends React.PureComponent<NumberFormatAllPro
     )
   }
 }
-
-let hasiOSFix = false
 
 NumberFormat._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
@@ -978,21 +978,6 @@ export function cleanNumber(
 }
 
 /**
- * So iOS v13 can select something on the first try, we run this add range trick.
- * NB: This hack may be removed in future iOS versions.
- */
-export function runIOSSelectionFix() {
-  try {
-    const selection = window.getSelection()
-    const range = document.createRange()
-    selection.removeAllRanges()
-    selection.addRange(range)
-  } catch (e) {
-    //
-  }
-}
-
-/**
  * Will return currency display value based on navigator/browser and locale
  *
  * @property {string} currencyDisplay (optional) code, name, symbol or narrowSymbol


### PR DESCRIPTION
iOS v13 workaround is no longer needed (iOS 13 was released in 2019).