### PR TITLE
feat(Icon): remove redundant icon suffix in aria-label

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -357,8 +357,8 @@ export function prepareIcon(props: IconAllProps, context: ContextProps) {
   const wrapperParams = validateDOMAttributes(props, {
     role: alt ? 'img' : 'presentation',
     alt, // in case the image don't shows up (because we define the role to be img)
-    'aria-label': alt 
-      ? alt 
+    'aria-label': alt
+      ? alt
       : label && !label.includes('default')
       ? label.replace(/_/g, ' ')
       : null, // for screen readers only - removed redundant 'icon' suffix

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -357,10 +357,11 @@ export function prepareIcon(props: IconAllProps, context: ContextProps) {
   const wrapperParams = validateDOMAttributes(props, {
     role: alt ? 'img' : 'presentation',
     alt, // in case the image don't shows up (because we define the role to be img)
-    'aria-label':
-      label && !label.includes('default')
-        ? label.replace(/_/g, ' ') + ' icon'
-        : null, // for screen readers only
+    'aria-label': alt 
+      ? alt 
+      : label && !label.includes('default')
+      ? label.replace(/_/g, ' ')
+      : null, // for screen readers only - removed redundant 'icon' suffix
     title, // to show on hover, if defined
     ...attributes,
   })


### PR DESCRIPTION
Is it really describing to have «icon» as a suffix? Not sure if that describes the icon better, as screen readers will already know it's an icon/img based on the alt="img" tag that we have 🤔 