### PR TITLE
chore: bem improvements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
@@ -704,42 +704,42 @@ export const DropdownListOpened = () => (
       <span className="dnb-drawer-list__list">
         <ul className="dnb-drawer-list__options">
           <li className="dnb-drawer-list__option first-of-type">
-            <span className="dnb-drawer-list__option__inner">
+            <span className="dnb-drawer-list__option-inner">
               Brukskonto - Kari Nordmann
             </span>
           </li>
           <li className="dnb-drawer-list__option dnb-drawer-list__option--selected">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat always_selectall key="n-1" ban>
                   12345678902
                 </NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Sparekonto - Ole Nordmann
               </span>
             </span>
           </li>
           <li className="dnb-drawer-list__option">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat always_selectall key="n-2" ban>
                   11345678962
                 </NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Feriekonto - Kari Nordmann med et kjempelangt etternavnsen
               </span>
             </span>
           </li>
           <li className="dnb-drawer-list__option last-of-type">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat always_selectall key="n-3" ban>
                   15349648901
                 </NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Oppussing - Ole Nordmann
               </span>
             </span>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list/Examples.tsx
@@ -55,26 +55,26 @@ export const DrawerListExampleOnlyToVisualize = () => (
       <span className="dnb-drawer-list__list">
         <ul className="dnb-drawer-list__options">
           <li className="dnb-drawer-list__option first-of-type">
-            <span className="dnb-drawer-list__option__inner">
+            <span className="dnb-drawer-list__option-inner">
               Brukskonto - Kari Nordmann
             </span>
           </li>
           <li className="dnb-drawer-list__option dnb-drawer-list__option--selected">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat ban>12345678902</NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Sparekonto - Ole Nordmann
               </span>
             </span>
           </li>
           <li className="dnb-drawer-list__option">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat ban>11345678962</NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item item-nr-2">
+              <span className="dnb-drawer-list__option-item item-nr-2">
                 <a
                   className="dnb-anchor dnb-anchor--has-icon"
                   href="/uilib/components/fragments/drawer-list/"
@@ -82,17 +82,17 @@ export const DrawerListExampleOnlyToVisualize = () => (
                   Long link that will wrap over several lines
                 </a>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Feriekonto - Kari Nordmann med et kjempelangt etternavnsen
               </span>
             </span>
           </li>
           <li className="dnb-drawer-list__option last-of-type">
-            <span className="dnb-drawer-list__option__inner">
-              <span className="dnb-drawer-list__option__item item-nr-1">
+            <span className="dnb-drawer-list__option-inner">
+              <span className="dnb-drawer-list__option-item item-nr-1">
                 <NumberFormat ban>15349648901</NumberFormat>
               </span>
-              <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-item">
                 Oppussing - Ole Nordmann
               </span>
             </span>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -445,7 +445,7 @@ export const StackedContainer = () => {
           .dnb-table__scroll-view {
             max-width: 70rem;
           }
-          .dnb-table__container__body {
+          .dnb-table__container-body {
             min-width: 800px;
           }
           table {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -31,8 +31,8 @@
 
 .drawerClassStyle {
   :global {
-    .dnb-drawer-list__option__inner {
-      .dnb-drawer-list__option__item {
+    .dnb-drawer-list__option-inner {
+      .dnb-drawer-list__option-item {
         white-space: normal;
         font-size: var(--font-size-small);
 
@@ -40,7 +40,7 @@
         overflow: visible; /* just to make sure we get anchors working properly */
       }
 
-      .dnb-drawer-list__option__item:first-of-type {
+      .dnb-drawer-list__option-item:first-of-type {
         color: var(--color-sea-green);
         font-weight: var(--font-weight-basis);
         font-size: var(--font-size-medium);

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
@@ -209,7 +209,7 @@
 
       transform: translateX(calc(-100% - 0.5rem));
 
-      .dnb-sidebar-menu__theme-badge__title {
+      .dnb-sidebar-menu__theme-badge-title {
         color: white;
       }
 
@@ -218,7 +218,7 @@
         font-family: var(--font-family-heading);
         font-weight: normal;
 
-        .dnb-sidebar-menu__theme-badge__title {
+        .dnb-sidebar-menu__theme-badge-title {
           width: 0.7em;
           height: 1.5rem;
           overflow: hidden;

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -237,7 +237,7 @@ const ThemeBadge = ({ theme, ...props }: { theme: ThemeNames }) => {
     >
       <span
         title={themeTitleTitle}
-        className={classnames('dnb-sidebar-menu__theme-badge__title')}
+        className={classnames('dnb-sidebar-menu__theme-badge-title')}
       >
         {themeTitle}
       </span>

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -18,7 +18,7 @@
 
   /* 
     - Higher than z-index of 2 by ContentWrapper (.dnb-app-content)
-    - and higher than z-index of 3200 by .dnb-drawer-list__portal__style 
+    - and higher than z-index of 3200 by .dnb-drawer-list__portal-style 
   */
   z-index: 3201;
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes/__tests__/__snapshots__/babelPluginIncludeDocs.test.js.snap
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/generateTypes/__tests__/__snapshots__/babelPluginIncludeDocs.test.js.snap
@@ -123,6 +123,100 @@ export default class PrimaryComponent extends React.PureComponent {
   }
 }
 PrimaryComponent.propTypes = {
+  boolean: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  number: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  spacing: PropTypes.shape({
+    top: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    right: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    bottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    left: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  }),
+  top: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  right: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  bottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  left: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  secondary: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  classProperty: PropTypes.string,
+  secondary_foo: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  secondary_spacing: PropTypes.shape({
+    secondary: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  }),
+  children: PropTypes.node
+};
+PrimaryComponent.defaultProps = {
+  boolean: null,
+  number: null,
+  spacing: null,
+  top: null,
+  ...primaryDefaultProps,
+  ...secondaryDefaultProps,
+  classProperty: null,
+  children: null
+};
+PrimaryComponent.Secondary = SecondaryComponent;
+PrimaryComponent.SecondaryDuplication = SecondaryComponent;
+const Element = () => {
+  return null;
+};
+Element.propTypes = {
+  boolean: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  number: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  spacing: PropTypes.shape({
+    top: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    right: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    bottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+    left: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  }),
+  top: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  right: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  bottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  left: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  secondary: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  secondary_foo: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  secondary_spacing: PropTypes.shape({
+    secondary: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  }),
+  children: PropTypes.node
+};
+Element.defaultProps = {
+  boolean: null,
+  number: null,
+  spacing: null,
+  top: null,
+  ...primaryDefaultProps,
+  children: null
+};"
+`;
+
+exports[`babelPluginIncludeDocs has to match code snapshot in strict mode 2`] = `
+"/**
+ * Test mock file
+ *
+ */
+
+import React from 'react';
+import { PropTypes } from "react";
+import SecondaryComponent, { secondaryDefaultProps, secondaryPropTypes } from './SecondaryComponent';
+import ClassComponent from './ClassComponent';
+export const primaryPropTypes = {
+  top: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  right: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  bottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  left: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+};
+export const primaryDefaultProps = {
+  space: null,
+  top: null,
+  right: null,
+  bottom: null,
+  left: null
+};
+export default class PrimaryComponent extends React.PureComponent {
+  render() {
+    return [this.props.boolean, this.props.number, this.props.spacing, this.props.top, this.props.secondary_foo, this.props.secondary_spacing, this.props.children];
+  }
+}
+PrimaryComponent.propTypes = {
   boolean: PropTypes.bool,
   number: PropTypes.number,
   spacing: PropTypes.shape({

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -119,8 +119,8 @@ function AccordionHeaderIcon({
   return (
     <span
       className={classnames(
-        'dnb-accordion__header__icon',
-        icon_position && `dnb-accordion__header__icon--${icon_position}`
+        'dnb-accordion__header-icon',
+        icon_position && `dnb-accordion__header-icon--${icon_position}`
       )}
     >
       <IconPrimary size={size} icon={icon} aria-hidden />
@@ -322,7 +322,7 @@ export const AccordionHeader = ({
   const partsToRender = []
   const wrapperParts = []
   const wrapperComp = (
-    <span className="dnb-accordion__header__wrapper" key="wrapper">
+    <span className="dnb-accordion__header-wrapper" key="wrapper">
       {wrapperParts}
     </span>
   )

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -140,33 +140,33 @@ p > .dnb-icon {
 .dnb-accordion__header--prevent-click {
   pointer-events: none;
 }
-.dnb-accordion__header__wrapper {
+.dnb-accordion__header-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
   margin: var(--accordion-header-margin-vertical) var(--accordion-header-wrapper-margin) var(--accordion-header-margin-vertical) 0;
 }
-.dnb-accordion__header--description .dnb-accordion__header__wrapper {
+.dnb-accordion__header--description .dnb-accordion__header-wrapper {
   margin-top: var(--accordion-header-margin-vertical--description);
   margin-bottom: var(--accordion-header-margin-vertical--description);
 }
 .dnb-accordion__header__container {
   margin: 0 1rem;
 }
-.dnb-accordion__header__icon {
+.dnb-accordion__header-icon {
   align-self: var(--accordion-header-icon-alignment);
   margin: var(--accordion-header-margin-vertical) var(--accordion-header-icon-gutter) var(--accordion-header-margin-vertical) var(--accordion-header-icon-margin);
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
   transition: transform 400ms var(--accordion-easing);
 }
-.dnb-accordion__header--description .dnb-accordion__header__icon {
+.dnb-accordion__header--description .dnb-accordion__header-icon {
   margin-top: var(--accordion-header-margin-vertical--description);
 }
 .dnb-accordion__header--icon-right {
   justify-content: space-between;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header__icon {
+.dnb-accordion__header--icon-right .dnb-accordion__header-icon {
   margin-right: var(--accordion-header-icon-margin);
   margin-left: var(--accordion-header-icon-gutter);
   order: 3;
@@ -174,15 +174,15 @@ p > .dnb-icon {
 .dnb-accordion__header--icon-right .dnb-accordion__header__container {
   order: 1;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header__wrapper {
+.dnb-accordion__header--icon-right .dnb-accordion__header-wrapper {
   order: 2;
   margin-right: 0;
   margin-left: var(--accordion-header-wrapper-margin--icon-right);
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header__wrapper + .dnb-accordion__header__container {
+.dnb-accordion__header--icon-right .dnb-accordion__header-wrapper + .dnb-accordion__header__container {
   margin-right: 0;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header__container + .dnb-accordion__header__wrapper {
+.dnb-accordion__header--icon-right .dnb-accordion__header__container + .dnb-accordion__header-wrapper {
   margin-left: 0;
 }
 .dnb-accordion__header--expanded {
@@ -206,7 +206,7 @@ p > .dnb-icon {
 .dnb-accordion__header__description + .dnb-accordion__header__title {
   margin-top: 0.25rem;
 }
-.dnb-accordion--expanded > .dnb-accordion__header .dnb-accordion__header__icon {
+.dnb-accordion--expanded > .dnb-accordion__header .dnb-accordion__header-icon {
   transform: rotate(-180deg);
 }
 .dnb-accordion__content {
@@ -240,7 +240,7 @@ p > .dnb-icon {
   }
 }
 @media screen and (min-width: 40.00625em) {
-  .dnb-accordion-group--single-container .dnb-accordion > .dnb-accordion__header .dnb-accordion__header__icon {
+  .dnb-accordion-group--single-container .dnb-accordion > .dnb-accordion__header .dnb-accordion__header-icon {
     transform: rotate(-90deg);
   }
 }
@@ -261,7 +261,7 @@ p > .dnb-icon {
     width: 60%;
   }
 }
-.dnb-accordion > .dnb-accordion__header--no-animation .dnb-accordion__header__icon, html[data-visual-test] .dnb-accordion .dnb-accordion__header .dnb-accordion__header__icon {
+.dnb-accordion > .dnb-accordion__header--no-animation .dnb-accordion__header-icon, html[data-visual-test] .dnb-accordion .dnb-accordion__header .dnb-accordion__header-icon {
   transition: none;
 }"
 `;

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -140,33 +140,33 @@ p > .dnb-icon {
 .dnb-accordion__header--prevent-click {
   pointer-events: none;
 }
-.dnb-accordion__header-wrapper {
+.dnb-accordion__header__wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
   margin: var(--accordion-header-margin-vertical) var(--accordion-header-wrapper-margin) var(--accordion-header-margin-vertical) 0;
 }
-.dnb-accordion__header--description .dnb-accordion__header-wrapper {
+.dnb-accordion__header--description .dnb-accordion__header__wrapper {
   margin-top: var(--accordion-header-margin-vertical--description);
   margin-bottom: var(--accordion-header-margin-vertical--description);
 }
 .dnb-accordion__header__container {
   margin: 0 1rem;
 }
-.dnb-accordion__header-icon {
+.dnb-accordion__header__icon {
   align-self: var(--accordion-header-icon-alignment);
   margin: var(--accordion-header-margin-vertical) var(--accordion-header-icon-gutter) var(--accordion-header-margin-vertical) var(--accordion-header-icon-margin);
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
   transition: transform 400ms var(--accordion-easing);
 }
-.dnb-accordion__header--description .dnb-accordion__header-icon {
+.dnb-accordion__header--description .dnb-accordion__header__icon {
   margin-top: var(--accordion-header-margin-vertical--description);
 }
 .dnb-accordion__header--icon-right {
   justify-content: space-between;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header-icon {
+.dnb-accordion__header--icon-right .dnb-accordion__header__icon {
   margin-right: var(--accordion-header-icon-margin);
   margin-left: var(--accordion-header-icon-gutter);
   order: 3;
@@ -174,15 +174,15 @@ p > .dnb-icon {
 .dnb-accordion__header--icon-right .dnb-accordion__header__container {
   order: 1;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header-wrapper {
+.dnb-accordion__header--icon-right .dnb-accordion__header__wrapper {
   order: 2;
   margin-right: 0;
   margin-left: var(--accordion-header-wrapper-margin--icon-right);
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header-wrapper + .dnb-accordion__header__container {
+.dnb-accordion__header--icon-right .dnb-accordion__header__wrapper + .dnb-accordion__header__container {
   margin-right: 0;
 }
-.dnb-accordion__header--icon-right .dnb-accordion__header__container + .dnb-accordion__header-wrapper {
+.dnb-accordion__header--icon-right .dnb-accordion__header__container + .dnb-accordion__header__wrapper {
   margin-left: 0;
 }
 .dnb-accordion__header--expanded {

--- a/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
@@ -140,7 +140,7 @@
     }
   }
 
-  &--expanded > &__header &__header__icon {
+  &--expanded > &__header &__header-icon {
     transform: rotate(-180deg);
   }
 
@@ -193,7 +193,7 @@
     //   }
     // }
   }
-  &-group--single-container & > &__header &__header__icon {
+  &-group--single-container & > &__header &__header-icon {
     @include allAbove(small) {
       transform: rotate(-90deg);
     }
@@ -231,8 +231,8 @@
   }
 
   // stylelint-disable-next-line
-  & > &__header--no-animation &__header__icon,
-  html[data-visual-test] & &__header &__header__icon {
+  & > &__header--no-animation &__header-icon,
+  html[data-visual-test] & &__header &__header-icon {
     transition: none;
   }
 }

--- a/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-sbanken.scss
@@ -59,7 +59,7 @@
       background-color: var(--sb-color-blue-light-3);
       color: var(--border-color);
 
-      .dnb-accordion__header__icon {
+      .dnb-accordion__header-icon {
         color: var(--border-color);
       }
     }

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -141,11 +141,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.js
@@ -1022,7 +1022,7 @@ class AutocompleteInstance extends React.PureComponent {
         (event?.currentTarget
           ? getClosestParent('dnb-drawer-list', event.currentTarget) ||
             getClosestParent(
-              'dnb-input__submit-button__button',
+              'dnb-input__submit-button-button',
               event.currentTarget
             )
           : false)
@@ -1434,7 +1434,7 @@ class AutocompleteInstance extends React.PureComponent {
 
     const strS = '\uFFFE'
     const strE = '\uFFFF'
-    const tagS = '<span class="dnb-drawer-list__option__item--highlight">'
+    const tagS = '<span class="dnb-drawer-list__option-item--highlight">'
     const tagE = '</span>'
 
     searchIndex = searchIndex.map((item, i) => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -302,14 +302,14 @@ describe('Autocomplete component', () => {
         document
           .querySelectorAll('.dnb-drawer-list__option')[1]
           .querySelector(
-            '.dnb-drawer-list__option-item.dnb-drawer-list__option__suffix'
+            '.dnb-drawer-list__option-item.dnb-drawer-list__option-suffix'
           ).textContent
       ).toBe('b suffix')
       expect(
         document
           .querySelectorAll('.dnb-drawer-list__option')[2]
           .querySelector(
-            '.dnb-drawer-list__option-item.dnb-drawer-list__option__suffix'
+            '.dnb-drawer-list__option-item.dnb-drawer-list__option-suffix'
           ).textContent
       ).toBe(mockData[2].suffix_value)
     })

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -68,7 +68,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">th</span>e <span class="dnb-drawer-list__option__item--highlight">g</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er</span></span></span></li>`
+      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span><span class="dnb-drawer-list__option-item--highlight">Th</span>e <span class="dnb-drawer-list__option-item--highlight">G</span>odfa<span class="dnb-drawer-list__option-item--highlight">th</span>er <span class="dnb-drawer-list__option-item--highlight">th</span>e <span class="dnb-drawer-list__option-item--highlight">g</span>odfa<span class="dnb-drawer-list__option-item--highlight">th</span>er <span class="dnb-drawer-list__option-item--highlight">Th</span>e <span class="dnb-drawer-list__option-item--highlight">G</span>odfa<span class="dnb-drawer-list__option-item--highlight">th</span>er</span></span></span></li>`
     )
   })
 
@@ -205,7 +205,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">BB</span> <span class="dnb-drawer-list__option__item--highlight">cc</span> ze<span class="dnb-drawer-list__option__item--highlight">thx</span></span></span></span></li>`
+      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span><span class="dnb-drawer-list__option-item--highlight">BB</span> <span class="dnb-drawer-list__option-item--highlight">cc</span> ze<span class="dnb-drawer-list__option-item--highlight">thx</span></span></span></span></li>`
     )
 
     // check "invalid"
@@ -230,7 +230,7 @@ describe('Autocomplete component', () => {
     )
 
     const styleElement = document.querySelector(
-      '.dnb-drawer-list__portal__style'
+      '.dnb-drawer-list__portal-style'
     )
 
     await waitFor(() => {
@@ -302,14 +302,14 @@ describe('Autocomplete component', () => {
         document
           .querySelectorAll('.dnb-drawer-list__option')[1]
           .querySelector(
-            '.dnb-drawer-list__option__item.dnb-drawer-list__option__suffix'
+            '.dnb-drawer-list__option-item.dnb-drawer-list__option__suffix'
           ).textContent
       ).toBe('b suffix')
       expect(
         document
           .querySelectorAll('.dnb-drawer-list__option')[2]
           .querySelector(
-            '.dnb-drawer-list__option__item.dnb-drawer-list__option__suffix'
+            '.dnb-drawer-list__option-item.dnb-drawer-list__option__suffix'
           ).textContent
       ).toBe(mockData[2].suffix_value)
     })
@@ -648,7 +648,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>item <span class="dnb-drawer-list__option-item--highlight">bb</span></span></span></span></li>'
     )
 
     // First result direction
@@ -658,7 +658,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="2" id="option-autocomplete-id-2"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span></li>'
+      '<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="2" id="option-autocomplete-id-2"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>item <span class="dnb-drawer-list__option-item--highlight">cc</span></span></span></span></li>'
     )
 
     // Second result direction
@@ -668,7 +668,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>item <span class="dnb-drawer-list__option-item--highlight">bb</span></span></span></span></li>'
     )
 
     // With three matches, we prioritize the second one to be on the first place
@@ -678,7 +678,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item closest-to-top closest-to-bottom dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="3" id="option-autocomplete-id-3"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span> second</span></span></span></li>'
+      '<li class="first-of-type first-item closest-to-top closest-to-bottom dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="3" id="option-autocomplete-id-3"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>item <span class="dnb-drawer-list__option-item--highlight">cc</span> second</span></span></span></li>'
     )
 
     // Do not find item, as there is defined a search_content
@@ -982,7 +982,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">2223</span> <span class="dnb-drawer-list__option__item--highlight">33</span> <span class="dnb-drawer-list__option__item--highlight">4442</span>5</span></span></span></li>`
+      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span><span class="dnb-drawer-list__option-item--highlight">2223</span> <span class="dnb-drawer-list__option-item--highlight">33</span> <span class="dnb-drawer-list__option-item--highlight">4442</span>5</span></span></span></li>`
     )
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
@@ -1241,21 +1241,21 @@ describe('Autocomplete component', () => {
           'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
         )[0].innerHTML
       ).toBe(
-        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>AA <span class="dnb-drawer-list__option__item--highlight">c</span></span></span></span>'
+        '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>AA <span class="dnb-drawer-list__option-item--highlight">c</span></span></span></span>'
       )
       expect(
         document.querySelectorAll(
           'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
         )[1].innerHTML
       ).toBe(
-        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>BB <span class="dnb-drawer-list__option__item--highlight">cc</span> zethx</span></span></span>'
+        '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span>BB <span class="dnb-drawer-list__option-item--highlight">cc</span> zethx</span></span></span>'
       )
       expect(
         document.querySelectorAll(
           'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
         )[2].innerHTML
       ).toBe(
-        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item item-nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item item-nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
+        '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item item-nr-1"><span><span class="dnb-drawer-list__option-item--highlight">CC</span></span></span><span class="dnb-drawer-list__option-item item-nr-2"><span><span class="dnb-drawer-list__option-item--highlight">cc</span></span></span></span>'
       )
     })
   })
@@ -1269,7 +1269,7 @@ describe('Autocomplete component', () => {
     expect(
       elem
         .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+          'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
         )
         .getAttribute('aria-expanded')
     ).toBe('true')
@@ -1294,7 +1294,7 @@ describe('Autocomplete component', () => {
     render(<Autocomplete {...props} data={mockData} />)
 
     const submitButton = document.querySelector(
-      'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+      'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
     )
     const elem = document.querySelector('.dnb-autocomplete')
 
@@ -1319,7 +1319,7 @@ describe('Autocomplete component', () => {
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
         .getAttribute('type')
     ).toBe('button')
   })
@@ -2614,7 +2614,7 @@ describe('Autocomplete component', () => {
 
     const result = document
       .querySelectorAll('li.dnb-drawer-list__option')[0]
-      .querySelector('.dnb-drawer-list__option__inner').outerHTML
+      .querySelector('.dnb-drawer-list__option-inner').outerHTML
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
       target: { value: 'aa' },
@@ -2623,7 +2623,7 @@ describe('Autocomplete component', () => {
     expect(
       document
         .querySelectorAll('li.dnb-drawer-list__option')[0]
-        .querySelector('.dnb-drawer-list__option__inner').outerHTML
+        .querySelector('.dnb-drawer-list__option-inner').outerHTML
     ).toBe(result)
   })
 
@@ -2833,7 +2833,7 @@ describe('Autocomplete component', () => {
     expect(options()).toHaveLength(1)
     expect(options()[0]).toHaveTextContent('first')
     expect(options()[0].innerHTML).toBe(
-      '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">first</span></span></span></span>'
+      '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span><span class="dnb-drawer-list__option-item--highlight">first</span></span></span></span>'
     )
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
@@ -2844,7 +2844,7 @@ describe('Autocomplete component', () => {
       expect(options()).toHaveLength(1)
       expect(options()[0]).toHaveTextContent('second')
       expect(options()[0].innerHTML).toBe(
-        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">second</span></span></span></span>'
+        '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item"><span><span class="dnb-drawer-list__option-item--highlight">second</span></span></span></span>'
       )
     })
 
@@ -2855,7 +2855,7 @@ describe('Autocomplete component', () => {
     expect(options()).toHaveLength(3)
     expect(options()[0]).toHaveTextContent('second')
     expect(options()[0].innerHTML).toBe(
-      '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item">second</span></span>'
+      '<span class="dnb-drawer-list__option-inner"><span class="dnb-drawer-list__option-item">second</span></span>'
     )
     expect(options()[1]).toHaveTextContent('bar')
     expect(options()[2]).toHaveTextContent('baz')
@@ -2947,13 +2947,13 @@ describe('Autocomplete component', () => {
     )
     expect(
       document.querySelector(
-        'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+        'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
       )
     ).toHaveAttribute('disabled')
     expect(
       document
         .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+          'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
         )
         .querySelector('.dnb-icon')
         .getAttribute('data-testid')
@@ -3067,13 +3067,13 @@ describe('Autocomplete component', () => {
     )
     expect(
       document.querySelector(
-        'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+        'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
       )
     ).toHaveAttribute('disabled')
     expect(
       document
         .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+          'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
         )
         .querySelector('.dnb-icon')
     ).toBeInTheDocument()
@@ -3081,7 +3081,7 @@ describe('Autocomplete component', () => {
     expect(
       document
         .querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+          'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
         )
         .querySelector('.dnb-icon')
         .getAttribute('data-testid')
@@ -3094,7 +3094,7 @@ describe('Autocomplete component', () => {
     // open first
     fireEvent.click(
       document.querySelector(
-        'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+        'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
       )
     )
 
@@ -3121,7 +3121,7 @@ describe('Autocomplete component', () => {
       'dnb-input__status--error'
     )
     expect(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
         .classList
     ).toContain('dnb-button__status--error')
   })
@@ -3147,7 +3147,7 @@ describe('Autocomplete component', () => {
       'dnb-input__status--error'
     )
     expect(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
         .classList
     ).toContain('dnb-button__status--error')
   })
@@ -3173,7 +3173,7 @@ describe('Autocomplete component', () => {
       'dnb-input__status--info'
     )
     expect(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
         .classList
     ).toContain('dnb-button__status--info')
   })
@@ -3506,7 +3506,7 @@ describe('Autocomplete component', () => {
 
       const submitElement = () =>
         document.querySelector(
-          'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+          'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
         )
 
       fireEvent.focus(inputElement())
@@ -4311,7 +4311,7 @@ const dispatchKeyDown = (keyCode) => {
 const toggle = () => {
   fireEvent.click(
     document.querySelector(
-      'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+      'button.dnb-input__submit-button-button:not(.dnb-input__clear-button)'
     )
   )
 }

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -154,11 +154,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -620,11 +620,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -1397,11 +1397,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -2515,7 +2515,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
 html[data-visual-test] .dnb-autocomplete .dnb-input__submit-button-button .dnb-icon {
   transition-duration: 1ms !important;
 }
-.dnb-autocomplete .dnb-input__inner__element {
+.dnb-autocomplete .dnb-input__inner-element {
   position: relative;
   z-index: 3;
   cursor: text;
@@ -2530,28 +2530,28 @@ html[data-visual-test] .dnb-autocomplete .dnb-input__submit-button-button .dnb-i
     padding-right: 2.5rem !important;
   }
 }
-.dnb-autocomplete .dnb-input__inner__element.dnb-p {
+.dnb-autocomplete .dnb-input__inner-element.dnb-p {
   white-space: nowrap;
   padding: 0 0.5rem;
 }
 @media screen and (max-width: 40em) {
-  .dnb-autocomplete .dnb-input__inner__element.dnb-p {
+  .dnb-autocomplete .dnb-input__inner-element.dnb-p {
     display: none;
   }
 }
-.dnb-autocomplete .dnb-input__inner__element.dnb-p, .dnb-spacing .dnb-autocomplete .dnb-input__inner__element.dnb-p {
+.dnb-autocomplete .dnb-input__inner-element.dnb-p, .dnb-spacing .dnb-autocomplete .dnb-input__inner-element.dnb-p {
   margin: 0;
 }
-.dnb-autocomplete .dnb-input--has-submit-element .dnb-input__inner__element {
+.dnb-autocomplete .dnb-input--has-submit-element .dnb-input__inner-element {
   margin-right: 2.5rem !important;
 }
-.dnb-autocomplete--icon-position-right .dnb-input__inner__element.dnb-p {
+.dnb-autocomplete--icon-position-right .dnb-input__inner-element.dnb-p {
   padding-right: 3rem;
 }
 .dnb-autocomplete--icon-position-right .dnb-input--icon-position-right .dnb-autocomplete--icon-position-right .dnb-input--icon-position-right.dnb-autocomplete--icon-position-right .dnb-input--has-icon .dnb-autocomplete--icon-position-right .dnb-input__input {
   padding-right: 1rem;
 }
-.dnb-autocomplete--disabled .dnb-input__inner__element {
+.dnb-autocomplete--disabled .dnb-input__inner-element {
   cursor: not-allowed;
 }
 .dnb-autocomplete__text {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -941,7 +941,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button-button {
+.dnb-input__submit-button__button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {
@@ -2688,13 +2688,13 @@ exports[`Autocomplete scss have to match default theme snapshot 1`] = `
   border-color: transparent;
 }
 
-.dnb-autocomplete__root .dnb-drawer-list__option-item:nth-of-type(1) {
+.dnb-autocomplete__root .dnb-drawer-list__option__item:nth-of-type(1) {
   font-weight: var(--font-weight-basis);
 }
 .dnb-autocomplete__root .dnb-drawer-list__option:not([disabled]) .dnb-drawer-list__option-item:nth-of-type(n + 2) {
   color: var(--color-black-55);
 }
-.dnb-autocomplete__root .dnb-drawer-list__option-item--highlight {
+.dnb-autocomplete__root .dnb-drawer-list__option__item--highlight {
   font-weight: var(--font-weight-bold);
 }
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -941,7 +941,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button__button {
+.dnb-input__submit-button-button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {
@@ -2476,16 +2476,16 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   justify-content: center;
   pointer-events: none;
 }
-.dnb-autocomplete__show-all .dnb-drawer-list__option__inner {
+.dnb-autocomplete__show-all .dnb-drawer-list__option-inner {
   display: flex;
   justify-content: center;
   align-items: center;
 }
-.dnb-autocomplete__show-all .dnb-drawer-list__option__inner .dnb-drawer-list__option__item {
+.dnb-autocomplete__show-all .dnb-drawer-list__option-inner .dnb-drawer-list__option-item {
   display: flex;
   flex-direction: column;
 }
-.dnb-autocomplete__show-all .dnb-drawer-list__option__inner .dnb-icon {
+.dnb-autocomplete__show-all .dnb-drawer-list__option-inner .dnb-icon {
   align-self: center;
 }
 .dnb-autocomplete__input {
@@ -2499,20 +2499,20 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
 .dnb-autocomplete__input .dnb-input__input {
   width: 100%;
 }
-.dnb-autocomplete--opened .dnb-input__submit-button__button .dnb-icon {
+.dnb-autocomplete--opened .dnb-input__submit-button-button .dnb-icon {
   transform: rotate(180deg);
   transform-origin: 50% 50%;
 }
-.dnb-autocomplete .dnb-input__submit-button__button[disabled]:not(.dnb-button--has-text) {
+.dnb-autocomplete .dnb-input__submit-button-button[disabled]:not(.dnb-button--has-text) {
   --border-color: var(--color-black-55);
   --border-width: 0.0625rem;
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-autocomplete .dnb-input__submit-button__button .dnb-icon {
+.dnb-autocomplete .dnb-input__submit-button-button .dnb-icon {
   transition: transform 400ms ease-out;
 }
-html[data-visual-test] .dnb-autocomplete .dnb-input__submit-button__button .dnb-icon {
+html[data-visual-test] .dnb-autocomplete .dnb-input__submit-button-button .dnb-icon {
   transition-duration: 1ms !important;
 }
 .dnb-autocomplete .dnb-input__inner__element {
@@ -2647,7 +2647,7 @@ label + .dnb-autocomplete[class*=__form-status] .dnb-autocomplete__shell {
     display: none;
   }
 }
-.dnb-autocomplete__list .dnb-drawer-list__option__item > span {
+.dnb-autocomplete__list .dnb-drawer-list__option-item > span {
   padding-right: 0.125em;
 }"
 `;
@@ -2660,7 +2660,7 @@ exports[`Autocomplete scss have to match default theme snapshot 1`] = `
 /*
  * Utilities
  */
-.dnb-autocomplete__show-all .dnb-drawer-list__option__inner {
+.dnb-autocomplete__show-all .dnb-drawer-list__option-inner {
   color: var(--color-sea-green);
 }
 .dnb-autocomplete--opened .dnb-input .dnb-input__shell .dnb-input__shell, .dnb-autocomplete:not(.dnb-autocomplete__status--error) .dnb-form-label:hover ~ .dnb-autocomplete__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__shell {
@@ -2669,7 +2669,7 @@ exports[`Autocomplete scss have to match default theme snapshot 1`] = `
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-autocomplete--opened .dnb-input .dnb-input__shell .dnb-input__submit-button__button, .dnb-autocomplete:not(.dnb-autocomplete__status--error) .dnb-form-label:hover ~ .dnb-autocomplete__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button__button {
+.dnb-autocomplete--opened .dnb-input .dnb-input__shell .dnb-input__submit-button-button, .dnb-autocomplete:not(.dnb-autocomplete__status--error) .dnb-form-label:hover ~ .dnb-autocomplete__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button-button {
   border-radius: 0;
   color: var(--color-white);
   background-color: var(--color-sea-green);
@@ -2688,17 +2688,17 @@ exports[`Autocomplete scss have to match default theme snapshot 1`] = `
   border-color: transparent;
 }
 
-.dnb-autocomplete__root .dnb-drawer-list__option__item:nth-of-type(1) {
+.dnb-autocomplete__root .dnb-drawer-list__option-item:nth-of-type(1) {
   font-weight: var(--font-weight-basis);
 }
-.dnb-autocomplete__root .dnb-drawer-list__option:not([disabled]) .dnb-drawer-list__option__item:nth-of-type(n + 2) {
+.dnb-autocomplete__root .dnb-drawer-list__option:not([disabled]) .dnb-drawer-list__option-item:nth-of-type(n + 2) {
   color: var(--color-black-55);
 }
-.dnb-autocomplete__root .dnb-drawer-list__option__item--highlight {
+.dnb-autocomplete__root .dnb-drawer-list__option-item--highlight {
   font-weight: var(--font-weight-bold);
 }
 
-.dnb-autocomplete__root .dnb-drawer-list__option--selected:not([disabled]) .dnb-drawer-list__option__item:nth-of-type(n + 2) {
+.dnb-autocomplete__root .dnb-drawer-list__option--selected:not([disabled]) .dnb-drawer-list__option-item:nth-of-type(n + 2) {
   color: var(--color-white);
 }
 

--- a/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
@@ -119,7 +119,7 @@
 
   // Support for "suffix_value"
   .dnb-input {
-    &__inner__element {
+    &__inner-element {
       position: relative;
       z-index: 3;
 
@@ -168,7 +168,7 @@
   }
   &--disabled .dnb-input {
     // stylelint-disable-next-line
-    &__inner__element {
+    &__inner-element {
       cursor: not-allowed;
     }
   }

--- a/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
@@ -71,12 +71,12 @@
   }
 
   &__show-all {
-    .dnb-drawer-list__option__inner {
+    .dnb-drawer-list__option-inner {
       display: flex;
       justify-content: center;
       align-items: center;
 
-      .dnb-drawer-list__option__item {
+      .dnb-drawer-list__option-item {
         display: flex;
         flex-direction: column;
       }
@@ -102,14 +102,14 @@
     }
   }
 
-  &--opened .dnb-input__submit-button__button .dnb-icon {
+  &--opened .dnb-input__submit-button-button .dnb-icon {
     transform: rotate(180deg);
     transform-origin: 50% 50%;
   }
-  .dnb-input__submit-button__button[disabled]:not(.dnb-button--has-text) {
+  .dnb-input__submit-button-button[disabled]:not(.dnb-button--has-text) {
     @include fakeBorder(var(--color-black-55), 0.0625rem, inset);
   }
-  .dnb-input__submit-button__button .dnb-icon {
+  .dnb-input__submit-button-button .dnb-icon {
     transition: transform 400ms ease-out;
 
     html[data-visual-test] & {
@@ -283,7 +283,7 @@
   }
 
   // Search highlight wrapper
-  &__list .dnb-drawer-list__option__item > span {
+  &__list .dnb-drawer-list__option-item > span {
     padding-right: 0.125em; // add one space because of the word split
   }
 }

--- a/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
@@ -138,7 +138,7 @@
       }
     }
 
-    &__inner__element.dnb-p {
+    &__inner-element.dnb-p {
       white-space: nowrap;
       padding: 0 0.5rem;
 
@@ -147,19 +147,19 @@
       }
     }
 
-    &__inner__element.dnb-p,
-    .dnb-spacing &__inner__element.dnb-p {
+    &__inner-element.dnb-p,
+    .dnb-spacing &__inner-element.dnb-p {
       margin: 0;
     }
 
-    &--has-submit-element .dnb-input__inner__element {
+    &--has-submit-element .dnb-input__inner-element {
       // same width of submit button
       margin-right: 2.5rem !important; // use important so we avoid to have all sizes in addition
     }
   }
   &--icon-position-right .dnb-input {
     // stylelint-disable-next-line
-    &__inner__element.dnb-p {
+    &__inner-element.dnb-p {
       padding-right: 3rem;
     }
     &--icon-position-right &--icon-position-right#{&}--has-icon &__input {

--- a/packages/dnb-eufemia/src/components/autocomplete/style/themes/dnb-autocomplete-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/themes/dnb-autocomplete-theme-sbanken.scss
@@ -7,7 +7,7 @@
 
 .dnb-autocomplete {
   &__show-all {
-    .dnb-drawer-list__option__inner {
+    .dnb-drawer-list__option-inner {
       color: var(--sb-color-violet);
     }
   }
@@ -52,7 +52,7 @@
   }
 
   &--selected:not(.dnb-drawer-list__option--focus)
-    .dnb-drawer-list__option__item:nth-of-type(n + 2) {
+    .dnb-drawer-list__option-item:nth-of-type(n + 2) {
     &,
     & .dnb-anchor {
       color: var(--sb-color-white);

--- a/packages/dnb-eufemia/src/components/autocomplete/style/themes/dnb-autocomplete-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/themes/dnb-autocomplete-theme-ui.scss
@@ -7,7 +7,7 @@
 
 .dnb-autocomplete {
   &__show-all {
-    .dnb-drawer-list__option__inner {
+    .dnb-drawer-list__option-inner {
       color: var(--color-sea-green);
     }
   }
@@ -21,7 +21,7 @@
       @include fakeBorder(var(--color-sea-green), 0.125rem);
     }
 
-    .dnb-input__submit-button__button {
+    .dnb-input__submit-button-button {
       border-radius: 0;
       color: var(--color-white);
       background-color: var(--color-sea-green);
@@ -53,7 +53,7 @@
     font-weight: var(--font-weight-basis);
   }
 
-  &:not([disabled]) .dnb-drawer-list__option__item:nth-of-type(n + 2) {
+  &:not([disabled]) .dnb-drawer-list__option-item:nth-of-type(n + 2) {
     color: var(--color-black-55);
   }
 
@@ -64,7 +64,7 @@
 
 .dnb-autocomplete__root
   .dnb-drawer-list__option--selected:not([disabled])
-  .dnb-drawer-list__option__item:nth-of-type(n + 2) {
+  .dnb-drawer-list__option-item:nth-of-type(n + 2) {
   color: var(--color-white);
 }
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbItem.tsx
@@ -166,7 +166,7 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
             {variant !== 'home' && (
               <IconPrimary
                 icon={iconToUse}
-                className="dnb-breadcrumb__item__span__icon"
+                className="dnb-breadcrumb__item-span-icon"
               />
             )}
             <Anchor
@@ -182,13 +182,13 @@ const BreadcrumbItem = (localProps: BreadcrumbItemProps) => {
         )
       ) : (
         <span
-          className="dnb-breadcrumb__item__span"
+          className="dnb-breadcrumb__item-span"
           // TODO: Consider deprecating passing down props to span in v11
           {...filterProps(props, (key) => !key.includes('-'))}
         >
           <IconPrimary
             icon={iconToUse}
-            className="dnb-breadcrumb__item__span__icon"
+            className="dnb-breadcrumb__item-span-icon"
           />
           <P space="0">{currentText}</P>
         </span>

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -69,7 +69,7 @@ describe('Breadcrumb', () => {
     expect(screen.queryByTestId(dataTestId)).toHaveClass('dnb-anchor')
   })
 
-  // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+  // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item-span
   it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
     const dataTestId = 'my-test-id'
     render(
@@ -86,10 +86,10 @@ describe('Breadcrumb', () => {
 
     expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
     expect(screen.queryByTestId(dataTestId)).toHaveClass(
-      'dnb-breadcrumb__item__span'
+      'dnb-breadcrumb__item-span'
     )
     expect(
-      document.querySelector('.dnb-breadcrumb__item__span')
+      document.querySelector('.dnb-breadcrumb__item-span')
     ).toHaveAttribute('aria-label', 'Label')
   })
 
@@ -479,7 +479,7 @@ describe('Breadcrumb', () => {
       expect(screen.queryByTestId(dataTestId)).toHaveClass('dnb-anchor')
     })
 
-    // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+    // TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item-span
     it('forwards rest props like data-testid, etc, to the breadcrumb item span when not interactive', () => {
       const dataTestId = 'my-test-id'
       render(
@@ -492,10 +492,10 @@ describe('Breadcrumb', () => {
 
       expect(screen.queryByTestId(dataTestId)).toBeInTheDocument()
       expect(screen.queryByTestId(dataTestId)).toHaveClass(
-        'dnb-breadcrumb__item__span'
+        'dnb-breadcrumb__item-span'
       )
       expect(
-        document.querySelector('.dnb-breadcrumb__item__span')
+        document.querySelector('.dnb-breadcrumb__item-span')
       ).not.toHaveAttribute('role')
     })
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -686,12 +686,12 @@ button.dnb-button::-moz-focus-inner {
   align-items: center;
   padding: 0.5rem 0;
 }
-.dnb-breadcrumb__item__span {
+.dnb-breadcrumb__item-span {
   display: flex;
   align-items: center;
   line-height: var(--line-height-basis);
 }
-.dnb-breadcrumb__item__span__icon {
+.dnb-breadcrumb__item-span-icon {
   margin-right: 0.5rem;
 }
 .dnb-breadcrumb__item .dnb-anchor {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -686,12 +686,12 @@ button.dnb-button::-moz-focus-inner {
   align-items: center;
   padding: 0.5rem 0;
 }
-.dnb-breadcrumb__item-span {
+.dnb-breadcrumb__item__span {
   display: flex;
   align-items: center;
   line-height: var(--line-height-basis);
 }
-.dnb-breadcrumb__item-span-icon {
+.dnb-breadcrumb__item__span__icon {
   margin-right: 0.5rem;
 }
 .dnb-breadcrumb__item .dnb-anchor {

--- a/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -176,7 +176,7 @@ export const SupportsChildrenAsNull = () => {
   )
 }
 
-// TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item__span
+// TODO – can be removed in v11 when we deprecate passing down props to dnb-breadcrumb__item-span
 export const BreadcrumbItemWithButtonPropsButNotInteractive = () => {
   const props = {
     ...Button.defaultProps,

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -140,11 +140,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -540,7 +540,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                   key={i}
                   role="columnheader"
                   scope="col"
-                  className="dnb-date-picker__labels__day"
+                  className="dnb-date-picker__labels-day"
                   aria-label={formatDate(day, {
                     locale,
                     options: { weekday: 'long' },

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -506,7 +506,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         <div className="dnb-date-picker__header dnb-date-picker__header--only-month-label">
           <label
             id={`${id}--title`}
-            className="dnb-date-picker__header__title dnb-no-focus"
+            className="dnb-date-picker__header-title dnb-no-focus"
             title={selectedMonth.replace(
               /%s/,
               formatDate(month, {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
@@ -112,11 +112,11 @@ export function DatePickerCalendarNav({
   return (
     <div
       className={classnames(
-        'dnb-date-picker__header__row',
-        type === 'year' && 'dnb-date-picker__header__row--year'
+        'dnb-date-picker__header-row',
+        type === 'year' && 'dnb-date-picker__header-row--year'
       )}
     >
-      <div className="dnb-date-picker__header__nav">
+      <div className="dnb-date-picker__header-nav">
         <CalendarNavButton
           type="prev"
           nr={nr}
@@ -130,7 +130,7 @@ export function DatePickerCalendarNav({
       </div>
       <label
         id={`${id}--title`}
-        className="dnb-date-picker__header__title dnb-no-focus"
+        className="dnb-date-picker__header-title dnb-no-focus"
         title={title.replace(
           /%s/,
           formatDate(date, { locale, options: titleFormat })
@@ -139,7 +139,7 @@ export function DatePickerCalendarNav({
       >
         {formatDate(date, { locale, options: titleFormat })}
       </label>
-      <div className="dnb-date-picker__header__nav">
+      <div className="dnb-date-picker__header-nav">
         <CalendarNavButton
           type="next"
           dateType={buttonDateType}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -927,7 +927,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       return (
         <span
           id={`${id}-input`}
-          className="dnb-date-picker__input__wrapper"
+          className="dnb-date-picker__input-wrapper"
         >
           {startDateList}
           {isRange && (

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2699,7 +2699,7 @@ describe('DatePicker component', () => {
     )
 
     const dayLabels = Array.from(
-      document.querySelectorAll('.dnb-date-picker__labels__day')
+      document.querySelectorAll('.dnb-date-picker__labels-day')
     )
 
     expect(dayLabels.at(0)).toHaveAttribute('aria-label', 'måndag')
@@ -2740,7 +2740,7 @@ describe('DatePicker component', () => {
     )
 
     const dayLabels = Array.from(
-      document.querySelectorAll('.dnb-date-picker__labels__day')
+      document.querySelectorAll('.dnb-date-picker__labels-day')
     )
 
     expect(dayLabels.at(0)).toHaveAttribute('aria-label', 'mandag')

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -905,7 +905,7 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      document.querySelector('label.dnb-date-picker__header__title')
+      document.querySelector('label.dnb-date-picker__header-title')
         .textContent
     ).toBe('mai 2020')
     expect(getDatePickerRoot().classList).toContain(
@@ -921,7 +921,7 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      document.querySelector('label.dnb-date-picker__header__title')
+      document.querySelector('label.dnb-date-picker__header-title')
         .textContent
     ).toBe('april 2020')
     expect(getDatePickerRoot().classList).not.toContain(
@@ -977,7 +977,7 @@ describe('DatePicker component', () => {
     await userEvent.click(day)
 
     const [leftPickerTitle, rightPickerTitle] = Array.from(
-      document.querySelectorAll('label.dnb-date-picker__header__title')
+      document.querySelectorAll('label.dnb-date-picker__header-title')
     )
 
     expect(leftPickerTitle).toHaveTextContent('mai 2024')
@@ -1080,12 +1080,12 @@ describe('DatePicker component', () => {
     const rightPrev = rightPicker.querySelector('.dnb-date-picker__prev')
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     // TODO: Fix this after conversion merge
     // The right picker should be november here, but this is a bug that exists in master/original version of DatePicker
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
 
     await userEvent.click(leftPrev)
@@ -1093,47 +1093,47 @@ describe('DatePicker component', () => {
     await userEvent.click(leftPrev)
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juli 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
 
     await userEvent.hover(screen.getByLabelText('torsdag 11. juli 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juli 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
 
     await userEvent.click(rightPrev)
     await userEvent.click(rightPrev)
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juli 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('august 2024')
 
     await userEvent.hover(screen.getByLabelText('tirsdag 20. august 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juli 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('august 2024')
 
     await userEvent.click(screen.getByLabelText('tirsdag 20. august 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juli 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('august 2024')
   })
 
@@ -1152,19 +1152,19 @@ describe('DatePicker component', () => {
     const rightNext = rightPicker.querySelector('.dnb-date-picker__next')
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(screen.getByLabelText('mandag 14. oktober 2024'))
     await userEvent.click(screen.getByLabelText('mandag 14. oktober 2024'))
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(
@@ -1174,10 +1174,10 @@ describe('DatePicker component', () => {
       screen.getByLabelText('lørdag 16. november 2024')
     )
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(rightNext)
@@ -1187,10 +1187,10 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('onsdag 1. januar 2025'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('januar 2025')
 
     await userEvent.click(leftPrev)
@@ -1216,19 +1216,19 @@ describe('DatePicker component', () => {
     const rightNext = rightPicker.querySelector('.dnb-date-picker__next')
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(screen.getByLabelText('mandag 14. oktober 2024'))
     await userEvent.click(screen.getByLabelText('onsdag 16. oktober 2024'))
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(
@@ -1239,10 +1239,10 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(rightNext)
@@ -1252,10 +1252,10 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('søndag 13. oktober 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('januar 2025')
 
     await userEvent.click(leftPrev)
@@ -1270,10 +1270,10 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('tirsdag 11. juni 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('juni 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('januar 2025')
 
     await userEvent.click(leftPrev)
@@ -1281,10 +1281,10 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('fredag 17. mai 2024'))
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('mai 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('januar 2025')
   })
 
@@ -1294,7 +1294,7 @@ describe('DatePicker component', () => {
     await userEvent.click(getDatePickerTriggerButton())
 
     const pickerTitle = document.querySelector(
-      '.dnb-date-picker__calendar .dnb-date-picker__header__title'
+      '.dnb-date-picker__calendar .dnb-date-picker__header-title'
     )
 
     const firstDayButton = document.querySelector(
@@ -1322,7 +1322,7 @@ describe('DatePicker component', () => {
 
     const [leftPickerTitle, rightPickerTitle] = Array.from(
       document.querySelectorAll(
-        '.dnb-date-picker__calendar .dnb-date-picker__header__title'
+        '.dnb-date-picker__calendar .dnb-date-picker__header-title'
       )
     )
 
@@ -2335,7 +2335,7 @@ describe('DatePicker component', () => {
     })
 
     expect(
-      document.querySelectorAll('.dnb-date-picker__header__title')[0]
+      document.querySelectorAll('.dnb-date-picker__header-title')[0]
         .textContent
     ).toBe('januar 2019')
 
@@ -2359,7 +2359,7 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      document.querySelectorAll('.dnb-date-picker__header__title')[1]
+      document.querySelectorAll('.dnb-date-picker__header-title')[1]
         .textContent
     ).toBe('mars 2019')
   })
@@ -2519,7 +2519,7 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
 
     const [startMonth, endMonth] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__header__title')
+      document.querySelectorAll('.dnb-date-picker__header-title')
     )
 
     expect(startMonth).toHaveTextContent('januar 2024')
@@ -2536,7 +2536,7 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
 
     const startMonth = document.querySelector(
-      '.dnb-date-picker__header__title'
+      '.dnb-date-picker__header-title'
     )
     const selectedMonth = document.querySelector('[aria-current="date"]')
 
@@ -2559,7 +2559,7 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
 
     const [startMonth, endMonth] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__header__title')
+      document.querySelectorAll('.dnb-date-picker__header-title')
     )
 
     const [selectedStartMonth, selectedEndMonth] = Array.from(
@@ -2604,7 +2604,7 @@ describe('DatePicker component', () => {
 
     function getDateElements() {
       const title: HTMLLabelElement = document.querySelector(
-        '.dnb-date-picker__header__title'
+        '.dnb-date-picker__header-title'
       )
       const button: HTMLButtonElement = document.querySelector(
         'button[aria-current="date"]'
@@ -3417,10 +3417,10 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(
@@ -3435,10 +3435,10 @@ describe('DatePicker component', () => {
     expect(endYear.value).toBe('åååå')
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
 
     await userEvent.click(screen.getByLabelText('onsdag 2. oktober 2024'))
@@ -3451,10 +3451,10 @@ describe('DatePicker component', () => {
     expect(endYear.value).toBe('2024')
 
     expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
+      leftPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('oktober 2024')
     expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
+      rightPicker.querySelector('.dnb-date-picker__header-title')
     ).toHaveTextContent('november 2024')
   })
 
@@ -3618,7 +3618,7 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
 
     const [monthTitle, yearTitle] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__header__title')
+      document.querySelectorAll('.dnb-date-picker__header-title')
     )
 
     const [prevMonthButton, prevYearButton] = Array.from(
@@ -3722,7 +3722,7 @@ describe('DatePicker component', () => {
       rightMonthTitle,
       rightYearTitle,
     ] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__header__title')
+      document.querySelectorAll('.dnb-date-picker__header-title')
     )
 
     const [
@@ -3932,7 +3932,7 @@ describe('DatePicker component', () => {
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
 
     const [, yearTitle] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__header__title')
+      document.querySelectorAll('.dnb-date-picker__header-title')
     )
 
     const [prevMonthButton, prevYearButton] = Array.from(

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -50,7 +50,7 @@ const getDatePickerRoot = () =>
 
 const getDatePickerTriggerButton = () =>
   getDatePickerRoot().querySelector(
-    'button.dnb-input__submit-button__button, button.dnb-button'
+    'button.dnb-input__submit-button-button, button.dnb-button'
   ) as HTMLButtonElement
 
 const getAnnouncementElement = () =>
@@ -71,7 +71,7 @@ describe('DatePicker component', () => {
       'disabled'
     )
     expect(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     ).toHaveAttribute('disabled')
   })
 
@@ -79,12 +79,12 @@ describe('DatePicker component', () => {
     render(<DatePicker {...defaultProps} />)
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
 
         .getAttribute('aria-expanded')
     ).toBe('true')
@@ -102,12 +102,12 @@ describe('DatePicker component', () => {
     render(<DatePicker {...defaultProps} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
         .getAttribute('aria-expanded')
     ).toBe('true')
 
@@ -119,7 +119,7 @@ describe('DatePicker component', () => {
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
         .getAttribute('aria-expanded')
     ).toBe('false')
 
@@ -252,7 +252,7 @@ describe('DatePicker component', () => {
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
 
         .getAttribute('aria-expanded')
     ).toBe('true')
@@ -267,7 +267,7 @@ describe('DatePicker component', () => {
 
     expect(
       document
-        .querySelector('button.dnb-input__submit-button__button')
+        .querySelector('button.dnb-input__submit-button-button')
         .getAttribute('aria-expanded')
     ).toBe('false')
 
@@ -283,7 +283,7 @@ describe('DatePicker component', () => {
     )
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(getDatePickerRoot().getAttribute('class')).toContain(
@@ -363,7 +363,7 @@ describe('DatePicker component', () => {
     )
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(getDatePickerRoot()).toHaveClass('dnb-date-picker--opened')
@@ -821,7 +821,7 @@ describe('DatePicker component', () => {
     )
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(getDatePickerRoot().getAttribute('class')).toContain(
@@ -863,7 +863,7 @@ describe('DatePicker component', () => {
     )
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
@@ -1055,7 +1055,7 @@ describe('DatePicker component', () => {
     render(<DatePicker {...defaultProps} />)
 
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
     expect(
       document.querySelector('.dnb-date-picker__views')
@@ -1447,7 +1447,7 @@ describe('DatePicker component', () => {
   it('should reset second input fields to blank during new date selection', () => {
     render(<DatePicker {...defaultProps} />)
     fireEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     fireEvent.click(
@@ -2434,7 +2434,7 @@ describe('DatePicker component', () => {
 
     const element = getDatePickerRoot()
     const buttonElement = document.querySelector(
-      'button.dnb-input__submit-button__button'
+      'button.dnb-input__submit-button-button'
     )
 
     fireEvent.click(buttonElement)
@@ -2461,7 +2461,7 @@ describe('DatePicker component', () => {
 
     const element = getDatePickerRoot()
     const buttonElement = document.querySelector(
-      'button.dnb-input__submit-button__button'
+      'button.dnb-input__submit-button-button'
     )
 
     expect(document.activeElement).toBe(document.body)
@@ -2614,7 +2614,7 @@ describe('DatePicker component', () => {
     }
 
     const inputButton = document.querySelector(
-      '.dnb-input__submit-button__button'
+      '.dnb-input__submit-button-button'
     )
 
     await userEvent.click(inputButton)
@@ -4720,7 +4720,7 @@ describe('DatePicker ARIA', () => {
 
       // Should not render input or button
       expect(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       ).not.toBeInTheDocument()
       expect(document.querySelector('input')).not.toBeInTheDocument()
 
@@ -4854,7 +4854,7 @@ describe('DatePicker ARIA', () => {
 
       // Open popover by clicking the input button first
       const inputButton = document.querySelector(
-        'button.dnb-input__submit-button__button, button.dnb-button'
+        'button.dnb-input__submit-button-button, button.dnb-button'
       ) as HTMLButtonElement
       expect(inputButton).toBeInTheDocument()
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -116,11 +116,11 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--inactive .dnb-button[di
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-date-picker--opened .dnb-input .dnb-input__submit-button__button.dnb-button--secondary, .dnb-date-picker:not(.dnb-date-picker__status--error) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button__button.dnb-button--secondary {
+.dnb-date-picker--opened .dnb-input .dnb-input__submit-button-button.dnb-button--secondary, .dnb-date-picker:not(.dnb-date-picker__status--error) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button-button.dnb-button--secondary {
   color: var(--color-white);
   background-color: var(--color-sea-green);
 }
-.dnb-date-picker--opened .dnb-input .dnb-input__submit-button__button.dnb-button--secondary::after, .dnb-date-picker:not(.dnb-date-picker__status--error) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button__button.dnb-button--secondary::after {
+.dnb-date-picker--opened .dnb-input .dnb-input__submit-button-button.dnb-button--secondary::after, .dnb-date-picker:not(.dnb-date-picker__status--error) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__submit-button-button.dnb-button--secondary::after {
   background-color: inherit;
 }
 .dnb-date-picker__status--error:not(.dnb-date-picker--opened) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__shell {
@@ -1072,7 +1072,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button__button {
+.dnb-input__submit-button-button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -37,27 +37,27 @@ exports[`DatePicker scss should match default theme snapshot 1`] = `
   justify-content: center;
   margin-bottom: 1rem;
 }
-.dnb-date-picker__header-row {
+.dnb-date-picker__header__row {
   min-width: 60%;
   display: flex;
   flex: 1 1 auto;
   align-items: center;
   justify-content: space-between;
 }
-.dnb-date-picker__header-row--year {
+.dnb-date-picker__header__row--year {
   min-width: calc(40% - var(--gap));
 }
-.dnb-date-picker__header-nav .dnb-button {
+.dnb-date-picker__header__nav .dnb-button {
   box-shadow: none;
 }
-.dnb-date-picker__header-title {
+.dnb-date-picker__header__title {
   text-transform: capitalize;
   text-align: center;
   font-size: var(--font-size-basis);
   font-weight: var(--font-weight-medium);
   color: var(--color-black-80);
 }
-.dnb-date-picker__labels-day {
+.dnb-date-picker__labels__day {
   text-transform: capitalize;
   font-weight: var(--font-weight-medium);
   color: var(--color-black-80);
@@ -1072,7 +1072,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button-button {
+.dnb-input__submit-button__button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {
@@ -3835,7 +3835,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   justify-content: space-between;
   padding: 1rem;
 }
-.dnb-date-picker__labels-day {
+.dnb-date-picker__labels__day {
   padding-top: 1.5rem;
   padding-bottom: 0.5rem;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -57,12 +57,12 @@ exports[`DatePicker scss should match default theme snapshot 1`] = `
   font-weight: var(--font-weight-medium);
   color: var(--color-black-80);
 }
-.dnb-date-picker__labels__day {
+.dnb-date-picker__labels-day {
   text-transform: capitalize;
   font-weight: var(--font-weight-medium);
   color: var(--color-black-80);
 }
-.dnb-date-picker__day, .dnb-date-picker__labels__day {
+.dnb-date-picker__day, .dnb-date-picker__labels-day {
   text-align: center;
 }
 .dnb-date-picker__day--today .dnb-button {
@@ -3624,7 +3624,7 @@ button .dnb-form-status__text {
   display: inline-flex;
   flex-direction: column;
 }
-.dnb-date-picker__input__wrapper {
+.dnb-date-picker__input-wrapper {
   display: inline-flex;
   white-space: nowrap;
   height: inherit;
@@ -3774,7 +3774,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker:not(.dnb-date-picker--show-input) .dnb-input__status--error .dnb-input__shell {
   box-shadow: none;
 }
-.dnb-input__submit-button button:focus ~ .dnb-date-picker__input__wrapper {
+.dnb-input__submit-button button:focus ~ .dnb-date-picker__input-wrapper {
   display: block;
 }
 .dnb-date-picker:not(.dnb-date-picker--show-input) .dnb-input__submit-element, .dnb-input__submit-element > .dnb-date-picker .dnb-input__submit-element {
@@ -3835,7 +3835,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   justify-content: space-between;
   padding: 1rem;
 }
-.dnb-date-picker__labels__day {
+.dnb-date-picker__labels-day {
   padding-top: 1.5rem;
   padding-bottom: 0.5rem;
 }
@@ -3848,7 +3848,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   padding: 0;
   list-style: none;
 }
-.dnb-date-picker__day, .dnb-date-picker__labels__day {
+.dnb-date-picker__day, .dnb-date-picker__labels-day {
   display: flex;
   flex-basis: 14.2857142857%;
   justify-content: center;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -37,20 +37,20 @@ exports[`DatePicker scss should match default theme snapshot 1`] = `
   justify-content: center;
   margin-bottom: 1rem;
 }
-.dnb-date-picker__header__row {
+.dnb-date-picker__header-row {
   min-width: 60%;
   display: flex;
   flex: 1 1 auto;
   align-items: center;
   justify-content: space-between;
 }
-.dnb-date-picker__header__row--year {
+.dnb-date-picker__header-row--year {
   min-width: calc(40% - var(--gap));
 }
-.dnb-date-picker__header__nav .dnb-button {
+.dnb-date-picker__header-nav .dnb-button {
   box-shadow: none;
 }
-.dnb-date-picker__header__title {
+.dnb-date-picker__header-title {
   text-transform: capitalize;
   text-align: center;
   font-size: var(--font-size-basis);
@@ -285,11 +285,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -751,11 +751,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -1431,11 +1431,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -1951,11 +1951,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -37,7 +37,7 @@
     flex-direction: column;
   }
 
-  &__input__wrapper {
+  &__input-wrapper {
     display: inline-flex;
     white-space: nowrap;
     height: inherit;
@@ -202,7 +202,7 @@
   &:not(#{&}--show-input) .dnb-input__status--error .dnb-input__shell {
     box-shadow: none;
   }
-  .dnb-input__submit-button button:focus ~ &__input__wrapper {
+  .dnb-input__submit-button button:focus ~ &__input-wrapper {
     display: block;
   }
   &:not(#{&}--show-input) .dnb-input__submit-element,
@@ -300,7 +300,7 @@
   }
 
   &__day,
-  &__labels__day {
+  &__labels-day {
     display: flex;
     flex-basis: calc(1 / 7 * 100%);
     justify-content: center;

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -83,7 +83,7 @@
   }
 
   &__day,
-  &__labels__day {
+  &__labels-day {
     text-align: center;
   }
 

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -180,7 +180,7 @@
       @include fakeBorder(var(--color-sea-green), 0.125rem);
     }
 
-    .dnb-input__submit-button__button.dnb-button--secondary {
+    .dnb-input__submit-button-button.dnb-button--secondary {
       color: var(--color-white);
       background-color: var(--color-sea-green);
 

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -161,11 +161,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -794,7 +794,7 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
 .dnb-modal__close-button {
   z-index: calc(var(--modal-z-index) + 1);
 }
-.dnb-modal__header__bar.dnb-section {
+.dnb-modal__header-bar.dnb-section {
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -162,11 +162,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -795,7 +795,7 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
 .dnb-modal__close-button {
   z-index: calc(var(--modal-z-index) + 1);
 }
-.dnb-modal__header__bar.dnb-section {
+.dnb-modal__header-bar.dnb-section {
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.js
@@ -626,7 +626,7 @@ class DropdownInstance extends React.PureComponent {
                     <>
                       {!isPopupMenu && (
                         <span className="dnb-dropdown__text dnb-button__text">
-                          <span className="dnb-dropdown__text__inner">
+                          <span className="dnb-dropdown__text-inner">
                             {title}
                           </span>
                         </span>

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -81,7 +81,7 @@ describe('Dropdown component', () => {
     let elem: HTMLUListElement
 
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[props.value] as DrawerListDataArrayObject).selected_value
     )
@@ -112,7 +112,7 @@ describe('Dropdown component', () => {
     expect(elem.classList).toContain('dnb-drawer-list__option--selected')
 
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[(props.value as number) + 1] as DrawerListDataArrayObject)
         .selected_value
@@ -1238,7 +1238,7 @@ describe('Dropdown component', () => {
     keydown(13) // enter
 
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[(props.value as number) + 1] as DrawerListDataArrayObject)
         .selected_value
@@ -1248,7 +1248,7 @@ describe('Dropdown component', () => {
   it('has correct selected value', () => {
     render(<Dropdown {...props} data={mockData} />)
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[props.value] as DrawerListDataArrayObject).selected_value
     )
@@ -1262,7 +1262,7 @@ describe('Dropdown component', () => {
     keydown(40) // down
 
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[props.value] as DrawerListDataArrayObject).selected_value
     )
@@ -1283,7 +1283,7 @@ describe('Dropdown component', () => {
     render(<UpdateValue />)
 
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').textContent
+      document.querySelector('.dnb-dropdown__text-inner').textContent
     ).toBe(
       (mockData[newValue] as DrawerListDataArrayObject).selected_value
     )
@@ -1303,7 +1303,7 @@ describe('Dropdown component', () => {
     const title = 'Make a selection'
     render(<Dropdown data={mockData} title={title} {...mockProps} />)
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').innerHTML
+      document.querySelector('.dnb-dropdown__text-inner').innerHTML
     ).toBe(title)
   })
 
@@ -1327,7 +1327,7 @@ describe('Dropdown component', () => {
       document.querySelector('#title-as-children')
     ).toBeInTheDocument()
     expect(
-      document.querySelector('.dnb-dropdown__text__inner')
+      document.querySelector('.dnb-dropdown__text-inner')
     ).toHaveTextContent('Title as children')
 
     rerender(
@@ -1339,7 +1339,7 @@ describe('Dropdown component', () => {
 
     expect(document.querySelector('#title-as-prop')).toBeInTheDocument()
     expect(
-      document.querySelector('.dnb-dropdown__text__inner')
+      document.querySelector('.dnb-dropdown__text-inner')
     ).toHaveTextContent('Title as prop')
   })
 
@@ -1558,17 +1558,17 @@ describe('Dropdown component', () => {
 
     render(<Dropdown data={mockData} value={4} {...mockProps} />)
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').innerHTML
+      document.querySelector('.dnb-dropdown__text-inner').innerHTML
     ).toBe(aStringOf)
 
     render(<Dropdown data={mockData} value={5} {...mockProps} />)
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').innerHTML
+      document.querySelector('.dnb-dropdown__text-inner').innerHTML
     ).toBe(aStringOf)
 
     render(<Dropdown data={mockData} value={6} {...mockProps} />)
     expect(
-      document.querySelector('.dnb-dropdown__text__inner').innerHTML
+      document.querySelector('.dnb-dropdown__text-inner').innerHTML
     ).toBe(aStringOf)
   })
 

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -1549,7 +1549,7 @@ describe('Dropdown component', () => {
     expect(
       document
         .querySelector('.dnb-drawer-list__option')
-        .querySelector('.dnb-drawer-list__option__inner').innerHTML
+        .querySelector('.dnb-drawer-list__option-inner').innerHTML
     ).toBe('')
   })
 

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -237,11 +237,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -771,7 +771,7 @@ button .dnb-form-status__text {
   line-height: inherit;
   font-size: var(--font-size-basis);
 }
-.dnb-dropdown__text__inner {
+.dnb-dropdown__text-inner {
   display: inherit;
   overflow: hidden;
   white-space: nowrap;

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -771,7 +771,7 @@ button .dnb-form-status__text {
   line-height: inherit;
   font-size: var(--font-size-basis);
 }
-.dnb-dropdown__text-inner {
+.dnb-dropdown__text__inner {
   display: inherit;
   overflow: hidden;
   white-space: nowrap;

--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -581,37 +581,37 @@ const DropdownStory = () => {
         >
           <ul className="dnb-drawer-list__options">
             <li className="dnb-drawer-list__option">
-              <span className="dnb-drawer-list__option__inner">
+              <span className="dnb-drawer-list__option-inner">
                 Brukskonto - Kari Nordmann
               </span>
             </li>
             <li className="dnb-drawer-list__option dnb-drawer-list__option--selected">
-              <span className="dnb-drawer-list__option__inner">
-                <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-inner">
+                <span className="dnb-drawer-list__option-item">
                   <NumberFormat ban>12345678902</NumberFormat>
                 </span>
-                <span className="dnb-drawer-list__option__item">
+                <span className="dnb-drawer-list__option-item">
                   Sparekonto - Ole Nordmann
                 </span>
               </span>
             </li>
             <li className="dnb-drawer-list__option">
-              <span className="dnb-drawer-list__option__inner">
-                <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-inner">
+                <span className="dnb-drawer-list__option-item">
                   <NumberFormat ban>11345678962</NumberFormat>
                 </span>
-                <span className="dnb-drawer-list__option__item">
+                <span className="dnb-drawer-list__option-item">
                   Feriekonto - Kari Nordmann med et kjempelangt
                   etternavnsen
                 </span>
               </span>
             </li>
             <li className="dnb-drawer-list__option last-of-type">
-              <span className="dnb-drawer-list__option__inner">
-                <span className="dnb-drawer-list__option__item">
+              <span className="dnb-drawer-list__option-inner">
+                <span className="dnb-drawer-list__option-item">
                   <NumberFormat ban>15349648901</NumberFormat>
                 </span>
-                <span className="dnb-drawer-list__option__item">
+                <span className="dnb-drawer-list__option-item">
                   Oppussing - Ole Nordmann
                 </span>
               </span>

--- a/packages/dnb-eufemia/src/components/dropdown/style/themes/dnb-dropdown-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/dropdown/style/themes/dnb-dropdown-theme-ui.scss
@@ -31,7 +31,7 @@
 
   // NB: We may use this medium font in future
   // .dnb-drawer-list--is-popup &__list {
-  //   .dnb-drawer-list__option__inner {
+  //   .dnb-drawer-list__option-inner {
   //     font-weight: var(--font-weight-medium);
   //   }
   // }

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -173,7 +173,7 @@ export default function GlobalError(localProps: GlobalErrorAllProps) {
   return (
     <Skeleton {...params} show={skeleton} element="section">
       <div className="dnb-global-error__inner">
-        <div className="dnb-global-error__inner__content">
+        <div className="dnb-global-error__inner-content">
           <H1 size="x-large" top bottom>
             {title}
           </H1>

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
@@ -24,7 +24,7 @@ describe('GlobalError', () => {
     render(<GlobalError statusCode="404" />)
 
     expect(
-      document.querySelector('.dnb-global-error__inner__content')
+      document.querySelector('.dnb-global-error__inner-content')
         .textContent
     ).toMatchInlineSnapshot(
       `"Vi finner ikke siden du leter etter …Sikker på at du har skrevet riktig adresse? Eller har vi rotet med lenkene?Feilmeldings-kode: 404"`
@@ -35,7 +35,7 @@ describe('GlobalError', () => {
     render(<GlobalError statusCode="500" />)
 
     expect(
-      document.querySelector('.dnb-global-error__inner__content')
+      document.querySelector('.dnb-global-error__inner-content')
         .textContent
     ).toMatchInlineSnapshot(
       `"Beklager, her skjedde det noe feil!Tjenesten fungerer ikke slik den skal for øyeblikket, men prøv igjen senere.Feilmeldings-kode: 500"`
@@ -46,7 +46,7 @@ describe('GlobalError', () => {
     render(<GlobalError statusCode="404" locale="en-GB" />)
 
     expect(
-      document.querySelector('.dnb-global-error__inner__content')
+      document.querySelector('.dnb-global-error__inner-content')
         .textContent
     ).toMatchInlineSnapshot(
       `"We can't find the page you're looking for …Are you sure you have entered the correct address? Or have we messed with the links?Error code: 404"`
@@ -61,7 +61,7 @@ describe('GlobalError', () => {
     )
 
     expect(
-      document.querySelector('.dnb-global-error__inner__content')
+      document.querySelector('.dnb-global-error__inner-content')
         .textContent
     ).toMatchInlineSnapshot(
       `"Sorry, a technical error happened!The service is not working properly at the moment. Try again later.Error code: 500"`
@@ -82,7 +82,7 @@ describe('GlobalError', () => {
       render(<GlobalError status="404" />)
 
       expect(
-        document.querySelector('.dnb-global-error__inner__content')
+        document.querySelector('.dnb-global-error__inner-content')
           .textContent
       ).toMatchInlineSnapshot(
         `"Vi finner ikke siden du leter etter …Sikker på at du har skrevet riktig adresse? Eller har vi rotet med lenkene?Feilmeldings-kode: 404"`
@@ -93,7 +93,7 @@ describe('GlobalError', () => {
       render(<GlobalError status="500" />)
 
       expect(
-        document.querySelector('.dnb-global-error__inner__content')
+        document.querySelector('.dnb-global-error__inner-content')
           .textContent
       ).toMatchInlineSnapshot(
         `"Beklager, her skjedde det noe feil!Tjenesten fungerer ikke slik den skal for øyeblikket, men prøv igjen senere.Feilmeldings-kode: 500"`
@@ -104,7 +104,7 @@ describe('GlobalError', () => {
       render(<GlobalError status="404" locale="en-GB" />)
 
       expect(
-        document.querySelector('.dnb-global-error__inner__content')
+        document.querySelector('.dnb-global-error__inner-content')
           .textContent
       ).toMatchInlineSnapshot(
         `"We can't find the page you're looking for …Are you sure you have entered the correct address? Or have we messed with the links?Error code: 404"`
@@ -119,7 +119,7 @@ describe('GlobalError', () => {
       )
 
       expect(
-        document.querySelector('.dnb-global-error__inner__content')
+        document.querySelector('.dnb-global-error__inner-content')
           .textContent
       ).toMatchInlineSnapshot(
         `"Sorry, a technical error happened!The service is not working properly at the moment. Try again later.Error code: 500"`
@@ -172,11 +172,11 @@ describe('GlobalError', () => {
     render(<GlobalError {...props} />)
 
     expect(
-      document.querySelector('.dnb-global-error__inner__content h1')
+      document.querySelector('.dnb-global-error__inner-content h1')
         .textContent
     ).toBe('title')
     expect(
-      document.querySelector('.dnb-global-error__inner__content .dnb-p')
+      document.querySelector('.dnb-global-error__inner-content .dnb-p')
         .textContent
     ).toBe('text')
   })
@@ -186,7 +186,7 @@ describe('GlobalError', () => {
     render(<GlobalError {...props} text={htmlText} />)
 
     const textElement = document.querySelector(
-      '.dnb-global-error__inner__content .dnb-p'
+      '.dnb-global-error__inner-content .dnb-p'
     ) as HTMLElement
 
     expect(textElement).not.toBeNull()

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -154,11 +154,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -523,7 +523,7 @@ button.dnb-button::-moz-focus-inner {
     padding: 0 var(--spacing-x-small);
   }
 }
-.dnb-global-error__inner__content {
+.dnb-global-error__inner-content {
   max-width: 37rem;
 }
 .dnb-global-error__links {

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -523,7 +523,7 @@ button.dnb-button::-moz-focus-inner {
     padding: 0 var(--spacing-x-small);
   }
 }
-.dnb-global-error__inner-content {
+.dnb-global-error__inner__content {
   max-width: 37rem;
 }
 .dnb-global-error__links {

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.js
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.js
@@ -676,7 +676,7 @@ export default class GlobalStatus extends React.PureComponent {
               <div className="dnb-global-status__message">
                 <div
                   className={classnames(
-                    'dnb-global-status__message__content',
+                    'dnb-global-status__message-content',
                     !renderedItems && 'dnb-space__bottom--small'
                   )}
                 >

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -137,13 +137,13 @@ describe('GlobalStatus component', () => {
 
     expect(
       document.querySelector(
-        'div.dnb-global-status__message__content > .dnb-p'
+        'div.dnb-global-status__message-content > .dnb-p'
       ).textContent
     ).toBe(newText)
 
     expect(
       document.querySelector(
-        'div.dnb-global-status__message__content > .dnb-ul'
+        'div.dnb-global-status__message-content > .dnb-ul'
       ).textContent
     ).toBe('item#1item#3')
 
@@ -763,7 +763,7 @@ describe('GlobalStatus component', () => {
     ).toBe("'error-message'")
     expect(
       document
-        .querySelectorAll('.dnb-global-status__message__content ul li')[0]
+        .querySelectorAll('.dnb-global-status__message-content ul li')[0]
         .querySelector('a.dnb-anchor').textContent
     ).toBe("custom anchor text 'my-label'")
   })
@@ -878,7 +878,7 @@ describe('GlobalStatus component', () => {
     ).not.toBeInTheDocument()
 
     expect(
-      document.querySelector('div.dnb-global-status__message__content')
+      document.querySelector('div.dnb-global-status__message-content')
     ).not.toBeInTheDocument()
 
     rerender(
@@ -893,7 +893,7 @@ describe('GlobalStatus component', () => {
       document.querySelector('div.dnb-global-status__content')
     ).toBeInTheDocument()
     expect(
-      document.querySelector('div.dnb-global-status__message__content')
+      document.querySelector('div.dnb-global-status__message-content')
     ).not.toBeInTheDocument()
 
     render(
@@ -906,7 +906,7 @@ describe('GlobalStatus component', () => {
     )
 
     expect(
-      document.querySelector('div.dnb-global-status__message__content')
+      document.querySelector('div.dnb-global-status__message-content')
     ).toBeInTheDocument()
 
     rerender(
@@ -930,7 +930,7 @@ describe('GlobalStatus component', () => {
       document.querySelector('div.dnb-global-status__content')
     ).not.toBeInTheDocument()
     expect(
-      document.querySelector('div.dnb-global-status__message__content')
+      document.querySelector('div.dnb-global-status__message-content')
     ).not.toBeInTheDocument()
   })
 

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -719,12 +719,12 @@ button.dnb-button::-moz-focus-inner {
   cursor: text;
   z-index: 1;
 }
-.dnb-global-status__message-content {
+.dnb-global-status__message__content {
   display: flex;
   flex-direction: column;
   padding: 0 0 0.5rem 2.5rem;
 }
-.dnb-global-status__message-content .dnb-p, .dnb-spacing .dnb-global-status__message-content .dnb-p, .dnb-spacing .dnb-global-status__message-content .dnb-p:not([class*=dnb-space]) {
+.dnb-global-status__message__content .dnb-p, .dnb-spacing .dnb-global-status__message__content .dnb-p, .dnb-spacing .dnb-global-status__message__content .dnb-p:not([class*=dnb-space]) {
   display: inline-block;
   margin: 0;
   padding: 0;
@@ -741,7 +741,7 @@ button.dnb-button::-moz-focus-inner {
   right: 1rem;
   left: auto;
 }
-.dnb-modal__content__inner .dnb-global-status__close-button {
+.dnb-modal__content-inner .dnb-global-status__close-button {
   right: 0;
 }
 .dnb-global-status__content {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -175,11 +175,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -719,12 +719,12 @@ button.dnb-button::-moz-focus-inner {
   cursor: text;
   z-index: 1;
 }
-.dnb-global-status__message__content {
+.dnb-global-status__message-content {
   display: flex;
   flex-direction: column;
   padding: 0 0 0.5rem 2.5rem;
 }
-.dnb-global-status__message__content .dnb-p, .dnb-spacing .dnb-global-status__message__content .dnb-p, .dnb-spacing .dnb-global-status__message__content .dnb-p:not([class*=dnb-space]) {
+.dnb-global-status__message-content .dnb-p, .dnb-spacing .dnb-global-status__message-content .dnb-p, .dnb-spacing .dnb-global-status__message-content .dnb-p:not([class*=dnb-space]) {
   display: inline-block;
   margin: 0;
   padding: 0;

--- a/packages/dnb-eufemia/src/components/global-status/style/dnb-global-status.scss
+++ b/packages/dnb-eufemia/src/components/global-status/style/dnb-global-status.scss
@@ -83,7 +83,7 @@
     left: auto;
   }
 
-  .dnb-modal__content__inner &__close-button {
+  .dnb-modal__content-inner &__close-button {
     right: 0;
   }
 

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -157,11 +157,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -168,7 +168,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
           <Button
             top={centered ? 'medium' : 'small'}
             type="button"
-            className="dnb-info-card__buttons__accept-button"
+            className="dnb-info-card__buttons-accept-button"
             variant="secondary"
             right={centered ? 'zero' : 'small'}
             on_click={onAccept}
@@ -179,7 +179,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
         {!closeButtonIsHidden && (
           <Button
             type="button"
-            className="dnb-info-card__buttons__close-button"
+            className="dnb-info-card__buttons-close-button"
             variant="tertiary"
             top="small"
             on_click={onClose}

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -137,10 +137,10 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" />)
 
     expect(
-      document.querySelector('.dnb-info-card__buttons__accept-button')
+      document.querySelector('.dnb-info-card__buttons-accept-button')
     ).not.toBeInTheDocument()
     expect(
-      document.querySelector('.dnb-info-card__buttons__close-button')
+      document.querySelector('.dnb-info-card__buttons-close-button')
     ).not.toBeInTheDocument()
   })
 
@@ -149,7 +149,7 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" onAccept={onAccept} />)
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__accept-button'
+      '.dnb-info-card__buttons-accept-button'
     )
 
     expect(buttonElement).toBeInTheDocument()
@@ -164,7 +164,7 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" acceptButtonText={acceptButtonText} />)
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__accept-button'
+      '.dnb-info-card__buttons-accept-button'
     )
 
     expect(buttonElement).toBeInTheDocument()
@@ -179,11 +179,11 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" acceptButtonText={acceptButtonText} />)
 
     expect(
-      document.querySelector('.dnb-info-card__buttons__accept-button')
+      document.querySelector('.dnb-info-card__buttons-accept-button')
     ).toBeInTheDocument()
     expect(
       within(
-        document.querySelector('.dnb-info-card__buttons__accept-button')
+        document.querySelector('.dnb-info-card__buttons-accept-button')
       ).queryByTestId('react-node')
     ).toBeInTheDocument()
   })
@@ -193,7 +193,7 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" onClose={onClose} />)
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__close-button'
+      '.dnb-info-card__buttons-close-button'
     )
 
     expect(buttonElement).toBeInTheDocument()
@@ -208,7 +208,7 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" closeButtonText={closeButtonText} />)
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__close-button'
+      '.dnb-info-card__buttons-close-button'
     )
 
     expect(buttonElement).toBeInTheDocument()
@@ -221,11 +221,11 @@ describe('InfoCard', () => {
     render(<InfoCard text="text" closeButtonText={closeButtonText} />)
 
     expect(
-      document.querySelector('.dnb-info-card__buttons__close-button')
+      document.querySelector('.dnb-info-card__buttons-close-button')
     ).toBeInTheDocument()
     expect(
       within(
-        document.querySelector('.dnb-info-card__buttons__close-button')
+        document.querySelector('.dnb-info-card__buttons-close-button')
       ).queryByTestId('react-node')
     ).toBeInTheDocument()
   })
@@ -242,7 +242,7 @@ describe('InfoCard', () => {
     )
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__accept-button'
+      '.dnb-info-card__buttons-accept-button'
     )
 
     expect(buttonElement.getAttribute('href')).toMatch(href)
@@ -260,7 +260,7 @@ describe('InfoCard', () => {
     )
 
     const buttonElement = document.querySelector(
-      '.dnb-info-card__buttons__close-button'
+      '.dnb-info-card__buttons-close-button'
     )
 
     expect(buttonElement.getAttribute('href')).toMatch(href)

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -941,7 +941,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button__button {
+.dnb-input__submit-button-button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -154,11 +154,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -620,11 +620,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -941,7 +941,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button-button {
+.dnb-input__submit-button__button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -749,7 +749,7 @@ class InputSubmitButton extends React.PureComponent {
       >
         <Button
           className={classnames(
-            'dnb-input__submit-button__button',
+            'dnb-input__submit-button-button',
             'dnb-button--input-button',
             className
           )}

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -551,7 +551,7 @@ export default class Input extends React.PureComponent {
               {InputElement || <input ref={this._ref} {...inputParams} />}
 
               {inner_element && (
-                <span className="dnb-input__inner__element dnb-p">
+                <span className="dnb-input__inner-element dnb-p">
                   {inner_element}
                 </span>
               )}

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -729,14 +729,14 @@ describe('Input with clear button', () => {
     expect(
       document
         .querySelector('.dnb-input')
-        .querySelector('.dnb-input__input ~ .dnb-input__inner__element')
+        .querySelector('.dnb-input__input ~ .dnb-input__inner-element')
         .textContent
     ).toBe('custom element')
 
     expect(
       document
         .querySelector('.dnb-input')
-        .querySelector('.dnb-input__inner__element ~ .dnb-input__icon')
+        .querySelector('.dnb-input__inner-element ~ .dnb-input__icon')
         .querySelector('svg')
     ).toBeInTheDocument()
   })

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -934,7 +934,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button-button {
+.dnb-input__submit-button__button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {
@@ -1211,15 +1211,15 @@ exports[`Input scss have to match default theme snapshot 1`] = `
 .dnb-input[data-input-state=disabled] .dnb-input__shell .dnb-icon {
   color: var(--color-black-55);
 }
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
-[disabled]):hover, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
-[disabled]):hover::after, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
-[disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+[disabled]):hover, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+[disabled]):hover::after, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+[disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
 [disabled]):focus-visible::after {
   background-color: var(--color-fire-red);
 }
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
-[disabled]):hover:active, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+[disabled]):hover:active, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
 [disabled]):focus-visible:active {
   color: var(--color-white);
 }

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -934,7 +934,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
   position: relative;
   align-self: center; /* IE needs this to stay centered */
 }
-.dnb-input__submit-button__button {
+.dnb-input__submit-button-button {
   border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
 }
 .dnb-input > .dnb-form-label {
@@ -1211,15 +1211,15 @@ exports[`Input scss have to match default theme snapshot 1`] = `
 .dnb-input[data-input-state=disabled] .dnb-input__shell .dnb-icon {
   color: var(--color-black-55);
 }
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover::after, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+[disabled]):hover, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+[disabled]):hover::after, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+[disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
 [disabled]):focus-visible::after {
   background-color: var(--color-fire-red);
 }
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover:active, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
+[disabled]):hover:active, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button-button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button-button--has-text,
 [disabled]):focus-visible:active {
   color: var(--color-white);
 }

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -613,11 +613,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/input/style/themes/dnb-input-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/input/style/themes/dnb-input-theme-sbanken.scss
@@ -54,7 +54,7 @@
     color: var(--input-color);
   }
 
-  &__submit-button__button {
+  &__submit-button-button {
     --button-secondary-color: var(--sb-color-violet);
     --button-secondary-color--active: var(--sb-color-violet);
   }
@@ -103,14 +103,14 @@
       --input-color--active: var(--sb-color-text);
       --input-button-border-color: var(--sb-color-red);
 
-      .dnb-input__submit-button__button {
+      .dnb-input__submit-button-button {
         --button-secondary-background--hover: var(--sb-color-red);
         --button-secondary-color--hover: var(--sb-color-white);
         --button-secondary-color--active: var(--sb-color-red);
       }
     }
 
-    .dnb-input__submit-button__button:not(:focus-visible) {
+    .dnb-input__submit-button-button:not(:focus-visible) {
       background-color: transparent;
       box-shadow: none;
       border-radius: 0 var(--input-button-border-radius)

--- a/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
+++ b/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
@@ -169,12 +169,12 @@ export const ModalProperties: PropertiesTableProps = {
     status: 'optional',
   },
   class: {
-    doc: 'Give the inner content wrapper a class name (maps to `dnb-modal__content__inner`).',
+    doc: 'Give the inner content wrapper a class name (maps to `dnb-modal__content-inner`).',
     type: 'string',
     status: 'optional',
   },
   className: {
-    doc: 'Give the inner content wrapper a class name (maps to `dnb-modal__content__inner`).',
+    doc: 'Give the inner content wrapper a class name (maps to `dnb-modal__content-inner`).',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -154,11 +154,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -787,7 +787,7 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
 .dnb-modal__close-button {
   z-index: calc(var(--modal-z-index) + 1);
 }
-.dnb-modal__header__bar.dnb-section {
+.dnb-modal__header-bar.dnb-section {
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
@@ -23,7 +23,7 @@ export interface ModalHeaderProps extends Omit<SectionProps, 'children'> {
   title?: React.ReactNode
 
   /**
-   * Give the inner content wrapper a class name (maps to `dnb-modal__content__inner`).
+   * Give the inner content wrapper a class name (maps to `dnb-modal__content-inner`).
    */
   className?: string
 

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
@@ -112,19 +112,19 @@ export default class ModalHeaderBar extends React.PureComponent<
       <Section
         style_type="white"
         className={classnames(
-          'dnb-modal__header__bar',
+          'dnb-modal__header-bar',
           showShadow && shadow_class,
           className
         )}
         inner_ref={this._ref}
         {...props}
       >
-        <div className="dnb-modal__header__bar__inner">
+        <div className="dnb-modal__header-bar-inner">
           {children as React.ReactNode}
         </div>
 
         {!isTrue(hide_close_button) && (
-          <div className="dnb-modal__header__bar__close">
+          <div className="dnb-modal__header-bar-close">
             <CloseButton
               on_click={onCloseClickHandler}
               close_title={close_title}

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeaderBar.tsx
@@ -20,7 +20,7 @@ export interface ModalHeaderBarProps
   children?: ReactChildType
 
   /**
-   * Give the inner content wrapper a class name (maps to `dnb-modal__content__inner`).
+   * Give the inner content wrapper a class name (maps to `dnb-modal__content-inner`).
    */
   className?: string
 

--- a/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
@@ -116,7 +116,7 @@ html[data-dnb-modal-active] {
     z-index: calc(var(--modal-z-index) + 1);
   }
 
-  &__header__bar {
+  &__header-bar {
     &.dnb-section {
       display: flex;
       flex-direction: row;

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
@@ -50,11 +50,11 @@ exports[`NumberFormat scss has to match style dependencies css 1`] = `
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -217,7 +217,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
           />
         </div>
 
-        <div className="dnb-pagination__bar__inner">
+        <div className="dnb-pagination__bar-inner">
           {(pageNumberGroups?.[0] || []).map((pageNumber) => (
             <Button
               key={pageNumber}

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -190,8 +190,8 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
         spacingClasses
       )}
     >
-      <div className="dnb-pagination__bar__wrapper">
-        <div className="dnb-pagination__bar__skip">
+      <div className="dnb-pagination__bar-wrapper">
+        <div className="dnb-pagination__bar-skip">
           <Button
             key="left-arrow"
             disabled={disabled || prevIsDisabled}

--- a/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.js
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.js
@@ -31,7 +31,7 @@ export class PaginationIndicator extends React.PureComponent {
     return (
       <Element>
         <ElementChild className="dnb-pagination__indicator">
-          <div className="dnb-pagination__indicator__inner">
+          <div className="dnb-pagination__indicator-inner">
             <ProgressIndicator />
             {
               this.context.getTranslation(this.props).Pagination

--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.js
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.js
@@ -515,7 +515,7 @@ class InteractionMarker extends React.PureComponent {
     return (
       <Element className="dnb-pagination__marker dnb-table--ignore">
         <ElementChild
-          className="dnb-pagination__marker__inner"
+          className="dnb-pagination__marker-inner"
           ref={this._ref}
         >
           {/* {this.props.pageNumber} */}

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.screenshot.test.ts
@@ -119,7 +119,7 @@ describe.each(['ui', 'sbanken'])('Pagination for %s', (themeName) => {
         width: '50rem',
       },
       simulateSelector:
-        '[data-visual-test="pagination-default"] div.dnb-pagination__bar__inner button.dnb-pagination__button:first-of-type',
+        '[data-visual-test="pagination-default"] div.dnb-pagination__bar-inner button.dnb-pagination__button:first-of-type',
       simulate: 'click',
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -132,7 +132,7 @@ describe.each(['ui', 'sbanken'])('Pagination for %s', (themeName) => {
         width: '50rem',
       },
       simulateSelector:
-        '[data-visual-test="pagination-default"] div.dnb-pagination__bar__inner button.dnb-pagination__button:last-of-type',
+        '[data-visual-test="pagination-default"] div.dnb-pagination__bar-inner button.dnb-pagination__button:last-of-type',
       simulate: 'click',
     })
     expect(screenshot).toMatchImageSnapshot()

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -26,7 +26,7 @@ describe('Pagination bar', () => {
 
   it('has correct state at startup', () => {
     render(<Pagination {...props} />)
-    const innerElem = document.querySelector('.dnb-pagination__bar__inner')
+    const innerElem = document.querySelector('.dnb-pagination__bar-inner')
 
     expect(
       innerElem.querySelectorAll('button.dnb-pagination__button').length
@@ -57,7 +57,7 @@ describe('Pagination bar', () => {
     expect(document.querySelector('div#page-content')).toBeInTheDocument()
 
     const buttonElements = document
-      .querySelector('.dnb-pagination__bar__inner')
+      .querySelector('.dnb-pagination__bar-inner')
       .querySelectorAll('button.dnb-pagination__button')
 
     const firstButton = buttonElements[0]
@@ -96,7 +96,7 @@ describe('Pagination bar', () => {
     expect(document.querySelector('div#page-no').textContent).toBe('15')
 
     const buttonElements = document
-      .querySelector('.dnb-pagination__bar__inner')
+      .querySelector('.dnb-pagination__bar-inner')
       .querySelectorAll('button.dnb-pagination__button')
 
     fireEvent.click(buttonElements[2])
@@ -159,7 +159,7 @@ describe('Pagination bar', () => {
 
     const nextButton = document
       .querySelector('div.dnb-pagination__bar')
-      .querySelector('.dnb-pagination__bar__skip')
+      .querySelector('.dnb-pagination__bar-skip')
       .querySelectorAll('.dnb-button')[1]
 
     expect(nextButton.getAttribute('title')).toBe('Neste side')
@@ -230,7 +230,7 @@ describe('Pagination bar', () => {
 
     const nextButton = document
       .querySelector('div.dnb-pagination__bar')
-      .querySelector('.dnb-pagination__bar__skip')
+      .querySelector('.dnb-pagination__bar-skip')
       .querySelectorAll('.dnb-button')[1]
 
     fireEvent.click(nextButton)
@@ -251,7 +251,7 @@ describe('Pagination bar', () => {
 
     const nextButton = document
       .querySelector('div.dnb-pagination__bar')
-      .querySelector('.dnb-pagination__bar__skip')
+      .querySelector('.dnb-pagination__bar-skip')
       .querySelectorAll('.dnb-button')[1]
 
     fireEvent.click(nextButton)
@@ -626,7 +626,7 @@ describe('Infinity scroller', () => {
     )
 
     const element = document.querySelector(
-      '.dnb-pagination__bar__skip button'
+      '.dnb-pagination__bar-skip button'
     )
 
     expect(element.textContent).toContain(nb.prev_title)

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -831,7 +831,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   justify-content: center;
   min-height: inherit;
 }
-.dnb-pagination__indicator__inner {
+.dnb-pagination__indicator-inner {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -849,7 +849,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   margin: -1px 0 0 -1px;
   overflow: hidden;
 }
-.dnb-pagination__marker td, .dnb-pagination__marker__inner {
+.dnb-pagination__marker td, .dnb-pagination__marker-inner {
   padding: 0 !important;
   width: 1px;
   height: 1px;

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -831,7 +831,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   justify-content: center;
   min-height: inherit;
 }
-.dnb-pagination__indicator-inner {
+.dnb-pagination__indicator__inner {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -849,7 +849,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   margin: -1px 0 0 -1px;
   overflow: hidden;
 }
-.dnb-pagination__marker td, .dnb-pagination__marker-inner {
+.dnb-pagination__marker td, .dnb-pagination__marker__inner {
   padding: 0 !important;
   width: 1px;
   height: 1px;

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -765,7 +765,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   display: flex;
   flex-direction: column-reverse;
 }
-.dnb-pagination__bar, .dnb-pagination__loadbar, .dnb-pagination__bar__inner {
+.dnb-pagination__bar, .dnb-pagination__loadbar, .dnb-pagination__bar-inner {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -791,25 +791,25 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
 .dnb-pagination--right .dnb-pagination__bar {
   justify-content: flex-end;
 }
-.dnb-pagination__bar__wrapper {
+.dnb-pagination__bar-wrapper {
   display: flex;
   flex-flow: column wrap;
   row-gap: 0.5rem;
 }
 @media screen and (min-width: 72.00625em) {
-  .dnb-pagination--layout-horizontal .dnb-pagination__bar__wrapper {
+  .dnb-pagination--layout-horizontal .dnb-pagination__bar-wrapper {
     flex-flow: row-reverse wrap;
     justify-content: space-between;
     flex: 1;
   }
 }
-.dnb-pagination--center .dnb-pagination__bar__wrapper {
+.dnb-pagination--center .dnb-pagination__bar-wrapper {
   align-items: center;
 }
-.dnb-pagination--right .dnb-pagination__bar__wrapper {
+.dnb-pagination--right .dnb-pagination__bar-wrapper {
   align-items: flex-end;
 }
-.dnb-pagination__bar__inner {
+.dnb-pagination__bar-inner {
   gap: 0.5rem;
 }
 .dnb-pagination__button {
@@ -855,7 +855,7 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
   height: 1px;
   opacity: 0;
 }
-.dnb-pagination__bar__skip {
+.dnb-pagination__bar-skip {
   display: flex;
   column-gap: 1.5rem;
 }

--- a/packages/dnb-eufemia/src/components/pagination/style/dnb-pagination.scss
+++ b/packages/dnb-eufemia/src/components/pagination/style/dnb-pagination.scss
@@ -11,7 +11,7 @@
 
   &__bar,
   &__loadbar,
-  &__bar__inner {
+  &__bar-inner {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -43,13 +43,13 @@
     justify-content: flex-end;
   }
 
-  &__bar__wrapper {
+  &__bar-wrapper {
     display: flex;
     flex-flow: column wrap;
     row-gap: 0.5rem;
   }
 
-  &--layout-horizontal &__bar__wrapper {
+  &--layout-horizontal &__bar-wrapper {
     @include allAbove(large) {
       flex-flow: row-reverse wrap;
       justify-content: space-between;
@@ -57,15 +57,15 @@
     }
   }
 
-  &--center &__bar__wrapper {
+  &--center &__bar-wrapper {
     align-items: center;
   }
 
-  &--right &__bar__wrapper {
+  &--right &__bar-wrapper {
     align-items: flex-end;
   }
 
-  &__bar__inner {
+  &__bar-inner {
     gap: 0.5rem;
   }
 
@@ -125,7 +125,7 @@
     }
   }
 
-  &__bar__skip {
+  &__bar-skip {
     display: flex;
     column-gap: 1.5rem;
   }

--- a/packages/dnb-eufemia/src/components/pagination/style/themes/dnb-pagination-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/pagination/style/themes/dnb-pagination-theme-sbanken.scss
@@ -6,7 +6,7 @@
 @import '../../../../style/core/utilities.scss';
 
 .dnb-pagination {
-  &__bar__skip {
+  &__bar-skip {
     // button tertiary
     .dnb-button--tertiary:not([disabled]) .dnb-button__text {
       color: var(--sb-color-text);

--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -862,7 +862,7 @@ function PopoverContainer(props: PopoverContainerProps) {
               (base) => `${base}__arrow__arrow--${arrowPosition}`
             ),
             baseClassNames.map(
-              (base) => `${base}__arrow__placement--${resolvedPlacement}`
+              (base) => `${base}__arrow-placement--${resolvedPlacement}`
             )
           )}
           style={{ ...arrowStyle }}

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -2163,7 +2163,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--top')
+          document.querySelector('.dnb-popover__arrow-placement--top')
         ).toBeInTheDocument()
       )
 
@@ -2219,7 +2219,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
       )
 
@@ -2275,7 +2275,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
       )
 
@@ -2331,7 +2331,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
       )
 
@@ -2388,7 +2388,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
       )
 
@@ -2445,7 +2445,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--top')
+          document.querySelector('.dnb-popover__arrow-placement--top')
         ).toBeInTheDocument()
       )
 
@@ -2457,7 +2457,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--top')
+          document.querySelector('.dnb-popover__arrow-placement--top')
         ).toBeInTheDocument()
       )
 
@@ -2514,7 +2514,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--top')
+          document.querySelector('.dnb-popover__arrow-placement--top')
         ).toBeInTheDocument()
       )
 
@@ -2526,7 +2526,7 @@ describe('Popover', () => {
 
       await waitFor(() =>
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
       )
 
@@ -2585,7 +2585,7 @@ describe('Popover', () => {
           '.dnb-popover'
         ) as HTMLElement
         expect(
-          document.querySelector('.dnb-popover__arrow__placement--bottom')
+          document.querySelector('.dnb-popover__arrow-placement--bottom')
         ).toBeInTheDocument()
         expect(popover?.style.top).toBe('60px')
       })

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.tsx
@@ -149,9 +149,9 @@ function ProgressIndicatorCircular(
       )}
       {...remainingDOMAttributes}
     >
-      <span className="dnb-progress-indicator__circular__background-padding">
+      <span className="dnb-progress-indicator__circular-background-padding">
         <span
-          className="dnb-progress-indicator__circular__background"
+          className="dnb-progress-indicator__circular-background"
           style={{ backgroundColor: customColors?.background }}
         />
       </span>
@@ -210,7 +210,7 @@ const Circle = forwardRef(function Circle(
   return (
     <svg
       className={classnames(
-        'dnb-progress-indicator__circular__line',
+        'dnb-progress-indicator__circular-line',
         className
       )}
       shapeRendering="geometricPrecision"
@@ -218,7 +218,7 @@ const Circle = forwardRef(function Circle(
       {...rest}
     >
       <circle
-        className="dnb-progress-indicator__circular__circle"
+        className="dnb-progress-indicator__circular-circle"
         fill="none"
         cx="50%"
         cy="50%"

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.tsx
@@ -70,11 +70,11 @@ function ProgressIndicatorLine(props: ProgressIndicatorLinearAllProps) {
     >
       <span
         className={classnames(
-          'dnb-progress-indicator__linear__bar',
+          'dnb-progress-indicator__linear-bar',
           hasProgressValue &&
-            'dnb-progress-indicator__linear__bar-transition',
+            'dnb-progress-indicator__linear-bar-transition',
           !hasProgressValue &&
-            'dnb-progress-indicator__linear__bar1-animation'
+            'dnb-progress-indicator__linear-bar1-animation'
         )}
         style={{
           backgroundColor: customColors?.line,
@@ -84,8 +84,8 @@ function ProgressIndicatorLine(props: ProgressIndicatorLinearAllProps) {
       {!hasProgressValue && (
         <span
           className={classnames(
-            'dnb-progress-indicator__linear__bar',
-            'dnb-progress-indicator__linear__bar2-animation'
+            'dnb-progress-indicator__linear-bar',
+            'dnb-progress-indicator__linear-bar2-animation'
           )}
           style={{
             backgroundColor: customColors?.line,

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
@@ -14,7 +14,7 @@ const props: ProgressIndicatorAllProps = {}
 
 describe('Circular ProgressIndicator component', () => {
   const mainLineSelector =
-    'svg.dnb-progress-indicator__circular__line.dark[style]'
+    'svg.dnb-progress-indicator__circular-line.dark[style]'
 
   it('should have a stroke-dashoffset of 44 on 50%', () => {
     render(<ProgressIndicator {...props} type="circular" progress={50} />)
@@ -210,23 +210,23 @@ describe('Circular ProgressIndicator component', () => {
 
     expect(
       container
-        .querySelector('.dnb-progress-indicator__circular__background')
+        .querySelector('.dnb-progress-indicator__circular-background')
         .getAttribute('style')
     ).toBe('background-color: blue;')
 
     expect(
       container
-        .querySelectorAll('.dnb-progress-indicator__circular__circle')[0]
+        .querySelectorAll('.dnb-progress-indicator__circular-circle')[0]
         .getAttribute('style')
     ).toBe('stroke: green;')
     expect(
       container
-        .querySelectorAll('.dnb-progress-indicator__circular__circle')[1]
+        .querySelectorAll('.dnb-progress-indicator__circular-circle')[1]
         .getAttribute('style')
     ).toBe('stroke: red;')
     expect(
       container
-        .querySelectorAll('.dnb-progress-indicator__circular__circle')[2]
+        .querySelectorAll('.dnb-progress-indicator__circular-circle')[2]
         .getAttribute('style')
     ).toBe('stroke: green;')
   })
@@ -290,7 +290,7 @@ describe('Circular ProgressIndicator component', () => {
 })
 
 describe('Linear ProgressIndicator component', () => {
-  const mainLineSelector = '.dnb-progress-indicator__linear__bar'
+  const mainLineSelector = '.dnb-progress-indicator__linear-bar'
 
   it('should have a transform of translateX(-50%) on 50%', () => {
     render(<ProgressIndicator {...props} type="linear" progress={50} />)
@@ -502,12 +502,12 @@ describe('Linear ProgressIndicator component', () => {
     ).toBe('background-color: green;')
     expect(
       container
-        .querySelectorAll('.dnb-progress-indicator__linear__bar')[0]
+        .querySelectorAll('.dnb-progress-indicator__linear-bar')[0]
         .getAttribute('style')
     ).toBe('background-color: red;')
     expect(
       container
-        .querySelectorAll('.dnb-progress-indicator__linear__bar')[1]
+        .querySelectorAll('.dnb-progress-indicator__linear-bar')[1]
         .getAttribute('style')
     ).toBe('background-color: red;')
   })

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -110,50 +110,50 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
 .dnb-progress-indicator__circular svg:not(:root) {
   overflow: visible;
 }
-.dnb-progress-indicator__circular-background-padding {
+.dnb-progress-indicator__circular__background-padding {
   display: block;
   height: 100%;
   padding: calc(var(--progress-indicator-circular-stroke-width) / 2);
 }
-.dnb-progress-indicator__circular-background {
+.dnb-progress-indicator__circular__background {
   display: block;
   height: 100%;
   background-color: transparent;
   border-radius: 50%;
 }
-.dnb-progress-indicator__circular-line {
+.dnb-progress-indicator__circular__line {
   animation-duration: 2s;
   animation-delay: 200ms;
   animation-timing-function: var(--progress-indicator-timing);
   animation-iteration-count: infinite;
 }
-.dnb-progress-indicator__circular-line.background {
+.dnb-progress-indicator__circular__line.background {
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--max);
 }
-.dnb-progress-indicator__circular-line.light {
+.dnb-progress-indicator__circular__line.light {
   animation-name: progress-indicator-circular-line-light;
   stroke-dasharray: var(--progress-indicator-circular-circle), var(--progress-indicator-circular-circle);
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--max);
 }
-.dnb-progress-indicator__circular-line.dark {
+.dnb-progress-indicator__circular__line.dark {
   animation-name: progress-indicator-circular-line-dark;
   stroke-dasharray: var(--progress-indicator-circular-circle), var(--progress-indicator-circular-circle);
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--min);
 }
-.dnb-progress-indicator__circular-line.paused {
+.dnb-progress-indicator__circular__line.paused {
   animation-play-state: paused;
 }
-.dnb-progress-indicator__circular--has-progress-value .dnb-progress-indicator__circular-line.dark {
+.dnb-progress-indicator__circular--has-progress-value .dnb-progress-indicator__circular__line.dark {
   transition: stroke-dashoffset 600ms var(--progress-indicator-timing);
 }
-.dnb-progress-indicator__circular-circle {
+.dnb-progress-indicator__circular__circle {
   stroke-linecap: round;
   stroke-width: var(--progress-indicator-circular-stroke-width);
 }
-.dnb-progress-indicator__circular-line.light .dnb-progress-indicator__circular-circle {
+.dnb-progress-indicator__circular__line.light .dnb-progress-indicator__circular__circle {
   stroke: var(--progress-indicator-circular-background-color);
 }
-.dnb-progress-indicator__circular-line.dark .dnb-progress-indicator__circular-circle {
+.dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
   stroke: var(--progress-indicator-circular-bar-color);
   stroke-width: calc(var(--progress-indicator-circular-stroke-width) - 0.5px);
 }
@@ -166,7 +166,7 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
   height: var(--progress-indicator-linear-size);
   border-radius: calc(var(--progress-indicator-linear-size) / 2);
 }
-.dnb-progress-indicator__linear-bar {
+.dnb-progress-indicator__linear__bar {
   background-color: var(--progress-indicator-linear-bar-color);
   width: 100%;
   position: absolute;
@@ -176,24 +176,24 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
   transform-origin: left;
   border-radius: inherit;
 }
-.dnb-progress-indicator__linear-bar-transition {
+.dnb-progress-indicator__linear__bar-transition {
   transition: transform 0.2s linear;
 }
-.dnb-progress-indicator__linear-bar1-animation {
+.dnb-progress-indicator__linear__bar1-animation {
   width: auto;
   animation: progress-indicator-linear-bar-1 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
 }
-.dnb-progress-indicator__linear-bar2-animation {
+.dnb-progress-indicator__linear__bar2-animation {
   width: auto;
   animation: progress-indicator-linear-bar-2 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) 1.15s infinite;
 }
-html[data-visual-test] .dnb-progress-indicator__linear-bar1-animation {
+html[data-visual-test] .dnb-progress-indicator__linear__bar1-animation {
   left: -35%;
   right: 100%;
   animation-duration: 0ms;
   animation-iteration-count: 0;
 }
-html[data-visual-test] .dnb-progress-indicator__linear-bar2-animation {
+html[data-visual-test] .dnb-progress-indicator__linear__bar2-animation {
   left: -200%;
   right: 100%;
   animation-duration: 0ms;

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -110,50 +110,50 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
 .dnb-progress-indicator__circular svg:not(:root) {
   overflow: visible;
 }
-.dnb-progress-indicator__circular__background-padding {
+.dnb-progress-indicator__circular-background-padding {
   display: block;
   height: 100%;
   padding: calc(var(--progress-indicator-circular-stroke-width) / 2);
 }
-.dnb-progress-indicator__circular__background {
+.dnb-progress-indicator__circular-background {
   display: block;
   height: 100%;
   background-color: transparent;
   border-radius: 50%;
 }
-.dnb-progress-indicator__circular__line {
+.dnb-progress-indicator__circular-line {
   animation-duration: 2s;
   animation-delay: 200ms;
   animation-timing-function: var(--progress-indicator-timing);
   animation-iteration-count: infinite;
 }
-.dnb-progress-indicator__circular__line.background {
+.dnb-progress-indicator__circular-line.background {
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--max);
 }
-.dnb-progress-indicator__circular__line.light {
+.dnb-progress-indicator__circular-line.light {
   animation-name: progress-indicator-circular-line-light;
   stroke-dasharray: var(--progress-indicator-circular-circle), var(--progress-indicator-circular-circle);
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--max);
 }
-.dnb-progress-indicator__circular__line.dark {
+.dnb-progress-indicator__circular-line.dark {
   animation-name: progress-indicator-circular-line-dark;
   stroke-dasharray: var(--progress-indicator-circular-circle), var(--progress-indicator-circular-circle);
   stroke-dashoffset: var(--progress-indicator-circular-circle-offset--min);
 }
-.dnb-progress-indicator__circular__line.paused {
+.dnb-progress-indicator__circular-line.paused {
   animation-play-state: paused;
 }
-.dnb-progress-indicator__circular--has-progress-value .dnb-progress-indicator__circular__line.dark {
+.dnb-progress-indicator__circular--has-progress-value .dnb-progress-indicator__circular-line.dark {
   transition: stroke-dashoffset 600ms var(--progress-indicator-timing);
 }
-.dnb-progress-indicator__circular__circle {
+.dnb-progress-indicator__circular-circle {
   stroke-linecap: round;
   stroke-width: var(--progress-indicator-circular-stroke-width);
 }
-.dnb-progress-indicator__circular__line.light .dnb-progress-indicator__circular__circle {
+.dnb-progress-indicator__circular-line.light .dnb-progress-indicator__circular-circle {
   stroke: var(--progress-indicator-circular-background-color);
 }
-.dnb-progress-indicator__circular__line.dark .dnb-progress-indicator__circular__circle {
+.dnb-progress-indicator__circular-line.dark .dnb-progress-indicator__circular-circle {
   stroke: var(--progress-indicator-circular-bar-color);
   stroke-width: calc(var(--progress-indicator-circular-stroke-width) - 0.5px);
 }
@@ -166,7 +166,7 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
   height: var(--progress-indicator-linear-size);
   border-radius: calc(var(--progress-indicator-linear-size) / 2);
 }
-.dnb-progress-indicator__linear__bar {
+.dnb-progress-indicator__linear-bar {
   background-color: var(--progress-indicator-linear-bar-color);
   width: 100%;
   position: absolute;
@@ -176,24 +176,24 @@ exports[`ProgressIndicator scss should match style dependencies css 1`] = `
   transform-origin: left;
   border-radius: inherit;
 }
-.dnb-progress-indicator__linear__bar-transition {
+.dnb-progress-indicator__linear-bar-transition {
   transition: transform 0.2s linear;
 }
-.dnb-progress-indicator__linear__bar1-animation {
+.dnb-progress-indicator__linear-bar1-animation {
   width: auto;
   animation: progress-indicator-linear-bar-1 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
 }
-.dnb-progress-indicator__linear__bar2-animation {
+.dnb-progress-indicator__linear-bar2-animation {
   width: auto;
   animation: progress-indicator-linear-bar-2 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) 1.15s infinite;
 }
-html[data-visual-test] .dnb-progress-indicator__linear__bar1-animation {
+html[data-visual-test] .dnb-progress-indicator__linear-bar1-animation {
   left: -35%;
   right: 100%;
   animation-duration: 0ms;
   animation-iteration-count: 0;
 }
-html[data-visual-test] .dnb-progress-indicator__linear__bar2-animation {
+html[data-visual-test] .dnb-progress-indicator__linear-bar2-animation {
   left: -200%;
   right: 100%;
   animation-duration: 0ms;

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -523,11 +523,11 @@ button.dnb-button::-moz-focus-inner {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -251,28 +251,28 @@ function StepIndicatorItem({
     >
       <div
         className={classnames(
-          'dnb-step-indicator__item__wrapper',
+          'dnb-step-indicator__item-wrapper',
           !status &&
             isVisited &&
-            'dnb-step-indicator__item__wrapper--check'
+            'dnb-step-indicator__item-wrapper--check'
         )}
       >
         <span
           className={classnames(
-            'dnb-step-indicator__item__bullet',
+            'dnb-step-indicator__item-bullet',
             isCurrent
-              ? 'dnb-step-indicator__item__bullet--current'
+              ? 'dnb-step-indicator__item-bullet--current'
               : !status &&
                   (isVisited
-                    ? 'dnb-step-indicator__item__bullet--check'
-                    : 'dnb-step-indicator__item__bullet--empty'),
+                    ? 'dnb-step-indicator__item-bullet--check'
+                    : 'dnb-step-indicator__item-bullet--empty'),
             createSkeletonClass('shape', skeleton)
           )}
         >
           {status && !isCurrent ? (
             <Icon
               icon={stateIcons[status_state] || stateIcons.warn}
-              className="dnb-step-indicator__item__icon"
+              className="dnb-step-indicator__item-icon"
               size="medium"
               inheritColor={false}
             />
@@ -280,8 +280,8 @@ function StepIndicatorItem({
             <IconPrimary
               icon="check"
               className={classnames(
-                'dnb-step-indicator__item__icon',
-                !isVisited && 'dnb-step-indicator__item__icon--hidden'
+                'dnb-step-indicator__item-icon',
+                !isVisited && 'dnb-step-indicator__item-icon--hidden'
               )}
               size="auto"
             />
@@ -295,20 +295,20 @@ function StepIndicatorItem({
         >
           {!hide_numbers && (
             <span
-              className="dnb-step-indicator__item-content__number"
+              className="dnb-step-indicator__item-content-number"
               aria-hidden
             >
               {`${currentItemNum + 1}.`}
             </span>
           )}
-          <div className="dnb-step-indicator__item-content__wrapper">
+          <div className="dnb-step-indicator__item-content-wrapper">
             <StepItemButton {...buttonParams}>{element}</StepItemButton>
             <FormStatus
               shellSpace={{ top: '1rem' }}
               no_animation={no_animation}
               state={status && status_state}
               variant="outlined"
-              className="dnb-step-indicator__item-content__status"
+              className="dnb-step-indicator__item-content-status"
               text={status}
             />
           </div>

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -252,9 +252,7 @@ function StepIndicatorItem({
       <div
         className={classnames(
           'dnb-step-indicator__item-wrapper',
-          !status &&
-            isVisited &&
-            'dnb-step-indicator__item-wrapper--check'
+          !status && isVisited && 'dnb-step-indicator__item-wrapper--check'
         )}
       >
         <span

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -63,8 +63,8 @@ function StepIndicatorTriggerButton({
   const buttonParams = {
     ...rest,
     className: classnames(
-      'dnb-step-indicator__trigger__button',
-      `dnb-step-indicator__trigger__button--${
+      'dnb-step-indicator__trigger-button',
+      `dnb-step-indicator__trigger-button--${
         openState ? 'expanded' : 'collapsed'
       }`,
       className

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.screenshot.test.ts
@@ -23,7 +23,7 @@ describe.each(['ui', 'sbanken'])('StepIndicator for %s', (themeName) => {
       selector: '[data-visual-test="step-indicator-statuses"]',
       simulate: 'click',
       simulateSelector:
-        '[data-visual-test="step-indicator-statuses"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="step-indicator-statuses"] .dnb-step-indicator__trigger-button',
       recalculateHeightAfterSimulate: true,
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -41,7 +41,7 @@ describe.each(['ui', 'sbanken'])('StepIndicator for %s', (themeName) => {
       selector: '[data-visual-test="step-indicator-loose"]',
       simulate: 'click',
       simulateSelector:
-        '[data-visual-test="step-indicator-loose"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="step-indicator-loose"] .dnb-step-indicator__trigger-button',
       recalculateHeightAfterSimulate: true,
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -67,7 +67,7 @@ describe.each(['ui', 'sbanken'])('StepIndicator for %s', (themeName) => {
       selector: '[data-visual-test="step-indicator-strict"]',
       simulate: 'click',
       simulateSelector:
-        '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger-button',
       recalculateHeightAfterSimulate: true,
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -92,7 +92,7 @@ describe.each(['ui', 'sbanken'])('StepIndicator for %s', (themeName) => {
     const screenshot = await makeScreenshot({
       selector: '[data-visual-test="step-indicator-static"]',
       simulateSelector:
-        '[data-visual-test="step-indicator-static"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="step-indicator-static"] .dnb-step-indicator__trigger-button',
       simulate: 'click',
       recalculateHeightAfterSimulate: true,
     })
@@ -136,7 +136,7 @@ describe.each(['ui', 'sbanken'])('StepIndicator for %s', (themeName) => {
     const screenshot = await makeScreenshot({
       selector: '[data-visual-test="step-indicator-strict"]',
       simulateSelector:
-        '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger-button',
       simulate: 'click',
       recalculateHeightAfterSimulate: true,
     })
@@ -161,7 +161,7 @@ describe('deprecated', () => {
         selector: '[data-visual-test="step-indicator-statuses"]',
         simulate: 'click',
         simulateSelector:
-          '[data-visual-test="step-indicator-statuses"] .dnb-step-indicator__trigger__button',
+          '[data-visual-test="step-indicator-statuses"] .dnb-step-indicator__trigger-button',
         recalculateHeightAfterSimulate: true,
       })
       expect(screenshot).toMatchImageSnapshot()
@@ -172,7 +172,7 @@ describe('deprecated', () => {
         selector: '[data-visual-test="step-indicator-loose"]',
         simulate: 'click',
         simulateSelector:
-          '[data-visual-test="step-indicator-loose"] .dnb-step-indicator__trigger__button',
+          '[data-visual-test="step-indicator-loose"] .dnb-step-indicator__trigger-button',
         recalculateHeightAfterSimulate: true,
       })
       expect(screenshot).toMatchImageSnapshot()
@@ -198,7 +198,7 @@ describe('deprecated', () => {
         selector: '[data-visual-test="step-indicator-strict"]',
         simulate: 'click',
         simulateSelector:
-          '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger__button',
+          '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger-button',
         recalculateHeightAfterSimulate: true,
       })
       expect(screenshot).toMatchImageSnapshot()
@@ -223,7 +223,7 @@ describe('deprecated', () => {
       const screenshot = await makeScreenshot({
         selector: '[data-visual-test="step-indicator-static"]',
         simulateSelector:
-          '[data-visual-test="step-indicator-static"] .dnb-step-indicator__trigger__button',
+          '[data-visual-test="step-indicator-static"] .dnb-step-indicator__trigger-button',
         simulate: 'click',
         recalculateHeightAfterSimulate: true,
       })
@@ -260,7 +260,7 @@ describe('deprecated', () => {
       const screenshot = await makeScreenshot({
         selector: '[data-visual-test="step-indicator-strict"]',
         simulateSelector:
-          '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger__button',
+          '[data-visual-test="step-indicator-strict"] .dnb-step-indicator__trigger-button',
         simulate: 'click',
         recalculateHeightAfterSimulate: true,
       })

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -296,7 +296,7 @@ describe('StepIndicator redesign', () => {
         .textContent
     ).toEqual('1.Step A')
     expect(
-      document.querySelector('.dnb-step-indicator__item-content__number')
+      document.querySelector('.dnb-step-indicator__item-content-number')
     ).toHaveAttribute('aria-hidden')
   })
 
@@ -852,7 +852,7 @@ describe('StepIndicator ARIA', () => {
 
     // Check that the step number has aria-hidden (when numbers are shown)
     const stepNumber = firstStepItem.querySelector(
-      '.dnb-step-indicator__item-content__number'
+      '.dnb-step-indicator__item-content-number'
     )
     expect(stepNumber).toBeInTheDocument()
     expect(stepNumber).toHaveAttribute('aria-hidden')

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -262,21 +262,21 @@ describe('StepIndicator redesign', () => {
     )
     expect(
       document
-        .querySelector('.dnb-step-indicator__trigger__button')
+        .querySelector('.dnb-step-indicator__trigger-button')
         .attributes.getNamedItem('aria-expanded').value
     ).toBe('true')
 
     act(() => {
       document
         .querySelector<HTMLButtonElement>(
-          'button.dnb-step-indicator__trigger__button--expanded'
+          'button.dnb-step-indicator__trigger-button--expanded'
         )
         ?.click()
     })
 
     expect(
       document
-        .querySelector('.dnb-step-indicator__trigger__button')
+        .querySelector('.dnb-step-indicator__trigger-button')
         .attributes.getNamedItem('aria-expanded').value
     ).toBe('false')
   })
@@ -325,8 +325,8 @@ describe('StepIndicator redesign', () => {
     )
 
     expect(
-      document.querySelector('button.dnb-step-indicator__trigger__button')
-    ).toHaveClass('dnb-step-indicator__trigger__button--collapsed')
+      document.querySelector('button.dnb-step-indicator__trigger-button')
+    ).toHaveClass('dnb-step-indicator__trigger-button--collapsed')
     expect(
       document.querySelectorAll('li.dnb-step-indicator__item')
     ).toHaveLength(0)
@@ -334,14 +334,14 @@ describe('StepIndicator redesign', () => {
     act(() => {
       document
         .querySelector<HTMLButtonElement>(
-          'button.dnb-step-indicator__trigger__button--collapsed'
+          'button.dnb-step-indicator__trigger-button--collapsed'
         )
         ?.click()
     })
 
     expect(
-      document.querySelector('button.dnb-step-indicator__trigger__button')
-    ).toHaveClass('dnb-step-indicator__trigger__button--expanded')
+      document.querySelector('button.dnb-step-indicator__trigger-button')
+    ).toHaveClass('dnb-step-indicator__trigger-button--expanded')
 
     expect(
       document.querySelectorAll('li.dnb-step-indicator__item')
@@ -603,7 +603,7 @@ describe('StepIndicator in loose mode', () => {
       document.querySelector('label.dnb-step-indicator__label').textContent
     ).toContain('Steg 2 av 4:')
     expect(
-      document.querySelector('button.dnb-step-indicator__trigger__button')
+      document.querySelector('button.dnb-step-indicator__trigger-button')
         .textContent
     ).toContain('Step B')
 
@@ -621,7 +621,7 @@ describe('StepIndicator in loose mode', () => {
       document.querySelector('label.dnb-step-indicator__label').textContent
     ).toContain('Steg 2 av 4:')
     expect(
-      document.querySelector('button.dnb-step-indicator__trigger__button')
+      document.querySelector('button.dnb-step-indicator__trigger-button')
         .textContent
     ).toContain('Step B')
   })
@@ -868,7 +868,7 @@ describe('StepIndicator ARIA', () => {
 
     // Find the trigger button
     const triggerButton = document.querySelector(
-      '.dnb-step-indicator__trigger__button'
+      '.dnb-step-indicator__trigger-button'
     )
     expect(triggerButton).toBeInTheDocument()
 

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -517,18 +517,18 @@ button.dnb-button::-moz-focus-inner {
   flex-wrap: wrap;
   align-items: flex-start;
 }
-.dnb-step-indicator__trigger__button {
+.dnb-step-indicator__trigger-button {
   --button-height: 1.5rem;
 }
-.dnb-step-indicator__trigger__button .dnb-button__text {
+.dnb-step-indicator__trigger-button .dnb-button__text {
   margin: 0;
   transform: none;
 }
-.dnb-step-indicator__trigger__button .dnb-button__icon {
+.dnb-step-indicator__trigger-button .dnb-button__icon {
   --button-icon-margin-top: 0.25rem;
   transition: transform 400ms var(--easing-default);
 }
-.dnb-step-indicator__trigger__button--expanded .dnb-button__icon {
+.dnb-step-indicator__trigger-button--expanded .dnb-button__icon {
   transform: rotate(180deg);
 }
 .dnb-step-indicator__item__wrapper {

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -154,11 +154,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -531,13 +531,13 @@ button.dnb-button::-moz-focus-inner {
 .dnb-step-indicator__trigger-button--expanded .dnb-button__icon {
   transform: rotate(180deg);
 }
-.dnb-step-indicator__item__wrapper {
+.dnb-step-indicator__item-wrapper {
   display: flex;
   gap: 1rem;
   padding-bottom: 1rem;
   position: relative;
 }
-.dnb-step-indicator__item__wrapper::before {
+.dnb-step-indicator__item-wrapper::before {
   content: "";
   display: block;
   position: absolute;
@@ -547,7 +547,7 @@ button.dnb-button::-moz-focus-inner {
   height: 100%;
   background-color: var(--color-black-20);
 }
-.dnb-step-indicator__item__bullet {
+.dnb-step-indicator__item-bullet {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -557,55 +557,55 @@ button.dnb-button::-moz-focus-inner {
   z-index: 0;
   border-radius: 50%;
 }
-.dnb-step-indicator__item__bullet--check, .dnb-step-indicator__item__bullet--empty, .dnb-step-indicator__item__bullet--current {
+.dnb-step-indicator__item-bullet--check, .dnb-step-indicator__item-bullet--empty, .dnb-step-indicator__item-bullet--current {
   background-color: var(--step-indicator-check-bg);
   border-width: 0.0625rem;
   border-style: solid;
   border-color: transparent;
 }
-.dnb-step-indicator__item__bullet--check {
+.dnb-step-indicator__item-bullet--check {
   font-size: 0.875rem;
   color: var(--step-indicator-check-color);
   border-color: var(--step-indicator-check-color);
 }
-.dnb-step-indicator__item__bullet--empty {
+.dnb-step-indicator__item-bullet--empty {
   color: var(--color-black-20);
   background-color: var(--color-white);
   border-color: var(--color-black-20);
 }
-.dnb-step-indicator__item__bullet--current {
+.dnb-step-indicator__item-bullet--current {
   border-width: 0.1875rem;
   border-color: var(--step-indicator-current-border);
 }
-.dnb-step-indicator__item__bullet.dnb-skeleton {
+.dnb-step-indicator__item-bullet.dnb-skeleton {
   border-width: 0.0625rem;
   border-color: var(--color-black-20);
 }
 .dnb-step-indicator__item-content {
   display: flex;
 }
-.dnb-step-indicator__item-content__number {
+.dnb-step-indicator__item-content-number {
   font-size: var(--font-size-basis);
   white-space: nowrap;
   margin-right: 0.5rem;
 }
-.dnb-step-indicator__item-content__wrapper {
+.dnb-step-indicator__item-content-wrapper {
   font-size: var(--font-size-basis);
   display: flex;
   flex-direction: column;
 }
-.dnb-step-indicator__item__icon {
+.dnb-step-indicator__item-icon {
   opacity: 1;
   transition: opacity 400ms ease-in-out;
 }
-.dnb-step-indicator__item__icon--hidden {
+.dnb-step-indicator__item-icon--hidden {
   opacity: 0;
   transition-timing-function: ease-out;
 }
-.dnb-step-indicator__item:last-child .dnb-step-indicator__item__wrapper::before {
+.dnb-step-indicator__item:last-child .dnb-step-indicator__item-wrapper::before {
   display: none;
 }
-html[data-visual-test] .dnb-step-indicator__item__icon {
+html[data-visual-test] .dnb-step-indicator__item-icon {
   transition-duration: 1ms !important;
 }
 .dnb-step-indicator__button {

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -531,13 +531,13 @@ button.dnb-button::-moz-focus-inner {
 .dnb-step-indicator__trigger-button--expanded .dnb-button__icon {
   transform: rotate(180deg);
 }
-.dnb-step-indicator__item-wrapper {
+.dnb-step-indicator__item__wrapper {
   display: flex;
   gap: 1rem;
   padding-bottom: 1rem;
   position: relative;
 }
-.dnb-step-indicator__item-wrapper::before {
+.dnb-step-indicator__item__wrapper::before {
   content: "";
   display: block;
   position: absolute;
@@ -547,7 +547,7 @@ button.dnb-button::-moz-focus-inner {
   height: 100%;
   background-color: var(--color-black-20);
 }
-.dnb-step-indicator__item-bullet {
+.dnb-step-indicator__item__bullet {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -557,55 +557,55 @@ button.dnb-button::-moz-focus-inner {
   z-index: 0;
   border-radius: 50%;
 }
-.dnb-step-indicator__item-bullet--check, .dnb-step-indicator__item-bullet--empty, .dnb-step-indicator__item-bullet--current {
+.dnb-step-indicator__item__bullet--check, .dnb-step-indicator__item__bullet--empty, .dnb-step-indicator__item__bullet--current {
   background-color: var(--step-indicator-check-bg);
   border-width: 0.0625rem;
   border-style: solid;
   border-color: transparent;
 }
-.dnb-step-indicator__item-bullet--check {
+.dnb-step-indicator__item__bullet--check {
   font-size: 0.875rem;
   color: var(--step-indicator-check-color);
   border-color: var(--step-indicator-check-color);
 }
-.dnb-step-indicator__item-bullet--empty {
+.dnb-step-indicator__item__bullet--empty {
   color: var(--color-black-20);
   background-color: var(--color-white);
   border-color: var(--color-black-20);
 }
-.dnb-step-indicator__item-bullet--current {
+.dnb-step-indicator__item__bullet--current {
   border-width: 0.1875rem;
   border-color: var(--step-indicator-current-border);
 }
-.dnb-step-indicator__item-bullet.dnb-skeleton {
+.dnb-step-indicator__item__bullet.dnb-skeleton {
   border-width: 0.0625rem;
   border-color: var(--color-black-20);
 }
 .dnb-step-indicator__item-content {
   display: flex;
 }
-.dnb-step-indicator__item-content-number {
+.dnb-step-indicator__item-content__number {
   font-size: var(--font-size-basis);
   white-space: nowrap;
   margin-right: 0.5rem;
 }
-.dnb-step-indicator__item-content-wrapper {
+.dnb-step-indicator__item-content__wrapper {
   font-size: var(--font-size-basis);
   display: flex;
   flex-direction: column;
 }
-.dnb-step-indicator__item-icon {
+.dnb-step-indicator__item__icon {
   opacity: 1;
   transition: opacity 400ms ease-in-out;
 }
-.dnb-step-indicator__item-icon--hidden {
+.dnb-step-indicator__item__icon--hidden {
   opacity: 0;
   transition-timing-function: ease-out;
 }
-.dnb-step-indicator__item:last-child .dnb-step-indicator__item-wrapper::before {
+.dnb-step-indicator__item:last-child .dnb-step-indicator__item__wrapper::before {
   display: none;
 }
-html[data-visual-test] .dnb-step-indicator__item-icon {
+html[data-visual-test] .dnb-step-indicator__item__icon {
   transition-duration: 1ms !important;
 }
 .dnb-step-indicator__button {

--- a/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
@@ -32,7 +32,7 @@
     align-items: flex-start;
   }
 
-  &__trigger__button {
+  &__trigger-button {
     --button-height: 1.5rem;
     .dnb-button__text {
       margin: 0;

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -398,7 +398,7 @@ export default function Switch(props: SwitchProps) {
                 aria-hidden
               >
                 <span className="dnb-switch__focus">
-                  <span className="dnb-switch__focus__inner" />
+                  <span className="dnb-switch__focus-inner" />
                 </span>
               </span>
             </span>

--- a/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableClickableHead.tsx
@@ -150,7 +150,7 @@ export function TableClickableButtonTd(props: {
 
   return (
     <Td
-      className="dnb-table__td__button-icon"
+      className="dnb-table__td-button-icon"
       onClick={() => {
         // Empty the selected text, so that the user can always expand/close accordion.
         // The selected text is not automatically cleared because we have
@@ -179,7 +179,7 @@ export function TableIconSrTh(props: { text: string }) {
   const { text } = props
 
   return (
-    <Th aria-hidden className="dnb-table__th__button-icon">
+    <Th aria-hidden className="dnb-table__th-button-icon">
       <div>{text}</div>
     </Th>
   )

--- a/packages/dnb-eufemia/src/components/table/TableContainer.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableContainer.tsx
@@ -80,7 +80,7 @@ export function TableContainerBody(
 
   return (
     <div
-      className={classnames('dnb-table__container__body', className)}
+      className={classnames('dnb-table__container-body', className)}
       {...rest}
     >
       {children}
@@ -103,8 +103,8 @@ export function TableContainerHead(
   return (
     <div
       className={classnames(
-        'dnb-table__container__head',
-        !children && 'dnb-table__container__head--empty',
+        'dnb-table__container-head',
+        !children && 'dnb-table__container-head--empty',
         className
       )}
       {...rest}
@@ -129,8 +129,8 @@ export function TableContainerFoot(
   return (
     <div
       className={classnames(
-        'dnb-table__container__foot',
-        !children && 'dnb-table__container__foot--empty',
+        'dnb-table__container-foot',
+        !children && 'dnb-table__container-foot--empty',
         className
       )}
       {...rest}

--- a/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
@@ -62,7 +62,7 @@ export const useStickyHeader = ({
               offsetTopPx =
                 (
                   modalElem.querySelector(
-                    '.dnb-modal__header__bar'
+                    '.dnb-modal__header-bar'
                   ) as HTMLElement
                 ).offsetHeight || 0
             }

--- a/packages/dnb-eufemia/src/components/table/TableTh.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTh.tsx
@@ -91,7 +91,7 @@ function Horizontal({
   return (
     <div
       {...rest}
-      className={classnames('dnb-table__th__horizontal', className)}
+      className={classnames('dnb-table__th-horizontal', className)}
     />
   )
 }

--- a/packages/dnb-eufemia/src/components/table/__tests__/Table.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/table/__tests__/Table.screenshot.test.ts
@@ -481,7 +481,7 @@ describe.each(['ui', 'sbanken'])(
           {
             action: 'click',
             selector:
-              '[data-visual-test="table-inside-of-accordion-table"] .dnb-table__td__button-icon',
+              '[data-visual-test="table-inside-of-accordion-table"] .dnb-table__td-button-icon',
           },
         ],
         recalculateHeightAfterSimulate: true,

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -481,10 +481,10 @@ describe('TableAccordion', () => {
     }
 
     expect(Array.from(getTh(0).classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
     expect(Array.from(getTd(0).classList)).toContain(
-      'dnb-table__td__button-icon'
+      'dnb-table__td-button-icon'
     )
 
     rerender(
@@ -504,10 +504,10 @@ describe('TableAccordion', () => {
     )
 
     expect(Array.from(getTh(-1).classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
     expect(Array.from(getTd(-1).classList)).toContain(
-      'dnb-table__td__button-icon'
+      'dnb-table__td-button-icon'
     )
   })
 
@@ -524,7 +524,7 @@ describe('TableAccordion', () => {
 
     const trElement = document.querySelector('thead tr th')
     expect(Array.from(trElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     const divElement = trElement.querySelector('div')
@@ -544,7 +544,7 @@ describe('TableAccordion', () => {
 
     const thElement = document.querySelector('thead tr th')
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)
@@ -567,7 +567,7 @@ describe('TableAccordion', () => {
 
     const thElement = document.querySelector('thead tr th')
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)
@@ -1445,10 +1445,10 @@ describe('TableAccordion', () => {
       }
 
       expect(Array.from(getTh(0).classList)).toContain(
-        'dnb-table__th__button-icon'
+        'dnb-table__th-button-icon'
       )
       expect(Array.from(getTd(0).classList)).toContain(
-        'dnb-table__td__button-icon'
+        'dnb-table__td-button-icon'
       )
 
       rerender(
@@ -1468,10 +1468,10 @@ describe('TableAccordion', () => {
       )
 
       expect(Array.from(getTh(-1).classList)).toContain(
-        'dnb-table__th__button-icon'
+        'dnb-table__th-button-icon'
       )
       expect(Array.from(getTd(-1).classList)).toContain(
-        'dnb-table__td__button-icon'
+        'dnb-table__td-button-icon'
       )
     })
 
@@ -1488,7 +1488,7 @@ describe('TableAccordion', () => {
 
       const trElement = document.querySelector('thead tr th')
       expect(Array.from(trElement.classList)).toContain(
-        'dnb-table__th__button-icon'
+        'dnb-table__th-button-icon'
       )
 
       const divElement = trElement.querySelector('div')
@@ -1508,7 +1508,7 @@ describe('TableAccordion', () => {
 
       const thElement = document.querySelector('thead tr th')
       expect(Array.from(thElement.classList)).toContain(
-        'dnb-table__th__button-icon'
+        'dnb-table__th-button-icon'
       )
 
       expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)
@@ -1531,7 +1531,7 @@ describe('TableAccordion', () => {
 
       const thElement = document.querySelector('thead tr th')
       expect(Array.from(thElement.classList)).toContain(
-        'dnb-table__th__button-icon'
+        'dnb-table__th-button-icon'
       )
 
       expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -1159,9 +1159,7 @@ describe('TableAccordion', () => {
       const element = accordionElem.querySelector('td')
 
       expect(
-        element.querySelector(
-          'div.dnb-table__tr-accordion-content-inner'
-        )
+        element.querySelector('div.dnb-table__tr-accordion-content-inner')
       ).toBeInTheDocument()
       expect(
         element.querySelector(

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -76,8 +76,8 @@ describe('TableAccordion', () => {
     expect(element.getAttribute('aria-hidden')).toBe('true')
     expect(element.getAttribute('hidden')).toBe('')
     expect(Array.from(element.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
     ])
   })
 
@@ -104,11 +104,11 @@ describe('TableAccordion', () => {
     expect(accordionElem.getAttribute('aria-hidden')).toBe('false')
     expect(accordionElem.getAttribute('role')).toBe('row')
     expect(Array.from(accordionElem.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
       'dnb-table__tr',
-      'dnb-table__tr__accordion-content--expanded',
-      'dnb-table__tr__accordion-content--parallax',
+      'dnb-table__tr-accordion-content--expanded',
+      'dnb-table__tr-accordion-content--parallax',
     ])
   })
 
@@ -205,11 +205,11 @@ describe('TableAccordion', () => {
     const element = accordionElem.querySelector('td')
 
     expect(
-      element.querySelector('div.dnb-table__tr__accordion-content__inner')
+      element.querySelector('div.dnb-table__tr-accordion-content-inner')
     ).toBeInTheDocument()
     expect(
       element.querySelector(
-        'div.dnb-table__tr__accordion-content__inner__spacing'
+        'div.dnb-table__tr-accordion-content-inner-spacing'
       )
     ).toBeInTheDocument()
   })
@@ -292,8 +292,8 @@ describe('TableAccordion', () => {
     const accordionElem = trElement.nextSibling as HTMLTableRowElement
 
     expect(Array.from(accordionElem.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
     ])
 
     fireEvent.click(trElement)
@@ -302,7 +302,7 @@ describe('TableAccordion', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -639,7 +639,7 @@ describe('TableAccordion', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
 
     // close
@@ -654,7 +654,7 @@ describe('TableAccordion', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).not.toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -733,7 +733,7 @@ describe('TableAccordion', () => {
 
     const accordionElem1 = trElement1.nextSibling as HTMLTableRowElement
     expect(Array.from(accordionElem1.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
 
     const trElement2 = document.querySelectorAll('tr')[1]
@@ -743,7 +743,7 @@ describe('TableAccordion', () => {
 
     const accordionElem2 = trElement2.nextSibling as HTMLTableRowElement
     expect(Array.from(accordionElem2.classList)).not.toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -931,7 +931,7 @@ describe('TableAccordion', () => {
         'tr.dnb-table__tr--clickable'
       )
       const accordionElems = document.querySelectorAll(
-        'tr.dnb-table__tr__accordion-content'
+        'tr.dnb-table__tr-accordion-content'
       )
 
       // Assert all are expanded
@@ -942,10 +942,10 @@ describe('TableAccordion', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElems[0].classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
       expect(Array.from(accordionElems[1].classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
 
       act(() => {
@@ -960,10 +960,10 @@ describe('TableAccordion', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElems[0].classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
       expect(Array.from(accordionElems[1].classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
     })
   })
@@ -1030,8 +1030,8 @@ describe('TableAccordion', () => {
       expect(element.getAttribute('aria-hidden')).toBe('true')
       expect(element.getAttribute('hidden')).toBe('')
       expect(Array.from(element.classList)).toEqual([
-        'dnb-table__tr__accordion-content',
-        'dnb-table__tr__accordion-content--single',
+        'dnb-table__tr-accordion-content',
+        'dnb-table__tr-accordion-content--single',
       ])
     })
 
@@ -1058,11 +1058,11 @@ describe('TableAccordion', () => {
       expect(accordionElem.getAttribute('aria-hidden')).toBe('false')
       expect(accordionElem.getAttribute('role')).toBe('row')
       expect(Array.from(accordionElem.classList)).toEqual([
-        'dnb-table__tr__accordion-content',
-        'dnb-table__tr__accordion-content--single',
+        'dnb-table__tr-accordion-content',
+        'dnb-table__tr-accordion-content--single',
         'dnb-table__tr',
-        'dnb-table__tr__accordion-content--expanded',
-        'dnb-table__tr__accordion-content--parallax',
+        'dnb-table__tr-accordion-content--expanded',
+        'dnb-table__tr-accordion-content--parallax',
       ])
     })
 
@@ -1160,12 +1160,12 @@ describe('TableAccordion', () => {
 
       expect(
         element.querySelector(
-          'div.dnb-table__tr__accordion-content__inner'
+          'div.dnb-table__tr-accordion-content-inner'
         )
       ).toBeInTheDocument()
       expect(
         element.querySelector(
-          'div.dnb-table__tr__accordion-content__inner__spacing'
+          'div.dnb-table__tr-accordion-content-inner-spacing'
         )
       ).toBeInTheDocument()
     })
@@ -1248,8 +1248,8 @@ describe('TableAccordion', () => {
       const accordionElem = trElement.nextSibling as HTMLTableRowElement
 
       expect(Array.from(accordionElem.classList)).toEqual([
-        'dnb-table__tr__accordion-content',
-        'dnb-table__tr__accordion-content--single',
+        'dnb-table__tr-accordion-content',
+        'dnb-table__tr-accordion-content--single',
       ])
 
       fireEvent.click(trElement)
@@ -1258,7 +1258,7 @@ describe('TableAccordion', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElem.classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
     })
 
@@ -1605,7 +1605,7 @@ describe('TableAccordion', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElem.classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
 
       // close
@@ -1620,7 +1620,7 @@ describe('TableAccordion', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElem.classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
     })
 
@@ -1703,7 +1703,7 @@ describe('TableAccordion', () => {
 
       const accordionElem1 = trElement1.nextSibling as HTMLTableRowElement
       expect(Array.from(accordionElem1.classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
 
       const trElement2 = document.querySelectorAll('tr')[1]
@@ -1713,7 +1713,7 @@ describe('TableAccordion', () => {
 
       const accordionElem2 = trElement2.nextSibling as HTMLTableRowElement
       expect(Array.from(accordionElem2.classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
     })
 
@@ -1834,7 +1834,7 @@ describe('TableAccordion', () => {
           'tr.dnb-table__tr--clickable'
         )
         const accordionElems = document.querySelectorAll(
-          'tr.dnb-table__tr__accordion-content'
+          'tr.dnb-table__tr-accordion-content'
         )
 
         // Assert all are expanded
@@ -1845,10 +1845,10 @@ describe('TableAccordion', () => {
           'dnb-table__tr--expanded'
         )
         expect(Array.from(accordionElems[0].classList)).toContain(
-          'dnb-table__tr__accordion-content--expanded'
+          'dnb-table__tr-accordion-content--expanded'
         )
         expect(Array.from(accordionElems[1].classList)).toContain(
-          'dnb-table__tr__accordion-content--expanded'
+          'dnb-table__tr-accordion-content--expanded'
         )
 
         act(() => {
@@ -1863,10 +1863,10 @@ describe('TableAccordion', () => {
           'dnb-table__tr--expanded'
         )
         expect(Array.from(accordionElems[0].classList)).not.toContain(
-          'dnb-table__tr__accordion-content--expanded'
+          'dnb-table__tr-accordion-content--expanded'
         )
         expect(Array.from(accordionElems[1].classList)).not.toContain(
-          'dnb-table__tr__accordion-content--expanded'
+          'dnb-table__tr-accordion-content--expanded'
         )
       })
     })

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
@@ -75,8 +75,8 @@ describe('Table using mode="accordion" prop', () => {
     expect(element.getAttribute('aria-hidden')).toBe('true')
     expect(element.getAttribute('hidden')).toBe('')
     expect(Array.from(element.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
     ])
   })
 
@@ -103,11 +103,11 @@ describe('Table using mode="accordion" prop', () => {
     expect(accordionElem.getAttribute('aria-hidden')).toBe('false')
     expect(accordionElem.getAttribute('role')).toBe('row')
     expect(Array.from(accordionElem.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
       'dnb-table__tr',
-      'dnb-table__tr__accordion-content--expanded',
-      'dnb-table__tr__accordion-content--parallax',
+      'dnb-table__tr-accordion-content--expanded',
+      'dnb-table__tr-accordion-content--parallax',
     ])
   })
 
@@ -204,11 +204,11 @@ describe('Table using mode="accordion" prop', () => {
     const element = accordionElem.querySelector('td')
 
     expect(
-      element.querySelector('div.dnb-table__tr__accordion-content__inner')
+      element.querySelector('div.dnb-table__tr-accordion-content-inner')
     ).toBeInTheDocument()
     expect(
       element.querySelector(
-        'div.dnb-table__tr__accordion-content__inner__spacing'
+        'div.dnb-table__tr-accordion-content-inner-spacing'
       )
     ).toBeInTheDocument()
   })
@@ -291,8 +291,8 @@ describe('Table using mode="accordion" prop', () => {
     const accordionElem = trElement.nextSibling as HTMLTableRowElement
 
     expect(Array.from(accordionElem.classList)).toEqual([
-      'dnb-table__tr__accordion-content',
-      'dnb-table__tr__accordion-content--single',
+      'dnb-table__tr-accordion-content',
+      'dnb-table__tr-accordion-content--single',
     ])
 
     fireEvent.click(trElement)
@@ -301,7 +301,7 @@ describe('Table using mode="accordion" prop', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -744,7 +744,7 @@ describe('Table using mode="accordion" prop', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
 
     // close
@@ -759,7 +759,7 @@ describe('Table using mode="accordion" prop', () => {
       'dnb-table__tr--expanded'
     )
     expect(Array.from(accordionElem.classList)).not.toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -838,7 +838,7 @@ describe('Table using mode="accordion" prop', () => {
 
     const accordionElem1 = trElement1.nextSibling as HTMLTableRowElement
     expect(Array.from(accordionElem1.classList)).toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
 
     const trElement2 = document.querySelectorAll('tr')[1]
@@ -848,7 +848,7 @@ describe('Table using mode="accordion" prop', () => {
 
     const accordionElem2 = trElement2.nextSibling as HTMLTableRowElement
     expect(Array.from(accordionElem2.classList)).not.toContain(
-      'dnb-table__tr__accordion-content--expanded'
+      'dnb-table__tr-accordion-content--expanded'
     )
   })
 
@@ -966,7 +966,7 @@ describe('Table using mode="accordion" prop', () => {
         'tr.dnb-table__tr--clickable'
       )
       const accordionElems = document.querySelectorAll(
-        'tr.dnb-table__tr__accordion-content'
+        'tr.dnb-table__tr-accordion-content'
       )
 
       // Assert all are expanded
@@ -977,10 +977,10 @@ describe('Table using mode="accordion" prop', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElems[0].classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
       expect(Array.from(accordionElems[1].classList)).toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
 
       act(() => {
@@ -995,10 +995,10 @@ describe('Table using mode="accordion" prop', () => {
         'dnb-table__tr--expanded'
       )
       expect(Array.from(accordionElems[0].classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
       expect(Array.from(accordionElems[1].classList)).not.toContain(
-        'dnb-table__tr__accordion-content--expanded'
+        'dnb-table__tr-accordion-content--expanded'
       )
     })
   })

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
@@ -586,10 +586,10 @@ describe('Table using mode="accordion" prop', () => {
     }
 
     expect(Array.from(getTh(0).classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
     expect(Array.from(getTd(0).classList)).toContain(
-      'dnb-table__td__button-icon'
+      'dnb-table__td-button-icon'
     )
 
     rerender(
@@ -609,10 +609,10 @@ describe('Table using mode="accordion" prop', () => {
     )
 
     expect(Array.from(getTh(-1).classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
     expect(Array.from(getTd(-1).classList)).toContain(
-      'dnb-table__td__button-icon'
+      'dnb-table__td-button-icon'
     )
   })
 
@@ -629,7 +629,7 @@ describe('Table using mode="accordion" prop', () => {
 
     const trElement = document.querySelector('thead tr th')
     expect(Array.from(trElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     const divElement = trElement.querySelector('div')
@@ -649,7 +649,7 @@ describe('Table using mode="accordion" prop', () => {
 
     const thElement = document.querySelector('thead tr th')
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)
@@ -672,7 +672,7 @@ describe('Table using mode="accordion" prop', () => {
 
     const thElement = document.querySelector('thead tr th')
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.accordionToggleButtonSR)

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableContainer.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableContainer.test.tsx
@@ -43,11 +43,11 @@ describe('TableContainer', () => {
     expect(element.textContent).toBe('HeaderTexttable 1table 2text')
 
     expect(
-      document.querySelector('.dnb-table__container__head--empty')
+      document.querySelector('.dnb-table__container-head--empty')
     ).not.toBeInTheDocument()
 
     expect(
-      document.querySelector('.dnb-table__container__foot--empty')
+      document.querySelector('.dnb-table__container-foot--empty')
     ).not.toBeInTheDocument()
   })
 
@@ -81,7 +81,7 @@ describe('TableContainer', () => {
     render(<TableContainer.Head />)
 
     expect(
-      document.querySelector('.dnb-table__container__head--empty')
+      document.querySelector('.dnb-table__container-head--empty')
     ).toBeInTheDocument()
   })
 
@@ -89,7 +89,7 @@ describe('TableContainer', () => {
     render(<TableContainer.Foot />)
 
     expect(
-      document.querySelector('.dnb-table__container__foot--empty')
+      document.querySelector('.dnb-table__container-foot--empty')
     ).toBeInTheDocument()
   })
 
@@ -109,11 +109,11 @@ describe('TableContainer', () => {
     )
 
     expect(
-      document.querySelector('.dnb-table__container__head--empty')
+      document.querySelector('.dnb-table__container-head--empty')
     ).toBeInTheDocument()
 
     expect(
-      document.querySelector('.dnb-table__container__foot--empty')
+      document.querySelector('.dnb-table__container-foot--empty')
     ).toBeInTheDocument()
   })
 

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableNavigationMode.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableNavigationMode.test.tsx
@@ -203,7 +203,7 @@ describe('Table using mode="navigation" prop', () => {
 
     const trElement = document.querySelectorAll('thead tr th')[1]
     expect(Array.from(trElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     const divElement = trElement.querySelector('div')
@@ -223,7 +223,7 @@ describe('Table using mode="navigation" prop', () => {
 
     const thElement = document.querySelectorAll('thead tr th')[1]
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.navigationButtonSR)
@@ -246,7 +246,7 @@ describe('Table using mode="navigation" prop', () => {
 
     const thElement = document.querySelectorAll('thead tr th')[1]
     expect(Array.from(thElement.classList)).toContain(
-      'dnb-table__th__button-icon'
+      'dnb-table__th-button-icon'
     )
 
     expect(thElement.textContent).toBe(nb.navigationButtonSR)

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
@@ -249,7 +249,7 @@ describe('useStickyHeader', () => {
   it('should use Modal/Drawer .dnb-scroll-view', () => {
     const { rerender } = render(
       <div className="dnb-modal__content">
-        <div className="dnb-modal__header__bar">bar</div>
+        <div className="dnb-modal__header-bar">bar</div>
         <div className="dnb-scroll-view">
           <Table sticky>
             <BasicTable />
@@ -261,7 +261,7 @@ describe('useStickyHeader', () => {
     const tableElement = document.querySelector('table')
     const trElem = document.querySelector('tr')
     const barElem: HTMLElement = document.querySelector(
-      '.dnb-modal__header__bar'
+      '.dnb-modal__header-bar'
     )
     const scrollElem: HTMLElement =
       document.querySelector('.dnb-scroll-view')
@@ -308,7 +308,7 @@ describe('useStickyHeader', () => {
 
     rerender(
       <div className="dnb-modal__content">
-        <div className="dnb-modal__header__bar">bar</div>
+        <div className="dnb-modal__header-bar">bar</div>
         <div className="dnb-scroll-view">
           <Table sticky stickyOffset="4rem">
             <BasicTable />
@@ -327,7 +327,7 @@ describe('useStickyHeader', () => {
 
     rerender(
       <div className="dnb-modal__content">
-        <div className="dnb-modal__header__bar">bar</div>
+        <div className="dnb-modal__header-bar">bar</div>
         <div className="dnb-scroll-view">
           <Table sticky>
             <BasicTable />

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -415,7 +415,7 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
 * Button mixins
 *
 */
-.dnb-table__th__horizontal {
+.dnb-table__th-horizontal {
   display: flex;
   align-items: flex-end;
 }
@@ -622,22 +622,22 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
 .dnb-table__container, .dnb-table__container::after {
   border-radius: var(--table-outline-radius);
 }
-.dnb-table__container, .dnb-table__container__body, .dnb-table__container__head, .dnb-table__container__foot {
+.dnb-table__container, .dnb-table__container-body, .dnb-table__container-head, .dnb-table__container-foot {
   display: flex;
   flex-direction: column;
 }
-.dnb-table__container__body .dnb-table {
+.dnb-table__container-body .dnb-table {
   position: relative;
   /* stylelint-disable */
   /* stylelint-enable */
 }
-.dnb-table__container__body .dnb-table:not([class*=space__bottom]) {
+.dnb-table__container-body .dnb-table:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
-.dnb-table__container__body .dnb-table__size--large .dnb-table__th {
+.dnb-table__container-body .dnb-table__size--large .dnb-table__th {
   padding-top: 1.5rem;
 }
-.dnb-table__container__body .dnb-table::after {
+.dnb-table__container-body .dnb-table::after {
   content: "";
   position: absolute;
   top: 0;
@@ -648,26 +648,26 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   pointer-events: none;
   border-bottom: var(--table-border);
 }
-.dnb-table__container__body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__th::after,
-.dnb-table__container__body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__td::after, .dnb-table__container__body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__th::after,
-.dnb-table__container__body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__td::after {
+.dnb-table__container-body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__th::after,
+.dnb-table__container-body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__td::after, .dnb-table__container-body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__th::after,
+.dnb-table__container-body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__td::after {
   border-top: none;
 }
-.dnb-table__container__head {
+.dnb-table__container-head {
   padding: 2rem 1rem 0;
 }
-.dnb-table__container__head--empty {
+.dnb-table__container-head--empty {
   padding: 0;
   min-height: 1.5rem;
 }
-.dnb-spacing .dnb-table__container__head .dnb-h--large:not([class*=space__top]) {
+.dnb-spacing .dnb-table__container-head .dnb-h--large:not([class*=space__top]) {
   margin: 0;
 }
-.dnb-table__container__foot {
+.dnb-table__container-foot {
   padding: 1rem;
   padding-bottom: 1.25rem;
 }
-.dnb-table__container__foot--empty {
+.dnb-table__container-foot--empty {
   padding: 0;
   min-height: 1rem;
 }
@@ -737,10 +737,10 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
 .dnb-table__tr--clickable.dnb-table__tr--no-animation .dnb-table__button .dnb-icon, html[data-visual-test] .dnb-table__tr--clickable .dnb-table__button .dnb-icon {
   transition: none !important;
 }
-.dnb-table__tr--clickable, .dnb-table__tr__accordion-content {
+.dnb-table__tr--clickable, .dnb-table__tr-accordion-content {
   position: relative;
 }
-.dnb-table__tr--clickable.dnb-table__tr--expanded, .dnb-table__tr__accordion-content {
+.dnb-table__tr--clickable.dnb-table__tr--expanded, .dnb-table__tr-accordion-content {
   z-index: 3;
 }
 .dnb-table__tr--clickable:active, html[data-whatinput=keyboard] .dnb-table__tr--clickable:focus, .dnb-table__tr--clickable:hover:not(.dnb-table__tr--hover.dnb-table__tr--expanded) {
@@ -824,27 +824,27 @@ html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-
 .dnb-table__tr--clickable.dnb-table__tr--disabled .dnb-table__td-button-icon .dnb-icon {
   color: var(--table-accordion-icon-color--disabled);
 }
-.dnb-table__tr__accordion-content__inner {
+.dnb-table__tr-accordion-content-inner {
   overflow: hidden;
   will-change: height;
   transition: height 400ms var(--easing-default);
   position: relative;
 }
-.dnb-table__tr__accordion-content__inner__spacing {
+.dnb-table__tr-accordion-content-inner-spacing {
   padding: 1rem;
   transform: translateY(-10px);
   transition: transform 500ms var(--easing-default);
 }
-.dnb-table__tr__accordion-content--parallax .dnb-table__tr__accordion-content__inner__spacing {
+.dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content-inner-spacing {
   transform: translateY(0);
 }
-html[data-visual-test] .dnb-table__tr__accordion-content--parallax .dnb-table__tr__accordion-content__inner__spacing {
+html[data-visual-test] .dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content-inner-spacing {
   transition: none;
 }
-.dnb-table__tr__accordion-content--expanded > td.dnb-table__td {
+.dnb-table__tr-accordion-content--expanded > td.dnb-table__td {
   background-color: var(--color-white);
 }
-.dnb-table__tr__accordion-content--expanded + .dnb-table__tr--clickable .dnb-table__td::after {
+.dnb-table__tr-accordion-content--expanded + .dnb-table__tr--clickable .dnb-table__td::after {
   content: "";
   position: absolute;
   top: 0;
@@ -855,20 +855,20 @@ html[data-visual-test] .dnb-table__tr__accordion-content--parallax .dnb-table__t
   pointer-events: none;
   border-top: var(--table-accordion-border);
 }
-.dnb-table__tr__accordion-content--expanded + .dnb-table__tr--clickable .dnb-table__td:last-child::after {
+.dnb-table__tr-accordion-content--expanded + .dnb-table__tr--clickable .dnb-table__td:last-child::after {
   right: 0;
 }
-.dnb-table__tr__accordion-content--single > td {
+.dnb-table__tr-accordion-content--single > td {
   padding: 0 !important;
   width: calc(100% - 3.5rem);
 }
-.dnb-table__size--medium .dnb-table__tr__accordion-content--single > td {
+.dnb-table__size--medium .dnb-table__tr-accordion-content--single > td {
   width: calc(100% - 3rem);
 }
-.dnb-table__size--small .dnb-table__tr__accordion-content--single > td {
+.dnb-table__size--small .dnb-table__tr-accordion-content--single > td {
   width: calc(100% - 2.5rem);
 }
-.dnb-table__tr__accordion-content--single > td::before {
+.dnb-table__tr-accordion-content--single > td::before {
   content: "";
   position: absolute;
   top: auto;
@@ -878,20 +878,20 @@ html[data-visual-test] .dnb-table__tr__accordion-content--parallax .dnb-table__t
   pointer-events: none;
   border-bottom: var(--table-accordion-border);
 }
-.dnb-table--outline .dnb-table__tr__accordion-content--single:last-of-type td::before {
+.dnb-table--outline .dnb-table__tr-accordion-content--single:last-of-type td::before {
   border-bottom: none;
 }
-.dnb-table--border .dnb-table__tr__accordion-content--single td::after {
+.dnb-table--border .dnb-table__tr-accordion-content--single td::after {
   border-top: none;
 }
-.dnb-table__tr__accordion-content--single > td.dnb-table__td {
+.dnb-table__tr-accordion-content--single > td.dnb-table__td {
   padding: 0;
 }
-.dnb-table__tr__accordion-content--single > td.dnb-table__td .dnb-dl,
-.dnb-table__tr__accordion-content--single > td.dnb-table__td .dnb-dl dt {
+.dnb-table__tr-accordion-content--single > td.dnb-table__td .dnb-dl,
+.dnb-table__tr-accordion-content--single > td.dnb-table__td .dnb-dl dt {
   margin: 0;
 }
-.dnb-table__tr__accordion-content.dnb-table__tr .dnb-table__td {
+.dnb-table__tr-accordion-content.dnb-table__tr .dnb-table__td {
   background-color: var(--table-accordion-background);
   /**
     * Safari on iOS and macOS has problems on animating when vertical-align is baseline.

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -622,22 +622,22 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
 .dnb-table__container, .dnb-table__container::after {
   border-radius: var(--table-outline-radius);
 }
-.dnb-table__container, .dnb-table__container-body, .dnb-table__container-head, .dnb-table__container-foot {
+.dnb-table__container, .dnb-table__container__body, .dnb-table__container__head, .dnb-table__container__foot {
   display: flex;
   flex-direction: column;
 }
-.dnb-table__container-body .dnb-table {
+.dnb-table__container__body .dnb-table {
   position: relative;
   /* stylelint-disable */
   /* stylelint-enable */
 }
-.dnb-table__container-body .dnb-table:not([class*=space__bottom]) {
+.dnb-table__container__body .dnb-table:not([class*=space__bottom]) {
   margin-bottom: 0;
 }
-.dnb-table__container-body .dnb-table__size--large .dnb-table__th {
+.dnb-table__container__body .dnb-table__size--large .dnb-table__th {
   padding-top: 1.5rem;
 }
-.dnb-table__container-body .dnb-table::after {
+.dnb-table__container__body .dnb-table::after {
   content: "";
   position: absolute;
   top: 0;
@@ -648,26 +648,26 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   pointer-events: none;
   border-bottom: var(--table-border);
 }
-.dnb-table__container-body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__th::after,
-.dnb-table__container-body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__td::after, .dnb-table__container-body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__th::after,
-.dnb-table__container-body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__td::after {
+.dnb-table__container__body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__th::after,
+.dnb-table__container__body .dnb-table tbody:first-child .dnb-table__tr:first-of-type .dnb-table__td::after, .dnb-table__container__body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__th::after,
+.dnb-table__container__body .dnb-table > :not(thead) + tbody .dnb-table__tr:first-of-type .dnb-table__td::after {
   border-top: none;
 }
-.dnb-table__container-head {
+.dnb-table__container__head {
   padding: 2rem 1rem 0;
 }
-.dnb-table__container-head--empty {
+.dnb-table__container__head--empty {
   padding: 0;
   min-height: 1.5rem;
 }
-.dnb-spacing .dnb-table__container-head .dnb-h--large:not([class*=space__top]) {
+.dnb-spacing .dnb-table__container__head .dnb-h--large:not([class*=space__top]) {
   margin: 0;
 }
-.dnb-table__container-foot {
+.dnb-table__container__foot {
   padding: 1rem;
   padding-bottom: 1.25rem;
 }
-.dnb-table__container-foot--empty {
+.dnb-table__container__foot--empty {
   padding: 0;
   min-height: 1rem;
 }
@@ -824,21 +824,21 @@ html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-
 .dnb-table__tr--clickable.dnb-table__tr--disabled .dnb-table__td-button-icon .dnb-icon {
   color: var(--table-accordion-icon-color--disabled);
 }
-.dnb-table__tr-accordion-content-inner {
+.dnb-table__tr-accordion-content__inner {
   overflow: hidden;
   will-change: height;
   transition: height 400ms var(--easing-default);
   position: relative;
 }
-.dnb-table__tr-accordion-content-inner-spacing {
+.dnb-table__tr-accordion-content__inner__spacing {
   padding: 1rem;
   transform: translateY(-10px);
   transition: transform 500ms var(--easing-default);
 }
-.dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content-inner-spacing {
+.dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content__inner__spacing {
   transform: translateY(0);
 }
-html[data-visual-test] .dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content-inner-spacing {
+html[data-visual-test] .dnb-table__tr-accordion-content--parallax .dnb-table__tr-accordion-content__inner__spacing {
   transition: none;
 }
 .dnb-table__tr-accordion-content--expanded > td.dnb-table__td {

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -704,26 +704,26 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   --table-accordion-outline-width: var(--focus-ring-width);
   --table-accordion-outline-background--active: var(--color-pistachio);
 }
-.dnb-table__th.dnb-table__th__button-icon.dnb-table__th {
+.dnb-table__th.dnb-table__th-button-icon.dnb-table__th {
   padding: 0;
 }
-.dnb-table__th.dnb-table__th__button-icon,
-.dnb-table__th.dnb-table__th__button-icon div {
+.dnb-table__th.dnb-table__th-button-icon,
+.dnb-table__th.dnb-table__th-button-icon div {
   width: 3.5rem;
   text-indent: -300vw;
 }
-.dnb-table__size--medium .dnb-table__th.dnb-table__th__button-icon,
-.dnb-table__size--medium .dnb-table__th.dnb-table__th__button-icon div {
+.dnb-table__size--medium .dnb-table__th.dnb-table__th-button-icon,
+.dnb-table__size--medium .dnb-table__th.dnb-table__th-button-icon div {
   width: 3rem;
 }
-.dnb-table__size--small .dnb-table__th.dnb-table__th__button-icon,
-.dnb-table__size--small .dnb-table__th.dnb-table__th__button-icon div {
+.dnb-table__size--small .dnb-table__th.dnb-table__th-button-icon,
+.dnb-table__size--small .dnb-table__th.dnb-table__th-button-icon div {
   width: 2.5rem;
 }
-.dnb-table__td.dnb-table__td__button-icon {
+.dnb-table__td.dnb-table__td-button-icon {
   user-select: none;
 }
-.dnb-table__td.dnb-table__td__button-icon.dnb-table__td {
+.dnb-table__td.dnb-table__td-button-icon.dnb-table__td {
   padding: 0;
 }
 .dnb-table__tr--clickable .dnb-table__button {
@@ -777,7 +777,7 @@ html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.d
 html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) td::before {
   border-color: var(--table-accordion-outline-color);
 }
-html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) .dnb-table__td__button-icon .dnb-icon {
+html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) .dnb-table__td-button-icon .dnb-icon {
   color: var(--table-accordion-icon-color--active);
 }
 .dnb-table--border tbody .dnb-table__tr--clickable:not(.dnb-table__tr--expanded):not(.dnb-table__tr--last) .dnb-table__td::before {
@@ -804,7 +804,7 @@ html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.d
 .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active .dnb-table__td {
   background-color: var(--table-accordion-outline-background--active);
 }
-.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active .dnb-table__td .dnb-table__td__button-icon .dnb-icon {
+.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active .dnb-table__td .dnb-table__td-button-icon .dnb-icon {
   color: var(--table-accordion-icon-color--active);
 }
 .dnb-table__tr--clickable.dnb-table__tr--expanded:not(.dnb-table__tr--disabled).dnb-table__tr--hover:not(:active):hover .dnb-table__td {
@@ -821,7 +821,7 @@ html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-
   border: none;
   border-top: var(--table-accordion-border);
 }
-.dnb-table__tr--clickable.dnb-table__tr--disabled .dnb-table__td__button-icon .dnb-icon {
+.dnb-table__tr--clickable.dnb-table__tr--disabled .dnb-table__td-button-icon .dnb-icon {
   color: var(--table-accordion-icon-color--disabled);
 }
 .dnb-table__tr__accordion-content__inner {

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -116,7 +116,7 @@ export const ContainerTable = () => {
     .dnb-table__scroll-view {
       max-width: 70rem;
     }
-    .dnb-table__container__body {
+    .dnb-table__container-body {
       min-width: 800px;
     }
     table {

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -75,11 +75,11 @@
   }
 
   &__tr--clickable,
-  &__tr__accordion-content {
+  &__tr-accordion-content {
     position: relative;
   }
   &__tr--clickable#{&}__tr--expanded,
-  &__tr__accordion-content {
+  &__tr-accordion-content {
     z-index: 3; // ensure borders are visible in certain states
   }
 
@@ -209,7 +209,7 @@
     @include tableAccordionDisabledColor();
   }
 
-  &__tr__accordion-content {
+  &__tr-accordion-content {
     &__inner {
       overflow: hidden;
       will-change: height;
@@ -246,7 +246,7 @@
     }
   }
 
-  &__tr__accordion-content--single {
+  &__tr-accordion-content--single {
     > td {
       padding: 0 !important; // medium and small size sets padding – but we never want a padding on this td
 
@@ -293,7 +293,7 @@
     }
   }
 
-  &__tr__accordion-content#{&}__tr &__td {
+  &__tr-accordion-content#{&}__tr &__td {
     background-color: var(--table-accordion-background);
 
     /**
@@ -311,7 +311,7 @@
 
   // prevent selection while animating – useful when user double-clicks
   // TODO: Our SASS version does not support :has – so we may use this in future
-  // &__tr--clickable:has(& + &__tr__accordion-content--animating) {
+  // &__tr--clickable:has(& + &__tr-accordion-content--animating) {
   //   user-select: none;
   // }
 

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -4,12 +4,12 @@
 */
 
 @mixin tableAccordionActiveColor {
-  .dnb-table__td__button-icon .dnb-icon {
+  .dnb-table__td-button-icon .dnb-icon {
     color: var(--table-accordion-icon-color--active);
   }
 }
 @mixin tableAccordionDisabledColor {
-  .dnb-table__td__button-icon .dnb-icon {
+  .dnb-table__td-button-icon .dnb-icon {
     color: var(--table-accordion-icon-color--disabled);
   }
 }
@@ -32,7 +32,7 @@
   --table-accordion-outline-width: var(--focus-ring-width);
   --table-accordion-outline-background--active: var(--color-pistachio);
 
-  &__th#{&}__th__button-icon {
+  &__th#{&}__th-button-icon {
     &.dnb-table__th {
       padding: 0;
     }
@@ -53,7 +53,7 @@
     }
   }
 
-  &__td#{&}__td__button-icon {
+  &__td#{&}__td-button-icon {
     &.dnb-table__td {
       padding: 0;
     }

--- a/packages/dnb-eufemia/src/components/table/style/table-th.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-th.scss
@@ -6,7 +6,7 @@
 @import './table-header-buttons.scss';
 
 .dnb-table {
-  &__th__horizontal {
+  &__th-horizontal {
     display: flex;
     align-items: flex-end; // bottom align help-button or other additional elements
   }

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
@@ -75,11 +75,11 @@ function TableAccordionContent(
       style={{ ...firstPaintStyle, ...style }}
       className={classnames(
         isInDOM && 'dnb-table__tr',
-        'dnb-table__tr__accordion-content',
-        `dnb-table__tr__accordion-content--${variant}`,
-        isInDOM && 'dnb-table__tr__accordion-content--expanded',
-        isAnimating && 'dnb-table__tr__accordion-content--animating',
-        isVisibleParallax && 'dnb-table__tr__accordion-content--parallax',
+        'dnb-table__tr-accordion-content',
+        `dnb-table__tr-accordion-content--${variant}`,
+        isInDOM && 'dnb-table__tr-accordion-content--expanded',
+        isAnimating && 'dnb-table__tr-accordion-content--animating',
+        isVisibleParallax && 'dnb-table__tr-accordion-content--parallax',
         className
       )}
       ref={trRef}
@@ -100,10 +100,10 @@ function TableAccordionContent(
         <ChevronTd {...chevronTdProps} colSpan={colSpan}>
           {isInDOM && (
             <div
-              className="dnb-table__tr__accordion-content__inner"
+              className="dnb-table__tr-accordion-content-inner"
               ref={innerRef}
             >
-              <div className="dnb-table__tr__accordion-content__inner__spacing">
+              <div className="dnb-table__tr-accordion-content-inner-spacing">
                 {children}
               </div>
             </div>

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -632,11 +632,11 @@ export default class Tabs extends React.PureComponent<TabsProps> {
       try {
         if (this.state.hasScrollbar && this._tablistRef.current) {
           const first = this._tablistRef.current.querySelector(
-            '.dnb-tabs__button__snap:first-of-type'
+            '.dnb-tabs__button-snap:first-of-type'
           )
           const isFirst = first.classList.contains(type)
           const last = this._tablistRef.current.querySelector(
-            '.dnb-tabs__button__snap:last-of-type'
+            '.dnb-tabs__button-snap:last-of-type'
           )
           const isLast = last.classList.contains(type)
           const elem = this._tablistRef.current.querySelector(
@@ -1146,7 +1146,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
         return (
           <div
             className={classnames(
-              'dnb-tabs__button__snap',
+              'dnb-tabs__button-snap',
               isFocus && 'focus',
               isSelected && 'selected'
             )}
@@ -1197,7 +1197,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
     return (
       <div
         role="tablist"
-        className="dnb-tabs__tabs__tablist"
+        className="dnb-tabs__tabs-tablist"
         tabIndex="0"
         onKeyDown={this.onTablistKeyDownHandler}
         ref={this._tablistRef}

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.screenshot.test.ts
@@ -113,7 +113,7 @@ describe.each(['ui', 'sbanken'])('Tabs for %s', (themeName) => {
     const screenshot = await makeScreenshot({
       selector: '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs',
       simulateSelector:
-        '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs__tablist .dnb-tabs__button__snap:nth-of-type(2) button',
+        '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs-tablist .dnb-tabs__button-snap:nth-of-type(2) button',
       simulate: 'focus',
       waitAfterSimulate: isCI ? 100 : 0, // ensure the buttons are "hidden", so give time for a slow CI
     })
@@ -125,7 +125,7 @@ describe.each(['ui', 'sbanken'])('Tabs for %s', (themeName) => {
       selector: '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs',
       style: { margin: '0 2rem' },
       simulateSelector:
-        '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs__tablist',
+        '[data-visual-test="tabs-tablist"] .dnb-tabs__tabs-tablist',
       simulate: 'focus',
     })
     expect(screenshot).toMatchImageSnapshot()
@@ -219,7 +219,7 @@ describe.each(['ui', 'sbanken'])('Tabs for %s', (themeName) => {
       },
       selector: '[data-visual-test="tabs-tablist-scrollable"]',
       simulateSelector:
-        '[data-visual-test="tabs-tablist-scrollable"] .dnb-tabs__tabs__tablist .dnb-tabs__button__snap:last-of-type button',
+        '[data-visual-test="tabs-tablist-scrollable"] .dnb-tabs__tabs-tablist .dnb-tabs__button-snap:last-of-type button',
       simulate: 'click',
     })
     expect(screenshot).toMatchImageSnapshot()

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -98,12 +98,12 @@ describe('Tabs component', () => {
       </Tabs>
     )
 
-    fireEvent.keyDown(document.querySelector('.dnb-tabs__tabs__tablist'), {
+    fireEvent.keyDown(document.querySelector('.dnb-tabs__tabs-tablist'), {
       keyCode: 39, // right
     })
     expect(on_focus).toHaveBeenCalledTimes(1)
 
-    fireEvent.keyDown(document.querySelector('.dnb-tabs__tabs__tablist'), {
+    fireEvent.keyDown(document.querySelector('.dnb-tabs__tabs-tablist'), {
       keyCode: 39, // right
     })
     expect(on_focus).toHaveBeenCalledTimes(2)
@@ -128,7 +128,7 @@ describe('Tabs component', () => {
 
     expect(
       document
-        .querySelector('.dnb-tabs__tabs__tablist')
+        .querySelector('.dnb-tabs__tabs-tablist')
         .querySelectorAll('a')[1].outerHTML
     ).toMatchInlineSnapshot(
       `"<a href="/second"><span class="dnb-tabs__button__title">Second</span><span aria-hidden="true" hidden="" class="dnb-dummy">Second</span></a>"`
@@ -306,7 +306,7 @@ describe('TabList component', () => {
     )
 
     expect(
-      document.querySelectorAll('.dnb-tabs__button__snap').length
+      document.querySelectorAll('.dnb-tabs__button-snap').length
     ).toBe(tablistData.length)
     expect(document.querySelectorAll('div[role="tabpanel"]').length).toBe(
       1
@@ -389,7 +389,7 @@ describe('A single Tab component', () => {
     render(<Tabs {...props} data={tablistDataWithContent} />)
     expect(
       document
-        .querySelectorAll('.dnb-tabs__button__snap')[0]
+        .querySelectorAll('.dnb-tabs__button-snap')[0]
         .querySelector('button').classList
     ).toContain('selected')
     expect(
@@ -516,7 +516,7 @@ describe('A single Tab component', () => {
     ).toBe('second-title')
     expect(
       document
-        .querySelectorAll('.dnb-tabs__button__snap button')[1]
+        .querySelectorAll('.dnb-tabs__button-snap button')[1]
         .getAttribute('data-tab-key')
     ).toBe('second-title')
     expect(

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tabs scss has to match style dependencies css 1`] = `
 .dnb-tabs__tabs, .dnb-tabs__tabs.dnb-section--spacing {
   padding-bottom: 0;
 }
-.dnb-tabs__tabs__tablist {
+.dnb-tabs__tabs-tablist {
   display: flex;
   flex: 0 1 auto;
   overflow-x: auto;
@@ -59,49 +59,49 @@ exports[`Tabs scss has to match style dependencies css 1`] = `
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
-.dnb-tabs__tabs__tablist:focus {
+.dnb-tabs__tabs-tablist:focus {
   outline: none;
   border-radius: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__tabs__tablist:focus {
+html[data-whatinput=keyboard] .dnb-tabs__tabs-tablist:focus {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
+html:not([data-visual-test]) .dnb-tabs__tabs-tablist {
   scroll-behavior: smooth;
 }
 @supports not (scrollbar-color: auto) {
-  .dnb-tabs__tabs__tablist::-webkit-scrollbar {
+  .dnb-tabs__tabs-tablist::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
     background-color: var(--scrollbar-track-color, #eee);
   }
-  .dnb-tabs__tabs__tablist::-webkit-scrollbar:vertical {
+  .dnb-tabs__tabs-tablist::-webkit-scrollbar:vertical {
     width: var(--scrollbar-track-width, 0.5rem);
   }
-  .dnb-tabs__tabs__tablist::-webkit-scrollbar:horizontal {
+  .dnb-tabs__tabs-tablist::-webkit-scrollbar:horizontal {
     height: var(--scrollbar-track-width, 0.5rem);
   }
-  .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
+  .dnb-tabs__tabs-tablist::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color, #888);
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
   }
-  .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb:hover {
+  .dnb-tabs__tabs-tablist::-webkit-scrollbar-thumb:hover {
     background-color: var(--scrollbar-thumb-hover-color, #666);
   }
 }
-.dnb-tabs__tabs__tablist::-webkit-scrollbar {
+.dnb-tabs__tabs-tablist::-webkit-scrollbar {
   display: none;
 }
-.dnb-tabs__tabs--left .dnb-tabs__tabs__tablist {
+.dnb-tabs__tabs--left .dnb-tabs__tabs-tablist {
   justify-content: flex-start;
 }
-.dnb-tabs__tabs--right .dnb-tabs__tabs__tablist {
+.dnb-tabs__tabs--right .dnb-tabs__tabs-tablist {
   flex: 1;
   justify-content: flex-end;
 }
-.dnb-tabs__tabs--center .dnb-tabs__tabs__tablist {
+.dnb-tabs__tabs--center .dnb-tabs__tabs-tablist {
   flex: 1;
   justify-content: center;
 }
@@ -152,7 +152,7 @@ html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
 .dnb-tabs--at-edge .dnb-tabs__scroll-nav-button:last-of-type {
   border-radius: 50% 0 0 50%;
 }
-.dnb-tabs--at-edge .dnb-tabs__tabs__tablist:focus {
+.dnb-tabs--at-edge .dnb-tabs__tabs-tablist:focus {
   border-radius: 0;
 }
 .dnb-tabs__button, .dnb-core-style .dnb-tabs .dnb-tabs__button {
@@ -274,31 +274,31 @@ html[data-whatinput=keyboard] .dnb-tabs__button:focus::before, html[data-whatinp
 .dnb-tabs__button:not([disabled]).selected .dnb-tabs__button__title, .dnb-tabs__button:not([disabled]).selected .dnb-core-style .dnb-tabs .dnb-tabs__button__title, .dnb-core-style .dnb-tabs .dnb-tabs__button:not([disabled]).selected .dnb-tabs__button__title, .dnb-core-style .dnb-tabs .dnb-tabs__button:not([disabled]).selected .dnb-core-style .dnb-tabs .dnb-tabs__button__title {
   font-weight: var(--tab-title-font-weight--selected);
 }
-.dnb-tabs__button__snap {
+.dnb-tabs__button-snap {
   display: flex;
   padding: 0 1rem 0 1.5rem;
   will-change: padding;
   transition: padding 1s var(--easing-default);
 }
 @media screen and (max-width: 40em) {
-  .dnb-tabs__button__snap {
+  .dnb-tabs__button-snap {
     padding: 0 1rem;
   }
 }
-.dnb-tabs__button__snap:first-of-type {
+.dnb-tabs__button-snap:first-of-type {
   padding-left: 0;
 }
-.dnb-tabs__button__snap:last-of-type {
+.dnb-tabs__button-snap:last-of-type {
   padding-right: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:first-of-type.focus .dnb-tabs__button:focus {
+html[data-whatinput=keyboard] .dnb-tabs__button-snap:first-of-type.focus .dnb-tabs__button:focus {
   margin-left: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus {
+html[data-whatinput=keyboard] .dnb-tabs__button-snap:last-of-type.focus {
   /* stylelint-disable */
   /* stylelint-enable */
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-tabs__button:focus {
+html[data-whatinput=keyboard] .dnb-tabs__button-snap:last-of-type.focus .dnb-tabs__button:focus {
   margin-right: 0.5rem;
 }
 .dnb-tabs__cached {
@@ -314,7 +314,7 @@ html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-ta
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
 }
-html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button__snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
+html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button-snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
   transition: none !important;
 }
 .dnb-tabs__content {

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tabs scss has to match style dependencies css 1`] = `
 .dnb-tabs__tabs, .dnb-tabs__tabs.dnb-section--spacing {
   padding-bottom: 0;
 }
-.dnb-tabs__tabs-tablist {
+.dnb-tabs__tabs__tablist {
   display: flex;
   flex: 0 1 auto;
   overflow-x: auto;
@@ -59,49 +59,49 @@ exports[`Tabs scss has to match style dependencies css 1`] = `
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
-.dnb-tabs__tabs-tablist:focus {
+.dnb-tabs__tabs__tablist:focus {
   outline: none;
   border-radius: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__tabs-tablist:focus {
+html[data-whatinput=keyboard] .dnb-tabs__tabs__tablist:focus {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-visual-test]) .dnb-tabs__tabs-tablist {
+html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
   scroll-behavior: smooth;
 }
 @supports not (scrollbar-color: auto) {
-  .dnb-tabs__tabs-tablist::-webkit-scrollbar {
+  .dnb-tabs__tabs__tablist::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
     background-color: var(--scrollbar-track-color, #eee);
   }
-  .dnb-tabs__tabs-tablist::-webkit-scrollbar:vertical {
+  .dnb-tabs__tabs__tablist::-webkit-scrollbar:vertical {
     width: var(--scrollbar-track-width, 0.5rem);
   }
-  .dnb-tabs__tabs-tablist::-webkit-scrollbar:horizontal {
+  .dnb-tabs__tabs__tablist::-webkit-scrollbar:horizontal {
     height: var(--scrollbar-track-width, 0.5rem);
   }
-  .dnb-tabs__tabs-tablist::-webkit-scrollbar-thumb {
+  .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color, #888);
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
   }
-  .dnb-tabs__tabs-tablist::-webkit-scrollbar-thumb:hover {
+  .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb:hover {
     background-color: var(--scrollbar-thumb-hover-color, #666);
   }
 }
-.dnb-tabs__tabs-tablist::-webkit-scrollbar {
+.dnb-tabs__tabs__tablist::-webkit-scrollbar {
   display: none;
 }
-.dnb-tabs__tabs--left .dnb-tabs__tabs-tablist {
+.dnb-tabs__tabs--left .dnb-tabs__tabs__tablist {
   justify-content: flex-start;
 }
-.dnb-tabs__tabs--right .dnb-tabs__tabs-tablist {
+.dnb-tabs__tabs--right .dnb-tabs__tabs__tablist {
   flex: 1;
   justify-content: flex-end;
 }
-.dnb-tabs__tabs--center .dnb-tabs__tabs-tablist {
+.dnb-tabs__tabs--center .dnb-tabs__tabs__tablist {
   flex: 1;
   justify-content: center;
 }
@@ -291,14 +291,14 @@ html[data-whatinput=keyboard] .dnb-tabs__button:focus::before, html[data-whatinp
 .dnb-tabs__button-snap:last-of-type {
   padding-right: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button-snap:first-of-type.focus .dnb-tabs__button:focus {
+html[data-whatinput=keyboard] .dnb-tabs__button__snap:first-of-type.focus .dnb-tabs__button:focus {
   margin-left: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button-snap:last-of-type.focus {
+html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus {
   /* stylelint-disable */
   /* stylelint-enable */
 }
-html[data-whatinput=keyboard] .dnb-tabs__button-snap:last-of-type.focus .dnb-tabs__button:focus {
+html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-tabs__button:focus {
   margin-right: 0.5rem;
 }
 .dnb-tabs__cached {
@@ -314,7 +314,7 @@ html[data-whatinput=keyboard] .dnb-tabs__button-snap:last-of-type.focus .dnb-tab
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
 }
-html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button-snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
+html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button__snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
   transition: none !important;
 }
 .dnb-tabs__content {

--- a/packages/dnb-eufemia/src/components/tabs/stories/Tabs.stories.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/stories/Tabs.stories.tsx
@@ -38,7 +38,7 @@ export const TabsSandbox = () => {
             padding: 0 2rem;
           } */
 
-          /* .dnb-tabs__tabs__tablist {
+          /* .dnb-tabs__tabs-tablist {
             padding: 0 2rem;
           } */
         `}

--- a/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
@@ -261,7 +261,7 @@
     /* stylelint-enable no-descending-specificity */
   }
 
-  &__button__snap {
+  &__button-snap {
     display: flex;
 
     padding: 0 1rem 0 1.5rem;

--- a/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
@@ -125,7 +125,7 @@
     }
   }
 
-  &--at-edge &__tabs__tablist:focus {
+  &--at-edge &__tabs-tablist:focus {
     border-radius: 0;
   }
 

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -147,11 +147,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -134,7 +134,7 @@ const TimelineItemLabel = ({
   ...iconProps
 }: TimelineItemLabelProps) => {
   return (
-    <span className="dnb-timeline__item__label">
+    <span className="dnb-timeline__item-label">
       <TimelineItemIcon {...iconProps} />
       <TimelineItemTitle title={title} />
     </span>
@@ -178,7 +178,7 @@ const TimelineItemIcon = ({
   const currentAltLabel = iconAlt || labels[state]
 
   return (
-    <span className="dnb-timeline__item__label__icon">
+    <span className="dnb-timeline__item-label-icon">
       <AlignmentHelper pseudoElementOnly />
       {!skeleton && currentIcon && (
         <IconPrimary
@@ -194,7 +194,7 @@ const TimelineItemIcon = ({
 type TimelineItemTitleProps = Pick<TimelineItemProps, 'title'>
 
 const TimelineItemTitle = ({ title }: TimelineItemTitleProps) => {
-  return <span className="dnb-timeline__item__label__title">{title}</span>
+  return <span className="dnb-timeline__item-label-title">{title}</span>
 }
 
 // Content
@@ -222,13 +222,13 @@ const TimelineItemContent = ({
   }
 
   return (
-    <div className="dnb-timeline__item__content">
+    <div className="dnb-timeline__item-content">
       {renderSubtitles()}
       {infoMessage && (
         <FormStatus
           text={infoMessage}
           state="info"
-          className="dnb-timeline__item__content__info"
+          className="dnb-timeline__item-content-info"
           stretch
         />
       )}
@@ -241,7 +241,7 @@ type TimelineItemSubtitleProps = {
 }
 
 const TimelineItemSubtitle = ({ subtitle }: TimelineItemSubtitleProps) => (
-  <div className="dnb-timeline__item__content__subtitle">{subtitle}</div>
+  <div className="dnb-timeline__item-content-subtitle">{subtitle}</div>
 )
 
 export default TimelineItem

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item {
   margin-left: var(--timeline-icon-width-diff);
 }
-.dnb-timeline__item-label-icon {
+.dnb-timeline__item__label__icon {
   width: var(--timeline-icon-width--small);
   line-height: var(--timeline-icon-height--small);
   border-radius: var(--timeline-icon-border-radius--small);
@@ -51,33 +51,33 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-timeline__item-label-title {
+.dnb-timeline__item__label__title {
   margin-left: var(--timeline-border-spacing--icon-adjusted);
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
 }
-.dnb-timeline__item-content {
+.dnb-timeline__item__content {
   margin-left: calc(var(--timeline-icon-width--small) / 2);
   padding-left: calc(var(--timeline-icon-width--small) / 2 + var(--timeline-border-spacing--icon-adjusted));
   border-left: 1px dashed var(--color-black-55);
 }
-.dnb-timeline__item--completed .dnb-timeline__item-content {
+.dnb-timeline__item--completed .dnb-timeline__item__content {
   border-left: 1px solid var(--color-black-80);
 }
-.dnb-timeline__item--completed .dnb-timeline__item-label-title {
+.dnb-timeline__item--completed .dnb-timeline__item__label__title {
   color: var(--color-black-80);
 }
-.dnb-timeline__item--current .dnb-timeline__item-content {
+.dnb-timeline__item--current .dnb-timeline__item__content {
   margin-left: calc(var(--timeline-icon-width--medium) / 2);
   padding-left: calc(var(--timeline-icon-width--medium) / 2 + var(--timeline-border-spacing));
 }
-.dnb-timeline__item--current .dnb-timeline__item-label-title {
+.dnb-timeline__item--current .dnb-timeline__item__label__title {
   margin-left: var(--timeline-border-spacing);
   font-weight: var(--font-weight-medium);
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
 }
-.dnb-timeline__item--current .dnb-timeline__item-label-icon {
+.dnb-timeline__item--current .dnb-timeline__item__label__icon {
   width: var(--timeline-icon-width--medium);
   line-height: var(--timeline-icon-height--medium);
   border-radius: var(--timeline-icon-border-radius--medium);
@@ -85,11 +85,11 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item--current {
   margin-left: 0;
 }
-.dnb-timeline__item--upcoming .dnb-timeline__item-label-title {
+.dnb-timeline__item--upcoming .dnb-timeline__item__label__title {
   font-weight: var(--font-weight-basis);
   color: var(--color-black-55);
 }
-.dnb-timeline__item--upcoming:not(.dnb-skeleton) .dnb-timeline__item-label-icon {
+.dnb-timeline__item--upcoming:not(.dnb-skeleton) .dnb-timeline__item__label__icon {
   color: var(--color-black-55);
   background-color: var(--color-black-3);
   --border-color: var(--color-black-3);
@@ -100,7 +100,7 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item:only-child {
   margin-left: 0;
 }
-.dnb-timeline__item:last-child .dnb-timeline__item-content {
+.dnb-timeline__item:last-child .dnb-timeline__item__content {
   border-left: none;
 }"
 `;
@@ -126,13 +126,13 @@ exports[`Timeline scss should match style dependencies css 1`] = `
   padding: 0;
   list-style: none;
 }
-.dnb-timeline__item-label {
+.dnb-timeline__item__label {
   display: flex;
   align-items: center;
   padding: 0;
   text-align: left;
 }
-.dnb-timeline__item-label-icon {
+.dnb-timeline__item__label__icon {
   display: flex;
   flex-shrink: 0;
   align-items: center;
@@ -140,19 +140,19 @@ exports[`Timeline scss should match style dependencies css 1`] = `
   height: auto;
   padding: 0;
 }
-.dnb-timeline__item-label-title {
+.dnb-timeline__item__label__title {
   cursor: text;
 }
-.dnb-timeline__item-content {
+.dnb-timeline__item__content {
   padding-bottom: var(--spacing-small);
 }
-.dnb-timeline__item-content-subtitle {
+.dnb-timeline__item__content__subtitle {
   cursor: text;
   font-size: var(--font-size-x-small);
   font-weight: var(--font-weight-basis);
   color: var(--color-black-55);
 }
-.dnb-timeline__item-content-info {
+.dnb-timeline__item__content__info {
   padding-top: var(--spacing-x-small);
 }"
 `;

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item {
   margin-left: var(--timeline-icon-width-diff);
 }
-.dnb-timeline__item__label__icon {
+.dnb-timeline__item-label-icon {
   width: var(--timeline-icon-width--small);
   line-height: var(--timeline-icon-height--small);
   border-radius: var(--timeline-icon-border-radius--small);
@@ -51,33 +51,33 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-timeline__item__label__title {
+.dnb-timeline__item-label-title {
   margin-left: var(--timeline-border-spacing--icon-adjusted);
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
 }
-.dnb-timeline__item__content {
+.dnb-timeline__item-content {
   margin-left: calc(var(--timeline-icon-width--small) / 2);
   padding-left: calc(var(--timeline-icon-width--small) / 2 + var(--timeline-border-spacing--icon-adjusted));
   border-left: 1px dashed var(--color-black-55);
 }
-.dnb-timeline__item--completed .dnb-timeline__item__content {
+.dnb-timeline__item--completed .dnb-timeline__item-content {
   border-left: 1px solid var(--color-black-80);
 }
-.dnb-timeline__item--completed .dnb-timeline__item__label__title {
+.dnb-timeline__item--completed .dnb-timeline__item-label-title {
   color: var(--color-black-80);
 }
-.dnb-timeline__item--current .dnb-timeline__item__content {
+.dnb-timeline__item--current .dnb-timeline__item-content {
   margin-left: calc(var(--timeline-icon-width--medium) / 2);
   padding-left: calc(var(--timeline-icon-width--medium) / 2 + var(--timeline-border-spacing));
 }
-.dnb-timeline__item--current .dnb-timeline__item__label__title {
+.dnb-timeline__item--current .dnb-timeline__item-label-title {
   margin-left: var(--timeline-border-spacing);
   font-weight: var(--font-weight-medium);
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
 }
-.dnb-timeline__item--current .dnb-timeline__item__label__icon {
+.dnb-timeline__item--current .dnb-timeline__item-label-icon {
   width: var(--timeline-icon-width--medium);
   line-height: var(--timeline-icon-height--medium);
   border-radius: var(--timeline-icon-border-radius--medium);
@@ -85,11 +85,11 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item--current {
   margin-left: 0;
 }
-.dnb-timeline__item--upcoming .dnb-timeline__item__label__title {
+.dnb-timeline__item--upcoming .dnb-timeline__item-label-title {
   font-weight: var(--font-weight-basis);
   color: var(--color-black-55);
 }
-.dnb-timeline__item--upcoming:not(.dnb-skeleton) .dnb-timeline__item__label__icon {
+.dnb-timeline__item--upcoming:not(.dnb-skeleton) .dnb-timeline__item-label-icon {
   color: var(--color-black-55);
   background-color: var(--color-black-3);
   --border-color: var(--color-black-3);
@@ -100,7 +100,7 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
 .dnb-timeline__item:only-child {
   margin-left: 0;
 }
-.dnb-timeline__item:last-child .dnb-timeline__item__content {
+.dnb-timeline__item:last-child .dnb-timeline__item-content {
   border-left: none;
 }"
 `;
@@ -126,13 +126,13 @@ exports[`Timeline scss should match style dependencies css 1`] = `
   padding: 0;
   list-style: none;
 }
-.dnb-timeline__item__label {
+.dnb-timeline__item-label {
   display: flex;
   align-items: center;
   padding: 0;
   text-align: left;
 }
-.dnb-timeline__item__label__icon {
+.dnb-timeline__item-label-icon {
   display: flex;
   flex-shrink: 0;
   align-items: center;
@@ -140,19 +140,19 @@ exports[`Timeline scss should match style dependencies css 1`] = `
   height: auto;
   padding: 0;
 }
-.dnb-timeline__item__label__title {
+.dnb-timeline__item-label-title {
   cursor: text;
 }
-.dnb-timeline__item__content {
+.dnb-timeline__item-content {
   padding-bottom: var(--spacing-small);
 }
-.dnb-timeline__item__content__subtitle {
+.dnb-timeline__item-content-subtitle {
   cursor: text;
   font-size: var(--font-size-x-small);
   font-weight: var(--font-weight-basis);
   color: var(--color-black-55);
 }
-.dnb-timeline__item__content__info {
+.dnb-timeline__item-content-info {
   padding-top: var(--spacing-x-small);
 }"
 `;

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -277,8 +277,8 @@ class ToggleButtonGroup extends React.PureComponent<ToggleButtonGroupProps> {
 
                 <span
                   className={classnames(
-                    'dnb-toggle-button-group__shell__children',
-                    `dnb-toggle-button-group__shell__children--${layout_direction}`
+                    'dnb-toggle-button-group__shell-children',
+                    `dnb-toggle-button-group__shell-children--${layout_direction}`
                   )}
                 >
                   {children}

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -343,11 +343,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -1832,7 +1832,7 @@ button .dnb-form-status__text {
   flex-direction: column;
   row-gap: var(--toggle-button-group-row-gap);
 }
-.dnb-toggle-button-group__shell__children {
+.dnb-toggle-button-group__shell-children {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -1840,10 +1840,10 @@ button .dnb-form-status__text {
   row-gap: var(--toggle-button-group-row-gap);
   order: 1;
 }
-.dnb-toggle-button-group__shell__children--row {
+.dnb-toggle-button-group__shell-children--row {
   flex-direction: row;
 }
-.dnb-toggle-button-group__shell__children--column {
+.dnb-toggle-button-group__shell-children--column {
   flex-direction: column;
 }
 .dnb-toggle-button-group__shell > .dnb-form-status {

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -1832,7 +1832,7 @@ button .dnb-form-status__text {
   flex-direction: column;
   row-gap: var(--toggle-button-group-row-gap);
 }
-.dnb-toggle-button-group__shell-children {
+.dnb-toggle-button-group__shell__children {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -1840,10 +1840,10 @@ button .dnb-form-status__text {
   row-gap: var(--toggle-button-group-row-gap);
   order: 1;
 }
-.dnb-toggle-button-group__shell-children--row {
+.dnb-toggle-button-group__shell__children--row {
   flex-direction: row;
 }
-.dnb-toggle-button-group__shell-children--column {
+.dnb-toggle-button-group__shell__children--column {
   flex-direction: column;
 }
 .dnb-toggle-button-group__shell > .dnb-form-status {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -172,7 +172,7 @@ describe('Tooltip', () => {
     ).toEqual(
       expect.arrayContaining([
         'dnb-tooltip__arrow__arrow--center',
-        'dnb-tooltip__arrow__placement--right',
+        'dnb-tooltip__arrow-placement--right',
       ])
     )
   })
@@ -189,7 +189,7 @@ describe('Tooltip', () => {
     ).toEqual(
       expect.arrayContaining([
         'dnb-tooltip__arrow__arrow--right',
-        'dnb-tooltip__arrow__placement--top',
+        'dnb-tooltip__arrow-placement--top',
       ])
     )
   })

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -43,11 +43,11 @@ exports[`Tooltip scss has to match style dependencies css 1`] = `
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }"

--- a/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
+++ b/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
@@ -41,7 +41,7 @@
       padding: 0 1rem;
     }
 
-    &__arrow__placement {
+    &__arrow-placement {
       &--right {
         left: -13px;
         top: auto !important;

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -137,8 +137,8 @@ const UploadFileListCell = ({
       )}
       ref={cellRef}
     >
-      <div className="dnb-upload__file-cell__content">
-        <div className="dnb-upload__file-cell__content__left">
+      <div className="dnb-upload__file-cell-content">
+        <div className="dnb-upload__file-cell-content-left">
           {getFileIcon(file, { isLoading }, hasWarning)}
           {getTitle()}
         </div>
@@ -152,14 +152,14 @@ const UploadFileListCell = ({
     return isLoading ? (
       <div
         className={classnames(
-          'dnb-upload__file-cell__text-container',
-          'dnb-upload__file-cell__text-container--loading'
+          'dnb-upload__file-cell-text-container',
+          'dnb-upload__file-cell-text-container--loading'
         )}
       >
         {loadingText}
       </div>
     ) : (
-      <div className="dnb-upload__file-cell__text-container">
+      <div className="dnb-upload__file-cell-text-container">
         <UploadFileLink
           text={file.name}
           href={imageUrl}

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListCell.test.tsx
@@ -49,7 +49,7 @@ describe('UploadFileListCell', () => {
     )
 
     const element = document.querySelector(
-      '.dnb-upload__file-cell__text-container a'
+      '.dnb-upload__file-cell-text-container a'
     )
 
     expect(element.textContent).toMatch('file.dat')

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -756,34 +756,34 @@ button .dnb-form-status__text {
 .dnb-upload__file-cell::after {
   top: auto;
 }
-.dnb-upload__file-cell-content {
+.dnb-upload__file-cell__content {
   display: flex;
   column-gap: var(--spacing-small);
   justify-content: space-between;
   align-items: center;
 }
-.dnb-upload__file-cell-content-left {
+.dnb-upload__file-cell__content__left {
   display: flex;
   column-gap: var(--spacing-small);
   align-items: center;
 }
-.dnb-upload__file-cell-content-left .dnb-icon {
+.dnb-upload__file-cell__content__left .dnb-icon {
   color: var(--upload-icon--default);
 }
-.dnb-upload__file-cell--warning .dnb-upload__file-cell-content-left .dnb-icon {
+.dnb-upload__file-cell--warning .dnb-upload__file-cell__content__left .dnb-icon {
   color: var(--upload-icon--warning);
 }
 .dnb-upload__file-cell--highlight {
   background-color: var(--upload-highlight);
 }
-.dnb-upload__file-cell-text-container {
+.dnb-upload__file-cell__text-container {
   display: flex;
   flex-direction: column;
 }
-.dnb-upload__file-cell-text-container--loading {
+.dnb-upload__file-cell__text-container--loading {
   font-size: var(--font-size-basis);
 }
-.dnb-upload__file-cell-text-container .dnb-button {
+.dnb-upload__file-cell__text-container .dnb-button {
   justify-content: flex-start;
 }
 .dnb-upload__text.dnb-p {

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -256,11 +256,11 @@ p > .dnb-icon {
   min-height: 1.5rem;
   padding: 0 1rem;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--right {
+.dnb-tooltip .dnb-popover__arrow-placement--right {
   left: -13px;
   top: auto !important;
 }
-.dnb-tooltip .dnb-popover__arrow__placement--left {
+.dnb-tooltip .dnb-popover__arrow-placement--left {
   right: -13px;
   top: auto !important;
 }
@@ -756,34 +756,34 @@ button .dnb-form-status__text {
 .dnb-upload__file-cell::after {
   top: auto;
 }
-.dnb-upload__file-cell__content {
+.dnb-upload__file-cell-content {
   display: flex;
   column-gap: var(--spacing-small);
   justify-content: space-between;
   align-items: center;
 }
-.dnb-upload__file-cell__content__left {
+.dnb-upload__file-cell-content-left {
   display: flex;
   column-gap: var(--spacing-small);
   align-items: center;
 }
-.dnb-upload__file-cell__content__left .dnb-icon {
+.dnb-upload__file-cell-content-left .dnb-icon {
   color: var(--upload-icon--default);
 }
-.dnb-upload__file-cell--warning .dnb-upload__file-cell__content__left .dnb-icon {
+.dnb-upload__file-cell--warning .dnb-upload__file-cell-content-left .dnb-icon {
   color: var(--upload-icon--warning);
 }
 .dnb-upload__file-cell--highlight {
   background-color: var(--upload-highlight);
 }
-.dnb-upload__file-cell__text-container {
+.dnb-upload__file-cell-text-container {
   display: flex;
   flex-direction: column;
 }
-.dnb-upload__file-cell__text-container--loading {
+.dnb-upload__file-cell-text-container--loading {
   font-size: var(--font-size-basis);
 }
-.dnb-upload__file-cell__text-container .dnb-button {
+.dnb-upload__file-cell-text-container .dnb-button {
   justify-content: flex-start;
 }
 .dnb-upload__text.dnb-p {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -793,7 +793,7 @@ describe('Field.Date', () => {
     expect(startYear).toHaveValue('2024')
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
@@ -821,7 +821,7 @@ describe('Field.Date', () => {
     expect(startYear).toHaveValue('2024')
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
@@ -897,7 +897,7 @@ describe('Field.Date', () => {
     render(<Field.Date hideNavigation />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
@@ -912,7 +912,7 @@ describe('Field.Date', () => {
     render(<Field.Date hideDays />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(
@@ -924,7 +924,7 @@ describe('Field.Date', () => {
     render(<Field.Date />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [resetButton, cancelButton] = Array.from(
@@ -972,7 +972,7 @@ describe('Field.Date', () => {
     })
 
     const openButton = document.querySelector(
-      'button.dnb-input__submit-button__button'
+      'button.dnb-input__submit-button-button'
     )
     await userEvent.click(openButton)
 
@@ -1024,7 +1024,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [submitButton, resetButton, cancelButton] = Array.from(
@@ -1062,7 +1062,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [submitButton, resetButton, cancelButton] = Array.from(
@@ -1078,7 +1078,7 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-11-01|2024-12-01" range link />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [rightCalendar, leftCalendar] = Array.from(
@@ -1123,7 +1123,7 @@ describe('Field.Date', () => {
     render(<Field.Date firstDay="tuesday" />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [firstDay] = Array.from(
@@ -1151,7 +1151,7 @@ describe('Field.Date', () => {
     render(<Field.Date onlyMonth />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const calendar = document.querySelector('.dnb-date-picker__calendar')
@@ -1197,7 +1197,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [
@@ -1281,7 +1281,7 @@ describe('Field.Date', () => {
     expect(year).toHaveValue('2024')
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const addonElement = document.querySelector(
@@ -1307,7 +1307,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const monthTable = document.querySelector(
@@ -1352,7 +1352,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const submitButton = document.querySelector(
@@ -1373,7 +1373,7 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-10-31" onCancel={onCancel} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const cancelButton = document.querySelector(
@@ -1394,7 +1394,7 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-10-31" onReset={onReset} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const resetButton = document.querySelector(
@@ -1413,7 +1413,7 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-10-31" onShow={onShow} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(onShow).toHaveBeenCalledTimes(1)
@@ -1428,10 +1428,10 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-10-31" onHide={onHide} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
     await waitFor(() =>
       expect(
@@ -1451,7 +1451,7 @@ describe('Field.Date', () => {
     render(<Field.Date value="2024-10-01" onDaysRender={onDaysRender} />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     expect(onDaysRender).toHaveBeenCalledTimes(1)
@@ -1477,7 +1477,7 @@ describe('Field.Date', () => {
     render(<Field.Date skipPortal />)
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     // dnb-date-picker__container is within dnb-date-picker__shell when portal is skipped (wrapped by Popover span)
@@ -1501,7 +1501,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [monthTitle, yearTitle] = Array.from(
@@ -1596,7 +1596,7 @@ describe('Field.Date', () => {
     )
 
     await userEvent.click(
-      document.querySelector('button.dnb-input__submit-button__button')
+      document.querySelector('button.dnb-input__submit-button-button')
     )
 
     const [
@@ -1970,7 +1970,7 @@ describe('Field.Date', () => {
       )
 
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
 
       const [startMonth, endMonth] = Array.from(
@@ -1994,7 +1994,7 @@ describe('Field.Date', () => {
       )
 
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
 
       const [rightCalendar, leftCalendar] = Array.from(
@@ -2090,7 +2090,7 @@ describe('Field.Date', () => {
       )
 
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
 
       // Clicking the minDate should not trigger error
@@ -2103,7 +2103,7 @@ describe('Field.Date', () => {
       // Clicking the maxDate should not trigger error
       await userEvent.click(screen.getByText('Tilbake'))
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
       await userEvent.click(screen.getByLabelText('mandag 31. mars 2025'))
       await userEvent.click(screen.getByText('Neste'))
@@ -2114,7 +2114,7 @@ describe('Field.Date', () => {
       // Double check that dates before min and max date are disabled in the calendar
       await userEvent.click(screen.getByText('Tilbake'))
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
       expect(
         screen.getByLabelText('onsdag 12. mars 2025')
@@ -2146,7 +2146,7 @@ describe('Field.Date', () => {
       )
 
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
 
       // Clicking the minDate should not trigger error
@@ -2159,7 +2159,7 @@ describe('Field.Date', () => {
       // Clicking the maxDate should not trigger error
       await userEvent.click(screen.getByText('Tilbake'))
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
       await userEvent.click(screen.getByLabelText('mandag 31. mars 2025'))
       await userEvent.click(screen.getByText('Neste'))
@@ -2170,7 +2170,7 @@ describe('Field.Date', () => {
       // Double check that dates before min and max date are disabled in the calendar
       await userEvent.click(screen.getByText('Tilbake'))
       await userEvent.click(
-        document.querySelector('button.dnb-input__submit-button__button')
+        document.querySelector('button.dnb-input__submit-button-button')
       )
       expect(
         screen.getByLabelText('onsdag 12. mars 2025')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -845,7 +845,7 @@ describe('Field.Date', () => {
     render(<Field.Date />)
 
     expect(
-      document.querySelector('.dnb-date-picker__input__wrapper')
+      document.querySelector('.dnb-date-picker__input-wrapper')
     ).toBeInTheDocument()
   })
 
@@ -1127,7 +1127,7 @@ describe('Field.Date', () => {
     )
 
     const [firstDay] = Array.from(
-      document.querySelectorAll('.dnb-date-picker__labels__day')
+      document.querySelectorAll('.dnb-date-picker__labels-day')
     )
 
     expect(firstDay).toHaveTextContent('ti')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
@@ -1,6 +1,6 @@
 .dnb-forms-field-password {
   // Make sure submit element receives red text color on error.
-  .dnb-input__status--error .dnb-input__submit-button__button {
+  .dnb-input__status--error .dnb-input__submit-button-button {
     color: var(--color-fire-red);
 
     &:hover {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -251,7 +251,7 @@ describe('Field.PhoneNumber', () => {
     expect(legend).toHaveTextContent('Phone Number Field')
 
     const labelDescription = fieldBlock.querySelector(
-      '.dnb-forms-field-block__label__description'
+      '.dnb-forms-field-block__label-description'
     )
     expect(labelDescription).toBeInTheDocument()
     expect(labelDescription).toHaveTextContent(
@@ -277,7 +277,7 @@ describe('Field.PhoneNumber', () => {
     expect(legend).toHaveTextContent('Phone Number Field')
 
     const labelDescription = fieldBlock.querySelector(
-      '.dnb-forms-field-block__label__description'
+      '.dnb-forms-field-block__label-description'
     )
     expect(labelDescription).toBeInTheDocument()
     expect(labelDescription).toHaveTextContent(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -1883,7 +1883,7 @@ describe('Field.PhoneNumber', () => {
       const currentOptions = () =>
         Array.from(
           document.querySelectorAll(
-            '.dnb-drawer-list__options .dnb-drawer-list__option__inner'
+            '.dnb-drawer-list__options .dnb-drawer-list__option-inner'
           )
         ).map((option: HTMLSpanElement) => option.textContent)
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -562,7 +562,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
             <FormLabel {...labelProps}>
               <span>
                 {label && (
-                  <span className="dnb-forms-field-block__label__content">
+                  <span className="dnb-forms-field-block__label-content">
                     {label}
                   </span>
                 )}
@@ -583,7 +583,7 @@ function FieldBlock<Value = unknown>(props: Props<Value>) {
                   !labelDescriptionInline && <br />}
 
                 {hasLabelDescription && (
-                  <span className="dnb-forms-field-block__label__description">
+                  <span className="dnb-forms-field-block__label-description">
                     {labelDescription}
                   </span>
                 )}

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -239,7 +239,7 @@ describe('FieldBlock', () => {
 
       expect(
         document.querySelector(
-          '.dnb-forms-field-block__label__description'
+          '.dnb-forms-field-block__label-description'
         )
       ).toBeNull()
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -238,9 +238,7 @@ describe('FieldBlock', () => {
       render(<FieldBlock labelDescription={<></>}>content</FieldBlock>)
 
       expect(
-        document.querySelector(
-          '.dnb-forms-field-block__label-description'
-        )
+        document.querySelector('.dnb-forms-field-block__label-description')
       ).toBeNull()
 
       const labelElement = document.querySelector('label')

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-sbanken.scss
@@ -1,5 +1,5 @@
 .dnb-forms-field-block {
-  &__label__description {
+  &__label-description {
     color: var(--sb-color-gray-dark);
     font-size: var(--font-size-small);
   }

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-ui.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-ui.scss
@@ -1,5 +1,5 @@
 .dnb-forms-field-block {
-  &__label__description {
+  &__label-description {
     color: var(--color-black-55);
     font-size: var(--font-size-small);
   }

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -263,7 +263,7 @@ function ValueBlock(localProps: Props) {
               srOnly={labelSrOnly}
             >
               {label && (
-                <span className="dnb-forms-value-block__label__content">
+                <span className="dnb-forms-value-block__label-content">
                   {label}
                 </span>
               )}

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -104,9 +104,8 @@ describe('ValueBlock', () => {
       document.querySelector('.dnb-forms-value-block__label-content')
         .textContent
     ).toContain('Item no. 1 – ready')
-    expect(
-      document.querySelector('.dnb-forms-value-block__label-content')
-    ).toMatchInlineSnapshot(`
+    expect(document.querySelector('.dnb-forms-value-block__label-content'))
+      .toMatchInlineSnapshot(`
       <span
         class="dnb-forms-value-block__label-content"
       >

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/__tests__/ValueBlock.test.tsx
@@ -101,14 +101,14 @@ describe('ValueBlock', () => {
     )
 
     expect(
-      document.querySelector('.dnb-forms-value-block__label__content')
+      document.querySelector('.dnb-forms-value-block__label-content')
         .textContent
     ).toContain('Item no. 1 – ready')
     expect(
-      document.querySelector('.dnb-forms-value-block__label__content')
+      document.querySelector('.dnb-forms-value-block__label-content')
     ).toMatchInlineSnapshot(`
       <span
-        class="dnb-forms-value-block__label__content"
+        class="dnb-forms-value-block__label-content"
       >
         Item no. 
         <code

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/style/dnb-value-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/style/dnb-value-block.scss
@@ -175,7 +175,7 @@
 
     // For a composition block with horizontal layout in a SummaryList and no label,
     // the help button should be on the end of the content.
-    &:not(&__label__content):has(
+    &:not(&__label-content):has(
         > .dnb-forms-value-block__label:not(&__content)
       ):has(.dnb-forms-value-block__content) {
       flex-direction: row-reverse;

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.screenshot.test.ts
@@ -27,7 +27,7 @@ describe('Wizard.Container', () => {
       addWrapper: false, // because it destroys the media query handling
       simulate: 'click',
       simulateSelector:
-        '[data-visual-test="wizard-layout-card-border"] .dnb-step-indicator__trigger__button',
+        '[data-visual-test="wizard-layout-card-border"] .dnb-step-indicator__trigger-button',
       selector: '[data-visual-test="wizard-layout-card-border"]',
     })
     expect(screenshot).toMatchImageSnapshot()

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -33,7 +33,7 @@ function simulateSmallScreen() {
 const expandStepIndicator = async () => {
   await fireEvent.click(
     document.querySelector(
-      'button.dnb-step-indicator__trigger__button--collapsed'
+      'button.dnb-step-indicator__trigger-button--collapsed'
     )
   )
 }
@@ -956,7 +956,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 2')
 
       await expandStepIndicator()
@@ -982,7 +982,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 2 av 2')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 1')
 
       expect(
@@ -1007,7 +1007,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 2')
 
       expect(
@@ -1032,7 +1032,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('')
       expect(
         document.querySelectorAll('.dnb-step-indicator__item')
@@ -1251,7 +1251,7 @@ describe('Wizard.Container', () => {
 
       expect(output()).toBeNull()
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('')
       expect(
         document.querySelectorAll('.dnb-step-indicator__item')
@@ -1452,7 +1452,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 2')
 
       await expandStepIndicator()
@@ -1478,7 +1478,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 2 av 2')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 1')
 
       expect(
@@ -1503,7 +1503,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('Step 2')
 
       expect(
@@ -1528,7 +1528,7 @@ describe('Wizard.Container', () => {
         document.querySelector('.dnb-step-indicator')
       ).toHaveTextContent('Steg 1 av 1')
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('')
       expect(
         document.querySelectorAll('.dnb-step-indicator__item')
@@ -1746,7 +1746,7 @@ describe('Wizard.Container', () => {
 
       expect(output()).toBeNull()
       expect(
-        document.querySelector('.dnb-step-indicator__trigger__button')
+        document.querySelector('.dnb-step-indicator__trigger-button')
       ).toHaveTextContent('')
       expect(
         document.querySelectorAll('.dnb-step-indicator__item')
@@ -2639,7 +2639,7 @@ describe('Wizard.Container', () => {
     )
 
     expect(
-      document.querySelector('.dnb-step-indicator__trigger__button')
+      document.querySelector('.dnb-step-indicator__trigger-button')
     ).toHaveTextContent('Title missing')
 
     expandStepIndicator()
@@ -5475,8 +5475,8 @@ describe('Wizard.Container', () => {
       </>
     )
     expect(
-      document.querySelector('button.dnb-step-indicator__trigger__button')
-    ).toHaveClass('dnb-step-indicator__trigger__button--expanded')
+      document.querySelector('button.dnb-step-indicator__trigger-button')
+    ).toHaveClass('dnb-step-indicator__trigger-button--expanded')
 
     expect(
       document.querySelectorAll('li.dnb-step-indicator__item')

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -167,14 +167,14 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
    * Flex container to house provider logos (e.g., Visa, Mastercard, BankAxept).
    * Includes a visual separator if two providers are present. */
 }
-.dnb-payment-card__card-wrapper {
+.dnb-payment-card__card__wrapper {
   position: relative;
   width: 343px;
   height: 216px;
   border-radius: inherit;
   border: 1px solid var(--color-black-8);
 }
-.dnb-payment-card__card-wrapper::after {
+.dnb-payment-card__card__wrapper::after {
   content: "";
   position: absolute;
   top: 0;
@@ -232,7 +232,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   background-color: var(--color-white);
   color: var(--sb-color-text);
 }
-.dnb-payment-card__card-content {
+.dnb-payment-card__card__content {
   display: flex;
   height: 100%;
   width: 100%;
@@ -345,7 +345,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   height: 62px;
   border-radius: var(--dnb-payment-border-radius) var(--dnb-payment-border-radius) 0 0;
 }
-.dnb-payment-card--compact .dnb-payment-card__card-wrapper {
+.dnb-payment-card--compact .dnb-payment-card__card__wrapper {
   height: auto;
 }
 .dnb-payment-card--compact .dnb-payment-card__card__providers {

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -167,14 +167,14 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
    * Flex container to house provider logos (e.g., Visa, Mastercard, BankAxept).
    * Includes a visual separator if two providers are present. */
 }
-.dnb-payment-card__card__wrapper {
+.dnb-payment-card__card-wrapper {
   position: relative;
   width: 343px;
   height: 216px;
   border-radius: inherit;
   border: 1px solid var(--color-black-8);
 }
-.dnb-payment-card__card__wrapper::after {
+.dnb-payment-card__card-wrapper::after {
   content: "";
   position: absolute;
   top: 0;
@@ -232,7 +232,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   background-color: var(--color-white);
   color: var(--sb-color-text);
 }
-.dnb-payment-card__card__content {
+.dnb-payment-card__card-content {
   display: flex;
   height: 100%;
   width: 100%;
@@ -345,7 +345,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   height: 62px;
   border-radius: var(--dnb-payment-border-radius) var(--dnb-payment-border-radius) 0 0;
 }
-.dnb-payment-card--compact .dnb-payment-card__card__wrapper {
+.dnb-payment-card--compact .dnb-payment-card__card-wrapper {
   height: auto;
 }
 .dnb-payment-card--compact .dnb-payment-card__card__providers {

--- a/packages/dnb-eufemia/src/extensions/payment-card/components/CardFigure.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/components/CardFigure.tsx
@@ -75,7 +75,7 @@ function CardFigure({
   }
 
   return (
-    <div className="dnb-payment-card__card__wrapper">
+    <div className="dnb-payment-card__card-wrapper">
       <div
         id={id}
         className={cardClasses}
@@ -87,16 +87,16 @@ function CardFigure({
             }
           : {})}
       >
-        <div className="dnb-payment-card__card__content">
-          <div className="dnb-payment-card__card__top">
-            <div className="dnb-payment-card__card__top__left">
+        <div className="dnb-payment-card__card-content">
+          <div className="dnb-payment-card__card-top">
+            <div className="dnb-payment-card__card-top-left">
               <BankLogo logoType={data.cardDesign.bankLogo} />
               <ProductLogo
                 productType={data.productType}
                 cardDesign={data.cardDesign}
               />
             </div>
-            <div className="dnb-payment-card__card__top__right">
+            <div className="dnb-payment-card__card-top-right">
               {compact ? (
                 <ProviderIcons />
               ) : (
@@ -108,14 +108,14 @@ function CardFigure({
             </div>
           </div>
           {!compact && (
-            <div className="dnb-payment-card__card__bottom">
-              <div className="dnb-payment-card__card__bottom__left">
+            <div className="dnb-payment-card__card-bottom">
+              <div className="dnb-payment-card__card-bottom-left">
                 <CardNumberText
                   cardNumber={cardNumber}
                   skeleton={skeleton}
                 />
               </div>
-              <div className="dnb-payment-card__card__bottom__right">
+              <div className="dnb-payment-card__card-bottom__right">
                 <ProviderIcons />
               </div>
             </div>

--- a/packages/dnb-eufemia/src/extensions/payment-card/icons/index.js
+++ b/packages/dnb-eufemia/src/extensions/payment-card/icons/index.js
@@ -27,13 +27,13 @@ const BankLogo = ({ logoType }) =>
     Colored: (color) => (
       <DNB
         fill={color}
-        className="dnb-payment-card__card__bank-logo"
+        className="dnb-payment-card__card-bank-logo"
       />
     ),
     Sbanken: (color) => (
       <Sbanken
         fill={color}
-        className="dnb-payment-card__card__bank-logo"
+        className="dnb-payment-card__card-bank-logo"
       />
     ),
   })

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -185,7 +185,7 @@ export interface DrawerListProps {
    */
   skip_portal?: boolean
   /**
-   * Define an HTML class that will be set on the DOM portal beside `dnb-drawer-list__portal__style`. Can be useful to handle e.g. a custom `z-index` in relation to a header.
+   * Define an HTML class that will be set on the DOM portal beside `dnb-drawer-list__portal-style`. Can be useful to handle e.g. a custom `z-index` in relation to a header.
    */
   portal_class?: string
   /**

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -92,7 +92,7 @@ export const DrawerListProperties = {
     status: 'optional',
   },
   portal_class: {
-    doc: 'Define an HTML class that will be set on the DOM portal beside `dnb-drawer-list__portal__style`. Can be useful to handle e.g. a custom `z-index` in relation to a header.',
+    doc: 'Define an HTML class that will be set on the DOM portal beside `dnb-drawer-list__portal-style`. Can be useful to handle e.g. a custom `z-index` in relation to a header.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
@@ -120,7 +120,7 @@ export function ItemContent({ hash = '', children }: ItemContentProps) {
     <>
       {renderedContent}
       {isDataObject && children.suffix_value && (
-        <DrawerListOptionItem className="dnb-drawer-list__option__suffix">
+        <DrawerListOptionItem className="dnb-drawer-list__option-suffix">
           {children.suffix_value}
         </DrawerListOptionItem>
       )}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
@@ -71,7 +71,7 @@ export const DrawerListItem = forwardRef(function DrawerListItem(
 
   return (
     <li {...params} {...rest} ref={ref} key={'li' + hash}>
-      <span className="dnb-drawer-list__option__inner">
+      <span className="dnb-drawer-list__option-inner">
         <ItemContent hash={hash}>{children}</ItemContent>
       </span>
     </li>
@@ -135,7 +135,7 @@ function DrawerListOptionItem({
 }) {
   return (
     <span
-      className={classnames(['dnb-drawer-list__option__item', className])}
+      className={classnames(['dnb-drawer-list__option-item', className])}
       {...props}
     >
       {children}
@@ -154,7 +154,7 @@ export function DrawerListHorizontalItem({
   return (
     <DrawerListOptionItem
       className={classnames([
-        'dnb-drawer-list__option__item--horizontal',
+        'dnb-drawer-list__option-item--horizontal',
         className,
       ])}
       {...props}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
@@ -226,8 +226,8 @@ function DrawerListPortal({
         >
           <span
             className={classnames(
-              'dnb-drawer-list__portal__style',
-              fixed_position && 'dnb-drawer-list__portal__style--fixed',
+              'dnb-drawer-list__portal-style',
+              fixed_position && 'dnb-drawer-list__portal-style--fixed',
               className
             )}
             style={style}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -1141,7 +1141,7 @@ describe('DrawerList component', () => {
 
       expect(
         document
-          .querySelector('span.dnb-drawer-list__option__item')
+          .querySelector('span.dnb-drawer-list__option-item')
           .getAttribute('style')
       ).toBe('hyphens: auto;')
     })
@@ -1378,7 +1378,7 @@ describe('DrawerList portal', () => {
     const { rerender } = render(<DrawerList opened no_animation />)
 
     const styleElement = document.querySelector(
-      '.dnb-drawer-list__portal__style'
+      '.dnb-drawer-list__portal-style'
     )
 
     await waitFor(() => {
@@ -1413,7 +1413,7 @@ describe('DrawerList portal', () => {
     )
 
     const styleElement = document.querySelector(
-      '.dnb-drawer-list__portal__style'
+      '.dnb-drawer-list__portal-style'
     )
 
     await waitFor(() => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -157,7 +157,7 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   outline: none;
   background-color: var(--color-white);
 }
-.dnb-drawer-list__option-inner {
+.dnb-drawer-list__option__option-inner {
   position: relative;
   z-index: 1;
   display: grid;
@@ -169,21 +169,21 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   color: inherit;
   background-color: var(--drawer-list-option-inner-background);
 }
-.dnb-drawer-list__option-inner > * {
+.dnb-drawer-list__option__option-inner > * {
   align-self: self-start;
 }
-.dnb-drawer-list__option-item {
+.dnb-drawer-list__option__item {
   display: block;
   text-overflow: ellipsis;
   grid-column: 1;
 }
-.dnb-drawer-list__option-item--horizontal {
+.dnb-drawer-list__option__item--horizontal {
   display: flex;
 }
-.dnb-drawer-list__option-item > .dnb-icon {
+.dnb-drawer-list__option__item > .dnb-icon {
   vertical-align: initial;
 }
-.dnb-drawer-list__option-item .dnb-anchor {
+.dnb-drawer-list__option__item .dnb-anchor {
   display: inline-block;
   margin-right: 0.5rem;
   word-break: break-word;
@@ -339,7 +339,7 @@ html[data-visual-test] .dnb-drawer-list--opened .dnb-drawer-list__list, .dnb-dra
 html[data-visual-test] .dnb-drawer-list:not(.dnb-drawer-list--opened) .dnb-drawer-list__list, .dnb-drawer-list:not(.dnb-drawer-list--opened) .dnb-drawer-list__list--no-animation {
   animation-duration: 1ms !important;
 }
-.dnb-drawer-list--action-menu .dnb-drawer-list__option-inner {
+.dnb-drawer-list--action-menu .dnb-drawer-list__option__inner {
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
@@ -469,7 +469,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
 .dnb-drawer-list__option.ignore-events {
   pointer-events: none;
 }
-.dnb-drawer-list__option-inner::before {
+.dnb-drawer-list__option__inner::before {
   pointer-events: none;
   content: "";
   position: absolute;
@@ -481,7 +481,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
   height: var(--drawer-list-option-border-width);
   background-color: var(--color-mint-green-25);
 }
-.dnb-drawer-list__option-item.item-nr-1 {
+.dnb-drawer-list__option__item.item-nr-1 {
   font-weight: var(--font-weight-medium);
 }
 html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover[disabled] {
@@ -500,7 +500,7 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
 .dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option-inner, html:not([data-whatintent=touch]) .dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option-inner {
   color: var(--color-black);
 }
-.dnb-drawer-list__option--focus .dnb-drawer-list__option-inner::before {
+.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
   z-index: 3;
   top: var(--drawer-list-focus-border-width);
   left: var(--drawer-list-focus-border-width);
@@ -513,30 +513,30 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-drawer-list__option--ignore .dnb-drawer-list__option-inner {
+.dnb-drawer-list__option--ignore .dnb-drawer-list__option__inner {
   color: var(--color-black-80);
   background-color: var(--color-white);
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner {
   color: var(--color-white);
   background-color: var(--color-emerald-green);
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner .dnb-drawer-list__option-inner {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner .dnb-drawer-list__option-inner {
   color: inherit;
   background-color: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover[disabled] {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover:not([disabled]) {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) {
   color: var(--color-white);
   background-color: var(--color-emerald-green);
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover:not([disabled]) .dnb-drawer-list__option-inner {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) .dnb-drawer-list__option-inner {
   color: inherit;
   background-color: inherit;
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner::after {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner::after {
   content: "";
   grid-column: 2;
   grid-row: 1/-1;
@@ -547,7 +547,7 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer
   background-size: cover;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSI+ICA8cGF0aCAgICBmaWxsPSIjRTlGOEY0IiAgICBkPSJNMyA4LjhhLjc1Ljc1IDAgMSAwLTEuMjIuODZMMyA4Ljc5em0xLjg0IDMuOWwuNjMtLjQxdi0uMDFoLS4wMWwtLjYyLjQyem0xLjcxLjA1bC0uNTktLjQ2di4wMWwuNTkuNDV6bTguNDMtOS40NWEuNzUuNzUgMCAwIDAtMS4xOC0uOTNsMS4xOC45M3pNMS43OCA5LjY2bDIuNDUgMy40OCAxLjIzLS44N0wzIDguOGwtMS4yMy44N3ptMi40NCAzLjQ2Yy4zMi40OC44Ni43OCAxLjQ0LjhsLjA1LTEuNWEuMy4zIDAgMCAxLS4yNC0uMTNsLTEuMjUuODN6bTEuNDQuOGExLjggMS44IDAgMCAwIDEuNDktLjcxbC0xLjItLjlhLjMuMyAwIDAgMS0uMjQuMWwtLjA1IDEuNXptMS40OC0uN2w3Ljg0LTkuOTItMS4xOC0uOTMtNy44NCA5LjkyIDEuMTguOTN6Ii8+PC9zdmc+");
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner::before {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner::before {
   visibility: hidden;
 }
 @media screen and (min-width: 40.00625em) {
@@ -555,28 +555,28 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer
     z-index: 2;
     background-color: inherit;
   }
-  .dnb-drawer-list__option:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__suffix.dnb-drawer-list__option-item:nth-of-type(n + 2) {
+  .dnb-drawer-list__option:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__suffix.dnb-drawer-list__option__item:nth-of-type(n + 2) {
     color: var(--color-black-80);
   }
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option-inner::before {
+html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
   visibility: visible;
   --border-color: var(--color-mint-green);
   --border-width: var(--drawer-list-focus-border-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-drawer-list__option--focus:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option-inner {
+.dnb-drawer-list__option--focus:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__inner {
   color: var(--color-sea-green);
   background-color: var(--color-mint-green-12);
 }
-.dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option-inner::before {
+.dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   content: none;
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option-item .dnb-anchor:focus {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option-item .dnb-anchor:focus {
+html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
   --border-color: var(--color-white);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -40,15 +40,15 @@ exports[`DrawerList scss has to match style dependencies css 1`] = `
 .dnb-drawer-list__portal {
   --drawer-list-width: 16rem;
 }
-.dnb-drawer-list__portal__style {
+.dnb-drawer-list__portal-style {
   position: absolute;
   transition: all 300ms var(--easing-default);
   z-index: calc(var(--modal-z-index, 3200) + 300);
 }
-html[data-visual-test] .dnb-drawer-list__portal__style {
+html[data-visual-test] .dnb-drawer-list__portal-style {
   transition: none !important;
 }
-.dnb-drawer-list__portal__style--fixed {
+.dnb-drawer-list__portal-style--fixed {
   position: fixed;
 }
 .dnb-drawer-list__root {
@@ -157,7 +157,7 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   outline: none;
   background-color: var(--color-white);
 }
-.dnb-drawer-list__option__inner {
+.dnb-drawer-list__option-inner {
   position: relative;
   z-index: 1;
   display: grid;
@@ -169,21 +169,21 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   color: inherit;
   background-color: var(--drawer-list-option-inner-background);
 }
-.dnb-drawer-list__option__inner > * {
+.dnb-drawer-list__option-inner > * {
   align-self: self-start;
 }
-.dnb-drawer-list__option__item {
+.dnb-drawer-list__option-item {
   display: block;
   text-overflow: ellipsis;
   grid-column: 1;
 }
-.dnb-drawer-list__option__item--horizontal {
+.dnb-drawer-list__option-item--horizontal {
   display: flex;
 }
-.dnb-drawer-list__option__item > .dnb-icon {
+.dnb-drawer-list__option-item > .dnb-icon {
   vertical-align: initial;
 }
-.dnb-drawer-list__option__item .dnb-anchor {
+.dnb-drawer-list__option-item .dnb-anchor {
   display: inline-block;
   margin-right: 0.5rem;
   word-break: break-word;
@@ -339,7 +339,7 @@ html[data-visual-test] .dnb-drawer-list--opened .dnb-drawer-list__list, .dnb-dra
 html[data-visual-test] .dnb-drawer-list:not(.dnb-drawer-list--opened) .dnb-drawer-list__list, .dnb-drawer-list:not(.dnb-drawer-list--opened) .dnb-drawer-list__list--no-animation {
   animation-duration: 1ms !important;
 }
-.dnb-drawer-list--action-menu .dnb-drawer-list__option__inner {
+.dnb-drawer-list--action-menu .dnb-drawer-list__option-inner {
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
@@ -469,7 +469,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
 .dnb-drawer-list__option.ignore-events {
   pointer-events: none;
 }
-.dnb-drawer-list__option__inner::before {
+.dnb-drawer-list__option-inner::before {
   pointer-events: none;
   content: "";
   position: absolute;
@@ -481,7 +481,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
   height: var(--drawer-list-option-border-width);
   background-color: var(--color-mint-green-25);
 }
-.dnb-drawer-list__option__item.item-nr-1 {
+.dnb-drawer-list__option-item.item-nr-1 {
   font-weight: var(--font-weight-medium);
 }
 html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover[disabled] {
@@ -490,17 +490,17 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover[disabled] {
 html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled]) {
   background-color: var(--color-mint-green-12);
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled]) .dnb-drawer-list__option__inner {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled]) .dnb-drawer-list__option-inner {
   color: var(--color-sea-green);
   background-color: var(--color-mint-green-12);
 }
 .dnb-drawer-list__option:active[disabled], html:not([data-whatintent=touch]) .dnb-drawer-list__option:active[disabled] {
   cursor: not-allowed;
 }
-.dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option__inner, html:not([data-whatintent=touch]) .dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option-inner, html:not([data-whatintent=touch]) .dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option-inner {
   color: var(--color-black);
 }
-.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list__option--focus .dnb-drawer-list__option-inner::before {
   z-index: 3;
   top: var(--drawer-list-focus-border-width);
   left: var(--drawer-list-focus-border-width);
@@ -513,30 +513,30 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-drawer-list__option--ignore .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option--ignore .dnb-drawer-list__option-inner {
   color: var(--color-black-80);
   background-color: var(--color-white);
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner {
   color: var(--color-white);
   background-color: var(--color-emerald-green);
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner .dnb-drawer-list__option-inner {
   color: inherit;
   background-color: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover[disabled] {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover:not([disabled]) {
   color: var(--color-white);
   background-color: var(--color-emerald-green);
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) .dnb-drawer-list__option__inner {
+html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option-inner:hover:not([disabled]) .dnb-drawer-list__option-inner {
   color: inherit;
   background-color: inherit;
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner::after {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner::after {
   content: "";
   grid-column: 2;
   grid-row: 1/-1;
@@ -547,7 +547,7 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer
   background-size: cover;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSI+ICA8cGF0aCAgICBmaWxsPSIjRTlGOEY0IiAgICBkPSJNMyA4LjhhLjc1Ljc1IDAgMSAwLTEuMjIuODZMMyA4Ljc5em0xLjg0IDMuOWwuNjMtLjQxdi0uMDFoLS4wMWwtLjYyLjQyem0xLjcxLjA1bC0uNTktLjQ2di4wMWwuNTkuNDV6bTguNDMtOS40NWEuNzUuNzUgMCAwIDAtMS4xOC0uOTNsMS4xOC45M3pNMS43OCA5LjY2bDIuNDUgMy40OCAxLjIzLS44N0wzIDguOGwtMS4yMy44N3ptMi40NCAzLjQ2Yy4zMi40OC44Ni43OCAxLjQ0LjhsLjA1LTEuNWEuMy4zIDAgMCAxLS4yNC0uMTNsLTEuMjUuODN6bTEuNDQuOGExLjggMS44IDAgMCAwIDEuNDktLjcxbC0xLjItLjlhLjMuMyAwIDAgMS0uMjQuMWwtLjA1IDEuNXptMS40OC0uN2w3Ljg0LTkuOTItMS4xOC0uOTMtNy44NCA5LjkyIDEuMTguOTN6Ii8+PC9zdmc+");
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option-inner::before {
   visibility: hidden;
 }
 @media screen and (min-width: 40.00625em) {
@@ -555,42 +555,42 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer
     z-index: 2;
     background-color: inherit;
   }
-  .dnb-drawer-list__option:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__suffix.dnb-drawer-list__option__item:nth-of-type(n + 2) {
+  .dnb-drawer-list__option:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__suffix.dnb-drawer-list__option-item:nth-of-type(n + 2) {
     color: var(--color-black-80);
   }
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
+html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option-inner::before {
   visibility: visible;
   --border-color: var(--color-mint-green);
   --border-width: var(--drawer-list-focus-border-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-drawer-list__option--focus:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option--focus:not(.dnb-drawer-list__option--selected) .dnb-drawer-list__option-inner {
   color: var(--color-sea-green);
   background-color: var(--color-mint-green-12);
 }
-.dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option-inner::before {
   content: none;
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option-item .dnb-anchor:focus {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
+html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option-item .dnb-anchor:focus {
   --border-color: var(--color-white);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-drawer-list--scroll .dnb-drawer-list__option:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list--scroll .dnb-drawer-list__option:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option-inner::before {
   left: 0.5rem;
   right: 0.5rem;
 }
-.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option-inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option-inner::before {
   border-top-left-radius: var(--drawer-list-options-border-radius);
   border-top-right-radius: var(--drawer-list-options-border-radius);
 }
-.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option-inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option-inner::before {
   border-bottom-left-radius: var(--drawer-list-options-border-radius);
   border-bottom-right-radius: var(--drawer-list-options-border-radius);
 }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -74,7 +74,7 @@
     --drawer-list-width: 16rem;
   }
 
-  &__portal__style {
+  &__portal-style {
     position: absolute;
     transition: all 300ms var(--easing-default);
 
@@ -193,7 +193,7 @@
 
     background-color: var(--color-white);
 
-    &__inner {
+    &__option-inner {
       position: relative;
       z-index: 1; // only to go over &__triangle
 

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-sbanken.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  &__option__inner {
+  &__option-inner {
     overflow: visible;
     padding: 1rem 0.75rem;
     margin: 0 var(--drawer-list-option-border-width);
@@ -76,7 +76,7 @@
       --drawer-list-option-border-color: var(--sb-color-violet);
       z-index: 1;
 
-      .dnb-drawer-list__option__inner::before {
+      .dnb-drawer-list__option-inner::before {
         display: var(--drawer-list-option-inner-border-display);
       }
     }
@@ -85,7 +85,7 @@
       --drawer-list-option-border-color: var(--sb-color-violet);
       z-index: 1;
 
-      .dnb-drawer-list__option__inner::before {
+      .dnb-drawer-list__option-inner::before {
         display: var(--drawer-list-option-inner-border-display);
       }
     }
@@ -101,12 +101,12 @@
         border-bottom-color: var(--sb-color-gray-dark-2);
       }
 
-      .dnb-drawer-list__option__inner::before {
+      .dnb-drawer-list__option-inner::before {
         display: var(--drawer-list-option-inner-border-display);
       }
 
       // check icon
-      .dnb-drawer-list__option__inner::after {
+      .dnb-drawer-list__option-inner::after {
         content: '';
 
         grid-column: 2;
@@ -149,15 +149,15 @@
       z-index: 1;
 
       /* stylelint-disable no-descending-specificity */
-      .dnb-drawer-list__option__inner {
+      .dnb-drawer-list__option-inner {
         --drawer-list-option-inner-background: transparent;
       }
 
-      .dnb-drawer-list__option__inner::before {
+      .dnb-drawer-list__option-inner::before {
         display: var(--drawer-list-option-inner-border-display);
       }
 
-      .dnb-drawer-list__option__inner::after {
+      .dnb-drawer-list__option-inner::after {
         // Selected check mark icon
         background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTUuOTk5OTYgMTEuMDU3M0wxNC42NjY2IDIuMzkwNjdMMTUuNjA5MyAzLjMzMzM0TDUuOTk5OTYgMTIuOTQyN0wwLjM5MDYyNSA3LjMzMzM0TDEuMzMzMjkgNi4zOTA2N0w1Ljk5OTk2IDExLjA1NzNaIiBmaWxsPSIjMDA1Q0ZGIi8+Cjwvc3ZnPgo=');
       }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
@@ -72,14 +72,14 @@
     @include hover() {
       background-color: var(--color-mint-green-12);
 
-      .dnb-drawer-list__option__inner {
+      .dnb-drawer-list__option-inner {
         color: var(--color-sea-green);
         background-color: var(--color-mint-green-12);
       }
     }
 
     @include active() {
-      .dnb-drawer-list__option__inner {
+      .dnb-drawer-list__option-inner {
         color: var(--color-black);
       }
     }
@@ -114,7 +114,7 @@
       color: var(--color-white);
       background-color: var(--color-emerald-green);
 
-      .dnb-drawer-list__option__inner {
+      .dnb-drawer-list__option-inner {
         color: inherit;
         background-color: inherit;
       }
@@ -123,7 +123,7 @@
         color: var(--color-white);
         background-color: var(--color-emerald-green);
 
-        .dnb-drawer-list__option__inner {
+        .dnb-drawer-list__option-inner {
           color: inherit;
           background-color: inherit;
         }
@@ -196,19 +196,19 @@
   }
 
   // make sure we have a spacing on the right side if we have a scrollbar
-  &--scroll &__option:not(#{&}__option--focus) &__option__inner::before {
+  &--scroll &__option:not(#{&}__option--focus) &__option-inner::before {
     left: 0.5rem;
     right: 0.5rem;
   }
 
-  &--bottom &__option--focus.closest-to-top &__option__inner::before,
-  &--top &__option--focus.closest-to-top &__option__inner::before {
+  &--bottom &__option--focus.closest-to-top &__option-inner::before,
+  &--top &__option--focus.closest-to-top &__option-inner::before {
     border-top-left-radius: var(--drawer-list-options-border-radius);
     border-top-right-radius: var(--drawer-list-options-border-radius);
   }
 
-  &--bottom &__option--focus.closest-to-bottom &__option__inner::before,
-  &--top &__option--focus.closest-to-bottom &__option__inner::before {
+  &--bottom &__option--focus.closest-to-bottom &__option-inner::before,
+  &--top &__option--focus.closest-to-bottom &__option-inner::before {
     border-bottom-left-radius: var(--drawer-list-options-border-radius);
     border-bottom-right-radius: var(--drawer-list-options-border-radius);
   }

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -207,7 +207,7 @@ describe('Portals', () => {
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual(
       expect.arrayContaining([
-        'dnb-drawer-list__portal__style',
+        'dnb-drawer-list__portal-style',
         'eufemia-theme',
         'eufemia-theme__eiendom',
         'eufemia-theme__eiendom--soft',
@@ -226,7 +226,7 @@ describe('Portals', () => {
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual(
       expect.arrayContaining([
-        'dnb-drawer-list__portal__style',
+        'dnb-drawer-list__portal-style',
         'eufemia-theme',
         'eufemia-theme__eiendom',
         'eufemia-theme__eiendom--soft',


### PR DESCRIPTION
This can potentially be breaking, so nothing to include in v10, but could be worth looking into for v11.

Perhaps there's some kind of BEM plugin/linter that we could use to help us write correct BEM style. 

Some improvements suggested by AI:
- Avoid nested component references - Style through your own BEM elements/modifiers
- Keep element hierarchy flat - Use single __ separator (e.g., __header-icon not __header__icon)
- Limit modifier chaining - Consider combined modifiers for complex states
- Use context-specific modifiers instead of styling external components
- Consider CSS custom properties (which you're already doing well) for theming variations