### PR TITLE
chore: increase performance of our tests

### DIFF
--- a/packages/dnb-eufemia/jest.config.js
+++ b/packages/dnb-eufemia/jest.config.js
@@ -3,6 +3,7 @@ const config = {
   testEnvironmentOptions: {
     url: 'http://localhost',
   },
+  maxWorkers: '50%',
   testRegex: '(/__tests__/\\.js|(\\.|/)test)\\.(js|jsx|ts|tsx)?$',
   testPathIgnorePatterns: [
     'not_in_use',


### PR DESCRIPTION
Attempt at improving performance of our unit tests.

AI says:

```
Why This Works:
- Reduces overhead: 11 workers create significant memory and context-switching overhead
- Better cache utilization: Fewer workers = better CPU cache hits
- Memory efficiency: Each Jest worker can use ~200-500MB of memory
- Optimal throughput: Studies show 50% of cores often gives best results for I/O bound tests
```

Let's see if the test it takes to run the unit tests actually is improved...