### PR TITLE
chore: remove jest-matchmedia-mock

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -229,7 +229,6 @@
     "jest-axe": "10.0.0",
     "jest-environment-jsdom": "30.0.5",
     "jest-image-snapshot": "6.5.1",
-    "jest-matchmedia-mock": "1.1.0",
     "jest-playwright-preset": "4.0.0",
     "jest-raw-loader": "1.0.1",
     "jest-tobetype": "1.2.3",

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -11,10 +11,8 @@ import {
   subtract_medium as SubtractIcon,
 } from '../../../icons'
 import { render, fireEvent, act } from '@testing-library/react'
-import MatchMediaMock from 'jest-matchmedia-mock'
+import 'mock-match-media/jest-setup'
 import userEvent from '@testing-library/user-event'
-
-new MatchMediaMock()
 
 const props: AccordionProps = {
   no_animation: true,

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -17,18 +17,17 @@ import StepIndicator, {
   StepIndicatorProps,
 } from '../StepIndicator'
 import Provider from '../../../shared/Provider'
-import MatchMediaMock from 'jest-matchmedia-mock'
+import 'mock-match-media/jest-setup'
+import { setMedia } from 'mock-match-media'
 import { StepIndicatorSidebarProps } from '../StepIndicatorSidebar'
 
-const matchMedia = new MatchMediaMock()
-
 beforeEach(() => {
-  matchMedia.useMediaQuery('(min-width: 60em)')
+  setMedia({ width: '70em' }) // Large screen (>60em)
   document.body.innerHTML = `<div id="root"></div>`
 })
 
 function simulateSmallScreen() {
-  matchMedia.useMediaQuery('(min-width: 0) and (max-width: 60em)')
+  setMedia({ width: '50em' }) // Small screen (<60em)
 }
 
 const stepIndicatorListData: StepIndicatorData = [

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import MatchMediaMock from 'jest-matchmedia-mock'
+import 'mock-match-media/jest-setup'
+import { setMedia } from 'mock-match-media'
 import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
 import { Translation } from '../../../../../shared'
 import {
@@ -19,15 +20,13 @@ import WizardContext from '../../Context'
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
-const matchMedia = new MatchMediaMock()
-
 beforeEach(() => {
-  matchMedia.useMediaQuery('(min-width: 60em)')
+  setMedia({ width: '70em' }) // Large screen (>60em)
   globalThis.IS_TEST = true
 })
 
 function simulateSmallScreen() {
-  matchMedia.useMediaQuery('(min-width: 0) and (max-width: 60em)')
+  setMedia({ width: '50em' }) // Small screen (<60em)
 }
 
 const expandStepIndicator = async () => {

--- a/packages/dnb-eufemia/src/shared/__tests__/MediaQuery.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/MediaQuery.test.tsx
@@ -6,7 +6,8 @@
 import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 
-import MatchMediaMock from 'jest-matchmedia-mock'
+import 'mock-match-media/jest-setup'
+import { setMedia } from 'mock-match-media'
 import MediaQuery, { MediaQueryProps } from '../MediaQuery'
 import Provider from '../Provider'
 import { isMatchMediaSupported as _isMatchMediaSupported } from '../MediaQueryUtils'
@@ -22,28 +23,12 @@ jest.mock('../MediaQueryUtils', () => {
 })
 
 describe('MediaQuery', () => {
-  let matchMedia: MatchMediaMock
-
-  beforeAll(() => {
-    matchMedia = new MatchMediaMock()
-  })
-
   beforeEach(() => {
     isMatchMediaSupported.mockReturnValue(true)
   })
 
-  afterEach(() => {
-    matchMedia?.clear()
-  })
-
-  afterAll(() => {
-    matchMedia?.destroy()
-  })
-
   it('renders with props as an object', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 60.00625em) and (max-width: 72em)'
-    )
+    setMedia({ width: '65em' }) // Between 60em and 72em
 
     const props: MediaQueryProps = {
       when: { min: 'medium', max: 'large' },
@@ -55,9 +40,7 @@ describe('MediaQuery', () => {
   })
 
   it('should match for query with medium width', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 60.00625em) and (max-width: 72em)'
-    )
+    setMedia({ width: '65em' }) // Between 60em and 72em
 
     render(
       <MediaQuery when={{ min: 'medium', max: 'large' }}>
@@ -68,9 +51,7 @@ describe('MediaQuery', () => {
   })
 
   it('should match for query when different breakpoints are given', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 40.00625em) and (max-width: 80em), (min-width: 0) and (max-width: 30rem), (max-width: 90em)'
-    )
+    setMedia({ width: '50em' }) // Matches the query ranges
 
     render(
       <Provider
@@ -97,9 +78,7 @@ describe('MediaQuery', () => {
   })
 
   it('should match for query when custom breakpoints are given', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 0) and (max-width: 20rem), (max-width: 90rem)'
-    )
+    setMedia({ width: '10rem' }) // Less than 20rem (xsmall)
 
     render(
       <Provider
@@ -120,9 +99,7 @@ describe('MediaQuery', () => {
   })
 
   it('should match for query when breakpoint is got removed', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 0) and (max-width: 20rem), (min-width: 71rem)'
-    )
+    setMedia({ width: '10rem' }) // Less than 20rem (xsmall)
 
     render(
       <Provider
@@ -161,9 +138,7 @@ describe('MediaQuery', () => {
   })
 
   it('should match for query with medium and large width', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 60.00625em) and (max-width: 72em), (min-width: 72.00625em) and (max-width: 80em)'
-    )
+    setMedia({ width: '65em' }) // Between 60em and 80em
 
     render(
       <MediaQuery
@@ -179,9 +154,7 @@ describe('MediaQuery', () => {
   })
 
   it('should handle media query changes', () => {
-    matchMedia.useMediaQuery(
-      'not screen and (min-width: 0) and (max-width: 72em)'
-    )
+    setMedia({ width: '80em' }) // Above 72em to not match initially
 
     const Playground = () => {
       const [query, updateQuery] = React.useState({

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers/MediaQueryMocker.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers/MediaQueryMocker.ts
@@ -1,5 +1,5 @@
 import { isMatchMediaSupported as _isMatchMediaSupported } from '../../MediaQueryUtils'
-import MatchMediaMock from 'jest-matchmedia-mock'
+import { matchMedia } from 'mock-match-media'
 
 const isMatchMediaSupported = _isMatchMediaSupported as jest.Mock
 
@@ -9,19 +9,9 @@ jest.mock('../../MediaQueryUtils', () => ({
 }))
 
 export function mockMediaQuery() {
-  const matchMedia = new MatchMediaMock()
-
   beforeEach(() => {
     isMatchMediaSupported.mockReturnValue(true)
   })
 
-  afterEach(() => {
-    matchMedia?.clear()
-  })
-
-  afterAll(() => {
-    matchMedia?.destroy()
-  })
-
-  return matchMedia
+  return { useMediaQuery: (query: string) => matchMedia(query).matches }
 }

--- a/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
@@ -814,7 +814,7 @@ describe('useMedia', () => {
     })
   })
 
-  describe('using jest-matchmedia-mock mocker', () => {
+  describe('using mockMediaQuery helper', () => {
     const matchMedia = mockMediaQuery()
     const matchMediaMock = window.matchMedia // set in mockMediaQuery
 

--- a/packages/dnb-eufemia/src/shared/__tests__/useMediaQuery.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useMediaQuery.test.tsx
@@ -10,7 +10,8 @@ import {
   fireEvent,
   renderHook,
 } from '@testing-library/react'
-import MatchMediaMock from 'jest-matchmedia-mock'
+import 'mock-match-media/jest-setup'
+import { setMedia } from 'mock-match-media'
 import useMediaQuery from '../useMediaQuery'
 import Provider from '../Provider'
 import {
@@ -35,28 +36,12 @@ const RenderMediaQueryHook = (props: MediaQueryProps) => {
 }
 
 describe('useMediaQuery', () => {
-  let matchMedia: MatchMediaMock
-
-  beforeAll(() => {
-    matchMedia = new MatchMediaMock()
-  })
-
   beforeEach(() => {
     isMatchMediaSupported.mockReturnValue(true)
   })
 
-  afterEach(() => {
-    matchMedia?.clear()
-  })
-
-  afterAll(() => {
-    matchMedia?.destroy()
-  })
-
   it('should have valid strings inside render and rerender', () => {
-    matchMedia.useMediaQuery(
-      '(min-width: 60.00625em) and (max-width: 72em)'
-    )
+    setMedia({ width: '65em' }) // Between 60em and 72em
 
     const { rerender } = render(
       <RenderMediaQueryHook when={{ min: 'medium', max: 'large' }}>
@@ -76,7 +61,7 @@ describe('useMediaQuery', () => {
   })
 
   it('should match for query when different breakpoints are given', () => {
-    matchMedia.useMediaQuery('(min-width: 20rem) and (max-width: 80rem)')
+    setMedia({ width: '50rem' }) // Between 20rem and 80rem
 
     render(
       <Provider
@@ -97,7 +82,7 @@ describe('useMediaQuery', () => {
   })
 
   it('should have valid strings inside render', () => {
-    matchMedia.useMediaQuery('(min-width: 0) and (max-width: 80em)')
+    setMedia({ width: '40em' }) // Less than 80em (x-large)
 
     render(
       <RenderMediaQueryHook when={{ min: '0', max: 'x-large' }}>
@@ -109,9 +94,7 @@ describe('useMediaQuery', () => {
   })
 
   it('should handle media query changes', () => {
-    matchMedia.useMediaQuery(
-      'not screen and (min-width: 40.00625em) and (max-width: 72em)'
-    )
+    setMedia({ width: '30em' }) // Less than 40em to not match the query
 
     const match1Handler = jest.fn()
     const match2Handler = jest.fn()
@@ -172,7 +155,7 @@ describe('useMediaQuery', () => {
       .spyOn(window, 'matchMedia')
       .mockImplementationOnce(jest.fn(window.matchMedia))
 
-    matchMedia.useMediaQuery('(min-width: 0) and (max-width: 80em)')
+    setMedia({ width: '40em' }) // Less than 80em (x-large)
 
     const when = { min: '0', max: 'x-large' }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,7 +4423,6 @@ __metadata:
     jest-axe: "npm:10.0.0"
     jest-environment-jsdom: "npm:30.0.5"
     jest-image-snapshot: "npm:6.5.1"
-    jest-matchmedia-mock: "npm:1.1.0"
     jest-playwright-preset: "npm:4.0.0"
     jest-raw-loader: "npm:1.0.1"
     jest-tobetype: "npm:1.2.3"
@@ -23566,15 +23565,6 @@ __metadata:
     jest-get-type: "npm:^29.4.3"
     pretty-format: "npm:^29.5.0"
   checksum: 10/80686b629d40489f09ef987a187d24c63528614fcfe34e62ec83f0485729396e11354e9ab9a28d6d80e82c9454e06cc810e936a2155e033bd112ab1fead11f1a
-  languageName: node
-  linkType: hard
-
-"jest-matchmedia-mock@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jest-matchmedia-mock@npm:1.1.0"
-  peerDependencies:
-    jest: ">=13"
-  checksum: 10/e812b9dce5a3b55057ec0db47fe07737d24f248d0ee5eb41754244ecb8ea9b906581af2c1ae434b4db8a037ce3e437af6c53075ac86538a56ce55e2645ea0138
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I don't think we need both `jest-matchmedia-mock` and `mock-match-media`, hence removing `jest-matchmedia-mock` in favor of only using `mock-match-media`.