### PR TITLE
chore: remove regenerator-runtime

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -254,7 +254,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-to-typescript-definitions": "3.1.1",
-    "regenerator-runtime": "0.13.9",
     "repo-utils": "workspace:*",
     "sass": "1.62.0",
     "sass-loader": "13.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4450,7 +4450,6 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     react-to-typescript-definitions: "npm:3.1.1"
-    regenerator-runtime: "npm:0.13.9"
     repo-utils: "workspace:*"
     sass: "npm:1.62.0"
     sass-loader: "npm:13.3.2"
@@ -32050,13 +32049,6 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 10/dc6c95ae4b3ba6adbd7687cafac260eee4640318c7a95239d5ce847d9b9263979758389e862fe9c93d633b5792ea4ada5708df75885dc5aa05a309fa18140a87
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:0.13.9":
-  version: 0.13.9
-  resolution: "regenerator-runtime@npm:0.13.9"
-  checksum: 10/efbbcee420cf89b90c634ac4c53e4ac8000c80b4650d6d34560f124185d43b21b824d385ec6147657603a1ec1bed6820fc5dfb78e669f9acc7c1b5d7238b1627
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The package is handled automatically by Babel and isn't needed as an explicit dependency.