### PR TITLE
chore: reduce yarn post-resolution validation warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,44 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+packageExtensions:
+  jest-playwright-preset@*:
+    peerDependenciesMeta:
+      jest-circus:
+        optional: true
+      jest-environment-node:
+        optional: true
+      jest-runner:
+        optional: true
+  css-loader@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  sass-loader@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  style-loader@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  raw-loader@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  gatsby-plugin-gatsby-cloud@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  webpack-assets-manifest@*:
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+  prism-react-renderer@*:
+    peerDependenciesMeta:
+      react:
+        optional: true
+
 pnpMode: loose
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs

--- a/tools/react-live-ssr/package.json
+++ b/tools/react-live-ssr/package.json
@@ -11,6 +11,7 @@
   "module": "dist/index.mjs",
   "dependencies": {
     "prism-react-renderer": "2.0.5",
+    "react": "18.2.0",
     "sucrase": "3.31.0",
     "use-editable": "2.3.3"
   },

--- a/tools/storybook-utils/package.json
+++ b/tools/storybook-utils/package.json
@@ -7,9 +7,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "peerDependencies": {
-    "@emotion/react": "11.9.3",
-    "@emotion/styled": "11.9.3",
-    "classnames": "2.3.1",
+    "@emotion/react": "^11.9.3",
+    "@emotion/styled": "^11.9.3",
+    "classnames": "^2.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -31597,6 +31597,7 @@ __metadata:
   resolution: "react-live-ssr@workspace:tools/react-live-ssr"
   dependencies:
     prism-react-renderer: "npm:2.0.5"
+    react: "npm:18.2.0"
     sucrase: "npm:3.31.0"
     use-editable: "npm:2.3.3"
   languageName: unknown
@@ -34448,9 +34449,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "storybook-utils@workspace:tools/storybook-utils"
   peerDependencies:
-    "@emotion/react": 11.9.3
-    "@emotion/styled": 11.9.3
-    classnames: 2.3.1
+    "@emotion/react": ^11.9.3
+    "@emotion/styled": ^11.9.3
+    classnames: ^2.3.1
     react: 18.2.0
     react-dom: 18.2.0
   languageName: unknown


### PR DESCRIPTION
Reduced the warnings from 20+ down to 6, and eliminated all YN0002 (missing peer dependency) warnings.