### PR TITLE
chore: remove classnames that do not have styling

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Item.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Item.tsx
@@ -79,11 +79,7 @@ function FlexItem(props: Props) {
   if (Object.keys(spaceStyles).length) {
     return (
       <Space element={element} className={cn} style={spaceStyles}>
-        <Space
-          className={clsx('dnb-flex-item__spacer', className)}
-          style={style}
-          {...rest}
-        >
+        <Space className={className} style={style} {...rest}>
           {children}
         </Space>
       </Space>

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Item.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Item.test.tsx
@@ -201,14 +201,10 @@ describe('Flex.Item', () => {
         '--size--default: 5;'
       )
       expect(
-        getFlexItem(0)
-          .querySelector('.dnb-flex-item__spacer')
-          .getAttribute('style')
+        getFlexItem(0).querySelector('div').getAttribute('style')
       ).toBe('background: blue;')
       expect(
-        getFlexItem(1)
-          .querySelector('.dnb-flex-item__spacer')
-          .getAttribute('style')
+        getFlexItem(1).querySelector('div').getAttribute('style')
       ).toBe('background: red;')
     })
 
@@ -473,7 +469,7 @@ function getSpacingClasses() {
   const elements = document.querySelectorAll('.dnb-flex-item')
 
   elements.forEach((node) => {
-    const element = node.querySelector('.dnb-flex-item__spacer')
+    const element = node.querySelector('div')
 
     const item = []
 

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -244,17 +244,12 @@ const InfoCard = (localProps: InfoCardAllProps) => {
 
         <div className="dnb-info-card__content">
           {title && (
-            <P
-              className="dnb-info-card__title"
-              size="small"
-              weight="medium"
-              bottom="x-small"
-            >
+            <P size="small" weight="medium" bottom="x-small">
               {title}
             </P>
           )}
           {text && (
-            <P size="small" className="dnb-info-card__text" bottom="0">
+            <P size="small" bottom="0">
               {text}
             </P>
           )}

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -21,9 +21,7 @@ describe('InfoCard', () => {
     const props: InfoCardAllProps = { text: 'text' }
     render(<InfoCard {...props} />)
 
-    expect(
-      screen.getByText('text')
-    ).toBeInTheDocument()
+    expect(screen.getByText('text')).toBeInTheDocument()
   })
 
   it('renders the title as string', () => {
@@ -251,7 +249,9 @@ describe('InfoCard', () => {
 
     render(<InfoCard skeleton text="skeleton" />)
 
-    const paragraphElement = document.querySelector('.dnb-info-card__content .dnb-p')
+    const paragraphElement = document.querySelector(
+      '.dnb-info-card__content .dnb-p'
+    )
     expect(paragraphElement.className).toMatch(skeletonClassName)
   })
 
@@ -264,7 +264,9 @@ describe('InfoCard', () => {
       </Provider>
     )
 
-    const paragraphElement = document.querySelector('.dnb-info-card__content .dnb-p')
+    const paragraphElement = document.querySelector(
+      '.dnb-info-card__content .dnb-p'
+    )
     expect(paragraphElement.className).toMatch(skeletonClassName)
   })
 

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -12,7 +12,7 @@ describe('InfoCard', () => {
     render(<InfoCard />)
 
     expect(
-      document.querySelector('.dnb-info-card__text')
+      document.querySelector('.dnb-info-card__content p')
     ).not.toBeInTheDocument()
     expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
   })
@@ -22,7 +22,7 @@ describe('InfoCard', () => {
     render(<InfoCard {...props} />)
 
     expect(
-      document.querySelector('.dnb-info-card__text')
+      screen.getByText('text')
     ).toBeInTheDocument()
   })
 
@@ -31,12 +31,9 @@ describe('InfoCard', () => {
 
     render(<InfoCard text="text" title={title} />)
 
-    expect(
-      document.querySelector('.dnb-info-card__title')
-    ).toBeInTheDocument()
-    expect(
-      document.querySelector('.dnb-info-card__title').textContent
-    ).toMatch(title)
+    const titleElement = screen.getByText(title)
+    expect(titleElement).toBeInTheDocument()
+    expect(titleElement.textContent).toMatch(title)
   })
 
   it('should support inline styling', () => {
@@ -52,14 +49,7 @@ describe('InfoCard', () => {
 
     render(<InfoCard text="text" title={title} />)
 
-    expect(
-      document.querySelector('.dnb-info-card__title')
-    ).toBeInTheDocument()
-    expect(
-      within(
-        document.querySelector('.dnb-info-card__title')
-      ).queryByTestId('react-node')
-    ).toBeInTheDocument()
+    expect(screen.queryByTestId('react-node')).toBeInTheDocument()
   })
 
   it('renders the text as string', () => {
@@ -67,12 +57,9 @@ describe('InfoCard', () => {
 
     render(<InfoCard text={text} />)
 
-    expect(
-      document.querySelector('.dnb-info-card__text')
-    ).toBeInTheDocument()
-    expect(
-      document.querySelector('.dnb-info-card__text').textContent
-    ).toMatch(text)
+    const textElement = screen.getByText(text)
+    expect(textElement).toBeInTheDocument()
+    expect(textElement.textContent).toMatch(text)
   })
 
   it('renders the text as react node', () => {
@@ -80,14 +67,7 @@ describe('InfoCard', () => {
 
     render(<InfoCard text={text} />)
 
-    expect(
-      document.querySelector('.dnb-info-card__text')
-    ).toBeInTheDocument()
-    expect(
-      within(document.querySelector('.dnb-info-card__text')).queryByTestId(
-        'react-node'
-      )
-    ).toBeInTheDocument()
+    expect(screen.queryByTestId('react-node')).toBeInTheDocument()
   })
 
   it('renders the icon', () => {
@@ -271,9 +251,8 @@ describe('InfoCard', () => {
 
     render(<InfoCard skeleton text="skeleton" />)
 
-    expect(
-      document.querySelector('.dnb-info-card__text').className
-    ).toMatch(skeletonClassName)
+    const paragraphElement = document.querySelector('.dnb-info-card__content .dnb-p')
+    expect(paragraphElement.className).toMatch(skeletonClassName)
   })
 
   it('inherits skeleton prop from provider', () => {
@@ -285,9 +264,8 @@ describe('InfoCard', () => {
       </Provider>
     )
 
-    expect(
-      document.querySelector('.dnb-info-card__text').className
-    ).toMatch(skeletonClassName)
+    const paragraphElement = document.querySelector('.dnb-info-card__content .dnb-p')
+    expect(paragraphElement.className).toMatch(skeletonClassName)
   })
 
   it('should support spacing props', () => {


### PR DESCRIPTION
Or should we apply classnames that does not have any styling?