### PR TITLE
feat(DatePicker): add visual focus indicator to calendar

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3670,6 +3670,19 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
+html:not([data-whatintent=touch]) .dnb-date-picker__container table:focus-visible[disabled] {
+  cursor: not-allowed;
+}
+html:not([data-whatintent=touch]) .dnb-date-picker__container table:focus-visible:not([disabled]) {
+  outline: none;
+  outline-offset: 2px;
+}
+html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-date-picker__container table:focus-visible:not([disabled]) {
+  --border-color: var(--focus-ring-color);
+  --border-width: var(--focus-ring-width);
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
+}
 .dnb-date-picker__container:not(.dnb-date-picker__container--show-footer) .dnb-date-picker__calendar::after {
   content: none;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -89,6 +89,12 @@
       &.dnb-no-focus:focus {
         @include focusRing();
       }
+
+      // Enhanced focus indicator for keyboard navigation
+      @include focus-visible() {
+        @include focusRing();
+        outline-offset: 2px;
+      }
     }
     &:not(#{&}--show-footer) .dnb-date-picker__calendar::after {
       content: none;


### PR DESCRIPTION
Can be tested in [this deploy preview,](https://chore-add-visual-focus-indic.eufemia-e25.pages.dev/uilib/components/date-picker/#inline-datepicker) and compared to [this in main](https://eufemia.dnb.no/uilib/components/date-picker/demos/#inline-datepicker)