### PR TITLE
feat(Anchor): add screenreader text for external links

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -227,6 +227,9 @@ export function AnchorInstance(localProps: AnchorAllProps) {
       >
         {prefix}
         {children}
+        {_opensNewTab && (
+          <span className="dnb-sr-only"> {targetBlankTitle}</span>
+        )}
         {suffix}
       </E>
 

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -114,6 +114,40 @@ describe('Anchor element', () => {
       })
     })
 
+    it('should have screen reader text for external links', () => {
+      const { container } = render(
+        <Anchor href="https://example.com" target="_blank" lang="nb-NO">
+          Example Link
+        </Anchor>
+      )
+
+      const srOnlyElement = container.querySelector('.dnb-sr-only')
+      expect(srOnlyElement).toBeInTheDocument()
+      expect(srOnlyElement).toHaveTextContent(nb.targetBlankTitle)
+    })
+
+    it('should not have screen reader text for internal links', () => {
+      const { container } = render(
+        <Anchor href="/internal" lang="nb-NO">
+          Internal Link
+        </Anchor>
+      )
+
+      const srOnlyElement = container.querySelector('.dnb-sr-only')
+      expect(srOnlyElement).not.toBeInTheDocument()
+    })
+
+    it('should not have screen reader text for mailto links even with target="_blank"', () => {
+      const { container } = render(
+        <Anchor href="mailto:test@example.com" target="_blank" lang="nb-NO">
+          Email
+        </Anchor>
+      )
+
+      const srOnlyElement = container.querySelector('.dnb-sr-only')
+      expect(srOnlyElement).not.toBeInTheDocument()
+    })
+
     it('has "__launch-icon" class', () => {
       render(
         <Anchor href="/url" target="_blank">

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -139,7 +139,11 @@ describe('Anchor element', () => {
 
     it('should not have screen reader text for mailto links even with target="_blank"', () => {
       const { container } = render(
-        <Anchor href="mailto:test@example.com" target="_blank" lang="nb-NO">
+        <Anchor
+          href="mailto:test@example.com"
+          target="_blank"
+          lang="nb-NO"
+        >
           Email
         </Anchor>
       )


### PR DESCRIPTION
This enhancement ensures external links meet [WCAG 2.4.4 (Link Purpose - Level A)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html) by providing programmatically determinable link context for screen reader users, complementing the existing visual indicators (launch icon and tooltip).