### PR TITLE
fix(InputMasked): should not cause infinite loop when props object reference changes

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedHooks.tsx
@@ -130,7 +130,21 @@ export const useLocalValue = () => {
     setLocalValue(value)
 
     // Do not set "localValue" and "maskParams" here
-  }, [props, context, locale]) // eslint-disable-line
+    // Only depend on the actual prop values that affect the calculation,
+    // not the entire props object to avoid infinite loops.
+    // Include mask-related props to ensure the component reacts to mask changes.
+  }, [
+    props.value,
+    props.number_format,
+    props.number_mask,
+    props.currency_mask,
+    props.mask_options,
+    props.as_number,
+    props.as_percent,
+    props.as_currency,
+    context,
+    locale,
+  ]) // eslint-disable-line
 
   return { localValue, setLocalValue }
 }


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1769430863097359

This is for now just a draft.
Will ask if reporter can validate if this fixes it (waiting for stackblitz pkg-pr-new to build).