### PR TITLE
chore: add @modelcontextprotocol/sdk as a dev dependency

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -102,7 +102,6 @@
   "typings": "./index.d.ts",
   "dependencies": {
     "@babel/runtime-corejs3": "7.28.4",
-    "@modelcontextprotocol/sdk": "1.25.3",
     "@navikt/fnrvalidator": "2.1.5",
     "@ungap/structured-clone": "1.2.0",
     "ajv": "8.17.1",
@@ -155,6 +154,7 @@
     "@emotion/styled": "11.11.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",
+    "@modelcontextprotocol/sdk": "1.25.3",
     "@playwright/test": "1.49.1",
     "@semantic-release/changelog": "6.0.2",
     "@semantic-release/commit-analyzer": "9.0.2",


### PR DESCRIPTION
Is this needed in the browser bundle or only server-side?
If server-only, then I think we can move it to devDependencies.

Also, does this actually belong in `packages/dnb-eufemia`, or could/should we make an own package for this MCP server?