### PR TITLE
chore: remove named exports that's already by default exported

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -181,7 +181,7 @@ const accordionHeaderDefaultProps = {
   iconSize: 'medium',
 }
 
-export const AccordionHeader = ({
+const AccordionHeader = ({
   iconSize: iconSizeDefault = 'medium',
   ...restOfProps
 }: AccordionHeaderProps) => {

--- a/packages/dnb-eufemia/src/components/table/table-accordion/useTableAnimationHandler.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/useTableAnimationHandler.tsx
@@ -15,7 +15,7 @@ export type useTableAnimationHandlerProps = {
   trRef: React.RefObject<HTMLTableRowElement>
 }
 
-export function useTableAnimationHandler({
+function useTableAnimationHandler({
   contentRef,
   trRef,
   expanded,

--- a/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
+++ b/packages/dnb-eufemia/src/components/table/useHandleSortState.tsx
@@ -55,7 +55,7 @@ type GetNextMode = {
   defaults: useHandleSortStateOptions
 }
 
-export function useHandleSortState(
+function useHandleSortState(
   config: useHandleSortStateConfig,
   defaults: useHandleSortStateOptions = {
     direction: 'off',

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
@@ -9,7 +9,7 @@ import { createSpacingClasses } from '../space/SpacingUtils'
 export type UploadFileLinkProps = UploadFileAnchorProps &
   UploadFileButtonProps
 
-export const UploadFileLink = (props: UploadFileLinkProps) => {
+const UploadFileLink = (props: UploadFileLinkProps) => {
   const { onClick, text, href, download, ...rest } = props
 
   if (!onClick && !href) {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
@@ -14,7 +14,7 @@ import {
   transformFiles,
 } from '../../Field/Upload/Upload'
 import { format } from '../../../../components/number-format/NumberUtils'
-import { UploadFileLink } from '../../../../components/upload/UploadFileListLink'
+import UploadFileLink from '../../../../components/upload/UploadFileListLink'
 import { isAsync } from '../../../../shared/helpers/isAsync'
 
 export type Props = ValueProps<Array<UploadFile>> &


### PR DESCRIPTION
Motivation of the PR is to remove the named exports, as we usually don't do both named and default export of a component/function.

Can be breaking.
Should probably add notes to v11 as well