### PR TITLE
chore(CountryFlag): test flag in Autocomplete and Dropdown using `cache_hash`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
@@ -5,6 +5,7 @@
 
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 import {
+  Autocomplete,
   Button,
   CountryFlag,
   Dropdown,
@@ -23,6 +24,8 @@ import {
 
 // Import the flag icons styles
 import '@dnb/eufemia/src/components/country-flag/style/dnb-country-flag-icons.scss'
+import countries from '@dnb/eufemia/src/extensions/forms/constants/countries'
+import { useMemo, useState } from 'react'
 
 export const AllSizes = () => (
   <ComponentBox data-visual-test="country-flag-sizes">
@@ -154,3 +157,47 @@ export const InComponents = () => (
     </Flex.Vertical>
   </ComponentBox>
 )
+
+export const ForTestingPurposes = () => (
+  <ComponentBox scope={{ useValueProps }}>
+    {() => {
+      const MyComponent = () => {
+        const [value, setValue] = useState()
+        const memoizedCountries = useMemo(() => {
+          return countries.map((country) => {
+            return {
+              selectedKey: country.iso,
+              selected_value: country.i18n.nb,
+              content: getContent(country.i18n.nb, country.iso),
+            }
+          })
+        }, [countries])
+
+        return (
+          <>
+            <Autocomplete
+              data={memoizedCountries}
+              value={value}
+              on_change={({ data }) => setValue(data?.selectedKey)}
+            />
+            <Dropdown
+              data={memoizedCountries}
+              value={value}
+              on_change={({ data }) => setValue(data?.selectedKey)}
+            />
+          </>
+        )
+      }
+
+      return <MyComponent />
+    }}
+  </ComponentBox>
+)
+function getContent(countryName: string, countryCode: string) {
+  return (
+    <Flex.Horizontal align="center">
+      <CountryFlag iso={countryCode} size="medium" right="small" />
+      {countryName}
+    </Flex.Horizontal>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
@@ -171,7 +171,13 @@ export const ForTestingPurposes = () => (
               content: getContent(country.i18n.nb, country.iso),
             }
           })
-        }, [countries])
+        }, [])
+
+        // Create a stable cache hash from the data length
+        const cacheHash = useMemo(
+          () => `countries-${memoizedCountries.length}`,
+          [memoizedCountries.length]
+        )
 
         return (
           <>
@@ -179,11 +185,13 @@ export const ForTestingPurposes = () => (
               data={memoizedCountries}
               value={value}
               on_change={({ data }) => setValue(data?.selectedKey)}
+              cache_hash={cacheHash}
             />
             <Dropdown
               data={memoizedCountries}
               value={value}
               on_change={({ data }) => setValue(data?.selectedKey)}
+              cache_hash={cacheHash}
             />
           </>
         )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/Examples.tsx
@@ -159,7 +159,7 @@ export const InComponents = () => (
 )
 
 export const ForTestingPurposes = () => (
-  <ComponentBox scope={{ useValueProps }}>
+  <ComponentBox scope={{ countries, getContent, useMemo, useState }}>
     {() => {
       const MyComponent = () => {
         const [value, setValue] = useState()

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/demos.mdx
@@ -21,3 +21,7 @@ import * as Examples from './Examples'
 ### In various components
 
 <Examples.InComponents />
+
+### For testing purposes
+
+<Examples.ForTestingPurposes />

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 import styled from '@emotion/styled'
 import {
@@ -20,7 +20,17 @@ import {
   GlobalStatus,
   Input,
 } from '../..'
-import { Anchor, Flex, Li, Ol, P, Section, Space } from '../../../'
+import {
+  Anchor,
+  CountryFlag,
+  Dropdown,
+  Flex,
+  Li,
+  Ol,
+  P,
+  Section,
+  Space,
+} from '../../../'
 import { Context, Provider } from '../../../shared'
 import { SubmitButton } from '../../input/Input'
 import { format } from '../../number-format/NumberUtils'
@@ -28,6 +38,7 @@ import {
   DrawerListData,
   DrawerListDataArray,
 } from '../../../fragments/DrawerList'
+import countries from '../../../extensions/forms/constants/countries'
 
 export default {
   title: 'Eufemia/Components/Autocomplete',
@@ -1102,5 +1113,42 @@ export const Memo = () => {
       <AutoComplete getInputIcon={getIconString} label="String" />
       <AutoComplete getInputIcon={getIconElement} label="Element" />
     </Flex.Vertical>
+  )
+}
+
+export const CountryFlagUsage = () => {
+  const [value, setValue] = useState()
+  const memoizedCountries = useMemo(() => {
+    return countries.map((country) => {
+      return {
+        selectedKey: country.iso,
+        selected_value: country.i18n.nb,
+        content: getContent(country.i18n.nb, country.iso),
+      }
+    })
+  }, [countries])
+
+  return (
+    <>
+      <Autocomplete
+        data={memoizedCountries}
+        value={value}
+        on_change={({ data }) => setValue(data?.selectedKey)}
+      />
+      <Dropdown
+        data={memoizedCountries}
+        value={value}
+        on_change={({ data }) => setValue(data?.selectedKey)}
+      />
+    </>
+  )
+}
+
+function getContent(countryName: string, countryCode: string) {
+  return (
+    <Flex.Horizontal align="center">
+      <CountryFlag iso={countryCode} size="medium" right="small" />
+      {countryName}
+    </Flex.Horizontal>
   )
 }


### PR DESCRIPTION
Motivation: _Verdt å merke seg at en dropdown med en liste over alle landene blir relativt treg når vi rendrer et flagg for hvert land. Vi gikk over til å bruke Autocomplete her også, da den virker å ha litt bedre performance._ - feedback from developer.

For testing purposes in deploy preview.

https://chore-test-flag-cache-hash.eufemia-e25.pages.dev/uilib/components/country-flag/demos/#for-testing-purposes