### PR TITLE
chore: upgrade @navikt/fnrvalidator

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.28.4",
     "@modelcontextprotocol/sdk": "1.25.3",
-    "@navikt/fnrvalidator": "2.1.5",
+    "@navikt/fnrvalidator": "2.2.0",
     "@ungap/structured-clone": "1.2.0",
     "ajv": "8.17.1",
     "ajv-errors": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,7 +4297,7 @@ __metadata:
     "@eslint/eslintrc": "npm:3.3.3"
     "@eslint/js": "npm:9.39.2"
     "@modelcontextprotocol/sdk": "npm:1.25.3"
-    "@navikt/fnrvalidator": "npm:2.1.5"
+    "@navikt/fnrvalidator": "npm:2.2.0"
     "@playwright/test": "npm:1.49.1"
     "@semantic-release/changelog": "npm:6.0.2"
     "@semantic-release/commit-analyzer": "npm:9.0.2"
@@ -6378,10 +6378,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/fnrvalidator@npm:2.1.5":
-  version: 2.1.5
-  resolution: "@navikt/fnrvalidator@npm:2.1.5"
-  checksum: 10/6004890b3046d957f117b8566d6b12bc254cb5417a6fa9dd800a807bbb78d6775165d8c2aba5f1c1561b499341d4e97d662589a9d708651ae59aee06411ce66d
+"@navikt/fnrvalidator@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@navikt/fnrvalidator@npm:2.2.0"
+  checksum: 10/7877acc2f23aa99943c70ea3414028f8a2ce2239847cae68f80d81473b79836d8756cada273606d337b217e84b9168cac89fd6bb6d316d7532d9f17f5b7de4e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This improvement seems nice to have, as we use this as our validator for `Field.NationalIdentityNumber`.

To me, it seems to have had some changes/updates to the validation of fødselsnummer - https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/

But this change is probably not needed to do before year 2032, if I read the docs correctly 🤔 

https://github.com/navikt/fnrvalidator/releases/tag/v2.2.0