### PR TITLE
fix(Field.Email): support unicode in local part and domain

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react'
+import * as z from 'zod'
 import StringField, { Props as StringFieldProps } from '../String'
 import useTranslation from '../../hooks/useTranslation'
+import type { Schema } from '../../types'
 
 export type Props = StringFieldProps
 
-// Allow Unicode characters in local part (before @)
+// Allow Unicode characters in local part (before @) - SMTPUTF8 support
 const aText = `[A-Za-z0-9!#$%&'*+/=?^_\\x60{|}~\\u0080-\\uFFFF-]+`
 export const pattern =
   `^${aText}(?:\\.${aText})*@` + // Local part: RFC 5322 aText segments separated by dots, plus Unicode
@@ -25,6 +27,34 @@ export const pattern =
   `)\\]` +
   `)$`
 
+/**
+ * Convert internationalized domain names (IDN) to Punycode for validation.
+ * This enables full SMTPUTF8 support by allowing Unicode in both local part and domain.
+ */
+export function convertDomainToPunycode(email: string): string {
+  if (!email || typeof email !== 'string') {
+    return email
+  }
+
+  const atIndex = email.lastIndexOf('@')
+  if (atIndex === -1) {
+    return email
+  }
+
+  const localPart = email.substring(0, atIndex)
+  const domain = email.substring(atIndex + 1)
+
+  // Convert domain to ASCII using the URL API (WHATWG URL Standard)
+  try {
+    const url = new URL(`http://${domain}`)
+    const asciiDomain = url.hostname
+    return `${localPart}@${asciiDomain}`
+  } catch {
+    // If URL parsing fails, return original email
+    return email
+  }
+}
+
 function Email(props: Props) {
   const { label, errorRequired, errorPattern } = useTranslation().Email
 
@@ -37,13 +67,46 @@ function Email(props: Props) {
     [errorPattern, errorRequired, props.errorMessages]
   )
 
+  // Create custom schema that converts domain to Punycode before pattern validation
+  const schema = useMemo<Schema<string>>(() => {
+    if (props.schema) {
+      return props.schema
+    }
+
+    // Use custom pattern if provided, otherwise use default email pattern
+    const patternToUse = props.pattern ?? pattern
+
+    return () => {
+      return z.string().superRefine((val, ctx) => {
+        // Convert domain to Punycode for validation (SMTPUTF8 support)
+        // Only apply conversion if using default email pattern
+        const emailToValidate = props.pattern
+          ? val
+          : convertDomainToPunycode(val)
+
+        // Apply pattern validation
+        if (!new RegExp(patternToUse, 'u').test(emailToValidate)) {
+          ctx.addIssue({
+            code: 'invalid_format',
+            validation: 'regex',
+            format: 'regex',
+            message: 'Field.errorPattern',
+            messageValues: {
+              pattern: patternToUse,
+            },
+          })
+        }
+      })
+    }
+  }, [props.schema, props.pattern])
+
   const StringFieldProps: Props = {
     label,
     autoComplete: 'email',
     inputMode: 'email',
-    pattern,
     trim: true,
     ...props,
+    schema,
     errorMessages,
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/Email.tsx
@@ -4,9 +4,10 @@ import useTranslation from '../../hooks/useTranslation'
 
 export type Props = StringFieldProps
 
-const aText = `[A-Za-z0-9!#$%&'*+/=?^_\\x60{|}~-]+`
+// Allow Unicode characters in local part (before @)
+const aText = `[A-Za-z0-9!#$%&'*+/=?^_\\x60{|}~\\u0080-\\uFFFF-]+`
 export const pattern =
-  `^${aText}(?:\\.${aText})*@` + // Local part: RFC 5322 aText segments separated by dots
+  `^${aText}(?:\\.${aText})*@` + // Local part: RFC 5322 aText segments separated by dots, plus Unicode
   `(?:` +
   // Multi-label domain ending with a TLD (e.g. example.com, sub.example.co.uk)
   `(?:` +

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
@@ -192,6 +192,11 @@ describe('Field.Email', () => {
       'firstname.lastname@example.co',
       'blåbærsyltetøy@domene.no',
 
+      // SMTPUTF8 - Unicode in domain (automatically converted to Punycode)
+      'user@café.com', // Will be converted to xn--caf-dma.com
+      'usér@exämple.com', // Unicode in both local and domain parts
+      'abc@blåbærsyltetøy.no', // Will be converted to xn--blbrsyltety-y8ao3x.no
+
       // IP address literal
       'user@[192.168.1.1]',
       'user@[255.255.255.255]',
@@ -238,13 +243,6 @@ describe('Field.Email', () => {
       // Long values
       'hehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehehe',
       '@longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongdomain.com',
-
-      // Unicode - the regex we have does not take such addresses into account as of now
-      'user@café.com', // raw Unicode not supported by ASCII regex
-      'usér@exämple.com',
-
-      // Punycode conversion for domain not supported at this time, but may be in the future
-      'abc@blåbærsyltetøy.no',
 
       // The regex we have does not take such invalid addresses into account
       // 'user@[256.100.50.25]', // Invalid IPv4, 256 is out of range

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Email/__tests__/Email.test.tsx
@@ -190,6 +190,7 @@ describe('Field.Email', () => {
       'user123@example.info',
       'user@example123.com',
       'firstname.lastname@example.co',
+      'blåbærsyltetøy@domene.no',
 
       // IP address literal
       'user@[192.168.1.1]',
@@ -241,6 +242,9 @@ describe('Field.Email', () => {
       // Unicode - the regex we have does not take such addresses into account as of now
       'user@café.com', // raw Unicode not supported by ASCII regex
       'usér@exämple.com',
+
+      // Punycode conversion for domain not supported at this time, but may be in the future
+      'abc@blåbærsyltetøy.no',
 
       // The regex we have does not take such invalid addresses into account
       // 'user@[256.100.50.25]', // Invalid IPv4, 256 is out of range


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1770281489118729

This automatically convert internationalized domain names to their ASCII Punycode representation before validation, providing seamless SMTPUTF8 support

We should either implement https://github.com/dnbexperience/eufemia/pull/6543 or https://github.com/dnbexperience/eufemia/pull/6544

Other thoughts, should we support displaying punicode values, like `user@xn--mller-kva.com` as unicode to the user in both `Field.Email` and `Value.Email`? So that the user would see `user@müller.com` instead of the punycode version `user@xn--mller-kva.com`?
