### PR TITLE
chore: remove the legacy document.execCommand('copy')

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -289,80 +289,16 @@ export function getSelectedElement() {
 }
 
 export async function copyToClipboard(string) {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
+  if (typeof navigator === 'undefined' || !navigator?.clipboard) {
     return false
   }
 
-  // get the selection range
-  const selection = window.getSelection()
-  const range =
-    selection.rangeCount > 0 // Check if there is any content selected previously
-      ? selection.getRangeAt(0) // Store selection if found
-      : false // Mark as false to know no selection existed before
-
-  const resetSelection = () => {
-    try {
-      // If a selection existed before copying
-      selection.removeAllRanges() // Unselect everything on the HTML document
-      selection.addRange(range) // Restore the original selection
-    } catch (e) {
-      //
-    }
+  try {
+    await navigator.clipboard.writeText(String(string))
+    return true
+  } catch (e) {
+    return e
   }
-
-  const copyFallback = () => {
-    try {
-      // create the focusable element
-      const elem = document.createElement('textarea')
-      elem.value = String(string)
-      elem.contentEditable = true
-      elem.readOnly = false
-      elem.style.position = 'fixed'
-      elem.style.top = '-1000px'
-      document.body.appendChild(elem)
-
-      elem.select()
-
-      // NB: copy only works as a result of a user action (e.g. click events)
-      const success = document.execCommand('copy')
-
-      // Cleanup
-      document.body.removeChild(elem)
-
-      resetSelection()
-
-      if (success) {
-        return true
-      }
-    } catch (e) {
-      return e
-    }
-
-    return `Could not copy! Unknown reason. ${string}`
-  }
-
-  let success
-
-  // eslint-disable-next-line compat/compat
-  if (typeof navigator !== 'undefined' && navigator?.clipboard) {
-    try {
-      // eslint-disable-next-line compat/compat
-      await navigator.clipboard.writeText(String(string))
-      success = true
-      resetSelection()
-    } catch (e) {
-      success = e
-      const newTry = copyFallback()
-      if (newTry === true) {
-        success = newTry
-      }
-    }
-  } else {
-    // use the fallback as the primary, because we get
-    success = copyFallback()
-  }
-
-  return success
 }
 
 /**


### PR DESCRIPTION
Looks like it's a bit early to do this, as:

```
/home/runner/work/eufemia/eufemia/packages/dnb-eufemia/src/shared/helpers.js
Error:   292:44  error  navigator.clipboard() is not supported in iOS Safari 13.0-13.1  compat/compat
```

https://github.com/dnbexperience/eufemia/actions/runs/21982197774/job/63507333238?pr=6628