### PR TITLE
chore: add forwardRef

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -111,7 +111,10 @@ export const defaultProps = {
   skeleton: false,
 }
 
-const Avatar = (localProps: AvatarProps & SpacingProps) => {
+const Avatar = React.forwardRef<
+  HTMLSpanElement,
+  AvatarProps & SpacingProps
+>((localProps, ref) => {
   // Every component should have a context
   const context = React.useContext(Context)
   const avatarGroupContext = React.useContext(AvatarGroupContext)
@@ -190,6 +193,7 @@ const Avatar = (localProps: AvatarProps & SpacingProps) => {
 
   return (
     <span
+      ref={ref}
       className={clsx(
         'dnb-avatar',
         `dnb-avatar--${variant || 'primary'}`,
@@ -207,7 +211,9 @@ const Avatar = (localProps: AvatarProps & SpacingProps) => {
       {children}
     </span>
   )
-}
+})
+
+Avatar.displayName = 'Avatar'
 
 Avatar.Group = AvatarGroup
 

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -84,7 +84,7 @@ export type BadgeProps = {
 
 type BadgeAndSpacingProps = BadgeProps &
   SpacingProps &
-  Omit<React.HTMLProps<HTMLElement>, 'content' | 'label'>
+  Omit<React.HTMLProps<HTMLElement>, 'content' | 'label' | 'ref'>
 
 type BadgeElemProps = BadgeAndSpacingProps & { context: ContextProps }
 
@@ -102,7 +102,10 @@ export const defaultProps: BadgeAndSpacingProps = {
   hideBadge: false,
 }
 
-function Badge(localProps: BadgeAndSpacingProps) {
+function Badge(
+  localProps: BadgeAndSpacingProps,
+  ref: React.ForwardedRef<HTMLSpanElement>
+) {
   // Every component should have a context
   const context = React.useContext(Context)
 
@@ -118,7 +121,7 @@ function Badge(localProps: BadgeAndSpacingProps) {
 
   if (children) {
     return (
-      <BadgeRoot className={clsx(spacingClasses)}>
+      <BadgeRoot className={clsx(spacingClasses)} ref={ref}>
         {children}
         <BadgeElem context={context} {...allProps} className={className} />
       </BadgeRoot>
@@ -137,12 +140,14 @@ function Badge(localProps: BadgeAndSpacingProps) {
 function BadgeRoot({
   children,
   className,
+  ref,
 }: {
   children: React.ReactNode
   className?: string
+  ref?: React.ForwardedRef<HTMLSpanElement>
 }) {
   return (
-    <span className={clsx('dnb-badge__root', className)}>{children}</span>
+    <span ref={ref} className={clsx('dnb-badge__root', className)}>{children}</span>
   )
 }
 
@@ -224,6 +229,10 @@ const BadgeElem = propGuard((props: BadgeElemProps) => {
   )
 })
 
-Badge._supportsSpacingProps = true
+const BadgeWithRef = React.forwardRef(Badge)
+BadgeWithRef.displayName = 'Badge'
 
-export default Badge
+// @ts-expect-error - Adding custom property to component
+BadgeWithRef._supportsSpacingProps = true
+
+export default BadgeWithRef

--- a/packages/dnb-eufemia/src/components/button/Button.js
+++ b/packages/dnb-eufemia/src/components/button/Button.js
@@ -51,7 +51,7 @@ export const buttonVariantPropType = {
 /**
  * The button component should be used as the call-to-action in a form, or as a user interaction mechanism. Generally speaking, a button should not be used when a link would do the trick. Exceptions are made at times when it is used as a navigation element in the action-nav element.
  */
-export default class Button extends React.PureComponent {
+class Button extends React.PureComponent {
   static contextType = Context
 
   static getContent(props) {
@@ -411,3 +411,12 @@ Button.defaultProps = {
 
 Button._formElement = true
 Button._supportsSpacingProps = true
+
+const ButtonWithRef = React.forwardRef((props, ref) => {
+  return <Button {...props} innerRef={ref || props.innerRef} />
+})
+ButtonWithRef.displayName = 'Button'
+ButtonWithRef._formElement = true
+ButtonWithRef._supportsSpacingProps = true
+
+export default ButtonWithRef

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -419,7 +419,15 @@ function Checkbox(localProps: CheckboxProps) {
   )
 }
 
-export default Checkbox
+const CheckboxWithRef = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  (props, ref) => {
+    return <Checkbox {...props} innerRef={ref || props.innerRef} />
+  }
+)
+CheckboxWithRef.displayName = 'Checkbox'
 
-// Mark as form element for FieldBlock
+// @ts-expect-error - Adding custom property to component
+CheckboxWithRef._formElement = true
 Checkbox._formElement = true
+
+export default CheckboxWithRef

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -52,7 +52,7 @@ export type FormLabelAllProps = FormLabelProps &
   React.HTMLAttributes<HTMLLabelElement> &
   SpacingProps
 
-export default function FormLabel(localProps: FormLabelAllProps) {
+function FormLabel(localProps: FormLabelAllProps) {
   const context = React.useContext(Context)
 
   // use only the props from context, who are available here anyway
@@ -65,8 +65,12 @@ export default function FormLabel(localProps: FormLabelAllProps) {
   )
 
   const nestedContent = props?.text || props?.children
+  const nestedType = nestedContent?.['type']
   const nestedNode =
-    nestedContent?.['type'] === FormLabel ? nestedContent?.['type'] : null
+    nestedType === FormLabel ||
+    nestedType?.displayName === 'FormLabel'
+      ? nestedType
+      : null
   const nestedElement = nestedNode
     ? () => React.createElement(nestedNode, nestedContent['props'])
     : null
@@ -211,5 +215,18 @@ export default function FormLabel(localProps: FormLabelAllProps) {
   return <Element {...params}>{content}</Element>
 }
 
+const FormLabelWithRef = React.forwardRef<HTMLElement, FormLabelAllProps>(
+  (props, ref) => {
+    return <FormLabel {...props} innerRef={ref || props.innerRef} />
+  }
+)
+FormLabelWithRef.displayName = 'FormLabel'
+
+// @ts-expect-error - Adding custom property to component
+FormLabelWithRef._formElement = true
+// @ts-expect-error - Adding custom property to component
+FormLabelWithRef._supportsSpacingProps = true
 FormLabel._formElement = true
 FormLabel._supportsSpacingProps = true
+
+export default FormLabelWithRef

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -139,9 +139,14 @@ export type HeadingAllProps = HeadingProps &
   SpacingProps
 
 export default function Heading(props: HeadingAllProps) {
+  return <HeadingInstance {...props} />
+}
+
+function HeadingInstance(props: HeadingAllProps & { innerRef?: React.Ref<HTMLElement> }) {
   const context = React.useContext(Context)
   const headingContext = React.useContext(HeadingContext)
-  const _ref = React.useRef()
+  const internalRef = React.useRef()
+  const _ref = props.innerRef || internalRef
 
   const {
     text,
@@ -159,6 +164,7 @@ export default function Heading(props: HeadingAllProps) {
     size: _size, // eslint-disable-line
     skeleton: _skeleton, // eslint-disable-line
     element: _element, // eslint-disable-line
+    innerRef, // eslint-disable-line
     className,
     children,
     ...rest
@@ -316,6 +322,13 @@ export default function Heading(props: HeadingAllProps) {
 
 type HeadingStaticProps = Omit<HeadingAllProps, 'ref' | 'size'>
 
+const HeadingWithRef = React.forwardRef<HTMLElement, HeadingAllProps>(
+  (props, ref) => {
+    return <HeadingInstance {...props} innerRef={ref} />
+  }
+)
+HeadingWithRef.displayName = 'Heading'
+
 Heading.Level = HeadingProvider
 Heading.Increase = (props: HeadingStaticProps) => (
   <HeadingProvider increase {...props} />
@@ -338,6 +351,21 @@ Heading.setNextLevel = setNextLevel
 
 Heading._isHeadingElement = true
 Heading._supportsSpacingProps = true
+
+// @ts-expect-error - Adding custom property to component
+HeadingWithRef._isHeadingElement = true
+// @ts-expect-error - Adding custom property to component
+HeadingWithRef._supportsSpacingProps = true
+HeadingWithRef['Level'] = HeadingProvider
+HeadingWithRef['Increase'] = Heading.Increase
+HeadingWithRef['Decrease'] = Heading.Decrease
+HeadingWithRef['Up'] = Heading.Up
+HeadingWithRef['Down'] = Heading.Down
+HeadingWithRef['Reset'] = Heading.Reset
+HeadingWithRef['resetLevels'] = resetLevels
+HeadingWithRef['setNextLevel'] = setNextLevel
+
+export { HeadingWithRef }
 
 // Interceptor to reset leveling
 export { resetAllLevels, resetLevels, setNextLevel }

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
@@ -19,7 +19,7 @@ export type IconPrimaryAllProps = IconAllProps
 
 const icons = { ...primary_icons, ...primary_icons_medium }
 
-export default function IconPrimary(localProps: IconAllProps) {
+function IconPrimary(localProps: IconAllProps) {
   const context = useContext(Context)
 
   // use only the props from context, who are available here anyway
@@ -31,7 +31,7 @@ export default function IconPrimary(localProps: IconAllProps) {
     context.IconPrimary
   )
 
-  const { icon, size, wrapperParams, iconParams, alt } = prepareIcon(
+  const { icon, size, wrapperParams, iconParams, alt, innerRef } = prepareIcon(
     props,
     context
   )
@@ -48,10 +48,20 @@ export default function IconPrimary(localProps: IconAllProps) {
   }
 
   return (
-    <span {...wrapperParams}>
+    <span ref={innerRef} {...wrapperParams}>
       <IconContainer {...iconParams} />
     </span>
   )
 }
 
+const IconPrimaryWithRef = React.forwardRef<HTMLSpanElement, IconAllProps>(
+  (props, ref) => {
+    return <IconPrimary {...props} innerRef={ref} />
+  }
+)
+IconPrimaryWithRef.displayName = 'IconPrimary'
+// @ts-expect-error - Adding custom property to component
+IconPrimaryWithRef._supportsSpacingProps = true
 IconPrimary._supportsSpacingProps = true
+
+export default IconPrimaryWithRef

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -114,7 +114,7 @@ export type IconAllProps = IconProps &
   SpacingProps &
   Omit<React.HTMLProps<HTMLElement>, 'size' | 'children'>
 
-export default function Icon(localProps: IconAllProps) {
+function Icon(localProps: IconAllProps) {
   const context = useContext(Context)
 
   // use only the props from context, who are available here anyway
@@ -132,6 +132,7 @@ export default function Icon(localProps: IconAllProps) {
     iconParams,
     alt,
     children,
+    innerRef,
   } = usePrepareIcon(props, context)
   const icon = iconProp ?? children
 
@@ -147,7 +148,7 @@ export default function Icon(localProps: IconAllProps) {
   }
 
   return (
-    <span {...wrapperParams}>
+    <span ref={innerRef} {...wrapperParams}>
       <IconContainer {...iconParams} />
     </span>
   )
@@ -340,6 +341,7 @@ function prepareIconCore(
     title,
     skeleton,
     className,
+    innerRef, // eslint-disable-line
     ...attributes
   } = props
 
@@ -506,4 +508,14 @@ function getIcon(props) {
   return processChildren(props)
 }
 
+const IconWithRef = React.forwardRef<HTMLSpanElement, IconAllProps>(
+  (props, ref) => {
+    return <Icon {...props} innerRef={ref} />
+  }
+)
+IconWithRef.displayName = 'Icon'
+// @ts-expect-error - Adding custom property to component
+IconWithRef._supportsSpacingProps = true
 Icon._supportsSpacingProps = true
+
+export default IconWithRef

--- a/packages/dnb-eufemia/src/components/input/Input.js
+++ b/packages/dnb-eufemia/src/components/input/Input.js
@@ -130,7 +130,7 @@ export const inputPropTypes = {
   onClear: PropTypes.func,
 }
 
-export default class Input extends React.PureComponent {
+class Input extends React.PureComponent {
   static contextType = Context
 
   static propTypes = {
@@ -818,3 +818,12 @@ InputIcon.propTypes = {
 
 Input._formElement = true
 Input._supportsSpacingProps = true
+
+const InputWithRef = React.forwardRef((props, ref) => {
+  return <Input {...props} innerRef={ref || props.innerRef} />
+})
+InputWithRef.displayName = 'Input'
+InputWithRef._formElement = true
+InputWithRef._supportsSpacingProps = true
+
+export default InputWithRef

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
@@ -49,6 +49,7 @@ function ProgressIndicator(props: ProgressIndicatorAllProps) {
     customColors,
     customCircleWidth,
     style,
+    innerRef,
     ...rest
   } = allProps
 
@@ -100,6 +101,7 @@ function ProgressIndicator(props: ProgressIndicatorAllProps) {
 
   return (
     <span
+      ref={innerRef}
       className={clsx(
         'dnb-progress-indicator',
         show && 'dnb-progress-indicator--show',
@@ -179,6 +181,16 @@ function formatProgress(progress) {
   return null
 }
 
-export default ProgressIndicator
+const ProgressIndicatorWithRef = React.forwardRef<
+  HTMLSpanElement,
+  ProgressIndicatorAllProps
+>((props, ref) => {
+  return <ProgressIndicator {...props} innerRef={ref} />
+})
+ProgressIndicatorWithRef.displayName = 'ProgressIndicator'
+// @ts-expect-error - Adding custom property to component
+ProgressIndicatorWithRef._supportsSpacingProps = true
+
+export default ProgressIndicatorWithRef
 
 ProgressIndicator._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -148,9 +148,18 @@ const defaultProps = {
   element: 'section',
 }
 
-export default function Section(localProps: SectionAllProps) {
+function Section(localProps: SectionAllProps) {
   return <Space {...SectionParams(localProps)} />
 }
+
+const SectionWithRef = React.forwardRef<HTMLElement, SectionAllProps>(
+  (props, ref) => {
+    return <Section {...props} innerRef={ref || props.innerRef} />
+  }
+)
+SectionWithRef.displayName = 'Section'
+
+export { SectionWithRef as default }
 
 export function SectionParams(
   localProps: SectionAllProps
@@ -270,5 +279,9 @@ function computeStyle<T extends boolean | string | number | boolean[]>(
   return result
 }
 
+// @ts-expect-error - Adding custom property to component
+SectionWithRef._name = 'Section'
+// @ts-expect-error - Adding custom property to component
+SectionWithRef._supportsSpacingProps = true
 Section._name = 'Section'
 Section._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/Slider.tsx
@@ -15,15 +15,23 @@ export * from './types'
 // Export the extensions
 export { default as SliderMarker } from './SliderMarker'
 
-function Slider(localProps: SliderAllProps) {
+function Slider(
+  localProps: SliderAllProps,
+  ref: React.ForwardedRef<HTMLSpanElement>
+) {
   return (
-    <SliderProvider {...localProps}>
+    <SliderProvider {...localProps} innerRef={ref}>
       <SliderInstance />
     </SliderProvider>
   )
 }
 
-Slider._formElement = true
-Slider._supportsSpacingProps = true
+const SliderWithRef = React.forwardRef(Slider)
+SliderWithRef.displayName = 'Slider'
 
-export default Slider
+// @ts-expect-error - Adding custom property to component
+SliderWithRef._formElement = true
+// @ts-expect-error - Adding custom property to component
+SliderWithRef._supportsSpacingProps = true
+
+export default SliderWithRef

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -75,7 +75,7 @@ export type SpaceAllProps = SpaceProps &
 
 const defaultProps = {}
 
-export default function Space(localProps: SpaceAllProps) {
+function Space(localProps: SpaceAllProps) {
   const context = React.useContext<ContextProps & SpacingProps>(Context)
 
   // consume the space context
@@ -142,6 +142,17 @@ export default function Space(localProps: SpaceAllProps) {
 }
 
 Space._supportsSpacingProps = true
+
+const SpaceWithRef = React.forwardRef<HTMLElement, SpaceAllProps>(
+  (props, ref) => {
+    return <Space {...props} innerRef={ref || props.innerRef} />
+  }
+)
+SpaceWithRef.displayName = 'Space'
+// @ts-expect-error - Adding custom property to component
+SpaceWithRef._supportsSpacingProps = true
+
+export default SpaceWithRef
 
 function Element({
   element,

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -134,7 +134,7 @@ const defaultProps = {
   statusState: 'error',
 }
 
-export default function Switch(props: SwitchProps) {
+function Switch(props: SwitchProps) {
   const context = useContext(Context)
 
   const allProps = extractPropsFromContext()
@@ -407,3 +407,12 @@ export default function Switch(props: SwitchProps) {
     )
   }
 }
+
+const SwitchWithRef = React.forwardRef<HTMLInputElement, SwitchProps>(
+  (props, ref) => {
+    return <Switch {...props} innerRef={ref || props.innerRef} />
+  }
+)
+SwitchWithRef.displayName = 'Switch'
+
+export default SwitchWithRef

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -93,9 +93,10 @@ export const defaultProps = {
   omitOnKeyUpDeleteEvent: false,
 }
 
-const Tag = (
-  localProps: TagProps & SpacingProps & React.HTMLProps<HTMLElement>
-) => {
+const Tag = React.forwardRef<
+  HTMLElement,
+  TagProps & SpacingProps & React.HTMLProps<HTMLElement>
+>((localProps, ref) => {
   // Every component should have a context
   const context = React.useContext(Context)
   const tagGroupContext = React.useContext(TagGroupContext)
@@ -185,9 +186,12 @@ const Tag = (
       }
       {...additionalButtonParams}
       {...(props as any)}
+      innerRef={ref}
     />
   )
-}
+})
+
+Tag.displayName = 'Tag'
 
 const getIcon = (title: string) => (
   <IconPrimary

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.js
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.js
@@ -40,7 +40,7 @@ import Suffix from '../../shared/helpers/Suffix'
 /**
  * The textarea component is an umbrella component for all textareas which share the same style as the classic `text` textarea field.
  */
-export default class Textarea extends React.PureComponent {
+class Textarea extends React.PureComponent {
   static contextType = Context
 
   static propTypes = {
@@ -616,3 +616,12 @@ export default class Textarea extends React.PureComponent {
 
 Textarea._formElement = true
 Textarea._supportsSpacingProps = true
+
+const TextareaWithRef = React.forwardRef((props, ref) => {
+  return <Textarea {...props} innerRef={ref || props.innerRef} />
+})
+TextareaWithRef.displayName = 'Textarea'
+TextareaWithRef._formElement = true
+TextareaWithRef._supportsSpacingProps = true
+
+export default TextareaWithRef


### PR DESCRIPTION
Added React.forwardRef to 16 core components, following the existing pattern established by ScrollView.tsx and Anchor.tsx.
Why forwardRef? Without it, consumers must use a non-standard innerRef prop, which breaks compatibility with React ecosystem libraries (React Hook Form, Framer Motion, Floating UI) that pass refs via the standard ref prop. It also prevents ref composition with React.cloneElement and other standard React patterns.