### PR TITLE
break!: remove `checkIfHasScrollbar` from public API docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1475,6 +1475,12 @@ See docs about changed [Dropdown properties](/uilib/about-the-lib/releases/eufem
 
 - Replace `filterSubmitData` with rather using the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
 
+## Helpers
+
+### Removed helper functions
+
+- Removed `checkIfHasScrollbar` from the public API (`@dnb/eufemia/shared/component-helper`). It is still available internally but no longer documented for consumer use.
+
 ## Theming
 
 - Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -89,16 +89,6 @@ import { slugify } from '@dnb/eufemia/shared/component-helper'
 slugify(String) // returns String
 ```
 
-### checkIfHasScrollbar
-
-Checks if an element has a scrollbar.
-
-```js
-import { checkIfHasScrollbar } from '@dnb/eufemia/shared/component-helper'
-
-checkIfHasScrollbar(HTMLElement) // returns Boolean
-```
-
 ### convertJsxToString
 
 Converts one or more HTMLElements to a string.

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -48,7 +48,6 @@ You can use the internal Eufemia easing function.
 - [filterProps](/uilib/helpers/functions#filterprops): Filter out unwanted entries from either an object or an array.
 - [makeUniqueId](/uilib/helpers/functions#makeuniqueid): Creates a unique hash string.
 - [slugify](/uilib/helpers/functions#slugify): Breaks down phrases of words to be URI compatible.
-- [checkIfHasScrollbar](/uilib/helpers/functions#checkifhasscrollbar): Check if an element has a scrollbar.
 - [convertJsxToString](/uilib/helpers/functions#convertjsxtostring): Convert one or more HTMLElements to a string.
 - [InteractionInvalidation](/uilib/helpers/functions#interactioninvalidation): Invalidates DOM elements so they are not accessible to keyboard or screen reader.
 - [scrollToLocationHashId](/uilib/helpers/functions#scrolltolocationhashid): Scroll to a given HashId with optional offset and delay.


### PR DESCRIPTION
Remove checkIfHasScrollbar from public documentation. The function remains available internally but is no longer advertised as a consumer-facing helper.

