### PR TITLE
break!: remove `setPageFocusElement` from shared helpers

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1475,6 +1475,12 @@ See docs about changed [Dropdown properties](/uilib/about-the-lib/releases/eufem
 
 - Replace `filterSubmitData` with rather using the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
 
+## Helpers
+
+### Removed helper functions
+
+- Removed `setPageFocusElement` from `@dnb/eufemia/shared/helpers`. Use `applyPageFocus` with a CSS selector directly instead.
+
 ## Theming
 
 - Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -187,7 +187,7 @@ getOffsetTop(element: HTMLElement) // returns Number
 
 ### applyPageFocus
 
-More info about that function in the [focus section about better accessibility](/uilib/usage/accessibility/focus#focus-helper). Used together with [setPageFocusElement](/uilib/helpers/functions#setpagefocuselement).
+More info about that function in the [focus section about better accessibility](/uilib/usage/accessibility/focus#focus-helper).
 
 ```js
 import { applyPageFocus } from '@dnb/eufemia/shared/helpers'
@@ -199,20 +199,6 @@ applyPageFocus(selector*: String, callback*: Function)
 
 - selector = _'default'_ (can be an HTML element selector, starting with a `.` or `#`)
 - callback = _null_
-
-### setPageFocusElement
-
-More info about that function in the [focus section about better accessibility](/uilib/usage/accessibility/focus#focus-helper).
-
-```js
-import { setPageFocusElement } from '@dnb/eufemia/shared/helpers'
-
-setPageFocusElement(selectorOrElement: String|HTMLElement, key*: String) // returns Void
-```
-
-#### \* Optional values (defaults)
-
-- key = _''_
 
 ### debounce
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -54,7 +54,6 @@ You can use the internal Eufemia easing function.
 - [scrollToLocationHashId](/uilib/helpers/functions#scrolltolocationhashid): Scroll to a given HashId with optional offset and delay.
 - [getOffsetTop](/uilib/helpers/functions#getoffsettop): Get the HTML Element offset to the top of the browser window.
 - [applyPageFocus](/uilib/helpers/functions#applypagefocus): Applies a page focus to an element given by the setPageFocusElement.
-- [setPageFocusElement](/uilib/helpers/functions#setpagefocuselement): Defines a focus element to applyPageFocus.
 - [debounce](/uilib/helpers/functions#debounce): Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
 - [copyToClipboard](/uilib/helpers/functions#copytoclipboard): Copies a given string to the clipboard.
 

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -14,7 +14,6 @@ import {
 } from '../menu/SidebarMenuContext'
 import ToggleGrid, { GridActivator } from '../menu/ToggleGrid'
 import {
-  setPageFocusElement,
   scrollToLocationHashId,
 } from '@dnb/eufemia/src/shared/helpers'
 import { P, Logo, GlobalStatus } from '@dnb/eufemia/src'
@@ -58,9 +57,6 @@ function Layout(props: LayoutProps) {
   const { fullscreen, location, hideSidebar, children } = props
 
   React.useEffect(() => {
-    // gets applied on "onRouteUpdate"
-    setPageFocusElement('.dnb-app-content h1:nth-of-type(1)', 'content')
-
     scrollToAnimation()
   }, [])
 

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -13,9 +13,7 @@ import {
   SidebarMenuContext,
 } from '../menu/SidebarMenuContext'
 import ToggleGrid, { GridActivator } from '../menu/ToggleGrid'
-import {
-  scrollToLocationHashId,
-} from '@dnb/eufemia/src/shared/helpers'
+import { scrollToLocationHashId } from '@dnb/eufemia/src/shared/helpers'
 import { P, Logo, GlobalStatus } from '@dnb/eufemia/src'
 import './PortalStyle.scss'
 import {

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
@@ -7,7 +7,6 @@ import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 
 import {
-  setPageFocusElement,
   applyPageFocus,
   scrollToLocationHashId,
   copyToClipboard,
@@ -47,15 +46,12 @@ describe('"applyPageFocus" should', () => {
       <button class="focus-button">My Button</button>
       `
     )
-
-    setPageFocusElement('.focus-content', 'content')
   })
 
   it('set a focus on the given element', () => {
     expect(document.activeElement.tagName).toBe('BODY')
 
-    setPageFocusElement('.focus-content', 'content')
-    applyPageFocus('content')
+    applyPageFocus('.focus-content')
 
     const focusElement = document.querySelector('.focus-content')
     expect(focusElement === document.activeElement).toBe(true)

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -65,9 +65,7 @@ isLinux()
 
 export function applyPageFocus(selector = 'default', callback = null) {
   try {
-    let element = /^[.#]/.test(selector)
-      ? selector
-      : null
+    let element = /^[.#]/.test(selector) ? selector : null
     if (typeof element === 'string' && typeof document !== 'undefined') {
       element = document.querySelector(element)
     } else if (!element && typeof document !== 'undefined') {

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -63,16 +63,11 @@ isAndroid()
 isMac()
 isLinux()
 
-const pageFocusElements = {}
-export function setPageFocusElement(selectorOrElement, key = 'default') {
-  return (pageFocusElements[key] = selectorOrElement)
-}
-
 export function applyPageFocus(selector = 'default', callback = null) {
   try {
     let element = /^[.#]/.test(selector)
       ? selector
-      : pageFocusElements[selector]
+      : null
     if (typeof element === 'string' && typeof document !== 'undefined') {
       element = document.querySelector(element)
     } else if (!element && typeof document !== 'undefined') {


### PR DESCRIPTION
Remove setPageFocusElement and the pageFocusElements registry. Update applyPageFocus to only accept CSS selectors directly. Remove dead setPageFocusElement call from portal Layout.tsx. Update tests and documentation. 