### PR TITLE
break!: remove `dnb-drop-shadow` and `dnb-sharp-drop-shadow` CSS helper classes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1475,6 +1475,12 @@ See docs about changed [Dropdown properties](/uilib/about-the-lib/releases/eufem
 
 - Replace `filterSubmitData` with rather using the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
 
+## Helpers
+
+### Removed CSS helper classes
+
+- Removed `dnb-drop-shadow` and `dnb-sharp-drop-shadow` CSS classes. They were unused internally. Use the CSS custom properties `--shadow-default` and `--shadow-sharp` directly instead, or the SCSS mixins `defaultDropShadow()` / `sharpDropShadow()`.
+
 ## Theming
 
 - Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -91,52 +91,6 @@ Visually hide an element while keeping it accessible to screen readers. (_sr_ st
 
 <Examples.ScreenReaderOnly />
 
-## Drop shadow
-
-`dnb-drop-shadow`
-
-Adds a default drop shadow (`box-shadow: 0 8px 16px rgba(51, 51, 51, 0.08)`) to the component. The current shadow specification is designed to be softer and more blurred.
-
-### CSS properties
-
-The DNB Drop shadow is also available as a CSS Custom Property:
-
-```ts
-import properties from '@dnb/eufemia/style/themes/ui/properties.js'
-
-const cssBoxShadow = properties['--shadow-default']
-```
-
-If you only want to apply parts of the property, these are available as well:
-
-- `--shadow-default-x: 0;`
-- `--shadow-default-y: 8px;`
-- `--shadow-default-blur-radius: 16px;`
-- `--shadow-default-color: rgba(51, 51, 51, 0.08);`
-
-## Sharp drop shadow
-
-`dnb-sharp-drop-shadow`
-
-Adds a smaller but sharper drop shadow (`box-shadow: 0 1px 6px rgba(0, 0, 0, 0.16)`) to the component. Designed for hovering elements such as dropdowns or calendars.
-
-### CSS properties
-
-The DNB Sharp drop shadow is also available as a CSS Custom Property:
-
-```ts
-import properties from '@dnb/eufemia/style/themes/ui/properties.js'
-
-const cssBoxShadow = properties['--shadow-sharp']
-```
-
-If you only want to apply parts of the property, these are available as well:
-
-- `--shadow-sharp-x: 0;`
-- `--shadow-sharp-y: 1px;`
-- `--shadow-sharp-blur-radius: 6px;`
-- `--shadow-sharp-color: rgba(0, 0, 0, 0.16);`
-
 ## Responsive component
 
 `dnb-responsive-component`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -33,9 +33,7 @@ You can use the internal Eufemia easing function.
 - [dnb-spacing](/uilib/helpers/classes#spacing): Sets a default spacing on all nested HTML elements.
 - [dnb-scrollbar-appearance](/uilib/helpers/classes#scrollbar-appearance): Defines the DNB scrollbar appearance.
 - [dnb-sr-only](/uilib/helpers/classes#screen-reader-sr-only): An element that is reachable by screen readers, but is visually hidden.
-- [dnb-drop-shadow](/uilib/helpers/classes#drop-shadow): Adds the default drop shadow to the component.
-- [dnb-sharp-drop-shadow](/uilib/helpers/classes#sharp-drop-shadow): Adds the sharp drop shadow to the component.
-- [dnb-responsive-component](/uilib/helpers/classes#drop-shadow): Makes the component react to small sized screens.
+- [dnb-responsive-component](/uilib/helpers/classes#responsive-component): Makes the component react to small sized screens.
 - [dnb-unstyled-list](/uilib/helpers/classes#unstyled-list): Removes default styling for lists.
 - [dnb-selection](/uilib/helpers/classes#selection): Applies DNB selection colors to selected content.
 

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -49,14 +49,6 @@
   @include alignmentHelper();
 }
 
-.dnb-drop-shadow {
-  @include defaultDropShadow();
-}
-
-.dnb-sharp-drop-shadow {
-  @include sharpDropShadow();
-}
-
 .dnb-sr-only {
   @include srOnly();
 }


### PR DESCRIPTION
Remove unused dnb-drop-shadow and dnb-sharp-drop-shadow CSS classes. The CSS custom properties (--shadow-default, --shadow-sharp) and SCSS mixins remain available for direct use.

