### PR TITLE
break!: remove `dnb-scrollbar-appearance` CSS helper class

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1475,6 +1475,21 @@ See docs about changed [Dropdown properties](/uilib/about-the-lib/releases/eufem
 
 - Replace `filterSubmitData` with rather using the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
 
+## Helpers
+
+### Removed CSS helper classes
+
+- Removed `dnb-scrollbar-appearance` CSS class. It was unused internally and had incomplete browser support. Use the SCSS mixin `scrollbarAppearance()` directly if needed.
+- Removed `dnb-drop-shadow` and `dnb-sharp-drop-shadow` CSS classes. They were unused internally. Use the CSS custom properties `--shadow-default` and `--shadow-sharp` directly instead, or the SCSS mixins `defaultDropShadow()` / `sharpDropShadow()`.
+
+### Removed helper functions
+
+- Removed `filterProps` from `@dnb/eufemia/shared/component-helper`. It was barely used internally. Use standard JavaScript object destructuring or filtering instead.
+- Removed `scrollToLocationHashId` from `@dnb/eufemia/shared/helpers`. It was not used by any Eufemia component.
+- Removed `setPageFocusElement` from `@dnb/eufemia/shared/helpers`. It was not used by any Eufemia component. Use `applyPageFocus` with a CSS selector directly instead.
+- Removed `checkIfHasScrollbar` from the public API (`@dnb/eufemia/shared/component-helper`). It is still available internally but no longer exported for consumer use.
+- Removed `isTrue` from `@dnb/eufemia/shared/component-helper`. This was an outdated pattern from before TypeScript adoption. Use standard JavaScript truthiness checks (`Boolean(value)` or `!!value`) instead.
+
 ## Theming
 
 - Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -75,14 +75,6 @@ Sets default spacing (using _margin_) on all HTML elements inside the container 
 
 More details in [Styling](/uilib/usage/customisation/styling#spacing).
 
-## Scrollbar appearance
-
-`dnb-scrollbar-appearance`
-
-Define the DNB scrollbar appearance, including the color `--color-emerald-green` with `transparent`.
-
-NB: Browser support is not fully covered (2021).
-
 ## Screen Reader (sr) only
 
 `dnb-sr-only`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -31,7 +31,6 @@ You can use the internal Eufemia easing function.
 - [dnb-tab-focus](/uilib/helpers/classes#tab-focus): Adds a custom visual focus state on tab focus.
 - [dnb-skip-link](/uilib/helpers/classes#skip-link): For adding a link at the top of each page that goes directly to the main content area.
 - [dnb-spacing](/uilib/helpers/classes#spacing): Sets a default spacing on all nested HTML elements.
-- [dnb-scrollbar-appearance](/uilib/helpers/classes#scrollbar-appearance): Defines the DNB scrollbar appearance.
 - [dnb-sr-only](/uilib/helpers/classes#screen-reader-sr-only): An element that is reachable by screen readers, but is visually hidden.
 - [dnb-drop-shadow](/uilib/helpers/classes#drop-shadow): Adds the default drop shadow to the component.
 - [dnb-sharp-drop-shadow](/uilib/helpers/classes#sharp-drop-shadow): Adds the sharp drop shadow to the component.

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -35,10 +35,6 @@
   );
 }
 
-.dnb-scrollbar-appearance {
-  @include scrollbarAppearance();
-}
-
 @import './skip-link.scss';
 
 .dnb-alignment-helper {


### PR DESCRIPTION
Remove the unused dnb-scrollbar-appearance CSS class from helper-classes.scss. Remove from documentation (info.mdx and classes.mdx).

