### PR TITLE
break!: remove `IS_LINUX`/`isLinux` detection

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1199,6 +1199,10 @@ The following functions have been removed from `@dnb/eufemia/shared/component-he
 - `toCamelCase` – Converted snake_case strings to camelCase.
 - `toSnakeCase` – Converted PascalCase strings to snake_case.
 
+The following functions have been removed from `@dnb/eufemia/shared/helpers`:
+
+- `isLinux` / `IS_LINUX` – Linux platform detection. Had zero consumers.
+
 #### Removed HOCs and conversion utilities
 
 The following Higher-Order Components (HOCs), conversion functions, and types have been removed:

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -284,7 +284,6 @@ copyToClipboard(string) // returns success: String|Boolean|Error
 | `isiOS`    | Returns true or false, depending on the detection. | none       | `Boolean` |
 | `isMac`    | Returns true or false, depending on the detection. | none       | `Boolean` |
 | `isWin`    | Returns true or false, depending on the detection. | none       | `Boolean` |
-| `isLinux`  | Returns true or false, depending on the detection. | none       | `Boolean` |
 
 ### Device constants
 
@@ -295,4 +294,3 @@ copyToClipboard(string) // returns success: String|Boolean|Error
 | `IS_IOS`    | Gives you true or false, depending on the detection during startup. | `Boolean` |
 | `IS_MAC`    | Gives you true or false, depending on the detection during startup. | `Boolean` |
 | `IS_WIN`    | Gives you true or false, depending on the detection during startup. | `Boolean` |
-| `IS_LINUX`  | Gives you true or false, depending on the detection during startup. | `Boolean` |

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.js
@@ -20,7 +20,6 @@ import {
   isSafari,
   isWin,
   isMac,
-  isLinux,
   warn,
 } from '../helpers'
 
@@ -218,10 +217,6 @@ describe('platform', () => {
   it('"isWin" should result in true', () => {
     platformGetter.mockReturnValue('Win')
     expect(isWin()).toBe(true)
-  })
-  it('"isLinux" should result in true', () => {
-    platformGetter.mockReturnValue('Linux')
-    expect(isLinux()).toBe(true)
   })
   it('"isiOS" should result in true', () => {
     platformGetter.mockReturnValue('iPhone')

--- a/packages/dnb-eufemia/src/shared/helpers.js
+++ b/packages/dnb-eufemia/src/shared/helpers.js
@@ -18,7 +18,6 @@ export let IS_SAFARI = false
 export let IS_WIN = false
 export let IS_MAC = false
 export let IS_ANDROID = false
-export let IS_LINUX = false
 
 export const isMac = () =>
   (IS_MAC =
@@ -34,11 +33,6 @@ export const isAndroid = () =>
   (IS_ANDROID =
     typeof navigator !== 'undefined' &&
     new RegExp(PLATFORM_ANDROID, 'i').test(navigator?.userAgent))
-
-export const isLinux = () =>
-  (IS_LINUX =
-    typeof navigator !== 'undefined' &&
-    new RegExp(PLATFORM_LINUX, 'i').test(navigator?.platform))
 
 export const isiOS = () =>
   (IS_IOS =
@@ -61,7 +55,6 @@ isSafari()
 isWin()
 isAndroid()
 isMac()
-isLinux()
 
 const pageFocusElements = {}
 export function setPageFocusElement(selectorOrElement, key = 'default') {


### PR DESCRIPTION
IS_LINUX and isLinux had zero consumers in the codebase.

