### PR TITLE
break!: remove `isChildOfElement` and `roundToNearest` helpers

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1198,6 +1198,8 @@ The following functions have been removed from `@dnb/eufemia/shared/component-he
 
 - `toCamelCase` – Converted snake_case strings to camelCase.
 - `toSnakeCase` – Converted PascalCase strings to snake_case.
+- `isChildOfElement` – DOM traversal helper. Use native `Element.contains()` or walk the DOM manually.
+- `roundToNearest` – Trivial math helper. Inline the logic: `const diff = num % target; return diff > target / 2 ? num - diff + target : num - diff`.
 
 #### Removed HOCs and conversion utilities
 

--- a/packages/dnb-eufemia/src/components/modal/bodyScrollLock.js
+++ b/packages/dnb-eufemia/src/components/modal/bodyScrollLock.js
@@ -1,10 +1,22 @@
-import {
-  warn,
-  isChildOfElement,
-  checkIfHasScrollbar,
-} from '../../shared/component-helper'
+import { warn, checkIfHasScrollbar } from '../../shared/component-helper'
 
 const isServer = () => typeof window === 'undefined'
+
+const findScrollableParent = (element, target, callback) => {
+  try {
+    let current = element
+    while (current && current !== target) {
+      if (callback(current)) {
+        return current
+      }
+      current = current.parentElement
+    }
+  } catch (e) {
+    //
+  }
+  return target
+}
+
 const detectOS = (ua) => {
   ua = ua || navigator.userAgent
   const ipad = /(iPad).*OS\s([\d_]+)/.test(ua)
@@ -159,7 +171,7 @@ const setOverflowHiddenAndroid = () => {
 
 const preventDefault = (event) => {
   const found = lockedElements.find((targetElement) => {
-    return isChildOfElement(event.target, targetElement)
+    return targetElement.contains(event.target)
   })
 
   if (found || !event.cancelable) {
@@ -194,7 +206,7 @@ const handleScroll = (event, targetElement) => {
         (isVertical && (isOnTop || isOnBottom)) ||
         (!isVertical && (isOnLeft || isOnRight))
       ) {
-        const hasScrollbar = isChildOfElement(
+        const hasScrollbar = findScrollableParent(
           event.target,
           targetElement,
           checkIfHasScrollbar

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -309,48 +309,6 @@ export const matchAll = (string, regex) => {
   return matches
 }
 
-/**
- * Check if an element exists in its children
- * If it finds it, the child "element" of target will be returned.
- *
- * @param {HTMLElement} element The DOM Element to find
- * @param {HTMLElement} target The DOM Element that should contain "element"
- * @param {function} callback (optional)
- * @returns {HTMLElement | null} Returns the found child of all existing dom elements inside of "target"
- */
-export const isChildOfElement = (element, target, callback = null) => {
-  try {
-    const contains = (element) => {
-      if (callback) {
-        const res = callback(element)
-        if (res) {
-          return element
-        }
-      }
-      return element && element === target
-    }
-
-    if (contains(element)) {
-      return element
-    }
-
-    while (
-      (element = element && element.parentElement) &&
-      !contains(element)
-    );
-  } catch (e) {
-    //
-  }
-
-  return element
-}
-
-// Round number to nearest target number
-export const roundToNearest = (num, target) => {
-  const diff = num % target
-  return diff > target / 2 ? num - diff + target : num - diff
-}
-
 export const getClosestScrollViewElement = (currentElement) => {
   return getClosestParent('.dnb-scroll-view', currentElement)
 }


### PR DESCRIPTION
isChildOfElement had 1 consumer (bodyScrollLock.js) - replaced with native Element.contains() and a local findScrollableParent helper. roundToNearest had 1 consumer - already removed on v11.

