### PR TITLE
break!: remove what-input dependency

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -17,6 +17,7 @@ v11 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 1. Replace `innerRef` with `ref` on all Eufemia components.
 2. Replace `<Context.Provider>` with `<Context>` when using Eufemia contexts directly (React 19 deprecation).
 3. If you import Eufemia SCSS source files with `@import`, replace with `@use` and namespace your mixin/variable calls (see [SCSS: @import → @use](#scss-import--use)).
+4. If you use `html[data-whatinput]` or `html[data-whatintent]` selectors in your own SCSS, replace them with `:focus-visible` or `@media (hover: hover)` (see [Removed what-input](#removed-what-input)).
 
 ### innerRef → ref
 
@@ -74,6 +75,7 @@ $ pnpm add @dnb/eufemia@11
 
 - All **snake case** (`on_click`) events and properties has been converted to use **camel case** (`onClick`). The reason for previously using **snake case** was to support Web Components – but the support was discontinued in [v10](/uilib/about-the-lib/releases/eufemia/v10-info/).
 - Replaced deprecated `<Context.Provider>` with direct `<Context>` rendering across all internal context providers (React 19).
+- Removed the `what-input` dependency. Focus ring styles now use native `:focus-visible` and hover detection uses `@media (hover: hover)` instead of `html[data-whatinput]`/`html[data-whatintent]` selectors.
 
 ## Components
 
@@ -1285,6 +1287,42 @@ These were previously used to support dual snake_case/camelCase prop naming. Sin
 #### Updated SCSS mixin: `IS_FF`
 
 The `IS_FF()` SCSS mixin now uses `@supports (-moz-appearance: none)` instead of the deprecated `@-moz-document url-prefix()` hack. No changes needed if you use the mixin — it works the same way.
+
+### Removed `what-input`
+
+The [`what-input`](https://github.com/ten1seven/what-input) JavaScript library has been removed. Eufemia no longer sets `data-whatinput` or `data-whatintent` attributes on the `<html>` element.
+
+**What changed:**
+
+- **Focus rings** now use the native CSS pseudo-class `:focus-visible` instead of `html[data-whatinput='keyboard']` selectors. This means focus rings are shown when navigating with the keyboard and hidden during mouse/touch interaction — without any JavaScript.
+- **Hover styles** now use `@media (hover: hover)` instead of `html:not([data-whatintent='touch'])`. This uses the browser's built-in capability detection to determine if the device supports hover.
+- **Touch-specific active styles** now use `@media (hover: none)` instead of `html[data-whatintent='touch']`.
+
+**Migration required** if you have custom SCSS that targets these selectors:
+
+| Before (v10)                                          | After (v11)                                 |
+| ----------------------------------------------------- | ------------------------------------------- |
+| `html[data-whatinput='keyboard'] & { ... }`           | `&:focus-visible { ... }`                   |
+| `html:not([data-whatinput='keyboard']) & { ... }`     | `&:focus:not(:focus-visible) { ... }`       |
+| `html:not([data-whatintent='touch']) &:hover { ... }` | `@media (hover: hover) { &:hover { ... } }` |
+| `html[data-whatintent='touch'] & { ... }`             | `@media (hover: none) { & { ... } }`        |
+
+**Updated SCSS utility mixins:**
+
+If you use Eufemia's SCSS utility mixins, they have been updated automatically — no changes needed on your end:
+
+- `hover()` — now wraps content in `@media (hover: hover)` instead of `html:not([data-whatintent='touch'])`.
+- `active()` — now uses a plain `&:active` selector (previously duplicated with `html:not([data-whatintent='touch'])`).
+- `focus-visible()` — now uses `&:focus-visible` directly (with an `@supports` fallback for older browsers).
+- `focusRing()` — now applies unconditionally instead of only for `html[data-whatinput='keyboard']`.
+- `whatInput()` / `whatInputNot()` — deprecated as no-op passthroughs. Remove calls to these mixins.
+
+**Visual changes:**
+
+Some components may show minor visual differences:
+
+- Focus rings may appear in slightly different scenarios since `:focus-visible` behavior is determined by the browser rather than the `what-input` library.
+- On touch devices, hover styles are no longer applied since `@media (hover: hover)` correctly excludes them.
 
 ## Eufemia Forms
 

--- a/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
@@ -32,7 +32,7 @@
     }
   }
 
-  [data-whatinput='keyboard'] &:focus {
+  &:focus-visible {
     box-shadow: none;
   }
 
@@ -84,7 +84,7 @@
     outline: none;
   }
 
-  html[data-whatinput='keyboard'] &:focus {
+  &:focus-visible {
     @include utilities.focusRing();
   }
 }

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -110,7 +110,6 @@
     "core-js-pure": "3.47.0",
     "date-fns": "4.1.0",
     "postcss-selector-parser": "7.1.0",
-    "what-input": "5.2.12",
     "zod": "4.1.8"
   },
   "peerDependencies": {

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -336,44 +336,46 @@ exports[`Accordion scss have to match default theme snapshot 1`] = `
     --ui-accordion-expanded-color
   );
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:focus-visible[disabled] {
+.dnb-accordion__header--outlined:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:focus-visible:not([disabled]) {
+.dnb-accordion__header--outlined:focus-visible:not([disabled]) {
   --accordion-border-width: 0.125rem;
   --ui-accordion-border-color: var(--color-emerald-green);
   --ui-accordion-expanded-border-color: var(--color-emerald-green);
   --ui-accordion-expanded-color: var(--color-emerald-green);
   --ui-accordion-expanded-background: var(--color-mint-green);
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover[disabled] {
+@media (hover: hover) {
+  .dnb-accordion__header--outlined:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-accordion__header--outlined:hover:not([disabled]) {
+    --accordion-border-width: 0.125rem;
+    --ui-accordion-color: var(--color-emerald-green);
+    --ui-accordion-background: var(--color-white);
+    --ui-accordion-border-color: var(--color-emerald-green);
+    --ui-accordion-description-color: var(--color-black-55);
+    --ui-accordion-border-inset: ;
+    --ui-accordion-expanded-color: var(--ui-accordion-color);
+    --ui-accordion-expanded-background: var(--ui-accordion-background);
+    --ui-accordion-expanded-border-color: var(
+      --ui-accordion-border-color
+    );
+    --ui-accordion-expanded-description-color: var(
+      --ui-accordion-description-color
+    );
+    --ui-accordion-after-click-color: var(--color-white);
+    --ui-accordion-after-click-background: var(--color-sea-green);
+    --ui-accordion-after-click-border-color: var(--color-sea-green);
+    --ui-accordion-after-click-description-color: var(--color-white);
+    z-index: 1;
+  }
+}
+.dnb-accordion__header--outlined:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover:not([disabled]) {
-  --accordion-border-width: 0.125rem;
-  --ui-accordion-color: var(--color-emerald-green);
-  --ui-accordion-background: var(--color-white);
-  --ui-accordion-border-color: var(--color-emerald-green);
-  --ui-accordion-description-color: var(--color-black-55);
-  --ui-accordion-border-inset: ;
-  --ui-accordion-expanded-color: var(--ui-accordion-color);
-  --ui-accordion-expanded-background: var(--ui-accordion-background);
-  --ui-accordion-expanded-border-color: var(
-    --ui-accordion-border-color
-  );
-  --ui-accordion-expanded-description-color: var(
-    --ui-accordion-description-color
-  );
-  --ui-accordion-after-click-color: var(--color-white);
-  --ui-accordion-after-click-background: var(--color-sea-green);
-  --ui-accordion-after-click-border-color: var(--color-sea-green);
-  --ui-accordion-after-click-description-color: var(--color-white);
-  z-index: 1;
-}
-.dnb-accordion__header--outlined:active[disabled], html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-accordion__header--outlined:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:active:not([disabled]) {
+.dnb-accordion__header--outlined:active:not([disabled]) {
   --accordion-border-width: 0.0625rem;
   --ui-accordion-background: var(--color-pistachio);
   --ui-accordion-border-inset: inset;
@@ -386,25 +388,27 @@ html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover:not([di
   --ui-accordion-border-color: var(--color-pistachio);
   --ui-accordion-description-color: var(--color-black-55);
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--filled:hover[disabled] {
+@media (hover: hover) {
+  .dnb-accordion__header--filled:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-accordion__header--filled:hover:not([disabled]) {
+    --ui-accordion-background: var(--color-white);
+  }
+}
+.dnb-accordion__header--filled:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--filled:hover:not([disabled]) {
-  --ui-accordion-background: var(--color-white);
-}
-.dnb-accordion__header--filled:active[disabled], html:not([data-whatintent=touch]) .dnb-accordion__header--filled:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-accordion__header--filled:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-accordion__header--filled:active:not([disabled]) {
+.dnb-accordion__header--filled:active:not([disabled]) {
   --ui-accordion-color: var(--color-white);
   --ui-accordion-background: var(--color-sea-green);
   --ui-accordion-border-color: var(--color-sea-green);
   --ui-accordion-description-color: ar(--color-white);
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--filled:focus-visible[disabled] {
+.dnb-accordion__header--filled:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-accordion__header--filled:focus-visible:not([disabled]) {
+.dnb-accordion__header--filled:focus-visible:not([disabled]) {
   --ui-accordion-border-color: var(--color-sea-green);
 }
 .dnb-accordion__header {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -431,26 +431,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -805,8 +802,10 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
   margin: auto;
 }
-html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
-  cursor: default;
+@media (hover: hover) {
+  .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+    cursor: default;
+  }
 }
 .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
   width: 1rem;
@@ -1002,23 +1001,25 @@ html[data-visual-test] .dnb-input__input {
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover[disabled] {
+@media (hover: hover) {
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) {
+    color: var(--dropdown-foreground-color-error);
+    --border-color: var(--dropdown-foreground-color-error);
+    --border-width: var(--dropdown-error-border-width);
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) .dnb-dropdown__icon .dnb-icon {
+    color: var(--dropdown-foreground-color-error);
+  }
+}
+.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) {
-  color: var(--dropdown-foreground-color-error);
-  --border-color: var(--dropdown-foreground-color-error);
-  --border-width: var(--dropdown-error-border-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) .dnb-dropdown__icon .dnb-icon {
-  color: var(--dropdown-foreground-color-error);
-}
-.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled], html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]) {
+.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]) {
   color: var(--dropdown-foreground-color-error);
   background-color: var(--dropdown-background-color-error-active);
 }

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -423,26 +423,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -529,13 +526,13 @@ exports[`Button scss has to match theme css for sbanken 1`] = `
 .dnb-skeleton .dnb-button--tertiary .dnb-button__text::after {
   content: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible[disabled] {
+.dnb-button--tertiary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) {
+.dnb-button--tertiary:focus-visible:not([disabled]) {
   outline: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled])::before {
+.dnb-button--tertiary:focus-visible:not([disabled])::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -551,31 +548,35 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disab
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) .dnb-button__text::after {
+.dnb-button--tertiary:focus-visible:not([disabled]) .dnb-button__text::after {
   visibility: hidden;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--tertiary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
+    visibility: visible;
+  }
+}
+.dnb-button--tertiary:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
-  visibility: visible;
-}
-.dnb-button--tertiary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--tertiary:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-button--tertiary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) {
+.dnb-button--tertiary:active:not([disabled]) {
   outline: initial;
-}
-html[data-whatinput=keyboard] .dnb-button--tertiary:active:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) {
   box-shadow: none;
 }
-html[data-whatintent=touch] .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after, html[data-whatintent=touch] html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
-  transition: none;
-  visibility: visible;
-  opacity: 1;
+@media (hover: none) {
+  .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
+    transition: none;
+    visibility: visible;
+    opacity: 1;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
-  visibility: hidden;
+@media (hover: hover) {
+  .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
+    visibility: hidden;
+  }
 }
 .dnb-button--tertiary.dnb-button--has-text {
   --button-padding-left: 0;
@@ -637,7 +638,7 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .
   --button-tertiary-focus-left: 0;
   --button-tertiary-focus-right: 0;
 }
-html[data-whatinput=keyboard] .dnb-button--tertiary:hover:focus .dnb-button__text::after {
+.dnb-button--tertiary:hover:focus-visible .dnb-button__text::after {
   visibility: hidden;
 }
 
@@ -684,21 +685,23 @@ html[data-whatinput=keyboard] .dnb-button--tertiary:hover:focus .dnb-button__tex
   background-color: var(--button-primary-background);
   box-shadow: var(--button-primary-shadow);
 }
-html:not([data-whatintent=touch]) .dnb-button--primary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--primary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--primary:hover:not([disabled]) {
+    color: var(--button-primary-color--hover);
+    background-color: var(--button-primary-background--hover);
+    --border-color: var(--button-primary-border--hover);
+    --border-width: 0.0625rem;
+    box-shadow: inset 0 0 0 var(--border-width) var(--border-color), var(--button-primary-shadow--hover);
+    border-color: transparent;
+  }
+}
+.dnb-button--primary:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]) {
-  color: var(--button-primary-color--hover);
-  background-color: var(--button-primary-background--hover);
-  --border-color: var(--button-primary-border--hover);
-  --border-width: 0.0625rem;
-  box-shadow: inset 0 0 0 var(--border-width) var(--border-color), var(--button-primary-shadow--hover);
-  border-color: transparent;
-}
-.dnb-button--primary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--primary:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-button--primary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--primary:active:not([disabled]) {
+.dnb-button--primary:active:not([disabled]) {
   color: var(--button-primary-color--active);
   background-color: var(--button-primary-background--active);
 }
@@ -710,18 +713,20 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]) {
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--secondary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--secondary:hover:not([disabled]) {
+    --button-secondary-border: var(--button-secondary-border--hover);
+    color: var(--button-secondary-color--hover);
+    background-color: var(--button-secondary-background--hover);
+  }
+}
+.dnb-button--secondary:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:hover:not([disabled]) {
-  --button-secondary-border: var(--button-secondary-border--hover);
-  color: var(--button-secondary-color--hover);
-  background-color: var(--button-secondary-background--hover);
-}
-.dnb-button--secondary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-button--secondary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:active:not([disabled]) {
+.dnb-button--secondary:active:not([disabled]) {
   --button-secondary-border: var(--button-secondary-border--active);
   color: var(--button-secondary-color--active);
   background-color: var(--button-secondary-background--active);
@@ -730,17 +735,19 @@ html:not([data-whatintent=touch]) .dnb-button--secondary:hover:not([disabled]) {
   box-shadow: none;
   border: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover[disabled], .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover:not([disabled]), .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
+}
+.dnb-button--primary:focus-visible[disabled], .dnb-button--secondary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-html:not([data-whatintent=touch]) .dnb-button--primary:focus-visible[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:focus-visible[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-button--primary:focus-visible:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:focus-visible:not([disabled]) {
+.dnb-button--primary:focus-visible:not([disabled]), .dnb-button--secondary:focus-visible:not([disabled]) {
   color: var(--sb-color-blue-dark);
   background-color: var(--button-background--focus);
   outline: none;
@@ -816,19 +823,49 @@ html:not([data-whatintent=touch]) .dnb-button--primary:focus-visible:not([disabl
   --button-tertiary-text-bottom--icon: 0.75rem;
   --button-tertiary-text-top--icon: 0.25rem;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--tertiary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--tertiary:hover:not([disabled]):not(:focus-visible) .dnb-button__text::after {
+    color: var(--button-tertiary-border);
+    transition: none;
+  }
+  .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text) {
+    --focus-ring-width: 0.0625rem;
+    --sb-shadow-medium: 0 0 transparent;
+    color: var(--sb-color-blue-dark);
+  }
+  .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text)::before {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: var(--button-tertiary-focus-left);
+    bottom: 0;
+    right: var(--button-tertiary-focus-right);
+    height: inherit;
+    border-radius: inherit;
+    outline: none;
+    --border-color: var(--focus-ring-color);
+    --border-width: var(--focus-ring-width);
+    box-shadow: inset 0 0 0 var(--border-width) var(--border-color), var(--sb-shadow-medium);
+    border-color: transparent;
+  }
+  .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text)::before {
+    background-color: var(--button-background--focus);
+  }
+  .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text) > * {
+    z-index: 2;
+  }
+}
+.dnb-button--tertiary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):not(:focus-visible) .dnb-button__text::after {
-  color: var(--button-tertiary-border);
-  transition: none;
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text) {
-  --focus-ring-width: 0.0625rem;
-  --sb-shadow-medium: 0 0 transparent;
+.dnb-button--tertiary:focus-visible:not([disabled]) {
   color: var(--sb-color-blue-dark);
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text)::before {
+.dnb-button--tertiary:focus-visible:not([disabled])::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -844,38 +881,10 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):no
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color), var(--sb-shadow-medium);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text)::before {
+.dnb-button--tertiary:focus-visible:not([disabled])::before {
   background-color: var(--button-background--focus);
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]):not(.dnb-button--has-text) > * {
-  z-index: 2;
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) {
-  color: var(--sb-color-blue-dark);
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled])::before {
-  content: "";
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  left: var(--button-tertiary-focus-left);
-  bottom: 0;
-  right: var(--button-tertiary-focus-right);
-  height: inherit;
-  border-radius: inherit;
-  outline: none;
-  --border-color: var(--focus-ring-color);
-  --border-width: var(--focus-ring-width);
-  box-shadow: inset 0 0 0 var(--border-width) var(--border-color), var(--sb-shadow-medium);
-  border-color: transparent;
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled])::before {
-  background-color: var(--button-background--focus);
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) > * {
+.dnb-button--tertiary:focus-visible:not([disabled]) > * {
   z-index: 2;
 }
 .dnb-button--tertiary[disabled] {
@@ -966,13 +975,13 @@ exports[`Button scss has to match theme css for ui 1`] = `
 .dnb-skeleton .dnb-button--tertiary .dnb-button__text::after {
   content: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible[disabled] {
+.dnb-button--tertiary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) {
+.dnb-button--tertiary:focus-visible:not([disabled]) {
   outline: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled])::before {
+.dnb-button--tertiary:focus-visible:not([disabled])::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -988,31 +997,35 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disab
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) .dnb-button__text::after {
+.dnb-button--tertiary:focus-visible:not([disabled]) .dnb-button__text::after {
   visibility: hidden;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--tertiary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
+    visibility: visible;
+  }
+}
+.dnb-button--tertiary:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
-  visibility: visible;
-}
-.dnb-button--tertiary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--tertiary:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-button--tertiary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) {
+.dnb-button--tertiary:active:not([disabled]) {
   outline: initial;
-}
-html[data-whatinput=keyboard] .dnb-button--tertiary:active:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) {
   box-shadow: none;
 }
-html[data-whatintent=touch] .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after, html[data-whatintent=touch] html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
-  transition: none;
-  visibility: visible;
-  opacity: 1;
+@media (hover: none) {
+  .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
+    transition: none;
+    visibility: visible;
+    opacity: 1;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
-  visibility: hidden;
+@media (hover: hover) {
+  .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
+    visibility: hidden;
+  }
 }
 .dnb-button--tertiary.dnb-button--has-text {
   --button-padding-left: 0;
@@ -1074,7 +1087,7 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .
   --button-tertiary-focus-left: 0;
   --button-tertiary-focus-right: 0;
 }
-html[data-whatinput=keyboard] .dnb-button--tertiary:hover:focus .dnb-button__text::after {
+.dnb-button--tertiary:hover:focus-visible .dnb-button__text::after {
   visibility: hidden;
 }
 
@@ -1082,37 +1095,37 @@ html[data-whatinput=keyboard] .dnb-button--tertiary:hover:focus .dnb-button__tex
   color: var(--color-white);
   background-color: var(--color-sea-green);
 }
-html:not([data-whatintent=touch]) .dnb-button--primary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--primary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--primary:hover:not([disabled]) {
+    color: var(--color-sea-green);
+    background-color: var(--color-white);
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button--primary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]) {
+.dnb-button--primary:focus-visible:not([disabled]) {
   color: var(--color-sea-green);
   background-color: var(--color-white);
-  --border-color: var(--color-emerald-green);
-  --border-width: 0.125rem;
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-.dnb-button--primary:focus[disabled], html:not([data-whatintent=touch]) .dnb-button--primary:focus[disabled] {
-  cursor: not-allowed;
-}
-html[data-whatinput=keyboard] .dnb-button--primary:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--primary:focus:not([disabled]) {
-  color: var(--color-sea-green);
-  background-color: var(--color-white);
-}
-.dnb-button--primary:focus:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--primary:focus:not([disabled]) {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--primary:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--primary:focus:not([disabled]) {
+html[data-whatinput=keyboard] .dnb-button--primary:focus-visible:not([disabled]) {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-button--primary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--primary:active[disabled] {
+.dnb-button--primary:active[disabled] {
   cursor: not-allowed;
 }
-.dnb-button--primary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--primary:active:not([disabled]) {
+.dnb-button--primary:active:not([disabled]) {
   color: var(--color-sea-green);
   background-color: var(--color-mint-green-50);
   --border-color: transparent;
@@ -1128,6 +1141,30 @@ html[data-whatinput=keyboard] .dnb-button--primary:focus:not([disabled]), html[d
   color: var(--color-white);
   background-color: var(--color-fire-red);
 }
+@media (hover: hover) {
+  .dnb-button:not([disabled]).dnb-button--primary.dnb-button__status--error:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button:not([disabled]).dnb-button--primary.dnb-button__status--error:hover:not([disabled]) {
+    color: var(--color-sea-green);
+    background-color: var(--color-white);
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button:not([disabled]).dnb-button--primary.dnb-button__status--error:active[disabled] {
+  cursor: not-allowed;
+}
+.dnb-button:not([disabled]).dnb-button--primary.dnb-button__status--error:active:not([disabled]) {
+  color: var(--color-sea-green);
+  background-color: var(--color-mint-green-50);
+  --border-color: transparent;
+  --border-width: 0.0625rem;
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
+}
 .dnb-button--secondary {
   color: var(--color-sea-green);
   background-color: var(--color-white);
@@ -1136,37 +1173,37 @@ html[data-whatinput=keyboard] .dnb-button--primary:focus:not([disabled]), html[d
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--secondary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--secondary:hover:not([disabled]) {
+    color: var(--color-sea-green);
+    background-color: var(--color-white);
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button--secondary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:hover:not([disabled]) {
+.dnb-button--secondary:focus-visible:not([disabled]) {
   color: var(--color-sea-green);
   background-color: var(--color-white);
-  --border-color: var(--color-emerald-green);
-  --border-width: 0.125rem;
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-.dnb-button--secondary:focus[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:focus[disabled] {
-  cursor: not-allowed;
-}
-html[data-whatinput=keyboard] .dnb-button--secondary:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--secondary:focus:not([disabled]) {
-  color: var(--color-sea-green);
-  background-color: var(--color-white);
-}
-.dnb-button--secondary:focus:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:focus:not([disabled]) {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--secondary:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--secondary:focus:not([disabled]) {
+html[data-whatinput=keyboard] .dnb-button--secondary:focus-visible:not([disabled]) {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-button--secondary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:active[disabled] {
+.dnb-button--secondary:active[disabled] {
   cursor: not-allowed;
 }
-.dnb-button--secondary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:active:not([disabled]) {
+.dnb-button--secondary:active:not([disabled]) {
   color: var(--color-sea-green);
   background-color: var(--color-mint-green-50);
   --border-color: transparent;
@@ -1192,37 +1229,61 @@ html[data-whatinput=keyboard] .dnb-button--secondary:focus:not([disabled]), html
 .dnb-button:not([disabled]).dnb-button--secondary.dnb-button__status--error .dnb-button__icon {
   color: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):hover[disabled] {
+@media (hover: hover) {
+  .dnb-button:not([disabled]).dnb-button--secondary.dnb-button__status--error:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button:not([disabled]).dnb-button--secondary.dnb-button__status--error:hover:not([disabled]) {
+    color: var(--color-sea-green);
+    background-color: var(--color-white);
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button:not([disabled]).dnb-button--secondary.dnb-button__status--error:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):hover:not([disabled]) {
-  color: var(--color-emerald-green);
-  background-color: var(--color-white);
-  --border-color: var(--color-emerald-green);
-  --border-width: 0.125rem;
+.dnb-button:not([disabled]).dnb-button--secondary.dnb-button__status--error:active:not([disabled]) {
+  color: var(--color-sea-green);
+  background-color: var(--color-mint-green-50);
+  --border-color: transparent;
+  --border-width: 0.0625rem;
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-button--secondary:not(.dnb-button--has-text):focus[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):focus[disabled] {
+@media (hover: hover) {
+  .dnb-button--secondary:not(.dnb-button--has-text):hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--secondary:not(.dnb-button--has-text):hover:not([disabled]) {
+    color: var(--color-emerald-green);
+    background-color: var(--color-white);
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button--secondary:not(.dnb-button--has-text):focus-visible[disabled] {
   cursor: not-allowed;
 }
-html[data-whatinput=keyboard] .dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]) {
+.dnb-button--secondary:not(.dnb-button--has-text):focus-visible:not([disabled]) {
   color: var(--color-emerald-green);
   background-color: var(--color-white);
-}
-.dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]) {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):focus:not([disabled]) {
+html[data-whatinput=keyboard] .dnb-button--secondary:not(.dnb-button--has-text):focus-visible:not([disabled]) {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-button--secondary:not(.dnb-button--has-text):active[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):active[disabled] {
+.dnb-button--secondary:not(.dnb-button--has-text):active[disabled] {
   cursor: not-allowed;
 }
-.dnb-button--secondary:not(.dnb-button--has-text):active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text):active:not([disabled]) {
+.dnb-button--secondary:not(.dnb-button--has-text):active:not([disabled]) {
   color: var(--color-emerald-green);
   background-color: var(--color-mint-green-50);
   --border-color: transparent;
@@ -1238,12 +1299,14 @@ html[data-whatinput=keyboard] .dnb-button--secondary:not(.dnb-button--has-text):
   box-shadow: none;
   border: none;
 }
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover[disabled], html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
+@media (hover: hover) {
+  .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover[disabled], .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-before:hover:not([disabled]), .dnb-button--secondary:not(.dnb-button--has-text).dnb-button--control-after:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
 .dnb-button--active {
   --border-color: var(--color-emerald-green);
@@ -1255,28 +1318,32 @@ html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-te
   color: var(--color-sea-green);
   background-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--tertiary:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--tertiary:hover:not([disabled]) {
+    color: var(--color-sea-green);
+  }
+  .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
+    color: var(--color-emerald-green);
+  }
+}
+.dnb-button--tertiary:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]) {
+.dnb-button--tertiary:active:not([disabled]) {
   color: var(--color-sea-green);
 }
-html:not([data-whatintent=touch]) .dnb-button--tertiary:hover:not([disabled]) .dnb-button__text::after {
-  color: var(--color-emerald-green);
+@media (hover: none) {
+  .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
+    color: var(--color-emerald-green);
+  }
 }
-.dnb-button--tertiary:active[disabled], html:not([data-whatintent=touch]) .dnb-button--tertiary:active[disabled] {
+.dnb-button--tertiary:focus-visible[disabled] {
   cursor: not-allowed;
 }
-.dnb-button--tertiary:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) {
-  color: var(--color-sea-green);
-}
-html[data-whatintent=touch] .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after, html[data-whatintent=touch] html:not([data-whatintent=touch]) .dnb-button--tertiary:active:not([disabled]) .dnb-button__text::after {
-  color: var(--color-emerald-green);
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disabled]) {
+.dnb-button--tertiary:focus-visible:not([disabled]) {
   color: var(--color-sea-green);
 }
 .dnb-button--tertiary.dnb-button--icon-position-top .dnb-button__text {
@@ -1295,48 +1362,50 @@ html:not([data-whatintent=touch]) .dnb-button--tertiary:focus-visible:not([disab
   color: var(--color-ocean-green);
   background-color: var(--color-accent-yellow);
 }
-html:not([data-whatintent=touch]) .dnb-button--signal:hover[disabled] {
+@media (hover: hover) {
+  .dnb-button--signal:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--signal:hover:not([disabled]) {
+    color: var(--color-ocean-green);
+    background-color: var(--color-accent-yellow);
+    --border-color: var(--color-ocean-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+@media (hover: none) {
+  .dnb-button--signal:active[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--signal:active:not([disabled]) {
+    color: var(--color-ocean-green);
+    background-color: var(--color-accent-yellow);
+    --border-color: var(--color-ocean-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+}
+.dnb-button--signal:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-button--signal:hover:not([disabled]) {
+.dnb-button--signal:focus-visible:not([disabled]) {
   color: var(--color-ocean-green);
   background-color: var(--color-accent-yellow);
-  --border-color: var(--color-ocean-green);
-  --border-width: 0.125rem;
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-html[data-whatintent=touch] .dnb-button--signal:active[disabled], html:not([data-whatintent=touch]) html[data-whatintent=touch] .dnb-button--signal:active[disabled] {
-  cursor: not-allowed;
-}
-html[data-whatintent=touch] .dnb-button--signal:active:not([disabled]), html:not([data-whatintent=touch]) html[data-whatintent=touch] .dnb-button--signal:active:not([disabled]) {
-  color: var(--color-ocean-green);
-  background-color: var(--color-accent-yellow);
-  --border-color: var(--color-ocean-green);
-  --border-width: 0.125rem;
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-.dnb-button--signal:focus[disabled], html:not([data-whatintent=touch]) .dnb-button--signal:focus[disabled] {
-  cursor: not-allowed;
-}
-html[data-whatinput=keyboard] .dnb-button--signal:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--signal:focus:not([disabled]) {
-  color: var(--color-ocean-green);
-  background-color: var(--color-accent-yellow);
-}
-.dnb-button--signal:focus:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--signal:focus:not([disabled]) {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--signal:focus:not([disabled]), html[data-whatinput=keyboard] html:not([data-whatintent=touch]) .dnb-button--signal:focus:not([disabled]) {
+html[data-whatinput=keyboard] .dnb-button--signal:focus-visible:not([disabled]) {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-button--signal:active[disabled], html:not([data-whatintent=touch]) .dnb-button--signal:active[disabled] {
+.dnb-button--signal:active[disabled] {
   cursor: not-allowed;
 }
-.dnb-button--signal:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-button--signal:active:not([disabled]) {
+.dnb-button--signal:active:not([disabled]) {
   color: var(--color-ocean-green);
   background-color: var(--color-accent-yellow);
   --border-color: transparent;
@@ -1361,31 +1430,35 @@ html[data-whatinput=keyboard] .dnb-button--signal:focus:not([disabled]), html[da
   width: var(--input-border-width);
   background-color: currentcolor;
 }
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover {
-  color: var(--color-white);
+@media (hover: hover) {
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover {
+    color: var(--color-white);
+  }
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible::after, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover::after {
+    background-color: var(--color-sea-green);
+  }
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover {
+    box-shadow: none;
+  }
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active {
+    color: var(--color-sea-green);
+  }
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active, .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active::after {
+    background-color: var(--color-mint-green-50);
+  }
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active::after {
+    top: var(--input-border-width);
+    bottom: var(--input-border-width);
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible::after, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover::after {
-  background-color: var(--color-sea-green);
-}
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):hover {
-  box-shadow: none;
-}
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active {
-  color: var(--color-sea-green);
-}
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active, html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active::after {
-  background-color: var(--color-mint-green-50);
-}
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text):not([disabled]):active::after {
-  top: var(--input-border-width);
-  bottom: var(--input-border-width);
-}
-html:not([data-whatintent=touch]) .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text)[disabled] {
-  color: var(--color-black-55);
-  background-color: var(--color-black-3);
-  --border-color: var(--color-black-55);
-  --border-width: var(--input-border-width);
-  box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
+@media (hover: hover) {
+  .dnb-button--input-button.dnb-button--secondary:not(.dnb-button--has-text)[disabled] {
+    color: var(--color-black-55);
+    background-color: var(--color-black-3);
+    --border-color: var(--color-black-55);
+    --border-width: var(--input-border-width);
+    box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
 }"
 `;

--- a/packages/dnb-eufemia/src/components/button/style/button--tertiary.scss
+++ b/packages/dnb-eufemia/src/components/button/style/button--tertiary.scss
@@ -54,16 +54,16 @@
     }
 
     @include utilities.active() {
-      @include utilities.removeFocusRing('keyboard');
+      @include utilities.removeFocusRing();
 
       // underline
       .dnb-button__text::after {
-        html[data-whatintent='touch'] & {
+        @media (hover: none) {
           transition: none;
           visibility: visible;
           opacity: 1;
         }
-        html:not([data-whatintent='touch']) & {
+        @media (hover: hover) {
           visibility: hidden;
         }
       }
@@ -145,11 +145,8 @@
       }
     }
 
-    // stylelint-disable-next-line
-    html[data-whatinput='keyboard']
-		// webkit fix
-		  &:hover:focus
-		  .dnb-button__text::after {
+    // webkit fix
+    &:hover:focus-visible .dnb-button__text::after {
       visibility: hidden;
     }
   }

--- a/packages/dnb-eufemia/src/components/button/style/dnb-button.scss
+++ b/packages/dnb-eufemia/src/components/button/style/dnb-button.scss
@@ -252,16 +252,8 @@
       border: none;
     }
 
-    &:not([disabled]):focus,
-    &:not([disabled]):active {
+    &:not([disabled]):focus-visible {
       @include utilities.focusRing();
-    }
-
-    html[data-whatinput='mouse'] &:not([disabled]):focus,
-    html[data-whatinput='mouse'] &:not([disabled]):active {
-      box-shadow: none;
-      color: inherit;
-      border: none;
     }
   }
 

--- a/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
@@ -27,7 +27,7 @@
   }
 
   @if $enable-touch == 'touch' {
-    html[data-whatintent='touch'] & {
+    @media (hover: none) {
       @include utilities.active() {
         @include buttonHoverStyle(
           $color,
@@ -57,11 +57,9 @@
   $focus-color: null,
   $extendShadow: null
 ) {
-  @include utilities.focus() {
-    html[data-whatinput='keyboard'] & {
-      color: $color;
-      background-color: $background-color;
-    }
+  @include utilities.focus-visible() {
+    color: $color;
+    background-color: $background-color;
 
     @include utilities.focusRing(
       null,

--- a/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-ui.scss
@@ -37,6 +37,15 @@
     &--error {
       color: var(--color-white);
       background-color: var(--color-fire-red);
+
+      @include button-mixins.buttonHover(
+        var(--color-sea-green),
+        var(--color-white)
+      );
+      @include button-mixins.buttonActive(
+        var(--color-sea-green),
+        var(--color-mint-green-50)
+      );
     }
   }
 
@@ -89,6 +98,15 @@
       .dnb-button__icon {
         color: inherit;
       }
+
+      @include button-mixins.buttonHover(
+        var(--color-sea-green),
+        var(--color-white)
+      );
+      @include button-mixins.buttonActive(
+        var(--color-sea-green),
+        var(--color-mint-green-50)
+      );
     }
   }
 
@@ -150,7 +168,7 @@
 
       // underline
       .dnb-button__text::after {
-        html[data-whatintent='touch'] & {
+        @media (hover: none) {
           color: var(--color-emerald-green);
         }
       }
@@ -224,38 +242,40 @@
       background-color: currentcolor;
     }
   }
-  html:not([data-whatintent='touch'])
+  @media (hover: hover) {
     &--input-button#{&}--secondary:not(&--has-text):not([disabled]) {
-    &:focus-visible,
-    &:hover {
-      color: var(--color-white);
-      &,
-      &::after {
-        background-color: var(--color-sea-green);
+      &:focus-visible,
+      &:hover {
+        color: var(--color-white);
+        &,
+        &::after {
+          background-color: var(--color-sea-green);
+        }
+        box-shadow: none;
       }
-      box-shadow: none;
-    }
-    &:active {
-      color: var(--color-sea-green);
-      &,
-      &::after {
-        background-color: var(--color-mint-green-50);
-      }
-      &::after {
-        top: var(--input-border-width);
-        bottom: var(--input-border-width);
+      &:active {
+        color: var(--color-sea-green);
+        &,
+        &::after {
+          background-color: var(--color-mint-green-50);
+        }
+        &::after {
+          top: var(--input-border-width);
+          bottom: var(--input-border-width);
+        }
       }
     }
   }
-  html:not([data-whatintent='touch'])
+  @media (hover: hover) {
     &--input-button#{&}--secondary:not(&--has-text)[disabled] {
-    color: var(--color-black-55);
-    background-color: var(--color-black-3);
-    @include utilities.fakeBorder(
-      var(--color-black-55),
-      var(--input-border-width),
-      inset
-    );
+      color: var(--color-black-55);
+      background-color: var(--color-black-3);
+      @include utilities.fakeBorder(
+        var(--color-black-55),
+        var(--input-border-width),
+        inset
+      );
+    }
   }
 
   // For internal usage only, we have also "unstyled"

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -465,14 +465,14 @@ html[data-whatinput=keyboard] .dnb-checkbox__focus {
 .dnb-checkbox {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--focus);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--focus);
 }
-.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus, .dnb-checkbox__input:not([disabled]):active ~ .dnb-checkbox__button .dnb-checkbox__focus {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus {
   display: block;
 }
 .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__indeterminate {
@@ -503,7 +503,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover) ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus ~ .dnb-checkbox__button, html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__button {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--error-contrast);
   --border-color: var(--checkbox-color-border--error);
@@ -511,7 +511,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__gfx {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error-contrast);
 }
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover):checked ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover)[data-checked=true] ~ .dnb-checkbox__button {

--- a/packages/dnb-eufemia/src/components/checkbox/style/dnb-checkbox.scss
+++ b/packages/dnb-eufemia/src/components/checkbox/style/dnb-checkbox.scss
@@ -398,20 +398,15 @@
 
   // General
   &__input:not([disabled]):focus-visible ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      border: none;
-      background-color: var(--checkbox-color-background--focus);
-    }
+    border: none;
+    background-color: var(--checkbox-color-background--focus);
   }
 
   &__input:not([disabled]):focus-visible ~ &__gfx {
-    html[data-whatinput='keyboard'] & {
-      color: var(--checkbox-color-gfx--focus);
-    }
+    color: var(--checkbox-color-gfx--focus);
   }
 
-  &__input:not([disabled]):focus-visible ~ &__button &__focus,
-  &__input:not([disabled]):active ~ &__button &__focus {
+  &__input:not([disabled]):focus-visible ~ &__button &__focus {
     display: block;
   }
 
@@ -456,22 +451,20 @@
     color: var(--checkbox-color-gfx--error);
   }
 
-  &__status--error &__input:not([disabled]):focus ~ &__button,
-  &__status--error &__input:not([disabled]):focus:hover ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      border: none;
-      background-color: var(--checkbox-color-background--error-contrast);
-      @include utilities.fakeBorder(
-        var(--checkbox-color-border--error),
-        calc(var(--checkbox-border-width--hover))
-      );
-    }
+  &__status--error &__input:not([disabled]):focus-visible ~ &__button,
+  &__status--error
+    &__input:not([disabled]):focus-visible:hover
+    ~ &__button {
+    border: none;
+    background-color: var(--checkbox-color-background--error-contrast);
+    @include utilities.fakeBorder(
+      var(--checkbox-color-border--error),
+      calc(var(--checkbox-border-width--hover))
+    );
   }
 
-  &__status--error &__input:not([disabled]):focus:hover ~ &__gfx {
-    html[data-whatinput='keyboard'] & {
-      color: var(--checkbox-color-gfx--error-contrast);
-    }
+  &__status--error &__input:not([disabled]):focus-visible:hover ~ &__gfx {
+    color: var(--checkbox-color-gfx--error-contrast);
   }
 
   // On

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -94,9 +94,11 @@ exports[`DatePicker scss should match default theme snapshot 1`] = `
 .dnb-date-picker__day--start-date:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--preview) .dnb-button:hover, .dnb-date-picker__day--end-date:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--preview) .dnb-button:hover {
   box-shadow: none;
 }
-html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]) {
-  color: var(--color-mint-green-25);
-  background-color: var(--color-emerald-green);
+@media (hover: hover) {
+  .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]), .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]) {
+    color: var(--color-mint-green-25);
+    background-color: var(--color-emerald-green);
+  }
 }
 .dnb-date-picker__day--disabled .dnb-button {
   text-decoration: line-through;
@@ -107,8 +109,10 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-pic
 .dnb-date-picker__day--inactive .dnb-button[disabled], .dnb-date-picker__day--disabled .dnb-button[disabled] {
   box-shadow: none;
 }
-html:not([data-whatintent=touch]) .dnb-date-picker__day--inactive .dnb-button[disabled] {
-  cursor: default;
+@media (hover: hover) {
+  .dnb-date-picker__day--inactive .dnb-button[disabled] {
+    cursor: default;
+  }
 }
 .dnb-date-picker--open .dnb-input .dnb-input__shell, .dnb-date-picker:not(.dnb-date-picker__status--error) .dnb-form-label:hover ~ .dnb-date-picker__inner .dnb-input:not([data-input-state=disabled]) .dnb-input__shell {
   --border-color: var(--color-sea-green);
@@ -562,26 +566,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -936,8 +937,10 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
   margin: auto;
 }
-html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
-  cursor: default;
+@media (hover: hover) {
+  .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+    cursor: default;
+  }
 }
 .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
   width: 1rem;
@@ -1334,14 +1337,14 @@ html[data-whatinput=keyboard] .dnb-checkbox__focus {
 .dnb-checkbox {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--focus);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--focus);
 }
-.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus, .dnb-checkbox__input:not([disabled]):active ~ .dnb-checkbox__button .dnb-checkbox__focus {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus {
   display: block;
 }
 .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__indeterminate {
@@ -1372,7 +1375,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover) ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus ~ .dnb-checkbox__button, html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__button {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--error-contrast);
   --border-color: var(--checkbox-color-border--error);
@@ -1380,7 +1383,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__gfx {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error-contrast);
 }
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover):checked ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover)[data-checked=true] ~ .dnb-checkbox__button {
@@ -1727,20 +1730,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__button {
   border-width: var(--radio-border-width--focus);
   border: none;
 }
-.dnb-radio__input:not([disabled]):focus ~ .dnb-radio__focus, .dnb-radio__input:not([disabled]):active ~ .dnb-radio__focus {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__focus {
   display: block;
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__button, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__button, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-on--focus);
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__dot, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__dot {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__dot, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__dot {
   background-color: var(--radio-color-dot-on--focus, var(--focus-ring-color));
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-off--focus);
 }
 .dnb-radio {
@@ -1967,10 +1970,10 @@ html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:checked):no
   z-index: 1;
   margin: 0;
 }
-.dnb-date-picker__container table.dnb-no-focus:focus {
+.dnb-date-picker__container table.dnb-no-focus:focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:focus {
+html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -57,7 +57,7 @@
 
       margin: 0;
 
-      &.dnb-no-focus:focus {
+      &.dnb-no-focus:focus-visible {
         @include utilities.focusRing();
       }
     }

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -141,14 +141,13 @@
       }
     }
 
-    html:not([data-whatintent='touch'])
+    @media (hover: hover) {
       &--start-date#{&}--within-selection
-      .dnb-button:hover:not([disabled]),
-    html:not([data-whatintent='touch'])
-      &--end-date#{&}--within-selection
-      .dnb-button:hover:not([disabled]) {
-      color: var(--color-mint-green-25);
-      background-color: var(--color-emerald-green);
+        .dnb-button:hover:not([disabled]),
+      &--end-date#{&}--within-selection .dnb-button:hover:not([disabled]) {
+        color: var(--color-mint-green-25);
+        background-color: var(--color-emerald-green);
+      }
     }
 
     &--disabled .dnb-button {
@@ -166,8 +165,10 @@
       }
     }
 
-    html:not([data-whatintent='touch']) &--inactive .dnb-button[disabled] {
-      cursor: default;
+    @media (hover: hover) {
+      &--inactive .dnb-button[disabled] {
+        cursor: default;
+      }
     }
   }
 

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -435,26 +435,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -436,26 +436,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -431,26 +431,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -605,23 +602,25 @@ legend.dnb-form-label {
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover[disabled] {
+@media (hover: hover) {
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) {
+    color: var(--dropdown-foreground-color-error);
+    --border-color: var(--dropdown-foreground-color-error);
+    --border-width: var(--dropdown-error-border-width);
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+  }
+  .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) .dnb-dropdown__icon .dnb-icon {
+    color: var(--dropdown-foreground-color-error);
+  }
+}
+.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) {
-  color: var(--dropdown-foreground-color-error);
-  --border-color: var(--dropdown-foreground-color-error);
-  --border-width: var(--dropdown-error-border-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:hover:not([disabled]) .dnb-dropdown__icon .dnb-icon {
-  color: var(--dropdown-foreground-color-error);
-}
-.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled], html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]) {
+.dnb-dropdown__status--error:not(.dnb-dropdown--open) .dnb-dropdown__trigger:active:not([disabled]) {
   color: var(--dropdown-foreground-color-error);
   background-color: var(--dropdown-background-color-error-active);
 }
@@ -821,11 +820,13 @@ exports[`Dropdown scss have to match default theme snapshot 1`] = `
   --dropdown-background-color-disabled: var(--color-black-3);
   --dropdown-background-color-error-active: var(--color-fire-red-8);
 }
-html:not([data-whatintent=touch]) .dnb-dropdown__trigger:hover[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-dropdown__trigger:hover:not([disabled]) {
-  color: var(--color-emerald-green);
+@media (hover: hover) {
+  .dnb-dropdown__trigger:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-dropdown__trigger:hover:not([disabled]) {
+    color: var(--color-emerald-green);
+  }
 }
 .dnb-dropdown__trigger[disabled] {
   color: var(--dropdown-foreground-color-primary);

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -434,26 +434,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -452,26 +452,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -437,26 +437,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -431,26 +431,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -805,8 +802,10 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
   margin: auto;
 }
-html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
-  cursor: default;
+@media (hover: hover) {
+  .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+    cursor: default;
+  }
 }
 .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
   width: 1rem;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -801,8 +798,10 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 .dnb-input--clear.dnb-input__submit-element .dnb-button .dnb-button__icon {
   margin: auto;
 }
-html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
-  cursor: default;
+@media (hover: hover) {
+  .dnb-input--clear.dnb-input__submit-element .dnb-button:not(.dnb-button--has-text):hover[disabled] {
+    cursor: default;
+  }
 }
 .dnb-input--small .dnb-input--clear.dnb-input__submit-element .dnb-button {
   width: 1rem;
@@ -958,17 +957,19 @@ exports[`Input scss have to match default theme snapshot 1`] = `
   -webkit-text-fill-color: currentcolor;
   background-color: var(--color-black-3);
 }
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover::after, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):focus-visible, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):focus-visible::after {
-  background-color: var(--color-fire-red);
-}
-html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):hover:active, html:not([data-whatintent=touch]) .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
-[disabled]):focus-visible:active {
-  color: var(--color-white);
+@media (hover: hover) {
+  .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):hover, .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):hover::after, .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):focus-visible, .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):focus-visible::after {
+    background-color: var(--color-fire-red);
+  }
+  .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):hover:active, .dnb-input__status--error .dnb-input__submit-button__button.dnb-button--secondary:not(.dnb-input__status--error .dnb-input__submit-button__button--has-text,
+  [disabled]):focus-visible:active {
+    color: var(--color-white);
+  }
 }
 .dnb-input__icon {
   color: var(--color-sea-green);

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -390,9 +390,10 @@
         margin: auto;
       }
 
-      html:not([data-whatintent='touch'])
+      @media (hover: hover) {
         &:not(.dnb-button--has-text):hover[disabled] {
-        cursor: default;
+          cursor: default;
+        }
       }
     }
   }

--- a/packages/dnb-eufemia/src/components/input/style/themes/dnb-input-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/input/style/themes/dnb-input-theme-ui.scss
@@ -60,23 +60,23 @@
   }
 
   &__status--error &__submit-button {
-    html:not([data-whatintent='touch'])
+    @media (hover: hover) {
       &__button.dnb-button--secondary:not(
-        &__button--has-text,
-        [disabled]
-      ):hover,
-    html:not([data-whatintent='touch'])
+          &__button--has-text,
+          [disabled]
+        ):hover,
       &__button.dnb-button--secondary:not(
-        &__button--has-text,
-        [disabled]
-      ):focus-visible {
-      &,
-      &::after {
-        background-color: var(--color-fire-red);
-      }
+          &__button--has-text,
+          [disabled]
+        ):focus-visible {
+        &,
+        &::after {
+          background-color: var(--color-fire-red);
+        }
 
-      &:active {
-        color: var(--color-white);
+        &:active {
+          color: var(--color-white);
+        }
       }
     }
   }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -431,26 +431,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -852,7 +852,20 @@ describe('NumberFormat component', () => {
 
   it('should not call setFocus on touch devices', async () => {
     // Simulate touch device
-    document.documentElement.setAttribute('data-whatintent', 'touch')
+    const originalMatchMedia = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: query === '(hover: none)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
 
     render(<NumberFormat selectAll value={1234568} />)
 
@@ -881,7 +894,10 @@ describe('NumberFormat component', () => {
     focusSpy.mockRestore()
 
     // Clean up
-    document.documentElement.removeAttribute('data-whatintent')
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    })
   })
 
   it('should not call setFocus when text is already selected', async () => {

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -892,7 +889,7 @@ exports[`Pagination scss have to match default theme snapshot 1`] = `
   background-color: var(--color-emerald-green);
   color: var(--color-mint-green);
 }
-html[data-whatinput=keyboard] .dnb-core-style .dnb-pagination__button.dnb-button--primary:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-pagination__button.dnb-button--primary:not([disabled]):not(:active):not(:hover):focus {
+.dnb-core-style .dnb-pagination__button.dnb-button--primary:not([disabled]):not(:active):not(:hover):focus-visible, .dnb-pagination__button.dnb-button--primary:not([disabled]):not(:active):not(:hover):focus-visible {
   color: var(--color-emerald-green);
   background-color: var(--color-mint-green);
 }

--- a/packages/dnb-eufemia/src/components/pagination/style/themes/dnb-pagination-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/pagination/style/themes/dnb-pagination-theme-ui.scss
@@ -13,8 +13,7 @@
       color: var(--color-mint-green);
     }
 
-    html[data-whatinput='keyboard']
-      &:not([disabled]):not(:active):not(:hover):focus {
+    &:not([disabled]):not(:active):not(:hover):focus-visible {
       color: var(--color-emerald-green);
       background-color: var(--color-mint-green);
     }

--- a/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -434,20 +434,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__button {
   border-width: var(--radio-border-width--focus);
   border: none;
 }
-.dnb-radio__input:not([disabled]):focus ~ .dnb-radio__focus, .dnb-radio__input:not([disabled]):active ~ .dnb-radio__focus {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__focus {
   display: block;
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__button, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__button, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-on--focus);
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__dot, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__dot {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__dot, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__dot {
   background-color: var(--radio-color-dot-on--focus, var(--focus-ring-color));
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-off--focus);
 }
 .dnb-radio {

--- a/packages/dnb-eufemia/src/components/radio/style/dnb-radio.scss
+++ b/packages/dnb-eufemia/src/components/radio/style/dnb-radio.scss
@@ -401,47 +401,41 @@
   /** Focus state **/
 
   // General
-  &__input:not([disabled]):focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      border-width: var(--radio-border-width--focus);
-      border: none;
-    }
+  &__input:not([disabled]):focus-visible ~ &__button {
+    border-width: var(--radio-border-width--focus);
+    border: none;
   }
-  &__input:not([disabled]):focus ~ &__focus,
-  &__input:not([disabled]):active ~ &__focus {
+  &__input:not([disabled]):focus-visible ~ &__focus {
     display: block;
   }
 
   // On
-  &__input:not([disabled]):not(:active):not(:hover):checked:focus
+  &__input:not([disabled]):not(:active):not(:hover):checked:focus-visible
     ~ &__button,
   &__input:not([disabled]):not(:active):not(
       :hover
-    )[data-checked='true']:focus
+    )[data-checked='true']:focus-visible
     ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(--radio-color-background-on--focus);
-    }
+    background-color: var(--radio-color-background-on--focus);
   }
-  &__input:not([disabled]):not(:active):not(:hover):checked:focus ~ &__dot,
+  &__input:not([disabled]):not(:active):not(:hover):checked:focus-visible
+    ~ &__dot,
   &__input:not([disabled]):not(:active):not(
       :hover
-    )[data-checked='true']:focus
+    )[data-checked='true']:focus-visible
     ~ &__dot {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(
-        --radio-color-dot-on--focus,
-        var(--focus-ring-color)
-      );
-    }
+    background-color: var(
+      --radio-color-dot-on--focus,
+      var(--focus-ring-color)
+    );
   }
 
   // Off
-  &__input:not([disabled]):not(:checked):not([data-checked='true']):focus
+  &__input:not([disabled]):not(:checked):not(
+      [data-checked='true']
+    ):focus-visible
     ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(--radio-color-background-off--focus);
-    }
+    background-color: var(--radio-color-background-off--focus);
   }
 
   /** Error state **/

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -315,13 +315,13 @@ exports[`Section scss have to match default theme snapshot 1`] = `
 .dnb-section--fire-red .dnb-button--tertiary:hover .dnb-button__text::after, .dnb-section--emerald-green .dnb-button--tertiary:hover .dnb-button__text::after, .dnb-section--sea-green .dnb-button--tertiary:hover .dnb-button__text::after {
   --text-color: var(--color-white) !important;
 }
-.dnb-section--fire-red .dnb-button--tertiary:focus, .dnb-section--emerald-green .dnb-button--tertiary:focus, .dnb-section--sea-green .dnb-button--tertiary:focus {
+.dnb-section--fire-red .dnb-button--tertiary:focus-visible, .dnb-section--emerald-green .dnb-button--tertiary:focus-visible, .dnb-section--sea-green .dnb-button--tertiary:focus-visible {
   --text-color: var(--color-white);
 }
-.dnb-section--fire-red .dnb-button--tertiary:focus::before, .dnb-section--emerald-green .dnb-button--tertiary:focus::before, .dnb-section--sea-green .dnb-button--tertiary:focus::before {
+.dnb-section--fire-red .dnb-button--tertiary:focus-visible::before, .dnb-section--emerald-green .dnb-button--tertiary:focus-visible::before, .dnb-section--sea-green .dnb-button--tertiary:focus-visible::before {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-section--fire-red .dnb-button--tertiary:focus::before, html[data-whatinput=keyboard] .dnb-section--emerald-green .dnb-button--tertiary:focus::before, html[data-whatinput=keyboard] .dnb-section--sea-green .dnb-button--tertiary:focus::before {
+html[data-whatinput=keyboard] .dnb-section--fire-red .dnb-button--tertiary:focus-visible::before, html[data-whatinput=keyboard] .dnb-section--emerald-green .dnb-button--tertiary:focus-visible::before, html[data-whatinput=keyboard] .dnb-section--sea-green .dnb-button--tertiary:focus-visible::before {
   --border-color: var(--color-white);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/section/style/themes/dnb-section-theme-ui.scss
@@ -129,7 +129,7 @@
       --text-color: var(--color-white) !important;
     }
 
-    &:focus {
+    &:focus-visible {
       --text-color: var(--color-white);
 
       &::before {

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -645,16 +642,16 @@ button.dnb-button::-moz-focus-inner {
 .dnb-skip-content .dnb-button {
   margin: 1rem 0;
 }
-.dnb-skip-content__focus:focus {
+.dnb-skip-content__focus:focus-visible {
   position: relative;
 }
-.dnb-skip-content__focus:focus::before {
+.dnb-skip-content__focus:focus-visible::before {
   content: "";
   position: absolute;
   inset: var(--focus-ring-width);
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-skip-content__focus:focus::before {
+html[data-whatinput=keyboard] .dnb-skip-content__focus:focus-visible::before {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/skip-content/style/dnb-skip-content.scss
+++ b/packages/dnb-eufemia/src/components/skip-content/style/dnb-skip-content.scss
@@ -14,7 +14,7 @@
     margin: 1rem 0;
   }
 
-  &__focus:focus {
+  &__focus:focus-visible {
     position: relative;
 
     &::before {

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -571,11 +568,11 @@ legend.dnb-form-label {
   height: var(--slider-marker-height);
   background-color: var(--slider-marker);
 }
-.dnb-slider__marker:focus {
+.dnb-slider__marker:focus-visible {
   outline: none;
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-slider__marker:focus {
+html[data-whatinput=keyboard] .dnb-slider__marker:focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
@@ -710,10 +707,10 @@ html[data-visual-test] .dnb-slider__thumb, html[data-visual-test] .dnb-slider__l
   opacity: 0;
   transform: translate3d(0.0625rem, 0, 0);
 }
-.dnb-slider__button-helper:not(:disabled):focus ~ .dnb-button {
+.dnb-slider__button-helper:not(:disabled):focus-visible ~ .dnb-button {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-slider__button-helper:not(:disabled):focus ~ .dnb-button {
+html[data-whatinput=keyboard] .dnb-slider__button-helper:not(:disabled):focus-visible ~ .dnb-button {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
+++ b/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
@@ -81,7 +81,7 @@
     height: var(--slider-marker-height);
     background-color: var(--slider-marker);
 
-    &:focus {
+    &:focus-visible {
       outline: none; // we show a Tooltip instead
       @include utilities.focusRing();
     }
@@ -275,7 +275,7 @@
     transform: translate3d(0.0625rem, 0, 0);
   }
 
-  &__button-helper:not(:disabled):focus ~ .dnb-button {
+  &__button-helper:not(:disabled):focus-visible ~ .dnb-button {
     @include utilities.focusRing();
   }
 

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -434,26 +434,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -94,10 +94,10 @@ exports[`Switch scss should match default theme snapshot 1`] = `
     *
     */
 }
-html[data-whatinput=keyboard] .dnb-switch__input:not([disabled]):focus ~ .dnb-switch__button {
+.dnb-switch__input:not([disabled]):focus-visible ~ .dnb-switch__button {
   border: none;
 }
-html[data-whatinput=keyboard] .dnb-switch__input:not([disabled]):not(:checked):focus ~ .dnb-switch__button {
+.dnb-switch__input:not([disabled]):not(:checked):focus-visible ~ .dnb-switch__button {
   background-color: var(--color-mint-green-50);
 }
 .dnb-switch__input:not([disabled]):checked ~ .dnb-switch__button .dnb-switch__focus {
@@ -436,16 +436,16 @@ html[data-whatinput=keyboard] .dnb-switch__focus {
 .dnb-switch__input:not([disabled]) {
   cursor: pointer;
 }
-.dnb-switch__input:not([disabled]):focus ~ .dnb-switch__background, .dnb-switch__input:not([disabled]):active ~ .dnb-switch__background {
+.dnb-switch__input:not([disabled]):focus-visible ~ .dnb-switch__background {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-switch__input:not([disabled]):focus ~ .dnb-switch__background, html[data-whatinput=keyboard] .dnb-switch__input:not([disabled]):active ~ .dnb-switch__background {
+html[data-whatinput=keyboard] .dnb-switch__input:not([disabled]):focus-visible ~ .dnb-switch__background {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-switch__input:not([disabled]):focus ~ .dnb-switch__button .dnb-switch__focus, .dnb-switch__input:not([disabled]):active ~ .dnb-switch__button .dnb-switch__focus {
+.dnb-switch__input:not([disabled]):focus-visible ~ .dnb-switch__button .dnb-switch__focus {
   display: block;
 }
 .dnb-switch .dnb-form-label {

--- a/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
@@ -187,13 +187,11 @@
     cursor: pointer;
   }
 
-  &__input:not([disabled]):focus ~ &__background,
-  &__input:not([disabled]):active ~ &__background {
+  &__input:not([disabled]):focus-visible ~ &__background {
     @include utilities.focusRing();
   }
 
-  &__input:not([disabled]):focus ~ &__button &__focus,
-  &__input:not([disabled]):active ~ &__button &__focus {
+  &__input:not([disabled]):focus-visible ~ &__button &__focus {
     display: block;
   }
 

--- a/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-sbanken.scss
@@ -168,38 +168,28 @@
    * On focus state
    *
    */
-  &__input:not([disabled]):focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      @include utilities.removeFocusRing();
+  &__input:not([disabled]):focus-visible ~ &__button {
+    @include utilities.removeFocusRing();
+  }
+
+  &__input:not([disabled]):checked:focus-visible ~ &__button {
+    background-color: var(--focus-ring-color);
+  }
+
+  &__input:not([disabled]):not(:checked):focus-visible ~ &__button {
+    @include utilities.removeFocusRing();
+  }
+
+  &__input:not([disabled]):focus-visible ~ &__background {
+    background-color: var(--sb-color-blue-light-3);
+    &::after {
+      color: var(--focus-ring-color);
+      font-weight: var(--sb-font-weight-bold);
     }
   }
 
-  &__input:not([disabled]):checked:focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(--focus-ring-color);
-    }
-  }
-
-  &__input:not([disabled]):not(:checked):focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      @include utilities.removeFocusRing();
-    }
-  }
-
-  &__input:not([disabled]):focus ~ &__background {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(--sb-color-blue-light-3);
-      &::after {
-        color: var(--focus-ring-color);
-        font-weight: var(--sb-font-weight-bold);
-      }
-    }
-  }
-
-  &__input:not([disabled]):focus ~ &__button &__focus {
-    html[data-whatinput='keyboard'] & {
-      @include utilities.fakeBorder(var(--focus-ring-color), 0.0625rem);
-    }
+  &__input:not([disabled]):focus-visible ~ &__button &__focus {
+    @include utilities.fakeBorder(var(--focus-ring-color), 0.0625rem);
   }
 
   /*

--- a/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-ui.scss
@@ -110,15 +110,11 @@
     * On focus state
     *
     */
-  &__input:not([disabled]):focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      border: none;
-    }
+  &__input:not([disabled]):focus-visible ~ &__button {
+    border: none;
   }
-  &__input:not([disabled]):not(:checked):focus ~ &__button {
-    html[data-whatinput='keyboard'] & {
-      background-color: var(--color-mint-green-50);
-    }
+  &__input:not([disabled]):not(:checked):focus-visible ~ &__button {
+    background-color: var(--color-mint-green-50);
   }
   &__input:not([disabled]):checked ~ &__button &__focus {
     transform: rotate(180deg);

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -261,22 +261,24 @@ html[data-visual-test] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-tab
   opacity: 1;
   color: var(--color-sea-green);
 }
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover[disabled] {
+@media (hover: hover) {
+  .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover[disabled], .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]), .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) {
+    color: var(--color-sea-green);
+  }
+  .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon {
+    opacity: 1;
+  }
+  .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
+    opacity: 0;
+  }
+}
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible[disabled], .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) {
-  color: var(--color-sea-green);
-}
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon {
-  opacity: 1;
-}
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
-  opacity: 0;
-}
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus[disabled], html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus[disabled], .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus[disabled] {
-  cursor: not-allowed;
-}
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled])::before {
   content: "";
   position: absolute;
   top: -0.5rem;
@@ -284,23 +286,23 @@ html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortab
   left: -1rem;
   right: 0.5rem;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled])::before {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled])::before {
   right: -0.5rem;
 }
-html[data-visual-test] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon, :not(.dnb-table--active) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test] html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon, :not(.dnb-table--active) html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test] .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon, :not(.dnb-table--active) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon, html[data-visual-test] html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-icon, :not(.dnb-table--active) html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):active .dnb-icon {
+html[data-visual-test] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]) .dnb-icon, :not(.dnb-table--active) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]):active .dnb-icon, html[data-visual-test] .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]) .dnb-icon, :not(.dnb-table--active) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]):active .dnb-icon {
   opacity: 1;
 }
-html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test]) html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-visual-test]) html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
+html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]) .dnb-button__text::after, html:not([data-visual-test]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]) .dnb-button__text::after {
   opacity: 1;
   color: inherit;
 }
-html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test]) html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test]) html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus:not([disabled]):not(:active) .dnb-button__text::after {
+html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]):not(:active) .dnb-button__text::after, html:not([data-visual-test]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:focus-visible:not([disabled]):not(:active) .dnb-button__text::after {
   visibility: visible;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled], .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled] {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled], .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active[disabled] {
   cursor: not-allowed;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -311,32 +313,12 @@ html:not([data-visual-test]) .dnb-table > thead > tr > th.dnb-table--sortable .d
   height: inherit;
   border-radius: inherit;
   outline: none;
-}
-html[data-whatinput=mouse] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=mouse] html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=mouse] .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=mouse] html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
-  content: "";
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  left: -0.5rem;
-  bottom: 0;
-  right: -0.5rem;
-  height: inherit;
-  border-radius: inherit;
-  outline: none;
-}
-html[data-whatinput=touch] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=touch] html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=touch] .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html[data-whatinput=touch] html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
-  --border-color: var(--focus-ring-color);
-  --border-width: var(--focus-ring-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
   content: "";
   position: absolute;
   top: -0.5rem;
@@ -344,10 +326,10 @@ html[data-whatinput=touch] .dnb-table > thead > tr > th.dnb-table--sortable .dnb
   left: -1rem;
   right: 0.5rem;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled])::before {
   right: -0.5rem;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]), .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]) {
+.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]), .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:active:not([disabled]) {
   color: var(--color-sea-green);
 }
 .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after {
@@ -377,23 +359,25 @@ html[data-whatinput=touch] .dnb-table > thead > tr > th.dnb-table--sortable .dnb
 .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button .dnb-icon, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button .dnb-icon {
   opacity: 1;
 }
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled] {
+@media (hover: hover) {
+  .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled], .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
+    color: var(--color-sea-green);
+    opacity: 1;
+  }
+}
+.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled], .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
-  color: var(--color-sea-green);
-  opacity: 1;
-}
-.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled], html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled], .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled] {
-  cursor: not-allowed;
-}
-.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
+.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
   opacity: 0;
 }
 .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after {
   visibility: visible;
 }
-html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus .dnb-button__text::after, html[data-whatinput=keyboard] .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus .dnb-button__text::after {
+.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus-visible .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus-visible .dnb-button__text::after {
   visibility: hidden;
 }
 .dnb-table > thead > tr > th.dnb-table--reversed .dnb-table__sort-button.dnb-button .dnb-icon, .dnb-table .dnb-table__th.dnb-table--reversed .dnb-table__sort-button.dnb-button .dnb-icon {
@@ -831,7 +815,7 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   z-index: 3;
 }
 
-.dnb-table__tr--clickable:active, html[data-whatinput=keyboard] .dnb-table__tr--clickable:focus, .dnb-table__tr--clickable:hover:not(.dnb-table__tr--hover.dnb-table__tr--expanded) {
+.dnb-table__tr--clickable:active, .dnb-table__tr--clickable:focus-visible, .dnb-table__tr--clickable:hover:not(.dnb-table__tr--hover.dnb-table__tr--expanded) {
   z-index: 5;
 }
 
@@ -866,18 +850,17 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   border-right: none;
 }
 
-html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) td::before {
+    border-color: var(--table-accordion-outline-color);
+  }
+  .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) .dnb-table__td__button-icon .dnb-icon {
+    color: var(--table-accordion-icon-color--active);
+  }
 }
-
-html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) td::before {
-  border-color: var(--table-accordion-outline-color);
-}
-
-html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):hover:not([disabled]) .dnb-table__td__button-icon .dnb-icon {
-  color: var(--table-accordion-icon-color--active);
-}
-
 .dnb-table--border tbody .dnb-table__tr--clickable:not(.dnb-table__tr--expanded):not(.dnb-table__tr--last) .dnb-table__td::before {
   bottom: calc(var(--table-border-width) * -1);
 }
@@ -886,20 +869,19 @@ html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.d
   background-color: var(--color-white);
 }
 
-html[data-whatinput=keyboard] .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus td::before {
+.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus-visible td::before {
   border-color: var(--focus-ring-color);
   border-width: var(--focus-ring-width);
 }
 
-.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus td:first-of-type::before {
+.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus-visible td:first-of-type::before {
   left: 0;
 }
 
-.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus td:last-of-type::before {
+.dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):not(:active):not(:hover):focus-visible td:last-of-type::before {
   right: 0;
 }
 
-html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active:hover td::before,
 .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active td::before {
   border-color: var(--table-accordion-outline-color);
   border-width: var(--table-accordion-border-width);
@@ -922,11 +904,11 @@ html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.d
   border-top: var(--table-accordion-border);
 }
 
-html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-table__tr--expanded:not(.dnb-table__tr--disabled):not(:active):not(:hover) {
+.dnb-table__tr--clickable.dnb-table__tr.dnb-table__tr--expanded:not(.dnb-table__tr--disabled):not(:active):not(:hover):not(:focus-visible) {
   background-color: var(--table-accordion-header-background);
 }
 
-html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-table__tr--expanded:not(.dnb-table__tr--disabled):not(:active):not(:hover) td::before {
+.dnb-table__tr--clickable.dnb-table__tr.dnb-table__tr--expanded:not(.dnb-table__tr--disabled):not(:active):not(:hover):not(:focus-visible) td::before {
   border: none;
   border-top: var(--table-accordion-border);
 }

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -92,7 +92,7 @@
 
   &__tr--clickable {
     &:active,
-    html[data-whatinput='keyboard'] &:focus,
+    &:focus-visible,
     &:hover:not(.dnb-table__tr--hover.dnb-table__tr--expanded) {
       z-index: 5; // over table outline border
     }
@@ -156,12 +156,10 @@
 
   &__tr--clickable#{&}__tr:not(&__tr--disabled):not(:active):not(
       :hover
-    ):focus {
+    ):focus-visible {
     td::before {
-      @include utilities.whatInput(keyboard) {
-        border-color: var(--focus-ring-color);
-        border-width: var(--focus-ring-width);
-      }
+      border-color: var(--focus-ring-color);
+      border-width: var(--focus-ring-width);
     }
     td:first-of-type::before {
       left: 0;
@@ -172,7 +170,6 @@
   }
 
   &__tr--clickable#{&}__tr:not(&__tr--disabled):active {
-    html:not([data-whatintent='touch']) &:hover td::before,
     td::before {
       border-color: var(--table-accordion-outline-color);
       border-width: var(
@@ -201,14 +198,12 @@
 
   &__tr--clickable#{&}__tr#{&}__tr--expanded:not(&__tr--disabled):not(
       :active
-    ):not(:hover) {
-    @include utilities.whatInputNot('keyboard') {
-      background-color: var(--table-accordion-header-background);
+    ):not(:hover):not(:focus-visible) {
+    background-color: var(--table-accordion-header-background);
 
-      td::before {
-        border: none;
-        border-top: var(--table-accordion-border);
-      }
+    td::before {
+      border: none;
+      border-top: var(--table-accordion-border);
     }
   }
 

--- a/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
@@ -92,7 +92,7 @@
         }
       }
 
-      @include utilities.focus() {
+      @include utilities.focus-visible() {
         @include tableFocusRing();
 
         // focus ring
@@ -119,12 +119,7 @@
       }
 
       @include utilities.active() {
-        @include button-mixins.buttonFocusRing(
-          'mouse'
-        ); // also, make a mouse ring
-        @include button-mixins.buttonFocusRing(
-          'touch'
-        ); // also, make a touch ring
+        @include button-mixins.buttonFocusRing($whatinput: 'always');
         @include tableFocusRing();
 
         // focus ring
@@ -198,9 +193,8 @@
         visibility: visible;
       }
 
-      html[data-whatinput='keyboard']
-        &:hover:focus
-        .dnb-button__text::after {
+      // webkit fix
+      &:hover:focus-visible .dnb-button__text::after {
         visibility: hidden;
       }
     }

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
@@ -68,21 +68,12 @@
       }
       @include utilities.active() {
         color: var(--sb-color-violet);
-        @include button-mixins.buttonFocusRing(
-          'mouse',
-          inset
-        ); // also, make a mouse ring
-        @include button-mixins.buttonFocusRing(
-          'touch',
-          inset
-        ); // also, make a touch ring
+        @include button-mixins.buttonFocusRing('always', inset);
         @include tableFocusRing();
       }
-      @include utilities.focus() {
+      @include utilities.focus-visible() {
         @include tableFocusRing();
-        &:focus-visible {
-          color: var(--sb-color-blue-dark);
-        }
+        color: var(--sb-color-blue-dark);
 
         &:not(:active) .dnb-button__text::after {
           visibility: hidden;

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -24,7 +24,6 @@ import {
   skeletonDOMAttributes,
 } from '../skeleton/SkeletonHelper'
 import Button from '../button/Button'
-import whatInput from 'what-input'
 import CustomContent from './TabsCustomContent'
 import ContentWrapper from './TabsContentWrapper'
 import {
@@ -428,7 +427,6 @@ export default class Tabs extends React.PureComponent<
 
   componentWillUnmount() {
     this._isMounted = false
-    this.resetWhatInput()
     if (this._sharedState) {
       this._sharedState = null
     }
@@ -853,16 +851,6 @@ export default class Tabs extends React.PureComponent<
       'onFocus',
       this.getEventArgs({ event, focusKey })
     )
-
-    this.setWhatInput()
-  }
-
-  setWhatInput() {
-    whatInput.specificKeys([9, 37, 39, 33, 34, 35, 36])
-  }
-
-  resetWhatInput() {
-    whatInput.specificKeys([9])
   }
 
   setFocusOnTabButton = () => {
@@ -894,7 +882,6 @@ export default class Tabs extends React.PureComponent<
     // saving the position will avoid flickering if the new tab will be done by a new page load
     this.saveLastPosition()
     this.saveLastUsedTab()
-    this.resetWhatInput()
 
     // for handling openPrevTab and openNextTab
     if (mode === 'step' && parseFloat(selectedKey)) {

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.screenshot.test.ts
@@ -144,9 +144,6 @@ describe.each(['ui', 'sbanken'])('Tabs for %s', (themeName) => {
       simulateSelector:
         '[data-visual-test="tabs-section-styles"] .dnb-tabs__content',
       simulate: 'focus',
-      executeBeforeSimulate: () => {
-        document.documentElement.setAttribute('data-whatinput', 'keyboard')
-      },
     })
     expect(screenshot).toMatchImageSnapshot()
   })

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -47,16 +47,16 @@ exports[`Tabs scss has to match style dependencies css 1`] = `
   display: flex;
   flex: 0 1 auto;
 }
-.dnb-tabs__tabs__tablist:focus {
+.dnb-tabs__tabs__tablist:focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-tabs__tabs__tablist:focus {
+html[data-whatinput=keyboard] .dnb-tabs__tabs__tablist:focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-tabs__tabs__tablist:focus {
+.dnb-tabs__tabs__tablist:focus-visible {
   border-radius: 0.5rem;
 }
 .dnb-tabs__tabs__tablist {
@@ -202,26 +202,30 @@ html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
   color: var(--tab-title-font-color);
   padding: 0.5rem 0 0.25rem;
 }
-html:not([data-whatintent=touch]) .dnb-tabs__button__title:hover[disabled], html:not([data-whatintent=touch]) .dnb-core-style .dnb-tabs__button__title:hover[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-tabs__button__title:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-core-style .dnb-tabs__button__title:hover:not([disabled]) {
-  color: var(--tab-title-color--hover);
+@media (hover: hover) {
+  .dnb-tabs__button__title:hover[disabled], .dnb-core-style .dnb-tabs__button__title:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-tabs__button__title:hover:not([disabled]), .dnb-core-style .dnb-tabs__button__title:hover:not([disabled]) {
+    color: var(--tab-title-color--hover);
+  }
 }
 .dnb-tabs__button__title .dnb-icon, .dnb-core-style .dnb-tabs__button__title .dnb-icon {
   font-size: var(--font-size-small);
   transform: translateY(-0.125rem);
 }
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover[disabled], html:not([data-whatintent=touch]) .dnb-core-style .dnb-tabs__button:hover[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-core-style .dnb-tabs__button:hover:not([disabled]) {
-  background-color: var(--tab-title-background--hover);
-}
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled])::after, html:not([data-whatintent=touch]) .dnb-core-style .dnb-tabs__button:hover:not([disabled])::after {
-  height: 2px;
-  border-radius: 2px;
-  background-color: var(--tab-title-border--hover);
+@media (hover: hover) {
+  .dnb-tabs__button:hover[disabled], .dnb-core-style .dnb-tabs__button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-tabs__button:hover:not([disabled]), .dnb-core-style .dnb-tabs__button:hover:not([disabled]) {
+    background-color: var(--tab-title-background--hover);
+  }
+  .dnb-tabs__button:hover:not([disabled])::after, .dnb-core-style .dnb-tabs__button:hover:not([disabled])::after {
+    height: 2px;
+    border-radius: 2px;
+    background-color: var(--tab-title-border--hover);
+  }
 }
 .dnb-tabs__button .dnb-dummy, .dnb-core-style .dnb-tabs__button .dnb-dummy {
   display: flex;
@@ -255,7 +259,7 @@ html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled])::after
 .dnb-tabs__button, .dnb-core-style .dnb-tabs__button {
   /* stylelint-disable no-descending-specificity */
 }
-.dnb-tabs__button:focus::before, .dnb-core-style .dnb-tabs__button:focus::before {
+.dnb-tabs__button:focus-visible::before, .dnb-core-style .dnb-tabs__button:focus-visible::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -267,16 +271,16 @@ html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled])::after
   border-radius: inherit;
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button:focus::before, html[data-whatinput=keyboard] .dnb-core-style .dnb-tabs__button:focus::before {
+html[data-whatinput=keyboard] .dnb-tabs__button:focus-visible::before, html[data-whatinput=keyboard] .dnb-core-style .dnb-tabs__button:focus-visible::before {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-tabs__button:focus, .dnb-core-style .dnb-tabs__button:focus {
+.dnb-tabs__button:focus-visible, .dnb-core-style .dnb-tabs__button:focus-visible {
   overflow: visible;
 }
-.dnb-tabs__button:focus::before, .dnb-core-style .dnb-tabs__button:focus::before {
+.dnb-tabs__button:focus-visible::before, .dnb-core-style .dnb-tabs__button:focus-visible::before {
   top: 0.5rem;
   left: -0.375rem;
   right: -0.375rem;
@@ -320,16 +324,16 @@ html[data-whatinput=keyboard] .dnb-tabs__button:focus::before, html[data-whatinp
 .dnb-tabs__button__snap:has(.dnb-badge) {
   margin-right: -0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:first-of-type.focus .dnb-tabs__button:focus {
+.dnb-tabs__button__snap:first-of-type.focus .dnb-tabs__button:focus-visible {
   margin-left: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus {
+.dnb-tabs__button__snap:last-of-type.focus {
   /* stylelint-disable */
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-tabs__button:focus {
+.dnb-tabs__button__snap:last-of-type.focus .dnb-tabs__button:focus-visible {
   margin-right: 0.5rem;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus {
+.dnb-tabs__button__snap:last-of-type.focus {
   /* stylelint-enable */
 }
 .dnb-tabs__cached {
@@ -357,10 +361,10 @@ html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-
 .dnb-tabs__content {
   padding-bottom: 0;
 }
-.dnb-tabs__content:focus {
+.dnb-tabs__content:focus-visible {
   position: relative;
 }
-.dnb-tabs__content:focus::before {
+.dnb-tabs__content:focus-visible::before {
   content: "";
   position: absolute;
   z-index: calc(var(--section-z-index) + 1);
@@ -373,7 +377,7 @@ html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-
   border-radius: 0.5rem;
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-tabs__content:focus::before {
+html[data-whatinput=keyboard] .dnb-tabs__content:focus-visible::before {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
@@ -422,18 +426,20 @@ exports[`Tabs scss have to match default theme snapshot 1`] = `
   color: var(--color-sea-green);
   padding: 0.5rem 0 0.25rem;
 }
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-tabs__button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-tabs__button:hover:not([disabled]) {
+    background-color: var(--color-mint-green-50);
+  }
+  .dnb-tabs__button:hover:not([disabled])::after {
+    height: 2px;
+    border-radius: 2px;
+    background-color: var(--color-sea-green);
+  }
 }
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled]) {
-  background-color: var(--color-mint-green-50);
-}
-html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled])::after {
-  height: 2px;
-  border-radius: 2px;
-  background-color: var(--color-sea-green);
-}
-.dnb-tabs__button:focus::before {
+.dnb-tabs__button:focus-visible::before {
   content: "";
   position: absolute;
   z-index: 1;
@@ -445,16 +451,16 @@ html:not([data-whatintent=touch]) .dnb-tabs__button:hover:not([disabled])::after
   border-radius: inherit;
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-tabs__button:focus::before {
+html[data-whatinput=keyboard] .dnb-tabs__button:focus-visible::before {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-.dnb-tabs__button:focus {
+.dnb-tabs__button:focus-visible {
   overflow: visible;
 }
-.dnb-tabs__button:focus::before {
+.dnb-tabs__button:focus-visible::before {
   top: 0.5rem;
   left: -0.375rem;
   right: -0.375rem;

--- a/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
@@ -36,7 +36,7 @@
       display: flex;
       flex: 0 1 auto;
 
-      &:focus {
+      &:focus-visible {
         @include utilities.focusRing();
         border-radius: 0.5rem;
       }
@@ -229,7 +229,7 @@
     }
 
     /* stylelint-disable no-descending-specificity */
-    &:focus {
+    &:focus-visible {
       @include button-mixins.buttonFocusRing();
       overflow: visible;
 
@@ -283,16 +283,14 @@
 
     will-change: padding;
     transition: padding 1s var(--easing-default);
-  }
 
-  &__button__snap:has(.dnb-badge) {
-    margin-right: -0.5rem;
-  }
+    &:has(.dnb-badge) {
+      margin-right: -0.5rem;
+    }
 
-  html[data-whatinput='keyboard'] &__button__snap {
     &:first-of-type.focus {
       // add space so the focus ring is visible within our overflow
-      .dnb-tabs__button:focus {
+      .dnb-tabs__button:focus-visible {
         margin-left: 0.5rem;
       }
     }
@@ -300,7 +298,7 @@
     &:last-of-type.focus {
       // add space so the focus ring is visible within our overflow
       /* stylelint-disable */
-      .dnb-tabs__button:focus {
+      .dnb-tabs__button:focus-visible {
         margin-right: 0.5rem;
       }
       /* stylelint-enable */
@@ -338,7 +336,7 @@
   }
 
   // Make focus ring when keyboard is used to navigate
-  &__content:focus {
+  &__content:focus-visible {
     position: relative;
 
     // Use "before" (instead of after) in order to not collide with Section styles

--- a/packages/dnb-eufemia/src/components/tabs/style/themes/dnb-tabs-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/themes/dnb-tabs-theme-ui.scss
@@ -41,7 +41,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       @include button-mixins.buttonFocusRing();
       overflow: visible;
 

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -427,26 +427,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -509,10 +506,10 @@ button.dnb-button::-moz-focus-inner {
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:focus-visible[disabled] {
+.dnb-tag--interactive.dnb-button:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:focus-visible:not([disabled]) {
+.dnb-tag--interactive.dnb-button:focus-visible:not([disabled]) {
   outline: none;
   --border-color: var(--color-emerald-green);
   --border-width: var(--focus-ring-width);
@@ -520,20 +517,22 @@ html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:focus-visible
   border-color: transparent;
   --tag-icon-color: var(--color-emerald-green);
 }
-html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover[disabled] {
+@media (hover: hover) {
+  .dnb-tag--interactive.dnb-button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-tag--interactive.dnb-button:hover:not([disabled]) {
+    --border-color: var(--color-emerald-green);
+    --border-width: 0.125rem;
+    box-shadow: 0 0 0 var(--border-width) var(--border-color);
+    border-color: transparent;
+    --tag-icon-color: var(--color-emerald-green);
+  }
+}
+.dnb-tag--interactive.dnb-button:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover:not([disabled]) {
-  --border-color: var(--color-emerald-green);
-  --border-width: 0.125rem;
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-  --tag-icon-color: var(--color-emerald-green);
-}
-.dnb-tag--interactive.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-tag--interactive.dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:active:not([disabled]) {
+.dnb-tag--interactive.dnb-button:active:not([disabled]) {
   background-color: var(--color-mint-green-50);
   --border-color: transparent;
   --border-width: 0.0625rem;
@@ -554,24 +553,26 @@ html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover:not([di
   --tag-icon-fill: var(--tag-icon-fill-color);
   --tag-icon-stroke: var(--tag-icon-stroke-color);
 }
-html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:focus-visible[disabled], html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:focus-visible[disabled] {
+.dnb-tag--removable.dnb-button:focus-visible[disabled], .dnb-tag--addable.dnb-button:focus-visible[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:focus-visible:not([disabled]), html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:focus-visible:not([disabled]) {
+.dnb-tag--removable.dnb-button:focus-visible:not([disabled]), .dnb-tag--addable.dnb-button:focus-visible:not([disabled]) {
   --tag-icon-fill: var(--tag-icon-stroke-color);
   --tag-icon-stroke: var(--tag-icon-fill-color);
 }
-html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:hover[disabled], html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:hover[disabled] {
+@media (hover: hover) {
+  .dnb-tag--removable.dnb-button:hover[disabled], .dnb-tag--addable.dnb-button:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-tag--removable.dnb-button:hover:not([disabled]), .dnb-tag--addable.dnb-button:hover:not([disabled]) {
+    --tag-icon-fill: var(--tag-icon-stroke-color);
+    --tag-icon-stroke: var(--tag-icon-fill-color);
+  }
+}
+.dnb-tag--removable.dnb-button:active[disabled], .dnb-tag--addable.dnb-button:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:hover:not([disabled]) {
-  --tag-icon-fill: var(--tag-icon-stroke-color);
-  --tag-icon-stroke: var(--tag-icon-fill-color);
-}
-.dnb-tag--removable.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:active[disabled], .dnb-tag--addable.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-tag--removable.dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:active:not([disabled]), .dnb-tag--addable.dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-tag--addable.dnb-button:active:not([disabled]) {
+.dnb-tag--removable.dnb-button:active:not([disabled]), .dnb-tag--addable.dnb-button:active:not([disabled]) {
   --tag-icon-fill: var(--tag-icon-stroke-color);
   --tag-icon-stroke: var(--tag-icon-fill-color);
 }

--- a/packages/dnb-eufemia/src/components/textarea/style/themes/dnb-textarea-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/themes/dnb-textarea-theme-sbanken.scss
@@ -40,7 +40,10 @@
     ~ .dnb-textarea__state {
       --textarea-border-color: var(--sb-color-violet);
       --textarea-border-radius: 1.5rem;
-      @include utilities.focusRing(null, null, inset);
+
+      html[data-whatinput='keyboard'] & {
+        @include utilities.focusRing(null, null, inset);
+      }
     }
   }
 

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -35,13 +35,13 @@ exports[`ToggleButton scss should match default theme snapshot 1`] = `
 .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]) .dnb-radio__dot, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]) .dnb-radio__dot, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]) .dnb-radio__dot {
   background-color: var(--color-mint-green);
 }
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus .dnb-radio__button, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus .dnb-radio__button, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus .dnb-radio__button {
+.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus-visible .dnb-radio__button, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus-visible .dnb-radio__button, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus-visible .dnb-radio__button {
   --border-color: var(--color-emerald-green);
   --border-width: 0.09375rem;
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot {
+.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus-visible .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus-visible .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus-visible .dnb-radio__input:not([disabled]):not(:hover):not(:active):not(:hover) ~ .dnb-radio__dot {
   background-color: var(--color-emerald-green);
 }
 .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]) .dnb-checkbox__button, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]) .dnb-checkbox__button, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]) .dnb-checkbox__button {
@@ -52,10 +52,10 @@ html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__bu
 .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]) .dnb-checkbox__gfx, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]) .dnb-checkbox__gfx, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]) .dnb-checkbox__gfx {
   color: var(--color-emerald-green);
 }
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus .dnb-checkbox__button, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus .dnb-checkbox__button, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus .dnb-checkbox__button {
+.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus-visible .dnb-checkbox__button, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus-visible .dnb-checkbox__button, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus-visible .dnb-checkbox__button {
   background-color: var(--color-emerald-green);
 }
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus .dnb-checkbox__gfx, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus .dnb-checkbox__gfx, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus .dnb-checkbox__gfx {
+.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:hover):focus-visible .dnb-checkbox__gfx, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:hover):focus-visible .dnb-checkbox__gfx, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:hover):focus-visible .dnb-checkbox__gfx {
   color: var(--color-mint-green);
 }
 .dnb-toggle-button--checked .dnb-toggle-button__button[disabled] .dnb-radio__button,
@@ -64,12 +64,12 @@ html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__bu
 .dnb-toggle-button--checked .dnb-toggle-button__button:hover[disabled] .dnb-checkbox__button {
   box-shadow: none;
 }
-html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus {
+.dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus-visible, .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus-visible, .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus-visible {
   color: var(--color-emerald-green);
   background-color: var(--color-mint-green);
   outline: none;
 }
-html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus, html[data-whatinput=keyboard] html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus {
+html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:not([disabled]):not(:active):not(:hover):focus-visible, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:focus:not([disabled]):not(:active):not(:hover):focus-visible, html[data-whatinput=keyboard] .dnb-toggle-button--checked .dnb-toggle-button__button:hover:not([disabled]):not(:active):not(:hover):focus-visible {
   --border-color: var(--color-emerald-green);
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
@@ -626,26 +626,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;
@@ -966,14 +963,14 @@ html[data-whatinput=keyboard] .dnb-checkbox__focus {
 .dnb-checkbox {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--focus);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--focus);
 }
-.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus, .dnb-checkbox__input:not([disabled]):active ~ .dnb-checkbox__button .dnb-checkbox__focus {
+.dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button .dnb-checkbox__focus {
   display: block;
 }
 .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__indeterminate {
@@ -1004,7 +1001,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus-visible
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover) ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error);
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus ~ .dnb-checkbox__button, html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__button {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__button {
   border: none;
   background-color: var(--checkbox-color-background--error-contrast);
   --border-color: var(--checkbox-color-border--error);
@@ -1012,7 +1009,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html[data-whatinput=keyboard] .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus:hover ~ .dnb-checkbox__gfx {
+.dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):focus-visible:hover ~ .dnb-checkbox__gfx {
   color: var(--checkbox-color-gfx--error-contrast);
 }
 .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover):checked ~ .dnb-checkbox__button, .dnb-checkbox__status--error .dnb-checkbox__input:not([disabled]):not(:active):not(:hover)[data-checked=true] ~ .dnb-checkbox__button {
@@ -1367,20 +1364,20 @@ html[data-whatinput=keyboard] .dnb-radio__focus {
 .dnb-radio {
   /** Focus state **/
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__button {
   border-width: var(--radio-border-width--focus);
   border: none;
 }
-.dnb-radio__input:not([disabled]):focus ~ .dnb-radio__focus, .dnb-radio__input:not([disabled]):active ~ .dnb-radio__focus {
+.dnb-radio__input:not([disabled]):focus-visible ~ .dnb-radio__focus {
   display: block;
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__button, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__button, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-on--focus);
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus ~ .dnb-radio__dot, html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus ~ .dnb-radio__dot {
+.dnb-radio__input:not([disabled]):not(:active):not(:hover):checked:focus-visible ~ .dnb-radio__dot, .dnb-radio__input:not([disabled]):not(:active):not(:hover)[data-checked=true]:focus-visible ~ .dnb-radio__dot {
   background-color: var(--radio-color-dot-on--focus, var(--focus-ring-color));
 }
-html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus ~ .dnb-radio__button {
+.dnb-radio__input:not([disabled]):not(:checked):not([data-checked=true]):focus-visible ~ .dnb-radio__button {
   background-color: var(--radio-color-background-off--focus);
 }
 .dnb-radio {

--- a/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-sbanken.scss
@@ -34,8 +34,7 @@
       color: var(--sb-color-gray-dark);
     }
 
-    html[data-whatinput='keyboard']
-      &:not([disabled]):not(:active):not(:hover):focus {
+    &:not([disabled]):not(:active):not(:hover):focus-visible {
       .dnb-radio {
         &__button {
           background-color: transparent;
@@ -93,8 +92,9 @@
       color: var(--sb-color-violet-light-3);
     }
 
-    html[data-whatinput='keyboard']
-      &:not([disabled]):not(:active):not(:hover):focus {
+    // Use :focus to match the specificity of the UI theme's
+    // &--checked &__button:focus parent selector
+    &:focus:not([disabled]):not(:active):not(:hover):focus-visible {
       color: var(--sb-color-blue-dark-2);
       background-color: var(--sb-color-blue-light-2);
     }

--- a/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-ui.scss
@@ -51,7 +51,7 @@
         }
       }
     }
-    html[data-whatinput='keyboard'] &:not([disabled]):not(:hover):focus {
+    &:not([disabled]):not(:hover):focus-visible {
       .dnb-radio {
         &__button {
           @include utilities.fakeBorder(
@@ -82,7 +82,7 @@
         }
       }
     }
-    html[data-whatinput='keyboard'] &:not([disabled]):not(:hover):focus {
+    &:not([disabled]):not(:hover):focus-visible {
       .dnb-checkbox {
         &__button {
           background-color: var(--color-emerald-green);
@@ -100,8 +100,7 @@
       }
     }
 
-    html[data-whatinput='keyboard']
-      &:not([disabled]):not(:active):not(:hover):focus {
+    &:not([disabled]):not(:active):not(:hover):focus-visible {
       color: var(--color-emerald-green);
       background-color: var(--color-mint-green);
       @include utilities.focusRing(

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -450,26 +450,23 @@ button .dnb-form-status__text {
   text-align: inherit;
   line-height: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover[disabled] {
-  cursor: not-allowed;
+@media (hover: hover) {
+  .dnb-button--reset:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-button--reset:hover:not([disabled]) {
+    box-shadow: none;
+    border: none;
+  }
 }
-html:not([data-whatintent=touch]) .dnb-button--reset:hover:not([disabled]) {
-  box-shadow: none;
-  border: none;
-}
-.dnb-button--reset:not([disabled]):focus, .dnb-button--reset:not([disabled]):active {
+.dnb-button--reset:not([disabled]):focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):active {
+html[data-whatinput=keyboard] .dnb-button--reset:not([disabled]):focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-}
-html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):focus, html[data-whatinput=mouse] .dnb-button--reset:not([disabled]):active {
-  box-shadow: none;
-  color: inherit;
-  border: none;
 }
 .dnb-button[type=button], .dnb-button[type=reset], .dnb-button[type=submit] {
   appearance: none;

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
@@ -37,8 +37,7 @@
           // Remove original border outline
           &,
           &:hover,
-          &:focus-within,
-          html[data-whatinput='keyboard'] &:focus-within {
+          &:focus-within {
             box-shadow: none;
           }
         }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -461,10 +461,10 @@ exports[`DrawerList scss have to match default theme snapshot 1`] = `
   background-color: var(--color-white);
   border-radius: calc(var(--drawer-list-options-border-radius) + 0.15rem);
 }
-.dnb-drawer-list__options:focus {
+.dnb-drawer-list__options:focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__options:focus {
+html[data-whatinput=keyboard] .dnb-drawer-list__options:focus-visible {
   --border-color: var(--focus-ring-color);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
@@ -502,20 +502,22 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
 .dnb-drawer-list__option__item.item-nr-1 {
   font-weight: var(--font-weight-medium);
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover[disabled] {
+@media (hover: hover) {
+  .dnb-drawer-list__option:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-drawer-list__option:hover:not([disabled]) {
+    background-color: var(--color-mint-green-12);
+  }
+  .dnb-drawer-list__option:hover:not([disabled]) .dnb-drawer-list__option__inner {
+    color: var(--color-sea-green);
+    background-color: var(--color-mint-green-12);
+  }
+}
+.dnb-drawer-list__option:active[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled]) {
-  background-color: var(--color-mint-green-12);
-}
-html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled]) .dnb-drawer-list__option__inner {
-  color: var(--color-sea-green);
-  background-color: var(--color-mint-green-12);
-}
-.dnb-drawer-list__option:active[disabled], html:not([data-whatintent=touch]) .dnb-drawer-list__option:active[disabled] {
-  cursor: not-allowed;
-}
-.dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option__inner, html:not([data-whatintent=touch]) .dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option__inner {
+.dnb-drawer-list__option:active:not([disabled]) .dnb-drawer-list__option__inner {
   color: var(--color-black);
 }
 .dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
@@ -543,16 +545,18 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
   color: inherit;
   background-color: inherit;
 }
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover[disabled] {
-  cursor: not-allowed;
-}
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) {
-  color: var(--color-white);
-  background-color: var(--color-emerald-green);
-}
-html:not([data-whatintent=touch]) .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) .dnb-drawer-list__option__inner {
-  color: inherit;
-  background-color: inherit;
+@media (hover: hover) {
+  .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover[disabled] {
+    cursor: not-allowed;
+  }
+  .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) {
+    color: var(--color-white);
+    background-color: var(--color-emerald-green);
+  }
+  .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner:hover:not([disabled]) .dnb-drawer-list__option__inner {
+    color: inherit;
+    background-color: inherit;
+  }
 }
 .dnb-drawer-list__option--selected .dnb-drawer-list__option__inner::after {
   content: "";
@@ -591,10 +595,10 @@ html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list
 .dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   content: none;
 }
-.dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
+.dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus-visible {
   outline: none;
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus {
+html[data-whatinput=keyboard] .dnb-drawer-list__option--selected .dnb-drawer-list__option__item .dnb-anchor:focus-visible {
   --border-color: var(--color-white);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
@@ -28,7 +28,7 @@
       var(--drawer-list-options-border-radius) + 0.15rem
     );
 
-    &:focus {
+    &:focus-visible {
       @include utilities.focusRing();
     }
 
@@ -189,7 +189,7 @@
     }
 
     &--selected &__item {
-      .dnb-anchor:focus {
+      .dnb-anchor:focus-visible {
         @include utilities.focusRing(null, var(--color-white));
       }
     }

--- a/packages/dnb-eufemia/src/fragments/scroll-view/style/dnb-scroll-view.scss
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/style/dnb-scroll-view.scss
@@ -15,7 +15,7 @@
 
   // interactive prop
   &[tabindex='0'] {
-    &:focus {
+    &:focus-visible {
       outline: none;
 
       @include utilities.focusRing();

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -41,13 +41,38 @@ afterAll(() => {
 })
 
 describe('"isTouchDevice" should', () => {
-  it('return false if what-input did not run', () => {
+  it('return false if device has hover capability', () => {
     expect(isTouchDevice()).toBe(false)
   })
-  it('return true if device is touch', () => {
-    document.documentElement.setAttribute('data-whatintent', 'touch')
+  it('return true if device has no hover capability', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: query === '(hover: none)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
     expect(isTouchDevice()).toBe(true)
-    document.documentElement.removeAttribute('data-whatintent')
+    // restore default matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -5,11 +5,11 @@
 
 import React from 'react'
 
-import whatInput from 'what-input'
 import { warn } from './helpers'
 import { getClosestParent } from './helpers/getClosest'
 import { init } from './Eufemia'
 import { defineNavigator } from './legacy/component-helper-legacy'
+import { initInputTracker } from './helpers/inputTracker'
 
 export * from './legacy/component-helper-legacy'
 export { InteractionInvalidation } from './helpers/InteractionInvalidation'
@@ -25,7 +25,7 @@ export { getClosestParent, warn }
 init()
 
 // run component helper functions
-whatInput.specificKeys([9])
+initInputTracker()
 defineNavigator()
 
 /** @private */

--- a/packages/dnb-eufemia/src/shared/helpers/inputTracker.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/inputTracker.ts
@@ -1,0 +1,35 @@
+/**
+ * Lightweight replacement for `what-input`.
+ *
+ * Sets `data-whatinput` on `<html>` to `'keyboard'`, `'mouse'`, or `'touch'`
+ * based on the most recent user interaction.
+ *
+ * Only the Tab key triggers `'keyboard'` – other key presses are ignored
+ * so that typing inside a text field does not flip the state.
+ */
+
+let currentInput: string | undefined
+
+function onPointerDown(e: PointerEvent) {
+  const next = e.pointerType === 'touch' ? 'touch' : 'mouse'
+  if (currentInput !== next) {
+    currentInput = next
+    document.documentElement.setAttribute('data-whatinput', next)
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.key === 'Tab' && currentInput !== 'keyboard') {
+    currentInput = 'keyboard'
+    document.documentElement.setAttribute('data-whatinput', 'keyboard')
+  }
+}
+
+export function initInputTracker() {
+  if (typeof document === 'undefined') {
+    return // stop here
+  }
+
+  document.addEventListener('pointerdown', onPointerDown, true)
+  document.addEventListener('keydown', onKeyDown, true)
+}

--- a/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
+++ b/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
@@ -16,14 +16,11 @@ import {
  * Check if device is touch device or not
  */
 export function isTouchDevice() {
-  if (typeof document !== 'undefined') {
-    let intent: string | null = null
-    try {
-      intent = document.documentElement.getAttribute('data-whatintent')
-    } catch (e) {
-      //
-    }
-    return intent === 'touch'
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function'
+  ) {
+    return window.matchMedia('(hover: none)').matches
   }
   return false
 }

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -14,16 +14,16 @@
 .dnb-tab-focus {
   outline: none;
 
-  &:focus {
-    @include utilities.focusRing('keyboard');
+  &:focus-visible {
+    @include utilities.focusRing();
   }
 }
 
 .dnb-mouse-focus {
   outline: none;
 
-  &:focus {
-    @include utilities.focusRing('mouse');
+  &:focus:not(:focus-visible) {
+    @include utilities.focusRing();
   }
 }
 

--- a/packages/dnb-eufemia/src/style/core/helper-classes/skip-link.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/skip-link.scss
@@ -54,8 +54,6 @@
     border-radius: 1.5rem; // same as anchor
 
     background-color: var(--skip-link-background);
-
-    @include utilities.focusRing('mouse');
   }
 
   &:hover::before {
@@ -65,8 +63,13 @@
     background-color: var(--skip-link-background--active);
   }
 
-  // focus
-  &:focus:not(:active)::before {
+  // Focus ring on mouse/touch focus
+  &:focus:not(:focus-visible)::before {
+    @include utilities.focusRing();
+  }
+
+  // Focus ring on keyboard focus (not during active)
+  &:focus-visible:not(:active)::before {
     @include utilities.focusRing();
   }
 
@@ -107,6 +110,8 @@
 .dnb-skip-link:focus {
   @include skipLink();
 }
-html[data-whatintent='touch'] .dnb-skip-link {
-  display: none;
+@media (hover: none) {
+  .dnb-skip-link {
+    display: none;
+  }
 }

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -16,22 +16,20 @@
   box-shadow: var(--shadow-sharp);
 }
 
-// Uses html:not([data-whatintent='touch'] )
-// classes on <html> element
-// based on js touch device test
 @mixin hover() {
-  html:not([data-whatintent='touch']) &:hover {
-    &[disabled] {
-      cursor: not-allowed;
-    }
-    &:not([disabled]) {
-      @content;
+  @media (hover: hover) {
+    &:hover {
+      &[disabled] {
+        cursor: not-allowed;
+      }
+      &:not([disabled]) {
+        @content;
+      }
     }
   }
 }
 @mixin active() {
-  &:active,
-  html:not([data-whatintent='touch']) &:active {
+  &:active {
     &[disabled] {
       cursor: not-allowed;
     }
@@ -43,7 +41,7 @@
 }
 
 @mixin focus-visible() {
-  html:not([data-whatintent='touch']) &:focus-visible {
+  &:focus-visible {
     &[disabled] {
       cursor: not-allowed;
     }
@@ -55,8 +53,7 @@
 }
 
 @mixin focus() {
-  &:focus,
-  html:not([data-whatintent='touch']) &:focus {
+  &:focus {
     &[disabled] {
       cursor: not-allowed;
     }
@@ -123,10 +120,10 @@
 
   @if $whatinput == null {
     box-shadow: $replace;
-  }
-
-  html[data-whatinput='#{$whatinput}'] & {
-    box-shadow: $replace;
+  } @else {
+    html[data-whatinput='#{$whatinput}'] & {
+      box-shadow: $replace;
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,7 +4485,6 @@ __metadata:
     tsdown: "npm:0.14.2"
     typescript: "npm:5.9.3"
     vd-tool: "npm:4.0.2"
-    what-input: "npm:5.2.12"
     zod: "npm:4.1.8"
   peerDependencies:
     "@types/react": ^19
@@ -36221,13 +36220,6 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: 10/eb16a58b3eb02bfb538c7716e28d7f601a03922e975c74007b41ba5926071ae70302d9acae9800fbd7ddd0c66a675b1069fc6ebb88123b87895a52882e2dc06a
-  languageName: node
-  linkType: hard
-
-"what-input@npm:5.2.12":
-  version: 5.2.12
-  resolution: "what-input@npm:5.2.12"
-  checksum: 10/eeda7ce832e0f02e20d0bc4c0540053b2fa3e2c8e9f9217e5506785860422b4a58b54ae65d16495d68d8cce415b27236c4f62ad058e131c14d4a5a56a9741e25
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Deploy preview: https://chore-remove-what-input.eufemia-e25.pages.dev/uilib/

Replace the what-input library (~3.5KB) with a lightweight
inputTracker utility (~35 lines) that sets data-whatinput on <html>.

CSS changes:
- Replace html[data-whatinput] selectors with :focus-visible for
  buttons, checkboxes, radios, switches, tabs, sliders, and other
  non-text-input components
- Replace html[data-whatintent] hover guards with @media (hover: hover)
- Keep html[data-whatinput='keyboard'] gating for text inputs, textareas,
  and drawer-list where :focus-visible cannot distinguish keyboard from
  mouse focus per CSS spec
- Remove @supports not selector(:focus-visible) fallbacks
- Remove deprecated whatInput()/whatInputNot() SCSS mixin wrappers

JS changes:
- Add src/shared/helpers/inputTracker.ts as a minimal what-input
  replacement (tracks pointer/keyboard via pointerdown and keydown)
- Remove what-input import and Tabs whatInput integration
- Update component-helper to initialize inputTracker on load

BREAKING CHANGE: Removes what-input npm dependency. Consumer code relying
on html[data-whatinput] or html[data-whatintent] attributes set by
what-input will need to provide its own input tracking.

