### PR TITLE
break(onChange)!: consolidate callback event properties to use `value`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -2,6 +2,10 @@
 
 - [Card](/uilib/components/card): changed default outline to `1px` with color `#ebebeb` and changed corner radius to `24px` and changed default inner spacing on all sides to `16px`.
 
+## March, 5. 2026
+
+- **Breaking:** Standardized `onChange` callback parameters across components to use `value` as the primary data property. Removed duplicate property names (`checked`, `expanded`, `pageNumber`, `key`, `currentStep`, `files`). Affected components: [Checkbox](/uilib/components/checkbox), [Switch](/uilib/components/switch), [Tabs](/uilib/components/tabs), [Pagination](/uilib/components/pagination), [Accordion](/uilib/components/accordion), [StepIndicator](/uilib/components/step-indicator), [Upload](/uilib/components/upload). A shared `ComponentChangeEvent` type is now available from `@dnb/eufemia` for type-safe event handling.
+
 ## January, 30. 2025
 
 - New component: [List](/uilib/components/list) for structured list layouts with items, navigation, accordion, and selection variants.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.tsx
@@ -20,7 +20,7 @@ export const CheckboxChecked = () => (
       label="Label"
       labelPosition="left"
       checked
-      onChange={({ checked }) => console.log(checked)}
+      onChange={({ value }) => console.log(value)}
     />
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.tsx
@@ -34,8 +34,8 @@ export const PaginationExampleDefault = () => (
     <Pagination
       pageCount={888}
       currentPage={4}
-      onChange={({ pageNumber }) => {
-        console.log('onChange:', pageNumber)
+      onChange={({ value }) => {
+        console.log('onChange:', value)
       }}
     >
       <P>Current Page Content</P>
@@ -48,8 +48,8 @@ export const PaginationExampleWithHorizontalLayout = () => (
     <Pagination
       pageCount={888}
       currentPage={4}
-      onChange={({ pageNumber }) => {
-        console.log('onChange:', pageNumber)
+      onChange={({ value }) => {
+        console.log('onChange:', value)
       }}
       paginationBarLayout="horizontal"
     >
@@ -63,8 +63,8 @@ export const PaginationExampleWithCallback = () => (
     <Pagination
       pageCount={5}
       startupPage={3}
-      onChange={({ pageNumber }) => {
-        console.log('onChange:', pageNumber)
+      onChange={({ value }) => {
+        console.log('onChange:', value)
       }}
     >
       {({ pageNumber }) => <P>Page {pageNumber}</P>}
@@ -169,19 +169,19 @@ export const InfinityPaginationTable = ({ tableItems, ...props }) => {
   let serverDelayTimeout
   React.useEffect(() => () => clearTimeout(serverDelayTimeout))
 
-  const action = ({ pageNumber }) => {
-    console.log('onChange: with page', pageNumber)
+  const action = ({ value }) => {
+    console.log('onChange: with page', value)
 
     // simulate server delay
     clearTimeout(serverDelayTimeout)
     serverDelayTimeout = setTimeout(
       () => {
-        if (pageNumber === currentPage) {
+        if (value === currentPage) {
           // once we set current page, we force a re-render, and sync of data
           // but only if we are on the same page
           forceRerender(new Date().getTime())
         } else {
-          setLocalPage(pageNumber)
+          setLocalPage(value)
         }
       },
       Math.ceil(Math.random() * 1e3)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/events.mdx
@@ -17,29 +17,29 @@ Events have several useful methods to change / manipulate the content.
 
 ```jsx
 <Pagination
-  onChange={({ pageNumber, ...methods }) => {
+  onChange={({ value, ...methods }) => {
     // ...
   }}
 />
 ```
 
-- `pageNumber` the current page number
-- `setContent` use it to add update a page including content: `setContent(pageNumber, ReactComponent)`
+- `value` the current page number
+- `setContent` use it to add update a page including content: `setContent(value, ReactComponent)`
 
 ### Infinity mode
 
 ```jsx
 <Pagination
   mode="infinity"
-  onChange={({ pageNumber, ...methods }) => {
+  onChange={({ value, ...methods }) => {
     // ...
   }}
 />
 ```
 
-- `pageNumber` the current page number
-- `setContent` use it to add update a page including content: `setContent(pageNumber, ReactComponent, position = 'after')`
-- `endInfinity` use it to tell the infinity pagination to end the infinity scrolling interaction. Use this handler to end the infinity scrolling procedure, in case the pageCount is unknown: `endInfinity(pageNumber)`
+- `value` the current page number
+- `setContent` use it to add update a page including content: `setContent(value, ReactComponent, position = 'after')`
+- `endInfinity` use it to tell the infinity pagination to end the infinity scrolling interaction. Use this handler to end the infinity scrolling procedure, in case the pageCount is unknown: `endInfinity(value)`
 - `resetContent` use it to invalidate all internal pages: `resetContent()`
 - `resetInfinity` use it to reset the internal pagination states: `resetInfinity(pageNumber = startupPage)`
 - `items` internal stored pages

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
@@ -98,10 +98,7 @@ export const PaginationExampleInfinityIndicator = () => (
           return () => clearTimeout(timeout)
         }}
         onEnd={({ value, setContent }) => {
-          setContent(
-            value,
-            <LargePage color="lightgreen">End</LargePage>
-          )
+          setContent(value, <LargePage color="lightgreen">End</LargePage>)
         }}
       />
     </HeightLimit>
@@ -131,10 +128,7 @@ export const PaginationExampleInfinityUnknown = () => (
           return () => clearTimeout(timeout)
         }}
         onEnd={({ value, setContent }) => {
-          setContent(
-            value,
-            <LargePage color="lightgreen">End</LargePage>
-          )
+          setContent(value, <LargePage color="lightgreen">End</LargePage>)
         }}
       />
     </HeightLimit>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
@@ -59,11 +59,11 @@ export const PaginationExampleInfinityLoadButton = () => (
         useLoadButton
         startupPage={5}
         minWaitTime={0}
-        onLoad={({ pageNumber, setContent }) => {
+        onLoad={({ value, setContent }) => {
           // simulate server communication delay
           const timeout = setTimeout(
             () => {
-              setContent(pageNumber, <LargePage>{pageNumber}</LargePage>)
+              setContent(value, <LargePage>{value}</LargePage>)
             },
             Math.ceil(Math.random() * 500)
           )
@@ -86,20 +86,20 @@ export const PaginationExampleInfinityIndicator = () => (
         startupPage={3}
         pageCount={10}
         minWaitTime={0}
-        onLoad={({ pageNumber, setContent }) => {
+        onLoad={({ value, setContent }) => {
           // simulate server communication delay
           const timeout = setTimeout(
             () => {
-              setContent(pageNumber, <LargePage>{pageNumber}</LargePage>)
+              setContent(value, <LargePage>{value}</LargePage>)
             },
             Math.ceil(Math.random() * 500)
           )
 
           return () => clearTimeout(timeout)
         }}
-        onEnd={({ pageNumber, setContent }) => {
+        onEnd={({ value, setContent }) => {
           setContent(
-            pageNumber,
+            value,
             <LargePage color="lightgreen">End</LargePage>
           )
         }}
@@ -115,14 +115,14 @@ export const PaginationExampleInfinityUnknown = () => (
         mode="infinity"
         parallelLoadCount={2}
         minWaitTime={0}
-        onLoad={({ pageNumber, setContent, endInfinity }) => {
+        onLoad={({ value, setContent, endInfinity }) => {
           // simulate server communication delay
           const timeout = setTimeout(
             () => {
-              if (pageNumber > 10) {
+              if (value > 10) {
                 endInfinity()
               } else {
-                setContent(pageNumber, <LargePage>{pageNumber}</LargePage>)
+                setContent(value, <LargePage>{value}</LargePage>)
               }
             },
             Math.ceil(Math.random() * 1e3)
@@ -130,9 +130,9 @@ export const PaginationExampleInfinityUnknown = () => (
 
           return () => clearTimeout(timeout)
         }}
-        onEnd={({ pageNumber, setContent }) => {
+        onEnd={({ value, setContent }) => {
           setContent(
-            pageNumber,
+            value,
             <LargePage color="lightgreen">End</LargePage>
           )
         }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/info.mdx
@@ -71,8 +71,8 @@ import { Pagination } from '@dnb/eufemia/components'
 render(
   <Pagination
     mode="infinity"
-    onChange={({ pageNumber, setContent }) => {
-      setContent(pageNumber, ReactComponent)
+    onChange={({ value, setContent }) => {
+      setContent(value, ReactComponent)
     }}
   />
 )
@@ -95,8 +95,8 @@ React.useEffect(() => {
 render(
   <InfinityScroller
     setContentHandler={(fn) => (setContent = fn)}
-    onChange={({ pageNumber }) => {
-      setLocalPage(pageNumber)
+    onChange={({ value }) => {
+      setLocalPage(value)
     }}
   />
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.mdx
@@ -78,8 +78,8 @@ import { Pagination } from '@dnb/eufemia/components'
 render(
   <Pagination
     pageCount={2}
-    onChange={({ pageNumber, setContent }) => {
-      setContent(pageNumber, ReactComponent)
+    onChange={({ value, setContent }) => {
+      setContent(value, ReactComponent)
     }}
   />
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
@@ -12,8 +12,8 @@ export const StepIndicatorStatic = () => (
     <StepIndicator
       mode="static"
       currentStep={1}
-      onChange={({ currentStep }) => {
-        console.log('onChange', currentStep)
+      onChange={({ value }) => {
+        console.log('onChange', value)
       }}
       data={[
         {
@@ -21,7 +21,7 @@ export const StepIndicatorStatic = () => (
         },
         {
           title: 'Ditt lån og egenkapital',
-          onClick: ({ currentStep }) => console.log(currentStep),
+          onClick: ({ value }) => console.log(value),
         },
         {
           title: 'Oppsummering',
@@ -36,8 +36,8 @@ export const StepIndicatorStrict = () => (
     <StepIndicator
       mode="strict"
       currentStep={1}
-      onChange={({ currentStep }) => {
-        console.log('onChange', currentStep)
+      onChange={({ value }) => {
+        console.log('onChange', value)
       }}
       data={[
         {
@@ -45,8 +45,8 @@ export const StepIndicatorStrict = () => (
         },
         {
           title: 'Bestill eller erstatt',
-          onClick: ({ currentStep }) =>
-            console.log('currentStep:', currentStep),
+          onClick: ({ value }) =>
+            console.log('value:', value),
           status:
             'Du må velge bestill nytt kort eller erstatt kort for å kunne fullføre bestillingen din.',
         },
@@ -70,8 +70,8 @@ export const StepIndicatorLoose = () => (
               <StepIndicator
                 mode="loose"
                 currentStep={step}
-                onChange={({ currentStep }) => {
-                  setStep(currentStep)
+                onChange={({ value }) => {
+                  setStep(value)
                 }}
                 data={[
                   'Cum odio si bolig bla et ta',
@@ -114,7 +114,7 @@ export const StepIndicatorCustomized = () => (
               mode="loose"
               data={data}
               currentStep={step}
-              onChange={({ currentStep }) => setStep(currentStep)}
+              onChange={({ value }) => setStep(value)}
               bottom
               {...props}
             />
@@ -187,8 +187,8 @@ export const StepIndicatorRouter = () => (
             <StepIndicator
               mode="loose"
               currentStep={currentStep - 1}
-              onChange={({ currentStep }) => {
-                const step = currentStep + 1
+              onChange={({ value }) => {
+                const step = value + 1
                 setCurrentStep(step)
                 window.history.pushState({}, '', '?' + step)
               }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
@@ -45,8 +45,7 @@ export const StepIndicatorStrict = () => (
         },
         {
           title: 'Bestill eller erstatt',
-          onClick: ({ value }) =>
-            console.log('value:', value),
+          onClick: ({ value }) => console.log('value:', value),
           status:
             'Du må velge bestill nytt kort eller erstatt kort for å kunne fullføre bestillingen din.',
         },

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.tsx
@@ -19,7 +19,7 @@ export const SwitchExampleChecked = () => (
       label="Label"
       labelPosition="left"
       checked
-      onChange={({ checked }) => console.log(checked)}
+      onChange={({ value }) => console.log(value)}
     />
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
@@ -274,7 +274,7 @@ export const TabsExampleReachRouterNavigation = () =>
                   { title: 'Topics', key: '/topics' },
                 ]}
                 selectedKey={pathname}
-                onChange={({ key }) => navigate(key)}
+                onChange={({ value }) => navigate(value)}
                 tabsStyle="info"
               >
                 <React.Suspense fallback={<em>Loading ...</em>}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/Examples.tsx
@@ -62,7 +62,7 @@ export const UploadBasic = () => (
   <ComponentBox data-visual-test="upload-basic">
     <Upload
       acceptedFileTypes={['jpg', 'png']}
-      onChange={({ files }) => console.log('onChange', files)}
+      onChange={({ value }) => console.log('onChange', value)}
     />
   </ComponentBox>
 )
@@ -72,7 +72,7 @@ export const UploadBasicCompactVariant = () => (
     <Upload
       variant="compact"
       acceptedFileTypes={['jpg', 'png']}
-      onChange={({ files }) => console.log('onChange', files)}
+      onChange={({ value }) => console.log('onChange', value)}
     />
   </ComponentBox>
 )
@@ -84,7 +84,7 @@ export const UploadCompactVariantWithoutLabels = () => (
       acceptedFileTypes={['jpg', 'png']}
       title={false}
       text={false}
-      onChange={({ files }) => console.log('onChange', files)}
+      onChange={({ value }) => console.log('onChange', value)}
     />
   </ComponentBox>
 )
@@ -94,7 +94,7 @@ export const UploadDisabled = () => (
     <Upload
       acceptedFileTypes={['jpg', 'png']}
       disabled
-      onChange={({ files }) => console.log('onChange', files)}
+      onChange={({ value }) => console.log('onChange', value)}
     />
   </ComponentBox>
 )
@@ -612,7 +612,7 @@ export const UploadDisabledDragAndDrop = () => (
     <Upload
       disableDragAndDrop
       acceptedFileTypes={['jpg', 'png']}
-      onChange={({ files }) => console.log('onChange', files)}
+      onChange={({ value }) => console.log('onChange', value)}
     />
   </ComponentBox>
 )
@@ -666,9 +666,9 @@ export const UploadDescription = () => (
           <Upload
             acceptedFileTypes={['jpg', 'png']}
             id="upload-description"
-            onChange={({ files }) =>
+            onChange={({ value }) =>
               setFiles(
-                files.map((fileItem) => {
+                value.map((fileItem) => {
                   return {
                     ...fileItem,
                     description: 'This is my description',
@@ -728,9 +728,9 @@ export const UploadRemoveDeleteButton = () => (
           <Upload
             acceptedFileTypes={['jpg', 'png']}
             id="upload-remove-delete-button"
-            onChange={({ files }) =>
+            onChange={({ value }) =>
               setFiles(
-                files.map((fileItem) => {
+                value.map((fileItem) => {
                   return {
                     ...fileItem,
                     deleteButtonProps: {

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -306,7 +306,7 @@ function Accordion({
     changeOpened(expanded)
 
     dispatchCustomElementEvent(thisInstance, 'onChange', {
-      expanded,
+      value: expanded,
       event,
     })
   }

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -158,7 +158,7 @@ export const AccordionProviderGroupProperties: PropertiesTableProps = {
 
 export const AccordionEvents: PropertiesTableProps = {
   onChange: {
-    doc: 'Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, event }`.',
+    doc: 'Will be called by user click interaction. Returns an object with a boolean `value` inside `{ value, event }`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -39,7 +39,7 @@ const AccordionGroup = (props: AccordionGroupProps) => {
   function onChangeHandler(event) {
     dispatchCustomElementEvent(thisInstance, 'onChange', {
       id: event.id,
-      expanded: event.expanded,
+      value: event.expanded,
       event,
     })
   }

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -53,12 +53,12 @@ describe('Accordion component', () => {
     fireEvent.click(document.querySelector('.dnb-accordion__header'))
 
     expect(myEvent.mock.calls.length).toBe(1)
-    expect(myEvent.mock.calls[0][0]).toHaveProperty('expanded')
-    expect(myEvent.mock.calls[0][0].expanded).toBe(true)
+    expect(myEvent.mock.calls[0][0]).toHaveProperty('value')
+    expect(myEvent.mock.calls[0][0].value).toBe(true)
 
     // second click
     fireEvent.click(document.querySelector('.dnb-accordion__header'))
-    expect(myEvent.mock.calls[1][0].expanded).toBe(false)
+    expect(myEvent.mock.calls[1][0].value).toBe(false)
   })
 
   it('uses a p element when string content is given', () => {

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -26,6 +26,7 @@ import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
 import useId from '../../shared/helpers/useId'
 import type { SpacingProps } from '../space/types'
+import type { ComponentChangeEvent } from '../../shared/types'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
 import type { FormStatusBaseProps } from '../FormStatus'
@@ -37,10 +38,10 @@ import CheckIcon from './CheckIcon'
 
 export type CheckboxLabelPosition = 'left' | 'right'
 export type CheckboxSize = 'default' | 'medium' | 'large'
-export type OnChangeParams = {
-  checked: boolean
-  event: React.ChangeEvent<HTMLInputElement>
-}
+export type OnChangeParams = ComponentChangeEvent<
+  boolean,
+  { event: React.ChangeEvent<HTMLInputElement> }
+>
 export type OnClickParams = React.MouseEvent<HTMLInputElement> & {
   checked: boolean
   event: React.MouseEvent<HTMLInputElement>
@@ -200,7 +201,7 @@ function Checkbox(localProps: CheckboxProps) {
 
       isCheckedRef.current = updatedCheck
       forceUpdate()
-      callOnChange({ checked: updatedCheck, event })
+      callOnChange({ value: updatedCheck, event })
 
       // help firefox and safari to have a correct state after a click
       if (ref.current) {

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -81,7 +81,7 @@ export const CheckboxProperties: PropertiesTableProps = {
 export const CheckboxEvents: PropertiesTableProps = {
   onChange: {
     doc: 'Will be called on state changes made by the user.',
-    type: '({ checked: boolean; event: ChangeEvent }) => void',
+    type: '({ value: boolean; event: ChangeEvent }) => void',
     status: 'optional',
   },
   onClick: {

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -53,7 +53,7 @@ describe('Checkbox component', () => {
     )
   })
 
-  it('should return "checked" and "event" from onChange event', async () => {
+  it('should return "value" and "event" from onChange event', async () => {
     const onChange = jest.fn()
     render(<Checkbox onChange={onChange} value="foo" />)
 
@@ -63,7 +63,7 @@ describe('Checkbox component', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        checked: true,
+        value: true,
         event: expect.objectContaining({
           target: expect.objectContaining({ value: 'foo' }),
         }),
@@ -215,8 +215,8 @@ describe('Checkbox component', () => {
     screen.getByRole('checkbox').click()
 
     expect(myEvent.mock.calls.length).toBe(1)
-    expect(myEvent.mock.calls[0][0]).toHaveProperty('checked')
-    expect(myEvent.mock.calls[0][0].checked).toBe(true)
+    expect(myEvent.mock.calls[0][0]).toHaveProperty('value')
+    expect(myEvent.mock.calls[0][0].value).toBe(true)
   })
 
   describe('controlled vs uncontrolled', () => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -150,8 +150,8 @@ function DatePickerProvider(props: DatePickerProviderProps) {
       // Handle range props
       if (range) {
         const formattedStartDate = startDateIsValid
-            ? format(startDate, returnFormat)
-            : null
+          ? format(startDate, returnFormat)
+          : null
         return {
           ...returnObject,
           daysBetween:

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -149,15 +149,16 @@ function DatePickerProvider(props: DatePickerProviderProps) {
 
       // Handle range props
       if (range) {
+        const formattedStartDate = startDateIsValid
+            ? format(startDate, returnFormat)
+            : null
         return {
           ...returnObject,
           daysBetween:
             startDateIsValid && endDateIsValid
               ? differenceInCalendarDays(endDate, startDate)
               : null,
-          startDate: startDateIsValid
-            ? format(startDate, returnFormat)
-            : null,
+          startDate: formattedStartDate,
           endDate: endDateIsValid ? format(endDate, returnFormat) : null,
           isValidStartDate:
             hasMinOrMaxDates &&

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -87,7 +87,7 @@ export type LoadButtonProps =
     }
 
 export type PaginationEvent = {
-  pageNumber: number
+  value: number
   setContent: (...args: unknown[]) => void
   endInfinity: () => void
   event?: React.SyntheticEvent

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -148,7 +148,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
     updatePageContent(currentPageInternal)
 
     dispatchCustomElementEvent(props, 'onChange', {
-      pageNumber: currentPageInternal,
+      value: currentPageInternal,
       ...props,
       event,
     })

--- a/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
@@ -160,7 +160,7 @@ export const PaginationProperties: PropertiesTableProps = {
 
 export const PaginationEvents: PropertiesTableProps = {
   onChange: {
-    doc: 'Will be called for every page change, regardless if the mode is `mode="infinity"` or not. Returns an object with number of useful properties and methods. See below for more details.',
+    doc: 'Will be called for every page change, regardless if the mode is `mode="infinity"` or not. Returns an object with `value` (the current page number) and other useful properties and methods. See below for more details.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.tsx
@@ -159,7 +159,7 @@ export default class InfinityScroller extends React.PureComponent<any> {
             pageNumber = 1
           }
           const ret = dispatchCustomElementEvent(context, eventName, {
-            pageNumber,
+            value: pageNumber,
             ...context,
           })
 

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -256,11 +256,11 @@ describe('Pagination bar', () => {
 
     fireEvent.click(nextButton)
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange.mock.calls[0][0].pageNumber).toBe(16)
+    expect(onChange.mock.calls[0][0].value).toBe(16)
 
     fireEvent.click(nextButton)
     expect(onChange).toHaveBeenCalledTimes(2)
-    expect(onChange.mock.calls[1][0].pageNumber).toBe(17)
+    expect(onChange.mock.calls[1][0].value).toBe(17)
   })
 })
 
@@ -289,8 +289,8 @@ describe('Infinity scroller', () => {
   }
 
   it('should load pages with intersection observer (after)', async () => {
-    const action = ({ pageNumber, setContent }) => {
-      setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)
+    const action = ({ value, setContent }) => {
+      setContent(value, <PageItem>{value}</PageItem>)
     }
 
     const onEnd = jest.fn()
@@ -413,10 +413,10 @@ describe('Infinity scroller', () => {
         })
       const items = Object.values(localStack.current)
 
-      const action = ({ pageNumber }) => {
-        setCurrentPage(pageNumber)
+      const action = ({ value }) => {
+        setCurrentPage(value)
 
-        if (pageNumber === 1) {
+        if (value === 1) {
           endInfinity()
         }
       }
@@ -556,8 +556,8 @@ describe('Infinity scroller', () => {
   })
 
   it('should load pages with load more button (before)', async () => {
-    const action = ({ pageNumber, setContent }) => {
-      setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)
+    const action = ({ value, setContent }) => {
+      setContent(value, <PageItem>{value}</PageItem>)
     }
 
     const onStartup = jest.fn(action)
@@ -733,10 +733,10 @@ describe('Infinity scroller', () => {
 
       resetInfinityHandler = resetInfinity
 
-      const action = ({ pageNumber }) => {
-        setCurrentPage(pageNumber)
+      const action = ({ value }) => {
+        setCurrentPage(value)
 
-        if (pageNumber === 1) {
+        if (value === 1) {
           endInfinity()
         }
       }
@@ -820,8 +820,8 @@ describe('Infinity scroller', () => {
   })
 
   it('should forward load button props', async () => {
-    const action = ({ pageNumber, setContent }) => {
-      setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)
+    const action = ({ value, setContent }) => {
+      setContent(value, <PageItem>{value}</PageItem>)
     }
 
     const onStartup = jest.fn(action)
@@ -847,8 +847,8 @@ describe('Infinity scroller', () => {
   })
 
   it('should accept custom component as value for loadButton', async () => {
-    const action = ({ pageNumber, setContent }) => {
-      setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)
+    const action = ({ value, setContent }) => {
+      setContent(value, <PageItem>{value}</PageItem>)
     }
 
     const onStartup = jest.fn(action)

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -15,7 +15,7 @@ import StepIndicatorContext, {
   StepIndicatorProvider,
 } from './StepIndicatorContext'
 
-import type { SpacingProps } from '../../shared/types'
+import type { SpacingProps, ComponentChangeEvent } from '../../shared/types'
 import type { SkeletonShow } from '../Skeleton'
 import type { StepIndicatorItemProps } from './StepIndicatorItem'
 import { stepIndicatorDefaultProps } from './StepIndicatorProps'
@@ -37,11 +37,13 @@ export type StepIndicatorDataItem = Pick<
 >
 export type StepIndicatorData = string | string[] | StepIndicatorDataItem[]
 
-export type StepIndicatorMouseEvent = {
-  event: React.MouseEvent<HTMLButtonElement>
-  item: StepIndicatorItemProps
-  currentStep: number
-}
+export type StepIndicatorMouseEvent = ComponentChangeEvent<
+  number,
+  {
+    event: React.MouseEvent<HTMLButtonElement>
+    item: StepIndicatorItemProps
+  }
+>
 
 export type StepIndicatorProps = Omit<
   React.HTMLProps<HTMLAnchorElement>,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -15,7 +15,10 @@ import StepIndicatorContext, {
   StepIndicatorProvider,
 } from './StepIndicatorContext'
 
-import type { SpacingProps, ComponentChangeEvent } from '../../shared/types'
+import type {
+  SpacingProps,
+  ComponentChangeEvent,
+} from '../../shared/types'
 import type { SkeletonShow } from '../Skeleton'
 import type { StepIndicatorItemProps } from './StepIndicatorItem'
 import { stepIndicatorDefaultProps } from './StepIndicatorProps'
@@ -80,21 +83,13 @@ export type StepIndicatorProps = Omit<
      */
     hideNumbers?: boolean
     /**
-     * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ event, item, currentStep, currentStep }`.
+     * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ value, event, item }`.
      */
-    onClick?: ({
-      event,
-      item,
-      currentStep,
-    }: StepIndicatorMouseEvent) => void
+    onClick?: ({ event, item, value }: StepIndicatorMouseEvent) => void
     /**
-     * Will be called once the user visits actively a new step. Will be emitted only once. Returns an object `{ event, item, currentStep, currentStep }`.
+     * Will be called once the user visits actively a new step. Will be emitted only once. Returns an object `{ value, event, item }`.
      */
-    onChange?: ({
-      event,
-      item,
-      currentStep,
-    }: StepIndicatorMouseEvent) => void
+    onChange?: ({ event, item, value }: StepIndicatorMouseEvent) => void
     /**
      * Status text. Status is only shown if this prop has text. Defaults to `undefined`
      */

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -116,7 +116,7 @@ export const StepIndicatorStepProperties: PropertiesTableProps = {
 
 export const StepIndicatorStepEvents: PropertiesTableProps = {
   onClick: {
-    doc: \"Called when user clicks the step. Is called right before the main component's `onClick`. Receives parameter `{ value, event, item }`\",
+    doc: "Called when user clicks the step. Is called right before the main component's `onClick`. Receives parameter `{ value, event, item }`",
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -70,12 +70,12 @@ export const StepIndicatorProperties: PropertiesTableProps = {
 
 export const StepIndicatorEvents: PropertiesTableProps = {
   onClick: {
-    doc: 'Will be called when the user clicks on any clickable step in the list. Is called right before `onChange`. Receives parameter `{ event, item, currentStep, currentStep }`.',
+    doc: 'Will be called when the user clicks on any clickable step in the list. Is called right before `onChange`. Receives parameter `{ value, event, item }`.',
     type: 'function',
     status: 'optional',
   },
   onChange: {
-    doc: 'Will be called when the user changes step by clicking in the steps list (changing the `currentStep` property does not trigger the event). Receives parameter `{ event, item, currentStep, currentStep }`.',
+    doc: 'Will be called when the user changes step by clicking in the steps list (changing the `currentStep` property does not trigger the event). Receives parameter `{ value, event, item }`.',
     type: 'function',
     status: 'optional',
   },
@@ -116,7 +116,7 @@ export const StepIndicatorStepProperties: PropertiesTableProps = {
 
 export const StepIndicatorStepEvents: PropertiesTableProps = {
   onClick: {
-    doc: "Called when user clicks the step. Is called right before the main component's `onClick`. Receives parameter `{ event, item, currentStep, currentStep }`",
+    doc: \"Called when user clicks the step. Is called right before the main component's `onClick`. Receives parameter `{ value, event, item }`\",
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -52,9 +52,9 @@ export type StepIndicatorItemProps = Omit<
    */
   statusState?: StepIndicatorStatusState
   /**
-   * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ event, item, currentStep }`.
+   * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ value, event, item }`.
    */
-  onClick?: ({ event, item, currentStep }: StepIndicatorMouseEvent) => void
+  onClick?: ({ event, item, value }: StepIndicatorMouseEvent) => void
   currentItemNum: number
 }
 

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -86,9 +86,9 @@ function StepIndicatorItem({
   const onClickHandler = useCallback(
     ({ event, item, currentItemNum }) => {
       const params = {
+        value: currentItemNum,
         event,
         item,
-        currentStep: currentItemNum,
       }
 
       const onClickItem = dispatchCustomElementEvent(

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -310,7 +310,7 @@ describe('StepIndicator in loose mode', () => {
     fireEvent.click(items[0].querySelector('button'))
 
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange.mock.calls[0][0].currentStep).toBe(0)
+    expect(onChange.mock.calls[0][0].value).toBe(0)
     expect(typeof onChange.mock.calls[0][0].event.preventDefault).toBe(
       'function'
     )

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -29,14 +29,15 @@ import FormStatus, { FormStatusBaseProps } from '../form-status/FormStatus'
 import useId from '../../shared/helpers/useId'
 import { SkeletonShow } from '../Skeleton'
 import { SpacingProps } from '../space/types'
+import type { ComponentChangeEvent } from '../../shared/types'
 
 export type SwitchLabelPosition = 'left' | 'right'
 export type SwitchSize = 'default' | 'medium' | 'large'
 export type SwitchAttributes = string | Record<string, unknown>
-export type SwitchOnChangeParams = {
-  checked: boolean
-  event: MouseEvent | TouchEvent | KeyboardEvent
-}
+export type SwitchOnChangeParams = ComponentChangeEvent<
+  boolean,
+  { event: MouseEvent | TouchEvent | KeyboardEvent }
+>
 export type SwitchOnClickParams = React.MouseEvent<HTMLInputElement> & {
   checked: boolean
   event: React.MouseEvent<HTMLInputElement>
@@ -168,8 +169,8 @@ export default function Switch(props: SwitchProps) {
   }, [checkedProp])
 
   const callOnChange = useCallback(
-    ({ checked, event }) => {
-      onChange?.({ checked, event })
+    ({ value, event }) => {
+      onChange?.({ value, event })
     },
     [onChange]
   )
@@ -184,14 +185,14 @@ export default function Switch(props: SwitchProps) {
 
       isCheckedRef.current = updatedChecked
       forceUpdate()
-      callOnChange({ checked: updatedChecked, event })
+      callOnChange({ value: updatedChecked, event })
 
       if (onChangeEnd) {
         if (event && event.persist) {
           event.persist()
         }
         setTimeout(
-          () => onChangeEnd({ checked: updatedChecked, event }),
+          () => onChangeEnd({ value: updatedChecked, event }),
           500
         )
       }

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -76,12 +76,12 @@ export const SwitchProperties: PropertiesTableProps = {
 export const SwitchEvents: PropertiesTableProps = {
   onChange: {
     doc: 'Will be called on state changes made by the user.',
-    type: '({ checked: boolean; event }) => void',
+    type: '({ value: boolean; event }) => void',
     status: 'optional',
   },
   onChangeEnd: {
-    doc: 'Will be called on state changes made by the user, but with a delay. This way the user sees the animation before e.g. an error will be removed. Returns a boolean { checked, event }.',
-    type: '({ checked: boolean; event }) => void',
+    doc: 'Will be called on state changes made by the user, but with a delay. This way the user sees the animation before e.g. an error will be removed.',
+    type: '({ value: boolean; event }) => void',
     status: 'optional',
   },
   onClick: {

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -45,8 +45,8 @@ describe('Switch component', () => {
     fireEvent.click(document.querySelector('input'))
 
     expect(myEvent.mock.calls.length).toBe(1)
-    expect(myEvent.mock.calls[0][0]).toHaveProperty('checked')
-    expect(myEvent.mock.calls[0][0].checked).toBe(true)
+    expect(myEvent.mock.calls[0][0]).toHaveProperty('value')
+    expect(myEvent.mock.calls[0][0].value).toBe(true)
   })
 
   it('does handle controlled vs uncontrolled state properly', () => {

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -942,7 +942,7 @@ export default class Tabs extends React.PureComponent<
         : selectedKey
 
     return {
-      key,
+      value: key,
       selectedKey,
       focusKey,
       title: this.getCurrentTitle(key),

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
@@ -13,7 +13,7 @@ import {
 import HeightAnimation from '../height-animation/HeightAnimation'
 
 type ContentWrapperState = {
-  key: string | number | null
+  value: string | number | null
 }
 
 type SharedState = SharedStateReturn<ContentWrapperState> & {
@@ -36,9 +36,9 @@ export default function ContentWrapper({
     if (id) {
       const shared = createSharedState(id) as unknown as SharedState
       sharedStateRef.current = shared
-      return shared.get() || { key: null }
+      return shared.get() || { value: null }
     }
-    return { key: null }
+    return { value: null }
   })
 
   useEffect(() => {
@@ -50,9 +50,9 @@ export default function ContentWrapper({
 
     const subscriber = () => {
       const params = sharedState.get()
-      if (params?.key !== undefined) {
+      if (params?.value !== undefined) {
         setState((prev) => {
-          if (params.key !== prev.key) {
+          if (params.value !== prev.value) {
             return params
           }
           return prev
@@ -74,9 +74,9 @@ export default function ContentWrapper({
 
   const params = { ...rest }
 
-  // Use state.key if available (when linked with shared state),
+  // Use state.value if available (when linked with shared state),
   // otherwise fall back to selectedKey prop
-  const activeKey = state.key !== null ? state.key : selectedKey
+  const activeKey = state.value !== null ? state.value : selectedKey
 
   if (activeKey) {
     params['aria-labelledby'] = combineLabelledBy(
@@ -100,9 +100,9 @@ export default function ContentWrapper({
 
   let content: React.ReactNode = children as React.ReactNode
   if (typeof children === 'function') {
-    // If state.key is null but we have an activeKey, create a proper state object
+    // If state.value is null but we have an activeKey, create a proper state object
     const stateToPass =
-      state.key !== null ? state : { ...state, key: activeKey }
+      state.value !== null ? state : { ...state, value: activeKey }
     content = children(stateToPass) as React.ReactNode
   }
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
@@ -131,7 +131,7 @@ export const TabsDataObject: PropertiesTableProps = {
 
 export const TabsEvents: PropertiesTableProps = {
   onChange: {
-    doc: '(preferred) this event gets triggered once the tab changes its selected key. Returns `{ key, selectedKey, focusKey, title, event }`.',
+    doc: '(preferred) this event gets triggered once the tab changes its selected key. Returns `{ value, selectedKey, focusKey, title, event }`.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -71,10 +71,12 @@ describe('Tabs component', () => {
     fireEvent.click(document.querySelectorAll('.dnb-tabs__button')[1])
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0].value).toBe('second')
 
     fireEvent.click(document.querySelectorAll('.dnb-tabs__button')[2])
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onClick).toHaveBeenCalledTimes(2)
+    expect(onChange.mock.calls[1][0].value).toBe('third')
 
     preventChange = true
 
@@ -514,11 +516,11 @@ describe('A single Tab component', () => {
         <>
           <Tabs id="linked" data={tablistData} {...props} />
           <Tabs.Content id="linked">
-            {({ key, title }) => {
-              testKey = key
+            {({ value, title }) => {
+              testKey = value
               testTitle = title
 
-              return key
+              return value
             }}
           </Tabs.Content>
         </>

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -126,7 +126,7 @@ const Upload = (localProps: UploadAllProps) => {
       setInternalFiles(mergedFiles)
 
       if (typeof onChange === 'function') {
-        onChange({ files: validFiles })
+        onChange({ value: validFiles })
       }
 
       return validFiles

--- a/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
@@ -148,7 +148,7 @@ export const AcceptedFileTypeProperties: PropertiesTableProps = {
 
 export const UploadEvents: PropertiesTableProps = {
   onChange: {
-    doc: 'Will be called on `files` changes made by the user. Access the files with `{ files }` (containing each a `fileItem`).',
+    doc: 'Will be called on file changes made by the user. Access the files with `{ value }` (an array of file items).',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileList.tsx
@@ -64,7 +64,7 @@ function UploadFileList() {
     setInternalFiles(updatedFiles)
 
     if (typeof onChange === 'function') {
-      onChange({ files: updatedFiles })
+      onChange({ value: updatedFiles })
     }
   }
 

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -1678,7 +1678,7 @@ describe('Upload', () => {
           <Upload
             acceptedFileTypes={['jpg', 'png']}
             id="upload-error-message"
-            onChange={({ files: internalFiles }) => {
+            onChange={({ value: internalFiles }) => {
               setFiles(
                 internalFiles.map((fileItem) => {
                   const fileNameTooBig = fileItem?.file?.name?.length > 5
@@ -1833,7 +1833,7 @@ describe('Upload', () => {
 
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(onChange).toHaveBeenCalledWith({
-        files: [{ file: file1, id: expect.any(String), exists: false }],
+        value: [{ file: file1, id: expect.any(String), exists: false }],
       })
 
       const deleteButton = screen.queryByRole('button', {
@@ -1843,7 +1843,7 @@ describe('Upload', () => {
       fireEvent.click(deleteButton)
 
       expect(onChange).toHaveBeenCalledTimes(2)
-      expect(onChange).toHaveBeenCalledWith({ files: [] })
+      expect(onChange).toHaveBeenLastCalledWith({ value: [] })
     })
 
     it('will call onFileClick when file gets clicked', async () => {

--- a/packages/dnb-eufemia/src/components/upload/types.ts
+++ b/packages/dnb-eufemia/src/components/upload/types.ts
@@ -53,7 +53,7 @@ export type UploadProps = {
   /**
    * will be called on `files` changes made by the user. Access the files with `{ files }`.
    */
-  onChange?: ({ files }: { files: Array<UploadFile> }) => void
+  onChange?: (args: { value: Array<UploadFile> }) => void
 
   /**
    * will be called once a file gets deleted by the user. Access the deleted file with `{ fileItem }`.

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -106,6 +106,12 @@ function Toggle(props: Props) {
   )
   const handleCheckboxChange = useCallback(
     (args: OnChangeParams) => {
+      handleChange?.(args.value ? valueOn : valueOff, args)
+    },
+    [handleChange, valueOn, valueOff]
+  )
+  const handleToggleButtonChange = useCallback(
+    (args: { checked: boolean; event: React.SyntheticEvent }) => {
       handleChange?.(args.checked ? valueOn : valueOff, args)
     },
     [handleChange, valueOn, valueOff]
@@ -118,7 +124,7 @@ function Toggle(props: Props) {
   )
   const handleSwitchChange = useCallback(
     (args: SwitchOnChangeParams) => {
-      handleChange?.(args.checked ? valueOn : valueOff, args)
+      handleChange?.(args.value ? valueOn : valueOff, args)
     },
     [handleChange, valueOn, valueOff]
   )
@@ -215,7 +221,7 @@ function Toggle(props: Props) {
             status={hasError ? 'error' : undefined}
             value={value ? 'true' : 'false'}
             size={size}
-            onChange={handleCheckboxChange}
+            onChange={handleToggleButtonChange}
             role="checkbox"
             {...htmlAttributes}
           />
@@ -301,7 +307,7 @@ function Toggle(props: Props) {
             status={hasError ? 'error' : undefined}
             value={value ? 'true' : 'false'}
             size={size}
-            onChange={handleCheckboxChange}
+            onChange={handleToggleButtonChange}
             role="checkbox"
             {...htmlAttributes}
           />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
@@ -382,8 +382,8 @@ function UploadComponent(props: Props) {
   )
 
   const changeHandler = useCallback(
-    ({ files }: { files: UploadValue }) => {
-      let changeValue = files?.length === 0 ? undefined : files
+    ({ value }: { value: UploadValue }) => {
+      let changeValue = value?.length === 0 ? undefined : value
 
       // Prevents the form-status from showing up
       handleBlur()

--- a/packages/dnb-eufemia/src/shared/types.tsx
+++ b/packages/dnb-eufemia/src/shared/types.tsx
@@ -59,10 +59,7 @@ export type DeepPartial<T> = T extends object
  * type OnChangeParams = ComponentChangeEvent<boolean, { event: React.ChangeEvent }>
  * // Result: { value: boolean; event: React.ChangeEvent }
  */
-export type ComponentChangeEvent<
-  V,
-  Extra = Record<never, never>,
-> = {
+export type ComponentChangeEvent<V, Extra = Record<never, never>> = {
   value: V
 } & Extra
 

--- a/packages/dnb-eufemia/src/shared/types.tsx
+++ b/packages/dnb-eufemia/src/shared/types.tsx
@@ -50,6 +50,22 @@ export type DeepPartial<T> = T extends object
     }
   : T
 
+/**
+ * Standard event callback parameter type for component onChange events.
+ * Enforces `value` as the primary data property across all components.
+ *
+ * @example
+ * // Simple usage:
+ * type OnChangeParams = ComponentChangeEvent<boolean, { event: React.ChangeEvent }>
+ * // Result: { value: boolean; event: React.ChangeEvent }
+ */
+export type ComponentChangeEvent<
+  V,
+  Extra = Record<never, never>,
+> = {
+  value: V
+} & Extra
+
 type IsAny<T> = 0 extends 1 & T ? true : false
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: onChange callbacks for Checkbox, Switch, Tabs,
Pagination, Accordion, StepIndicator, and Upload now use a unified
`value` property instead of component-specific names (`checked`,
`key`, `pageNumber`, `expanded`, `currentStep`, `files`).

- Add shared `ComponentChangeEvent<V, Extra>` type in shared/types.tsx
- Update source components to dispatch `{ value, ... }` in onChange
- Update Forms Toggle and Upload to consume `value` from callbacks
- Update all related tests, Docs.ts, Examples.tsx, and .mdx files
- Exclude DatePicker and ToggleButton from standardization