### PR TITLE
chore(Modal): remove internal isInTransition handling

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -183,11 +183,6 @@ class Modal extends React.PureComponent<ModalAllProps, ModalState> {
   }
 
   componentDidUpdate(prevProps) {
-    // Don't interfere if modal is currently transitioning, added to fix an issue with rapid state changes in React v19.
-    // Could be considered to be removed in the future, when Eufemia is using React v19.
-    if (this.isInTransition) {
-      return
-    }
     if (prevProps !== this.props) {
       this.openBasedOnStateUpdate()
     }


### PR DESCRIPTION
Not sure about this yet, will have to test.

Motivation is to check if we need the code we added in https://github.com/dnbexperience/eufemia/pull/5959, now that we use react v19. The test from https://github.com/dnbexperience/eufemia/pull/5959 is still intact.