### PR TITLE
fix(Stat.Info): change default variant from `'subtle'` to `'default'`

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/Info.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Info.tsx
@@ -17,7 +17,7 @@ function Info(props: InfoProps) {
     children,
     element: Element = 'span',
     className = null,
-    variant = 'subtle',
+    variant = 'default',
     ...rest
   } = props
 

--- a/packages/dnb-eufemia/src/components/stat/InfoDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/InfoDocs.ts
@@ -10,7 +10,7 @@ export const InfoProperties: PropertiesTableProps = {
   variant: {
     doc: 'Info color style variant.',
     type: ['"default"', '"subtle"', '"prominent"'],
-    defaultValue: 'subtle',
+    defaultValue: 'default',
     status: 'optional',
   },
   '[Space](/uilib/layout/space/properties)': spacingProperties,

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
@@ -12,18 +12,18 @@ describe('Stat.Info', () => {
     expect(info.tagName.toLowerCase()).toBe('span')
     expect(info.textContent).toBe('Some additional content')
     expect(info.classList).toContain('dnb-stat')
-    expect(info.classList).toContain('dnb-stat__info--subtle')
+    expect(info.classList).toContain('dnb-stat__info--default')
   })
 
-  it('supports default variant', () => {
+  it('supports subtle variant', () => {
     render(
-      <Stat.Info variant="default">Some additional content</Stat.Info>
+      <Stat.Info variant="subtle">Some additional content</Stat.Info>
     )
 
     const info = document.querySelector('.dnb-stat__info')
 
-    expect(info.classList).toContain('dnb-stat__info--default')
-    expect(info.classList).not.toContain('dnb-stat__info--subtle')
+    expect(info.classList).toContain('dnb-stat__info--subtle')
+    expect(info.classList).not.toContain('dnb-stat__info--default')
   })
 
   it('supports prominent variant', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
@@ -16,9 +16,7 @@ describe('Stat.Info', () => {
   })
 
   it('supports subtle variant', () => {
-    render(
-      <Stat.Info variant="subtle">Some additional content</Stat.Info>
-    )
+    render(<Stat.Info variant="subtle">Some additional content</Stat.Info>)
 
     const info = document.querySelector('.dnb-stat__info')
 


### PR DESCRIPTION
As of today the default value for variant is `subtle` and not `default`. 
I find it strange that the default value is not `default`.