### PR TITLE
feat(Stat.Root): add `tooltip` prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -1,3 +1,7 @@
+## March, 12. 2026
+
+- [Stat](/uilib/components/stat): Added `tooltip` prop to `Stat.Root` for showing additional context on hover.
+
 ## February, 27. 2026
 
 - New component: [Stat](/uilib/components/stat), including `Stat.Currency`, `Stat.Percent`, `Stat.Trend`, and `Stat.Label` for prominent metric formatting.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
@@ -234,6 +234,22 @@ export const RatingDefault = () => (
   </ComponentBox>
 )
 
+export const WithTooltip = () => (
+  <ComponentBox>
+    <Stat.Root tooltip="Revenue growth compared to previous fiscal quarter">
+      <Stat.Label>Revenue growth</Stat.Label>
+      <Stat.Content direction="vertical">
+        <Stat.Currency
+          value={1234}
+          signDisplay="always"
+          srLabel="Revenue"
+        />
+        <Stat.Trend srLabel="Change">+12.4%</Stat.Trend>
+      </Stat.Content>
+    </Stat.Root>
+  </ComponentBox>
+)
+
 export const WithSubtleLabel = () => (
   <ComponentBox
     data-visual-test="stat-content-label-order-subtle-label"

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/demos.mdx
@@ -44,6 +44,12 @@ You can use `mainSize` and `auxiliarySize` to adjust the relative size of the cu
 
 <Examples.RatingDefault />
 
+### With Tooltip
+
+Provide a `tooltip` prop on `Stat.Root` to show additional context on hover.
+
+<Examples.WithTooltip />
+
 ### With Subtle Label
 
 Also, the order of the content and label can be switched for visual users (not screen readers), and the label is styled with the `subtle` variant to further de-emphasize it.

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -47,9 +47,7 @@ function Root(props: RootProps) {
         {children}
       </Space>
 
-      {tooltip && (
-        <Tooltip targetElement={rootRef} tooltip={tooltip} />
-      )}
+      {tooltip && <Tooltip targetElement={rootRef} tooltip={tooltip} />}
     </StatRootContext.Provider>
   )
 }

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import classnames from 'classnames'
 import Space from '../space/Space'
+import Tooltip from '../tooltip/Tooltip'
 import type { SpacingProps } from '../../shared/types'
 import { warn } from '../../shared/component-helper'
 import StatRootContext from './StatRootContext'
@@ -9,6 +10,7 @@ export type RootProps = {
   children?: React.ReactNode
   className?: string
   visualOrder?: 'label-content' | 'content-label'
+  tooltip?: React.ReactNode
 } & SpacingProps
 
 function Root(props: RootProps) {
@@ -16,8 +18,11 @@ function Root(props: RootProps) {
     children,
     className = null,
     visualOrder = 'label-content',
+    tooltip = null,
     ...rest
   } = props
+
+  const rootRef = useRef<HTMLElement>(null)
 
   if (!hasOnlySupportedChildren(children)) {
     warn('Stat.Root should only contain Stat.Label and Stat.Content.')
@@ -30,6 +35,7 @@ function Root(props: RootProps) {
     <StatRootContext.Provider value={{ inRoot: true }}>
       <Space
         element="dl"
+        innerRef={rootRef}
         className={classnames(
           'dnb-stat',
           'dnb-stat__root',
@@ -40,6 +46,10 @@ function Root(props: RootProps) {
       >
         {children}
       </Space>
+
+      {tooltip && (
+        <Tooltip targetElement={rootRef} tooltip={tooltip} />
+      )}
     </StatRootContext.Provider>
   )
 }

--- a/packages/dnb-eufemia/src/components/stat/RootDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/RootDocs.ts
@@ -13,5 +13,10 @@ export const RootProperties: PropertiesTableProps = {
     defaultValue: 'label-content',
     status: 'optional',
   },
+  tooltip: {
+    doc: 'Tooltip content shown on hover. Uses the internal Tooltip component.',
+    type: ['React.ReactNode'],
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': spacingProperties,
 }

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Root.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Root.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { axeComponent } from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 
@@ -163,5 +163,39 @@ describe('Stat.Root', () => {
 
     expect(await axeComponent(component)).not.toHaveNoViolations()
     spy.mockRestore()
+  })
+
+  it('renders a tooltip when tooltip prop is provided', async () => {
+    render(
+      <Stat.Root tooltip="Additional details">
+        <Stat.Label>Revenue growth</Stat.Label>
+        <Stat.Content>
+          <Stat.Currency value={1234} />
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const root = document.querySelector('.dnb-stat__root')
+
+    fireEvent.mouseEnter(root)
+
+    await waitFor(() => {
+      const tooltip = document.querySelector('.dnb-tooltip')
+      expect(tooltip).toBeTruthy()
+    })
+  })
+
+  it('does not render a tooltip when tooltip prop is not provided', () => {
+    render(
+      <Stat.Root>
+        <Stat.Label>Revenue growth</Stat.Label>
+        <Stat.Content>
+          <Stat.Currency value={1234} />
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const tooltip = document.querySelector('.dnb-tooltip')
+    expect(tooltip).toBeNull()
   })
 })


### PR DESCRIPTION
Add support for showing a tooltip on hover via the `tooltip` prop on `Stat.Root`. Uses the internal Tooltip component with `targetElement` ref, rendered as a sibling to the `<dl>` to maintain valid HTML semantics.