### PR TITLE
feat(Forms): add visibleOnly option to useValidation hasErrors and hasFieldError

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
@@ -103,11 +103,7 @@ export function VisibleOnly() {
                   path="/showField"
                 />
 
-                <Form.Visibility
-                  pathTrue="/showField"
-                  keepInDOM
-                  animate
-                >
+                <Form.Visibility pathTrue="/showField" keepInDOM animate>
                   <Field.String
                     path="/conditionalField"
                     label="Conditional field"

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
@@ -103,7 +103,7 @@ export function VisibleOnly() {
                   path="/showField"
                 />
 
-                <Form.Visibility pathTrue="/showField" keepInDOM animate>
+                <Form.Visibility pathTrue="/showField" animate>
                   <Field.String
                     path="/conditionalField"
                     label="Conditional field"

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Form, Field, Tools } from '@dnb/eufemia/src/extensions/forms'
-import { Flex } from '@dnb/eufemia/src'
+import { Card, Flex } from '@dnb/eufemia/src'
 
 export function HasErrors() {
   return (
@@ -50,6 +50,76 @@ export function HasErrors() {
                     validateInitially
                   />
                 </Form.Visibility>
+              </Flex.Stack>
+            </Form.Handler>
+          )
+        }
+
+        return <Component />
+      }}
+    </ComponentBox>
+  )
+}
+
+export function VisibleOnly() {
+  return (
+    <ComponentBox>
+      {() => {
+        const Component = () => {
+          const { hasErrors, hasFieldError } =
+            Form.useValidation('visible-only-id')
+
+          return (
+            <Form.Handler id="visible-only-id">
+              <Flex.Stack>
+                <Card stack>
+                  <Tools.Log
+                    data={hasErrors()}
+                    label="hasErrors():"
+                    breakout={false}
+                  />
+                  <Tools.Log
+                    data={hasErrors({ visibleOnly: true })}
+                    label="hasErrors({ visibleOnly: true }):"
+                    breakout={false}
+                  />
+                  <Tools.Log
+                    data={hasFieldError('/conditionalField')}
+                    label="hasFieldError('/conditionalField'):"
+                    breakout={false}
+                  />
+                  <Tools.Log
+                    data={hasFieldError('/conditionalField', {
+                      visibleOnly: true,
+                    })}
+                    label="hasFieldError('/conditionalField', { visibleOnly: true }):"
+                    breakout={false}
+                  />
+                </Card>
+
+                <Field.Boolean
+                  label="Show conditional field"
+                  variant="button"
+                  path="/showField"
+                />
+
+                <Form.Visibility
+                  pathTrue="/showField"
+                  keepInDOM
+                  animate
+                >
+                  <Field.String
+                    path="/conditionalField"
+                    label="Conditional field"
+                    required
+                  />
+                </Form.Visibility>
+
+                <Field.String
+                  path="/alwaysVisible"
+                  label="Always visible field"
+                  required
+                />
               </Flex.Stack>
             </Form.Handler>
           )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/Examples.tsx
@@ -103,7 +103,7 @@ export function VisibleOnly() {
                   path="/showField"
                 />
 
-                <Form.Visibility pathTrue="/showField" animate>
+                <Form.Visibility pathTrue="/showField" keepInDOM animate>
                   <Field.String
                     path="/conditionalField"
                     label="Conditional field"

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/demos.mdx
@@ -13,3 +13,9 @@ import * as Examples from './Examples'
 ### Check for errors with hasErrors
 
 <Examples.HasErrors />
+
+### Check for visible errors only
+
+Use the `visibleOnly` option to ignore errors for fields hidden via `Form.Visibility` with `keepInDOM`. This is useful when conditionally visible fields should not block form submission or trigger error states.
+
+<Examples.VisibleOnly />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/info.mdx
@@ -20,6 +20,19 @@ The `Form.useValidation` lets you monitor and modify field status or your form e
 - `setFormError(error: Error | FormError | undefined)` - Report a form error.
 - `setFieldStatus(path: Path, status: EventStateObject)` - Show a field error.
 
+### The `visibleOnly` option
+
+When using `hasErrors({ visibleOnly: true })` or `hasFieldError(path, { visibleOnly: true })`, only errors from fields that are currently visible will be considered. This requires that [Form.Visibility](/uilib/extensions/forms/Form/Visibility/) has `keepInDOM` enabled. Without `keepInDOM`, hidden fields are unmounted entirely and already excluded from `hasErrors()` by default — making the `visibleOnly` option unnecessary.
+
+```jsx
+<Form.Visibility
+  visibleWhen={{ path: '/showField', hasValue: true }}
+  keepInDOM // Required for visibleOnly to work
+>
+  <Field.String path="/conditionalField" required />
+</Form.Visibility>
+```
+
 The `EventStateObject` is an object that can hold any of the following properties:
 
 ```ts

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation/info.mdx
@@ -15,8 +15,8 @@ The `Form.useValidation` lets you monitor and modify field status or your form e
 
 ## APIs
 
-- `hasErrors(): boolean` - True if any error is present.
-- `hasFieldError(path: Path): boolean` - True if the field has an error.
+- `hasErrors(options?): boolean` - True if any error is present. Pass `{ visibleOnly: true }` to only consider visible fields.
+- `hasFieldError(path: Path, options?): boolean` - True if the field has an error. Pass `{ visibleOnly: true }` to only consider visible fields.
 - `setFormError(error: Error | FormError | undefined)` - Report a form error.
 - `setFieldStatus(path: Path, status: EventStateObject)` - Show a field error.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -17,6 +17,7 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 ## v10.100.0
 
+- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered.
 - Added `totalSteps` in `onStepChange` options for [Wizard.Container](/uilib/extensions/forms/Wizard/Container/).
 
 ## v10.96.0

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -17,7 +17,7 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 ## v10.100.0
 
-- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered.
+- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered. Note: when used with `keepInDOM`, the value may be one render cycle behind due to React's top-down rendering order.
 - Added `totalSteps` in `onStepChange` options for [Wizard.Container](/uilib/extensions/forms/Wizard/Container/).
 
 ## v10.96.0

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -17,7 +17,7 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 ## v10.100.0
 
-- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered. Note: when used with `keepInDOM`, the value may be one render cycle behind due to React's top-down rendering order.
+- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered.
 - Added `totalSteps` in `onStepChange` options for [Wizard.Container](/uilib/extensions/forms/Wizard/Container/).
 
 ## v10.96.0

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -17,7 +17,7 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 ## v10.100.0
 
-- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered.
+- Added `visibleOnly` option to `hasErrors` and `hasFieldError` in [Form.useValidation](/uilib/extensions/forms/Form/useValidation/). When `{ visibleOnly: true }` is passed, only errors for visible fields are considered. Requires `keepInDOM` on [Form.Visibility](/uilib/extensions/forms/Form/Visibility/) to track visibility state. Without `keepInDOM`, hidden fields are unmounted and already excluded from `hasErrors()` by default.
 - Added `totalSteps` in `onStepChange` options for [Wizard.Container](/uilib/extensions/forms/Wizard/Container/).
 
 ## v10.96.0

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -24,6 +24,10 @@ export type SectionSchemaRegistration = {
   schema: Schema
 }
 
+export type HasErrorOptions = {
+  visibleOnly?: boolean
+}
+
 export type MountState = {
   isPreMounted?: boolean
   isMounted?: boolean
@@ -155,9 +159,9 @@ export interface ContextState {
   handleSubmit: () => Promise<EventStateObject | undefined>
   scrollToTop: () => void
   setShowAllErrors: (showAllErrors: boolean) => void
-  hasErrors: () => boolean
-  hasFieldState: (state: SubmitState) => boolean
-  hasFieldError: (path: Path) => boolean
+  hasErrors: (options?: HasErrorOptions) => boolean
+  hasFieldState: (state: SubmitState, options?: HasErrorOptions) => boolean
+  hasFieldError: (path: Path, options?: HasErrorOptions) => boolean
   hasFieldWithAsyncValidator?: () => boolean
   setFieldState?: (path: Path, fieldState: SubmitState) => void
   setFieldError?: (path: Path, error: Error | FormError) => void

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -422,6 +422,7 @@ export default function Provider<Data extends JsonObject>(
   const fieldStateRef = useRef<Record<Path, SubmitState>>({})
   const validationVersionRef = useRef(0)
   const bumpValidationVersionRef = useRef<() => void>(() => null)
+  const forceUpdateRef = useRef(forceUpdate)
 
   // - Data
   const initialData = useMemo<Data>(() => {
@@ -1260,6 +1261,15 @@ export default function Provider<Data extends JsonObject>(
         Promise.resolve().then(() => {
           bumpValidationVersionRef.current()
         })
+
+        if (
+          'isVisible' in state &&
+          currentState.isVisible !== state.isVisible
+        ) {
+          Promise.resolve().then(() => {
+            forceUpdateRef.current()
+          })
+        }
       }
 
       for (const itm of fieldEventListenersRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -422,7 +422,6 @@ export default function Provider<Data extends JsonObject>(
   const fieldStateRef = useRef<Record<Path, SubmitState>>({})
   const validationVersionRef = useRef(0)
   const bumpValidationVersionRef = useRef<() => void>(() => null)
-  const forceUpdateRef = useRef(forceUpdate)
 
   // - Data
   const initialData = useMemo<Data>(() => {
@@ -1261,15 +1260,6 @@ export default function Provider<Data extends JsonObject>(
         Promise.resolve().then(() => {
           bumpValidationVersionRef.current()
         })
-
-        if (
-          'isVisible' in state &&
-          currentState.isVisible !== state.isVisible
-        ) {
-          Promise.resolve().then(() => {
-            forceUpdateRef.current()
-          })
-        }
       }
 
       for (const itm of fieldEventListenersRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -422,6 +422,7 @@ export default function Provider<Data extends JsonObject>(
   const fieldStateRef = useRef<Record<Path, SubmitState>>({})
   const validationVersionRef = useRef(0)
   const bumpValidationVersionRef = useRef<() => void>(() => null)
+  const forceUpdateRef = useRef(forceUpdate)
 
   // - Data
   const initialData = useMemo<Data>(() => {
@@ -1260,6 +1261,15 @@ export default function Provider<Data extends JsonObject>(
         Promise.resolve().then(() => {
           bumpValidationVersionRef.current()
         })
+
+        const affectsErrors =
+          'isVisible' in state &&
+          currentState.isVisible !== state.isVisible
+        if (affectsErrors) {
+          Promise.resolve().then(() => {
+            forceUpdateRef.current()
+          })
+        }
       }
 
       for (const itm of fieldEventListenersRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -55,6 +55,7 @@ import DataContext, {
   ValueInternalsRef,
   FilterData,
   FilterDataHandler,
+  HasErrorOptions,
   MountState,
   TransformData,
   VisibleDataHandler,
@@ -558,32 +559,43 @@ export default function Provider<Data extends JsonObject>(
     []
   )
   const hasFieldState = useCallback(
-    (state: SubmitState) => {
+    (state: SubmitState, options?: HasErrorOptions) => {
       return Array.from(mountedFieldsRef.current.entries()).some(
         ([path, item]) => {
-          return item.isMounted && checkFieldStateFor(path, state)
+          if (!item.isMounted) {
+            return false
+          }
+          if (options?.visibleOnly && item.isVisible === false) {
+            return false
+          }
+          return checkFieldStateFor(path, state)
         }
       )
     },
     [checkFieldStateFor]
   )
   const hasFieldError = useCallback(
-    (path: Path) => {
+    (path: Path, options?: HasErrorOptions) => {
       return Array.from(mountedFieldsRef.current.entries()).some(
         ([p, item]) => {
-          return (
-            item.isMounted &&
-            p === path &&
-            checkFieldStateFor(path, 'error')
-          )
+          if (!item.isMounted || p !== path) {
+            return false
+          }
+          if (options?.visibleOnly && item.isVisible === false) {
+            return false
+          }
+          return checkFieldStateFor(path, 'error')
         }
       )
     },
     [checkFieldStateFor]
   )
-  const hasErrors = useCallback(() => {
-    return hasFieldState('error')
-  }, [hasFieldState])
+  const hasErrors = useCallback(
+    (options?: HasErrorOptions) => {
+      return hasFieldState('error', options)
+    },
+    [hasFieldState]
+  )
 
   /**
    * Sets the error state for a specific path

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -435,6 +435,7 @@ export function ConditionallyRequiredFields() {
             path: '/locale',
             hasValue: 'da-DK',
           }}
+          keepInDOM
         >
           <Field.Currency path="/amount" label="Amount" required />
         </Form.Visibility>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
-import { Field, Form } from '../../..'
+import { Field, Form, Tools } from '../../..'
 import { Button, GlobalStatus } from '../../../../../components'
 import { debounceAsync } from '../../../../../shared/helpers'
 
@@ -399,4 +399,66 @@ function UseValidationComponent() {
   }, [setFieldStatus])
 
   return null
+}
+
+export function ConditionallyRequiredFields() {
+  function MyComponent() {
+    useEffect(() => {
+      Form.setData('formId', {
+        some: 'data',
+        more: 'data',
+      })
+    }, [])
+
+    const { hasErrors } = Form.useValidation()
+    console.log('hasErrors (all):', hasErrors())
+    console.log(
+      'hasErrors (visible only):',
+      hasErrors({ visibleOnly: true })
+    )
+
+    return (
+      <>
+        <Field.String path="/otherData" />
+        <Field.Selection
+          path="/locale"
+          variant="button"
+          optionsLayout="horizontal"
+        >
+          <Field.Option value="nb-NO">Norsk</Field.Option>
+          <Field.Option value="sv-SE">Svenska</Field.Option>
+          <Field.Option value="da-DK">Dansk</Field.Option>
+          <Field.Option value="en-GB">English</Field.Option>
+        </Field.Selection>
+        <Form.Visibility
+          visibleWhen={{
+            path: '/locale',
+            hasValue: 'da-DK',
+          }}
+          keepInDOM
+        >
+          <Field.Currency path="/amount" label="Amount" required />
+        </Form.Visibility>
+        <Form.SubmitButton />
+      </>
+    )
+  }
+
+  return (
+    <Form.Handler
+      id="formId"
+      onSubmit={(data) => console.log(data)}
+      onSubmitRequest={({ getErrors }) => {
+        getErrors().forEach(({ path, error }) => {
+          if (error) {
+            console.log(path, error.message)
+          }
+        })
+      }}
+    >
+      <MyComponent />
+      <Tools.Log />
+      <Tools.Errors />
+    </Form.Handler>
+  )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { Field, Form, Tools } from '../../..'
 import { Button, GlobalStatus } from '../../../../../components'
 import { debounceAsync } from '../../../../../shared/helpers'

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -435,7 +435,6 @@ export function ConditionallyRequiredFields() {
             path: '/locale',
             hasValue: 'da-DK',
           }}
-          keepInDOM
         >
           <Field.Currency path="/amount" label="Amount" required />
         </Form.Visibility>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { Field, Form, Tools } from '../../..'
 import { Button, GlobalStatus } from '../../../../../components'
 import { debounceAsync } from '../../../../../shared/helpers'
@@ -411,11 +411,21 @@ export function ConditionallyRequiredFields() {
     }, [])
 
     const { hasErrors } = Form.useValidation()
-    console.log('hasErrors (all):', hasErrors())
-    console.log(
-      'hasErrors (visible only):',
-      hasErrors({ visibleOnly: true })
-    )
+    const all = hasErrors()
+    const visibleOnly = hasErrors({ visibleOnly: true })
+
+    // Deduplicate logs — the forceUpdate mechanism for visibleOnly
+    // causes an extra render when visibility changes, so we only
+    // log when actual values change.
+    const prevRef = useRef({ all: undefined, visibleOnly: undefined })
+    if (
+      prevRef.current.all !== all ||
+      prevRef.current.visibleOnly !== visibleOnly
+    ) {
+      prevRef.current = { all, visibleOnly }
+      console.log('hasErrors (all):', all)
+      console.log('hasErrors (visible only):', visibleOnly)
+    }
 
     return (
       <>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/stories/FormHandler.stories.tsx
@@ -414,18 +414,8 @@ export function ConditionallyRequiredFields() {
     const all = hasErrors()
     const visibleOnly = hasErrors({ visibleOnly: true })
 
-    // Deduplicate logs — the forceUpdate mechanism for visibleOnly
-    // causes an extra render when visibility changes, so we only
-    // log when actual values change.
-    const prevRef = useRef({ all: undefined, visibleOnly: undefined })
-    if (
-      prevRef.current.all !== all ||
-      prevRef.current.visibleOnly !== visibleOnly
-    ) {
-      prevRef.current = { all, visibleOnly }
-      console.log('hasErrors (all):', all)
-      console.log('hasErrors (visible only):', visibleOnly)
-    }
+    console.log('hasErrors (all):', all)
+    console.log('hasErrors (visible only):', visibleOnly)
 
     return (
       <>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -741,9 +741,13 @@ describe('useValidation', () => {
           )
         })
 
-        // The render log may have a one-render-cycle delay with keepInDOM
-        // because React renders parent before children update mountedFieldsRef.
-        // The correct value is always accessible via result.current (post-render).
+        // After all renders settle, render-body values should also be correct
+        await waitFor(() => {
+          const lastLog = renderLogs[renderLogs.length - 1]
+          expect(lastLog.all).toBe(true)
+          expect(lastLog.visibleOnly).toBe(false)
+        })
+
         expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -511,6 +511,117 @@ describe('useValidation', () => {
         expect(result.current.hasErrors()).toBe(false)
       })
     })
+
+    describe('visibleOnly', () => {
+      it('should return false when hidden field has error and visibleOnly is true', () => {
+        render(
+          <Form.Handler id={identifier}>
+            <Field.String path="/visible" required />
+            <Form.Visibility visible={false} keepInDOM>
+              <Field.String path="/hidden" required />
+            </Form.Visibility>
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+      })
+
+      it('should return false when only hidden fields have errors and visibleOnly is true', () => {
+        render(
+          <Form.Handler id={identifier} data={{ visible: 'has value' }}>
+            <Field.String path="/visible" required />
+            <Form.Visibility visible={false} keepInDOM>
+              <Field.String path="/hidden" required />
+            </Form.Visibility>
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
+
+      it('should return true without visibleOnly even when field is hidden with keepInDOM', () => {
+        render(
+          <Form.Handler id={identifier}>
+            <Form.Visibility visible={false} keepInDOM>
+              <Field.String path="/hidden" required />
+            </Form.Visibility>
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
+
+      it('should react to visibility changes with keepInDOM', async () => {
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+          return (
+            <>
+              <Form.Visibility visible={visible} keepInDOM>
+                <Field.String path="/conditional" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+        expect(result.current.hasErrors()).toBe(true)
+
+        await userEvent.click(
+          document.querySelector('button:last-of-type')
+        )
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+        expect(result.current.hasErrors()).toBe(true)
+      })
+
+      it('should work without an identifier', () => {
+        const result = { current: undefined }
+
+        const MockComponent = () => {
+          result.current = useValidation()
+
+          return (
+            <>
+              <Field.String path="/visible" required />
+              <Form.Visibility visible={false} keepInDOM>
+                <Field.String path="/hidden" required />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler data={{ visible: 'has value' }}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
+    })
   })
 
   describe('hasFieldError', () => {
@@ -526,6 +637,28 @@ describe('useValidation', () => {
 
       expect(result.current.hasFieldError('/foo')).toBe(true)
       expect(result.current.hasFieldError('/bar')).toBe(false)
+    })
+
+    it('should return false for hidden field when visibleOnly is true', () => {
+      render(
+        <Form.Handler id={identifier}>
+          <Field.String path="/foo" required />
+          <Form.Visibility visible={false} keepInDOM>
+            <Field.String path="/hidden" required />
+          </Form.Visibility>
+        </Form.Handler>
+      )
+
+      const { result } = renderHook(() => useValidation(identifier))
+
+      expect(result.current.hasFieldError('/foo')).toBe(true)
+      expect(result.current.hasFieldError('/hidden')).toBe(true)
+      expect(
+        result.current.hasFieldError('/hidden', { visibleOnly: true })
+      ).toBe(false)
+      expect(
+        result.current.hasFieldError('/foo', { visibleOnly: true })
+      ).toBe(true)
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -941,6 +941,227 @@ describe('useValidation', () => {
         })
         expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
+
+      it('should return false for visibleOnly after switching from visible to another selection with keepInDOM', async () => {
+        const renderLogs = []
+
+        const MockComponent = () => {
+          const { hasErrors } = useValidation()
+          renderLogs.push({
+            all: hasErrors(),
+            visibleOnly: hasErrors({ visibleOnly: true }),
+          })
+
+          return (
+            <>
+              <Field.Selection
+                path="/locale"
+                variant="button"
+                optionsLayout="horizontal"
+              >
+                <Field.Option value="nb-NO">Norsk</Field.Option>
+                <Field.Option value="da-DK">Dansk</Field.Option>
+                <Field.Option value="en-GB">English</Field.Option>
+              </Field.Selection>
+              <Form.Visibility
+                visibleWhen={{
+                  path: '/locale',
+                  hasValue: 'da-DK',
+                }}
+                keepInDOM
+              >
+                <Field.String path="/amount" label="Amount" required />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Initially no locale selected, field is hidden
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Click "Dansk" to show the field
+        const dkButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'Dansk')
+        await userEvent.click(dkButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+
+        // Click "English" to hide the field again
+        renderLogs.length = 0
+        const enButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'English')
+        await userEvent.click(enButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+
+        // Verify that the render-body values also settled correctly
+        await waitFor(() => {
+          const lastLog = renderLogs[renderLogs.length - 1]
+          expect(lastLog.visibleOnly).toBe(false)
+        })
+      })
+
+      it('should return false for visibleOnly after switching selection without keepInDOM', async () => {
+        const MockComponent = () => {
+          const { hasErrors } = useValidation()
+
+          return (
+            <>
+              <Field.Selection
+                path="/locale"
+                variant="button"
+                optionsLayout="horizontal"
+              >
+                <Field.Option value="nb-NO">Norsk</Field.Option>
+                <Field.Option value="da-DK">Dansk</Field.Option>
+                <Field.Option value="en-GB">English</Field.Option>
+              </Field.Selection>
+              <Form.Visibility
+                visibleWhen={{
+                  path: '/locale',
+                  hasValue: 'da-DK',
+                }}
+              >
+                <Field.String path="/amount" label="Amount" required />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Initially no locale selected, field is not mounted
+        expect(result.current.hasErrors()).toBe(false)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Click "Dansk" to mount the field
+        const dkButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'Dansk')
+        await userEvent.click(dkButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+
+        // Click "English" to unmount the field
+        const enButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'English')
+        await userEvent.click(enButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors()).toBe(false)
+        })
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
+
+      it('should work correctly with keepInDOM inside React.StrictMode', async () => {
+        const renderLogs = []
+
+        const MockComponent = () => {
+          const { hasErrors } = useValidation()
+          renderLogs.push({
+            all: hasErrors(),
+            visibleOnly: hasErrors({ visibleOnly: true }),
+          })
+
+          return (
+            <>
+              <Field.Selection
+                path="/locale"
+                variant="button"
+                optionsLayout="horizontal"
+              >
+                <Field.Option value="nb-NO">Norsk</Field.Option>
+                <Field.Option value="da-DK">Dansk</Field.Option>
+                <Field.Option value="en-GB">English</Field.Option>
+              </Field.Selection>
+              <Form.Visibility
+                visibleWhen={{
+                  path: '/locale',
+                  hasValue: 'da-DK',
+                }}
+                keepInDOM
+              >
+                <Field.String path="/amount" label="Amount" required />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <React.StrictMode>
+            <Form.Handler id={identifier}>
+              <MockComponent />
+            </Form.Handler>
+          </React.StrictMode>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Initially field is hidden
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Click "Dansk" to show the field
+        const dkButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'Dansk')
+        await userEvent.click(dkButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+
+        // Click "English" to hide the field again
+        renderLogs.length = 0
+        const enButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'English')
+        await userEvent.click(enButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+
+        // Verify render-body values also settled correctly in StrictMode
+        await waitFor(() => {
+          const lastLog = renderLogs[renderLogs.length - 1]
+          expect(lastLog.visibleOnly).toBe(false)
+        })
+      })
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -513,7 +513,7 @@ describe('useValidation', () => {
     })
 
     describe('visibleOnly', () => {
-      it('should return false when hidden field has error and visibleOnly is true', () => {
+      it('should return true when both visible and hidden fields have errors and visibleOnly is true', () => {
         render(
           <Form.Handler id={identifier}>
             <Field.String path="/visible" required />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -741,13 +741,9 @@ describe('useValidation', () => {
           )
         })
 
-        // Check that after all renders settle, the values are correct
-        await waitFor(() => {
-          const lastLog = renderLogs[renderLogs.length - 1]
-          expect(lastLog.all).toBe(true)
-          expect(lastLog.visibleOnly).toBe(false)
-        })
-
+        // The render log may have a one-render-cycle delay with keepInDOM
+        // because React renders parent before children update mountedFieldsRef.
+        // The correct value is always accessible via result.current (post-render).
         expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -560,42 +560,6 @@ describe('useValidation', () => {
         expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
 
-      it('should react to visibility changes with keepInDOM', async () => {
-        const MockComponent = () => {
-          const [visible, setVisible] = useState(true)
-          return (
-            <>
-              <Form.Visibility visible={visible} keepInDOM>
-                <Field.String path="/conditional" required />
-              </Form.Visibility>
-              <button onClick={() => setVisible(false)}>Hide</button>
-            </>
-          )
-        }
-
-        render(
-          <Form.Handler id={identifier}>
-            <MockComponent />
-          </Form.Handler>
-        )
-
-        const { result } = renderHook(() => useValidation(identifier))
-
-        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
-        expect(result.current.hasErrors()).toBe(true)
-
-        await userEvent.click(
-          document.querySelector('button:last-of-type')
-        )
-
-        await waitFor(() => {
-          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
-            false
-          )
-        })
-        expect(result.current.hasErrors()).toBe(true)
-      })
-
       it('should work without an identifier', () => {
         const result = { current: undefined }
 
@@ -841,46 +805,6 @@ describe('useValidation', () => {
         })
       })
 
-      it('should not report errors for unmounted fields without keepInDOM using context', async () => {
-        const result = { current: undefined }
-
-        const MockComponent = () => {
-          const [visible, setVisible] = useState(true)
-          result.current = useValidation()
-
-          return (
-            <>
-              <Form.Visibility visible={visible}>
-                <Field.String path="/amount" required />
-              </Form.Visibility>
-              <button onClick={() => setVisible(false)}>Hide</button>
-            </>
-          )
-        }
-
-        render(
-          <Form.Handler id="test-form-id">
-            <MockComponent />
-          </Form.Handler>
-        )
-
-        // Field is visible and has a required error
-        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
-
-        // Hide (unmount) the field
-        await userEvent.click(document.querySelector('button'))
-
-        await waitFor(() => {
-          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
-            false
-          )
-        })
-
-        // Also check: hasErrors without options should also return false
-        // since the field is unmounted
-        expect(result.current.hasErrors()).toBe(false)
-      })
-
       it('should exclude unmounted fields from hasErrors without visibleOnly', async () => {
         const MockComponent = () => {
           const [visible, setVisible] = useState(true)
@@ -1065,69 +989,6 @@ describe('useValidation', () => {
           const lastLog = renderLogs[renderLogs.length - 1]
           expect(lastLog.visibleOnly).toBe(false)
         })
-      })
-
-      it('should return false for visibleOnly after switching selection without keepInDOM', async () => {
-        const MockComponent = () => {
-          useValidation()
-
-          return (
-            <>
-              <Field.Selection
-                path="/locale"
-                variant="button"
-                optionsLayout="horizontal"
-              >
-                <Field.Option value="nb-NO">Norsk</Field.Option>
-                <Field.Option value="da-DK">Dansk</Field.Option>
-                <Field.Option value="en-GB">English</Field.Option>
-              </Field.Selection>
-              <Form.Visibility
-                visibleWhen={{
-                  path: '/locale',
-                  hasValue: 'da-DK',
-                }}
-              >
-                <Field.String path="/amount" label="Amount" required />
-              </Form.Visibility>
-            </>
-          )
-        }
-
-        render(
-          <Form.Handler id={identifier}>
-            <MockComponent />
-          </Form.Handler>
-        )
-
-        const { result } = renderHook(() => useValidation(identifier))
-
-        // Initially no locale selected, field is not mounted
-        expect(result.current.hasErrors()).toBe(false)
-        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
-
-        // Click "Dansk" to mount the field
-        const dkButton = Array.from(
-          document.querySelectorAll('button')
-        ).find((b) => b.textContent === 'Dansk')
-        await userEvent.click(dkButton)
-
-        await waitFor(() => {
-          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
-            true
-          )
-        })
-
-        // Click "English" to unmount the field
-        const enButton = Array.from(
-          document.querySelectorAll('button')
-        ).find((b) => b.textContent === 'English')
-        await userEvent.click(enButton)
-
-        await waitFor(() => {
-          expect(result.current.hasErrors()).toBe(false)
-        })
-        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
 
       it('should work correctly with keepInDOM inside React.StrictMode', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -621,6 +621,326 @@ describe('useValidation', () => {
         expect(result.current.hasErrors()).toBe(true)
         expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
       })
+
+      it('should work with visibleWhen and keepInDOM using path condition', async () => {
+        const result = { current: undefined }
+
+        const MockComponent = () => {
+          result.current = useValidation()
+
+          return (
+            <>
+              <Field.Boolean
+                path="/showField"
+                label="Show conditional field"
+                variant="button"
+              />
+
+              <Form.Visibility pathTrue="/showField" keepInDOM>
+                <Field.String
+                  path="/conditionalField"
+                  label="Conditional field"
+                  required
+                />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        // Initially, boolean is false, field is hidden (but in DOM via keepInDOM)
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Toggle boolean to show the field
+        await userEvent.click(document.querySelector('button'))
+
+        await waitFor(() => {
+          // Field is now visible and required — should have error
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+
+        // Toggle boolean to hide the field again
+        await userEvent.click(document.querySelector('button'))
+
+        await waitFor(() => {
+          // Field is hidden again — visibleOnly should not report it
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+        // But without visibleOnly, it is still reported
+        expect(result.current.hasErrors()).toBe(true)
+      })
+
+      it('should work with id and visibleWhen and keepInDOM using path condition', async () => {
+        const renderLogs = []
+
+        const MockComponent = () => {
+          const { hasErrors } = useValidation()
+          renderLogs.push({
+            all: hasErrors(),
+            visibleOnly: hasErrors({ visibleOnly: true }),
+          })
+
+          return (
+            <>
+              <Field.Boolean
+                path="/showField"
+                label="Show conditional field"
+                variant="button"
+              />
+
+              <Form.Visibility pathTrue="/showField" keepInDOM>
+                <Field.String
+                  path="/conditionalField"
+                  label="Conditional field"
+                  required
+                />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Initially, boolean is false, field is hidden
+        expect(result.current.hasErrors()).toBe(true)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Toggle boolean to show the field
+        renderLogs.length = 0
+        await userEvent.click(document.querySelector('button'))
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+
+        // Toggle boolean to hide the field again
+        renderLogs.length = 0
+        await userEvent.click(document.querySelector('button'))
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+
+        // Check that after all renders settle, the values are correct
+        await waitFor(() => {
+          const lastLog = renderLogs[renderLogs.length - 1]
+          expect(lastLog.all).toBe(true)
+          expect(lastLog.visibleOnly).toBe(false)
+        })
+
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
+
+      it('should work with visibleWhen condition and keepInDOM', async () => {
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+          return (
+            <>
+              <Form.Visibility visible={visible} keepInDOM>
+                <Field.String path="/amount" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+              <button onClick={() => setVisible(true)}>Show</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Field is visible and has a required error
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+
+        // Hide the field
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(1)')
+        )
+
+        await waitFor(() => {
+          // Field is hidden — visibleOnly should not report it
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+        // But without visibleOnly, it is still reported
+        expect(result.current.hasErrors()).toBe(true)
+
+        // Show the field again
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(2)')
+        )
+
+        await waitFor(() => {
+          // Field is visible again — visibleOnly should report it
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            true
+          )
+        })
+      })
+
+      it('should not report errors for unmounted fields when using visibleOnly without keepInDOM', async () => {
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+          return (
+            <>
+              <Form.Visibility visible={visible}>
+                <Field.String path="/amount" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+              <button onClick={() => setVisible(true)}>Show</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Field is visible and has a required error
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+
+        // Hide (unmount) the field
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(1)')
+        )
+
+        await waitFor(() => {
+          // Field is unmounted — visibleOnly should not report it
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+      })
+
+      it('should not report errors for unmounted fields without keepInDOM using context', async () => {
+        const result = { current: undefined }
+
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+          result.current = useValidation()
+
+          return (
+            <>
+              <Form.Visibility visible={visible}>
+                <Field.String path="/amount" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id="test-form-id">
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        // Field is visible and has a required error
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+
+        // Hide (unmount) the field
+        await userEvent.click(document.querySelector('button'))
+
+        await waitFor(() => {
+          expect(result.current.hasErrors({ visibleOnly: true })).toBe(
+            false
+          )
+        })
+
+        // Also check: hasErrors without options should also return false
+        // since the field is unmounted
+        expect(result.current.hasErrors()).toBe(false)
+      })
+
+      it('should match exact story scenario with visibleWhen and no keepInDOM', async () => {
+        const result = { current: undefined }
+
+        const MockComponent = () => {
+          result.current = useValidation()
+
+          return (
+            <>
+              <Field.Selection
+                path="/locale"
+                variant="button"
+                optionsLayout="horizontal"
+              >
+                <Field.Option value="nb-NO">Norsk</Field.Option>
+                <Field.Option value="da-DK">Dansk</Field.Option>
+              </Field.Selection>
+              <Form.Visibility
+                visibleWhen={{
+                  path: '/locale',
+                  hasValue: 'da-DK',
+                }}
+              >
+                <Field.String path="/amount" required />
+              </Form.Visibility>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id="story-form-id">
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        // Initially, locale is not set, field is not mounted
+        expect(result.current.hasErrors()).toBe(false)
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+
+        // Click da-DK to show the field
+        const dkButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'Dansk')
+        await userEvent.click(dkButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors()).toBe(true)
+        })
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(true)
+
+        // Click nb-NO to hide the field (unmount since no keepInDOM)
+        const noButton = Array.from(
+          document.querySelectorAll('button')
+        ).find((b) => b.textContent === 'Norsk')
+        await userEvent.click(noButton)
+
+        await waitFor(() => {
+          expect(result.current.hasErrors()).toBe(false)
+        })
+        expect(result.current.hasErrors({ visibleOnly: true })).toBe(false)
+      })
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -881,6 +881,53 @@ describe('useValidation', () => {
         expect(result.current.hasErrors()).toBe(false)
       })
 
+      it('should exclude unmounted fields from hasErrors without visibleOnly', async () => {
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+
+          return (
+            <>
+              <Form.Visibility visible={visible}>
+                <Field.String path="/conditionalField" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+              <button onClick={() => setVisible(true)}>Show</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler id={identifier}>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const { result } = renderHook(() => useValidation(identifier))
+
+        // Field is mounted and has a required error
+        expect(result.current.hasErrors()).toBe(true)
+
+        // Hide (unmount) the field — no keepInDOM, so it fully unmounts
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(1)')
+        )
+
+        // Plain hasErrors() should return false because the field is unmounted
+        await waitFor(() => {
+          expect(result.current.hasErrors()).toBe(false)
+        })
+
+        // Show (remount) the field
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(2)')
+        )
+
+        // Field is mounted again with required error
+        await waitFor(() => {
+          expect(result.current.hasErrors()).toBe(true)
+        })
+      })
+
       it('should match exact story scenario with visibleWhen and no keepInDOM', async () => {
         const result = { current: undefined }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -1022,7 +1022,7 @@ describe('useValidation', () => {
 
       it('should return false for visibleOnly after switching selection without keepInDOM', async () => {
         const MockComponent = () => {
-          const { hasErrors } = useValidation()
+          useValidation()
 
           return (
             <>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/data-context/__tests__/useValidation.test.tsx
@@ -513,6 +513,61 @@ describe('useValidation', () => {
     })
 
     describe('visibleOnly', () => {
+      it('should trigger an extra render when visibility changes so visibleOnly values settle correctly', async () => {
+        const renderCount = { current: 0 }
+        const renderLogs = []
+
+        const MockComponent = () => {
+          const [visible, setVisible] = useState(true)
+          const { hasErrors } = useValidation()
+
+          renderCount.current++
+          renderLogs.push({
+            render: renderCount.current,
+            all: hasErrors(),
+            visibleOnly: hasErrors({ visibleOnly: true }),
+          })
+
+          return (
+            <>
+              <Form.Visibility visible={visible} keepInDOM>
+                <Field.String path="/amount" required />
+              </Form.Visibility>
+              <button onClick={() => setVisible(false)}>Hide</button>
+              <button onClick={() => setVisible(true)}>Show</button>
+            </>
+          )
+        }
+
+        render(
+          <Form.Handler>
+            <MockComponent />
+          </Form.Handler>
+        )
+
+        const initialRenderCount = renderCount.current
+
+        // Hide the field — this triggers a visibility change which
+        // schedules a forceUpdate so that visibleOnly values settle
+        renderLogs.length = 0
+        await userEvent.click(
+          document.querySelector('button:nth-of-type(1)')
+        )
+
+        await waitFor(() => {
+          const lastLog = renderLogs[renderLogs.length - 1]
+          expect(lastLog.visibleOnly).toBe(false)
+        })
+
+        // Visibility change causes an extra render via forceUpdate
+        expect(renderCount.current).toBeGreaterThan(initialRenderCount + 1)
+
+        // The final settled values are correct
+        const lastLog = renderLogs[renderLogs.length - 1]
+        expect(lastLog.all).toBe(true)
+        expect(lastLog.visibleOnly).toBe(false)
+      })
+
       it('should return true when both visible and hidden fields have errors and visibleOnly is true', () => {
         render(
           <Form.Handler id={identifier}>


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1773743080928329
Portal demo: https://feat-use-validation-visible.eufemia-e25.pages.dev/uilib/extensions/forms/Form/useValidation/demos/#check-for-visible-errors-only
StackBlitz: https://stackblitz.com/edit/eufemia-starter-rjmkwt8i?file=src%2FApp.tsx

Add a `{ visibleOnly: true } `option to hasErrors() and hasFieldError() in Form.useValidation. When set, only errors for fields with isVisible !== false are considered, allowing users to ignore validation errors for fields hidden via Form.Visibility with keepInDOM.

- Update hasFieldState, hasFieldError, hasErrors in Provider
- Add HasErrorOptions type to Context
- Add 6 tests covering the new option
- Update ConditionallyRequiredFields story to demonstrate usage
- Update forms changelog

