### PR TITLE
refactor: extract useFormField hook to deduplicate FormLabel + FormStatus pattern

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -45,8 +45,7 @@ import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import Suffix from '../../shared/helpers/Suffix'
 import AriaLive from '../aria-live/AriaLive'
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 import IconPrimary from '../icon-primary/IconPrimary'
 import Input, {
   SubmitButton,
@@ -2426,6 +2425,22 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
       ? `${id}-inner`
       : null
 
+  const { labelElement, statusElement } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    widthSelector: innerId,
+    labelOnClick: toggleVisible as unknown as React.MouseEventHandler,
+  })
+
   validateDOMAttributes(null, mainParams)
   validateDOMAttributes(null, shellParams)
 
@@ -2470,35 +2485,12 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
   return (
     <span {...mainParams}>
-      {label && (
-        <FormLabel
-          id={id + '-label'}
-          forId={id}
-          text={label}
-          labelDirection={labelDirection}
-          srOnly={labelSrOnly}
-          disabled={disabled}
-          skeleton={skeleton}
-          onClick={toggleVisible as unknown as React.MouseEventHandler}
-        />
-      )}
+      {labelElement}
 
       <span className="dnb-autocomplete__inner" ref={_ref} id={innerId}>
         <AlignmentHelper />
 
-        <FormStatus
-          show={showStatus}
-          id={id + '-form-status'}
-          globalStatus={globalStatus}
-          label={label}
-          textId={id + '-status'}
-          text={status}
-          state={statusState}
-          noAnimation={statusNoAnimation}
-          skeleton={skeleton}
-          widthSelector={innerId}
-          {...statusProps}
-        />
+        {statusElement}
 
         <span className="dnb-autocomplete__row">
           <span {...shellParams}>

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -32,8 +32,7 @@ import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import type { FormStatusBaseProps } from '../FormStatus'
 import type { SkeletonShow } from '../Skeleton'
 
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 import CheckIcon from './CheckIcon'
 
 export type CheckboxLabelPosition = 'left' | 'right'
@@ -258,6 +257,20 @@ function Checkbox(localProps: CheckboxProps) {
 
   const showStatus = getStatusState(status)
 
+  const { labelElement, statusElement } = useFormField({
+    id,
+    label,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    widthSelector: id + ', ' + id + '-label',
+  })
+
   /**
    * Adds aria attributes, calls validateDOMAttributes and skeletonDOMAttributes and returns the result
    */
@@ -312,41 +325,16 @@ function Checkbox(localProps: CheckboxProps) {
 
   const inputParams = handleInputAttributes()
 
-  const statusComp = (
-    <FormStatus
-      show={showStatus}
-      id={id + '-form-status'}
-      globalStatus={globalStatus}
-      label={label}
-      textId={id + '-status'} // used for "aria-describedby"
-      widthSelector={id + ', ' + id + '-label'}
-      text={status}
-      state={statusState}
-      noAnimation={statusNoAnimation}
-      skeleton={skeleton}
-      {...statusProps}
-    />
-  )
-
   const Element = element || 'input'
 
   return (
     <span {...mainParams}>
       <span className="dnb-checkbox__order">
-        {label && (
-          <FormLabel
-            id={id + '-label'}
-            forId={id}
-            text={label}
-            disabled={disabled}
-            skeleton={skeleton}
-            srOnly={labelSrOnly}
-          />
-        )}
+        {labelElement}
 
         <span className="dnb-checkbox__inner">
           <AlignmentHelper />
-          {labelPosition === 'left' && statusComp}
+          {labelPosition === 'left' && statusElement}
 
           <span className="dnb-checkbox__shell">
             <Element
@@ -391,7 +379,7 @@ function Checkbox(localProps: CheckboxProps) {
         )}
       </span>
 
-      {(labelPosition === 'right' || !labelPosition) && statusComp}
+      {(labelPosition === 'right' || !labelPosition) && statusElement}
     </span>
   )
 }

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -18,7 +18,6 @@ import clsx from 'clsx'
 import {
   warn,
   extendPropsWithContext,
-  getStatusState,
   combineDescribedBy,
   validateDOMAttributes,
 } from '../../shared/component-helper'
@@ -28,9 +27,8 @@ import { skeletonDOMAttributes } from '../skeleton/SkeletonHelper'
 
 import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
-import FormLabel from '../form-label/FormLabel'
+import useFormField from '../../shared/helpers/useFormField'
 import type { FormStatusBaseProps } from '../form-status/FormStatus'
-import FormStatus from '../form-status/FormStatus'
 import DatePickerProvider from './DatePickerProvider'
 import type {
   DatePickerChangeEvent,
@@ -590,7 +588,20 @@ function DatePicker(externalProps: DatePickerAllProps) {
     [restProps]
   )
 
-  const showStatus = getStatusState(status)
+  const { labelElement, statusElement, showStatus } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    widthSelector: id + '-shell',
+  })
 
   const pickerParams = {} as HTMLProps<HTMLSpanElement>
 
@@ -682,17 +693,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
       hidePicker={hidePicker}
     >
       <span {...mainParams}>
-        {label && (
-          <FormLabel
-            id={id + '-label'}
-            forId={id}
-            text={label}
-            labelDirection={labelDirection}
-            srOnly={labelSrOnly}
-            disabled={disabled}
-            skeleton={skeleton}
-          />
-        )}
+        {labelElement}
 
         <span
           className="dnb-date-picker__inner"
@@ -701,19 +702,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
         >
           <AlignmentHelper />
 
-          <FormStatus
-            show={showStatus}
-            id={id + '-form-status'}
-            globalStatus={globalStatus}
-            label={String(label)}
-            textId={id + '-status'} // used for "aria-describedby"
-            widthSelector={id + '-shell'}
-            text={status}
-            state={statusState}
-            noAnimation={statusNoAnimation}
-            skeleton={skeleton}
-            {...statusProps}
-          />
+          {statusElement}
 
           <span className="dnb-date-picker__row">
             {inline ? (

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -7,7 +7,6 @@ import React, { useContext, useRef, useCallback } from 'react'
 import clsx from 'clsx'
 import {
   validateDOMAttributes,
-  getStatusState,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -24,8 +23,7 @@ import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
 import Suffix from '../../shared/helpers/Suffix'
 import Icon from '../icon-primary/IconPrimary'
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 import Button from '../button/Button'
 import DrawerList from '../../fragments/drawer-list/DrawerList'
 import DrawerListContext from '../../fragments/drawer-list/DrawerListContext'
@@ -543,7 +541,20 @@ const DropdownInstance = React.memo(function DropdownInstance({
   }
 
   const { id, selectedItem, direction, open } = context.drawerList
-  const showStatus = getStatusState(status)
+  const { labelElement, statusElement, showStatus } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    labelOnClick: onClickHandler,
+  })
 
   Object.assign(
     context.drawerList.attributes,
@@ -614,34 +625,12 @@ const DropdownInstance = React.memo(function DropdownInstance({
 
   return (
     <span ref={setRootRef} {...mainParams}>
-      {label && (
-        <FormLabel
-          id={id + '-label'}
-          forId={id}
-          text={label}
-          labelDirection={labelDirection}
-          srOnly={labelSrOnly}
-          disabled={disabled}
-          skeleton={skeleton}
-          onClick={onClickHandler}
-        />
-      )}
+      {labelElement}
 
       <span className="dnb-dropdown__inner" ref={wrapperRef}>
         <AlignmentHelper />
 
-        <FormStatus
-          show={showStatus}
-          id={id + '-form-status'}
-          globalStatus={globalStatus}
-          label={label}
-          textId={id + '-status'} // used for "aria-describedby"
-          text={status}
-          state={statusState}
-          noAnimation={statusNoAnimation}
-          skeleton={skeleton}
-          {...statusProps}
-        />
+        {statusElement}
 
         <span className="dnb-dropdown__row">
           <span className="dnb-dropdown__shell">

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -22,7 +22,6 @@ import {
   removeUndefinedProps,
   validateDOMAttributes,
   processChildren,
-  getStatusState,
   combineDescribedBy,
   dispatchCustomElementEvent,
   convertJsxToString,
@@ -34,8 +33,7 @@ import {
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
 import Button from '../button/Button'
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 import IconPrimary from '../icon-primary/IconPrimary'
 import Context from '../../shared/Context'
 
@@ -630,7 +628,19 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   const sizeIsNumber = parseFloat(size) > 0
 
   const id = _id
-  const showStatus = getStatusState(status)
+  const { labelElement, statusElement, showStatus } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+  })
   const hasSubmitButton =
     submitElement || (submitElement !== false && type === 'search')
   const hasVal = hasValue(value)
@@ -750,33 +760,12 @@ function InputComponent({ ref, ...restProps }: InputProps) {
 
   return (
     <span {...mainParams}>
-      {label && (
-        <FormLabel
-          id={id + '-label'}
-          forId={id}
-          text={label}
-          labelDirection={labelDirection}
-          srOnly={labelSrOnly}
-          disabled={disabled}
-          skeleton={skeleton}
-        />
-      )}
+      {labelElement}
 
       <span {...innerParams}>
         <AlignmentHelper />
 
-        <FormStatus
-          show={showStatus}
-          id={id + '-form-status'}
-          globalStatus={globalStatus}
-          label={label}
-          text={status}
-          state={statusState}
-          textId={id + '-status'} // used for "aria-describedby"
-          noAnimation={statusNoAnimation}
-          skeleton={skeleton}
-          {...statusProps}
-        />
+        {statusElement}
 
         <span className="dnb-input__row">
           <span {...shellParams}>

--- a/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
@@ -16,8 +16,7 @@ import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
 import Button from '../button/Button'
 import type { ButtonOnClick } from '../button/Button'
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 
 import {
   SliderMainTrack,
@@ -57,6 +56,21 @@ export function SliderInstance() {
     extensions,
   } = allProps
 
+  const { labelElement, statusElement } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    forId: `${id}-thumb-0`,
+  })
+
   const mainParams = {
     className: clsx(
       'dnb-slider',
@@ -82,32 +96,12 @@ export function SliderInstance() {
 
   return (
     <span {...mainParams}>
-      {label && (
-        <FormLabel
-          forId={`${id}-thumb-0`}
-          id={id + '-label'}
-          text={label}
-          disabled={disabled}
-          skeleton={skeleton}
-          labelDirection={labelDirection}
-          srOnly={labelSrOnly}
-        />
-      )}
+      {labelElement}
 
       <span className="dnb-slider__wrapper">
         <AlignmentHelper />
 
-        <FormStatus
-          show={showStatus}
-          id={id + '-form-status'}
-          globalStatus={globalStatus}
-          textId={id + '-status'} // used for "aria-describedby"
-          text={status}
-          state={statusState}
-          noAnimation={statusNoAnimation}
-          skeleton={skeleton}
-          {...statusProps}
-        />
+        {statusElement}
 
         <span className="dnb-slider__inner">
           {showButtons && (isReverse ? addButton : subtractButton)}

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -12,8 +12,7 @@ import React, {
 } from 'react'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import clsx from 'clsx'
-import FormLabel from '../form-label/FormLabel'
-import FormStatus from '../form-status/FormStatus'
+import useFormField from '../../shared/helpers/useFormField'
 import TextCounter from '../../fragments/text-counter/TextCounter'
 import useId from '../../shared/helpers/useId'
 import {
@@ -21,7 +20,6 @@ import {
   removeUndefinedProps,
   validateDOMAttributes,
   processChildren,
-  getStatusState,
   combineDescribedBy,
   warn,
   dispatchCustomElementEvent,
@@ -493,7 +491,19 @@ function TextareaComponent(
     }
   })
 
-  const showStatus = getStatusState(status)
+  const { labelElement, statusElement, showStatus } = useFormField({
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    disabled,
+    skeleton,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+  })
   const currentHasValue = hasValue(value)
 
   let TextareaElement: TextareaElement = props.textareaElement
@@ -593,33 +603,12 @@ function TextareaComponent(
 
   return (
     <span {...mainParams}>
-      {label && (
-        <FormLabel
-          id={id + '-label'}
-          forId={id}
-          text={label}
-          labelDirection={labelDirection}
-          srOnly={labelSrOnly}
-          disabled={disabled}
-          skeleton={skeleton}
-        />
-      )}
+      {labelElement}
 
       <span {...innerParams}>
         <AlignmentHelper />
 
-        <FormStatus
-          show={showStatus}
-          id={id + '-form-status'}
-          globalStatus={globalStatus}
-          label={label}
-          textId={id + '-status'}
-          text={status}
-          state={statusState}
-          noAnimation={statusNoAnimation}
-          skeleton={skeleton}
-          {...statusProps}
-        />
+        {statusElement}
 
         <span className="dnb-textarea__row">
           <span {...shellParams}>

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useFormField.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useFormField.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import useFormField from '../useFormField'
+
+function TestComponent(props: Parameters<typeof useFormField>[0]) {
+  const { labelElement, statusElement, showStatus } = useFormField(props)
+  return (
+    <div>
+      <div data-testid="label-container">{labelElement}</div>
+      <div data-testid="status-container">{statusElement}</div>
+      <span data-testid="show-status">{String(showStatus)}</span>
+    </div>
+  )
+}
+
+describe('useFormField', () => {
+  it('should render FormLabel when label is provided', () => {
+    const { container } = render(
+      <TestComponent id="test" label="My Label" />
+    )
+
+    const label = container.querySelector('.dnb-form-label')
+    expect(label).toBeTruthy()
+    expect(label.getAttribute('id')).toBe('test-label')
+    expect(label.getAttribute('for')).toBe('test')
+    expect(label.textContent).toBe('My Label')
+  })
+
+  it('should not render FormLabel when label is not provided', () => {
+    const { container } = render(<TestComponent id="test" />)
+
+    const label = container.querySelector('.dnb-form-label')
+    expect(label).toBeNull()
+  })
+
+  it('should render FormStatus with correct id', () => {
+    const { container } = render(
+      <TestComponent id="test" status="Error message" />
+    )
+
+    const status = container.querySelector('.dnb-form-status')
+    expect(status).toBeTruthy()
+    expect(status.getAttribute('id')).toBe('test-form-status')
+  })
+
+  it('should return showStatus as true when status is provided', () => {
+    const { container } = render(
+      <TestComponent id="test" status="Error" />
+    )
+
+    expect(
+      container.querySelector('[data-testid="show-status"]').textContent
+    ).toBe('true')
+  })
+
+  it('should return showStatus as falsy when no status', () => {
+    const { container } = render(<TestComponent id="test" />)
+
+    expect(
+      container.querySelector('[data-testid="show-status"]').textContent
+    ).not.toBe('true')
+  })
+
+  it('should pass forId override to FormLabel', () => {
+    const { container } = render(
+      <TestComponent id="test" label="Label" forId="custom-target" />
+    )
+
+    const label = container.querySelector('.dnb-form-label')
+    expect(label.getAttribute('for')).toBe('custom-target')
+  })
+
+  it('should pass labelDirection to FormLabel', () => {
+    const { container } = render(
+      <TestComponent
+        id="test"
+        label="Label"
+        labelDirection="vertical"
+      />
+    )
+
+    const label = container.querySelector('.dnb-form-label')
+    expect(label.classList.contains('dnb-form-label--vertical')).toBe(
+      true
+    )
+  })
+
+  it('should pass srOnly to FormLabel', () => {
+    const { container } = render(
+      <TestComponent id="test" label="Label" labelSrOnly />
+    )
+
+    const label = container.querySelector('.dnb-form-label')
+    expect(label.classList.contains('dnb-sr-only')).toBe(true)
+  })
+
+  it('should pass statusState to FormStatus', () => {
+    const { container } = render(
+      <TestComponent
+        id="test"
+        status="Info message"
+        statusState="info"
+      />
+    )
+
+    const status = container.querySelector('.dnb-form-status')
+    expect(
+      status.classList.contains('dnb-form-status--info')
+    ).toBeTruthy()
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useFormField.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useFormField.test.tsx
@@ -72,17 +72,11 @@ describe('useFormField', () => {
 
   it('should pass labelDirection to FormLabel', () => {
     const { container } = render(
-      <TestComponent
-        id="test"
-        label="Label"
-        labelDirection="vertical"
-      />
+      <TestComponent id="test" label="Label" labelDirection="vertical" />
     )
 
     const label = container.querySelector('.dnb-form-label')
-    expect(label.classList.contains('dnb-form-label--vertical')).toBe(
-      true
-    )
+    expect(label.classList.contains('dnb-form-label--vertical')).toBe(true)
   })
 
   it('should pass srOnly to FormLabel', () => {
@@ -96,16 +90,10 @@ describe('useFormField', () => {
 
   it('should pass statusState to FormStatus', () => {
     const { container } = render(
-      <TestComponent
-        id="test"
-        status="Info message"
-        statusState="info"
-      />
+      <TestComponent id="test" status="Info message" statusState="info" />
     )
 
     const status = container.querySelector('.dnb-form-status')
-    expect(
-      status.classList.contains('dnb-form-status--info')
-    ).toBeTruthy()
+    expect(status.classList.contains('dnb-form-status--info')).toBeTruthy()
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/useFormField.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/useFormField.tsx
@@ -1,0 +1,106 @@
+/**
+ * useFormField Hook
+ *
+ * Provides shared FormLabel and FormStatus elements used by form components.
+ * Eliminates duplicated label + status JSX across Input, Textarea, Checkbox,
+ * Slider, Dropdown, Autocomplete, DatePicker, and others.
+ */
+
+import React from 'react'
+import FormLabel from '../../components/form-label/FormLabel'
+import FormStatus from '../../components/form-status/FormStatus'
+import { getStatusState } from '../component-helper'
+import type { FormLabelProps } from '../../components/form-label/FormLabel'
+import type { FormStatusBaseProps } from '../../components/form-status/FormStatus'
+
+export type UseFormFieldProps = {
+  /** Component id used to derive label and status ids */
+  id: string
+
+  /** Label text */
+  label?: React.ReactNode
+
+  /** Layout direction for the label */
+  labelDirection?: FormLabelProps['labelDirection']
+
+  /** Visually hide the label, keeping it accessible */
+  labelSrOnly?: boolean
+
+  /** Override the forId on FormLabel (defaults to id) */
+  forId?: string
+
+  /** Disabled state passed to FormLabel */
+  disabled?: boolean
+
+  /** Skeleton loading state */
+  skeleton?: boolean
+
+  /** Click handler for FormLabel */
+  labelOnClick?: React.MouseEventHandler
+
+  /** CSS selector used by FormStatus to determine its width */
+  widthSelector?: string
+} & FormStatusBaseProps
+
+export type UseFormFieldReturn = {
+  /** FormLabel element (or null when no label is provided) */
+  labelElement: React.ReactNode
+  /** FormStatus element */
+  statusElement: React.ReactNode
+  /** Whether the status is currently visible */
+  showStatus: boolean
+}
+
+export default function useFormField(
+  props: UseFormFieldProps
+): UseFormFieldReturn {
+  const {
+    id,
+    label,
+    labelDirection,
+    labelSrOnly,
+    forId,
+    disabled,
+    skeleton,
+    labelOnClick,
+    status,
+    statusState,
+    statusProps,
+    statusNoAnimation,
+    globalStatus,
+    widthSelector,
+  } = props
+
+  const showStatus = getStatusState(status)
+
+  const labelElement = label ? (
+    <FormLabel
+      id={id + '-label'}
+      forId={forId ?? id}
+      text={label}
+      labelDirection={labelDirection}
+      srOnly={labelSrOnly}
+      disabled={disabled}
+      skeleton={skeleton}
+      onClick={labelOnClick}
+    />
+  ) : null
+
+  const statusElement = (
+    <FormStatus
+      show={showStatus}
+      id={id + '-form-status'}
+      globalStatus={globalStatus}
+      label={label}
+      textId={id + '-status'}
+      text={status}
+      state={statusState}
+      noAnimation={statusNoAnimation}
+      skeleton={skeleton}
+      widthSelector={widthSelector}
+      {...statusProps}
+    />
+  )
+
+  return { labelElement, statusElement, showStatus }
+}


### PR DESCRIPTION
Creates a shared useFormField hook that encapsulates the duplicated FormLabel + FormStatus JSX rendering pattern found across 7 form components.
