### PR TITLE
break(HeightAnimation)!: rename 'animate' prop to 'noAnimation'

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -25,6 +25,7 @@ v11 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 9. Replace the `as` prop with `element` on the `H` heading element.
 10. Replace `prerender` with `keepInDOM` on Tabs and Accordion components.
 11. Replace `styleType` (or `style_type`) with `backgroundColor` on Breadcrumb, Dialog.Body, and Drawer.Body components.
+12. Replace the `animate` prop with `noAnimation` on `HeightAnimation` (inverted logic: `animate={false}` → `noAnimation`).
 
 ### innerRef → ref
 
@@ -925,6 +926,24 @@ render(<Logo svg={SbankenCompact} />)
 <H element="h2" size="medium">
   Heading
 </H>
+```
+
+### [HeightAnimation](/uilib/components/height-animation/)
+
+#### Properties
+
+- Replace `animate` with `noAnimation` (inverted logic). The `animate` prop defaulted to `true`; the new `noAnimation` prop defaults to `false`. This aligns HeightAnimation with all other Eufemia components that use `noAnimation`.
+
+**Before:**
+
+```tsx
+<HeightAnimation animate={false}>...</HeightAnimation>
+```
+
+**After:**
+
+```tsx
+<HeightAnimation noAnimation>...</HeightAnimation>
 ```
 
 ### [Table](/uilib/components/table/)

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -416,7 +416,7 @@ function ListItem({
         </div>
         {hasSubheadings && (
           <HeightAnimation
-            animate={isAccordion === true}
+            noAnimation={isAccordion !== true}
             element="ul"
             open={isExpanded}
             onAnimationEnd={(state) => {

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -170,13 +170,14 @@ export default function AccordionContent(props: AccordionContentProps) {
   validateDOMAttributes(props, wrapperParams)
   validateDOMAttributes(null, innerParams)
 
-  const animate = !noAnimation && (singleContainer ? isSmallScreen : true)
+  const shouldSkipAnimation =
+    noAnimation || !(singleContainer ? isSmallScreen : true)
 
   return (
     <HeightAnimation
       {...wrapperParams}
       open={expanded}
-      animate={animate}
+      noAnimation={shouldSkipAnimation}
       keepInDOM={keepInDOMContent}
       ref={elementRef}
     >

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -23,7 +23,7 @@ export const BreadcrumbMultiple = ({
   return (
     <HeightAnimation
       open={!collapsed}
-      animate={!noAnimation}
+      noAnimation={noAnimation}
       className="dnb-breadcrumb__multiple"
     >
       <Section

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -570,7 +570,7 @@ export default class FormStatus extends React.PureComponent<
       <HeightAnimation
         element="span"
         open={this.isReadyToGetVisible()}
-        animate={this.shouldAnimate()}
+        noAnimation={!this.shouldAnimate()}
         duration={600}
         {...(params as any)}
         ref={this._ref}

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -873,7 +873,7 @@ export default class GlobalStatus extends React.PureComponent<
             duration={800}
             delay={delay}
             open={isActive}
-            animate={!noAnimationUsed}
+            noAnimation={noAnimationUsed}
             onAnimationEnd={this.onAnimationEnd}
             onAnimationStart={this.onAnimationStart as any}
             onOpen={this.onOpen}

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -106,7 +106,9 @@ function HeightAnimation({
         'dnb-height-animation',
         isInDOM && 'dnb-height-animation--is-in-dom',
         isVisible && 'dnb-height-animation--is-visible',
-        !noAnimation && isVisibleParallax && 'dnb-height-animation--parallax',
+        !noAnimation &&
+          isVisibleParallax &&
+          'dnb-height-animation--parallax',
         isAnimating && 'dnb-height-animation--animating',
         !isVisible &&
           !isAnimating &&

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -51,7 +51,7 @@ export type HeightAnimationAllProps = HeightAnimationProps &
 
 function HeightAnimation({
   open = true,
-  animate = true,
+  noAnimation = false,
   keepInDOM = false,
   showOverflow = false,
   element,
@@ -78,7 +78,7 @@ function HeightAnimation({
     firstPaintStyle,
   } = useHeightAnimation(targetRef, {
     open,
-    animate,
+    noAnimation,
     children,
     compensateForGap,
     onInit,
@@ -106,7 +106,7 @@ function HeightAnimation({
         'dnb-height-animation',
         isInDOM && 'dnb-height-animation--is-in-dom',
         isVisible && 'dnb-height-animation--is-visible',
-        animate && isVisibleParallax && 'dnb-height-animation--parallax',
+        !noAnimation && isVisibleParallax && 'dnb-height-animation--parallax',
         isAnimating && 'dnb-height-animation--animating',
         !isVisible &&
           !isAnimating &&

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -6,8 +6,8 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  animate: {
-    doc: 'Set to `false` to omit the animation. Defaults to `true`.',
+  noAnimation: {
+    doc: 'Set to `true` to disable the animation. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
@@ -8,7 +8,7 @@ export type HeightAnimationStates =
   | HeightAnimationOnEndStates
   | 'init'
 export type HeightAnimationOptions = {
-  animate?: boolean
+  noAnimation?: boolean
 }
 export type HeightAnimationOnStartCallback = (
   state: HeightAnimationStates
@@ -32,7 +32,7 @@ export default class HeightAnimation {
   onStartStack: HeightAnimationOnStartStack = []
   onEndStack: HeightAnimationOnEndStack = []
   events: HeightAnimationEvents = []
-  opts: HeightAnimationOptions = { animate: true }
+  opts: HeightAnimationOptions = { noAnimation: false }
   elem: HeightAnimationElement
   reqId1: number
   reqId2: number
@@ -253,7 +253,7 @@ export default class HeightAnimation {
     }
 
     const opts = this.getOptions()
-    if (opts.animate === false) {
+    if (opts.noAnimation) {
       return
     }
 
@@ -362,7 +362,7 @@ export default class HeightAnimation {
 
     if (
       !this.elem ||
-      opts.animate === false ||
+      opts.noAnimation ||
       this.state === 'opening' ||
       this.state === 'closing'
     ) {
@@ -437,7 +437,7 @@ export default class HeightAnimation {
   shouldBypassAnimation() {
     const opts = this.getOptions()
 
-    if (!this.elem || opts.animate === false) {
+    if (!this.elem || opts.noAnimation) {
       return true
     }
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -343,7 +343,7 @@ describe('HeightAnimation', () => {
 
   it('should have correct classes when animation is disabled', () => {
     const { rerender } = render(
-      <HeightAnimation animate={false} keepInDOM />
+      <HeightAnimation noAnimation keepInDOM />
     )
 
     expect(getElement()).toHaveClass('dnb-height-animation--is-visible')
@@ -351,7 +351,7 @@ describe('HeightAnimation', () => {
     expect(getElement()).not.toHaveClass('dnb-height-animation--parallax')
     expect(getElement()).not.toHaveClass('dnb-height-animation--hidden')
 
-    rerender(<HeightAnimation open={false} animate={false} keepInDOM />)
+    rerender(<HeightAnimation open={false} noAnimation keepInDOM />)
 
     expect(getElement()).not.toHaveClass(
       'dnb-height-animation--is-visible'

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -342,9 +342,7 @@ describe('HeightAnimation', () => {
   })
 
   it('should have correct classes when animation is disabled', () => {
-    const { rerender } = render(
-      <HeightAnimation noAnimation keepInDOM />
-    )
+    const { rerender } = render(<HeightAnimation noAnimation keepInDOM />)
 
     expect(getElement()).toHaveClass('dnb-height-animation--is-visible')
     expect(getElement()).not.toHaveClass('dnb-height-animation--animating')

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimationInstance.test.ts
@@ -298,7 +298,7 @@ describe('HeightAnimationInstance', () => {
     it('start without animation should work properly', () => {
       const inst = new HeightAnimationInstance()
       inst.setElement(element)
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       const onStart = jest.fn()
       inst.onStart(onStart)
@@ -446,13 +446,13 @@ describe('HeightAnimationInstance', () => {
       const setAsOpen = jest.fn()
       jest.spyOn(inst, 'setAsOpen').mockImplementation(setAsOpen)
 
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       inst.open()
 
       expect(setAsOpen).toHaveBeenCalledTimes(1)
 
-      inst.setOptions({ animate: true })
+      inst.setOptions({ noAnimation: false })
 
       inst.setState('opened')
       inst.open()
@@ -479,7 +479,7 @@ describe('HeightAnimationInstance', () => {
       const inst = new HeightAnimationInstance()
       inst.setElement(element)
       inst.setState('closed')
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       const onStart = jest.fn()
       inst.onStart(onStart)
@@ -573,13 +573,13 @@ describe('HeightAnimationInstance', () => {
       const setAsClosed = jest.fn()
       jest.spyOn(inst, 'setAsClosed').mockImplementation(setAsClosed)
 
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       inst.close()
 
       expect(setAsClosed).toHaveBeenCalledTimes(1)
 
-      inst.setOptions({ animate: true })
+      inst.setOptions({ noAnimation: false })
 
       inst.setState('closed')
       inst.close()
@@ -606,7 +606,7 @@ describe('HeightAnimationInstance', () => {
       const inst = new HeightAnimationInstance()
       inst.setElement(element)
       inst.setState('opened')
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       const onStart = jest.fn()
       inst.onStart(onStart)
@@ -843,9 +843,9 @@ describe('HeightAnimationInstance', () => {
   })
 
   describe('shouldBypassAnimation', () => {
-    it('should return true when element is not set or animate option is false', () => {
+    it('should return true when element is not set or noAnimation option is true', () => {
       const inst = new HeightAnimationInstance()
-      inst.setOptions({ animate: false })
+      inst.setOptions({ noAnimation: true })
 
       expect(inst.shouldBypassAnimation()).toBe(true)
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
@@ -22,13 +22,13 @@ initializeTestSetup()
 describe('useHeightAnimation', () => {
   const AnimatedContent = ({
     open = false,
-    animate = true,
+    noAnimation = false,
   }: UseHeightAnimationOptions) => {
     const element = React.useRef<HTMLDivElement | null>(null)
     const { isOpen, isVisible, isInDOM, isVisibleParallax } =
       useHeightAnimation(element, {
         open,
-        animate,
+        noAnimation,
       })
 
     return (
@@ -48,7 +48,7 @@ describe('useHeightAnimation', () => {
     )
   }
 
-  const MockComponent = ({ open = false, animate = true }) => {
+  const MockComponent = ({ open = false, noAnimation = false }) => {
     const [openState, setOpenState] = useState(open)
 
     const onChangeHandler = useCallback(({ checked }) => {
@@ -61,7 +61,7 @@ describe('useHeightAnimation', () => {
           Toggle me
         </ToggleButton>
 
-        <AnimatedContent open={open || openState} animate={animate} />
+        <AnimatedContent open={open || openState} noAnimation={noAnimation} />
       </>
     )
   }
@@ -160,7 +160,7 @@ describe('useHeightAnimation', () => {
   })
 
   it('should only set isInDOM when animation is disabled', async () => {
-    render(<MockComponent animate={false} />)
+    render(<MockComponent noAnimation />)
 
     const element = document.querySelector('.wrapper-element')
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/useHeightAnimation.test.tsx
@@ -61,7 +61,10 @@ describe('useHeightAnimation', () => {
           Toggle me
         </ToggleButton>
 
-        <AnimatedContent open={open || openState} noAnimation={noAnimation} />
+        <AnimatedContent
+          open={open || openState}
+          noAnimation={noAnimation}
+        />
       </>
     )
   }

--- a/packages/dnb-eufemia/src/components/height-animation/stories/HeightAnimation.stories.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/stories/HeightAnimation.stories.tsx
@@ -55,7 +55,7 @@ export const HeightAnimationSandbox = () => {
         <HeightAnimation
           open={openState}
           element="div" // Optional
-          animate={true} // Optional
+          noAnimation={false} // Optional
           keepInDOM={true} // Optional
           duration={1000}
           onOpen={setIsOpen}

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
@@ -12,10 +12,10 @@ export type UseHeightAnimationOptions = {
   open?: boolean
 
   /**
-   * Set to `false` to omit the animation.
-   * Default: true
+   * Set to `true` to disable the animation.
+   * Default: false
    */
-  animate?: boolean
+  noAnimation?: boolean
 
   /**
    * To compensate for CSS gap between the rows, so animation does not jump during the animation.
@@ -57,7 +57,7 @@ export function useHeightAnimation(
   targetRef: React.RefObject<HTMLElement>,
   {
     open = true,
-    animate = true,
+    noAnimation = false,
     children = null,
     compensateForGap,
     onInit = null,
@@ -99,12 +99,12 @@ export function useHeightAnimation(
   }, [])
 
   useLayoutEffect(() => {
-    instRef.current.setOptions({ animate })
+    instRef.current.setOptions({ noAnimation })
 
     if (typeof global !== 'undefined' && globalThis.IS_TEST) {
-      instRef.current.setOptions({ animate: false })
+      instRef.current.setOptions({ noAnimation: true })
     }
-  }, [animate])
+  }, [noAnimation])
 
   const handleCompensateForGap = useCallback(() => {
     if (compensateForGap) {

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorList.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorList.tsx
@@ -31,7 +31,7 @@ function StepIndicatorList() {
   skeletonDOMAttributes(params, skeleton)
   return (
     <HeightAnimation
-      animate={!noAnimation}
+      noAnimation={noAnimation}
       open={open}
       onOpen={(state) => {
         if (state) {

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -105,7 +105,7 @@ function StepIndicatorTriggerButton({
       outset={isNested ? true : undefined}
       aria-label={overviewTitle}
     >
-      <HeightAnimation animate={!noAnimation}>
+      <HeightAnimation noAnimation={noAnimation}>
         <div {...(triggerParams as React.HTMLProps<HTMLDivElement>)}>
           <FormLabel
             aria-describedby={id}

--- a/packages/dnb-eufemia/src/components/table/table-accordion/useTableAnimationHandler.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/useTableAnimationHandler.tsx
@@ -66,8 +66,8 @@ export function useTableAnimationHandler({
   const { isInDOM, isAnimating, isVisibleParallax, firstPaintStyle } =
     useHeightAnimation(contentRef, {
       open,
-      animate: Boolean(
-        !noAnimation && !tableAccordionContext?.noAnimation
+      noAnimation: Boolean(
+        noAnimation || tableAccordionContext?.noAnimation
       ),
       onOpen,
       onAnimationStart,

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
@@ -143,7 +143,7 @@ export default function ContentWrapper({
         createSpacingClasses(rest)
       )}
       duration={600}
-      animate={animate === true}
+      noAnimation={animate !== true}
       {...params}
     >
       {content}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
@@ -190,7 +190,6 @@ function InfoOverlay(props: FormInfoOverlayProps) {
       <HeightAnimation
         open={childrenAreVisible}
         onAnimationEnd={onAnimationEnd}
-        animate
         keepInDOM
       >
         {children}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -65,12 +65,14 @@ export type FormVisibilityProps = {
   fieldPropsWhenHidden?: UseFieldProps & DataAttributes & AriaAttributes
   children: React.ReactNode
 
+  /** Define if the content should animate during show/hide. */
+  animate?: boolean
+
   /** For internal use only. Used by "Iterate.Visibility" */
   withinIterate?: boolean
 } & Pick<
   HeightAnimationAllProps,
   | 'onAnimationEnd'
-  | 'animate'
   | 'keepInDOM'
   | 'element'
   | 'compensateForGap'

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -72,10 +72,7 @@ export type FormVisibilityProps = {
   withinIterate?: boolean
 } & Pick<
   HeightAnimationAllProps,
-  | 'onAnimationEnd'
-  | 'keepInDOM'
-  | 'element'
-  | 'compensateForGap'
+  'onAnimationEnd' | 'keepInDOM' | 'element' | 'compensateForGap'
 >
 
 function Visibility(props: FormVisibilityProps) {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -78,7 +78,7 @@ export const VisibilityProperties: PropertiesTableProps = {
     status: 'optional',
   },
   element: {
-    doc: 'Define the type of element. Defaults to `div`. Only for when `animate` is true.',
+    doc: 'Define the type of element. Defaults to `div`. Only for when `animate` is `true`.',
     type: 'string or React.Element',
     status: 'optional',
   },


### PR DESCRIPTION
Replace the 'animate' prop (default: true) with 'noAnimation' (default: false) on HeightAnimation and useHeightAnimation. This aligns HeightAnimation with all other Eufemia components that use 'noAnimation' to disable animations.

BREAKING CHANGE: HeightAnimation 'animate' prop removed. Use 'noAnimation'
with inverted logic: animate={false} → noAnimation, animate={true} → (default).

