### PR TITLE
break(Autocomplete)!: rename drawerClass to contentClassName

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -188,7 +188,8 @@ $ pnpm add @dnb/eufemia@11
 - Replace `search_numbers` with `searchNumbers`.
 - Replace `input_value` with `inputValue`.
 - Replace `open_on_focus` with `openOnFocus`.
-- Replace `drawer_class` with `drawerClass`.
+- Replace `drawer_class` with `contentClassName`.
+- Replace `drawerClass` with `contentClassName`.
 - Replace `prevent_focus` with `preventFocus`.
 - Replace `action_menu` with `actionMenu`.
 - Replace `is_popup` with `isPopup`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -189,7 +189,6 @@ $ pnpm add @dnb/eufemia@11
 - Replace `input_value` with `inputValue`.
 - Replace `open_on_focus` with `openOnFocus`.
 - Replace `drawer_class` with `contentClassName`.
-- Replace `drawerClass` with `contentClassName`.
 - Replace `prevent_focus` with `preventFocus`.
 - Replace `action_menu` with `actionMenu`.
 - Replace `is_popup` with `isPopup`.

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -102,7 +102,7 @@ export const SearchBarInput = () => {
       labelSrOnly
       status={status}
       portalClass={portalClassStyle}
-      drawerClass={drawerClassStyle}
+      contentClassName={drawerClassStyle}
       onType={onTypeHandler}
       onChange={onChangeHandler}
       onFocus={onFocusHandler}

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -313,7 +313,7 @@ export type AutocompleteProps = {
   /**
    * Custom class for internal drawer list.
    */
-  drawerClass?: string
+  contentClassName?: string
   /**
    * Selected value.
    */
@@ -431,7 +431,7 @@ const autocompleteDefaultProps: Partial<AutocompleteAllProps> & {
   stretch: null,
   skeleton: null,
   portalClass: null,
-  drawerClass: null,
+  contentClassName: null,
   pageOffset: null,
   observerElement: null,
   enableBodyLock: false,
@@ -581,7 +581,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     submitButtonTitle,
     submitButtonIcon,
     portalClass,
-    drawerClass,
+    contentClassName,
     inputRef,
     className,
     disabled,
@@ -2560,7 +2560,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
             <DrawerList
               id={id}
-              className={clsx('dnb-autocomplete__root', drawerClass)}
+              className={clsx('dnb-autocomplete__root', contentClassName)}
               portalClass={portalClass}
               listClass="dnb-autocomplete__list"
               value={selectedItem}

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -106,7 +106,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  drawerClass: {
+  contentClassName: {
     doc: 'Define a custom class for the internal drawer-list. This makes it possible more easily customize the drawer-list style with styled-components and the `css` style method. Defaults to `null`.',
     type: 'string',
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -251,7 +251,7 @@ export const AutocompleteSandbox = () => {
       <Box>
         <CustomStyle>
           <Autocomplete
-            drawerClass="drawerClass"
+            contentClassName="drawerClass"
             size="small"
             value="A"
             data={['A']}


### PR DESCRIPTION
Renames the drawerClass prop to contentClassName on Autocomplete to better describe its purpose and align with Popover/FieldBlock patterns.

BREAKING CHANGE: drawerClass prop renamed to contentClassName on Autocomplete

