### PR TITLE
break(Modal, Drawer, Dialog)!: rename openDelay to showDelay

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -812,7 +812,8 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `class` with `className`.
 - Replace `focus_selector` with `focusSelector`.
 - Replace `labelled_by` with `labelledBy`.
-- Replace `open_delay` with `openDelay`.
+- Replace `open_delay` with `showDelay`.
+- Replace `openDelay` with `showDelay`.
 - Replace `content_id` with `contentId`.
 - Replace `dialog_title` with `dialogTitle`.
 - Replace `close_title` with `closeTitle`.

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -58,7 +58,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
     preventClose,
     preventOverlayClose,
     open,
-    openDelay,
+    showDelay,
 
     trigger,
     omitTriggerButton = false,
@@ -102,7 +102,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
     disabled,
     spacing,
     verticalAlignment,
-    openDelay,
+    showDelay,
     contentId,
     dialogTitle,
     closeTitle,

--- a/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
@@ -43,7 +43,7 @@ function Drawer({
   preventClose,
   preventOverlayClose,
   open,
-  openDelay,
+  showDelay,
 
   omitTriggerButton,
   trigger,
@@ -71,7 +71,7 @@ function Drawer({
     labelledBy,
     disabled,
     spacing,
-    openDelay,
+    showDelay,
     contentId,
     dialogTitle,
     closeTitle,

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -88,7 +88,7 @@ class Modal extends React.PureComponent<ModalAllProps, ModalState> {
     title: null,
     disabled: null,
     spacing: true,
-    openDelay: null,
+    showDelay: null,
     contentId: null,
     dialogTitle: 'Vindu',
     closeTitle: 'Lukk', // Close Modal Window
@@ -256,10 +256,10 @@ class Modal extends React.PureComponent<ModalAllProps, ModalState> {
     }
 
     const waitBeforeOpen = () => {
-      const { openDelay } = this.props
+      const { showDelay } = this.props
       const { noAnimation } = this.state
       const delay =
-        typeof openDelay === 'string' ? parseFloat(openDelay) : openDelay
+        typeof showDelay === 'string' ? parseFloat(showDelay) : showDelay
       if (delay > 0 && !noAnimation) {
         this._openTimeout = setTimeout(toggleNow, delay) // custom delay
       } else {
@@ -445,7 +445,7 @@ class Modal extends React.PureComponent<ModalAllProps, ModalState> {
       verticalAlignment = 'center',
 
       id,
-      openDelay,
+      showDelay,
 
       omitTriggerButton = false,
       trigger = null,

--- a/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
+++ b/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
@@ -31,7 +31,7 @@ export const ModalProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  openDelay: {
+  showDelay: {
     doc: 'Forces the modal to delay the opening. The delay is given in `ms`.',
     type: ['number', 'string'],
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -858,7 +858,7 @@ describe('Modal component', () => {
           </button>
           <Modal
             id="modal-id"
-            openDelay={2}
+            showDelay={2}
             animationDuration={2}
             open={open}
             onOpen={onOpen}

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -41,7 +41,7 @@ export type ModalProps = ModalRootProps & {
   /**
    * Forces the modal/drawer to delay the opening. The delay is given in `ms`.
    */
-  openDelay?: string | number
+  showDelay?: string | number
 
   /**
    * If set to `true` (boolean or string), then the user can&#39;t close the modal/drawer.


### PR DESCRIPTION
Renames the openDelay prop to showDelay on Modal, Dialog, and Drawer to align with Tooltip and Popover's showDelay naming convention.

BREAKING CHANGE: openDelay prop renamed to showDelay on Modal, Dialog, and Drawer

