### PR TITLE
break(Modal, Dialog, Drawer)!: rename dialogTitle to ariaLabel

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -814,7 +814,8 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `labelled_by` with `labelledBy`.
 - Replace `open_delay` with `openDelay`.
 - Replace `content_id` with `contentId`.
-- Replace `dialog_title` with `dialogTitle`.
+- Replace `dialog_title` with `ariaLabel`.
+- Replace `dialogTitle` with `ariaLabel`.
 - Replace `close_title` with `closeTitle`.
 - Replace `hide_close_button` with `hideCloseButton`.
 - Replace `close_button_attributes` with `closeButtonAttributes`.
@@ -858,7 +859,8 @@ render(<Logo svg={SbankenCompact} />)
 
 #### Translations
 
-- Replace `Modal.dialog_title` with `Modal.dialogTitle`.
+- Replace `Modal.dialog_title` with `Modal.ariaLabel`.
+- Replace `Modal.dialogTitle` with `Modal.ariaLabel`.
 - Replace `Modal.close_title` with `Modal.closeTitle`.
 
 #### Opening and closing a modal

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -859,7 +859,6 @@ render(<Logo svg={SbankenCompact} />)
 #### Translations
 
 - Replace `Modal.dialog_title` with `Modal.ariaLabel`.
-- Replace `Modal.dialogTitle` with `Modal.ariaLabel`.
 - Replace `Modal.close_title` with `Modal.closeTitle`.
 
 #### Opening and closing a modal

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -815,7 +815,6 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `open_delay` with `openDelay`.
 - Replace `content_id` with `contentId`.
 - Replace `dialog_title` with `ariaLabel`.
-- Replace `dialogTitle` with `ariaLabel`.
 - Replace `close_title` with `closeTitle`.
 - Replace `hide_close_button` with `hideCloseButton`.
 - Replace `close_button_attributes` with `closeButtonAttributes`.

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -39,7 +39,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
 
     variant,
     title,
-    dialogTitle,
+    ariaLabel,
     closeTitle,
     spacing,
     verticalAlignment,
@@ -104,7 +104,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
     verticalAlignment,
     openDelay,
     contentId,
-    dialogTitle,
+    ariaLabel,
     closeTitle,
     hideCloseButton: currentHideCloseButton,
     preventClose,

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -155,7 +155,7 @@ describe('Dialog', () => {
         <Dialog
           noAnimation
           open
-          title={<Translation id="Modal.dialogTitle" />}
+          title={<Translation id="Modal.ariaLabel" />}
         />
       </Provider>
     )
@@ -171,7 +171,7 @@ describe('Dialog', () => {
         <Dialog
           noAnimation
           open
-          title={<Translation id="Modal.dialogTitle" />}
+          title={<Translation id="Modal.ariaLabel" />}
         />
       </Provider>
     )

--- a/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/Drawer.tsx
@@ -26,7 +26,7 @@ function Drawer({
   disabled,
 
   title,
-  dialogTitle,
+  ariaLabel,
   closeTitle,
   containerPlacement = 'right',
   spacing = true,
@@ -73,7 +73,7 @@ function Drawer({
     spacing,
     openDelay,
     contentId,
-    dialogTitle,
+    ariaLabel,
     closeTitle,
     hideCloseButton,
     preventClose,

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -90,7 +90,7 @@ class Modal extends React.PureComponent<ModalAllProps, ModalState> {
     spacing: true,
     openDelay: null,
     contentId: null,
-    dialogTitle: 'Vindu',
+    ariaLabel: 'Vindu',
     closeTitle: 'Lukk', // Close Modal Window
     hideCloseButton: false,
     closeButtonAttributes: null,

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -441,7 +441,7 @@ export default class ModalContent extends React.PureComponent<
       labelledBy,
       id: _id,
       closeTitle = 'Lukk',
-      dialogTitle = 'Vindu',
+      ariaLabel = 'Vindu',
       hideCloseButton = false,
       closeButtonAttributes,
       noAnimation = false,
@@ -496,9 +496,9 @@ export default class ModalContent extends React.PureComponent<
 
       /**
        * If no labelledBy and no title is given,
-       * set a fallback "dialogTitle"
+       * set a fallback "ariaLabel"
        */
-      'aria-label': !title && !labelledBy ? dialogTitle : undefined,
+      'aria-label': !title && !labelledBy ? ariaLabel : undefined,
 
       className: clsx(
         'dnb-modal__content',

--- a/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
+++ b/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
@@ -106,7 +106,7 @@ export const ModalProperties: PropertiesTableProps = {
     type: 'Various',
     status: 'optional',
   },
-  dialogTitle: {
+  ariaLabel: {
     doc: 'The aria label of the dialog when no labelledBy and no title is given. Defaults to `Vindu`.',
     type: 'string',
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -200,7 +200,7 @@ export type ModalContentProps = {
   /**
    * The aria label of the dialog when no labelledBy and no title is given. Defaults to `Vindu`.
    */
-  dialogTitle?: string
+  ariaLabel?: string
 
   /**
    * If boolean, the close button will not be shown.

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -92,7 +92,7 @@ export default {
       indicatorLabel: 'Henter data ...',
     },
     Modal: {
-      dialogTitle: 'Separat vindue',
+      ariaLabel: 'Separat vindue',
       closeTitle: 'Luk',
     },
     Dialog: {

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -91,7 +91,7 @@ export default {
       indicatorLabel: 'Getting data ...',
     },
     Modal: {
-      dialogTitle: 'Dialog Window',
+      ariaLabel: 'Dialog Window',
       closeTitle: 'Close',
     },
     Dialog: {

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -90,7 +90,7 @@ export default {
       indicatorLabel: 'Henter data ...',
     },
     Modal: {
-      dialogTitle: 'Separat Vindu',
+      ariaLabel: 'Separat Vindu',
       closeTitle: 'Lukk',
     },
     Dialog: {

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -91,7 +91,7 @@ export default {
       indicatorLabel: 'Hämtar data ...',
     },
     Modal: {
-      dialogTitle: 'Separat fönster',
+      ariaLabel: 'Separat fönster',
       closeTitle: 'Stäng',
     },
     Dialog: {


### PR DESCRIPTION
Renames the dialogTitle prop to ariaLabel on Modal, Dialog, and Drawer to better describe its actual purpose — it serves as the aria-label fallback when no title or labelledBy is provided.

Also updates locale translation keys from Modal.dialogTitle to Modal.ariaLabel across all 4 locale files.

BREAKING CHANGE: dialogTitle prop renamed to ariaLabel on Modal, Dialog, and Drawer. Translation key Modal.dialogTitle renamed to Modal.ariaLabel.

