### PR TITLE
break(Autocomplete)!: rename submitButtonTitle to submitButtonAriaLabel

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -214,7 +214,6 @@ $ pnpm add @dnb/eufemia@11
 - Replace `Autocomplete.show_options_sr` with `Autocomplete.showOptionsSr`.
 - Replace `Autocomplete.selected_sr` with `Autocomplete.selectedSr`.
 - Replace `Autocomplete.submit_button_title` with `Autocomplete.submitButtonAriaLabel`.
-- Replace `Autocomplete.submitButtonTitle` with `Autocomplete.submitButtonAriaLabel`.
 
 #### Styling
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -162,7 +162,8 @@ $ pnpm add @dnb/eufemia@11
 - Replace `indicator_label` with `indicatorLabel`.
 - Replace `show_options_sr` with `showOptionsSr`.
 - Replace `selected_sr` with `selectedSr`.
-- Replace `submit_button_title` with `submitButtonTitle`.
+- Replace `submit_button_title` with `submitButtonAriaLabel`.
+- Replace `submitButtonTitle` with `submitButtonAriaLabel`.
 - Replace `submit_button_icon` with `submitButtonIcon`.
 - Replace `input_ref` with `inputRef`.
 - Replace `icon_size` with `iconSize`.
@@ -213,7 +214,8 @@ $ pnpm add @dnb/eufemia@11
 - Replace `Autocomplete.indicator_label` with `Autocomplete.indicatorLabel`.
 - Replace `Autocomplete.show_options_sr` with `Autocomplete.showOptionsSr`.
 - Replace `Autocomplete.selected_sr` with `Autocomplete.selectedSr`.
-- Replace `Autocomplete.submit_button_title` with `Autocomplete.submitButtonTitle`.
+- Replace `Autocomplete.submit_button_title` with `Autocomplete.submitButtonAriaLabel`.
+- Replace `Autocomplete.submitButtonTitle` with `Autocomplete.submitButtonAriaLabel`.
 
 #### Styling
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -163,7 +163,6 @@ $ pnpm add @dnb/eufemia@11
 - Replace `show_options_sr` with `showOptionsSr`.
 - Replace `selected_sr` with `selectedSr`.
 - Replace `submit_button_title` with `submitButtonAriaLabel`.
-- Replace `submitButtonTitle` with `submitButtonAriaLabel`.
 - Replace `submit_button_icon` with `submitButtonIcon`.
 - Replace `input_ref` with `inputRef`.
 - Replace `icon_size` with `iconSize`.

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -194,9 +194,9 @@ export type AutocompleteProps = {
    */
   selectAll?: boolean
   /**
-   * Title on submit button.
+   * Aria-label on submit button.
    */
-  submitButtonTitle?: string
+  submitButtonAriaLabel?: string
   /**
    * The icon used in the submit button.
    */
@@ -371,7 +371,7 @@ const autocompleteDefaultProps: Partial<AutocompleteAllProps> & {
   indicatorLabel: null,
   showOptionsSr: null,
   selectedSr: null,
-  submitButtonTitle: null,
+  submitButtonAriaLabel: null,
   submitButtonIcon: 'chevron_down',
   inputRef: null,
   icon: 'loupe',
@@ -568,7 +568,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     searchMatch,
     showOptionsSr,
     selectedSr,
-    submitButtonTitle,
+    submitButtonAriaLabel,
     submitButtonIcon,
     portalClass,
     drawerClass,
@@ -2374,8 +2374,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     onMouseDown: reserveActivityHandler,
     'aria-haspopup': 'listbox' as const,
     'aria-expanded': isExpanded,
-    'aria-label': !hidden ? submitButtonTitle : undefined,
-    tooltip: showSubmitButton ? submitButtonTitle : null,
+    'aria-label': !hidden ? submitButtonAriaLabel : undefined,
+    tooltip: showSubmitButton ? submitButtonAriaLabel : null,
     className: open ? 'dnb-button--active' : null,
   }
 

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -152,8 +152,8 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  submitButtonTitle: {
-    doc: 'Title on submit button. Defaults to `Vis alternativer`.',
+  submitButtonAriaLabel: {
+    doc: 'Aria-label on submit button. Defaults to `Vis alternativer`.',
     type: 'React.ReactNode',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -2386,7 +2386,7 @@ describe('variants', () => {
           value="bar"
           autocompleteProps={{
             showSubmitButton: true,
-            submitButtonTitle: 'Custom title',
+            submitButtonAriaLabel: 'Custom title',
           }}
         >
           <Field.Option value="foo">Foo</Field.Option>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/stories/Selection.stories.tsx
@@ -60,7 +60,7 @@ export function Autocomplete() {
         onChange={(value) => console.log('onChange', value)}
         autocompleteProps={{
           showSubmitButton: true,
-          submitButtonTitle: 'Custom title',
+          submitButtonAriaLabel: 'Custom title',
         }}
         help={{
           title: 'Title',

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -83,7 +83,7 @@ export default {
     },
     Autocomplete: {
       title: 'Skriv og vælg',
-      submitButtonTitle: 'Vis muligheder',
+      submitButtonAriaLabel: 'Vis muligheder',
       noOptions: 'Ingen muligheder',
       showAll: 'Vis alt',
       showOptionsSr: 'Gennemse muligheder, luk med esc-knappen',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -82,7 +82,7 @@ export default {
     },
     Autocomplete: {
       title: 'Type and select',
-      submitButtonTitle: 'Show options',
+      submitButtonAriaLabel: 'Show options',
       noOptions: 'No options',
       showAll: 'Show everything',
       showOptionsSr: 'Browse options, close with esc button',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -81,7 +81,7 @@ export default {
     },
     Autocomplete: {
       title: 'Skriv og velg',
-      submitButtonTitle: 'Vis alternativer',
+      submitButtonAriaLabel: 'Vis alternativer',
       noOptions: 'Ingen alternativer',
       showAll: 'Vis alt',
       showOptionsSr: 'Bla gjennom alternativer, lukk med esc knappen',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -82,7 +82,7 @@ export default {
     },
     Autocomplete: {
       title: 'Skriv och välj',
-      submitButtonTitle: 'Visa alternativ',
+      submitButtonAriaLabel: 'Visa alternativ',
       noOptions: 'Inga alternativ',
       showAll: 'Visa allt',
       showOptionsSr: 'Bläddra genom alternativ, stäng med esc-knappen',


### PR DESCRIPTION
Rename submitButtonTitle to submitButtonAriaLabel on Autocomplete since this prop sets an aria-label attribute, not a visible title.

Also updates locale keys, Selection test/story, and v11 migration guide.

BREAKING CHANGE: Autocomplete submitButtonTitle renamed to submitButtonAriaLabel. Locale key Autocomplete.submitButtonTitle renamed to Autocomplete.submitButtonAriaLabel.

