### PR TITLE
break(Pagination)!: rename buttonTitle to buttonAriaLabel

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -986,7 +986,6 @@ render(<Logo svg={SbankenCompact} />)
 #### Translations
 
 - Replace `Pagination.button_title` with `Pagination.buttonAriaLabel`.
-- Replace `Pagination.buttonTitle` with `Pagination.buttonAriaLabel`.
 - Replace `Pagination.prev_title` with `Pagination.prevTitle`.
 - Replace `Pagination.next_title` with `Pagination.nextTitle`.
 - Replace `Pagination.more_pages` with `Pagination.morePages`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -969,7 +969,8 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `fallback_element` with `fallbackElement`.
 - Replace `marker_element` with `markerElement`.
 - Replace `indicator_element` with `indicatorElement`.
-- Replace `button_title` with `buttonTitle`.
+- Replace `button_title` with `buttonAriaLabel`.
+- Replace `buttonTitle` with `buttonAriaLabel`.
 - Replace `prev_title` with `prevTitle`.
 - Replace `next_title` with `nextTitle`.
 - Replace `more_pages` with `morePages`.
@@ -985,7 +986,8 @@ render(<Logo svg={SbankenCompact} />)
 
 #### Translations
 
-- Replace `Pagination.button_title` with `Pagination.buttonTitle`.
+- Replace `Pagination.button_title` with `Pagination.buttonAriaLabel`.
+- Replace `Pagination.buttonTitle` with `Pagination.buttonAriaLabel`.
 - Replace `Pagination.prev_title` with `Pagination.prevTitle`.
 - Replace `Pagination.next_title` with `Pagination.nextTitle`.
 - Replace `Pagination.more_pages` with `Pagination.morePages`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -970,7 +970,6 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `marker_element` with `markerElement`.
 - Replace `indicator_element` with `indicatorElement`.
 - Replace `button_title` with `buttonAriaLabel`.
-- Replace `buttonTitle` with `buttonAriaLabel`.
 - Replace `prev_title` with `prevTitle`.
 - Replace `next_title` with `nextTitle`.
 - Replace `more_pages` with `morePages`.

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -187,9 +187,9 @@ export type PaginationProps = {
    */
   align?: string
   /**
-   * The title used in every button shown in the bar. Defaults to `Side %s`.
+   * The aria-label used in every button shown in the bar. Defaults to `Side %s`.
    */
-  buttonTitle?: string
+  buttonAriaLabel?: string
   /**
    * The title used in the previous page button. Defaults to `Forrige side`.
    */
@@ -254,7 +254,7 @@ const paginationDefaultProps = {
   markerElement: undefined,
   indicatorElement: undefined,
   align: 'left',
-  buttonTitle: null,
+  buttonAriaLabel: null,
   prevTitle: null,
   nextTitle: null,
   morePages: null,
@@ -354,7 +354,7 @@ class PaginationInstance extends React.PureComponent<PaginationProps> {
       pageElement: _pageElement,
       startupCount: _startupCount,
       parallelLoadCount: _parallelLoadCount,
-      buttonTitle: _buttonTitle,
+      buttonAriaLabel: _buttonAriaLabel,
       prevTitle: _prevTitle,
       nextTitle: _nextTitle,
       morePages: _morePages,

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -26,9 +26,9 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type PaginationBarProps = {
   /**
-   * The title used in every button shown in the bar. Defaults to Side %s.
+   * The aria-label used in every button shown in the bar. Defaults to Side %s.
    */
-  buttonTitle?: string
+  buttonAriaLabel?: string
 
   /**
    *  The title used in the previous page button. Defaults to Forrige side.
@@ -74,7 +74,7 @@ type PaginationBarContext = {
 }
 
 const defaultProps: Partial<PaginationBarProps> = {
-  buttonTitle: null,
+  buttonAriaLabel: null,
   prevTitle: null,
   nextTitle: null,
   morePages: null,
@@ -168,7 +168,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
   }
 
   const { getTranslation } = useContext(Context)
-  const { buttonTitle, prevTitle, nextTitle, morePages } =
+  const { buttonAriaLabel, prevTitle, nextTitle, morePages } =
     extendPropsWithContext(
       props,
       defaultProps,
@@ -234,7 +234,10 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
               key={pageNumber}
               className="dnb-pagination__button"
               text={String(pageNumber)}
-              aria-label={buttonTitle.replace('%s', String(pageNumber))}
+              aria-label={buttonAriaLabel.replace(
+                '%s',
+                String(pageNumber)
+              )}
               variant={
                 pageNumber === currentPageInternal
                   ? 'primary'
@@ -276,7 +279,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
                         : null
                     )}
                     text={String(pageNumber)}
-                    aria-label={buttonTitle.replace(
+                    aria-label={buttonAriaLabel.replace(
                       '%s',
                       String(pageNumber)
                     )}
@@ -302,7 +305,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
       </div>
 
       <span className="dnb-sr-only" aria-live="assertive">
-        {buttonTitle.replace('%s', String(currentPageInternal))}
+        {buttonAriaLabel.replace('%s', String(currentPageInternal))}
       </span>
     </div>
   )

--- a/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
@@ -106,8 +106,8 @@ export const PaginationProperties: PropertiesTableProps = {
     type: 'function',
     status: 'optional',
   },
-  buttonTitle: {
-    doc: 'The title used in every button shown in the bar. Defaults to `Side %s`.',
+  buttonAriaLabel: {
+    doc: 'The aria-label used in every button shown in the bar. Defaults to `Side %s`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -115,7 +115,7 @@ export default {
       clearButtonTitle: 'Nulstil',
     },
     Pagination: {
-      buttonTitle: 'Side %s',
+      buttonAriaLabel: 'Side %s',
       nextTitle: 'Næste side',
       prevTitle: 'Forrige side',
       morePages: '%s flere sider',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -118,7 +118,7 @@ export default {
       clearButtonTitle: 'Clear value',
     },
     Pagination: {
-      buttonTitle: 'Page %s',
+      buttonAriaLabel: 'Page %s',
       nextTitle: 'Next page',
       prevTitle: 'Previous page',
       morePages: '%s more pages',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -113,7 +113,7 @@ export default {
       clearButtonTitle: 'Nullstill',
     },
     Pagination: {
-      buttonTitle: 'Side %s',
+      buttonAriaLabel: 'Side %s',
       nextTitle: 'Neste side',
       prevTitle: 'Forrige side',
       morePages: '%s flere sider',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -114,7 +114,7 @@ export default {
       clearButtonTitle: 'Återställ',
     },
     Pagination: {
-      buttonTitle: 'Sida %s',
+      buttonAriaLabel: 'Sida %s',
       nextTitle: 'Nästa sida',
       prevTitle: 'Föregående sida',
       morePages: '%s fler sidor',


### PR DESCRIPTION
Rename buttonTitle to buttonAriaLabel on Pagination since this prop sets aria-label attributes on page buttons, not visible titles.

Also updates locale keys and v11 migration guide.

BREAKING CHANGE: Pagination buttonTitle renamed to buttonAriaLabel. Locale key Pagination.buttonTitle renamed to Pagination.buttonAriaLabel.

