### PR TITLE
break(Input)!: rename submitButtonTitle/clearButtonTitle to *AriaLabel

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -384,8 +384,10 @@ $ pnpm add @dnb/eufemia@11
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `input_state` with `inputState`.
-- Replace `submit_button_title` with `submitButtonTitle`.
-- Replace `clear_button_title` with `clearButtonTitle`.
+- Replace `submit_button_title` with `submitButtonAriaLabel`.
+- Replace `submitButtonTitle` with `submitButtonAriaLabel`.
+- Replace `clear_button_title` with `clearButtonAriaLabel`.
+- Replace `clearButtonTitle` with `clearButtonAriaLabel`.
 - Replace `keep_placeholder` with `keepPlaceholder`.
 - Replace `input_class` with `inputClass`.
 - Replace `input_attributes` with `inputAttributes`.
@@ -414,8 +416,10 @@ $ pnpm add @dnb/eufemia@11
 
 #### Translations
 
-- Replace `Input.submit_button_title` with `Input.submitButtonTitle`.
-- Replace `Input.clear_button_title` with `Input.clearButtonTitle`.
+- Replace `Input.submit_button_title` with `Input.submitButtonAriaLabel`.
+- Replace `Input.submitButtonTitle` with `Input.submitButtonAriaLabel`.
+- Replace `Input.clear_button_title` with `Input.clearButtonAriaLabel`.
+- Replace `Input.clearButtonTitle` with `Input.clearButtonAriaLabel`.
 
 #### SubmitButton (do we need to document this, I don't see any docs of this, but it's exposed/exported)
 
@@ -452,8 +456,10 @@ New props added:
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `input_state` with `inputState`.
-- Replace `submit_button_title` with `submitButtonTitle`.
-- Replace `clear_button_title` with `clearButtonTitle`.
+- Replace `submit_button_title` with `submitButtonAriaLabel`.
+- Replace `submitButtonTitle` with `submitButtonAriaLabel`.
+- Replace `clear_button_title` with `clearButtonAriaLabel`.
+- Replace `clearButtonTitle` with `clearButtonAriaLabel`.
 - Replace `keep_placeholder` with `keepPlaceholder`.
 - Replace `input_class` with `inputClass`.
 - Replace `input_attributes` with `inputAttributes`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -385,7 +385,6 @@ $ pnpm add @dnb/eufemia@11
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `input_state` with `inputState`.
 - Replace `submit_button_title` with `submitButtonAriaLabel`.
-- Replace `submitButtonTitle` with `submitButtonAriaLabel`.
 - Replace `clear_button_title` with `clearButtonAriaLabel`.
 - Replace `clearButtonTitle` with `clearButtonAriaLabel`.
 - Replace `keep_placeholder` with `keepPlaceholder`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -386,7 +386,6 @@ $ pnpm add @dnb/eufemia@11
 - Replace `input_state` with `inputState`.
 - Replace `submit_button_title` with `submitButtonAriaLabel`.
 - Replace `clear_button_title` with `clearButtonAriaLabel`.
-- Replace `clearButtonTitle` with `clearButtonAriaLabel`.
 - Replace `keep_placeholder` with `keepPlaceholder`.
 - Replace `input_class` with `inputClass`.
 - Replace `input_attributes` with `inputAttributes`.

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -138,8 +138,8 @@ export type InputMaskedProps = Omit<
     labelSrOnly?: boolean
     inputState?: string
     autocomplete?: string
-    submitButtonTitle?: string
-    clearButtonTitle?: string
+    submitButtonAriaLabel?: string
+    clearButtonAriaLabel?: string
     placeholder?: React.ReactNode
     clear?: boolean
     keepPlaceholder?: boolean

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -149,10 +149,10 @@ export type InputProps = Omit<
      */
     autocomplete?: string
     /**
-     * Title attribute for the search/submit button. Only relevant when `type="search"`.
+     * Aria-label for the search/submit button. Only relevant when `type="search"`.
      */
-    submitButtonTitle?: string
-    clearButtonTitle?: string
+    submitButtonAriaLabel?: string
+    clearButtonAriaLabel?: string
     /**
      * The placeholder which shows up once the input value is empty.
      */
@@ -317,8 +317,8 @@ export const inputDefaultProps = {
 
   // Submit button
   submitElement: null,
-  submitButtonTitle: null,
-  clearButtonTitle: null,
+  submitButtonAriaLabel: null,
+  clearButtonAriaLabel: null,
   submitButtonVariant: 'secondary',
   submitButtonIcon: 'loupe',
   submitButtonStatus: null,
@@ -586,8 +586,8 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     suffix,
     align,
     inputClass,
-    submitButtonTitle,
-    clearButtonTitle,
+    submitButtonAriaLabel,
+    clearButtonAriaLabel,
     submitButtonVariant,
     submitButtonIcon,
     submitButtonStatus,
@@ -821,8 +821,8 @@ function InputComponent({ ref, ...restProps }: InputProps) {
                   type="button"
                   variant="tertiary"
                   aria-controls={id}
-                  aria-label={clearButtonTitle}
-                  tooltip={hasVal && clearButtonTitle}
+                  aria-label={clearButtonAriaLabel}
+                  tooltip={hasVal && clearButtonAriaLabel}
                   icon="close"
                   iconSize={size === 'small' ? 'small' : undefined}
                   skeleton={skeleton}
@@ -851,7 +851,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
                       ? 'medium'
                       : 'default'
                   }
-                  title={submitButtonTitle}
+                  title={submitButtonAriaLabel}
                   variant={submitButtonVariant}
                   disabled={disabled}
                   skeleton={skeleton}

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -86,8 +86,8 @@ export const InputProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  submitButtonTitle: {
-    doc: 'Title attribute for the search/submit button. Only relevant when `type="search"`.',
+  submitButtonAriaLabel: {
+    doc: 'Aria-label for the search/submit button. Only relevant when `type="search"`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
@@ -199,7 +199,7 @@ export const InputSandbox = () => {
             type="search"
             align="right"
             stretch
-            submitButtonTitle="Custom search button title"
+            submitButtonAriaLabel="Custom search button title"
             placeholder="Large input clear button with right aligned text"
           />
         </Box>
@@ -209,7 +209,7 @@ export const InputSandbox = () => {
             status="Error"
             label="Disabled search:"
             type="search"
-            submitButtonTitle="Custom search button title"
+            submitButtonAriaLabel="Custom search button title"
             placeholder="Search text placeholder"
           />
         </Box>

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -111,8 +111,8 @@ export default {
       ariaRole: 'Hjælp-knap',
     },
     Input: {
-      submitButtonTitle: 'Indsend',
-      clearButtonTitle: 'Nulstil',
+      submitButtonAriaLabel: 'Indsend',
+      clearButtonAriaLabel: 'Nulstil',
     },
     Pagination: {
       buttonTitle: 'Side %s',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -114,8 +114,8 @@ export default {
       ariaReady: 'Ready to interact',
     },
     Input: {
-      submitButtonTitle: 'Submit button',
-      clearButtonTitle: 'Clear value',
+      submitButtonAriaLabel: 'Submit button',
+      clearButtonAriaLabel: 'Clear value',
     },
     Pagination: {
       buttonTitle: 'Page %s',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -109,8 +109,8 @@ export default {
       ariaRole: 'Hjelp-knapp',
     },
     Input: {
-      submitButtonTitle: 'Send',
-      clearButtonTitle: 'Nullstill',
+      submitButtonAriaLabel: 'Send',
+      clearButtonAriaLabel: 'Nullstill',
     },
     Pagination: {
       buttonTitle: 'Side %s',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -110,8 +110,8 @@ export default {
       ariaRole: 'Hjälp-knapp',
     },
     Input: {
-      submitButtonTitle: 'Skicka',
-      clearButtonTitle: 'Återställ',
+      submitButtonAriaLabel: 'Skicka',
+      clearButtonAriaLabel: 'Återställ',
     },
     Pagination: {
       buttonTitle: 'Sida %s',


### PR DESCRIPTION
Rename submitButtonTitle to submitButtonAriaLabel and clearButtonTitle to clearButtonAriaLabel on Input (and InputMasked) since these props set aria-label attributes, not visible titles.

Also updates locale keys and v11 migration guide.

BREAKING CHANGE: Input submitButtonTitle renamed to submitButtonAriaLabel, clearButtonTitle renamed to clearButtonAriaLabel. Locale keys Input.submitButtonTitle and Input.clearButtonTitle renamed accordingly.

