### PR TITLE
break(StepIndicator)!: rename overviewTitle to overviewAriaLabel

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1131,7 +1131,6 @@ render(<Logo svg={SbankenCompact} />)
 #### Translations
 
 - Replace `StepIndicator.overview_title` with `StepIndicator.overviewAriaLabel`.
-- Replace `StepIndicator.overviewTitle` with `StepIndicator.overviewAriaLabel`.
 - Replace `StepIndicator.step_title` with `StepIndicator.stepTitle`.
 
 #### Events

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1121,7 +1121,8 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `status_state` with `statusState`.
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `current_step` with `currentStep`.
-- Replace `overview_title` with `overviewTitle`.
+- Replace `overview_title` with `overviewAriaLabel`.
+- Replace `overviewTitle` with `overviewAriaLabel`.
 - Replace `step_title` with `stepTitle`.
 - Replace `current_step` with `currentStep`.
 - Replace `hide_numbers` with `hideNumbers`.
@@ -1129,7 +1130,8 @@ render(<Logo svg={SbankenCompact} />)
 
 #### Translations
 
-- Replace `StepIndicator.overview_title` with `StepIndicator.overviewTitle`.
+- Replace `StepIndicator.overview_title` with `StepIndicator.overviewAriaLabel`.
+- Replace `StepIndicator.overviewTitle` with `StepIndicator.overviewAriaLabel`.
 - Replace `StepIndicator.step_title` with `StepIndicator.stepTitle`.
 
 #### Events

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1122,7 +1122,6 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `current_step` with `currentStep`.
 - Replace `overview_title` with `overviewAriaLabel`.
-- Replace `overviewTitle` with `overviewAriaLabel`.
 - Replace `step_title` with `stepTitle`.
 - Replace `current_step` with `currentStep`.
 - Replace `hide_numbers` with `hideNumbers`.

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -59,10 +59,10 @@ export type StepIndicatorProps = Omit<
      */
     data: StepIndicatorData
     /**
-     *  The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`
+     *  The aria-label for the `<StepIndicatorTriggerButton />` section
      *  Defaults to `Steps Overview`
      */
-    overviewTitle?: string
+    overviewAriaLabel?: string
     /**
      *  The label for `<StepIndicatorTriggerButton />` and supplemental screen reader text for `<StepIndicatorItem />`
      *  This value need to contain `%step` and `%count` if you want to display the current step and total amount of steps

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -16,8 +16,8 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     type: 'number',
     status: 'optional',
   },
-  overviewTitle: {
-    doc: 'The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps Overview`.',
+  overviewAriaLabel: {
+    doc: 'The aria-label for the `<StepIndicatorTriggerButton />` section. Defaults to `Steps Overview`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -36,7 +36,7 @@ function StepIndicatorTriggerButton({
   const {
     stepsLabel,
     activeStep,
-    overviewTitle,
+    overviewAriaLabel,
     open,
     closeHandler,
     openHandler,
@@ -103,7 +103,7 @@ function StepIndicatorTriggerButton({
         large: [true, true, !open, !open],
       }}
       outset={isNested ? true : undefined}
-      aria-label={overviewTitle}
+      aria-label={overviewAriaLabel}
     >
       <HeightAnimation animate={!noAnimation}>
         <div {...(triggerParams as React.HTMLProps<HTMLDivElement>)}>

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -619,7 +619,7 @@ describe('StepIndicator ARIA', () => {
       <StepIndicator
         mode="loose"
         data={stepIndicatorListData}
-        overviewTitle="Custom Overview Title"
+        overviewAriaLabel="Custom Overview Title"
       />
     )
 
@@ -636,7 +636,7 @@ describe('StepIndicator ARIA', () => {
     expect(triggerDiv).toBeInTheDocument()
   })
 
-  it('should have default aria-label when overviewTitle is not provided', () => {
+  it('should have default aria-label when overviewAriaLabel is not provided', () => {
     render(<StepIndicator mode="loose" data={stepIndicatorListData} />)
 
     // The aria-label is on the section element that contains the trigger

--- a/packages/dnb-eufemia/src/components/step-indicator/stories/StepIndicator.stories.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/stories/StepIndicator.stories.tsx
@@ -294,7 +294,7 @@ export const TitleTests = () => {
     <>
       <Box>
         <StepIndicator
-          overviewTitle="Custom Overview Title"
+          overviewAriaLabel="Custom Overview Title"
           stepTitle="Custom Step Title"
           top="large"
           mode="loose"

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -127,7 +127,7 @@ export default {
       ariaReady: 'Klar til at interagere',
     },
     StepIndicator: {
-      overviewTitle: 'Trinoverblik',
+      overviewAriaLabel: 'Trinoverblik',
       stepTitle: 'Trin %step af %count:',
     },
     Slider: {

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -126,7 +126,7 @@ export default {
       loadButtonText: 'Show more content',
     },
     StepIndicator: {
-      overviewTitle: 'Steps Overview',
+      overviewAriaLabel: 'Steps Overview',
       stepTitle: 'Step %step of %count:',
     },
     Slider: {

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -125,7 +125,7 @@ export default {
       ariaReady: 'Klar til å samhandle',
     },
     StepIndicator: {
-      overviewTitle: 'Stegoversikt',
+      overviewAriaLabel: 'Stegoversikt',
       stepTitle: 'Steg %step av %count:',
     },
     Slider: {

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -126,7 +126,7 @@ export default {
       ariaReady: 'Klar att interagera',
     },
     StepIndicator: {
-      overviewTitle: 'Stegöversikt',
+      overviewAriaLabel: 'Stegöversikt',
       stepTitle: 'Steg %step av %count:',
     },
     Slider: {


### PR DESCRIPTION
Rename the overviewTitle prop to overviewAriaLabel since it is used as an aria-label attribute on the trigger button, not as visible text.

BREAKING CHANGE: overviewTitle prop renamed to overviewAriaLabel

