### PR TITLE
refactor(List): fix semantic roles on ItemAction

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAction.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAction.tsx
@@ -38,48 +38,39 @@ function ItemAction(props: ItemActionProps) {
     ...rest
   } = props
 
-  const handleClick = useCallback(
-    (
-      event: React.MouseEvent<
-        HTMLDivElement | HTMLAnchorElement,
-        MouseEvent
-      >
-    ) => {
+  const handleButtonClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (!pending) {
-        onClick && onClick(event as React.MouseEvent<HTMLDivElement>)
+        onClick &&
+          onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
       }
     },
     [onClick, pending]
-  )
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault()
-        handleClick(
-          event as unknown as React.MouseEvent<
-            HTMLDivElement | HTMLAnchorElement,
-            MouseEvent
-          >
-        )
-      }
-    },
-    [handleClick]
   )
 
   const anchorRef = useRef<HTMLAnchorElement>(null)
 
-  const handleLinkKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Enter' || event.key === ' ') {
+  const handleAnchorClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (pending) {
+        event.preventDefault()
+        return // stop here
+      }
+      onClick?.(event as unknown as React.MouseEvent<HTMLDivElement>)
+    },
+    [onClick, pending]
+  )
+
+  const handleAnchorKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+      if (event.key === ' ') {
         event.preventDefault()
         if (!pending) {
           anchorRef.current?.click()
-          onClick?.(event as unknown as React.MouseEvent<HTMLDivElement>)
         }
       }
     },
-    [onClick, pending]
+    [pending]
   )
 
   const actionClassName = classnames(
@@ -101,22 +92,17 @@ function ItemAction(props: ItemActionProps) {
 
   if (href) {
     return (
-      <ItemContent
-        className={actionClassName}
-        role="link"
-        tabIndex={pending ? -1 : 0}
-        aria-disabled={pending ? true : undefined}
-        onKeyDown={handleLinkKeyDown}
-        pending={pending}
-        {...rest}
-      >
+      <ItemContent className={actionClassName} pending={pending} {...rest}>
         <Anchor
           noStyle
           ref={anchorRef}
           href={href}
           target={target}
           rel={rel}
-          tabIndex={-1}
+          tabIndex={pending ? -1 : 0}
+          aria-disabled={pending ? true : undefined}
+          onClick={handleAnchorClick}
+          onKeyDown={handleAnchorKeyDown}
         >
           {content}
         </Anchor>
@@ -125,17 +111,16 @@ function ItemAction(props: ItemActionProps) {
   }
 
   return (
-    <ItemContent
-      className={actionClassName}
-      role="button"
-      tabIndex={pending ? -1 : 0}
-      aria-disabled={pending ? true : undefined}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      pending={pending}
-      {...rest}
-    >
-      {content}
+    <ItemContent className={actionClassName} pending={pending} {...rest}>
+      <button
+        type="button"
+        className="dnb-list__item__action__button"
+        tabIndex={pending ? -1 : 0}
+        aria-disabled={pending ? true : undefined}
+        onClick={handleButtonClick}
+      >
+        {content}
+      </button>
     </ItemContent>
   )
 }

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
@@ -29,28 +29,33 @@ describe('ItemAction', () => {
     expect(element.classList).toContain('dnb-t__size--basis')
   })
 
-  it('has role="button" for accessibility', () => {
+  it('renders a native button inside the list item', () => {
     render(<ItemAction>Content</ItemAction>)
 
-    const element = document.querySelector('.dnb-list__item__action')
+    const listItem = document.querySelector('.dnb-list__item__action')
+    const button = listItem.querySelector('button')
 
-    expect(element.getAttribute('role')).toBe('button')
+    expect(listItem.tagName).toBe('LI')
+    expect(listItem.getAttribute('role')).toBeNull()
+    expect(button).toBeInTheDocument()
+    expect(button.getAttribute('type')).toBe('button')
   })
 
-  it('allows role to be overridden', () => {
-    render(<ItemAction role="link">Content</ItemAction>)
-
-    const element = document.querySelector('.dnb-list__item__action')
-
-    expect(element.getAttribute('role')).toBe('link')
-  })
-
-  it('has tabIndex 0 for keyboard navigation when not pending', () => {
+  it('preserves listitem role on the li element', () => {
     render(<ItemAction>Content</ItemAction>)
 
-    const element = document.querySelector('.dnb-list__item__action')
+    const listItem = document.querySelector('.dnb-list__item__action')
 
-    expect(element.getAttribute('tabindex')).toBe('0')
+    expect(listItem.tagName).toBe('LI')
+    expect(listItem.getAttribute('role')).toBeNull()
+  })
+
+  it('has tabIndex 0 on the button when not pending', () => {
+    render(<ItemAction>Content</ItemAction>)
+
+    const button = document.querySelector('.dnb-list__item__action button')
+
+    expect(button.getAttribute('tabindex')).toBe('0')
   })
 
   it('renders IconPrimary chevron_right at the end', () => {
@@ -90,38 +95,14 @@ describe('ItemAction', () => {
     expect(element.className).toContain('dnb-list__item--chevron-left')
   })
 
-  it('calls onClick when clicked', () => {
+  it('calls onClick when button is clicked', () => {
     const handleClick = jest.fn()
 
     render(<ItemAction onClick={handleClick}>Content</ItemAction>)
 
-    const element = document.querySelector('.dnb-list__item__action')
+    const button = document.querySelector('.dnb-list__item__action button')
 
-    fireEvent.click(element)
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('calls onClick when Enter key is pressed', () => {
-    const handleClick = jest.fn()
-
-    render(<ItemAction onClick={handleClick}>Content</ItemAction>)
-
-    const element = document.querySelector('.dnb-list__item__action')
-
-    fireEvent.keyDown(element, { key: 'Enter' })
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('calls onClick when Space key is pressed', () => {
-    const handleClick = jest.fn()
-
-    render(<ItemAction onClick={handleClick}>Content</ItemAction>)
-
-    const element = document.querySelector('.dnb-list__item__action')
-
-    fireEvent.keyDown(element, { key: ' ' })
+    fireEvent.click(button)
 
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
@@ -135,7 +116,7 @@ describe('ItemAction', () => {
     expect(element.classList).toContain('my-action')
   })
 
-  it('forwards custom HTML attributes', () => {
+  it('forwards custom HTML attributes to the list item', () => {
     render(
       <ItemAction
         data-testid="action-item"
@@ -189,13 +170,15 @@ describe('ItemAction', () => {
       ).toBeInTheDocument()
     })
 
-    it('has aria-disabled and tabIndex -1 when pending', () => {
+    it('has aria-disabled and tabIndex -1 on button when pending', () => {
       render(<ItemAction pending>Content</ItemAction>)
 
-      const element = document.querySelector('.dnb-list__item__action')
+      const button = document.querySelector(
+        '.dnb-list__item__action button'
+      )
 
-      expect(element.getAttribute('aria-disabled')).toBe('true')
-      expect(element.getAttribute('tabindex')).toBe('-1')
+      expect(button.getAttribute('aria-disabled')).toBe('true')
+      expect(button.getAttribute('tabindex')).toBe('-1')
     })
 
     it('does not call onClick on click when pending is true', () => {
@@ -207,41 +190,11 @@ describe('ItemAction', () => {
         </ItemAction>
       )
 
-      const element = document.querySelector('.dnb-list__item__action')
-
-      fireEvent.click(element)
-
-      expect(handleClick).not.toHaveBeenCalled()
-    })
-
-    it('does not call onClick on Enter key when pending is true', () => {
-      const handleClick = jest.fn()
-
-      render(
-        <ItemAction pending onClick={handleClick}>
-          Content
-        </ItemAction>
+      const button = document.querySelector(
+        '.dnb-list__item__action button'
       )
 
-      const element = document.querySelector('.dnb-list__item__action')
-
-      fireEvent.keyDown(element, { key: 'Enter' })
-
-      expect(handleClick).not.toHaveBeenCalled()
-    })
-
-    it('does not call onClick on Space key when pending is true', () => {
-      const handleClick = jest.fn()
-
-      render(
-        <ItemAction pending onClick={handleClick}>
-          Content
-        </ItemAction>
-      )
-
-      const element = document.querySelector('.dnb-list__item__action')
-
-      fireEvent.keyDown(element, { key: ' ' })
+      fireEvent.click(button)
 
       expect(handleClick).not.toHaveBeenCalled()
     })
@@ -289,84 +242,71 @@ describe('ItemAction', () => {
       expect(anchor?.getAttribute('href')).toBe('https://example.com/page')
     })
 
-    it('has role="link" on list item when href is provided', () => {
+    it('preserves listitem role on li when href is provided', () => {
       render(<ItemAction href="/path">Content</ItemAction>)
 
       const listItem = document.querySelector(hrefSelector)
 
-      expect(listItem.getAttribute('role')).toBe('link')
+      expect(listItem.tagName).toBe('LI')
+      expect(listItem.getAttribute('role')).toBeNull()
     })
 
-    it('allows role to be overridden when href is provided', () => {
-      render(
-        <ItemAction href="/path" role="button">
-          Content
-        </ItemAction>
-      )
-
-      const listItem = document.querySelector(hrefSelector)
-
-      expect(listItem.getAttribute('role')).toBe('button')
-    })
-
-    it('has tabIndex 0 on list item when href and not pending', () => {
-      render(<ItemAction href="/path">Link content</ItemAction>)
-
-      const listItem = document.querySelector(hrefSelector)
-
-      expect(listItem?.getAttribute('tabindex')).toBe('0')
-    })
-
-    it('has tabIndex -1 on anchor when href (focus on list item)', () => {
+    it('anchor is focusable when href is provided', () => {
       render(<ItemAction href="/path">Link content</ItemAction>)
 
       const container = document.querySelector(hrefSelector)
       const anchor = container?.querySelector('a')
 
-      expect(anchor?.getAttribute('tabindex')).toBe('-1')
+      expect(anchor?.getAttribute('tabindex')).toBe('0')
     })
 
-    it('has tabIndex -1 on list item when href and pending', () => {
+    it('anchor has tabIndex -1 and aria-disabled when pending', () => {
       render(
         <ItemAction href="/path" pending>
           Link content
         </ItemAction>
       )
 
-      const listItem = document.querySelector(hrefSelector)
+      const container = document.querySelector(hrefSelector)
+      const anchor = container?.querySelector('a')
 
-      expect(listItem?.getAttribute('tabindex')).toBe('-1')
+      expect(anchor?.getAttribute('tabindex')).toBe('-1')
+      expect(anchor?.getAttribute('aria-disabled')).toBe('true')
     })
 
-    it('triggers anchor click when list item receives Enter key (href)', () => {
+    it('activates anchor on Space key for backward compatibility', () => {
       render(<ItemAction href="/path">Link content</ItemAction>)
 
-      const listItem = document.querySelector(hrefSelector)
-      const anchor = listItem?.querySelector('a')
+      const container = document.querySelector(hrefSelector)
+      const anchor = container?.querySelector('a')
 
       expect(anchor).toBeInTheDocument()
 
       const clickSpy = jest.spyOn(anchor as HTMLAnchorElement, 'click')
 
-      fireEvent.keyDown(listItem as Element, { key: 'Enter' })
+      fireEvent.keyDown(anchor as Element, { key: ' ' })
 
       expect(clickSpy).toHaveBeenCalled()
       clickSpy.mockRestore()
     })
 
-    it('triggers anchor click when list item receives Space key (href)', () => {
-      render(<ItemAction href="/path">Link content</ItemAction>)
+    it('does not activate anchor on Space key when pending', () => {
+      render(
+        <ItemAction href="/path" pending>
+          Link content
+        </ItemAction>
+      )
 
-      const listItem = document.querySelector(hrefSelector)
-      const anchor = listItem?.querySelector('a')
+      const container = document.querySelector(hrefSelector)
+      const anchor = container?.querySelector('a')
 
       expect(anchor).toBeInTheDocument()
 
       const clickSpy = jest.spyOn(anchor as HTMLAnchorElement, 'click')
 
-      fireEvent.keyDown(listItem as Element, { key: ' ' })
+      fireEvent.keyDown(anchor as Element, { key: ' ' })
 
-      expect(clickSpy).toHaveBeenCalled()
+      expect(clickSpy).not.toHaveBeenCalled()
       clickSpy.mockRestore()
     })
 
@@ -389,10 +329,11 @@ describe('ItemAction', () => {
 
       const element = document.querySelector('.dnb-list__item__action')
       const hrefElement = document.querySelector(hrefSelector)
+      const button = element.querySelector('button')
 
       expect(element.tagName).toBe('LI')
-      expect(element.getAttribute('href')).toBeNull()
       expect(hrefElement).toBeNull()
+      expect(button).toBeInTheDocument()
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -274,10 +274,31 @@
 
     &__action {
       cursor: pointer;
-      outline: none;
 
       .dnb-icon {
         color: var(--item-icon-color);
+      }
+
+      // Button reset for click mode — wraps all slots
+      &__button {
+        appearance: none;
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: inherit;
+        text-align: inherit;
+        width: 100%;
+        cursor: pointer;
+        outline: none;
+
+        display: grid;
+        grid-template:
+          var(--item-grid-template-areas) /
+          var(--item-grid-template-columns);
+        grid-column: 1 / -1;
+        grid-row: 1 / -1;
       }
 
       // When href is set, the anchor wraps the slots; make it the grid container
@@ -292,11 +313,12 @@
         grid-row: 1 / -1; // Center vertically
         text-decoration: none;
         color: inherit;
+        outline: none;
       }
 
-      // Handle action states
+      // Handle action states — focus detection via inner button/anchor
       &:hover,
-      &:focus-visible {
+      &:has(:focus-visible) {
         --item-outline-color: var(--item-navigation-color);
         --item-outline-width: 0.125rem;
         z-index: 2;


### PR DESCRIPTION
Replace role="button" on <li> with a native <button> nested inside the list item, preserving both listitem and button semantics. For href mode, move focus target to the <Anchor> itself (tabIndex 0) instead of the <li>, with Space key handler for backward compatibility.

Add button reset CSS (.dnb-list__item__action__button) with grid layout to maintain the existing visual grid system.

