### PR TITLE
feat(List): extend ListVariant type for custom variants

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ListContext.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-export type ListVariant = 'basic'
+export type ListVariant = 'basic' | (string & {})
 export type ListContext = {
   variant: ListVariant
   separated: boolean

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -1,6 +1,12 @@
 import { PropertiesTableProps } from '../../shared/types'
 
 export const ContainerProperties: PropertiesTableProps = {
+  variant: {
+    doc: 'Visual variant of the list. Defaults to `basic`. Custom variant strings map to a `dnb-list--variant-{name}` CSS class for custom theming.',
+    type: 'string',
+    defaultValue: "'basic'",
+    status: 'optional',
+  },
   separated: {
     doc: 'When `true`, adds row gap between items so each row keeps its own outline and border radius instead of running edge-to-edge.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -56,6 +56,14 @@ describe('List Container', () => {
     expect(element.classList).toContain('dnb-list--variant-basic')
   })
 
+  it('supports custom variant strings', () => {
+    render(<Container variant="compact">Content</Container>)
+
+    const element = document.querySelector('.dnb-list')
+
+    expect(element.classList).toContain('dnb-list--variant-compact')
+  })
+
   it('adds separated modifier class when separated is true', () => {
     render(<Container separated>Content</Container>)
 


### PR DESCRIPTION
Change ListVariant from literal 'basic' to 'basic' | (string & {}) so consumers can pass custom variant strings for themed styling. Custom variants produce a dnb-list--variant-{name} CSS class. Also document the variant prop on ContainerProperties.

