### PR TITLE
feat(Stat): add localization keys for Trend screen reader text

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/Trend.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Trend.tsx
@@ -7,6 +7,7 @@ import {
   validateDOMAttributes,
 } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
+import { useTranslation } from '../../shared'
 import StatValueContext from './StatValueContext'
 import useStatSkeleton from './useStatSkeleton'
 
@@ -60,12 +61,30 @@ function Trend(props: TrendProps) {
     displayValue: string
   } = resolveTrendValue(rawValue)
 
+  const {
+    Stat: {
+      trendUp = 'up %value',
+      trendDown = 'down %value',
+      trendSteady = 'steady %value',
+    } = {},
+  } = useTranslation()
+
   const childText = hasCustomChildren ? convertJsxToString(children) : ''
   const visibleText = childText || `${sign || ''}${displayValue}`
   const usedTone = tone || resolvedTone
+
+  const trendTemplates = {
+    positive: trendUp,
+    negative: trendDown,
+    neutral: trendSteady,
+  }
+  const localizedTrendText = trendTemplates[usedTone].replace(
+    '%value',
+    visibleText
+  )
   const srText = srLabel
-    ? `${convertJsxToString(srLabel)}${' '}${visibleText}`
-    : visibleText
+    ? `${convertJsxToString(srLabel)}${' '}${localizedTrendText}`
+    : localizedTrendText
 
   const attributes = validateDOMAttributes(props, {
     ...rest,

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Trend.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Trend.test.tsx
@@ -16,7 +16,7 @@ describe('Stat.Trend', () => {
     expect(trend.classList).toContain('dnb-stat__trend--positive')
     expect(sign.textContent).toBe('+')
     expect(value.textContent).toBe('12.4')
-    expect(sr.getAttribute('data-text')).toBe('+12.4')
+    expect(sr.getAttribute('data-text')).toBe('opp +12.4')
   })
 
   it('renders negative sign and red state class', () => {
@@ -31,7 +31,7 @@ describe('Stat.Trend', () => {
     expect(sign.textContent).toBe('-')
     expect(value.textContent).toBe('2.1%')
     expect(sr.getAttribute('data-text')).toContain('Change:')
-    expect(sr.getAttribute('data-text')).toContain('-2.1%')
+    expect(sr.getAttribute('data-text')).toContain('ned -2.1%')
   })
 
   it('renders neutral tone for zero without sign', () => {
@@ -47,7 +47,7 @@ describe('Stat.Trend', () => {
     expect(trend.classList).not.toContain('dnb-stat__trend--negative')
     expect(sign).not.toBeInTheDocument()
     expect(value.textContent).toBe('0')
-    expect(sr.getAttribute('data-text')).toBe('0')
+    expect(sr.getAttribute('data-text')).toBe('uendret 0')
   })
 
   it('supports NumberFormat as children without duplicating sign', () => {

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -108,6 +108,9 @@ export default {
     },
     Stat: {
       rating: '%value of %max',
+      trendUp: 'up %value',
+      trendDown: 'down %value',
+      trendSteady: 'steady %value',
     },
     HelpButton: {
       title: 'Help text',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -107,6 +107,9 @@ export default {
     },
     Stat: {
       rating: '%value av %max',
+      trendUp: 'opp %value',
+      trendDown: 'ned %value',
+      trendSteady: 'uendret %value',
     },
     HelpButton: {
       title: 'Hjelpetekst',


### PR DESCRIPTION
Add trendUp, trendDown, trendSteady translation keys to nb-NO and en-GB locales. Trend now uses useTranslation() to build localized screen reader text (e.g. 'opp +12.4%' instead of raw '+12.4%').

