### PR TITLE
fix(Stat): add role="text" to Trend root element

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/Trend.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Trend.tsx
@@ -69,6 +69,7 @@ function Trend(props: TrendProps) {
 
   const attributes = validateDOMAttributes(props, {
     ...rest,
+    role: 'text',
     className: classnames(
       'dnb-stat',
       'dnb-stat__trend',

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Trend.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Trend.test.tsx
@@ -13,6 +13,7 @@ describe('Stat.Trend', () => {
     const value = document.querySelector('.dnb-stat__trend-value')
     const sr = document.querySelector('.dnb-stat .dnb-sr-only')
 
+    expect(trend).toHaveAttribute('role', 'text')
     expect(trend.classList).toContain('dnb-stat__trend--positive')
     expect(sign.textContent).toBe('+')
     expect(value.textContent).toBe('12.4')


### PR DESCRIPTION
The Trend component renders mixed visual + sr-only content that should be read as a single coherent string by screen readers. Adding role="text" prevents screen readers from splitting the content into separate stops.

