### PR TITLE
feat(List): support element="ol" on Container

### DIFF
--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -3,9 +3,12 @@ import classnames from 'classnames'
 import { ListVariant, ListContext } from './ListContext'
 import FlexContainer, { Props as FlexProps } from '../flex/Stack'
 
+export type ListContainerElement = 'ul' | 'ol'
+
 export type ListContainerProps = {
   variant?: ListVariant
   separated?: boolean
+  element?: ListContainerElement
 } & React.HTMLAttributes<HTMLDivElement> &
   FlexProps
 
@@ -15,6 +18,7 @@ function ListContainer(props: ListContainerProps) {
     children,
     variant = 'basic',
     separated,
+    element = 'ul',
     wrapChildrenInSpace = false,
     ...rest
   } = props
@@ -22,7 +26,7 @@ function ListContainer(props: ListContainerProps) {
   return (
     <ListContext.Provider value={{ variant, separated }}>
       <FlexContainer
-        element="ul"
+        element={element}
         rowGap={separated ? 'small' : false}
         wrapChildrenInSpace={wrapChildrenInSpace}
         className={classnames(

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -1,6 +1,12 @@
 import { PropertiesTableProps } from '../../shared/types'
 
 export const ContainerProperties: PropertiesTableProps = {
+  element: {
+    doc: 'The HTML element to render. Defaults to `ul`. Use `ol` for ordered list semantics.',
+    type: ["'ul'", "'ol'"],
+    defaultValue: "'ul'",
+    status: 'optional',
+  },
   separated: {
     doc: 'When `true`, adds row gap between items so each row keeps its own outline and border radius instead of running edge-to-edge.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -24,6 +24,14 @@ describe('List Container', () => {
     expect(element.tagName).toBe('UL')
   })
 
+  it('renders as ol element when element is ol', () => {
+    render(<Container element="ol">Content</Container>)
+
+    const element = document.querySelector('.dnb-list')
+
+    expect(element.tagName).toBe('OL')
+  })
+
   it('merges custom className', () => {
     render(
       <Container className="custom-class">


### PR DESCRIPTION
Container now accepts an element prop ('ul' | 'ol') that defaults to 'ul'. Setting element="ol" renders the list as an ordered list for proper semantics.

