### PR TITLE
docs(Stat): document Rating CSS custom properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/properties.mdx
@@ -12,6 +12,7 @@ import { InlineProperties } from '@dnb/eufemia/src/components/stat/InlineDocs'
 import { LabelProperties } from '@dnb/eufemia/src/components/stat/LabelDocs'
 import { PercentProperties } from '@dnb/eufemia/src/components/stat/PercentDocs'
 import { RatingProperties } from '@dnb/eufemia/src/components/stat/RatingDocs'
+import { RatingCSSProperties } from '@dnb/eufemia/src/components/stat/RatingDocs'
 import { RootProperties } from '@dnb/eufemia/src/components/stat/RootDocs'
 import { TrendProperties } from '@dnb/eufemia/src/components/stat/TrendDocs'
 
@@ -34,6 +35,12 @@ import { TrendProperties } from '@dnb/eufemia/src/components/stat/TrendDocs'
 ## Stat.Rating
 
 <PropertiesTable props={RatingProperties} />
+
+### CSS Custom Properties
+
+These properties are set automatically by the component based on the `value` and `max` props. They can be used for advanced style customization.
+
+<PropertiesTable props={RatingCSSProperties} />
 
 ## Stat.Info
 

--- a/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
@@ -25,3 +25,21 @@ export const RatingProperties: PropertiesTableProps = {
   skeleton: skeletonProperty,
   '[Space](/uilib/layout/space/properties)': spacingProperties,
 }
+
+export const RatingCSSProperties: PropertiesTableProps = {
+  '--dnb-stat-rating-fill': {
+    doc: 'Fill percentage for each star in the `stars` variant. Set automatically based on `value`.',
+    type: 'CSS Custom Property',
+    status: 'optional',
+  },
+  '--dnb-stat-rating-step-height': {
+    doc: 'Height of each step in the `progressive` variant. Scales from `0.25rem` to `1rem` based on position.',
+    type: 'CSS Custom Property',
+    status: 'optional',
+  },
+  '--dnb-stat-rating-step-fill': {
+    doc: 'Fill percentage for each step in the `progressive` variant. Set automatically based on `value`.',
+    type: 'CSS Custom Property',
+    status: 'optional',
+  },
+}


### PR DESCRIPTION
- Add RatingCSSProperties export documenting --dnb-stat-rating-fill, --dnb-stat-rating-step-height, and --dnb-stat-rating-step-fill
- Add CSS Custom Properties section to Stat.Rating on the properties page
- These properties are set automatically by the component but can be used for advanced style customization

