### PR TITLE
fix(Stat.Trend): use neutral background color for neutral tone

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
@@ -140,7 +140,7 @@
 
     &--neutral {
       color: var(--color-black-80);
-      background-color: var(--color-mint-green-25);
+      background-color: var(--color-black-8);
     }
   }
 


### PR DESCRIPTION
Stat.Trend --neutral used the same mint-green background as --positive, making them visually indistinguishable. Changed to --color-black-8 for a proper neutral appearance.

