### PR TITLE
chore(Stat,List): add HTML attribute forwarding tests

### DIFF
--- a/packages/dnb-eufemia/src/components/list/__tests__/List.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/List.test.tsx
@@ -315,4 +315,68 @@ describe('List', () => {
       expect(await axeComponent(container)).toHaveNoViolations()
     })
   })
+
+  it('forwards data-* attributes on Container', () => {
+    render(
+      <List.Container data-testid="my-list">
+        <List.Item.Basic title="Row">
+          <List.Cell.End>Value</List.Cell.End>
+        </List.Item.Basic>
+      </List.Container>
+    )
+
+    const list = document.querySelector('.dnb-list')
+
+    expect(list).toHaveAttribute('data-testid', 'my-list')
+  })
+
+  it('forwards custom className on Container', () => {
+    render(
+      <List.Container className="custom-list">
+        <List.Item.Basic title="Row">
+          <List.Cell.End>Value</List.Cell.End>
+        </List.Item.Basic>
+      </List.Container>
+    )
+
+    const list = document.querySelector('.dnb-list')
+
+    expect(list.classList).toContain('custom-list')
+  })
+
+  it('forwards data-* attributes on Item.Action', () => {
+    render(
+      <List.Container>
+        <List.Item.Action
+          title="Action"
+          onClick={() => {}}
+          data-testid="action-item"
+        >
+          <List.Cell.End>123</List.Cell.End>
+        </List.Item.Action>
+      </List.Container>
+    )
+
+    const item = document.querySelector('.dnb-list__item__action')
+
+    expect(item).toHaveAttribute('data-testid', 'action-item')
+  })
+
+  it('forwards aria-label on Item.Action', () => {
+    render(
+      <List.Container>
+        <List.Item.Action
+          title="Action"
+          onClick={() => {}}
+          aria-label="Perform action"
+        >
+          <List.Cell.End>123</List.Cell.End>
+        </List.Item.Action>
+      </List.Container>
+    )
+
+    const item = document.querySelector('.dnb-list__item__action')
+
+    expect(item).toHaveAttribute('aria-label', 'Perform action')
+  })
 })

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
@@ -545,4 +545,68 @@ describe('Stat integration', () => {
 
     expect(icon.classList).toContain('dnb-skeleton')
   })
+
+  it('forwards data-* attributes on Root', () => {
+    render(
+      <Stat.Root data-testid="my-stat">
+        <Stat.Label>Revenue</Stat.Label>
+        <Stat.Content>
+          <Stat.Currency value={1234} />
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const root = document.querySelector('.dnb-stat__root')
+
+    expect(root).toHaveAttribute('data-testid', 'my-stat')
+  })
+
+  it('forwards aria-label on Currency', () => {
+    render(
+      <Stat.Root>
+        <Stat.Label>Revenue</Stat.Label>
+        <Stat.Content>
+          <Stat.Currency value={1234} aria-label="Revenue amount" />
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const currency = document.querySelector(
+      '.dnb-stat__content-item > .dnb-stat'
+    )
+
+    expect(currency).toHaveAttribute('aria-label', 'Revenue amount')
+  })
+
+  it('forwards data-* attributes on Trend', () => {
+    render(
+      <Stat.Root>
+        <Stat.Label>Growth</Stat.Label>
+        <Stat.Content>
+          <Stat.Trend data-testid="trend-indicator">+5%</Stat.Trend>
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const trend = document.querySelector('.dnb-stat__trend')
+
+    expect(trend).toHaveAttribute('data-testid', 'trend-indicator')
+  })
+
+  it('forwards custom className on Label and Content', () => {
+    render(
+      <Stat.Root>
+        <Stat.Label className="custom-label">Revenue</Stat.Label>
+        <Stat.Content className="custom-content">
+          <Stat.Currency value={1234} />
+        </Stat.Content>
+      </Stat.Root>
+    )
+
+    const label = document.querySelector('.dnb-stat__label')
+    const content = document.querySelector('.dnb-stat__content-item')
+
+    expect(label.classList).toContain('custom-label')
+    expect(content.classList).toContain('custom-content')
+  })
 })


### PR DESCRIPTION
Add tests verifying data-* attributes, aria-label, and custom className forwarding on Stat.Root, Stat.Currency, Stat.Trend, Stat.Label, Stat.Content, List.Container, and List.Item.Action. These tests align with the standard Eufemia component test pattern.

