### PR TITLE
fix(List): distinguish controlled and uncontrolled modes in ItemAccordion

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -2,7 +2,6 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useState,
 } from 'react'
 import classnames from 'classnames'
@@ -63,7 +62,7 @@ function ItemAccordion(props: ItemAccordionProps) {
     pending,
     disabled,
     skeleton,
-    open = false,
+    open,
     keepInDOM = false,
     chevronPosition = 'right',
     icon,
@@ -72,7 +71,8 @@ function ItemAccordion(props: ItemAccordionProps) {
     ...rest
   } = props
 
-  const [openState, setOpen] = useState(open)
+  const isControlled = open !== undefined
+  const [internalOpen, setInternalOpen] = useState(open ?? false)
   const accordionId = useId(idProp)
   const inheritedDisabled = useContext(ListContext)?.disabled
   const appliedDisabled = disabled ?? inheritedDisabled
@@ -82,9 +82,14 @@ function ItemAccordion(props: ItemAccordionProps) {
       React.isValidElement(child) && child.type === AccordionHeader
   )
 
-  useEffect(() => {
-    setOpen(open)
-  }, [open])
+  const openState = isControlled ? open : internalOpen
+  const setOpen: React.Dispatch<React.SetStateAction<boolean>> =
+    isControlled
+      ? () => {
+          // In controlled mode, do not update internal state.
+          // The consumer drives open/close via the open prop.
+        }
+      : setInternalOpen
 
   return (
     <ItemAccordionContext.Provider

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
@@ -70,46 +70,8 @@ describe('ItemAccordion', () => {
     )
   })
 
-  it('syncs open state when open prop changes after mount', () => {
-    const { rerender } = render(
-      <ItemAccordion open={false}>
-        <ItemAccordion.Header>Title</ItemAccordion.Header>
-        <ItemAccordion.Content>Content</ItemAccordion.Content>
-      </ItemAccordion>
-    )
-
-    let accordion = document.querySelector('.dnb-list__item__accordion')
-    expect(accordion.classList).not.toContain(
-      'dnb-list__item__accordion--open'
-    )
-
-    rerender(
-      <ItemAccordion open>
-        <ItemAccordion.Header>Title</ItemAccordion.Header>
-        <ItemAccordion.Content>Content</ItemAccordion.Content>
-      </ItemAccordion>
-    )
-
-    accordion = document.querySelector('.dnb-list__item__accordion')
-    expect(accordion.classList).toContain(
-      'dnb-list__item__accordion--open'
-    )
-
-    rerender(
-      <ItemAccordion open={false}>
-        <ItemAccordion.Header>Title</ItemAccordion.Header>
-        <ItemAccordion.Content>Content</ItemAccordion.Content>
-      </ItemAccordion>
-    )
-
-    accordion = document.querySelector('.dnb-list__item__accordion')
-    expect(accordion.classList).not.toContain(
-      'dnb-list__item__accordion--open'
-    )
-  })
-
-  it('header click still toggles open state after open prop has changed', () => {
-    const { rerender } = render(
+  it('does not toggle internally when open prop is controlled', () => {
+    render(
       <ItemAccordion open={false}>
         <ItemAccordion.Header>Title</ItemAccordion.Header>
         <ItemAccordion.Content>Content</ItemAccordion.Content>
@@ -119,7 +81,28 @@ describe('ItemAccordion', () => {
     const header = document.querySelector(
       '.dnb-list__item__accordion__header'
     )
-    let accordion = document.querySelector('.dnb-list__item__accordion')
+    const accordion = document.querySelector('.dnb-list__item__accordion')
+
+    expect(accordion.classList).not.toContain(
+      'dnb-list__item__accordion--open'
+    )
+
+    fireEvent.click(header)
+
+    expect(accordion.classList).not.toContain(
+      'dnb-list__item__accordion--open'
+    )
+  })
+
+  it('follows controlled open prop changes via rerender', () => {
+    const { rerender } = render(
+      <ItemAccordion open={false}>
+        <ItemAccordion.Header>Title</ItemAccordion.Header>
+        <ItemAccordion.Content>Content</ItemAccordion.Content>
+      </ItemAccordion>
+    )
+
+    const accordion = document.querySelector('.dnb-list__item__accordion')
 
     expect(accordion.classList).not.toContain(
       'dnb-list__item__accordion--open'
@@ -132,24 +115,39 @@ describe('ItemAccordion', () => {
       </ItemAccordion>
     )
 
-    accordion = document.querySelector('.dnb-list__item__accordion')
     expect(accordion.classList).toContain(
       'dnb-list__item__accordion--open'
     )
 
-    fireEvent.click(header)
+    rerender(
+      <ItemAccordion open={false}>
+        <ItemAccordion.Header>Title</ItemAccordion.Header>
+        <ItemAccordion.Content>Content</ItemAccordion.Content>
+      </ItemAccordion>
+    )
 
-    accordion = document.querySelector('.dnb-list__item__accordion')
     expect(accordion.classList).not.toContain(
       'dnb-list__item__accordion--open'
     )
+  })
+
+  it('calls onClick in controlled mode so consumer can update open prop', () => {
+    const handleClick = jest.fn()
+
+    render(
+      <ItemAccordion open={false} onClick={handleClick}>
+        <ItemAccordion.Header>Title</ItemAccordion.Header>
+        <ItemAccordion.Content>Content</ItemAccordion.Content>
+      </ItemAccordion>
+    )
+
+    const header = document.querySelector(
+      '.dnb-list__item__accordion__header'
+    )
 
     fireEvent.click(header)
 
-    accordion = document.querySelector('.dnb-list__item__accordion')
-    expect(accordion.classList).toContain(
-      'dnb-list__item__accordion--open'
-    )
+    expect(handleClick).toHaveBeenCalledTimes(1)
   })
 
   it('header has role="button" and tabIndex 0', () => {


### PR DESCRIPTION
When the open prop is explicitly provided, ItemAccordion is now in controlled mode: the prop directly drives the open state and clicks call onClick without toggling internal state. When open is undefined, the component uses internal state (uncontrolled mode). This prevents the previous bug where a controlled open={false} could be overridden by internal state toggles.

