### PR TITLE
fix(List): memoize ItemAccordion context value to stabilize useCallback deps

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 import classnames from 'classnames'
@@ -86,21 +87,35 @@ function ItemAccordion(props: ItemAccordionProps) {
     setOpen(open)
   }, [open])
 
+  const contextValue = useMemo(
+    () => ({
+      openState,
+      pending,
+      disabled: appliedDisabled,
+      keepInDOM,
+      chevronPosition,
+      accordionId,
+      icon,
+      title,
+      setOpen,
+      onClick,
+    }),
+    [
+      openState,
+      pending,
+      appliedDisabled,
+      keepInDOM,
+      chevronPosition,
+      accordionId,
+      icon,
+      title,
+      setOpen,
+      onClick,
+    ]
+  )
+
   return (
-    <ItemAccordionContext.Provider
-      value={{
-        openState,
-        pending,
-        disabled: appliedDisabled,
-        keepInDOM,
-        chevronPosition,
-        accordionId,
-        icon,
-        title,
-        setOpen,
-        onClick,
-      }}
-    >
+    <ItemAccordionContext.Provider value={contextValue}>
       <ItemContent
         className={classnames(
           'dnb-list__item__accordion',


### PR DESCRIPTION
The Provider value was a new object literal each render, defeating useCallback memoization in AccordionHeader. Wrap the context value in useMemo so handleClick and handleKeyDown are only recreated when the actual values change.

