### PR TITLE
feat(Stat, List): add innerRef support

### DIFF
--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -215,4 +215,18 @@ describe('List Container', () => {
 
     expect(await axeComponent(container)).toHaveNoViolations()
   })
+
+  it('supports innerRef prop', () => {
+    const ref = React.createRef<HTMLElement>()
+
+    render(
+      <Container innerRef={ref}>
+        <ItemContent>Item one</ItemContent>
+      </Container>
+    )
+
+    const element = document.querySelector('.dnb-list')
+
+    expect(ref.current).toBe(element)
+  })
 })

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -13,6 +13,7 @@ export type RootProps = {
   style?: React.CSSProperties
   visualOrder?: 'label-content' | 'content-label'
   skeleton?: SkeletonShow
+  innerRef?: React.RefObject<HTMLElement>
 } & SpacingProps
 
 function Root(props: RootProps) {
@@ -23,6 +24,7 @@ function Root(props: RootProps) {
     style = null,
     visualOrder = 'label-content',
     skeleton = null,
+    innerRef = null,
     ...rest
   } = props
 
@@ -45,6 +47,7 @@ function Root(props: RootProps) {
         element="dl"
         id={id}
         style={style}
+        innerRef={innerRef}
         className={classnames(
           'dnb-stat',
           'dnb-stat__root',

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Root.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Root.test.tsx
@@ -228,4 +228,18 @@ describe('Stat.Root', () => {
     expect(didWarnOrder).toBe(false)
     spy.mockRestore()
   })
+
+  it('supports innerRef prop', () => {
+    const ref = React.createRef<HTMLElement>()
+
+    render(
+      <Stat.Root innerRef={ref}>
+        <Stat.Label>Revenue growth</Stat.Label>
+      </Stat.Root>
+    )
+
+    const root = document.querySelector('.dnb-stat__root')
+
+    expect(ref.current).toBe(root)
+  })
 })


### PR DESCRIPTION
Add innerRef prop to Stat.Root type definition and pass it to the underlying Space component. List.Container already supports innerRef through FlexProps, so only a test was needed.

Tests added for both components.

