### PR TITLE
feat(Forms): add id prop support to Form.Section

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
@@ -29,6 +29,11 @@ export type SectionBaseProps<
   Data extends JsonObject = JsonObject,
 > = {
   /**
+   * A unique identifier for the section wrapper element.
+   */
+  id?: string
+
+  /**
    * Path to the section.
    * When defined, fields inside the section will get this path as a prefix of their own path.
    */
@@ -95,6 +100,7 @@ function SectionComponent<overwriteProps = OverwritePropsDefaults>(
   props: LocalProps<overwriteProps>
 ) {
   const {
+    id,
     path,
     overwriteProps,
     translations,
@@ -197,6 +203,31 @@ function SectionComponent<overwriteProps = OverwritePropsDefaults>(
 
   const sectionProps = props as SectionProps
 
+  const content = (
+    <SectionContainerProvider
+      validateInitially={validateInitially}
+      containerMode={containerMode}
+      disableEditing={disableEditing}
+    >
+      <FieldPropsProvider
+        overwriteProps={{
+          ...overwriteProps,
+          ...(resolvedPath
+            ? (nestedProps?.overwriteProps?.[
+                resolvedPath.startsWith('/')
+                  ? resolvedPath.substring(1)
+                  : resolvedPath
+              ] as OverwritePropsDefaults)
+            : undefined),
+        }}
+        translations={translations}
+        {...fieldProps}
+      >
+        {children}
+      </FieldPropsProvider>
+    </SectionContainerProvider>
+  )
+
   return (
     <SectionContext
       value={{
@@ -205,28 +236,7 @@ function SectionComponent<overwriteProps = OverwritePropsDefaults>(
         props: sectionProps,
       }}
     >
-      <SectionContainerProvider
-        validateInitially={validateInitially}
-        containerMode={containerMode}
-        disableEditing={disableEditing}
-      >
-        <FieldPropsProvider
-          overwriteProps={{
-            ...overwriteProps,
-            ...(resolvedPath
-              ? (nestedProps?.overwriteProps?.[
-                  resolvedPath.startsWith('/')
-                    ? resolvedPath.substring(1)
-                    : resolvedPath
-                ] as OverwritePropsDefaults)
-              : undefined),
-          }}
-          translations={translations}
-          {...fieldProps}
-        >
-          {children}
-        </FieldPropsProvider>
-      </SectionContainerProvider>
+      {id ? <div id={id}>{content}</div> : content}
     </SectionContext>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -68,6 +68,50 @@ describe('Form.Section', () => {
     log.mockRestore()
   })
 
+  describe('id', () => {
+    it('should forward id to a wrapper div element', () => {
+      render(
+        <Form.Handler>
+          <Form.Section id="my-section" path="/myPath">
+            <Field.String path="/name" />
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const element = document.querySelector('#my-section')
+      expect(element).toBeInTheDocument()
+      expect(element.tagName).toBe('DIV')
+    })
+
+    it('should not render wrapper div when id is not provided', () => {
+      render(
+        <Form.Handler>
+          <Form.Section path="/myPath">
+            <Field.String path="/name" />
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const form = document.querySelector('form')
+      const wrapperDiv = form.querySelector(':scope > div:not([class])')
+      expect(wrapperDiv).not.toBeInTheDocument()
+    })
+
+    it('should render children inside the wrapper', () => {
+      render(
+        <Form.Handler>
+          <Form.Section id="my-section" path="/myPath">
+            <Field.String path="/name" />
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const wrapper = document.querySelector('#my-section')
+      const input = wrapper.querySelector('input')
+      expect(input).toBeInTheDocument()
+    })
+  })
+
   it('should render section with children', () => {
     render(<MySection />)
 
@@ -130,7 +174,7 @@ describe('Form.Section', () => {
             "current": <input
               autocomplete="given-name"
               class="dnb-input__input"
-              id="id-r1i"
+              id="id-r2a"
               name="firstName"
               type="text"
             />,
@@ -155,7 +199,7 @@ describe('Form.Section', () => {
               aria-required="true"
               autocomplete="family-name"
               class="dnb-input__input"
-              id="id-r1p"
+              id="id-r2h"
               name="lastName"
               type="text"
             />,


### PR DESCRIPTION
Add id prop to SectionBaseProps. When provided, wraps the section content in a div element with the given id. When not provided, the component renders no additional DOM elements (backwards compatible).

