### PR TITLE
feat(List): add emptyState prop for empty list rendering

### DIFF
--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -10,6 +10,7 @@ export type ListContainerProps = {
   separated?: boolean
   skeleton?: SkeletonShow
   disabled?: boolean
+  emptyState?: React.ReactNode
 } & FlexProps
 
 function ListContainer(props: ListContainerProps) {
@@ -20,6 +21,7 @@ function ListContainer(props: ListContainerProps) {
     separated = false,
     skeleton,
     disabled,
+    emptyState,
     wrapChildrenInSpace = false,
     ...rest
   } = props
@@ -29,6 +31,32 @@ function ListContainer(props: ListContainerProps) {
   const appliedSkeleton =
     skeleton ?? parentContext?.skeleton ?? globalContext?.skeleton
   const appliedDisabled = disabled ?? parentContext?.disabled
+
+  const hasChildren =
+    React.Children.toArray(children).filter(Boolean).length > 0
+
+  if (!hasChildren && emptyState) {
+    return (
+      <ListContext.Provider
+        value={{
+          variant,
+          separated,
+          skeleton: appliedSkeleton,
+          disabled: appliedDisabled,
+        }}
+      >
+        <div
+          className={classnames(
+            'dnb-list',
+            'dnb-list__empty-state',
+            className
+          )}
+        >
+          {emptyState}
+        </div>
+      </ListContext.Provider>
+    )
+  }
 
   return (
     <ListContext.Provider

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -215,4 +215,57 @@ describe('List Container', () => {
 
     expect(await axeComponent(container)).toHaveNoViolations()
   })
+
+  it('renders emptyState when children are empty', () => {
+    render(<Container emptyState="No items found" />)
+
+    const emptyState = document.querySelector('.dnb-list__empty-state')
+
+    expect(emptyState).toBeInTheDocument()
+    expect(emptyState.textContent).toBe('No items found')
+  })
+
+  it('renders emptyState as JSX', () => {
+    render(
+      <Container emptyState={<span data-testid="empty">Empty</span>} />
+    )
+
+    const emptyState = document.querySelector('.dnb-list__empty-state')
+    const content = emptyState.querySelector('[data-testid="empty"]')
+
+    expect(content).toBeInTheDocument()
+    expect(content.textContent).toBe('Empty')
+  })
+
+  it('does not render emptyState when children are present', () => {
+    render(
+      <Container emptyState="No items found">
+        <ItemContent>Item one</ItemContent>
+      </Container>
+    )
+
+    const emptyState = document.querySelector('.dnb-list__empty-state')
+    const list = document.querySelector('.dnb-list__container')
+
+    expect(emptyState).not.toBeInTheDocument()
+    expect(list).toBeInTheDocument()
+  })
+
+  it('renders normal list when no emptyState prop and no children', () => {
+    render(<Container />)
+
+    const list = document.querySelector('.dnb-list__container')
+
+    expect(list).toBeInTheDocument()
+  })
+
+  it('merges className on emptyState wrapper', () => {
+    render(<Container className="custom" emptyState="No items" />)
+
+    const emptyState = document.querySelector('.dnb-list__empty-state')
+
+    expect(emptyState.classList).toContain('dnb-list')
+    expect(emptyState.classList).toContain('dnb-list__empty-state')
+    expect(emptyState.classList).toContain('custom')
+  })
 })


### PR DESCRIPTION
Add emptyState prop to List.Container that renders custom content when the list has no children. This avoids rendering an empty ul element and enables user-friendly messaging like 'No items found'.

TODO: Discuss if this is something we should have or not.

