### PR TITLE
feat(Stat): add Sbanken theme support for Rating

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -1,3 +1,7 @@
+## March, 26. 2026
+
+- Added Sbanken theme support for [Stat.Rating](/uilib/components/stat) rating colors (stars and progressive variants).
+
 ## February, 27. 2026
 
 - New component: [Stat](/uilib/components/stat), including `Stat.Currency`, `Stat.Percent`, `Stat.Trend`, and `Stat.Label` for prominent metric formatting.

--- a/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
@@ -6,6 +6,9 @@
 @import '../../../style/core/utilities.scss';
 
 .dnb-stat {
+  --stat-rating-active-color: currentcolor;
+  --stat-rating-base-color: lightgray;
+
   &--tone-positive {
     color: var(--color-success-green);
   }
@@ -195,11 +198,11 @@
       }
 
       &--base {
-        color: var(--color-black-20);
+        color: var(--stat-rating-base-color);
       }
 
       &--active {
-        color: var(--color-black-80);
+        color: var(--stat-rating-active-color);
       }
     }
 
@@ -216,8 +219,8 @@
       border-radius: 0.0625rem;
       background: linear-gradient(
         to right,
-        var(--color-black-80) var(--dnb-stat-rating-step-fill, 0%),
-        var(--color-black-20) var(--dnb-stat-rating-step-fill, 0%)
+        var(--stat-rating-active-color) var(--dnb-stat-rating-step-fill, 0%),
+        var(--stat-rating-base-color) var(--dnb-stat-rating-step-fill, 0%)
       );
     }
   }

--- a/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
@@ -219,7 +219,8 @@
       border-radius: 0.0625rem;
       background: linear-gradient(
         to right,
-        var(--stat-rating-active-color) var(--dnb-stat-rating-step-fill, 0%),
+        var(--stat-rating-active-color)
+          var(--dnb-stat-rating-step-fill, 0%),
         var(--stat-rating-base-color) var(--dnb-stat-rating-step-fill, 0%)
       );
     }

--- a/packages/dnb-eufemia/src/components/stat/style/themes/dnb-stat-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/themes/dnb-stat-theme-sbanken.scss
@@ -1,0 +1,9 @@
+/*
+ * Stat theme for Sbanken
+ *
+ */
+
+.dnb-stat {
+  --stat-rating-active-color: var(--sb-color-purple-alternative);
+  --stat-rating-base-color: var(--sb-color-gray-light);
+}

--- a/packages/dnb-eufemia/src/components/stat/style/themes/dnb-stat-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/themes/dnb-stat-theme-ui.scss
@@ -1,0 +1,9 @@
+/*
+ * Stat theme
+ *
+ */
+
+.dnb-stat {
+  --stat-rating-active-color: var(--color-black-80);
+  --stat-rating-base-color: var(--color-black-20);
+}

--- a/packages/dnb-eufemia/src/components/stat/style/themes/ui.js
+++ b/packages/dnb-eufemia/src/components/stat/style/themes/ui.js
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-stat-theme-ui.scss'

--- a/packages/dnb-eufemia/src/style/themes/theme-sbanken/sbanken-theme-components.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-sbanken/sbanken-theme-components.scss
@@ -43,6 +43,7 @@ $fonts-path: '../../../../assets/fonts/dnb' !default;
 @import '../../../components/section/style/themes/dnb-section-theme-sbanken.scss';
 @import '../../../components/skeleton/style/themes/dnb-skeleton-theme-sbanken.scss';
 @import '../../../components/slider/style/themes/dnb-slider-theme-sbanken.scss';
+@import '../../../components/stat/style/themes/dnb-stat-theme-sbanken.scss';
 @import '../../../components/step-indicator/style/themes/dnb-step-indicator-theme-sbanken.scss';
 @import '../../../components/switch/style/themes/dnb-switch-theme-sbanken.scss';
 @import '../../../components/table/style/themes/dnb-table-theme-sbanken.scss';

--- a/packages/dnb-eufemia/src/style/themes/theme-ui/ui-theme-components.scss
+++ b/packages/dnb-eufemia/src/style/themes/theme-ui/ui-theme-components.scss
@@ -44,6 +44,7 @@ $fonts-path: '../../../../assets/fonts/dnb' !default;
 @import '../../../components/skeleton/style/themes/dnb-skeleton-theme-ui.scss';
 @import '../../../components/slider/style/themes/dnb-slider-theme-ui.scss';
 @import '../../../components/space/style/themes/dnb-space-theme-ui.scss';
+@import '../../../components/stat/style/themes/dnb-stat-theme-ui.scss';
 @import '../../../components/step-indicator/style/themes/dnb-step-indicator-theme-ui.scss';
 @import '../../../components/switch/style/themes/dnb-switch-theme-ui.scss';
 @import '../../../components/table/style/themes/dnb-table-theme-ui.scss';


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1774526737151199
Deploy preview: 

We can also just ignore this and wait until v11.
Not sure if this adds much more work in v11, I don't think so, now the themes is created at least.


- Extract rating colors into CSS custom properties (--stat-rating-active-color, --stat-rating-base-color)
- Add UI theme (black-80/black-20) preserving existing behavior
- Add Sbanken theme (purple-alternative/gray-light) matching brand palette
- Register theme imports in ui-theme-components and sbanken-theme-components

