### PR TITLE
feat(Stat): add size prop to Stat.Rating

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
@@ -259,7 +259,7 @@ export const RatingDefault = () => (
 )
 
 export const RatingSizes = () => (
-  <ComponentBox data-visual-test="stat-rating-sizes">
+  <ComponentBox>
     <Stat.Root>
       <Stat.Label>Small (default)</Stat.Label>
       <Stat.Content>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/Examples.tsx
@@ -258,6 +258,32 @@ export const RatingDefault = () => (
   </ComponentBox>
 )
 
+export const RatingSizes = () => (
+  <ComponentBox data-visual-test="stat-rating-sizes">
+    <Stat.Root>
+      <Stat.Label>Small (default)</Stat.Label>
+      <Stat.Content>
+        <Stat.Rating value={3.5} size="small" />
+      </Stat.Content>
+
+      <Stat.Label top>Default</Stat.Label>
+      <Stat.Content>
+        <Stat.Rating value={3.5} size="default" />
+      </Stat.Content>
+
+      <Stat.Label top>Medium</Stat.Label>
+      <Stat.Content>
+        <Stat.Rating value={3.5} size="medium" />
+      </Stat.Content>
+
+      <Stat.Label top>Large</Stat.Label>
+      <Stat.Content>
+        <Stat.Rating value={3.5} size="large" />
+      </Stat.Content>
+    </Stat.Root>
+  </ComponentBox>
+)
+
 export const WithSubtleLabel = () => (
   <ComponentBox
     data-visual-test="stat-content-label-order-subtle-label"

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/demos.mdx
@@ -48,6 +48,10 @@ You can use `mainSize` and `auxiliarySize` to adjust the relative size of the cu
 
 <Examples.RatingDefault />
 
+### Rating sizes
+
+<Examples.RatingSizes />
+
 ### Text
 
 <Examples.TextDefault />

--- a/packages/dnb-eufemia/src/components/stat/Rating.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Rating.tsx
@@ -9,9 +9,19 @@ import { TextInternal as Text } from './Text'
 
 const MAX_ALLOWED = 20
 
+const sizeScales: Record<RatingSize, number> = {
+  small: 1,
+  default: 1.333,
+  medium: 2,
+  large: 2.667,
+}
+
+export type RatingSize = 'small' | 'default' | 'medium' | 'large'
+
 type RatingOwnProps = {
   value?: number
   max?: number
+  size?: RatingSize
   variant?: 'stars' | 'progressive'
   element?: keyof JSX.IntrinsicElements
   srLabel?: React.ReactNode
@@ -30,6 +40,7 @@ function Rating(props: RatingProps) {
     value = 0,
     max = null,
     id = null,
+    size = 'small',
     variant = 'stars',
     element: Element = 'span',
     className = null,
@@ -52,6 +63,8 @@ function Rating(props: RatingProps) {
   const clampedMax = Math.min(resolvedMax, MAX_ALLOWED)
   const safeValue = Number.isFinite(value) ? value : 0
   const normalizedValue = clamp(safeValue, 0, clampedMax)
+
+  const sizeScale = sizeScales[size] ?? 1
   const labelValue = Number.isInteger(normalizedValue)
     ? String(normalizedValue)
     : String(parseFloat(normalizedValue.toFixed(2)))
@@ -73,6 +86,7 @@ function Rating(props: RatingProps) {
         'dnb-stat',
         'dnb-stat__rating',
         `dnb-stat__rating--${variant}`,
+        size !== 'small' && `dnb-stat__rating--${size}`,
         className
       )}
       style={style}
@@ -111,7 +125,9 @@ function Rating(props: RatingProps) {
           {Array.from({ length: clampedMax }).map((_, index) => {
             const fill = clamp(normalizedValue - index, 0, 1)
             const stepHeight =
-              clampedMax > 1 ? 0.25 + (index / (clampedMax - 1)) * 0.75 : 1
+              clampedMax > 1
+                ? (0.25 + (index / (clampedMax - 1)) * 0.75) * sizeScale
+                : 1 * sizeScale
 
             return (
               <span

--- a/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
@@ -21,6 +21,12 @@ export const RatingProperties: PropertiesTableProps = {
     defaultValue: 'stars',
     status: 'optional',
   },
+  size: {
+    doc: 'Size of the rating items. Aligns with the standard icon size scale.',
+    type: ['"small"', '"default"', '"medium"', '"large"'],
+    defaultValue: 'small',
+    status: 'optional',
+  },
   srLabel: NumberFormatPropertiesCamelCase.srLabel,
   skeleton: skeletonProperty,
   '[Space](/uilib/layout/space/properties)': spacingProperties,

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
@@ -257,4 +257,66 @@ describe('Stat.Rating', () => {
     expect(rating.getAttribute('max')).toBeNull()
     expect(rating.getAttribute('skeleton')).toBeNull()
   })
+
+  it('renders default small size without size class', () => {
+    render(<Stat.Rating value={3} />)
+
+    const rating = document.querySelector('.dnb-stat__rating')
+
+    expect(rating.classList).not.toContain('dnb-stat__rating--default')
+    expect(rating.classList).not.toContain('dnb-stat__rating--medium')
+    expect(rating.classList).not.toContain('dnb-stat__rating--large')
+  })
+
+  it('applies size class for default size', () => {
+    render(<Stat.Rating value={3} size="default" />)
+
+    const rating = document.querySelector('.dnb-stat__rating')
+
+    expect(rating.classList).toContain('dnb-stat__rating--default')
+  })
+
+  it('applies size class for medium size', () => {
+    render(<Stat.Rating value={3} size="medium" />)
+
+    const rating = document.querySelector('.dnb-stat__rating')
+
+    expect(rating.classList).toContain('dnb-stat__rating--medium')
+  })
+
+  it('applies size class for large size', () => {
+    render(<Stat.Rating value={3} size="large" />)
+
+    const rating = document.querySelector('.dnb-stat__rating')
+
+    expect(rating.classList).toContain('dnb-stat__rating--large')
+  })
+
+  it('scales progressive step heights with size', () => {
+    render(
+      <Stat.Rating variant="progressive" value={5} max={7} size="large" />
+    )
+
+    const steps = document.querySelectorAll(
+      '.dnb-stat__rating-progressive-step--base'
+    )
+
+    const firstHeight = (steps[0] as HTMLElement).style.getPropertyValue(
+      '--dnb-stat-rating-step-height'
+    )
+    const lastHeight = (
+      steps[steps.length - 1] as HTMLElement
+    ).style.getPropertyValue('--dnb-stat-rating-step-height')
+
+    expect(parseFloat(firstHeight)).toBeCloseTo(0.25 * 2.667, 1)
+    expect(parseFloat(lastHeight)).toBeCloseTo(1 * 2.667, 1)
+  })
+
+  it('does not forward size prop to the DOM', () => {
+    render(<Stat.Rating value={3} size="medium" />)
+
+    const rating = document.querySelector('.dnb-stat__rating')
+
+    expect(rating.getAttribute('size')).toBeNull()
+  })
 })

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
@@ -312,11 +312,4 @@ describe('Stat.Rating', () => {
     expect(parseFloat(lastHeight)).toBeCloseTo(1 * 2.667, 1)
   })
 
-  it('does not forward size prop to the DOM', () => {
-    render(<Stat.Rating value={3} size="medium" />)
-
-    const rating = document.querySelector('.dnb-stat__rating')
-
-    expect(rating.getAttribute('size')).toBeNull()
-  })
 })

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Rating.test.tsx
@@ -311,5 +311,4 @@ describe('Stat.Rating', () => {
     expect(parseFloat(firstHeight)).toBeCloseTo(0.25 * 2.667, 1)
     expect(parseFloat(lastHeight)).toBeCloseTo(1 * 2.667, 1)
   })
-
 })

--- a/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
+++ b/packages/dnb-eufemia/src/components/stat/style/dnb-stat.scss
@@ -150,20 +150,50 @@
   }
 
   &__rating {
+    --stat-rating-star-size: 0.75rem;
+    --stat-rating-container-height: 1.5rem;
+    --stat-rating-gap: 0.125rem;
+    --stat-rating-progressive-width: 0.25rem;
+    --stat-rating-progressive-radius: 0.0625rem;
+
     display: inline-flex;
     align-items: center;
 
     &--stars {
-      height: 1.5rem;
+      height: var(--stat-rating-container-height);
     }
 
     &--progressive {
-      height: 1.5rem;
+      height: var(--stat-rating-container-height);
+    }
+
+    &--default {
+      --stat-rating-star-size: 1rem;
+      --stat-rating-container-height: 2rem;
+      --stat-rating-gap: 0.1875rem;
+      --stat-rating-progressive-width: 0.375rem;
+      --stat-rating-progressive-radius: 0.125rem;
+    }
+
+    &--medium {
+      --stat-rating-star-size: 1.5rem;
+      --stat-rating-container-height: 2.5rem;
+      --stat-rating-gap: 0.25rem;
+      --stat-rating-progressive-width: 0.5rem;
+      --stat-rating-progressive-radius: 0.1875rem;
+    }
+
+    &--large {
+      --stat-rating-star-size: 2rem;
+      --stat-rating-container-height: 3rem;
+      --stat-rating-gap: 0.25rem;
+      --stat-rating-progressive-width: 0.625rem;
+      --stat-rating-progressive-radius: 0.25rem;
     }
 
     &-stars {
       display: inline-flex;
-      gap: 0.125rem;
+      gap: var(--stat-rating-gap);
       align-items: flex-end;
     }
 
@@ -173,8 +203,8 @@
       display: inline-block;
       flex-shrink: 0;
 
-      width: 0.75rem;
-      height: 0.75rem;
+      width: var(--stat-rating-star-size);
+      height: var(--stat-rating-star-size);
     }
 
     &-fill {
@@ -206,14 +236,14 @@
     &-progressive {
       display: inline-flex;
       align-items: flex-end;
-      gap: 0.125rem;
+      gap: var(--stat-rating-gap);
     }
 
     &-progressive-step {
       display: inline-block;
-      width: 0.25rem;
+      width: var(--stat-rating-progressive-width);
       height: var(--dnb-stat-rating-step-height, 0.25rem);
-      border-radius: 0.0625rem;
+      border-radius: var(--stat-rating-progressive-radius);
       background: linear-gradient(
         to right,
         var(--color-black-80) var(--dnb-stat-rating-step-fill, 0%),


### PR DESCRIPTION
Motivation: https://dnb.enterprise.slack.com/archives/CMXABCHEY/p1774527506813319?thread_ts=1774526737.151199&channel=CMXABCHEY&message_ts=1774527506.813319


- Support 'small' (default), 'default', 'medium', and 'large' sizes
- Use CSS custom properties for star size, gap, progressive width, and container height
- Scale progressive step heights proportionally via size scale factor
- Size names align with the Icon component naming convention

