### PR TITLE
feat(Forms): add support for Swedish bank account numbers and IBAN in BankAccountNumber

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -237,6 +237,20 @@ const string = cleanNumber('prefix -12 345,678 suffix') // returns -12345.678
 const string = cleanNumber('prefix -12.345,678 suffix') // returns -12345.678
 ```
 
+### Format bank account numbers
+
+Use `formatBankAccountNumberByType` to format bank account numbers with a specific type. It supports Norwegian BBAN, Swedish BBAN, Swedish Bankgiro, Swedish Plusgiro, and IBAN.
+
+```ts
+import { formatBankAccountNumberByType } from '@dnb/eufemia/components/NumberFormat'
+
+formatBankAccountNumberByType('20001234567') // { number: '2000 12 34567', aria: '20 00 12 34 56 7' }
+formatBankAccountNumberByType('50001234567', 'swedishBban') // { number: '5000-1234567', aria: '50 00 12 34 56 7' }
+formatBankAccountNumberByType('59140129', 'swedishBankgiro') // { number: '5914-0129', aria: '59 14 01 29' }
+formatBankAccountNumberByType('1263664', 'swedishPlusgiro') // { number: '126366-4', aria: '12 63 66 4' }
+formatBankAccountNumberByType('NO9386011117947', 'iban') // { number: 'NO93 8601 1117 947', aria: 'NO93 8601 1117 947' }
+```
+
 ### Element and style
 
 The number component is style-independent, so it has no visual styles. By default, a `<span>` is used (with [speak-as: numbers](https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/speak-as), even though the support is very low). However, you can easily change the element type by providing a different value to the `element="div"` property.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/Examples.tsx
@@ -53,3 +53,26 @@ export const Inline = () => {
     </ComponentBox>
   )
 }
+
+export const BankAccountTypes = () => {
+  return (
+    <ComponentBox>
+      <Value.BankAccountNumber
+        bankAccountType="swedishBban"
+        value="50001234567"
+      />
+      <Value.BankAccountNumber
+        bankAccountType="swedishBankgiro"
+        value="59140129"
+      />
+      <Value.BankAccountNumber
+        bankAccountType="swedishPlusgiro"
+        value="1263664"
+      />
+      <Value.BankAccountNumber
+        bankAccountType="iban"
+        value="NO9386011117947"
+      />
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/demos.mdx
@@ -29,3 +29,9 @@ import * as Examples from './Examples'
 ### Inline
 
 <Examples.Inline />
+
+### Bank account types
+
+Use the `bankAccountType` prop to switch between formats.
+
+<Examples.BankAccountTypes />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/info.mdx
@@ -13,12 +13,9 @@ render(<Value.BankAccountNumber />)
 
 `Value.BankAccountNumber` is a wrapper component for displaying string values, with user experience tailored for bank account number values.
 
-There is a corresponding [Field.BankAccountNumber](/uilib/extensions/forms/feature-fields/BankAccountNumber) component.
+Use the `bankAccountType` prop to format different account types: `norwegianBban` (default), `swedishBban`, `swedishBankgiro`, `swedishPlusgiro`, or `iban`.
 
-```jsx
-import { Value } from '@dnb/eufemia/extensions/forms'
-render(<Value.BankAccountNumber />)
-```
+There is a corresponding [Field.BankAccountNumber](/uilib/extensions/forms/feature-fields/BankAccountNumber) component.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/BankAccountNumber/properties.mdx
@@ -5,11 +5,18 @@ showTabs: true
 import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { ValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/ValueDocs'
+import { BankAccountNumberValueProperties } from '@dnb/eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumberDocs'
 
 ## Properties
+
+### BankAccountNumber-specific properties
+
+<PropertiesTable props={BankAccountNumberValueProperties} />
+
+### General properties
 
 <PropertiesTable props={ValueProperties} />
 
 ## Translations
 
-<TranslationsTable localeKey={['BankAccountNumber.label']} />
+<TranslationsTable localeKey={['BankAccountNumber']} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/changelog.mdx
@@ -17,6 +17,7 @@ Get more [details about releases](/uilib/releases) or have a look on all [releas
 
 ## v11.0.0
 
+- Added `bankAccountType` prop to [Field.BankAccountNumber](/uilib/extensions/forms/feature-fields/BankAccountNumber/) and [Value.BankAccountNumber](/uilib/extensions/forms/Value/BankAccountNumber/) with support for Swedish BBAN, Swedish Bankgiro, Swedish Plusgiro, and IBAN.
 - [Field.PhoneNumber](/uilib/extensions/forms/feature-fields/PhoneNumber/) now emits values in E.164 format (e.g. `+4712345678` instead of `+47 12345678`). Auto-detects country codes from E.164 and `00`-prefixed values. Patterns and schemas must be updated to match.
 - Added `detectCountryCode` utility, exported from `@dnb/eufemia/extensions/forms`, for detecting E.164 country codes from phone number strings.
 - Added `preventDefaultOnSubmit` to [Form.Handler](/uilib/extensions/forms/Form/Handler/), allowing native browser form submission such as `POST` to a form `action`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
@@ -145,3 +145,30 @@ export const ValidationExtendValidator = () => {
     </ComponentBox>
   )
 }
+
+export const BankAccountTypes = () => {
+  return (
+    <ComponentBox>
+      <Field.BankAccountNumber
+        bankAccountType="swedishBban"
+        value="50001234567"
+        onChange={(value) => console.log('onChange', value)}
+      />
+      <Field.BankAccountNumber
+        bankAccountType="swedishBankgiro"
+        value="59140129"
+        onChange={(value) => console.log('onChange', value)}
+      />
+      <Field.BankAccountNumber
+        bankAccountType="swedishPlusgiro"
+        value="1263664"
+        onChange={(value) => console.log('onChange', value)}
+      />
+      <Field.BankAccountNumber
+        bankAccountType="iban"
+        value="NO9386011117947"
+        onChange={(value) => console.log('onChange', value)}
+      />
+    </ComponentBox>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/demos.mdx
@@ -47,3 +47,9 @@ import * as Examples from './Examples'
 You can [extend the existing validation](/uilib/extensions/forms/create-component/useFieldProps/info/#validators) (`bankAccountNumberValidator`) with your own validation function.
 
 <Examples.ValidationExtendValidator />
+
+### Bank account types
+
+Use the `bankAccountType` prop to switch between formats.
+
+<Examples.BankAccountTypes />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/info.mdx
@@ -13,8 +13,17 @@ render(<Field.BankAccountNumber />)
 
 `Field.BankAccountNumber` is a wrapper component for [string input](/uilib/extensions/forms/base-fields/String), with user experience tailored for bank account values.
 
-This field is meant for Norwegian bank account numbers and therefore takes an 11-digit string as a value. A Norwegian bank account number can have a leading zero, which is why this value is a string and not a number. In addition, we validate `0000 00 00000` as invalid.
-More information can be found at [Wikipedia](https://no.wikipedia.org/wiki/Kontonummer).
+Use the `bankAccountType` prop to switch between formats:
+
+- `norwegianBban` (default): 11-digit Norwegian account number with mod-11 checksum validation.
+- `swedishBban`: 4-digit clearing number + account number (up to 14 digits).
+- `swedishBankgiro`: 7–8 digits.
+- `swedishPlusgiro`: 2–8 digits.
+- `iban`: Up to 34 alphanumeric characters, grouped in blocks of four.
+
+Only `norwegianBban` includes built-in validation. Use `onBlurValidator` for custom validation of other types.
+
+The value is always a string since account numbers can have leading zeros.
 
 There is a corresponding [Value.BankAccountNumber](/uilib/extensions/forms/Value/BankAccountNumber) component.
 

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
@@ -14,6 +14,7 @@ export type {
   NumberFormatOptions,
   NumberFormatOptionParams,
   NumberFormatFunction,
+  BankAccountType,
 } from './utils'
 
 export {
@@ -31,6 +32,7 @@ export {
   formatCurrency,
   formatPhoneNumber,
   formatBankAccountNumber,
+  formatBankAccountNumberByType,
   formatNationalIdentityNumber,
   formatOrganizationNumber,
   getFallbackCurrencyDisplay,

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -21,6 +21,7 @@ import {
   formatPhoneNumber,
   formatCurrency,
   formatPercent,
+  formatBankAccountNumberByType,
 } from '../NumberUtils'
 
 const locale = LOCALE
@@ -1198,6 +1199,187 @@ describe('formatPhoneNumber', () => {
       })
       expect(result.number).toBe('+47 12 34 56 78')
       expect(result.aria).toBe('+47 12 34 56 78')
+    })
+  })
+
+  describe('formatBankAccountNumberByType', () => {
+    describe('norwegianBban (default)', () => {
+      it('should format 11-digit Norwegian BBAN', () => {
+        const result = formatBankAccountNumberByType('20001234567')
+        expect(result.number).toBe('2000 12 34567')
+        expect(result.aria).toBe('20 00 12 34 56 7')
+      })
+
+      it('should default to norwegianBban when no type is given', () => {
+        const result = formatBankAccountNumberByType('20001234567')
+        expect(result.number).toBe('2000 12 34567')
+      })
+
+      it('should strip non-digit characters', () => {
+        const result = formatBankAccountNumberByType('2000 12 34567')
+        expect(result.number).toBe('2000 12 34567')
+      })
+    })
+
+    describe('swedishBban', () => {
+      it('should format Swedish BBAN with clearing number and account', () => {
+        const result = formatBankAccountNumberByType(
+          '50001234567',
+          'swedishBban'
+        )
+        expect(result.number).toBe('5000-1234567')
+      })
+
+      it('should format short Swedish BBAN (4 or fewer digits)', () => {
+        const result = formatBankAccountNumberByType('5000', 'swedishBban')
+        expect(result.number).toBe('5000')
+      })
+
+      it('should strip non-digit characters', () => {
+        const result = formatBankAccountNumberByType(
+          '5000-1234567',
+          'swedishBban'
+        )
+        expect(result.number).toBe('5000-1234567')
+      })
+    })
+
+    describe('swedishBankgiro', () => {
+      it('should format 8-digit Bankgiro as XXXX-XXXX', () => {
+        const result = formatBankAccountNumberByType(
+          '59140129',
+          'swedishBankgiro'
+        )
+        expect(result.number).toBe('5914-0129')
+        expect(result.aria).toBe('59 14 01 29')
+      })
+
+      it('should format 7-digit Bankgiro as XXX-XXXX', () => {
+        const result = formatBankAccountNumberByType(
+          '5914012',
+          'swedishBankgiro'
+        )
+        expect(result.number).toBe('591-4012')
+        expect(result.aria).toBe('59 14 01 2')
+      })
+
+      it('should return unformatted for other lengths', () => {
+        const result = formatBankAccountNumberByType(
+          '123456',
+          'swedishBankgiro'
+        )
+        expect(result.number).toBe('123456')
+      })
+
+      it('should strip non-digit characters', () => {
+        const result = formatBankAccountNumberByType(
+          '5914-0129',
+          'swedishBankgiro'
+        )
+        expect(result.number).toBe('5914-0129')
+      })
+    })
+
+    describe('swedishPlusgiro', () => {
+      it('should format 7-digit Plusgiro with dash before check digit', () => {
+        const result = formatBankAccountNumberByType(
+          '1263664',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('126366-4')
+        expect(result.aria).toBe('12 63 66 4')
+      })
+
+      it('should format 8-digit Plusgiro with dash before check digit', () => {
+        const result = formatBankAccountNumberByType(
+          '12636641',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('1263664-1')
+        expect(result.aria).toBe('12 63 66 41')
+      })
+
+      it('should format 3-digit Plusgiro with dash before check digit', () => {
+        const result = formatBankAccountNumberByType(
+          '123',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('12-3')
+        expect(result.aria).toBe('12 3')
+      })
+
+      it('should format 2-digit Plusgiro', () => {
+        const result = formatBankAccountNumberByType(
+          '12',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('1-2')
+        expect(result.aria).toBe('12')
+      })
+
+      it('should return single digit unformatted', () => {
+        const result = formatBankAccountNumberByType(
+          '5',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('5')
+      })
+
+      it('should strip non-digit characters', () => {
+        const result = formatBankAccountNumberByType(
+          '126366-4',
+          'swedishPlusgiro'
+        )
+        expect(result.number).toBe('126366-4')
+      })
+    })
+
+    describe('iban', () => {
+      it('should format IBAN in groups of 4', () => {
+        const result = formatBankAccountNumberByType(
+          'NO9386011117947',
+          'iban'
+        )
+        expect(result.number).toBe('NO93 8601 1117 947')
+      })
+
+      it('should format full-length IBAN', () => {
+        const result = formatBankAccountNumberByType(
+          'DE89370400440532013000',
+          'iban'
+        )
+        expect(result.number).toBe('DE89 3704 0044 0532 0130 00')
+      })
+
+      it('should generate aria with block-of-4 grouping', () => {
+        const result = formatBankAccountNumberByType(
+          'NO9386011117947',
+          'iban'
+        )
+        expect(result.aria).toBe('NO93 8601 1117 947')
+      })
+
+      it('should strip non-alphanumeric characters', () => {
+        const result = formatBankAccountNumberByType(
+          'NO93 8601 1117 947',
+          'iban'
+        )
+        expect(result.number).toBe('NO93 8601 1117 947')
+      })
+    })
+
+    describe('absent values', () => {
+      it('should handle undefined', () => {
+        const result = formatBankAccountNumberByType(undefined)
+        expect(result.number).toBe('–')
+        expect(result.aria).toBe('–')
+      })
+
+      it('should handle empty string', () => {
+        const result = formatBankAccountNumberByType('')
+        expect(result.number).toBe('–')
+        expect(result.aria).toBe('–')
+      })
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/number-format/index.ts
+++ b/packages/dnb-eufemia/src/components/number-format/index.ts
@@ -53,6 +53,8 @@ export {
   formatPercent,
   formatPhoneNumber,
   formatBankAccountNumber,
+  formatBankAccountNumberByType,
   formatNationalIdentityNumber,
   formatOrganizationNumber,
 } from './utils'
+export type { BankAccountType } from './utils'

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatBankAccountNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatBankAccountNumber.ts
@@ -1,47 +1,118 @@
 /**
- * Norwegian Bank Account Number formatter.
+ * Bank Account Number formatter.
+ *
+ * Supports Norwegian BBAN, Swedish BBAN, Swedish Bankgiro,
+ * Swedish Plusgiro, and IBAN formats.
  */
 
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { formatWith } from './formatCore'
 import type { NumberFormatValue, FormattedParts } from './types'
 
-const formatBankAccountNumberParts = (
+export type BankAccountType =
+  | 'norwegianBban'
+  | 'swedishBban'
+  | 'swedishBankgiro'
+  | 'swedishPlusgiro'
+  | 'iban'
+
+const cleanDigits = (val: string | number) =>
+  String(val).replace(/[^0-9]/g, '')
+
+const cleanAlphanumeric = (val: string | number) =>
+  String(val).replace(/[^A-Za-z0-9]/g, '')
+
+const pairwiseAria = (digits: string) =>
+  digits
+    .split(/([0-9]{2})/)
+    .filter((s) => s)
+    .join(' ')
+
+/**
+ * Format a bank account number into display and aria strings.
+ *
+ * @param number the bank account number value
+ * @param bankAccountType the type of bank account number
+ * @returns An object with `number` (display) and `aria` strings
+ */
+export const formatBankAccountNumberByType = (
   number: NumberFormatValue,
-  locale: string | null = null
+  bankAccountType: BankAccountType = 'norwegianBban'
 ): FormattedParts => {
   if (isAbsent(number)) {
     return { number: ABSENT_VALUE_FORMAT, aria: ABSENT_VALUE_FORMAT }
   }
-  // cleanup
-  const num = String(number).replace(/[^0-9]/g, '')
 
-  let display = num
-  let aria: string | null = null
+  let display: string
+  let aria: string
 
-  switch (locale) {
+  switch (bankAccountType) {
+    case 'iban': {
+      const cleaned = cleanAlphanumeric(number).toUpperCase()
+      display = cleaned.match(/.{1,4}/g)?.join(' ') ?? cleaned
+      // Block-of-4 aria mirrors the visual grouping for screen readers
+      aria = display
+      break
+    }
+
+    case 'swedishBban': {
+      const cleaned = cleanDigits(number)
+      display =
+        cleaned.length > 4
+          ? cleaned.slice(0, 4) + '-' + cleaned.slice(4)
+          : cleaned
+      aria = pairwiseAria(cleaned)
+      break
+    }
+
+    case 'swedishBankgiro': {
+      const cleaned = cleanDigits(number)
+      if (cleaned.length === 8) {
+        display = cleaned.slice(0, 4) + '-' + cleaned.slice(4)
+      } else if (cleaned.length === 7) {
+        display = cleaned.slice(0, 3) + '-' + cleaned.slice(3)
+      } else {
+        display = cleaned
+      }
+      aria = pairwiseAria(cleaned)
+      break
+    }
+
+    case 'swedishPlusgiro': {
+      const cleaned = cleanDigits(number)
+      if (cleaned.length >= 2) {
+        display =
+          cleaned.slice(0, cleaned.length - 1) +
+          '-' +
+          cleaned.slice(cleaned.length - 1)
+      } else {
+        display = cleaned
+      }
+      aria = pairwiseAria(cleaned)
+      break
+    }
+
+    case 'norwegianBban':
     default: {
-      // Get 2000 12 34567
-      display = num
+      const cleaned = cleanDigits(number)
+      display = cleaned
         .split(/([0-9]{4})([0-9]{2})([0-9]{1,})/)
         .filter((s) => s)
         .join(' ')
-
-      aria = num
-        .split(/([0-9]{2})/)
-        .filter((s) => s)
-        .join(' ')
+      aria = pairwiseAria(cleaned)
+      break
     }
-  }
-
-  if (aria === null) {
-    aria = display
   }
 
   return { number: display, aria }
 }
 
+const norwegianBbanParts = (
+  value: NumberFormatValue,
+  _locale: string | null = null
+): FormattedParts => formatBankAccountNumberByType(value, 'norwegianBban')
+
 export const formatBankAccountNumber = formatWith(
   'ban',
-  formatBankAccountNumberParts
+  norwegianBbanParts
 )

--- a/packages/dnb-eufemia/src/components/number-format/utils/index.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/index.ts
@@ -35,7 +35,11 @@ export { formatNumber } from './formatNumber'
 export { formatPercent } from './formatPercent'
 export { formatCurrency } from './formatCurrency'
 export { formatPhoneNumber } from './formatPhoneNumber'
-export { formatBankAccountNumber } from './formatBankAccountNumber'
+export {
+  formatBankAccountNumber,
+  formatBankAccountNumberByType,
+} from './formatBankAccountNumber'
+export type { BankAccountType } from './formatBankAccountNumber'
 export { formatNationalIdentityNumber } from './formatNationalIdentityNumber'
 export { formatOrganizationNumber } from './formatOrganizationNumber'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -1,10 +1,21 @@
-import React, { useCallback, useMemo } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type { FieldStringProps as StringFieldProps } from '../String'
 import StringField from '../String'
 
 import useTranslation from '../../hooks/useTranslation'
 import type { Validator, ValidatorWithCustomValidators } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
+import type { BankAccountType } from '../../../../components/number-format/utils/formatBankAccountNumber'
+import { norwegianBbanValidator } from './validators'
+import { getMask, getInputMode, getWidth, hasVariableMask } from './masks'
+
+export type { BankAccountType } from '../../../../components/number-format/utils/formatBankAccountNumber'
 
 export type BankAccountNumberValidator = ValidatorWithCustomValidators<
   string,
@@ -20,127 +31,164 @@ export type FieldBankAccountNumberProps = Omit<
   validate?: boolean
   omitMask?: boolean
   onBlurValidator?: BankAccountNumberValidator | false
+
+  /**
+   * The type of bank account number, used for input mask and formatting.
+   * Defaults to `norwegianBban`.
+   */
+  bankAccountType?: BankAccountType
 }
 
 function BankAccountNumber(props: FieldBankAccountNumberProps) {
-  const {
-    errorBankAccountNumber,
-    errorBankAccountNumberLength,
-    errorRequired,
-    label,
-  } = useTranslation().BankAccountNumber
-
-  const errorMessages = useMemo(() => {
-    return {
-      'Field.errorRequired': errorRequired,
-      'Field.errorPattern': errorBankAccountNumber,
-      ...props.errorMessages,
-    }
-  }, [errorBankAccountNumber, errorRequired, props.errorMessages])
-
-  const bankAccountNumberValidator = useCallback(
-    (value: string) => {
-      if (value !== undefined) {
-        const bankAccountNoIs11Digits = value?.length === 11
-
-        if (!bankAccountNoIs11Digits) {
-          return Error(errorBankAccountNumberLength)
-        }
-
-        if (bankAccountNoIs11Digits && !isValidAccountNumber(value)) {
-          return Error(errorBankAccountNumber)
-        }
-      }
-
-      return undefined
-    },
-    [errorBankAccountNumber, errorBankAccountNumberLength]
-  )
+  const translations = useTranslation().BankAccountNumber
 
   const {
     validate = true,
-    omitMask,
+    omitMask = false,
+    bankAccountType = 'norwegianBban',
     onChangeValidator,
-    onBlurValidator = bankAccountNumberValidator,
+    onBlurValidator: onBlurValidatorProp,
     label: labelProp,
     width,
+    value,
+    defaultValue,
+    onChange: onChangeProp,
+    onBlur: onBlurProp,
+    ...restProps
   } = props
 
+  const valueRef = useRef(value ?? defaultValue)
+  const [maskValue, setMaskValue] = useState(value ?? defaultValue)
+
+  useEffect(() => {
+    if (value !== undefined && hasVariableMask(bankAccountType)) {
+      setMaskValue(value)
+    }
+  }, [value, bankAccountType])
+
+  // Strip formatting characters while preserving letters for IBAN.
+  const cleanValue = useCallback(
+    (val: string) => {
+      if (!val) {
+        return val
+      }
+      if (bankAccountType === 'iban') {
+        return val.replace(/[^A-Za-z0-9]/g, '').toUpperCase()
+      }
+      return val.replace(/[^0-9]/g, '')
+    },
+    [bankAccountType]
+  )
+
+  // InputMasked's cleanedValue uses cleanNumber which strips non-numeric
+  // characters (including letters). For IBAN values this removes the
+  // country code prefix. We provide our own fromInput that cleans the
+  // display value instead, preserving letters for IBAN.
+  const fromInput = useCallback(
+    (event: { value: string; cleanedValue?: string }) => {
+      if (event?.value === '') {
+        return restProps.emptyValue
+      }
+      return cleanValue(event?.value)
+    },
+    [cleanValue, restProps.emptyValue]
+  )
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      valueRef.current = newValue
+      onChangeProp?.(newValue)
+    },
+    [onChangeProp]
+  )
+
+  const handleBlur = useCallback(
+    (...args: Parameters<NonNullable<StringFieldProps['onBlur']>>) => {
+      if (hasVariableMask(bankAccountType)) {
+        setMaskValue(valueRef.current)
+      }
+      onBlurProp?.(...args)
+    },
+    [bankAccountType, onBlurProp]
+  )
+
+  const label = useMemo(() => {
+    if (labelProp !== undefined) {
+      return labelProp
+    }
+
+    switch (bankAccountType) {
+      case 'swedishBban':
+        return translations.labelSwedishBban
+      case 'swedishBankgiro':
+        return translations.labelSwedishBankgiro
+      case 'swedishPlusgiro':
+        return translations.labelSwedishPlusgiro
+      case 'iban':
+        return translations.labelIban
+      default:
+        return translations.label
+    }
+  }, [labelProp, bankAccountType, translations])
+
+  const errorMessages = useMemo(() => {
+    return {
+      'Field.errorRequired': translations.errorRequired,
+      'Field.errorPattern': translations.errorBankAccountNumber,
+      ...props.errorMessages,
+    }
+  }, [
+    translations.errorRequired,
+    translations.errorBankAccountNumber,
+    props.errorMessages,
+  ])
+
+  const bankAccountNumberValidator = useCallback(
+    (value: string) => {
+      if (bankAccountType !== 'norwegianBban') {
+        return undefined
+      }
+
+      return norwegianBbanValidator(value, {
+        errorBankAccountNumber: translations.errorBankAccountNumber,
+        errorBankAccountNumberLength:
+          translations.errorBankAccountNumberLength,
+      })
+    },
+    [bankAccountType, translations]
+  )
+
+  const onBlurValidator = onBlurValidatorProp ?? bankAccountNumberValidator
+
   const mask = useMemo(
-    () =>
-      omitMask
-        ? [
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-          ]
-        : [
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            ' ',
-            /\d/,
-            /\d/,
-            ' ',
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-            /\d/,
-          ],
-    [omitMask]
+    () => getMask(bankAccountType, omitMask, maskValue),
+    [bankAccountType, omitMask, maskValue]
   )
 
   const onBlurValidatorToUse =
     onBlurValidator === false ? undefined : onBlurValidator
 
-  const StringFieldProps: StringFieldProps = {
-    ...props,
+  const stringFieldProps: StringFieldProps = {
+    ...restProps,
     className: 'dnb-forms-field-bank-account-number',
-    label: labelProp ?? label,
+    label,
     errorMessages,
     mask,
-    width: width ?? 'medium',
-    inputMode: 'numeric',
+    value,
+    defaultValue,
+    // @ts-expect-error - strictFunctionTypes
+    fromInput,
+    onChange: handleChange,
+    onBlur: handleBlur,
+    width: width ?? getWidth(bankAccountType),
+    inputMode: getInputMode(bankAccountType),
     onChangeValidator: validate ? onChangeValidator : undefined,
     // @ts-expect-error - strictFunctionTypes
     onBlurValidator: validate ? onBlurValidatorToUse : undefined,
     exportValidators: { bankAccountNumberValidator },
   }
 
-  return <StringField {...StringFieldProps} />
-}
-
-function isValidAccountNumber(digits: string) {
-  if (parseFloat(digits) === 0) {
-    return false
-  }
-  let checkDigit = 2
-  let sum = 0
-
-  for (let i = digits.length - 2; i >= 0; --i) {
-    sum += parseInt(digits.charAt(i), 10) * checkDigit
-
-    checkDigit += 1
-
-    if (checkDigit > 7) {
-      checkDigit = 2
-    }
-  }
-
-  const result = 11 - (sum % 11)
-  const finalCheckDigit = result === 11 ? 0 : result
-
-  return parseInt(digits.charAt(digits.length - 1), 10) === finalCheckDigit
+  return <StringField {...stringFieldProps} />
 }
 
 withComponentMarkers(BankAccountNumber, {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumberDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumberDocs.tsx
@@ -3,6 +3,11 @@ import { StringProperties } from '../String/StringDocs'
 
 export const BankAccountNumberProperties: PropertiesTableProps = {
   ...StringProperties,
+  bankAccountType: {
+    doc: 'The type of bank account number, used for input mask, label, and formatting. Can be `norwegianBban`, `swedishBban`, `swedishBankgiro`, `swedishPlusgiro`, or `iban`. Validation is currently only supported for `norwegianBban`. Defaults to `norwegianBban`.',
+    type: 'string',
+    status: 'optional',
+  },
   validate: {
     doc: 'Using this prop you can disable the default validation.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
@@ -460,4 +460,837 @@ describe('Field.BankAccountNumber', () => {
       })
     })
   })
+
+  describe('bankAccountType prop', () => {
+    it('should default to numeric inputMode when no bankAccountType is given', () => {
+      render(<Field.BankAccountNumber />)
+
+      const input = document.querySelector('.dnb-input__input')
+      expect(input).toHaveAttribute('inputmode', 'numeric')
+    })
+
+    it('should render omitMask for swedishBban', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBban"
+          value="50001234567"
+          omitMask
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('50001234567')
+    })
+
+    it('should render omitMask for swedishBankgiro', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="59140129"
+          omitMask
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('59140129')
+    })
+
+    it('should render omitMask for iban', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+          omitMask
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('NO9386011117947')
+    })
+
+    it('should use text inputMode for IBAN', () => {
+      render(<Field.BankAccountNumber bankAccountType="iban" />)
+
+      const input = document.querySelector('.dnb-input__input')
+      expect(input).toHaveAttribute('inputmode', 'text')
+    })
+
+    it('should use numeric inputMode for Swedish BBAN', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBban" />)
+
+      const input = document.querySelector('.dnb-input__input')
+      expect(input).toHaveAttribute('inputmode', 'numeric')
+    })
+
+    it('should use numeric inputMode for Swedish Bankgiro', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBankgiro" />)
+
+      const input = document.querySelector('.dnb-input__input')
+      expect(input).toHaveAttribute('inputmode', 'numeric')
+    })
+
+    it('should use numeric inputMode for Swedish Plusgiro', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishPlusgiro" />)
+
+      const input = document.querySelector('.dnb-input__input')
+      expect(input).toHaveAttribute('inputmode', 'numeric')
+    })
+
+    it('should not validate non-norwegianBban types', async () => {
+      render(
+        <Form.Handler>
+          <Field.BankAccountNumber
+            bankAccountType="iban"
+            value="NO9386011117947"
+            validateInitially
+          />
+        </Form.Handler>
+      )
+
+      fireEvent.blur(document.querySelector('input'))
+
+      await expect(() => {
+        expect(screen.queryByRole('alert')).toBeInTheDocument()
+      }).toNeverResolve()
+    })
+
+    it('should use default label for norwegianBban', () => {
+      render(<Field.BankAccountNumber />)
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        nb.BankAccountNumber.label
+      )
+    })
+
+    it('should use IBAN label for iban type', () => {
+      render(<Field.BankAccountNumber bankAccountType="iban" />)
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        nb.BankAccountNumber.labelIban
+      )
+    })
+
+    it('should use Swedish account number label for swedishBban type', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBban" />)
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishBban
+      )
+    })
+
+    it('should use Bankgiro label for swedishBankgiro type', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBankgiro" />)
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishBankgiro
+      )
+    })
+
+    it('should use Plusgiro label for swedishPlusgiro type', () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishPlusgiro" />)
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishPlusgiro
+      )
+    })
+
+    it('should allow overriding label via prop', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          label="Custom label"
+        />
+      )
+
+      expect(document.querySelector('label')).toHaveTextContent(
+        'Custom label'
+      )
+    })
+
+    it('should preserve IBAN country code in value on blur', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'CZ6508000000192000145399')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('CZ6508000000192000145399')
+      expect(input).toHaveValue('CZ65 0800 0000 1920 0014 5399')
+    })
+
+    it('should preserve IBAN country code when value is pre-filled', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('NO93 8601 1117 947')
+    })
+
+    it('should preserve IBAN country code for German IBAN', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'DE89370400440532013000')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('DE89370400440532013000')
+      expect(input).toHaveValue('DE89 3704 0044 0532 0130 00')
+    })
+
+    it('should preserve IBAN country code for British IBAN', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'GB29NWBK60161331926819')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('GB29NWBK60161331926819')
+      expect(input).toHaveValue('GB29 NWBK 6016 1331 9268 19')
+    })
+
+    it('should handle IBAN with lowercase letters', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'gb29nwbk60161331926819')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('GB29NWBK60161331926819')
+    })
+
+    it('should call onChange with cleaned IBAN value without spaces', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'SE4550000000058398257466')
+
+      expect(onChange).toHaveBeenLastCalledWith('SE4550000000058398257466')
+    })
+
+    it('should format Norwegian IBAN correctly', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('NO93 8601 1117 947')
+    })
+
+    it('should format long IBAN with letters in BBAN correctly', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="LC55HEMM000100010012001200023015"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('LC55 HEMM 0001 0001 0012 0012 0002 3015')
+    })
+
+    it('should format British IBAN with letters in BBAN correctly', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="GB29NWBK60161331926819"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('GB29 NWBK 6016 1331 9268 19')
+    })
+  })
+
+  describe('formatting and onChange value for all bankAccountTypes', () => {
+    it('should format norwegianBban on blur and return digits-only onChange', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="norwegianBban"
+          onChange={onChange}
+          validate={false}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '12345678901')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('12345678901')
+      expect(input).toHaveValue('1234 56 78901')
+    })
+
+    it('should format norwegianBban when pre-filled', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="norwegianBban"
+          value="12345678901"
+          validate={false}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('1234 56 78901')
+    })
+
+    it('should format swedishBban on blur and return digits-only onChange', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '50001234567890')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('50001234567890')
+      expect(input).toHaveValue('5000-1234567890')
+    })
+
+    it('should format swedishBban when pre-filled', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBban"
+          value="50001234567890"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('5000-1234567890')
+    })
+
+    it('should format swedishBankgiro on blur and return digits-only onChange', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '59140129')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('59140129')
+      await waitFor(() => {
+        expect(input).toHaveValue('5914-0129')
+      })
+    })
+
+    it('should format swedishPlusgiro on blur and return digits-only onChange', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '1263664')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('1263664')
+      await waitFor(() => {
+        expect(input).toHaveValue('126366-4')
+      })
+    })
+
+    it('should format iban on blur and return alphanumeric-only onChange', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'NO9386011117947')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenLastCalledWith('NO9386011117947')
+      expect(input).toHaveValue('NO93 8601 1117 947')
+    })
+  })
+
+  describe('blur-based mask update for variable-length types', () => {
+    it('should apply formatted mask for 8-digit Bankgiro on blur', async () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBankgiro" />)
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '59140129')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('5914-0129')
+      })
+    })
+
+    it('should apply formatted mask for 7-digit Bankgiro on blur', async () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishBankgiro" />)
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '5914012')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('591-4012')
+      })
+    })
+
+    it('should allow adding an 8th digit to a 7-digit Bankgiro', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="5914012"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('591-4012')
+
+      await userEvent.type(input, '9')
+
+      expect(onChange).toHaveBeenLastCalledWith('59140129')
+    })
+
+    it('should apply formatted mask for Plusgiro on blur', async () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishPlusgiro" />)
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '1263664')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('126366-4')
+      })
+    })
+
+    it('should apply formatted mask for 2-digit Plusgiro on blur', async () => {
+      render(<Field.BankAccountNumber bankAccountType="swedishPlusgiro" />)
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '12')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('1-2')
+      })
+    })
+
+    it('should allow adding a digit to Plusgiro', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="1263664"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('126366-4')
+
+      await userEvent.type(input, '1')
+
+      expect(onChange).toHaveBeenLastCalledWith('12636641')
+    })
+
+    it('should show formatted mask when Bankgiro has pre-filled 7-digit value', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="5914012"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('591-4012')
+    })
+
+    it('should show formatted mask when Bankgiro has pre-filled 8-digit value', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="59140129"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('5914-0129')
+    })
+
+    it('should show formatted mask when Plusgiro has pre-filled value', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="1263664"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('126366-4')
+    })
+
+    it('should call onChange and onBlur callbacks', async () => {
+      const onChange = jest.fn()
+      const onBlur = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '59140129')
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenCalled()
+      expect(onBlur).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reposition dash on blur when Bankgiro grows from 7 to 8 digits', async () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          defaultValue="5914012"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('591-4012')
+
+      await userEvent.type(input, '9')
+
+      // During typing, dash stays at old position
+      expect(input).toHaveValue('591-40129')
+
+      fireEvent.blur(input)
+
+      // On blur, dash moves to the 8-digit position
+      await waitFor(() => {
+        expect(input).toHaveValue('5914-0129')
+      })
+    })
+
+    it('should reposition dash on blur when Plusgiro grows by a digit', async () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          defaultValue="1263664"
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('126366-4')
+
+      await userEvent.type(input, '1')
+
+      // During typing, dash stays at old position
+      expect(input).toHaveValue('126366-41')
+
+      fireEvent.blur(input)
+
+      // On blur, dash moves before the new last digit
+      await waitFor(() => {
+        expect(input).toHaveValue('1263664-1')
+      })
+    })
+  })
+
+  describe('path-based values and data context', () => {
+    it('should display formatted value from Form.Handler data for norwegianBban', () => {
+      render(
+        <Form.Handler data={{ myAccount: '12345678901' }}>
+          <Field.BankAccountNumber path="/myAccount" validate={false} />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('1234 56 78901')
+    })
+
+    it('should display formatted value from Form.Handler data for iban', () => {
+      render(
+        <Form.Handler data={{ myIban: 'GB29NWBK60161331926819' }}>
+          <Field.BankAccountNumber path="/myIban" bankAccountType="iban" />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('GB29 NWBK 6016 1331 9268 19')
+    })
+
+    it('should display formatted value from Form.Handler data for swedishBban', () => {
+      render(
+        <Form.Handler data={{ myAccount: '50001234567890' }}>
+          <Field.BankAccountNumber
+            path="/myAccount"
+            bankAccountType="swedishBban"
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('5000-1234567890')
+    })
+
+    it('should submit clean value via Form.Handler onSubmit for iban', async () => {
+      const onSubmit = jest.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.BankAccountNumber path="/iban" bankAccountType="iban" />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'DE89370400440532013000')
+      fireEvent.blur(input)
+      fireEvent.submit(input.closest('form'))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { iban: 'DE89370400440532013000' },
+          expect.anything()
+        )
+      })
+    })
+
+    it('should submit clean value via Form.Handler onSubmit for norwegianBban', async () => {
+      const onSubmit = jest.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.BankAccountNumber path="/account" validate={false} />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '12345678901')
+      fireEvent.blur(input)
+      fireEvent.submit(input.closest('form'))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { account: '12345678901' },
+          expect.anything()
+        )
+      })
+    })
+
+    it('should submit clean value via Form.Handler onSubmit for swedishBankgiro', async () => {
+      const onSubmit = jest.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.BankAccountNumber
+            path="/bankgiro"
+            bankAccountType="swedishBankgiro"
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, '59140129')
+      fireEvent.blur(input)
+      fireEvent.submit(input.closest('form'))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { bankgiro: '59140129' },
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('transformIn and transformOut', () => {
+    it('should apply transformIn to display value for iban', () => {
+      render(
+        <Form.Handler data={{ iban: 'gb29nwbk60161331926819' }}>
+          <Field.BankAccountNumber
+            path="/iban"
+            bankAccountType="iban"
+            transformIn={(external) =>
+              typeof external === 'string'
+                ? external.toUpperCase()
+                : (external as string)
+            }
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('GB29 NWBK 6016 1331 9268 19')
+    })
+
+    it('should apply transformOut on submit for iban', async () => {
+      const onSubmit = jest.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.BankAccountNumber
+            path="/iban"
+            bankAccountType="iban"
+            transformOut={(internal) =>
+              typeof internal === 'string'
+                ? internal.toUpperCase()
+                : internal
+            }
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'gb29nwbk60161331926819')
+      fireEvent.blur(input)
+      fireEvent.submit(input.closest('form'))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit).toHaveBeenCalledWith(
+          { iban: 'GB29NWBK60161331926819' },
+          expect.anything()
+        )
+      })
+    })
+
+    it('should apply transformIn for norwegianBban with path', () => {
+      render(
+        <Form.Handler data={{ account: '12345678901' }}>
+          <Field.BankAccountNumber
+            path="/account"
+            validate={false}
+            transformIn={(external) =>
+              typeof external === 'string'
+                ? external.slice(0, 11)
+                : (external as string)
+            }
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('1234 56 78901')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty value', () => {
+      render(<Field.BankAccountNumber bankAccountType="iban" value="" />)
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('')
+    })
+
+    it('should handle undefined value', () => {
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value={undefined}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('')
+    })
+
+    it('should handle clearing the input for iban', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.clear(input)
+
+      expect(onChange).toHaveBeenLastCalledWith(undefined)
+    })
+
+    it('should handle clearing the input for norwegianBban', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <Field.BankAccountNumber
+          bankAccountType="norwegianBban"
+          value="12345678901"
+          validate={false}
+          onChange={onChange}
+        />
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.clear(input)
+
+      expect(onChange).toHaveBeenLastCalledWith(undefined)
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/masks.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/masks.ts
@@ -1,0 +1,206 @@
+import type { BankAccountType } from '../../../../components/number-format/utils/formatBankAccountNumber'
+import type { FieldBlockWidth } from '../../FieldBlock/FieldBlock'
+
+type MaskEntry = Array<RegExp | string>
+
+/**
+ * Norwegian BBAN: XXXX XX XXXXX (11 digits)
+ */
+const norwegianBbanMask: MaskEntry = [
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  ' ',
+  /\d/,
+  /\d/,
+  ' ',
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+]
+
+const norwegianBbanMaskNoFormat: MaskEntry = Array.from(
+  { length: 11 },
+  () => /\d/
+)
+
+/**
+ * Swedish BBAN: XXXX-XXXXXXXXXX (clearing 4 + account up to 10)
+ * Using a generous mask of 14 digits.
+ */
+const swedishBbanMask: MaskEntry = [
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  '-',
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+  /\d/,
+]
+
+const swedishBbanMaskNoFormat: MaskEntry = Array.from(
+  { length: 14 },
+  () => /\d/
+)
+
+/**
+ * Swedish Bankgiro: 7-8 digits.
+ * When the value length is known, the mask includes a dash at the correct position
+ * while still allowing up to 8 digits total.
+ * Otherwise digit-only to avoid a premature dash during input.
+ */
+const swedishBankgiroMaskDigitsOnly: MaskEntry = Array.from(
+  { length: 8 },
+  () => /\d/
+)
+
+function buildSwedishBankgiroMask(value?: string): MaskEntry {
+  const digits = value?.replace(/[^0-9]/g, '') ?? ''
+
+  if (digits.length === 7) {
+    // XXX-XXXXX — 9-slot mask (3 digits + dash + 5 digits) so the user
+    // can type an 8th digit. The dash stays after the 3rd digit until
+    // blur, which repositions it to XXXX-XXXX via setMaskValue.
+    return [/\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/, /\d/]
+  }
+
+  if (digits.length === 8) {
+    // XXXX-XXXX
+    return [/\d/, /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
+  }
+
+  return swedishBankgiroMaskDigitsOnly
+}
+
+/**
+ * Swedish Plusgiro: 2-8 digits.
+ * When the value length is known, the mask includes a dash before the check digit
+ * while still allowing up to 8 digits total.
+ * Otherwise digit-only to avoid a premature dash during input.
+ */
+const swedishPlusgiroMaskDigitsOnly: MaskEntry = Array.from(
+  { length: 8 },
+  () => /\d/
+)
+
+function buildSwedishPlusgiroMask(value?: string): MaskEntry {
+  const digits = value?.replace(/[^0-9]/g, '') ?? ''
+
+  if (digits.length >= 2 && digits.length <= 8) {
+    const maxDigits = 8
+    const dashPosition = digits.length - 1
+    const mask: MaskEntry = []
+
+    for (let i = 0; i < maxDigits; i++) {
+      if (i === dashPosition) {
+        mask.push('-')
+      }
+      mask.push(/\d/)
+    }
+
+    return mask
+  }
+
+  return swedishPlusgiroMaskDigitsOnly
+}
+
+/**
+ * IBAN: groups of 4 alphanumeric characters.
+ * Max 34 characters. Country code (2 letters) + check digits (2) + BBAN (up to 30).
+ */
+const ibanMask: MaskEntry = buildIbanMask()
+
+function buildIbanMask(): MaskEntry {
+  const alphanumeric = /[A-Za-z0-9]/
+  const mask: MaskEntry = []
+
+  for (let i = 0; i < 34; i++) {
+    if (i > 0 && i % 4 === 0) {
+      mask.push(' ')
+    }
+    mask.push(alphanumeric)
+  }
+
+  return mask
+}
+
+const ibanMaskNoFormat: MaskEntry = Array.from(
+  { length: 34 },
+  () => /[A-Za-z0-9]/
+)
+
+export function getMask(
+  bankAccountType: BankAccountType,
+  omitMask: boolean,
+  value?: string
+): MaskEntry {
+  if (omitMask) {
+    switch (bankAccountType) {
+      case 'swedishBban':
+        return swedishBbanMaskNoFormat
+      case 'swedishBankgiro':
+        return swedishBankgiroMaskDigitsOnly
+      case 'swedishPlusgiro':
+        return swedishPlusgiroMaskDigitsOnly
+      case 'iban':
+        return ibanMaskNoFormat
+      case 'norwegianBban':
+      default:
+        return norwegianBbanMaskNoFormat
+    }
+  }
+
+  switch (bankAccountType) {
+    case 'swedishBban':
+      return swedishBbanMask
+    case 'swedishBankgiro':
+      return buildSwedishBankgiroMask(value)
+    case 'swedishPlusgiro':
+      return buildSwedishPlusgiroMask(value)
+    case 'iban':
+      return ibanMask
+    case 'norwegianBban':
+    default:
+      return norwegianBbanMask
+  }
+}
+
+export function getInputMode(
+  bankAccountType: BankAccountType
+): 'numeric' | 'text' {
+  if (bankAccountType === 'iban') {
+    return 'text'
+  }
+  return 'numeric'
+}
+
+export function getWidth(
+  bankAccountType: BankAccountType
+): FieldBlockWidth {
+  switch (bankAccountType) {
+    case 'iban':
+      return 'large'
+    default:
+      return 'medium'
+  }
+}
+
+export function hasVariableMask(
+  bankAccountType: BankAccountType
+): boolean {
+  return (
+    bankAccountType === 'swedishBankgiro' ||
+    bankAccountType === 'swedishPlusgiro'
+  )
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/validators.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/validators.ts
@@ -1,0 +1,50 @@
+/**
+ * Norwegian BBAN: 11 digits, mod-11 checksum.
+ * Format: XXXX XX XXXXX
+ */
+export function norwegianBbanValidator(
+  value: string,
+  errorMessages: {
+    errorBankAccountNumber: string
+    errorBankAccountNumberLength: string
+  }
+): Error | undefined {
+  if (value !== undefined) {
+    if (value.length !== 11) {
+      return Error(errorMessages.errorBankAccountNumberLength)
+    }
+
+    if (!isValidNorwegianAccountNumber(value)) {
+      return Error(errorMessages.errorBankAccountNumber)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Mod-11 checksum for Norwegian bank account numbers.
+ */
+function isValidNorwegianAccountNumber(digits: string) {
+  if (parseFloat(digits) === 0) {
+    return false
+  }
+
+  let checkDigit = 2
+  let sum = 0
+
+  for (let i = digits.length - 2; i >= 0; --i) {
+    sum += parseInt(digits.charAt(i), 10) * checkDigit
+
+    checkDigit += 1
+
+    if (checkDigit > 7) {
+      checkDigit = 2
+    }
+  }
+
+  const result = 11 - (sum % 11)
+  const finalCheckDigit = result === 11 ? 0 : result
+
+  return parseInt(digits.charAt(digits.length - 1), 10) === finalCheckDigit
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -199,7 +199,7 @@ function StringComponent(props: FieldStringProps) {
     ...props,
     schema,
     // @ts-expect-error - strictFunctionTypes
-    fromInput,
+    fromInput: props.fromInput ?? fromInput,
     toEvent,
     transformValue,
     width:

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
@@ -1,29 +1,67 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import type { ValueStringProps as StringValueProps } from '../String'
 import StringValue from '../String'
 import {
-  formatBankAccountNumber,
-  cleanNumber,
-} from '../../../../components/number-format/NumberUtils'
+  formatBankAccountNumberByType,
+  type BankAccountType,
+} from '../../../../components/number-format/utils/formatBankAccountNumber'
 import useTranslation from '../../hooks/useTranslation'
 import { isValueEmpty } from '../../ValueBlock'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
-export type ValueBankAccountNumberProps = StringValueProps
+export type { BankAccountType } from '../../../../components/number-format/utils/formatBankAccountNumber'
+
+export type ValueBankAccountNumberProps = StringValueProps & {
+  /**
+   * The type of bank account number for formatting. Defaults to `norwegianBban`.
+   */
+  bankAccountType?: BankAccountType
+}
 
 function BankAccountNumber(props: ValueBankAccountNumberProps) {
+  const { bankAccountType = 'norwegianBban', ...restProps } = props
   const translations = useTranslation().BankAccountNumber
 
-  const toInput = useCallback((value) => {
-    if (isValueEmpty(value)) {
+  const toInput = useCallback(
+    (external: unknown) => {
+      if (isValueEmpty(external)) {
+        return undefined
+      }
+
+      return formatBankAccountNumberByType(
+        String(external),
+        bankAccountType
+      ).number
+    },
+    [bankAccountType]
+  )
+
+  const label = useMemo(() => {
+    if (restProps.label !== undefined) {
+      return restProps.label
+    }
+
+    if (restProps.inline) {
       return undefined
     }
-    return formatBankAccountNumber(cleanNumber(value)).toString()
-  }, [])
+
+    switch (bankAccountType) {
+      case 'swedishBban':
+        return translations.labelSwedishBban
+      case 'swedishBankgiro':
+        return translations.labelSwedishBankgiro
+      case 'swedishPlusgiro':
+        return translations.labelSwedishPlusgiro
+      case 'iban':
+        return translations.labelIban
+      default:
+        return translations.label
+    }
+  }, [restProps.label, restProps.inline, bankAccountType, translations])
 
   const stringValueProps: ValueBankAccountNumberProps = {
-    ...props,
-    label: props.label ?? (props.inline ? undefined : translations.label),
+    ...restProps,
+    label,
     toInput,
   }
   return <StringValue {...stringValueProps} />

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumberDocs.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumberDocs.tsx
@@ -1,0 +1,9 @@
+import type { PropertiesTableProps } from '../../../../shared/types'
+
+export const BankAccountNumberValueProperties: PropertiesTableProps = {
+  bankAccountType: {
+    doc: 'The type of bank account number, used for label and formatting. Can be `norwegianBban`, `swedishBban`, `swedishBankgiro`, `swedishPlusgiro`, or `iban`. Defaults to `norwegianBban`.',
+    type: 'string',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
@@ -71,4 +71,189 @@ describe('Value.BankAccountNumber', () => {
     const element = document.querySelector('.dnb-forms-value-block')
     expect(element).not.toBeInTheDocument()
   })
+
+  describe('bankAccountType prop', () => {
+    it('renders Norwegian BBAN by default', () => {
+      render(<Value.BankAccountNumber value="20001234567" />)
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('2000 12 34567')
+    })
+
+    it('renders IBAN formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('NO93 8601 1117 947')
+    })
+
+    it('renders Swedish BBAN formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishBban"
+          value="50001234567"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('5000-1234567')
+    })
+
+    it('renders Swedish Bankgiro formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="59140129"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('5914-0129')
+    })
+
+    it('renders 7-digit Swedish Bankgiro formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="5914012"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('591-4012')
+    })
+
+    it('renders Swedish Plusgiro formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="1263664"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('126366-4')
+    })
+
+    it('renders 8-digit Swedish Plusgiro formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="12636641"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('1263664-1')
+    })
+
+    it('renders 2-digit Swedish Plusgiro formatted value', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="12"
+        />
+      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-value-string .dnb-forms-value-block__content'
+        )
+      ).toHaveTextContent('1-2')
+    })
+  })
+
+  describe('labels per bankAccountType', () => {
+    it('uses default label for norwegianBban', () => {
+      render(<Value.BankAccountNumber value="20001234567" />)
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        nb.BankAccountNumber.label
+      )
+    })
+
+    it('uses IBAN label for iban type', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+        />
+      )
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        nb.BankAccountNumber.labelIban
+      )
+    })
+
+    it('uses Swedish account number label for swedishBban type', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishBban"
+          value="50001234567"
+        />
+      )
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishBban
+      )
+    })
+
+    it('uses Bankgiro label for swedishBankgiro type', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="59140129"
+        />
+      )
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishBankgiro
+      )
+    })
+
+    it('uses Plusgiro label for swedishPlusgiro type', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="swedishPlusgiro"
+          value="1263664"
+        />
+      )
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        nb.BankAccountNumber.labelSwedishPlusgiro
+      )
+    })
+
+    it('allows overriding label via prop', () => {
+      render(
+        <Value.BankAccountNumber
+          bankAccountType="iban"
+          value="NO9386011117947"
+          label="Custom label"
+        />
+      )
+
+      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
+        'Custom label'
+      )
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -185,6 +185,10 @@ export default {
     },
     BankAccountNumber: {
       label: 'Bankkonto',
+      labelSwedishBban: 'Svensk kontonummer',
+      labelSwedishBankgiro: 'Bankgiro',
+      labelSwedishPlusgiro: 'Plusgiro',
+      labelIban: 'IBAN',
       errorRequired: 'Du skal udfylde et kontonummer.',
       errorBankAccountNumber: 'Ugyldigt kontonummer.',
       errorBankAccountNumberLength:

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -183,6 +183,10 @@ export default {
     },
     BankAccountNumber: {
       label: 'Bank account',
+      labelSwedishBban: 'Swedish account number',
+      labelSwedishBankgiro: 'Bankgiro',
+      labelSwedishPlusgiro: 'Plusgiro',
+      labelIban: 'IBAN',
       errorRequired: 'You must enter an account number.',
       errorBankAccountNumber: 'Invalid account number.',
       errorBankAccountNumberLength:

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -184,6 +184,10 @@ export default {
     },
     BankAccountNumber: {
       label: 'Bankkonto',
+      labelSwedishBban: 'Svenskt kontonummer',
+      labelSwedishBankgiro: 'Bankgiro',
+      labelSwedishPlusgiro: 'Plusgiro',
+      labelIban: 'IBAN',
       errorRequired: 'Du må fylle inn et kontonummer.',
       errorBankAccountNumber: 'Ugyldig kontonummer.',
       errorBankAccountNumberLength:

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -185,6 +185,10 @@ export default {
     },
     BankAccountNumber: {
       label: 'Bankkonto',
+      labelSwedishBban: 'Svenskt kontonummer',
+      labelSwedishBankgiro: 'Bankgiro',
+      labelSwedishPlusgiro: 'Plusgiro',
+      labelIban: 'IBAN',
       errorRequired: 'Du måste fylla i ett kontonummer.',
       errorBankAccountNumber: 'Ogiltigt kontonummer.',
       errorBankAccountNumberLength:


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1774518164353249
Dependent on https://github.com/dnbexperience/eufemia/pull/7542
Deploy preview:
- [Field.BankAccountNumber](https://feat-multi-format-bank-accou.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/BankAccountNumber/demos/#swedish-bank-account-types)
- [Value.BankAccountNumber](https://feat-multi-format-bank-accou.eufemia-e25.pages.dev/uilib/extensions/forms/Value/BankAccountNumber/demos/#swedish-bank-account-types)
- [formatBAN](https://feat-multi-format-bank-accou.eufemia-e25.pages.dev/uilib/components/number-format/#format-bank-account-numbers)

Support multiple bank account formats in Field.BankAccountNumber and
Value.BankAccountNumber via a new `bankAccountType` prop.

Supported types: norwegianBban (default), swedishBban, swedishBankgiro,
swedishPlusgiro, and iban.

- Input masks per type (digit-only for variable-length formats)
- Type-aware display formatting in Value via formatBAN()
- Type-specific labels in all 4 locales (nb-NO, en-GB, sv-SE, da-DK)
- inputMode switching (text for IBAN, numeric for others)
- Width adjustment (large for IBAN, medium for others)

Validation remains Norwegian BBAN only; other types will be added later.