### PR TITLE
chore: remove unused SCSS browser-detection and focus mixins

### DIFF
--- a/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
@@ -5,7 +5,7 @@
 *
 */
 @mixin buttonHoverStyle($color, $background-color, $border-color) {
-  // NB: to get "over" sibling, because of the extendFocusRing
+  // NB: z-index needed to get "over" sibling due to the focus ring box-shadow
   // But if we would use it, then we have to take care of places we use position="absolute", like the Modal Close button
 
   color: $color;

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -191,17 +191,6 @@
   }
 }
 
-@mixin extendFocusRing(
-  $first-color: null,
-  $second-color: null,
-  $width: 0.0625rem /*1px*/
-) {
-  $second: 0 0 0 calc(var(--focus-ring-width) + #{$width}) $second-color;
-  box-shadow:
-    0 0 0 $width $first-color,
-    $second;
-}
-
 @mixin dummySpacing() {
   // we use "aria-hidden" SPAN to simulate a wider width for each tab
   .dnb-dummy {
@@ -287,36 +276,6 @@
     display: none;
   }
   scrollbar-width: none; /* Firefox */
-}
-
-// Firefox fix
-@mixin isFirefox() {
-  @supports (-moz-appearance: none) {
-    @content;
-  }
-}
-
-// Chrome fix
-@mixin isChrome() {
-  @supports (-webkit-appearance: none) and
-    (not (overflow: -webkit-marquee)) and (not (-moz-appearance: none)) {
-    @content;
-  }
-}
-
-// Safari Mobile fix
-@mixin isSafariMobile() {
-  @supports (-webkit-touch-callout: none) {
-    @content;
-  }
-}
-
-// Safari Desktop fix
-@mixin isSafariDesktop() {
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) and
-    (not (-webkit-touch-callout: none)) {
-    @content;
-  }
 }
 
 $breakpoints: (


### PR DESCRIPTION
Removed 5 unused mixins from utilities.scss:
- isFirefox() - @supports (-moz-appearance: none) hack
- isChrome() - @supports (-webkit-appearance: none) hack
- isSafariMobile() - @supports (-webkit-touch-callout: none) hack
- isSafariDesktop() - @supports webkit + stroke-color hack
- extendFocusRing() - focus ring box-shadow helper (never @included)

Also updated a stale comment in button-mixins.scss.

