### PR TITLE
refactor: remove unused SCSS mixins extendFocusRing and componentReset

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -28,6 +28,7 @@ v11 of @dnb/eufemia contains _breaking changes_. As a migration process, you can
 12. Replace `styleType` (or `style_type`) with `backgroundColor` on Breadcrumb, Dialog.Body, and Drawer.Body components.
 13. Remove `spacing` on Section. Use `innerSpace={{ block: 'large' }}` instead (see [Section](#section)).
 14. Replace `contentSpacing` with `contentInnerSpace` and `tabsSpacing` with `tabsInnerSpace` on the Tabs component.
+15. If you use the `extendFocusRing` or `componentReset` SCSS mixins, remove them — they have been deleted (see [Removed SCSS mixins](#removed-scss-mixins)).
 
 ### innerRef → ref
 
@@ -1458,6 +1459,13 @@ These were previously used to support dual snake_case/camelCase prop naming. Sin
 #### Updated SCSS mixin: `IS_FF`
 
 The `IS_FF()` SCSS mixin now uses `@supports (-moz-appearance: none)` instead of the deprecated `@-moz-document url-prefix()` hack. No changes needed if you use the mixin — it works the same way.
+
+#### Removed SCSS mixins
+
+The following SCSS mixins have been removed:
+
+- **`extendFocusRing`** (`style/core/utilities.scss`) — added an outer ring on top of `focusRing`. Replace with a custom `box-shadow` if needed.
+- **`componentReset`** (`style/core/scopes.scss`) — applied core CSS reset rules to a single component. Use the global Eufemia CSS reset instead.
 
 ## Eufemia Forms
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -53,9 +53,6 @@ You can import Eufemia _mixins_ directly into your SCSS styles:
 @include utilities.focusRing(
   /* $whatinput: 'keyboard', $color: var(--color-emerald-green), $inset: inset */
 );
-@include utilities.extendFocusRing(
-  /* $first-color: null, $second-color: null, width: 0.0625rem */
-);
 @include utilities.fakeBorder(
   /* $color: var(--color-emerald-green), $width: 0.0625rem, $inset: inset */
 );

--- a/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/button-mixins.scss
@@ -5,9 +5,6 @@
 *
 */
 @mixin buttonHoverStyle($color, $background-color, $border-color) {
-  // NB: to get "over" sibling, because of the extendFocusRing
-  // But if we would use it, then we have to take care of places we use position="absolute", like the Modal Close button
-
   color: $color;
   background-color: $background-color;
 

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -84,15 +84,3 @@
   // reset ePlatform css
   @include reset.resetLegacyStyles();
 }
-
-// Can be used to include the most important "CSS reset" rules to one component.
-// Should only be used when this component is imported in isolation.
-@mixin componentReset() {
-  @include coreDefault();
-  @include reset.coreReset();
-
-  margin: 0;
-  padding: 0;
-
-  @content;
-}

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -189,17 +189,6 @@
   }
 }
 
-@mixin extendFocusRing(
-  $first-color: null,
-  $second-color: null,
-  $width: 0.0625rem /*1px*/
-) {
-  $second: 0 0 0 calc(var(--focus-ring-width) + #{$width}) $second-color;
-  box-shadow:
-    0 0 0 $width $first-color,
-    $second;
-}
-
 @mixin dummySpacing() {
   // we use "aria-hidden" SPAN to simulate a wider width for each tab
   .dnb-dummy {


### PR DESCRIPTION
- Remove extendFocusRing() mixin from utilities.scss (never @included)
- Remove componentReset() mixin from scopes.scss (never @included)
- Remove extendFocusRing doc reference from sass.mdx
- Remove outdated extendFocusRing comment from button-mixins.scss

