### PR TITLE
fix(Field.Provider): avoid overwriting parent translations with undefined

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { renderHook } from '@testing-library/react'
 import useFieldProvider from '../useFieldProvider'
 import FieldProviderContext from '../FieldProviderContext'
+import Provider from '../../../../../shared/Provider'
 
 describe('useFieldProvider', () => {
   it('should return extend function and inherited props', () => {
@@ -85,5 +86,45 @@ describe('useFieldProvider', () => {
     expect(result.current.extend(valueProps)).toEqual({
       disabled: false,
     })
+  })
+
+  it('should not include translations in sharedProviderParams when no translations prop is given', () => {
+    const { result } = renderHook(useFieldProvider, {
+      wrapper: ({ children }) => (
+        <Provider
+          locale="nb-NO"
+          translations={{
+            'nb-NO': { Field: { errorRequired: 'Custom required' } },
+          }}
+        >
+          {children}
+        </Provider>
+      ),
+    })
+
+    expect(result.current.sharedProviderParams).not.toHaveProperty(
+      'translations'
+    )
+  })
+
+  it('should include translations in sharedProviderParams when translations prop is given', () => {
+    const translations = {
+      'nb-NO': { Field: { errorRequired: 'Override' } },
+    }
+
+    const { result } = renderHook(useFieldProvider, {
+      initialProps: { translations },
+      wrapper: ({ children }) => (
+        <Provider locale="nb-NO">{children}</Provider>
+      ),
+    })
+
+    expect(result.current.sharedProviderParams).toHaveProperty(
+      'translations'
+    )
+    expect(
+      result.current.sharedProviderParams.translations['nb-NO'].Field
+        .errorRequired
+    ).toBe('Override')
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
@@ -48,7 +48,8 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
   if (locale) {
     sharedProviderParams.locale = locale
   }
-  sharedProviderParams.translations = useMemo(() => {
+
+  const mergedTranslations = useMemo(() => {
     if (restProps.translations === undefined) {
       return restProps.translations
     }
@@ -62,6 +63,10 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
 
     return translations
   }, [restProps?.translations, sharedContext.translations])
+
+  if (mergedTranslations !== undefined) {
+    sharedProviderParams.translations = mergedTranslations
+  }
 
   const extend = useCallback(
     <T extends FieldProps>(fieldProps: T) => {


### PR DESCRIPTION
When Field.Provider is rendered without a translations prop, it was setting sharedProviderParams.translations to undefined. This caused SharedProvider to spread translations: undefined into the context, overwriting parent translations via { ...nestedContext, ...props }.

Extract the useMemo into a variable and only assign translations to sharedProviderParams when the value is defined.

Add tests verifying sharedProviderParams excludes the translations key when no translations prop is given, and includes it when provided.

Bug was introduced in #7220