### PR TITLE
chore: remove remaining event.persist() call

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -260,8 +260,6 @@ export default function ModalContent(props: ModalContentProps) {
         ...params
       }: ModalCloseHandlerParams & { ifIsLatest?: boolean }
     ) => {
-      event?.persist?.()
-
       close(event, {
         triggeredBy,
         ...params,


### PR DESCRIPTION
event.persist() has been a no-op since React 17. Removes the last remaining call in ModalContent.tsx.

