### PR TITLE
chore: replace deprecated navigator.platform with userAgentData

### DIFF
--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -199,20 +199,23 @@ function getValue(props: TextareaProps) {
   return props.value
 }
 
+import { getPlatform } from '../../shared/helpers'
+
 function getResizeModifier() {
   try {
     if (typeof navigator !== 'undefined') {
+      const platform = getPlatform()
+
       if (
         /Firefox|Edg/.test(navigator.userAgent) ||
-        (/Chrome/.test(navigator.userAgent) &&
-          /Win/.test(navigator.platform))
+        (/Chrome/.test(navigator.userAgent) && /Win/.test(platform))
       ) {
         return 'large'
       }
 
       if (
         /Safari|Chrome/.test(navigator.userAgent) &&
-        /Mac/.test(navigator.platform)
+        /Mac/.test(platform)
       ) {
         return 'medium'
       }

--- a/packages/dnb-eufemia/src/shared/helpers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers.ts
@@ -19,7 +19,7 @@ export let IS_MAC = false
 export let IS_ANDROID = false
 export let IS_LINUX = false
 
-const getPlatform = () => {
+export const getPlatform = () => {
   if (typeof navigator === 'undefined') {
     return ''
   }

--- a/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
+++ b/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
@@ -7,6 +7,7 @@
 import type React from 'react'
 import {
   warn,
+  getPlatform,
   PLATFORM_MAC,
   PLATFORM_WIN,
   PLATFORM_LINUX,
@@ -45,12 +46,7 @@ export function defineNavigator() {
           (window as Window & { IS_TEST?: boolean }).IS_TEST
         )
       ) {
-        const platform =
-          (
-            navigator as Navigator & {
-              userAgentData?: { platform?: string }
-            }
-          ).userAgentData?.platform || navigator.platform
+        const platform = getPlatform()
 
         if (platform.match(new RegExp(PLATFORM_MAC)) !== null) {
           document.documentElement.setAttribute('data-os', 'mac')


### PR DESCRIPTION
Migrate remaining navigator.platform usages to use navigator.userAgentData.platform with navigator.platform as fallback.

- Textarea: use shared getPlatform() for platform detection
- component-helper-legacy: use shared getPlatform() instead of inline logic
- helpers: export getPlatform() for reuse

