### PR TITLE
chore(useTranslation): replace RegExp with replaceAll for template args

### DIFF
--- a/packages/dnb-eufemia/src/shared/useTranslation.tsx
+++ b/packages/dnb-eufemia/src/shared/useTranslation.tsx
@@ -338,8 +338,7 @@ export function formatMessage(
 
   if (typeof str === 'string') {
     for (const t in args) {
-      const regex = new RegExp(`{${t}}`, 'g')
-      str = str.replace(regex, args[t])
+      str = str.replaceAll(`{${t}}`, args[t])
     }
   }
 


### PR DESCRIPTION
Replace 'new RegExp(`{${t}}`, "g")' with 'str.replaceAll(`{${t}}`, ...)' in formatMessage(). Avoids creating a new RegExp object per argument on every render for every translated string.

