### PR TITLE
chore: remove defineNavigator from public API exports

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.js
@@ -8,7 +8,6 @@ import { render } from '@testing-library/react'
 
 import {
   extendDeep,
-  defineNavigator,
   validateDOMAttributes,
   processChildren,
   dispatchCustomElementEvent,
@@ -26,6 +25,7 @@ import {
   escapeRegexChars,
   removeUndefinedProps,
 } from '../component-helper'
+import { defineNavigator } from '../legacy/component-helper-legacy'
 import userEvent from '@testing-library/user-event'
 
 beforeAll(() => {

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -11,7 +11,13 @@ import { getClosestParent } from './helpers/getClosest'
 import { init } from './Eufemia'
 import { defineNavigator } from './legacy/component-helper-legacy'
 
-export * from './legacy/component-helper-legacy'
+export {
+  isTouchDevice,
+  processChildren,
+  detectOutsideClick,
+  DetectOutsideClickClass,
+  checkIfHasScrollbar,
+} from './legacy/component-helper-legacy'
 export { InteractionInvalidation } from './helpers/InteractionInvalidation'
 export {
   extendPropsWithContext,


### PR DESCRIPTION
Remove defineNavigator from the public API surface. The function is still called internally at module load time to set the data-os attribute, but consumers should not import or call it directly.

