### PR TITLE
refactor(forms): prefix bare AllProps type exports with component name

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1872,8 +1872,13 @@ Several exported types lacked a component namespace prefix, risking name collisi
 | `End`                         | `FlexEnd`                           |
 | `Start`                       | `FlexStart`                         |
 | `Spans`                       | `FlexSpans`                         |
-| `Span` (flex)                 | `FlexSpan`                          |
-| `GroupProps`                  | `AccordionGroupProps`               |
+| `Span` (flex)                               | `FlexSpan`                              |
+| `AllProps` (Iterate/EditContainer)            | `IterateEditContainerAllProps`          |
+| `AllProps` (Iterate/ViewContainer)            | `IterateViewContainerAllProps`          |
+| `AllProps` (Iterate/PushContainer)            | `IteratePushContainerAllProps`          |
+| `AllProps` (Form/Section/EditContainer)       | `FormSectionEditContainerAllProps`      |
+| `AllProps` (Form/Section/ViewContainer)       | `FormSectionViewContainerAllProps`      |
+| `GroupProps`                                  | `AccordionGroupProps`                   |
 | `StoreDataReturn`             | `AccordionStoreDataReturn`          |
 | `StoreOptions`                | `AccordionStoreOptions`             |
 | `TextColor`                   | `SectionTextColor`                  |

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1867,74 +1867,74 @@ Types using a plural `Types` suffix have been renamed to use singular form for c
 
 Several exported types lacked a component namespace prefix, risking name collisions. They have been prefixed:
 
-| Before                        | After                               |
-| ----------------------------- | ----------------------------------- |
-| `End`                         | `FlexEnd`                           |
-| `Start`                       | `FlexStart`                         |
-| `Spans`                       | `FlexSpans`                         |
-| `Span` (flex)                               | `FlexSpan`                              |
-| `AllProps` (Iterate/EditContainer)            | `IterateEditContainerAllProps`          |
-| `AllProps` (Iterate/ViewContainer)            | `IterateViewContainerAllProps`          |
-| `AllProps` (Iterate/PushContainer)            | `IteratePushContainerAllProps`          |
-| `AllProps` (Form/Section/EditContainer)       | `FormSectionEditContainerAllProps`      |
-| `AllProps` (Form/Section/ViewContainer)       | `FormSectionViewContainerAllProps`      |
-| `GroupProps`                                  | `AccordionGroupProps`                   |
-| `StoreDataReturn`             | `AccordionStoreDataReturn`          |
-| `StoreOptions`                | `AccordionStoreOptions`             |
-| `TextColor`                   | `SectionTextColor`                  |
-| `OutlineColor`                | `SectionOutlineColor`               |
-| `BackgroundColor`             | `SectionBackgroundColor`            |
-| `DropShadow`                  | `SectionDropShadow`                 |
-| `RoundedCorner`               | `SectionRoundedCorner`              |
-| `TriggeredBy`                 | `ModalTriggeredBy`                  |
-| `CloseHandler`                | `ModalCloseHandler`                 |
-| `CloseHandlerParams`          | `ModalCloseHandlerParams`           |
-| `TriggerAttributes` (modal)   | `ModalTriggerAttributes`            |
-| `TriggerAttributes` (popover) | `PopoverTriggerAttributes`          |
-| `ValueTypes`                  | `SliderValue`                       |
-| `NumberFormatTypes`           | `SliderNumberFormat`                |
-| `ThumbState`                  | `SliderThumbState`                  |
-| `DummyProps`                  | `TabsDummyProps`                    |
-| `ContentWrapperProps`         | `TabsContentWrapperProps`           |
-| `ContentWrapperSelectedKey`   | `TabsContentWrapperSelectedKey`     |
-| `ContentWrapperChildren`      | `TabsContentWrapperChildren`        |
-| `CustomContentProps`          | `TabsCustomContentProps`            |
-| `CustomContentTitle`          | `TabsCustomContentTitle`            |
-| `CustomContentChildren`       | `TabsCustomContentChildren`         |
-| `AutoSizeProps`               | `SkeletonAutoSizeProps`             |
-| `ElementsHiddenProps`         | `AvatarElementsHiddenProps`         |
-| `LoadButtonProps`             | `PaginationLoadButtonProps`         |
-| `InfinityScrollerProps`       | `PaginationInfinityScrollerProps`   |
-| `InfinityLoadButtonProps`     | `PaginationInfinityLoadButtonProps` |
-| `CreatePaginationReturn`      | `PaginationCreateReturn`            |
-| `DateType`                    | `DatePickerDateType`                |
-| `CalendarDay`                 | `DatePickerCalendarDay`             |
-| `CalendarNavigationEvent`     | `DatePickerCalendarNavigationEvent` |
-| `CalendarView`                | `DatePickerCalendarView`            |
-| `ReturnObject`                | `DatePickerReturnObject`            |
-| `InvalidDates`                | `DatePickerInvalidDates`            |
-| `PartialDates`                | `DatePickerPartialDates`            |
-| `SubmittedDates`              | `DatePickerSubmittedDates`          |
-| `FormatType`                  | `NumberFormatType`                  |
-| `FormatCurrencyPosition`      | `NumberFormatCurrencyPosition`      |
-| `FormatReturnValue`           | `NumberFormatReturnValue`           |
-| `FormatValue`                 | `NumberFormatValue`                 |
-| `FormatReturnType`            | `NumberFormatReturnType`            |
-| `FormatOptionParams`          | `NumberFormatOptionParams`          |
-| `FormatDateOptions`           | `DateFormatOptions`                 |
-| `RelativeTimeUnit`            | `DateFormatRelativeTimeUnit`        |
-| `StickyTableHeaderProps`      | `TableStickyHeaderProps`            |
-| `SortState`                   | `TableSortState`                    |
-| `SortEventHandler`            | `TableSortEventHandler`             |
-| `SortHandler`                 | `TableSortHandler`                  |
-| `SubmitButtonProps`           | `InputSubmitButtonProps`            |
-| `CustomSize`                  | `ProgressIndicatorCustomSize`       |
-| `TimeLineItemStates`          | `TimelineItemState`                 |
-| `Columns` (grid/Item)         | `GridItemColumns`                   |
-| `Span` (grid/Item)            | `GridItemSpan`                      |
-| `Media` (grid/Item)           | `GridItemMedia`                     |
-| `Columns` (grid/Container)    | `GridContainerColumns`              |
-| `Media` (grid/Container)      | `GridContainerMedia`                |
+| Before                                  | After                               |
+| --------------------------------------- | ----------------------------------- |
+| `End`                                   | `FlexEnd`                           |
+| `Start`                                 | `FlexStart`                         |
+| `Spans`                                 | `FlexSpans`                         |
+| `Span` (flex)                           | `FlexSpan`                          |
+| `AllProps` (Iterate/EditContainer)      | `IterateEditContainerAllProps`      |
+| `AllProps` (Iterate/ViewContainer)      | `IterateViewContainerAllProps`      |
+| `AllProps` (Iterate/PushContainer)      | `IteratePushContainerAllProps`      |
+| `AllProps` (Form/Section/EditContainer) | `FormSectionEditContainerAllProps`  |
+| `AllProps` (Form/Section/ViewContainer) | `FormSectionViewContainerAllProps`  |
+| `GroupProps`                            | `AccordionGroupProps`               |
+| `StoreDataReturn`                       | `AccordionStoreDataReturn`          |
+| `StoreOptions`                          | `AccordionStoreOptions`             |
+| `TextColor`                             | `SectionTextColor`                  |
+| `OutlineColor`                          | `SectionOutlineColor`               |
+| `BackgroundColor`                       | `SectionBackgroundColor`            |
+| `DropShadow`                            | `SectionDropShadow`                 |
+| `RoundedCorner`                         | `SectionRoundedCorner`              |
+| `TriggeredBy`                           | `ModalTriggeredBy`                  |
+| `CloseHandler`                          | `ModalCloseHandler`                 |
+| `CloseHandlerParams`                    | `ModalCloseHandlerParams`           |
+| `TriggerAttributes` (modal)             | `ModalTriggerAttributes`            |
+| `TriggerAttributes` (popover)           | `PopoverTriggerAttributes`          |
+| `ValueTypes`                            | `SliderValue`                       |
+| `NumberFormatTypes`                     | `SliderNumberFormat`                |
+| `ThumbState`                            | `SliderThumbState`                  |
+| `DummyProps`                            | `TabsDummyProps`                    |
+| `ContentWrapperProps`                   | `TabsContentWrapperProps`           |
+| `ContentWrapperSelectedKey`             | `TabsContentWrapperSelectedKey`     |
+| `ContentWrapperChildren`                | `TabsContentWrapperChildren`        |
+| `CustomContentProps`                    | `TabsCustomContentProps`            |
+| `CustomContentTitle`                    | `TabsCustomContentTitle`            |
+| `CustomContentChildren`                 | `TabsCustomContentChildren`         |
+| `AutoSizeProps`                         | `SkeletonAutoSizeProps`             |
+| `ElementsHiddenProps`                   | `AvatarElementsHiddenProps`         |
+| `LoadButtonProps`                       | `PaginationLoadButtonProps`         |
+| `InfinityScrollerProps`                 | `PaginationInfinityScrollerProps`   |
+| `InfinityLoadButtonProps`               | `PaginationInfinityLoadButtonProps` |
+| `CreatePaginationReturn`                | `PaginationCreateReturn`            |
+| `DateType`                              | `DatePickerDateType`                |
+| `CalendarDay`                           | `DatePickerCalendarDay`             |
+| `CalendarNavigationEvent`               | `DatePickerCalendarNavigationEvent` |
+| `CalendarView`                          | `DatePickerCalendarView`            |
+| `ReturnObject`                          | `DatePickerReturnObject`            |
+| `InvalidDates`                          | `DatePickerInvalidDates`            |
+| `PartialDates`                          | `DatePickerPartialDates`            |
+| `SubmittedDates`                        | `DatePickerSubmittedDates`          |
+| `FormatType`                            | `NumberFormatType`                  |
+| `FormatCurrencyPosition`                | `NumberFormatCurrencyPosition`      |
+| `FormatReturnValue`                     | `NumberFormatReturnValue`           |
+| `FormatValue`                           | `NumberFormatValue`                 |
+| `FormatReturnType`                      | `NumberFormatReturnType`            |
+| `FormatOptionParams`                    | `NumberFormatOptionParams`          |
+| `FormatDateOptions`                     | `DateFormatOptions`                 |
+| `RelativeTimeUnit`                      | `DateFormatRelativeTimeUnit`        |
+| `StickyTableHeaderProps`                | `TableStickyHeaderProps`            |
+| `SortState`                             | `TableSortState`                    |
+| `SortEventHandler`                      | `TableSortEventHandler`             |
+| `SortHandler`                           | `TableSortHandler`                  |
+| `SubmitButtonProps`                     | `InputSubmitButtonProps`            |
+| `CustomSize`                            | `ProgressIndicatorCustomSize`       |
+| `TimeLineItemStates`                    | `TimelineItemState`                 |
+| `Columns` (grid/Item)                   | `GridItemColumns`                   |
+| `Span` (grid/Item)                      | `GridItemSpan`                      |
+| `Media` (grid/Item)                     | `GridItemMedia`                     |
+| `Columns` (grid/Container)              | `GridContainerColumns`              |
+| `Media` (grid/Container)                | `GridContainerMedia`                |
 
 ### Typed event handlers
 

--- a/packages/dnb-eufemia/scripts/eslint/plugins/naming-conventions/rules/no-bare-props-export.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/naming-conventions/rules/no-bare-props-export.js
@@ -1,49 +1,53 @@
 /**
  * ESLint rule: no-bare-props-export
  *
- * Disallows `export type Props` without a component-specific prefix.
- * Props types should be named with a prefix, e.g. `export type CardProps`
- * or `export type FieldStringProps`, to avoid ambiguity when re-exported
- * through barrel files.
+ * Disallows `export type Props` or `export type AllProps` without a
+ * component-specific prefix. Props types should be named with a prefix,
+ * e.g. `export type CardProps` or `export type FieldStringAllProps`,
+ * to avoid ambiguity when re-exported through barrel files.
  */
+
+const BARE_NAMES = ['Props', 'AllProps']
 
 module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
       description:
-        'Disallow exporting a type named "Props" — use a prefixed name instead',
+        'Disallow exporting a type named "Props" or "AllProps" — use a prefixed name instead',
     },
     messages: {
       noBarePropsExport:
-        'Do not export a type named "Props". Use a component-prefixed name instead (e.g. "CardProps", "FieldStringProps").',
+        'Do not export a type named "{{ name }}". Use a component-prefixed name instead (e.g. "CardProps", "FieldStringAllProps").',
     },
     schema: [],
   },
   create(context) {
     return {
       ExportNamedDeclaration(node) {
-        // Case 1: export type Props = ... or export type Props<T> = ...
+        // Case 1: export type Props = ... or export type AllProps = ...
         if (
           node.declaration &&
           node.declaration.type === 'TSTypeAliasDeclaration' &&
-          node.declaration.id.name === 'Props'
+          BARE_NAMES.includes(node.declaration.id.name)
         ) {
           context.report({
             node: node.declaration.id,
             messageId: 'noBarePropsExport',
+            data: { name: node.declaration.id.name },
           })
         }
 
-        // Case 2: export { Props } or export type { Props }
+        // Case 2: export { Props } or export type { AllProps }
         if (node.specifiers) {
           for (const specifier of node.specifiers) {
             const exportedName =
               specifier.exported && specifier.exported.name
-            if (exportedName === 'Props') {
+            if (BARE_NAMES.includes(exportedName)) {
               context.report({
                 node: specifier,
                 messageId: 'noBarePropsExport',
+                data: { name: exportedName },
               })
             }
           }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -20,11 +20,12 @@ export type FormSectionEditContainerProps = {
   onCancel?: () => void
 }
 
-export type AllProps = FormSectionEditContainerProps &
-  SectionContainerProps &
-  FlexContainerProps
+export type FormSectionEditContainerAllProps =
+  FormSectionEditContainerProps &
+    SectionContainerProps &
+    FlexContainerProps
 
-function EditContainer(props: AllProps) {
+function EditContainer(props: FormSectionEditContainerAllProps) {
   const { children, className, title, onDone, onCancel, ...restProps } =
     props || {}
   const ariaLabel = useMemo(() => convertJsxToString(title), [title])

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
@@ -16,11 +16,12 @@ export type FormSectionViewContainerProps = {
   onEdit?: () => void
 }
 
-export type AllProps = FormSectionViewContainerProps &
-  SectionContainerProps &
-  FlexContainerProps
+export type FormSectionViewContainerAllProps =
+  FormSectionViewContainerProps &
+    SectionContainerProps &
+    FlexContainerProps
 
-function ViewContainer(props: AllProps) {
+function ViewContainer(props: FormSectionViewContainerAllProps) {
   const { children, className, title, onEdit, ...restProps } = props || {}
   const ariaLabel = useMemo(() => convertJsxToString(title), [title])
   const { disableEditing } = useContext(SectionContainerContext) || {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/AnimatedContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/AnimatedContainer.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react'
 import IterateItemContext from '../IterateItemContext'
-import type { AllProps } from '../EditContainer'
+import type { IterateEditContainerAllProps } from '../EditContainer'
 import { EditContainerWithoutToolbar } from '../EditContainer'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
-function AnimatedContainer(props: AllProps) {
+function AnimatedContainer(props: IterateEditContainerAllProps) {
   const iterateItemContext = useContext(IterateItemContext)
   const { isNew } = iterateItemContext ?? {}
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
@@ -40,11 +40,13 @@ export type IterateEditContainerProps = {
   toolbarVariant?: ArrayItemAreaProps['toolbarVariant']
 }
 
-export type AllProps = IterateEditContainerProps &
+export type IterateEditContainerAllProps = IterateEditContainerProps &
   Omit<FlexContainerProps, 'onAnimationEnd'> &
   ArrayItemAreaProps
 
-export default function EditContainer(props: AllProps) {
+export default function EditContainer(
+  props: IterateEditContainerAllProps
+) {
   const { toolbar, toolbarVariant, children, ...rest } = props
   const { arrayValue } = useContext(IterateItemContext)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -19,7 +19,7 @@ import IterateItemContext from '../IterateItemContext'
 import DataContext from '../../DataContext/Context'
 import VisibilityContext from '../../Form/Visibility/VisibilityContext'
 import useDataValue from '../../hooks/useDataValue'
-import type { AllProps as EditContainerProps } from '../EditContainer'
+import type { IterateEditContainerAllProps as EditContainerProps } from '../EditContainer'
 import EditContainer, {
   DoneButton,
   CancelButton,
@@ -139,11 +139,11 @@ export type IteratePushContainerProps = (
   children: React.ReactNode
 } & Pick<IsolationProps<JsonObject>, 'dataReference'>
 
-export type AllProps = IteratePushContainerProps &
+export type IteratePushContainerAllProps = IteratePushContainerProps &
   SpacingProps &
   Omit<EditContainerProps, 'data'>
 
-function PushContainer(props: AllProps) {
+function PushContainer(props: IteratePushContainerAllProps) {
   const [, forceUpdate] = useReducer(() => ({}), {})
   const outerContext = useContext(DataContext)
   const { data: outerData, required: requiredInherited } = outerContext

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
@@ -29,11 +29,11 @@ export type IterateViewContainerProps = {
   toolbarVariant?: ArrayItemAreaProps['toolbarVariant']
 }
 
-export type AllProps = IterateViewContainerProps &
+export type IterateViewContainerAllProps = IterateViewContainerProps &
   Omit<FlexContainerProps, 'onAnimationEnd'> &
   ArrayItemAreaProps
 
-function ViewContainer(props: AllProps) {
+function ViewContainer(props: IterateViewContainerAllProps) {
   const {
     children,
     className,


### PR DESCRIPTION
Rename ambiguous bare 'AllProps' type exports in Forms extensions to use component-prefixed names for clarity when re-exported

