### PR TITLE
chore: add default export to useIsomorphicLayoutEffect

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/useIsomorphicLayoutEffect.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/useIsomorphicLayoutEffect.ts
@@ -11,5 +11,8 @@
 
 import { useEffect, useLayoutEffect } from 'react'
 
-export const useIsomorphicLayoutEffect =
+const useIsomorphicLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+export { useIsomorphicLayoutEffect }
+export default useIsomorphicLayoutEffect


### PR DESCRIPTION
Standardize hook exports so all hooks in shared/helpers/ have a default export, matching useMounted, useMountEffect, useUpdateEffect and useId. The named export is preserved for backward compatibility.

