### PR TITLE
chore: batch DrawerListProvider direction setState calls

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -464,15 +464,12 @@ export default class DrawerListProvider extends React.PureComponent<
       try {
         const { direction, maxHeight: maxHeight } = calculateMaxHeight()
 
-        // update the states
+        // update the states in a single setState call to avoid double render
+        const stateUpdate: Partial<DrawerListContextState> = { maxHeight }
         if (this.props.direction === 'auto') {
-          this.setState({
-            direction,
-          })
+          stateUpdate.direction = direction
         }
-        this.setState({
-          maxHeight,
-        })
+        this.setState(stateUpdate)
 
         // call the event, if set
         if (onResize) {


### PR DESCRIPTION
Merge two separate setState calls (direction and maxHeight) into a single call to avoid an unnecessary double render on every scroll/resize event.

