### PR TITLE
refactor: replace Context.Provider with Context (React 19)

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -215,11 +215,9 @@ function AccordionHeader(props: AccordionHeaderProps) {
 
   if (inheritedSkeleton) {
     return (
-      <Context.Provider
-        value={{ ...context, skeleton: inheritedSkeleton }}
-      >
+      <Context value={{ ...context, skeleton: inheritedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 
@@ -266,11 +264,9 @@ function AccordionContent(props: ItemContentProps) {
 
   if (inheritedSkeleton) {
     return (
-      <Context.Provider
-        value={{ ...context, skeleton: inheritedSkeleton }}
-      >
+      <Context value={{ ...context, skeleton: inheritedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
@@ -46,9 +46,9 @@ function ItemCenter({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemContent.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemContent.tsx
@@ -63,9 +63,9 @@ function ItemContent(props: ItemContentProps) {
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
@@ -51,9 +51,9 @@ function ItemEnd(props: ItemEndProps) {
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
@@ -45,9 +45,9 @@ function ItemFooter({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
@@ -49,9 +49,9 @@ function ItemOverline({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemStart.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemStart.tsx
@@ -50,9 +50,9 @@ function ItemStart({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
@@ -55,9 +55,9 @@ function ItemSubline({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
@@ -57,9 +57,9 @@ function ItemTitleBase({
 
   if (appliedSkeleton) {
     return (
-      <Context.Provider value={{ ...context, skeleton: appliedSkeleton }}>
+      <Context value={{ ...context, skeleton: appliedSkeleton }}>
         {content}
-      </Context.Provider>
+      </Context>
     )
   }
 

--- a/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
@@ -133,7 +133,7 @@ function ListScrollView(props: ListScrollViewProps) {
   const appliedDisabled = disabled ?? parentContext?.disabled
 
   return (
-    <ListContext.Provider
+    <ListContext
       value={{
         variant: parentContext?.variant ?? 'basic',
         separated: parentContext?.separated ?? false,
@@ -142,7 +142,7 @@ function ListScrollView(props: ListScrollViewProps) {
       }}
     >
       {scrollViewContent}
-    </ListContext.Provider>
+    </ListContext>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/stat/Content.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Content.tsx
@@ -59,11 +59,11 @@ function Content(props: ContentProps) {
   applySkeletonAttributes(attributes)
 
   return (
-    <StatRootContext.Provider value={{ inRoot, skeleton: hasSkeleton }}>
+    <StatRootContext value={{ inRoot, skeleton: hasSkeleton }}>
       <Provider skeleton={hasSkeleton}>
         <Element {...attributes}>{children}</Element>
       </Provider>
-    </StatRootContext.Provider>
+    </StatRootContext>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/stat/Info.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Info.tsx
@@ -70,9 +70,9 @@ function Info(props: InfoProps) {
       skeleton={skeleton}
       textClassName={false}
     >
-      <StatValueContext.Provider value={infoContextValue}>
+      <StatValueContext value={infoContextValue}>
         {children}
-      </StatValueContext.Provider>
+      </StatValueContext>
     </Text>
   )
 }

--- a/packages/dnb-eufemia/src/components/stat/Inline.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Inline.tsx
@@ -33,7 +33,7 @@ function Inline({
   applySkeletonAttributes(attributes as React.HTMLProps<HTMLElement>)
 
   return (
-    <StatRootContext.Provider value={{ inRoot, skeleton: hasSkeleton }}>
+    <StatRootContext value={{ inRoot, skeleton: hasSkeleton }}>
       <Provider skeleton={hasSkeleton}>
         <Flex.Horizontal
           {...rest}
@@ -50,7 +50,7 @@ function Inline({
           {children}
         </Flex.Horizontal>
       </Provider>
-    </StatRootContext.Provider>
+    </StatRootContext>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/stat/Label.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Label.tsx
@@ -93,11 +93,11 @@ function Label(props: LabelProps) {
   applySkeletonAttributes(attributes)
 
   return (
-    <StatRootContext.Provider value={{ inRoot, skeleton: childSkeleton }}>
+    <StatRootContext value={{ inRoot, skeleton: childSkeleton }}>
       <Provider skeleton={hasSkeleton}>
         <Element {...attributes}>{children}</Element>
       </Provider>
-    </StatRootContext.Provider>
+    </StatRootContext>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -43,7 +43,7 @@ function Root(props: RootProps) {
   }
 
   return (
-    <StatRootContext.Provider value={{ inRoot: true, skeleton }}>
+    <StatRootContext value={{ inRoot: true, skeleton }}>
       <Space
         element="dl"
         id={id}
@@ -58,7 +58,7 @@ function Root(props: RootProps) {
       >
         {children}
       </Space>
-    </StatRootContext.Provider>
+    </StatRootContext>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/stat/Trend.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Trend.tsx
@@ -82,7 +82,7 @@ function Trend(props: TrendProps) {
       skeleton={skeleton}
       textClassName={false}
     >
-      <StatValueContext.Provider value={trendContextValue}>
+      <StatValueContext value={trendContextValue}>
         <span className="dnb-stat__trend-content" aria-hidden>
           {!hasCustomChildren && sign ? (
             <span className="dnb-stat__trend-sign">{sign}</span>
@@ -91,7 +91,7 @@ function Trend(props: TrendProps) {
             {hasCustomChildren ? children : displayValue}
           </span>
         </span>
-      </StatValueContext.Provider>
+      </StatValueContext>
       <span className="dnb-sr-only" data-text={srText} />
     </Text>
   )

--- a/packages/dnb-eufemia/src/components/stat/__tests__/useStatSkeleton.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/useStatSkeleton.test.tsx
@@ -33,9 +33,9 @@ describe('useStatSkeleton', () => {
 
   it('resolves skeleton from StatRootContext', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <StatRootContext.Provider value={{ inRoot: true, skeleton: true }}>
+      <StatRootContext value={{ inRoot: true, skeleton: true }}>
         {children}
-      </StatRootContext.Provider>
+      </StatRootContext>
     )
 
     const { result } = renderHook(() => useStatSkeleton(), { wrapper })
@@ -57,9 +57,9 @@ describe('useStatSkeleton', () => {
 
   it('local prop takes priority over Root context', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <StatRootContext.Provider value={{ inRoot: true, skeleton: true }}>
+      <StatRootContext value={{ inRoot: true, skeleton: true }}>
         {children}
-      </StatRootContext.Provider>
+      </StatRootContext>
     )
 
     const { result } = renderHook(() => useStatSkeleton(false), {
@@ -73,9 +73,9 @@ describe('useStatSkeleton', () => {
   it('Root context takes priority over Provider', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <Provider skeleton={false}>
-        <StatRootContext.Provider value={{ inRoot: true, skeleton: true }}>
+        <StatRootContext value={{ inRoot: true, skeleton: true }}>
           {children}
-        </StatRootContext.Provider>
+        </StatRootContext>
       </Provider>
     )
 


### PR DESCRIPTION
Replace <Context.Provider> with direct <Context> rendering in Stat and List components, aligning with React 19's context-as-provider pattern.

Affected components:
- Stat: Content, Info, Inline, Label, Root, Trend
- List: ItemAccordion, ItemCenter, ItemContent, ItemEnd, ItemFooter, ItemOverline, ItemStart, ItemSubline, ItemTitle, ListScrollView

This is documented in v11-info.mdx migration guide.

