### PR TITLE
refactor: extract useCombinedRef hook to deduplicate ref-combining pattern

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -3,7 +3,8 @@
  */
 
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
-import React, { useCallback, useContext, useRef, useState } from 'react'
+import React, { useContext, useRef, useState } from 'react'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import clsx from 'clsx'
 import Context from '../../shared/Context'
 import {
@@ -240,19 +241,7 @@ function getContent(props: ButtonProps) {
 function Button({ ref, ...restProps }: ButtonProps) {
   const context = useContext(Context)
   const elementRef = useRef<HTMLElement | null>(null)
-
-  const combinedRef = useCallback(
-    (instance: HTMLElement | null) => {
-      elementRef.current = instance
-
-      if (typeof ref === 'function') {
-        ref(instance)
-      } else if (ref) {
-        ref.current = instance
-      }
-    },
-    [ref]
-  )
+  const combinedRef = useCombinedRef(ref, elementRef)
 
   // Generate an id only when explicitly provided or when status/tooltip
   // needs one for aria linking – mirrors the original class component logic.

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -11,6 +11,7 @@ import React, {
   useMemo,
 } from 'react'
 import clsx from 'clsx'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithContext'
@@ -355,19 +356,7 @@ function getValue(props: InputProps) {
 function InputComponent({ ref, ...restProps }: InputProps) {
   const context = useContext(Context)
   const inputRef = useRef<HTMLInputElement | null>(null)
-
-  const combinedRef = useCallback(
-    (instance: HTMLInputElement | null) => {
-      inputRef.current = instance
-
-      if (typeof ref === 'function') {
-        ref(instance)
-      } else if (ref) {
-        ref.current = instance
-      }
-    },
-    [ref]
-  )
+  const combinedRef = useCombinedRef(ref, inputRef)
 
   const formElement = context?.formElement as
     | (typeof context.formElement & { useId?: () => string })
@@ -907,19 +896,7 @@ function InputSubmitButton({
 }) {
   const context = useContext(Context)
   const buttonRef = useRef<HTMLElement | null>(null)
-
-  const combinedButtonRef = useCallback(
-    (instance: HTMLElement | null) => {
-      buttonRef.current = instance
-
-      if (typeof ref === 'function') {
-        ref(instance)
-      } else if (ref) {
-        ref.current = instance
-      }
-    },
-    [ref]
-  )
+  const combinedButtonRef = useCombinedRef(ref, buttonRef)
 
   const [focusState, setFocusState] = useState('virgin')
 

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -11,6 +11,7 @@ import React, {
   useState,
 } from 'react'
 import useMountEffect from '../../shared/helpers/useMountEffect'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import clsx from 'clsx'
 import FormLabel from '../form-label/FormLabel'
 import FormStatus from '../form-status/FormStatus'
@@ -275,18 +276,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
   } = props
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-
-  const combinedRef = useCallback(
-    (node: HTMLTextAreaElement | null) => {
-      textareaRef.current = node
-      if (typeof ref === 'function') {
-        ref(node)
-      } else if (ref) {
-        ref.current = node
-      }
-    },
-    [ref]
-  )
+  const combinedRef = useCombinedRef(ref, textareaRef)
 
   const id = useId(ownProps.id)
 

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useCombinedRef.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useCombinedRef.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import useCombinedRef from '../useCombinedRef'
+
+describe('useCombinedRef', () => {
+  it('should assign to a callback ref', () => {
+    const callbackRef = jest.fn()
+    const { result } = renderHook(() => useCombinedRef(callbackRef))
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+  })
+
+  it('should assign to an object ref', () => {
+    const objectRef = createRef<HTMLDivElement>()
+    const { result } = renderHook(() => useCombinedRef(objectRef))
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(objectRef.current).toBe(node)
+  })
+
+  it('should assign to multiple refs', () => {
+    const callbackRef = jest.fn()
+    const objectRef = createRef<HTMLDivElement>()
+    const { result } = renderHook(() =>
+      useCombinedRef(callbackRef, objectRef)
+    )
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+    expect(objectRef.current).toBe(node)
+  })
+
+  it('should handle undefined refs', () => {
+    const callbackRef = jest.fn()
+    const { result } = renderHook(() =>
+      useCombinedRef(undefined, callbackRef, undefined)
+    )
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+  })
+
+  it('should handle null unset', () => {
+    const callbackRef = jest.fn()
+    const objectRef = createRef<HTMLDivElement>()
+    const { result } = renderHook(() =>
+      useCombinedRef(callbackRef, objectRef)
+    )
+
+    const node = document.createElement('div')
+    result.current(node)
+    result.current(null)
+
+    expect(callbackRef).toHaveBeenLastCalledWith(null)
+    expect(objectRef.current).toBeNull()
+  })
+
+  it('should return a stable callback when refs do not change', () => {
+    const callbackRef = jest.fn()
+    const { result, rerender } = renderHook(() =>
+      useCombinedRef(callbackRef)
+    )
+
+    const first = result.current
+    rerender()
+    const second = result.current
+
+    expect(first).toBe(second)
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/useCombinedRef.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/useCombinedRef.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+
+/**
+ * Combines multiple React refs into a single callback ref.
+ *
+ * Useful when a component needs to maintain an internal ref
+ * while also forwarding a ref from props.
+ */
+export default function useCombinedRef<T>(
+  ...refs: Array<React.Ref<T> | undefined>
+): React.RefCallback<T> {
+  return useCallback(
+    (instance: T | null) => {
+      for (const ref of refs) {
+        if (typeof ref === 'function') {
+          ref(instance)
+        } else if (ref) {
+          ;(ref as React.MutableRefObject<T | null>).current = instance
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs
+  )
+}


### PR DESCRIPTION
Extract the repeated ref-combining callback pattern into a shared useCombinedRef hook in src/shared/helpers/useCombinedRef.ts.

This replaces identical boilerplate in Button, Input (component + submit button), Textarea, and ListScrollView that manually combined an internal useRef with a forwarded ref prop.

FormStatus is left as-is because HeightAnimation requires a ref object, not the callback ref returned by useCombinedRef.

