### PR TITLE
chore: bump prettier from 3.0.3 to 3.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ More information can be found in the [faq](https://eufemia.dnb.no/contribute/faq
 Find more information about how to contribute in [Eufemia Portal - Contribute](https://eufemia.dnb.no/contribute).
 
 ### Our contributors
+
 <!-- markdownlint-disable MD033 -->
 <a href="https://github.com/dnbexperience/eufemia/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=dnbexperience/eufemia" alt="Contributors" />

--- a/packages/dnb-design-system-portal/gatsby-config.js
+++ b/packages/dnb-design-system-portal/gatsby-config.js
@@ -165,18 +165,18 @@ const plugins = [
                 '**/src/extensions/payment-card/**/dnb-*.scss',
               ]
           : shouldUsePrebuild()
-          ? [
-              // Use the core package
-              '**/build/style/dnb-ui-core.min.css',
-              '**/build/style/themes/**/*-theme-{basis,components}.min.css',
-              '**/build/extensions/payment-card/**/dnb-*.min.css',
-            ]
-          : [
-              // Use the core package
-              '**/src/style/dnb-ui-core.scss',
-              '**/src/style/themes/**/*-theme-{basis,components}.scss',
-              '**/src/extensions/payment-card/**/dnb-*.scss',
-            ],
+            ? [
+                // Use the core package
+                '**/build/style/dnb-ui-core.min.css',
+                '**/build/style/themes/**/*-theme-{basis,components}.min.css',
+                '**/build/extensions/payment-card/**/dnb-*.min.css',
+              ]
+            : [
+                // Use the core package
+                '**/src/style/dnb-ui-core.scss',
+                '**/src/style/themes/**/*-theme-{basis,components}.scss',
+                '**/src/extensions/payment-card/**/dnb-*.scss',
+              ],
       includeFiles: [
         '**/dnb-ui-core*',
         '**/dnb-ui-basis*',

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -102,7 +102,7 @@
     "github-slugger": "1.4.0",
     "jest": "30.0.5",
     "mdast-util-to-string": "^2",
-    "prettier": "3.0.3",
+    "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",
     "prism-react-renderer": "2.0.5",
     "process": "0.11.10",

--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -201,7 +201,6 @@
 ## February, 8. 2022
 
 - New components released:
-
   - [VisuallyHidden](/uilib/components/visually-hidden)
 
 - New [Icons](/icons/secondary):
@@ -325,7 +324,6 @@ New [Icons](/icons/secondary):
 - Modal got a [Drawer mode](/uilib/components/drawer/) and has now a dark background color
 - **Breaking Changes** to the UMD [bundles](/uilib/usage/first-steps/bundles) structure (v7), including ESM (mjs)
 - **Breaking Changes** to headings:
-
   - `.dnb-h1` is now `.dnb-h--xx-large`
   - `.dnb-h1--small` is now `.dnb-h--x-large`
   - `.dnb-h2` is now `.dnb-h--large`

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
@@ -210,7 +210,6 @@ For those familiar with CSS, we establish typographic rules in the following way
     This will set the default size for paragraph text to **16px**.
 
 2.  Set font styles on paragraphs, headers, buttons, etc. (basically everything) in the following manner:
-
     - font sizes should be set with **em**
     - line-heights should be set with **rem**
     - margin-**bottom** should be set with **rem**

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v10-info.mdx
@@ -360,9 +360,7 @@ The Anchor was moved from `/elements` to `/components`.
    When you convert from `<Modal mode="custom" />` simply change to `<Modal />`.
 
    When you convert from `<Modal mode="drawer" />` to `<Drawer />` – follow these steps:
-
    1. All `trigger_*` properties are not supported for Drawer, use `triggerAttributes` instead to pass in properties for the trigger button.
-
       - Change property `trigger_hidden` to `omitTriggerButton` to omit the default trigger button from Modal.
 
    2. Only camelCase properties are supported for Drawer, so you will need to update the property names.
@@ -371,9 +369,7 @@ The Anchor was moved from `/elements` to `/components`.
    5. `Modal` was a class component and `Drawer` is a functional component.
 
    When you convert from `<Modal />` or `<Modal mode="dialog" />` to `<Dialog />` – follow these steps:
-
    1. All `trigger_*` properties are not supported for Dialog, use `triggerAttributes` instead to pass in properties for the trigger button.
-
       - Change property `trigger_hidden` to `omitTriggerButton` to omit the default trigger button from Modal.
 
    2. Only camelCase properties are supported for Dialog, so you will need to update the property names.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/info.mdx
@@ -15,7 +15,6 @@ import { Stat } from '@dnb/eufemia'
 ## Available components
 
 - `Stat.Root` renders a definition list (`dl`).
-
   - `Stat.Label` renders descriptive text with dedicated typography and color for metric context (`dt`).
 
   - `Stat.Content` renders the main value as a definition description (`dd`).
@@ -23,7 +22,6 @@ import { Stat } from '@dnb/eufemia'
 - `Stat.Number` is the base value formatter built on the [NumberFormat](/uilib/components/number-format/) formatting logic.
 
 - `Stat.Currency` and `Stat.Percent` are convenience wrappers around `Stat.Number`.
-
   - It adds typography-specific properties such as `fontSize`, `fontWeight` and `colorizeBySign`, along with `mainSize` and `auxiliarySize` as well as `mainWeight` and `auxiliaryWeight` that can be used to customize the visual emphasis of the different parts of the value (currency symbol or percent sign).
 
 - `Stat.Trend` renders explicit `+` / `-` indicators with red/green background states and screen-reader text.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -1691,8 +1691,8 @@ export const ResponsiveInCard = () => (
         const align = isLarge
           ? 'flex-end'
           : isSmall
-          ? 'center'
-          : 'flex-start'
+            ? 'center'
+            : 'flex-start'
 
         const tableRow = (
           <>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/info.mdx
@@ -81,7 +81,6 @@ The validation happens on blur, internally using the `onBlurValidator` [property
 `Field.Name` and `Field.Name.Company` expose validators through their `onBlurValidator` property:
 
 - **`nameValidator`**: Validates names for `Field.Name`, `Field.Name.First`, and `Field.Name.Last`. It checks that the name:
-
   - Is at least 1 character long.
   - Matches the name pattern (starts and ends with a letter, no consecutive hyphens or spaces).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/info.mdx
@@ -18,7 +18,6 @@ To make it easier to build application layout and [form](/uilib/extensions/forms
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/layout/flex)
 
 - **[Flex.Container](/uilib/layout/flex/container)** is a building block for CSS flexbox based layout of contents and components.
-
   - **`Flex.Vertical`** can be used as an alias instead of the property `direction="vertical"`.
   - **`Flex.Horizontal`** can be used as an alias instead of the property `direction="horizontal"`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/grid/visual-tests/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/grid/visual-tests/Examples.tsx
@@ -46,10 +46,10 @@ export function PageLayoutExample() {
             const pageColumns = isSmall
               ? 4
               : isMedium
-              ? 6
-              : isLarge
-              ? 12
-              : 0
+                ? 6
+                : isLarge
+                  ? 12
+                  : 0
 
             return (
               <PageContainerWithStyles>

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/design-tokens/Examples.tsx
@@ -367,8 +367,8 @@ export function TokenSectionOverview() {
                 {section.id === 'component'
                   ? 'For internal use only.'
                   : section.id === 'decorative'
-                  ? 'For advanced custom decorative needs.'
-                  : 'For external use. Prefer base tokens; advanced tokens carry semantic intent and may change across themes.'}
+                    ? 'For advanced custom decorative needs.'
+                    : 'For external use. Prefer base tokens; advanced tokens carry semantic intent and may change across themes.'}
               </Td>
             </Tr>
           )

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -179,15 +179,18 @@ You can import the pre-generated `properties-tailwind.css` files that contain al
 
 /* Import Eufemia styles */
 @import '@dnb/eufemia/style/dnb-ui-core.min.css' layer(eufemia);
-@import '@dnb/eufemia/style/themes/ui/ui-theme-components.min.css' layer(eufemia);
-@import '@dnb/eufemia/style/themes/ui/ui-theme-basis.min.css' layer(eufemia);
+@import '@dnb/eufemia/style/themes/ui/ui-theme-components.min.css'
+  layer(eufemia);
+@import '@dnb/eufemia/style/themes/ui/ui-theme-basis.min.css'
+  layer(eufemia);
 
 /* Import Tailwind base, theme and utilities layers */
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
 /* Import Eufemia properties in Tailwind format */
-@import '@dnb/eufemia/style/themes/ui/properties-tailwind.css' layer(utilities);
+@import '@dnb/eufemia/style/themes/ui/properties-tailwind.css'
+  layer(utilities);
 
 /* Import Eufemia design tokens in Tailwind format */
 @import '@dnb/eufemia/style/themes/ui/tokens-tailwind.css' layer(utilities);

--- a/packages/dnb-design-system-portal/src/shared/menu/ToggleGrid.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/ToggleGrid.tsx
@@ -20,7 +20,7 @@ function setGridVisibility(visibility = true) {
 function isGridVisible() {
   return Boolean(
     typeof window !== 'undefined' &&
-      parseFloat(window.localStorage.getItem('showGrid'))
+    parseFloat(window.localStorage.getItem('showGrid'))
   )
 }
 

--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -53,8 +53,8 @@ export const FormattedCode = ({
         style.color = isString(children)
           ? colors.type.string
           : isPrimitive(children)
-          ? colors.type.primitive
-          : colors.type.default
+            ? colors.type.primitive
+            : colors.type.default
         style.background = 'none'
         style.boxShadow = 'none'
         break
@@ -63,8 +63,8 @@ export const FormattedCode = ({
         style.color = isString(children)
           ? colors.value.string
           : children === 'undefined' || children === 'null'
-          ? colors.value.undefined
-          : colors.value.default
+            ? colors.value.undefined
+            : colors.value.default
         style.background = 'none'
         style.boxShadow = 'none'
         break

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -228,7 +228,7 @@
     "packpath": "0.1.0",
     "postcss": "8.4.32",
     "postcss-preset-env": "9.6.0",
-    "prettier": "3.0.3",
+    "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/dnb-eufemia/scripts/figma/tasks/__tests__/assetsExtractors.test.ts
+++ b/packages/dnb-eufemia/scripts/figma/tasks/__tests__/assetsExtractors.test.ts
@@ -15,12 +15,10 @@ import {
   formatIconsMetaFile,
 } from '../assetsExtractors'
 
-const localFile = require.resolve(
-  '../../helpers/__tests__/files/FigmaTestDoc.json'
-)
-const iconsLockFile = require.resolve(
-  '../../helpers/__tests__/files/icons-svg.lock'
-)
+const localFile =
+  require.resolve('../../helpers/__tests__/files/FigmaTestDoc.json')
+const iconsLockFile =
+  require.resolve('../../helpers/__tests__/files/icons-svg.lock')
 
 afterEach(() => {
   jest.clearAllMocks()

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/__snapshots__/makePropertiesFile.test.ts.snap
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/__snapshots__/makePropertiesFile.test.ts.snap
@@ -5,7 +5,8 @@ exports[`makePropertiesFile Properties for sbanken has to validate 1`] = `
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -109,7 +110,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': 'var(--sb-font-family-default)',
   '--font-family-heading': 'var(--sb-font-family-heading)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',
@@ -204,7 +206,8 @@ exports[`makePropertiesFile Properties for ui has to validate 1`] = `
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -308,7 +311,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': "'DNB', sans-serif",
   '--font-family-heading': 'var(--font-family-default)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
@@ -21,6 +21,41 @@ const TOKEN_GROUP_SEPARATOR = '-'
 const TOKEN_CSS_PREFIX = '--'
 const CSS_VARIABLE_REFERENCE_REGEX = /var\(\s*(--[a-z0-9-]+)\s*\)/gi
 const CSS_VARIABLE_DECLARATION_REGEX = /^\s*(--[a-z0-9-]+)\s*:/i
+
+function parseCSSVariables(content: string): Record<string, string> {
+  const variables: Record<string, string> = {}
+  const lines = content.split('\n')
+  let currentProp = ''
+  let currentValue = ''
+  let collecting = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    if (trimmed.startsWith('--')) {
+      const colonIdx = trimmed.indexOf(':')
+      if (colonIdx !== -1) {
+        currentProp = trimmed.substring(0, colonIdx).trim()
+        currentValue = trimmed.substring(colonIdx + 1).trim()
+        collecting = true
+      }
+    } else if (collecting) {
+      currentValue += ' ' + trimmed
+    }
+
+    if (collecting && currentValue.includes(';')) {
+      variables[currentProp] = currentValue
+        .split(';')[0]
+        .replace(/\/\* .* \*\//g, '')
+        .trim()
+      collecting = false
+      currentProp = ''
+      currentValue = ''
+    }
+  }
+
+  return variables
+}
 const TOKEN_SETS = {
   colors: {
     fileName: 'color.tokens.json',
@@ -41,18 +76,7 @@ export default async function makePropertiesFile() {
 }
 
 const transformModulesContent = async (content: string) => {
-  const variables = content
-    .split('\n')
-    .map((s) => s.trim())
-    .filter((s) => s.startsWith('--'))
-    .map((s) => s.split(':').map((s) => s.trim()))
-    .reduce((acc, [k, v]) => {
-      acc[k] = v
-        .split(';')[0]
-        .replace(/\/\* .* \*\//g, '')
-        .trim()
-      return acc
-    }, {})
+  const variables = parseCSSVariables(content)
 
   return (
     String(
@@ -72,18 +96,7 @@ export default ${JSON.stringify(variables, null, 2)}`,
 }
 
 const transformModulesContentCSS = async (content: string) => {
-  const variables = content
-    .split('\n')
-    .map((s) => s.trim())
-    .filter((s) => s.startsWith('--'))
-    .map((s) => s.split(':').map((s) => s.trim()))
-    .reduce((acc, [k, v]) => {
-      acc[k] = v
-        .split(';')[0]
-        .replace(/\/\* .* \*\//g, '')
-        .trim()
-      return acc
-    }, {})
+  const variables = parseCSSVariables(content)
 
   // Convert --sb-* variables to Tailwind-compatible format
   const convertedVariables = convertVariablesToTailwindFormat(variables)

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -47,9 +47,8 @@ export async function makeReleaseVersion() {
 
   // JS – for handling Eufemia.version
   {
-    const file = require.resolve(
-      '@dnb/eufemia/src/shared/build-info/BuildInfoData.ts'
-    )
+    const file =
+      require.resolve('@dnb/eufemia/src/shared/build-info/BuildInfoData.ts')
     const fileContent = await fs.readFile(file, 'utf-8')
 
     // Update the extracted version of package.json with the build version
@@ -58,9 +57,8 @@ export async function makeReleaseVersion() {
 
   // CJS – for handling Eufemia.version
   {
-    const file = require.resolve(
-      '@dnb/eufemia/src/shared/build-info/BuildInfoData.cjs'
-    )
+    const file =
+      require.resolve('@dnb/eufemia/src/shared/build-info/BuildInfoData.cjs')
     const fileContent = await fs.readFile(file, 'utf-8')
 
     // Update the extracted version of package.json with the build version

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -271,8 +271,8 @@ function Accordion({
     return props.expanded !== undefined
       ? props.expanded
       : context?.expanded !== undefined
-      ? context.expanded
-      : false
+        ? context.expanded
+        : false
   }
 
   function setExpandedState(expanded: boolean) {
@@ -456,8 +456,8 @@ const Group = ({
   const group = props?.id
     ? props.id
     : !props.group
-    ? '#' + makeUniqueId()
-    : undefined
+      ? '#' + makeUniqueId()
+      : undefined
 
   const store = useMemo(() => new Store({ group }), [group])
 

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -1945,13 +1945,13 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     (event: React.KeyboardEvent | React.MouseEvent) => {
       preventFiringBlurEvent.current = Boolean(
         ('key' in event && event.key === 'Enter') ||
-          (event?.currentTarget
-            ? getClosestParent('dnb-drawer-list', event.currentTarget) ||
-              getClosestParent(
-                'dnb-input__submit-button__button',
-                event.currentTarget
-              )
-            : false)
+        (event?.currentTarget
+          ? getClosestParent('dnb-drawer-list', event.currentTarget) ||
+            getClosestParent(
+              'dnb-input__submit-button__button',
+              event.currentTarget
+            )
+          : false)
       )
 
       if (preventFiringBlurEvent.current) {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1012,7 +1012,8 @@ button.dnb-button::-moz-focus-inner {
   height: var(--height);
   color: var(--background-color, currentcolor);
   background-color: currentcolor;
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor;
   box-shadow: var(--box-shadow);
   border-radius: var(--rounded-corner, 0);
@@ -1105,7 +1106,8 @@ button.dnb-button::-moz-focus-inner {
   z-index: 0;
 }
 .dnb-section--divider::after {
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor,
     0 0.0625rem 0 0 var(--separator-color),
     99vw 0.0625rem 0 0 var(--separator-color),

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -358,8 +358,8 @@ function Button({ ref, ...restProps }: ButtonProps) {
   const Element = element
     ? element
     : props.href || props.to
-    ? Anchor
-    : 'button'
+      ? Anchor
+      : 'button'
   if (Element === Anchor) {
     if (opensNewTab(props.target, props.href) && !usedIcon) {
       usedIcon = launch

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1161,11 +1161,7 @@ html:not([data-whatintent=touch]) .dnb-button--secondary:not(.dnb-button--has-te
   --button-tertiary-focus-overflow--icon-top: 0;
   --button-tertiary-underline-overflow: -0.5rem;
   --button-tertiary-underline-overflow--icon: calc(
-    (
-        var(--button-icon-gutter) + var(--button-icon-size) - var(
-            --button-tertiary-underline-overflow
-          )
-      ) * -1
+    (var(--button-icon-gutter) + var(--button-icon-size) - var(--button-tertiary-underline-overflow)) * -1
   );
   --button-tertiary-underline-bottom: -0.5rem;
   --button-tertiary-text-bottom--icon: 0.5rem;

--- a/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-sbanken.scss
@@ -76,14 +76,9 @@
   &--tertiary {
     --button-tertiary-focus-overflow--icon-top: 0;
     --button-tertiary-underline-overflow: -0.5rem;
+    // prettier-ignore
     --button-tertiary-underline-overflow--icon: calc(
-      (
-          var(--button-icon-gutter) +
-            var(--button-icon-size) - var(
-              --button-tertiary-underline-overflow
-            )
-        ) *
-        -1
+      (var(--button-icon-gutter) + var(--button-icon-size) - var(--button-tertiary-underline-overflow)) * -1
     );
     --button-tertiary-underline-bottom: -0.5rem;
     --button-tertiary-text-bottom--icon: 0.5rem;

--- a/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-sbanken.scss
@@ -78,10 +78,12 @@
     --button-tertiary-underline-overflow: -0.5rem;
     --button-tertiary-underline-overflow--icon: calc(
       (
-          var(--button-icon-gutter) + var(--button-icon-size) - var(
+          var(--button-icon-gutter) +
+            var(--button-icon-size) - var(
               --button-tertiary-underline-overflow
             )
-        ) * -1
+        ) *
+        -1
     );
     --button-tertiary-underline-bottom: -0.5rem;
     --button-tertiary-text-bottom--icon: 0.5rem;

--- a/packages/dnb-eufemia/src/components/card/Card.tsx
+++ b/packages/dnb-eufemia/src/components/card/Card.tsx
@@ -95,8 +95,8 @@ function Card(props: CardProps) {
     outset: nestedContext?.isNested
       ? false
       : outset === true
-      ? falseWhenSmall
-      : outset,
+        ? falseWhenSmall
+        : outset,
     roundedCorner: responsive ? falseWhenSmall : true,
     outline: 'var(--card-outline-color)',
     outlineWidth,

--- a/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
+++ b/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
@@ -64,7 +64,8 @@
       &.dnb-section::before {
         left: var(--left);
 
-        --outline: 99vw 0 0 0 var(--background-color),
+        --outline:
+          99vw 0 0 0 var(--background-color),
           198vw 0 0 0 var(--background-color),
           297vw 0 0 0 var(--background-color),
           396vw 0 0 0 var(--background-color),

--- a/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
@@ -162,8 +162,8 @@ function DateFormat(props: DateFormatProps) {
         value !== undefined
           ? value
           : children !== undefined
-          ? convertJsxToString(children)
-          : date
+            ? convertJsxToString(children)
+            : date
 
       // When timeStyle is provided, format date and time separately and join with separator
       // Uses custom dateTimeSeparator if provided, otherwise uses locale-aware separator

--- a/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
@@ -117,8 +117,8 @@ export function formatDate(
     typeof dateValue === 'string'
       ? dateValue
       : typeof dateValue === 'number'
-      ? String(dateValue)
-      : null
+        ? String(dateValue)
+        : null
 
   // Convert to DateType (Date | string) for convertStringToDate
   // Numbers are converted to strings to preserve UTC detection
@@ -263,8 +263,8 @@ export function getRelativeTime(
       dateStyle === 'short'
         ? 'narrow'
         : dateStyle === 'medium'
-        ? 'short'
-        : 'long',
+          ? 'short'
+          : 'long',
   }
   try {
     // eslint-disable-next-line compat/compat
@@ -277,8 +277,8 @@ export function getRelativeTime(
       relativeTimeReference instanceof Date
         ? relativeTimeReference
         : typeof relativeTimeReference === 'function'
-        ? relativeTimeReference()
-        : new Date()
+          ? relativeTimeReference()
+          : new Date()
 
     const msDateDifference = date.getTime() - nowDate.getTime()
     const timeUnit = getTimeUnit(msDateDifference)
@@ -309,8 +309,8 @@ export function getRelativeTimeNextUpdateMs(
     relativeTimeReference instanceof Date
       ? relativeTimeReference
       : typeof relativeTimeReference === 'function'
-      ? relativeTimeReference()
-      : new Date()
+        ? relativeTimeReference()
+        : new Date()
   const diff = date.getTime() - nowDate.getTime()
   if (!Number.isFinite(diff)) {
     return 1000
@@ -502,8 +502,8 @@ function createDurationFormatter(
         dateStyle === 'short'
           ? 'narrow'
           : dateStyle === 'medium'
-          ? 'short'
-          : 'long',
+            ? 'short'
+            : 'long',
     })
   } catch {
     return null

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerAddon.tsx
@@ -80,15 +80,15 @@ function DatePickerAddon(props: DatePickerAddonProps) {
         typeof usedStartDate === 'function'
           ? usedStartDate(currentDates)
           : usedStartDate
-          ? convertStringToDate(usedStartDate)
-          : null
+            ? convertStringToDate(usedStartDate)
+            : null
 
       const endDate =
         typeof usedEndDate === 'function'
           ? usedEndDate(currentDates)
           : usedEndDate
-          ? convertStringToDate(usedEndDate)
-          : null
+            ? convertStringToDate(usedEndDate)
+            : null
 
       callOnChange({
         startDate,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -366,8 +366,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         newDate = !isRange
           ? currentMonth
           : nr === 0
-          ? setDate(currentMonth, 1)
-          : lastDayOfMonth(currentMonth)
+            ? setDate(currentMonth, 1)
+            : lastDayOfMonth(currentMonth)
 
         // only to make sure we navigate the calendar to the new date
       } else if (currentMonth && !isSameMonth(currentDate, currentMonth)) {
@@ -600,8 +600,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                   const dateType = day.isStartDate
                     ? 'start'
                     : day.isEndDate
-                    ? 'end'
-                    : undefined
+                      ? 'end'
+                      : undefined
                   const isSelectedDate =
                     nr === 0 ? day.isStartDate : day.isEndDate
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerFooter.tsx
@@ -81,10 +81,10 @@ function DatePickerFooter({
             dateFormat,
           })
         : previousDateProps.date
-        ? convertStringToDate(previousDateProps.date, {
-            dateFormat,
-          })
-        : undefined
+          ? convertStringToDate(previousDateProps.date, {
+              dateFormat,
+            })
+          : undefined
 
       const endDate = previousDateProps.endDate
         ? convertStringToDate(previousDateProps.endDate, {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -219,8 +219,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         p.toLowerCase().startsWith('d')
           ? 'day'
           : p.toLowerCase().startsWith('m')
-          ? 'month'
-          : 'year'
+            ? 'month'
+            : 'year'
       ) as Array<'day' | 'month' | 'year'>
   }, [resolvedMaskOrder, separatorRegExp])
 
@@ -366,16 +366,16 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
                 getInitialValue: () => new Date().getDate(),
               }
             : part === 'month'
-            ? {
-                min: 1,
-                max: 12,
-                getInitialValue: () => new Date().getMonth() + 1,
-              }
-            : {
-                min: 0,
-                max: 9999,
-                getInitialValue: () => new Date().getFullYear(),
-              }
+              ? {
+                  min: 1,
+                  max: 12,
+                  getInitialValue: () => new Date().getMonth() + 1,
+                }
+              : {
+                  min: 0,
+                  max: 9999,
+                  getInitialValue: () => new Date().getFullYear(),
+                }
         return {
           id: part,
           label,

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -130,8 +130,8 @@ function mapDates(
     typeof dateProps?.startDate !== 'undefined'
       ? getDate(dateProps.startDate, dateFormat)
       : typeof date !== 'undefined'
-      ? getDate(date, dateFormat)
-      : undefined
+        ? getDate(date, dateFormat)
+        : undefined
 
   const endDate = !isRange
     ? startDate
@@ -158,7 +158,7 @@ function mapDates(
       ? // If startMonth is explicitly provided, use it + 1 month; otherwise fallback to endDate
         hasExplicitStartMonth
         ? addMonths(startMonth, 1)
-        : endDate ?? addMonths(startMonth, 1)
+        : (endDate ?? addMonths(startMonth, 1))
       : startMonth)
 
   const minDate = convertStringToDate(dateProps.minDate, {

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -88,8 +88,8 @@ function FormLabel(localProps: FormLabelAllProps) {
 
   const isInteractive = Boolean(
     !props.disabled &&
-      !srOnly &&
-      (typeof props.onClick === 'function' || forId)
+    !srOnly &&
+    (typeof props.onClick === 'function' || forId)
   )
 
   const params = {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -1012,7 +1012,8 @@ button.dnb-button::-moz-focus-inner {
   height: var(--height);
   color: var(--background-color, currentcolor);
   background-color: currentcolor;
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor;
   box-shadow: var(--box-shadow);
   border-radius: var(--rounded-corner, 0);
@@ -1105,7 +1106,8 @@ button.dnb-button::-moz-focus-inner {
   z-index: 0;
 }
 .dnb-section--divider::after {
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor,
     0 0.0625rem 0 0 var(--separator-color),
     99vw 0.0625rem 0 0 var(--separator-color),

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
@@ -416,8 +416,8 @@ export default class HeightAnimation {
   canFinish() {
     return Boolean(
       this.startTime &&
-        Date.now() - this.startTime >
-          (globalThis.animationDuration ?? this.duration)
+      Date.now() - this.startTime >
+        (globalThis.animationDuration ?? this.duration)
     )
   }
   /**
@@ -441,7 +441,7 @@ export default class HeightAnimation {
 
     return Boolean(
       this.firstTime &&
-        Date.now() - this.firstTime < (globalThis.bypassTime ?? 100)
+      Date.now() - this.firstTime < (globalThis.bypassTime ?? 100)
     )
   }
 }

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -202,8 +202,8 @@ export function calcSize(props: IconProps) {
         typeof icon === 'function'
           ? icon
           : React.isValidElement(icon) && typeof icon.type === 'function'
-          ? (icon.type as (props?: unknown) => React.JSX.Element)
-          : null
+            ? (icon.type as (props?: unknown) => React.JSX.Element)
+            : null
 
       // Skip direct execution for hook-based components to avoid invalid hook call order.
       const hasHooks = iconFn

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
@@ -97,8 +97,8 @@ export const correctNumberValue = ({
     props.value === null
       ? null
       : props.value === undefined
-      ? undefined
-      : String(props.value)
+        ? undefined
+        : String(props.value)
 
   if (isNaN(parseFloat(value))) {
     return value
@@ -363,8 +363,8 @@ export const handleCurrencyMask = ({
     typeof currencyMask === 'string'
       ? currencyMask
       : typeof givenParams.currency === 'string'
-      ? givenParams.currency
-      : 'kr'
+        ? givenParams.currency
+        : 'kr'
   const hasCurrencyLabel =
     typeof currencyLabel === 'string' && currencyLabel
   const shouldShowCurrencyLabel =

--- a/packages/dnb-eufemia/src/components/input-masked/hooks/useCallEvent.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/hooks/useCallEvent.tsx
@@ -122,8 +122,8 @@ export const useCallEvent = ({
             selStart > firstNumberIndex
               ? selStart - (value.length - newValue.length)
               : isNegative
-              ? 1
-              : 0
+                ? 1
+                : 0
         }
 
         if (newValue !== value) {

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldSection.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldSection.tsx
@@ -175,8 +175,8 @@ export default function SegmentedFieldSection({
           typeof initialValue === 'number' && !Number.isNaN(initialValue)
             ? initialValue
             : direction === 'up'
-            ? min
-            : max
+              ? min
+              : max
       } else {
         nextValue = parsedValue + (direction === 'up' ? step : step * -1)
 
@@ -292,8 +292,9 @@ export default function SegmentedFieldSection({
         })
 
         if (nextSectionId) {
-          const nextMask = inputs.find(({ id }) => id === nextSectionId)
-            ?.mask
+          const nextMask = inputs.find(
+            ({ id }) => id === nextSectionId
+          )?.mask
           if (!nextMask?.[0]?.test(char)) {
             return false
           }
@@ -522,7 +523,7 @@ export default function SegmentedFieldSection({
         aria-valuemax={spinButton ? spinButton.max : undefined}
         aria-valuenow={
           spinButton && hasTypedValue
-            ? spinButton?.parseValue?.(value) ?? Number(value)
+            ? (spinButton?.parseValue?.(value) ?? Number(value))
             : undefined
         }
         aria-valuetext={

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/dom.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/dom.ts
@@ -36,7 +36,7 @@ export function setSectionDomApi({
       get() {
         return sectionSelectionModeRef.current[inputId] === 'all'
           ? 0
-          : caretPositionsRef.current[inputId] ?? displayValue.length
+          : (caretPositionsRef.current[inputId] ?? displayValue.length)
       },
     },
     selectionEnd: {
@@ -44,7 +44,7 @@ export function setSectionDomApi({
       get() {
         return sectionSelectionModeRef.current[inputId] === 'all'
           ? displayValue.length
-          : caretPositionsRef.current[inputId] ?? displayValue.length
+          : (caretPositionsRef.current[inputId] ?? displayValue.length)
       },
     },
     setSelectionRange: {

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/utils.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/utils.ts
@@ -155,7 +155,7 @@ export function insertCharIntoSection({
   const isAllSelected = sectionSelectionModeRef.current[inputId] === 'all'
   const currentPosition = isAllSelected
     ? 0
-    : caretPositionsRef.current[inputId] ?? 0
+    : (caretPositionsRef.current[inputId] ?? 0)
 
   if (!mask[Math.min(currentPosition, mask.length - 1)]?.test(char)) {
     return false

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
@@ -349,8 +349,8 @@ describe('MenuAccordion', () => {
     expect(items).toHaveLength(3)
 
     // Open accordion
-    const exportTrigger = Array.from(items).find(
-      (el) => el.textContent?.includes('Export as')
+    const exportTrigger = Array.from(items).find((el) =>
+      el.textContent?.includes('Export as')
     )
     fireEvent.click(exportTrigger)
 

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuIntegration.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuIntegration.test.tsx
@@ -91,8 +91,8 @@ describe('Menu integration with real Popover', () => {
     expect(items.length).toBeGreaterThanOrEqual(2)
 
     // Focus the "Export as" sub-menu trigger
-    const exportTrigger = Array.from(items).find(
-      (item) => item.textContent?.includes('Export as')
+    const exportTrigger = Array.from(items).find((item) =>
+      item.textContent?.includes('Export as')
     ) as HTMLElement
     expect(exportTrigger).toBeTruthy()
     exportTrigger.focus()

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -138,11 +138,11 @@ function ModalComponent(ownProps: ModalAllProps) {
   const animationDuration =
     typeof window !== 'undefined' && window['IS_TEST']
       ? 0
-      : props.animationDuration ?? ANIMATION_DURATION
+      : (props.animationDuration ?? ANIMATION_DURATION)
   const noAnimation =
     typeof window !== 'undefined' && window['IS_TEST']
       ? true
-      : props.noAnimation ?? false
+      : (props.noAnimation ?? false)
 
   // Refs for latest state values used in callbacks
   const stateRef = useRef({ hide, modalActive, preventAutoFocus })

--- a/packages/dnb-eufemia/src/components/number-format/stories/NumberFormat.stories.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/stories/NumberFormat.stories.tsx
@@ -113,7 +113,8 @@ export const NumberFormatSandbox = () => {
                   12 345 678
                 </NumberFormat>{' '}
                 text <NumberFormat currency>12345.0</NumberFormat> text{' '}
-                <NumberFormat currency="EUR">-12345,68</NumberFormat> text{' '}
+                <NumberFormat currency="EUR">-12345,68</NumberFormat>{' '}
+                text{' '}
               </P>
             </Provider>
           </Box>

--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -416,8 +416,8 @@ function PopoverContainer(props: PopoverContainerProps) {
       alignOnTarget === 'left'
         ? -targetBodySize.width / 2
         : alignOnTarget === 'right'
-        ? targetBodySize.width / 2
-        : 0
+          ? targetBodySize.width / 2
+          : 0
     let anchorX = centerX + (isInitialVertical ? alignOffset : 0)
 
     if (arrowPositionSelector) {
@@ -515,8 +515,8 @@ function PopoverContainer(props: PopoverContainerProps) {
       autoAlignMode === 'never'
         ? false
         : autoAlignMode === 'initial'
-        ? initialAutoAlignAllowed
-        : true
+          ? initialAutoAlignAllowed
+          : true
 
     if (initialAutoAlignAllowed) {
       autoAlignInitialUsedRef.current = true

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
@@ -68,8 +68,8 @@ function ProgressIndicator(props: ProgressIndicatorAllProps) {
     typeof progress === 'string'
       ? parseFloat(progress)
       : typeof progress === 'number'
-      ? progress
-      : undefined
+        ? progress
+        : undefined
 
   const usedIndicatorLabel = label || (showDefaultLabel && indicatorLabel)
   const progressTitle = title || formatProgress(progressNumber)

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/ProgressIndicator.test.tsx
@@ -566,9 +566,7 @@ describe('ProgressIndicator scss', () => {
 
   it('should match default theme snapshot', () => {
     const css = loadScss(
-      require.resolve(
-        '../style/themes/dnb-progress-indicator-theme-ui.scss'
-      )
+      require.resolve('../style/themes/dnb-progress-indicator-theme-ui.scss')
     )
     expect(css).toMatchSnapshot()
   })

--- a/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
+++ b/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
@@ -143,7 +143,8 @@
 
     &__line.light {
       animation-name: progress-indicator-circular-line-light;
-      stroke-dasharray: var(--progress-indicator-circular-circle),
+      stroke-dasharray:
+        var(--progress-indicator-circular-circle),
         var(--progress-indicator-circular-circle);
       stroke-dashoffset: var(
         --progress-indicator-circular-circle-offset--max
@@ -152,7 +153,8 @@
 
     &__line.dark {
       animation-name: progress-indicator-circular-line-dark;
-      stroke-dasharray: var(--progress-indicator-circular-circle),
+      stroke-dasharray:
+        var(--progress-indicator-circular-circle),
         var(--progress-indicator-circular-circle);
       stroke-dashoffset: var(
         --progress-indicator-circular-circle-offset--min

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -61,7 +61,8 @@ exports[`Section scss has to match style dependencies css 1`] = `
   height: var(--height);
   color: var(--background-color, currentcolor);
   background-color: currentcolor;
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor;
   box-shadow: var(--box-shadow);
   border-radius: var(--rounded-corner, 0);
@@ -154,7 +155,8 @@ exports[`Section scss has to match style dependencies css 1`] = `
   z-index: 0;
 }
 .dnb-section--divider::after {
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor,
     0 0.0625rem 0 0 var(--separator-color),
     99vw 0.0625rem 0 0 var(--separator-color),

--- a/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
@@ -52,7 +52,8 @@
     position: absolute;
     inset: 0;
     z-index: -1;
-    box-shadow: var(--drop-shadow, var(--outline-none)),
+    box-shadow:
+      var(--drop-shadow, var(--outline-none)),
       var(--outline, var(--outline-none));
     border-radius: var(--rounded-corner, 0);
   }
@@ -70,7 +71,8 @@
     color: var(--background-color, currentcolor);
     background-color: currentcolor;
 
-    --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+    --box-shadow:
+      99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
       297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor;
 
     // we use box-shadow to avoid a horizontal scrollbar
@@ -184,7 +186,8 @@
     z-index: 0;
 
     &::after {
-      --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+      --box-shadow:
+        99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
         297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor,
         0 0.0625rem 0 0 var(--separator-color),
         99vw 0.0625rem 0 0 var(--separator-color),

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -1012,7 +1012,8 @@ button.dnb-button::-moz-focus-inner {
   height: var(--height);
   color: var(--background-color, currentcolor);
   background-color: currentcolor;
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor;
   box-shadow: var(--box-shadow);
   border-radius: var(--rounded-corner, 0);
@@ -1105,7 +1106,8 @@ button.dnb-button::-moz-focus-inner {
   z-index: 0;
 }
 .dnb-section--divider::after {
-  --box-shadow: 99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
+  --box-shadow:
+    99vw 0 0 0 currentcolor, 198vw 0 0 0 currentcolor,
     297vw 0 0 0 currentcolor, 396vw 0 0 0 currentcolor,
     0 0.0625rem 0 0 var(--separator-color),
     99vw 0.0625rem 0 0 var(--separator-color),

--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -114,8 +114,8 @@ function AmountBase(props: AmountProps) {
     typeof value !== 'undefined'
       ? value
       : typeof children === 'string' || typeof children === 'number'
-      ? children
-      : null
+        ? children
+        : null
 
   const suffixStartsWithSlash =
     typeof suffix === 'string' && suffix.startsWith('/')

--- a/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/themes/dnb-switch-theme-sbanken.scss
@@ -75,9 +75,9 @@
   &__input:checked ~ &__button {
     transform: translateX(
       calc(
-        var(--switch-width--medium) - var(--button-dimension--medium) - var(
-            --switch-spacing-width--medium
-          )
+        var(--switch-width--medium) - var(
+            --button-dimension--medium
+          ) - var(--switch-spacing-width--medium)
       )
     );
   }

--- a/packages/dnb-eufemia/src/components/table/style/dnb-table.scss
+++ b/packages/dnb-eufemia/src/components/table/style/dnb-table.scss
@@ -65,9 +65,8 @@
     // because firefox clip-path ignores caption
     // Use "clip-path" instead of "overflow" because display=table-row does not give the expected/same result like display=block would.
     clip-path: inset(
-      0 0 -10rem 0 round var(--table-outline-radius) var(
-          --table-outline-radius
-        ) 0 0
+      0 0 -10rem 0 round var(--table-outline-radius)
+        var(--table-outline-radius) 0 0
     );
     z-index: 1; // firefox places caption in from of table without z-index
 

--- a/packages/dnb-eufemia/src/components/table/style/table-sticky.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-sticky.scss
@@ -25,7 +25,8 @@
 
     // The @mixin defaultDropShadow() does not work in this case
     // because we need only a bottom shadow (with clip-path)
-    box-shadow: var(--shadow-default-x) -2px 12px 8px var(--shadow-default-color);
+    box-shadow: var(--shadow-default-x) -2px 12px 8px
+      var(--shadow-default-color);
     clip-path: inset(6px 0 -48px 0);
   }
 }

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -32,7 +32,8 @@ exports[`Timeline scss should match default theme snapshot 1`] = `
         var(--timeline-icon-width--medium) - var(
             --timeline-icon-width--small
           )
-      ) / 2
+      ) /
+      2
   );
   --timeline-border-spacing: var(--spacing-small);
   --timeline-border-spacing--icon-adjusted: calc(

--- a/packages/dnb-eufemia/src/components/timeline/style/themes/dnb-timeline-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/timeline/style/themes/dnb-timeline-theme-ui.scss
@@ -30,7 +30,8 @@
         var(--timeline-icon-width--medium) - var(
             --timeline-icon-width--small
           )
-      ) / 2
+      ) /
+      2
   );
   --timeline-border-spacing: var(--spacing-small);
   --timeline-border-spacing--icon-adjusted: calc(

--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -133,10 +133,10 @@ function UploadInfoAcceptedFileTypesTable() {
       const groupName = itemFileMaxSize
         ? itemFileMaxSize
         : fileMaxSizeIsFalseOrZero(itemFileMaxSize)
-        ? 0
-        : fileMaxSizeIsFalseOrZero(fallBackFileMaxSize)
-        ? 0
-        : fallBackFileMaxSize
+          ? 0
+          : fileMaxSizeIsFalseOrZero(fallBackFileMaxSize)
+            ? 0
+            : fallBackFileMaxSize
 
       group[groupName] = group[groupName] || []
       group[groupName].push(item)

--- a/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.css
+++ b/packages/dnb-eufemia/src/core/jest/jestSetupScreenshots.css
@@ -36,9 +36,9 @@ html {
 }
 
 [data-visual-test]:has(
-    .dnb-section[style*='--outset--medium: 1'],
-    .dnb-section[style*='--outset--large: 1']
-  ) {
+  .dnb-section[style*='--outset--medium: 1'],
+  .dnb-section[style*='--outset--large: 1']
+) {
   @media (min-width: 40em) {
     padding-left: 1.5rem;
     padding-right: 1.5rem;

--- a/packages/dnb-eufemia/src/core/jest/setupJestScreenshot.js
+++ b/packages/dnb-eufemia/src/core/jest/setupJestScreenshot.js
@@ -12,8 +12,8 @@ jest.setTimeout(
     config.delayDuringNonheadless > config.timeout
     ? config.delayDuringNonheadless
     : config.timeout > 0
-    ? config.timeout
-    : 60e3
+      ? config.timeout
+      : 60e3
 )
 
 setMatchConfig(config.matchConfig)

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -326,8 +326,8 @@ export default function Provider<Data extends JsonObject>(
           normalizedPath === '/'
             ? internalDataRef.current
             : pointer.has(internalDataRef.current, normalizedPath)
-            ? pointer.get(internalDataRef.current, normalizedPath)
-            : undefined
+              ? pointer.get(internalDataRef.current, normalizedPath)
+              : undefined
 
         const validationResult = validator(sectionData)
         if (validationResult === true) {
@@ -1102,8 +1102,8 @@ export default function Provider<Data extends JsonObject>(
           ? // When setting the root of the data, the whole data set should be the new value
             value
           : // For sub paths, use the existing data set (or empty array/object), but modify it below (since pointer.set is not immutable)
-            internalDataRef.current ??
-            (path.match(isArrayJsonPointer) ? [] : {})
+            (internalDataRef.current ??
+            (path.match(isArrayJsonPointer) ? [] : {}))
       ) as Data
 
       let newData: Data = null
@@ -1417,16 +1417,15 @@ export default function Provider<Data extends JsonObject>(
 
         setShowAllErrors(true)
 
-        const submitRequestResult = await resolveStateResult(
-          () =>
-            onSubmitRequest?.({
-              getErrors: () =>
-                Object.keys(fieldErrorRef.current)
-                  .map((path) => {
-                    return getDataPathHandlerParameters(path)
-                  })
-                  .filter(({ error }) => error),
-            })
+        const submitRequestResult = await resolveStateResult(() =>
+          onSubmitRequest?.({
+            getErrors: () =>
+              Object.keys(fieldErrorRef.current)
+                .map((path) => {
+                  return getDataPathHandlerParameters(path)
+                })
+                .filter(({ error }) => error),
+          })
         )
 
         applySubmitState(submitRequestResult)
@@ -1695,8 +1694,8 @@ export default function Provider<Data extends JsonObject>(
     typeof rest?.['disabled'] === 'boolean'
       ? rest?.['disabled']
       : formState === 'pending'
-      ? true
-      : undefined
+        ? true
+        : undefined
   const contextErrorMessages =
     errorMessages?.[locale ?? sharedLocale] || errorMessages
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -3695,9 +3695,8 @@ describe('Field.Date', () => {
     it('should align popover to right when width is large and showInput is true', async () => {
       let capturedAlignPicker: string | undefined
 
-      const DatePickerModule = await import(
-        '../../../../../components/date-picker/DatePicker'
-      )
+      const DatePickerModule =
+        await import('../../../../../components/date-picker/DatePicker')
 
       jest
         .spyOn(DatePickerModule, 'default')
@@ -3729,9 +3728,8 @@ describe('Field.Date', () => {
     it('should align popover to right when width is stretch and showInput is true', async () => {
       let capturedAlignPicker: string | undefined
 
-      const DatePickerModule = await import(
-        '../../../../../components/date-picker/DatePicker'
-      )
+      const DatePickerModule =
+        await import('../../../../../components/date-picker/DatePicker')
 
       jest
         .spyOn(DatePickerModule, 'default')
@@ -3763,9 +3761,8 @@ describe('Field.Date', () => {
     it('should not align popover to right when width is large but showInput is false', async () => {
       let capturedAlignPicker: string | undefined
 
-      const DatePickerModule = await import(
-        '../../../../../components/date-picker/DatePicker'
-      )
+      const DatePickerModule =
+        await import('../../../../../components/date-picker/DatePicker')
 
       jest
         .spyOn(DatePickerModule, 'default')
@@ -3795,9 +3792,8 @@ describe('Field.Date', () => {
     it('should not align popover to right when width is small and showInput is true', async () => {
       let capturedAlignPicker: string | undefined
 
-      const DatePickerModule = await import(
-        '../../../../../components/date-picker/DatePicker'
-      )
+      const DatePickerModule =
+        await import('../../../../../components/date-picker/DatePicker')
 
       jest
         .spyOn(DatePickerModule, 'default')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -390,16 +390,18 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
       // If the value is a number, find the corresponding month
       const nr = parseFloat(event.value ?? '')
       if (!isNaN(nr)) {
-        const monthValue = months.find((m) => parseFloat(m.value) === nr)
-          ?.value
+        const monthValue = months.find(
+          (m) => parseFloat(m.value) === nr
+        )?.value
         const month = monthValue || emptyValue
         monthRef.current = month
         forceUpdate()
         callOnChange({ month })
       } else {
         // If the value is a month name, find the corresponding value
-        const monthValue = months.find((m) => m.title === event.value)
-          ?.value
+        const monthValue = months.find(
+          (m) => m.title === event.value
+        )?.value
         if (monthValue) {
           monthRef.current = monthValue
           forceUpdate()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -239,10 +239,10 @@ function Expiry(props: ExpiryProps = {}) {
   const status = hasError
     ? 'error'
     : warning
-    ? 'warning'
-    : info
-    ? 'information'
-    : null
+      ? 'warning'
+      : info
+        ? 'information'
+        : null
 
   const fieldBlockProps: FieldBlockProps = {
     id,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
@@ -109,8 +109,8 @@ function Password({
               ? IconViewMedium
               : IconViewOffMedium
             : hidden
-            ? IconView
-            : IconViewOff
+              ? IconView
+              : IconViewOff
         }
         disabled={disabled}
         skeleton={sharedContext.skeleton}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -521,7 +521,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
           label={
             countryCodeLabel === false
               ? defaultCountryCodeLabel
-              : countryCodeLabel ?? defaultCountryCodeLabel
+              : (countryCodeLabel ?? defaultCountryCodeLabel)
           }
           labelSrOnly={countryCodeLabel === false ? true : undefined}
           data={dataRef.current}
@@ -553,7 +553,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
         label={
           numberLabel === false
             ? defaultLabel
-            : numberLabel ?? defaultLabel
+            : (numberLabel ?? defaultLabel)
         }
         labelSrOnly={numberLabel === false ? true : undefined}
         placeholder={
@@ -575,8 +575,8 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
           width === 'stretch'
             ? 'stretch'
             : props.omitCountryCodeField && width === 'large'
-            ? 'large'
-            : 'medium'
+              ? 'large'
+              : 'medium'
         }
         help={{ ...help, breakout: false, outset: false }}
         required={required}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -315,8 +315,9 @@ function Selection(props: FieldSelectionProps) {
       )
         .concat(makeOptions(renderedChildren, transformSelection))
         .filter(Boolean)
-      const displayValue = data.find((item) => item.selectedKey === value)
-        ?.content
+      const displayValue = data.find(
+        (item) => item.selectedKey === value
+      )?.content
       setDisplayValue(displayValue)
 
       const sharedProps: Omit<

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -169,8 +169,8 @@ function Toggle(props: FieldToggleProps) {
             label={
               labelWithItemNo ??
               (isOn
-                ? textOn ?? translations.yes
-                : textOff ?? translations.no)
+                ? (textOn ?? translations.yes)
+                : (textOff ?? translations.no))
             }
             labelSrOnly={labelSrOnly}
             checked={isOn}
@@ -193,8 +193,8 @@ function Toggle(props: FieldToggleProps) {
             label={
               labelWithItemNo ??
               (isOn
-                ? textOn ?? translations.yes
-                : textOff ?? translations.no)
+                ? (textOn ?? translations.yes)
+                : (textOff ?? translations.no))
             }
             labelSrOnly={labelSrOnly}
             checked={isOn}
@@ -215,8 +215,8 @@ function Toggle(props: FieldToggleProps) {
             id={id}
             text={
               isOn
-                ? textOn ?? translations.yes
-                : textOff ?? translations.no
+                ? (textOn ?? translations.yes)
+                : (textOff ?? translations.no)
             }
             checked={isOn}
             disabled={disabled}
@@ -301,8 +301,8 @@ function Toggle(props: FieldToggleProps) {
             variant="checkbox"
             text={
               isOn
-                ? textOn ?? translations.yes
-                : textOff ?? translations.no
+                ? (textOn ?? translations.yes)
+                : (textOff ?? translations.no)
             }
             checked={isOn}
             disabled={disabled}

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -393,8 +393,8 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
           process.env.NODE_ENV === 'test'
             ? true
             : typeof globalThis !== 'undefined'
-            ? globalThis.IS_TEST === true
-            : false,
+              ? globalThis.IS_TEST === true
+              : false,
       }
 
       const found = statesWithMessages.find((item) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
@@ -130,7 +130,7 @@ function InfoOverlay(props: FormInfoOverlayProps) {
           <MainHeading>{title ?? tr.title}</MainHeading>
           <P>{description ?? tr.description}</P>
           <Button
-            href={buttonClickHandler ? undefined : buttonHref ?? '/'}
+            href={buttonClickHandler ? undefined : (buttonHref ?? '/')}
             onClick={buttonClickHandler}
           >
             {buttonText ?? tr.buttonText}
@@ -154,7 +154,7 @@ function InfoOverlay(props: FormInfoOverlayProps) {
             <P>
               {formState === 'pending'
                 ? tr.retryingText
-                : description ?? tr.description}
+                : (description ?? tr.description)}
             </P>
           </HeightAnimation>
           <Flex.Horizontal>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/extractZodSubSchema.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/extractZodSubSchema.ts
@@ -94,8 +94,8 @@ export function unwrap(t: z.ZodTypeAny | unknown): z.ZodTypeAny {
     t instanceof z.ZodPromise
     ? unwrap(t.unwrap())
     : t instanceof z.ZodPipe
-    ? unwrap(t.out)
-    : (t as z.ZodTypeAny)
+      ? unwrap(t.out)
+      : (t as z.ZodTypeAny)
 }
 
 export function decodePointerSegment(seg: string): string {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/containers/SectionContainerProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/containers/SectionContainerProvider.tsx
@@ -23,8 +23,8 @@ function SectionContainerProvider(props: SectionContainerProviderProps) {
     disableEditing === true
       ? 'view'
       : containerMode === 'auto'
-      ? 'view'
-      : containerMode
+        ? 'view'
+        : containerMode
   )
 
   const switchContainerMode = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -60,8 +60,8 @@ function SubmitButton(props: FormSubmitButtonProps) {
   const indicatorState = showIndicator
     ? 'pending'
     : isActiveSubmitButton
-    ? formState
-    : undefined
+      ? formState
+      : undefined
 
   return (
     <Button

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -273,7 +273,7 @@ function ArrayComponent(props: IterateArrayProps) {
         modesRef.current[id] = {
           current:
             containerMode ??
-            (isNew ? getNextContainerMode() ?? 'edit' : 'auto'),
+            (isNew ? (getNextContainerMode() ?? 'edit') : 'auto'),
         }
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
@@ -66,13 +66,13 @@ export default function EditContainer(
       toolbar={
         hasToolbar
           ? null
-          : toolbarElement ??
+          : (toolbarElement ??
             (toolbarVariant !== 'custom' && (
               <Toolbar>
                 <DoneButton />
                 <CancelButton />
               </Toolbar>
-            ))
+            )))
       }
       toolbarVariant={toolbarVariant}
       {...rest}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -394,8 +394,8 @@ function NewContainer({
       ? false
       : Boolean(
           !showOpenButton ||
-            containerMode === 'edit' ||
-            ((required || hasContentChanged) && showStatus)
+          containerMode === 'edit' ||
+          ((required || hasContentChanged) && showStatus)
         )
 
   const { preventUncommittedChangesText } = useTranslation().Isolation

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
@@ -74,13 +74,13 @@ function ViewContainer(props: IterateViewContainerAllProps) {
       {children}
       {hasToolbar
         ? null
-        : toolbarElement ??
+        : (toolbarElement ??
           (toolbarVariant !== 'custom' && (
             <Toolbar>
               <EditButton />
               <RemoveButton />
             </Toolbar>
-          ))}
+          )))}
     </ArrayItemArea>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Boolean/Boolean.tsx
@@ -23,8 +23,8 @@ function BooleanComponent(props: ValueBooleanProps) {
     >
       {value === true || value === false
         ? value === true
-          ? trueText ?? translations.yes
-          : falseText ?? translations.no
+          ? (trueText ?? translations.yes)
+          : (falseText ?? translations.no)
         : null}
     </ValueBlock>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/ValueBlock/ValueBlock.tsx
@@ -177,8 +177,8 @@ function ValueBlock(localProps: ValueBlockProps) {
     const Item = summaryListContext.isNested
       ? Dl
       : summaryListContext.layout === 'horizontal'
-      ? Dl.Item
-      : Fragment
+        ? Dl.Item
+        : Fragment
 
     if (!label && !hasHelp && isCompositionInContext) {
       content = children ? (

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -255,16 +255,16 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const sectionSchemaPaths = sectionSchemaPathsRef?.current
   const hasSectionSchema = Boolean(
     sectionSchemaPaths?.size &&
-      identifier &&
-      Array.from(sectionSchemaPaths).some((sectionSchemaPath) => {
-        if (sectionSchemaPath === '/') {
-          return true
-        }
-        return (
-          identifier === sectionSchemaPath ||
-          identifier.startsWith(`${sectionSchemaPath}/`)
-        )
-      })
+    identifier &&
+    Array.from(sectionSchemaPaths).some((sectionSchemaPath) => {
+      if (sectionSchemaPath === '/') {
+        return true
+      }
+      return (
+        identifier === sectionSchemaPath ||
+        identifier.startsWith(`${sectionSchemaPath}/`)
+      )
+    })
   )
 
   const defaultValueRef = useRef(defaultValue)
@@ -1239,8 +1239,8 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         storePath === '/'
           ? internalData
           : hasValue
-          ? pointer.get(internalData, storePath)
-          : undefined
+            ? pointer.get(internalData, storePath)
+            : undefined
 
       // If no data where found in the dataContext, look for shared data
       if (

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -223,8 +223,8 @@ type EventArgs<Value, ExtraValue extends ProvideAdditionalEventArgs> = [
 export type DataValueWriteProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
-  ExtraValue extends
-    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
+  ExtraValue extends ProvideAdditionalEventArgs =
+    ProvideAdditionalEventArgs,
 > = {
   emptyValue?: EmptyValue
   onFocus?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
@@ -510,8 +510,8 @@ export type FieldProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
-  ExtraValue extends
-    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
+  ExtraValue extends ProvideAdditionalEventArgs =
+    ProvideAdditionalEventArgs,
 > = UseFieldProps<Value, EmptyValue, ErrorMessages, ExtraValue> &
   SharedFieldBlockProps
 
@@ -527,8 +527,8 @@ export type FieldPropsGeneric<
 
 export type FieldPropsWithExtraValue<
   Value = unknown,
-  ExtraValue extends
-    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
+  ExtraValue extends ProvideAdditionalEventArgs =
+    ProvideAdditionalEventArgs,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
 > = Omit<

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -357,9 +357,11 @@ interface UseFieldPropsInterface<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
-  ExtraValue extends
-    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
-> extends DataValueReadWriteComponentProps<Value, EmptyValue>,
+  ExtraValue extends ProvideAdditionalEventArgs =
+    ProvideAdditionalEventArgs,
+>
+  extends
+    DataValueReadWriteComponentProps<Value, EmptyValue>,
     AriaAttributes {
   // - HTML Element Attributes
   /**
@@ -502,8 +504,8 @@ export type UseFieldProps<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
-  ExtraValue extends
-    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
+  ExtraValue extends ProvideAdditionalEventArgs =
+    ProvideAdditionalEventArgs,
 > = UseFieldPropsInterface<Value, EmptyValue, ErrorMessages, ExtraValue>
 
 export type FieldProps<
@@ -538,8 +540,9 @@ export type FieldPropsWithExtraValue<
   DataValueWriteProps<Value, EmptyValue, ExtraValue>
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-interface ValuePropsInterface<Value = unknown>
-  extends DataValueReadComponentProps<Value> {
+interface ValuePropsInterface<
+  Value = unknown,
+> extends DataValueReadComponentProps<Value> {
   /**
    * Field label to show above the data value.
    */

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -16,8 +16,8 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
  */
 :root {
   --sb-font-family-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --sb-font-family-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica',
-    'Arial', sans-serif;
+  --sb-font-family-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
   --sb-font-weight-default: normal;
   --sb-font-weight-basis: normal;
   --sb-font-weight-regular: normal;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -203,11 +203,11 @@ function normalizeDataItem(
   return dataItem === null
     ? undefined
     : typeof dataItem === 'object' && 'content' in dataItem
-    ? dataItem
-    : {
-        content: dataItem,
-        ...(markAsTransformed ? { __isTransformed: true } : {}),
-      }
+      ? dataItem
+      : {
+          content: dataItem,
+          ...(markAsTransformed ? { __isTransformed: true } : {}),
+        }
 }
 
 export const getData = (props) => {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
@@ -134,13 +134,13 @@ function DrawerListPortal({
       const scrollY = fixedPosition
         ? 0
         : window.scrollY !== undefined
-        ? window.scrollY
-        : window.pageYOffset
+          ? window.scrollY
+          : window.pageYOffset
       const scrollX = fixedPosition
         ? 0
         : window.scrollX !== undefined
-        ? window.scrollX
-        : window.pageXOffset
+          ? window.scrollX
+          : window.pageXOffset
 
       let top = scrollY + rect.top
       let left =

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -318,8 +318,8 @@
   &--top &__arrow {
     top: auto;
     bottom: calc(
-      var(--drawer-list-focus-border-width) - var(--drawer-list-height) / 2 -
-        2px
+      var(--drawer-list-focus-border-width) - var(--drawer-list-height) /
+        2 - 2px
     );
     transform: rotate(180deg);
     &::before {

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -222,16 +222,17 @@ export type TranslationFlat = Partial<
   Record<TranslationObjectToFlat<TranslationValues>, string>
 >
 
-export type TranslationFlatToObject<T> = T extends Record<string, unknown>
-  ? {
-      // Mapped type to transform dot-notation keys to nested objects
-      [K in keyof T as K extends `${infer First}.${string}`
-        ? First
-        : K]: K extends `${string}.${infer Rest}`
-        ? TranslationFlatToObject<Record<Rest, T[K]>>
-        : T[K]
-    }
-  : T
+export type TranslationFlatToObject<T> =
+  T extends Record<string, unknown>
+    ? {
+        // Mapped type to transform dot-notation keys to nested objects
+        [K in keyof T as K extends `${infer First}.${string}`
+          ? First
+          : K]: K extends `${string}.${infer Rest}`
+          ? TranslationFlatToObject<Record<Rest, T[K]>>
+          : T[K]
+      }
+    : T
 
 export type TranslationObjectToFlat<T, Prefix extends string = ''> = {
   [K in keyof T]: T[K] extends Record<string, unknown>

--- a/packages/dnb-eufemia/src/shared/IsolatedStyleScope.tsx
+++ b/packages/dnb-eufemia/src/shared/IsolatedStyleScope.tsx
@@ -98,7 +98,7 @@ export default function IsolatedStyleScope(
           <div
             data-scope-hash={
               scopeHash === 'auto'
-                ? styleScopeContext?.scopeHash ?? scopeHash
+                ? (styleScopeContext?.scopeHash ?? scopeHash)
                 : scopeHash
             }
             data-scope-hash-id={uniqueKey || undefined}

--- a/packages/dnb-eufemia/src/shared/useMedia.tsx
+++ b/packages/dnb-eufemia/src/shared/useMedia.tsx
@@ -25,8 +25,8 @@ const makeLayoutEffect = () => {
   return typeof window === 'undefined'
     ? useEffect
     : window['__SSR_TEST__'] // To be able to test this hook like we are in SSR land
-    ? () => null
-    : React.useLayoutEffect
+      ? () => null
+      : React.useLayoutEffect
 }
 
 export type UseMediaProps = {

--- a/packages/dnb-eufemia/src/style/core/reset.scss
+++ b/packages/dnb-eufemia/src/style/core/reset.scss
@@ -387,8 +387,7 @@
 
 // reset ePlatform css
 @mixin resetLegacyStyles() {
-  html[xmlns="http://www.w3.org/1999/xhtml"]
-  {
+  html[xmlns='http://www.w3.org/1999/xhtml'] {
     .dnb-anchor--active {
       color: var(--color-mint-green) !important;
     }

--- a/packages/dnb-eufemia/src/style/themes/carnegie/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/carnegie/properties-tailwind.css
@@ -3,7 +3,8 @@
 /* stylelint-disable-next-line scss/at-rule-no-unknown */
 @theme {
   --font-sb-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --font-sb-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica';
+  --font-sb-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
   --font-weight-sb-default: normal;
   --font-weight-sb-basis: normal;
   --font-weight-sb-regular: normal;
@@ -107,7 +108,9 @@
   --color-ca-pale-red: #ffdedb;
   --font-default: 'DNB', sans-serif;
   --font-heading: var(--font-ca-heading);
-  --font-monospace: 'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono';
+  --font-monospace:
+    'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace;
   --font-weight-default: normal;
   --font-weight-basis: normal;
   --font-weight-regular: normal;

--- a/packages/dnb-eufemia/src/style/themes/carnegie/properties.js
+++ b/packages/dnb-eufemia/src/style/themes/carnegie/properties.js
@@ -2,7 +2,8 @@
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -106,7 +107,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': "'DNB', sans-serif",
   '--font-family-heading': 'var(--ca-font-family-heading)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',

--- a/packages/dnb-eufemia/src/style/themes/eiendom/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/eiendom/properties-tailwind.css
@@ -3,7 +3,8 @@
 /* stylelint-disable-next-line scss/at-rule-no-unknown */
 @theme {
   --font-sb-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --font-sb-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica';
+  --font-sb-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
   --font-weight-sb-default: normal;
   --font-weight-sb-basis: normal;
   --font-weight-sb-regular: normal;
@@ -107,7 +108,9 @@
   --color-ca-pale-red: #ffdedb;
   --font-default: 'DNB', sans-serif;
   --font-heading: var(--font-family-default);
-  --font-monospace: 'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono';
+  --font-monospace:
+    'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace;
   --font-weight-default: normal;
   --font-weight-basis: normal;
   --font-weight-regular: normal;

--- a/packages/dnb-eufemia/src/style/themes/eiendom/properties.js
+++ b/packages/dnb-eufemia/src/style/themes/eiendom/properties.js
@@ -2,7 +2,8 @@
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -106,7 +107,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': "'DNB', sans-serif",
   '--font-family-heading': 'var(--font-family-default)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',

--- a/packages/dnb-eufemia/src/style/themes/figma/color.tokens.json
+++ b/packages/dnb-eufemia/src/style/themes/figma/color.tokens.json
@@ -6,18 +6,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.95686274766922,
-            0.9843137264251709,
-            0.9764705896377563
+            0.95686274766922, 0.9843137264251709, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#F4FBF9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:dca8dc06de646234a154f28ed16c14a10c814ca5/5552:1442",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -27,18 +23,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8666666746139526,
-              0.9490196108818054,
-              0.9254902005195618
+              0.8666666746139526, 0.9490196108818054, 0.9254902005195618
             ],
             "alpha": 0.4000000059604645,
             "hex": "#DDF2EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:c17d1760acfcdd32f671272495d4032cfb0486d0/5552:1551",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -47,18 +39,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8470588326454163,
-              0.9529411792755127,
-              0.9254902005195618
+              0.8470588326454163, 0.9529411792755127, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#D8F3EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:e9a6135d08f7d5e6c7a2eadb5a424244670c9a3a/5552:1441",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -68,18 +56,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7372549176216125,
-            0.9098039269447327,
-            0.8627451062202454
+            0.7372549176216125, 0.9098039269447327, 0.8627451062202454
           ],
           "alpha": 1,
           "hex": "#BCE8DC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:678ab3e2c594804877461365d853f80e638a7ac2/5552:1440",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -89,9 +73,7 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 0.4000000059604645,
             "hex": "#A5E1D2"
@@ -106,18 +88,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 1,
             "hex": "#A5E1D2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:419aa063ca48588cf4757b791cf0524f07f3bef2/5552:1433",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -127,18 +105,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f9de36361eb570a086c2016c7317ffadc5416512/5552:1439",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -147,18 +121,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.29019609093666077,
-            0.5803921818733215,
-            0.5529412031173706
+            0.29019609093666077, 0.5803921818733215, 0.5529412031173706
           ],
           "alpha": 1,
           "hex": "#4A948D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b564379eac4665cd2dcbbdc736c2e965e6411d90/5552:1438",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -167,11 +137,7 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.4470588266849518,
-              0.4470588266849518
-            ],
+            "components": [0, 0.4470588266849518, 0.4470588266849518],
             "alpha": 0.4000000059604645,
             "hex": "#007272"
           },
@@ -184,19 +150,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.4470588266849518,
-              0.4470588266849518
-            ],
+            "components": [0, 0.4470588266849518, 0.4470588266849518],
             "alpha": 1,
             "hex": "#007272"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2c6eacc9cb63e915c7a511c82e186fa43cd591e2/5552:1432",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -207,18 +167,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 0.4000000059604645,
             "hex": "#14555A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:42e30cf670bb061e2f129d3838036f85a3212806/5552:1535",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--ColdGreen-700-40"
             },
@@ -230,18 +186,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 1,
             "hex": "#14555A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b08403154335d69091fc995f95f803b7ceb88a34/5552:1437",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -252,18 +204,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0313725508749485,
-              0.2705882489681244,
-              0.3019607961177826
+              0.0313725508749485, 0.2705882489681244, 0.3019607961177826
             ],
             "alpha": 0.4000000059604645,
             "hex": "#08454D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:9307450f9fa6c13d8de58d5152070cb4e2b29401/5552:1561",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -272,18 +220,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0313725508749485,
-              0.2705882489681244,
-              0.3019607961177826
+              0.0313725508749485, 0.2705882489681244, 0.3019607961177826
             ],
             "alpha": 1,
             "hex": "#08454D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:fbee9093c6a2b41c73a2df7ae8c89643080aabe5/5552:1436",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -293,18 +237,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.007843137718737125,
-            0.2235294133424759,
-            0.2235294133424759
+            0.007843137718737125, 0.2235294133424759, 0.2235294133424759
           ],
           "alpha": 1,
           "hex": "#023939"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:574fb13650143fec2ede94ff03d0ec47f611df7d/5552:1434",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -313,19 +253,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 0.4000000059604645,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:1b2c0dffda2d2a94a6e7f2dc39db1e5f40b30fdc/5552:1550",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -333,19 +267,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 1,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:51eb4bb52de36d242672a1319a66a11abab25aaa/5552:1435",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -357,19 +285,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 0.30000001192092896,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:948b9d32dab1486df822751376b327c9ae2af44f/5552:1668",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -377,19 +299,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 0.4000000059604645,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:642a3d146a85ed0c63806b279054d3c043554331/5552:1667",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -397,19 +313,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 0,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:c54c613803441ec57ae65b70441423d84dc1a507/5616:2",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -417,19 +327,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 1,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:6298df1ecd7673ad11a868ad535d1c74d6eb319e/5552:1666",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -439,18 +343,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.9803921580314636,
-            0.9803921580314636
+            0.9803921580314636, 0.9803921580314636, 0.9803921580314636
           ],
           "alpha": 1,
           "hex": "#FAFAFA"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b7f0c99476a66429f50b07b420e238c581361e87/5552:1672",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -459,18 +359,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9725490212440491,
-            0.9725490212440491,
-            0.9725490212440491
+            0.9725490212440491, 0.9725490212440491, 0.9725490212440491
           ],
           "alpha": 1,
           "hex": "#F8F8F8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:10cd172140cfac4ebfffefd88002d7fdc3cbec89/5552:1664",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -479,18 +375,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d1d1f864154f34329a870d96ce84c1a6d78ec2ef/5552:1663",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -499,18 +391,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:64efc26473d44f26f5653021e9da1b3f3cef8405/5552:1662",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -519,18 +407,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5ba36e97a7d08733de5ced82d4b9bd6501cc9a5e/5552:1661",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -539,18 +423,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ea9bcdf614811b28de8e9e371def14e169936ccb/5552:1660",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -559,18 +439,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f036ba9eb768742f5ba961410ea18895a917ae78/5552:1659",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -579,18 +455,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.38823530077934265,
-            0.38823530077934265,
-            0.4000000059604645
+            0.38823530077934265, 0.38823530077934265, 0.4000000059604645
           ],
           "alpha": 1,
           "hex": "#636366"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ebbbb6f188615e5e8e17cefa252402b28ea9e388/5552:1658",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -599,18 +471,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2823529541492462,
-            0.2823529541492462,
-            0.29019609093666077
+            0.2823529541492462, 0.2823529541492462, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#48484A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:27e40ae1cb0ebb30b1528d97e6689669d30ddc48/5552:1657",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -620,18 +488,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.20000000298023224,
-              0.20000000298023224,
-              0.20000000298023224
+              0.20000000298023224, 0.20000000298023224, 0.20000000298023224
             ],
             "alpha": 0.4000000059604645,
             "hex": "#333333"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2ed256bdcd912cd78ae3e6c50bcd1c7b94b8cf81/5552:1670",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -640,18 +504,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.20000000298023224,
-              0.20000000298023224,
-              0.20000000298023224
+              0.20000000298023224, 0.20000000298023224, 0.20000000298023224
             ],
             "alpha": 0.6000000238418579,
             "hex": "#333333"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:7badcc0c7e3414a4ecc8883af02d2e934f1cc595/5552:1671",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -660,18 +520,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.20000000298023224,
-              0.20000000298023224,
-              0.20000000298023224
+              0.20000000298023224, 0.20000000298023224, 0.20000000298023224
             ],
             "alpha": 1,
             "hex": "#333333"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b916c331c1588d8835c30dc9077f1d1689ec0c07/5552:1656",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -681,18 +537,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1725490242242813,
-            0.1725490242242813,
-            0.18039216101169586
+            0.1725490242242813, 0.1725490242242813, 0.18039216101169586
           ],
           "alpha": 1,
           "hex": "#2C2C2E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:aafc62ed5dd3d43f513cc7f0eb4570c8b272cdd6/5552:1655",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -701,18 +553,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10980392247438431,
-            0.11764705926179886
+            0.10980392247438431, 0.10980392247438431, 0.11764705926179886
           ],
           "alpha": 1,
           "hex": "#1C1C1E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:48cb0b31ba799838872b1d5b16f461f6980516d8/5552:1654",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -721,20 +569,14 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.20000000298023224,
             "hex": "#000000"
           },
           "$description": "Screendimmer iOS26",
           "$extensions": {
             "com.figma.variableId": "VariableID:42577f16d024e6c23ad2b3bc4ea702728bc1922e/5552:1673",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -742,19 +584,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b9540b7d108771cd545fccbf79563af9c01f8026/5552:1669",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -762,20 +598,14 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.47999998927116394,
             "hex": "#000000"
           },
           "$description": "Screendimmer iOS26",
           "$extensions": {
             "com.figma.variableId": "VariableID:19101e73c4357d631f8a3ada173d9ac154f73335/5552:1674",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -783,19 +613,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:640c1667d38a11a5da1648a8e432670a1dc70008/5616:6",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -803,19 +627,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 1,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:648ca7f1b5bc51b4792a98af8419b23a0905eead/5552:1665",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -827,18 +645,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.95686274766922,
-            0.9254902005195618
+            0.9490196108818054, 0.95686274766922, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#F2F4EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6d7183c0d54d696c175872f599a3f73f2c7a6cb0/5552:1566",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -847,18 +661,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8941176533699036,
-            0.9333333373069763,
-            0.843137264251709
+            0.8941176533699036, 0.9333333373069763, 0.843137264251709
           ],
           "alpha": 1,
           "hex": "#E4EED7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:486db807f238c98dc8572df54538ffcd70408569/5552:1565",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -867,18 +677,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8313725590705872,
-            0.9254902005195618,
-            0.772549033164978
+            0.8313725590705872, 0.9254902005195618, 0.772549033164978
           ],
           "alpha": 1,
           "hex": "#D4ECC5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2cf303a569d1f6c05cab433c3bf4a2f67cfaa2df/5552:1564",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -887,18 +693,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7372549176216125,
-            0.8980392217636108,
-            0.6745098233222961
+            0.7372549176216125, 0.8980392217636108, 0.6745098233222961
           ],
           "alpha": 1,
           "hex": "#BCE5AC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8a9a301709eddc718012556d7e698a886e517755/5552:1563",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -907,18 +709,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6235294342041016,
-            0.843137264251709,
-            0.5568627715110779
+            0.6235294342041016, 0.843137264251709, 0.5568627715110779
           ],
           "alpha": 1,
           "hex": "#9FD78E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c76d98721f04f936a5735c8fbecc4ef221effafc/5552:1562",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -927,18 +725,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5018489956855774,
-            0.7291666865348816,
-            0.46484375
+            0.5018489956855774, 0.7291666865348816, 0.46484375
           ],
           "alpha": 1,
           "hex": "#80BA77"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:70f6e05689f0882eaec84898449d38e808ed2fde/5552:1567",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -947,18 +741,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4470588266849518,
-            0.5843137502670288,
-            0.3803921639919281
+            0.4470588266849518, 0.5843137502670288, 0.3803921639919281
           ],
           "alpha": 1,
           "hex": "#729561"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d914d223d2495c75397c65e0a7472a12dafb14b7/5552:1568",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -967,18 +757,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.364705890417099,
-            0.4627451002597809,
-            0.3137255012989044
+            0.364705890417099, 0.4627451002597809, 0.3137255012989044
           ],
           "alpha": 1,
           "hex": "#5D7650"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ae1ac71d8025a607f9cde2a7ccf820b6f9a9a839/5552:1569",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -987,18 +773,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2980392277240753,
-            0.3803921639919281,
-            0.25882354378700256
+            0.2980392277240753, 0.3803921639919281, 0.25882354378700256
           ],
           "alpha": 1,
           "hex": "#4C6142"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:75bdebefa7b90846b5cd86562afa748fbfd54f5f/5552:1570",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1007,18 +789,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.23137255012989044,
-            0.27843138575553894,
-            0.21176470816135406
+            0.23137255012989044, 0.27843138575553894, 0.21176470816135406
           ],
           "alpha": 1,
           "hex": "#3B4736"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:85d318998a57aded601cec8e22c1b141f4cec179/5552:1571",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1027,18 +805,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.16862745583057404,
-            0.20000000298023224,
-            0.1568627506494522
+            0.16862745583057404, 0.20000000298023224, 0.1568627506494522
           ],
           "alpha": 1,
           "hex": "#2B3328"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:becfa32a00899cf99f9e4136a0fbd9dc040a7922/5552:1572",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -1049,18 +823,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:19fd7218a6732a10a73bc5590cecb0b36b46b9f0/5552:1582",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1069,18 +839,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8627451062202454,
-            0.9529411792755127,
-            0.9098039269447327
+            0.8627451062202454, 0.9529411792755127, 0.9098039269447327
           ],
           "alpha": 1,
           "hex": "#DCF3E8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ac5b63f10e6d7939ed0367e13d98aee9b986dc3a/5552:1581",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1089,18 +855,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7882353067398071,
-            0.9411764740943909,
-            0.8666666746139526
+            0.7882353067398071, 0.9411764740943909, 0.8666666746139526
           ],
           "alpha": 1,
           "hex": "#C9F0DD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:cf7d4aa0ad42e59812e3e0103c2d9ed9d16573ce/5552:1580",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1109,18 +871,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7254902124404907,
-            0.9058823585510254,
-            0.8078431487083435
+            0.7254902124404907, 0.9058823585510254, 0.8078431487083435
           ],
           "alpha": 1,
           "hex": "#B9E7CE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1aacf168f966ad10cea65f0de9df60bce794d6f2/5552:1579",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1129,18 +887,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5333333611488342,
-            0.8549019694328308,
-            0.7019608020782471
+            0.5333333611488342, 0.8549019694328308, 0.7019608020782471
           ],
           "alpha": 1,
           "hex": "#88DAB3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:fbf185b6353097040116d5712118484519cb1bf3/5552:1578",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1149,18 +903,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2801666557788849,
-            0.8199999928474426,
-            0.593269944190979
+            0.2801666557788849, 0.8199999928474426, 0.593269944190979
           ],
           "alpha": 1,
           "hex": "#47D197"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:303187c8c9e92d929631b1022de31e5c35d1c7e4/5552:1577",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1169,18 +919,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1568627506494522,
-            0.7058823704719543,
-            0.5098039507865906
+            0.1568627506494522, 0.7058823704719543, 0.5098039507865906
           ],
           "alpha": 1,
           "hex": "#28B482"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8d8b47b2b123e1abae441977c30b93d42b482ce1/5552:1576",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1188,19 +934,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0a34ae85d1fa46131e7aa1e27270d2985b08de73/5552:1575",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1208,19 +948,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.34583333134651184,
-            0.26429539918899536
-          ],
+          "components": [0, 0.34583333134651184, 0.26429539918899536],
           "alpha": 1,
           "hex": "#005843"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b00dc74657778475e76855b073eeaa1c6c867fc5/5552:1574",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1229,18 +963,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.05098039284348488,
-            0.27450981736183167,
-            0.21568627655506134
+            0.05098039284348488, 0.27450981736183167, 0.21568627655506134
           ],
           "alpha": 1,
           "hex": "#0D4637"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:18ee9796e97e12b0ccabcf41e6a3bb7c621bb11f/5552:1573",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1249,18 +979,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.20392157137393951,
-            0.1764705926179886
+            0.10980392247438431, 0.20392157137393951, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#1C342D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1232f484066d86ad789e4f88212071f7b438e5f7/5552:1583",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -1271,18 +997,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d17859db5d6e1250078a52e441983869e719480f/5552:1594",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1291,18 +1013,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.8666666746139526,
-            0.8666666746139526
+            0.9882352948188782, 0.8666666746139526, 0.8666666746139526
           ],
           "alpha": 1,
           "hex": "#FCDDDD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:93704bea7acfb78818ca3b0edbb239ffb1579eae/5552:1592",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1311,18 +1029,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.8039215803146362,
-            0.8039215803146362
+            0.9803921580314636, 0.8039215803146362, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#FACDCD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9138276f2b95a5fe9be72b6660883cfcb5f1e536/5552:1591",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1331,18 +1045,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.6745098233222961,
-            0.6745098233222961
+            0.9843137264251709, 0.6745098233222961, 0.6745098233222961
           ],
           "alpha": 1,
           "hex": "#FBACAC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5044cb1dd5cbab1e349ee4034bde06a9c88a20a5/5552:1590",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1351,18 +1061,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.5333333611488342,
-            0.5333333611488342
+            0.9647058844566345, 0.5333333611488342, 0.5333333611488342
           ],
           "alpha": 1,
           "hex": "#F68888"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1385c4d0e798e80725951c33eea5dc3aa8540b91/5552:1589",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1371,18 +1077,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9300000071525574,
-            0.29760000109672546,
-            0.29760000109672546
+            0.9300000071525574, 0.29760000109672546, 0.29760000109672546
           ],
           "alpha": 1,
           "hex": "#ED4C4C"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7f9baf946ea77b1b3beed96bf00735952bee29f1/5552:1588",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1392,18 +1094,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8352941274642944,
-              0.14509804546833038,
-              0.14509804546833038
+              0.8352941274642944, 0.14509804546833038, 0.14509804546833038
             ],
             "alpha": 0.4000000059604645,
             "hex": "#D52525"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:951df90be104b9f9d985fa772d3a638d3c3baae7/5552:1595",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -1412,18 +1110,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8352941274642944,
-              0.14509804546833038,
-              0.14509804546833038
+              0.8352941274642944, 0.14509804546833038, 0.14509804546833038
             ],
             "alpha": 1,
             "hex": "#D52525"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:37818821b2e21a587e9b3145c9afcb2548772f91/5552:1587",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -1433,18 +1127,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6980392336845398,
-            0.11764705926179886,
-            0.11764705926179886
+            0.6980392336845398, 0.11764705926179886, 0.11764705926179886
           ],
           "alpha": 1,
           "hex": "#B21E1E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:64aeb26ad215e533535d71f42251d5c138f0c94f/5552:1586",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1453,18 +1143,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.47843137383461,
-            0.07450980693101883,
-            0.07450980693101883
+            0.47843137383461, 0.07450980693101883, 0.07450980693101883
           ],
           "alpha": 1,
           "hex": "#7A1313"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0fede4adb9b6c826b9034d5a3ddda62b89458524/5552:1585",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1473,18 +1159,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.33000001311302185,
-            0.08250000327825546,
-            0.08250000327825546
+            0.33000001311302185, 0.08250000327825546, 0.08250000327825546
           ],
           "alpha": 1,
           "hex": "#541515"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d07119ac675dc1674c21d77f13a7e024bd42f9b2/5552:1593",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1493,18 +1175,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.250980406999588,
-            0.10196078568696976,
-            0.10196078568696976
+            0.250980406999588, 0.10196078568696976, 0.10196078568696976
           ],
           "alpha": 1,
           "hex": "#401A1A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:30d1b6225c03c35343daae8df45ec0ed6dc0b6b0/5552:1584",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -1514,19 +1192,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9490196108818054,
-            0.9490196108818054
-          ],
+          "components": [1, 0.9490196108818054, 0.9490196108818054],
           "alpha": 1,
           "hex": "#FFF2F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:83f2d5bb27a1d895dc3c4d241d98ea09eb73d3b5/5552:1606",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1534,19 +1206,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9176470637321472,
-            0.8784313797950745
-          ],
+          "components": [1, 0.9176470637321472, 0.8784313797950745],
           "alpha": 1,
           "hex": "#FFEAE0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:20201454a1e198d5e7855dd0225a2ebd8128b9d3/5552:1604",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1554,19 +1220,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8666666746139526,
-            0.800000011920929
-          ],
+          "components": [1, 0.8666666746139526, 0.800000011920929],
           "alpha": 1,
           "hex": "#FFDDCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d8d9d60f79b2720f3f49afa23c5139ec68784416/5552:1603",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1574,19 +1234,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.7333333492279053,
-            0.6000000238418579
-          ],
+          "components": [1, 0.7333333492279053, 0.6000000238418579],
           "alpha": 1,
           "hex": "#FFBB99"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f6c464920400a088c8b3f4a514e4d42422c35d2b/5552:1602",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1594,19 +1248,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.5960784554481506,
-            0.4000000059604645
-          ],
+          "components": [1, 0.5960784554481506, 0.4000000059604645],
           "alpha": 1,
           "hex": "#FF9866"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:308aecb3667953ce84509bf6f0c75ff254acab59/5552:1601",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1614,19 +1262,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.4627451002597809,
-            0.20000000298023224
-          ],
+          "components": [1, 0.4627451002597809, 0.20000000298023224],
           "alpha": 1,
           "hex": "#FF7633"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:af5eb08733e8f80fc67ce6e5cb96bfe1500a2bda/5552:1600",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1636,18 +1278,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9254902005195618,
-              0.3803921639919281,
-              0.16470588743686676
+              0.9254902005195618, 0.3803921639919281, 0.16470588743686676
             ],
             "alpha": 0.4000000059604645,
             "hex": "#EC612A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:46b48f2b4209c1236bf277b6b6900593c06ecfdc/5552:1607",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -1655,19 +1293,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.3294117748737335,
-              0
-            ],
+            "components": [1, 0.3294117748737335, 0],
             "alpha": 1,
             "hex": "#FF5400"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:e09fd7635beb464bb1e2eb1f639502bde2c2b34a/5552:1599",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -1676,19 +1308,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.800000011920929,
-            0.26274511218070984,
-            0
-          ],
+          "components": [0.800000011920929, 0.26274511218070984, 0],
           "alpha": 1,
           "hex": "#CC4300"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:710e99a5ca41d0da446f1ff7ba986eb979427c0b/5552:1598",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1696,19 +1322,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.6000000238418579,
-            0.19607843458652496,
-            0
-          ],
+          "components": [0.6000000238418579, 0.19607843458652496, 0],
           "alpha": 1,
           "hex": "#993200"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5b23c24ca261769942fc3aed3c2c79dab443cf6e/5552:1597",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1717,18 +1337,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4000000059604645,
-            0.14509804546833038,
-            0.019607843831181526
+            0.4000000059604645, 0.14509804546833038, 0.019607843831181526
           ],
           "alpha": 1,
           "hex": "#662505"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8f3ca7dea38c4aca2d460988eabac3b0789d5e5c/5552:1596",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1737,18 +1353,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3019607961177826,
-            0.11764705926179886,
-            0.0313725508749485
+            0.3019607961177826, 0.11764705926179886, 0.0313725508749485
           ],
           "alpha": 1,
           "hex": "#4D1E08"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:821bf099c3ac77d4ca8005b1ed7a6f2a7fd2cfe1/5552:1605",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -1759,18 +1371,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a99817a2fcef40289dfee3b4256cb827f8fc2d45/5552:1617",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1779,18 +1387,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.95686274766922,
-            0.8784313797950745
+            0.9921568632125854, 0.95686274766922, 0.8784313797950745
           ],
           "alpha": 1,
           "hex": "#FDF4E0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5c0d48b8427b0113d0ad11c4458487f05b332550/5552:1616",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1798,19 +1402,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.929411768913269,
-            0.7843137383460999
-          ],
+          "components": [1, 0.929411768913269, 0.7843137383460999],
           "alpha": 1,
           "hex": "#FFEDC8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:83aa3b247aa6004e66a9513c4847a5748b97a1d0/5552:1615",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1819,18 +1417,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.8823529481887817,
-            0.6627451181411743
+            0.9882352948188782, 0.8823529481887817, 0.6627451181411743
           ],
           "alpha": 1,
           "hex": "#FCE1A9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:82995f723b07ca4f6c09f3b14c7aa8e342e0d4aa/5552:1614",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1839,18 +1433,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.8235294222831726,
-            0.501960813999176
+            0.9803921580314636, 0.8235294222831726, 0.501960813999176
           ],
           "alpha": 1,
           "hex": "#FAD280"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:35a4ceb420c80d00584871397daeb45b6ada2cc2/5552:1613",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1859,18 +1449,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9973a65cf0f54c691333f0cc68e4491ac3c53fb2/5552:1612",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1879,18 +1465,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.5921568870544434,
-            0.062745101749897
+            0.8509804010391235, 0.5921568870544434, 0.062745101749897
           ],
           "alpha": 1,
           "hex": "#D99710"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:67cc3196182d16d389be23641178ed191dbfdfaf/5552:1611",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1899,18 +1481,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7019608020782471,
-            0.48235294222831726,
-            0.027450980618596077
+            0.7019608020782471, 0.48235294222831726, 0.027450980618596077
           ],
           "alpha": 1,
           "hex": "#B37B07"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:50fe9d87d32a54dc739e0f4af88d585ecdc5168a/5552:1610",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1919,18 +1497,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.501960813999176,
-            0.35686275362968445,
-            0.054901961237192154
+            0.501960813999176, 0.35686275362968445, 0.054901961237192154
           ],
           "alpha": 1,
           "hex": "#805B0E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d241b8c9d26c8762b63935d61eea8e57da4ddf18/5552:1609",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1939,18 +1513,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.37254902720451355,
-            0.2705882489681244,
-            0.05882352963089943
+            0.37254902720451355, 0.2705882489681244, 0.05882352963089943
           ],
           "alpha": 1,
           "hex": "#5F450F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a6735d7c2bdb6e95819ca598cfb90ad60d581aba/5552:1608",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -1959,18 +1529,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.239215686917305,
-            0.18039216101169586,
-            0.05882352963089943
+            0.239215686917305, 0.18039216101169586, 0.05882352963089943
           ],
           "alpha": 1,
           "hex": "#3D2E0F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8139db4cb4f95f70e6bbfa17d19f1bf28103cf49/5552:1618",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -1981,18 +1547,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9764705896377563,
-            0.95686274766922,
-            0.9137254953384399
+            0.9764705896377563, 0.95686274766922, 0.9137254953384399
           ],
           "alpha": 1,
           "hex": "#F9F4E9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:77864082cfd7db71e3afdd34ea845c11eace58a9/5552:1628",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2001,18 +1563,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.9254902005195618,
-            0.8274509906768799
+            0.9647058844566345, 0.9254902005195618, 0.8274509906768799
           ],
           "alpha": 1,
           "hex": "#F6ECD3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a48e387d36307fa8ca7d24e7d2405ec16c733ce1/5552:1627",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2021,18 +1579,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.8823529481887817,
-            0.7529411911964417
+            0.9215686321258545, 0.8823529481887817, 0.7529411911964417
           ],
           "alpha": 1,
           "hex": "#EBE1C0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e6b7476d968c98c960755335b6ef25f011c434c9/5552:1626",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2042,18 +1596,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8470588326454163,
-              0.772549033164978,
-              0.5137255191802979
+              0.8470588326454163, 0.772549033164978, 0.5137255191802979
             ],
             "alpha": 0.4000000059604645,
             "hex": "#D8C583"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:25fc3c5aa3cd57b62f207f3a18ae2c9ebbe59980/5552:1631",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -2062,18 +1612,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.845833420753479,
-              0.7729506492614746,
-              0.514548659324646
+              0.845833420753479, 0.7729506492614746, 0.514548659324646
             ],
             "alpha": 1,
             "hex": "#D8C583"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:82e2d8d5162a3940de6490e8e527ac3b3480ef7b/5552:1625",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -2083,18 +1629,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7916666865348816,
-            0.6714136600494385,
-            0.3166666626930237
+            0.7916666865348816, 0.6714136600494385, 0.3166666626930237
           ],
           "alpha": 1,
           "hex": "#CAAB51"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ef70c621dd7b9dffa870431234a122857f4d8558/5552:1624",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2103,18 +1645,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6392157077789307,
-            0.5333333611488342,
-            0.16470588743686676
+            0.6392157077789307, 0.5333333611488342, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#A3882A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a0b0eb7e892c1b487c072992313b93c1e5da9dc0/5552:1623",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2124,18 +1662,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.529411792755127,
-              0.43921568989753723,
-              0.11372549086809158
+              0.529411792755127, 0.43921568989753723, 0.11372549086809158
             ],
             "alpha": 0.4000000059604645,
             "hex": "#87701D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:292cd26b729d37a7731d5eedac9686b464b1cc97/5552:1630",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -2144,18 +1678,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.5291666388511658,
-              0.43748849630355835,
-              0.11244788765907288
+              0.5291666388511658, 0.43748849630355835, 0.11244788765907288
             ],
             "alpha": 1,
             "hex": "#87701D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:74ec674c2bd3b4a8662cb20d977093f9d2373559/5552:1622",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -2165,18 +1695,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.40784314274787903,
-            0.3294117748737335,
-            0.09803921729326248
+            0.40784314274787903, 0.3294117748737335, 0.09803921729326248
           ],
           "alpha": 1,
           "hex": "#685419"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f3c5d61b8ab9754b6bef68cdf78c1b4634543598/5552:1621",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2185,18 +1711,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.24705882370471954,
-            0.07450980693101883
+            0.30588236451148987, 0.24705882370471954, 0.07450980693101883
           ],
           "alpha": 1,
           "hex": "#4E3F13"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:fe264d34cecf564deecf366415c27b6d7a3c11be/5552:1620",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2205,18 +1727,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.18431372940540314,
-            0.14509804546833038,
-            0.03529411926865578
+            0.18431372940540314, 0.14509804546833038, 0.03529411926865578
           ],
           "alpha": 1,
           "hex": "#2F2509"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0ff5a35d20f1d1e0abe45ebfe0b3e84a6955ca92/5552:1629",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2225,18 +1743,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.12156862765550613,
-            0.10588235408067703,
-            0.062745101749897
+            0.12156862765550613, 0.10588235408067703, 0.062745101749897
           ],
           "alpha": 1,
           "hex": "#1F1B10"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:721999f8a839147630fad37127ad7eeef831ce0a/5552:1619",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -2247,18 +1761,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:76c5e004e15557cb32d2d1cbcb7e7c88584d57ac/5552:1636",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2267,18 +1777,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:30d59e3587135b4eefd312e8ebd93665586c8fdb/5552:1635",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2287,18 +1793,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8039215803146362,
-            0.8588235378265381,
-            0.95686274766922
+            0.8039215803146362, 0.8588235378265381, 0.95686274766922
           ],
           "alpha": 1,
           "hex": "#CDDBF4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f7c200255a7d4eb4b255051cff1c419a34a1f45e/5552:1634",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2307,18 +1809,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6627451181411743,
-            0.7529411911964417,
-            0.9372549057006836
+            0.6627451181411743, 0.7529411911964417, 0.9372549057006836
           ],
           "alpha": 1,
           "hex": "#A9C0EF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:979b388e303bb7426431af56c8242f437d456648/5552:1633",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2327,18 +1825,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4901960790157318,
-            0.6431372761726379,
-            0.9098039269447327
+            0.4901960790157318, 0.6431372761726379, 0.9098039269447327
           ],
           "alpha": 1,
           "hex": "#7DA4E8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:054896ca7dd134ab3eff30aee817c3542a79605e/5552:1632",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2347,18 +1841,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.27843138575553894,
-            0.5176470875740051,
-            0.8823529481887817
+            0.27843138575553894, 0.5176470875740051, 0.8823529481887817
           ],
           "alpha": 1,
           "hex": "#4784E1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f3dfaeb548e1f3aaf1ee5d02f87430be742446ca/5552:1637",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2367,18 +1857,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:33c7740ba59394f9128151bc91acebaf6cc6e226/5552:1638",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2387,18 +1873,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.09803921729326248,
-            0.3333333432674408,
-            0.6627451181411743
+            0.09803921729326248, 0.3333333432674408, 0.6627451181411743
           ],
           "alpha": 1,
           "hex": "#1955A9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:24d99ef0805e6755773a0c175695d0d66853e93a/5552:1639",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2407,18 +1889,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08235294371843338,
-            0.24705882370471954,
-            0.49803921580314636
+            0.08235294371843338, 0.24705882370471954, 0.49803921580314636
           ],
           "alpha": 1,
           "hex": "#153F7F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b8707a745b59d8ebe7f6f4bf827517a6a6de4e0c/5552:1640",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2427,18 +1905,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.1921568661928177,
-            0.3529411852359772
+            0.08627451211214066, 0.1921568661928177, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#16315A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e199d6529542925002b944b3d36cbca5c9aec7d9/5552:1641",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2447,18 +1921,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08235294371843338,
-            0.14901961386203766,
-            0.250980406999588
+            0.08235294371843338, 0.14901961386203766, 0.250980406999588
           ],
           "alpha": 1,
           "hex": "#152640"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:215d618bbe61199c2a18e5e80d45273a89791a87/5552:1642",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -2469,18 +1939,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0ba05a1e1624c7d33e62f51aa89e67439b67b44d/5552:1653",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2489,18 +1955,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8941176533699036,
-            0.8941176533699036,
-            0.9450980424880981
+            0.8941176533699036, 0.8941176533699036, 0.9450980424880981
           ],
           "alpha": 1,
           "hex": "#E4E4F1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f07c14967fab931e9a2e83883b4921f693b42002/5552:1652",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2509,18 +1971,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8392156958580017,
-            0.8392156958580017,
-            0.9215686321258545
+            0.8392156958580017, 0.8392156958580017, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#D6D6EB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:07c8cf7da25a1aac18b955ac3052803dfe147d10/5552:1651",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2529,18 +1987,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7215686440467834,
-            0.7215686440467834,
-            0.8784313797950745
+            0.7215686440467834, 0.7215686440467834, 0.8784313797950745
           ],
           "alpha": 1,
           "hex": "#B8B8E0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:313352df5502f4dde7b3ceb6de8eb2ca7525d6b3/5552:1650",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2549,18 +2003,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6078431606292725,
-            0.6078431606292725,
-            0.8313725590705872
+            0.6078431606292725, 0.6078431606292725, 0.8313725590705872
           ],
           "alpha": 1,
           "hex": "#9B9BD4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53c6ae5db676589748c0b69f756b70bd46a85831/5552:1649",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2569,18 +2019,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4901960790157318,
-            0.4901960790157318,
-            0.8313725590705872
+            0.4901960790157318, 0.4901960790157318, 0.8313725590705872
           ],
           "alpha": 1,
           "hex": "#7D7DD4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:31aada513eb8ac41ca6e6df8d56e181deac19e61/5552:1648",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2589,18 +2035,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4000000059604645,
-            0.4000000059604645,
-            0.800000011920929
+            0.4000000059604645, 0.4000000059604645, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#6666CC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2d4b2b5ed976a19988f472eefb0bc970eb63b330/5552:1647",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2609,18 +2051,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.23529411852359772,
-            0.23529411852359772,
-            0.6666666865348816
+            0.23529411852359772, 0.23529411852359772, 0.6666666865348816
           ],
           "alpha": 1,
           "hex": "#3C3CAA"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f23186cd1fb248761b0f2994642e82aa90c452fb/5552:1646",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2629,18 +2067,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1725490242242813,
-            0.1725490242242813,
-            0.4901960790157318
+            0.1725490242242813, 0.1725490242242813, 0.4901960790157318
           ],
           "alpha": 1,
           "hex": "#2C2C7D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:67266042a7020a2edae50dfb923325c4c6e4e933/5552:1645",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2649,18 +2083,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13725490868091583,
-            0.09803921729326248,
-            0.3529411852359772
+            0.13725490868091583, 0.09803921729326248, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#23195A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e823970d67449998e12c12ef39eeb11c6821f0ce/5552:1644",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2669,18 +2099,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11372549086809158,
-            0.09019608050584793,
-            0.250980406999588
+            0.11372549086809158, 0.09019608050584793, 0.250980406999588
           ],
           "alpha": 1,
           "hex": "#1D1740"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:70c37e8559b9d0a25e085e19310a182946063053/5552:1643",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -2692,19 +2118,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9843137264251709,
-            0.9764705896377563,
-            1
-          ],
+          "components": [0.9843137264251709, 0.9764705896377563, 1],
           "alpha": 1,
           "hex": "#FBF9FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:97a8a6e9ffe6dabd8713cba774b0e4cacaa03807/5552:1776",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2712,19 +2132,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9450980424880981,
-            0.9215686321258545,
-            1
-          ],
+          "components": [0.9450980424880981, 0.9215686321258545, 1],
           "alpha": 1,
           "hex": "#F1EBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9bd6a10f5a415136fcb490d1f8162923959de0c2/5552:1775",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2732,19 +2146,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8784313797950745,
-            0.8156862854957581,
-            1
-          ],
+          "components": [0.8784313797950745, 0.8156862854957581, 1],
           "alpha": 1,
           "hex": "#E0D0FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e467555bf89da7429217e35463648c9365bdb46d/5552:1774",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2753,19 +2161,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 0.4000000059604645,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:2d8ab08e3fcf1663123630c69431f97f2bf6625a/5552:1781",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -2773,19 +2175,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 1,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:37c03ff34f9ada51de052c4bd02a1ffead1de438/5552:1777",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -2794,19 +2190,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.7450980544090271,
-            0.6000000238418579,
-            1
-          ],
+          "components": [0.7450980544090271, 0.6000000238418579, 1],
           "alpha": 1,
           "hex": "#BE99FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a67d4c7c38351f5ecf8b3be9d93ba415f06fa93b/5552:1773",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2815,18 +2205,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5921568870544434,
-            0.3803921639919281,
-            0.9450980424880981
+            0.5921568870544434, 0.3803921639919281, 0.9450980424880981
           ],
           "alpha": 1,
           "hex": "#9761F1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:98fcb5f050b38058c880350e2396de1b98b6f57d/5552:1772",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2835,18 +2221,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4431372582912445,
-            0.16078431904315948,
-            0.886274516582489
+            0.4431372582912445, 0.16078431904315948, 0.886274516582489
           ],
           "alpha": 1,
           "hex": "#7129E2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e0f9c21eba19628492ae26be12a83a35c682b3d1/5552:1771",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2856,18 +2238,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 0.4000000059604645,
             "hex": "#4E08BC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:7a2845f64ead21d1789bd1dd0cdf72459d784bc6/5552:1780",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -2876,18 +2254,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 1,
             "hex": "#4E08BC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b0daac6edcc09913450d78d51401f9ebc5728f22/5552:1770",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -2897,18 +2271,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1882352977991104,
-            0.1411764770746231,
-            0.501960813999176
+            0.1882352977991104, 0.1411764770746231, 0.501960813999176
           ],
           "alpha": 1,
           "hex": "#302480"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:215c62170218f576e01df6ef14934bfa2978951f/5552:1769",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2918,18 +2288,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 0.4000000059604645,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:76bc255eda85ced8ea7355f630b0eed2770cb6b0/5552:1779",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -2938,18 +2304,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 1,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:a2c4e07893f1563b939dcbbc3883c991dd234b9c/5552:1768",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -2959,18 +2321,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c83918bc36c77c5768b264bd211764e6bfe1a3f3/5552:1767",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -2979,18 +2337,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0941176488995552,
-            0.09019608050584793,
-            0.16470588743686676
+            0.0941176488995552, 0.09019608050584793, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#18172A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:49dd47b856d4df495b833ce30ce59206be120147/5552:1778",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -3000,19 +2354,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9583333134651184,
-            1,
-            0.9850000143051147
-          ],
+          "components": [0.9583333134651184, 1, 0.9850000143051147],
           "alpha": 1,
           "hex": "#F4FFFB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b70a49069c8588ca6fe71c2b9f35d61fe019e11b/5552:1790",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3020,19 +2368,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8980392217636108,
-            1,
-            0.9686274528503418
-          ],
+          "components": [0.8980392217636108, 1, 0.9686274528503418],
           "alpha": 1,
           "hex": "#E5FFF7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:681c54c60cc208cb9216f77c9b087d6208ad16ac/5552:1789",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3041,18 +2383,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7843137383460999,
-            0.9647058844566345,
-            0.8980392217636108
+            0.7843137383460999, 0.9647058844566345, 0.8980392217636108
           ],
           "alpha": 1,
           "hex": "#C8F6E5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a67b0dae5ed0854e6de2d73c21758d519e803f8d/5552:1788",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3062,18 +2400,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.572549045085907,
-              0.9333333373069763,
-              0.8039215803146362
+              0.572549045085907, 0.9333333373069763, 0.8039215803146362
             ],
             "alpha": 0.4000000059604645,
             "hex": "#92EECD"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:ba623efe33147e2fdc31617a89084b66bfd01bbb/5552:1793",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -3082,18 +2416,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.572549045085907,
-              0.9333333373069763,
-              0.8039215803146362
+              0.572549045085907, 0.9333333373069763, 0.8039215803146362
             ],
             "alpha": 1,
             "hex": "#92EECD"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:7d4f5eff80fa7e179e28b3e6815b16783630406e/5552:1791",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -3103,18 +2433,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:4db65323ff3e46e326f8010302dd8fdbdf8b6b37/5552:1792",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3123,18 +2449,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.21447916328907013,
-            0.7250000238418579,
-            0.5718437433242798
+            0.21447916328907013, 0.7250000238418579, 0.5718437433242798
           ],
           "alpha": 1,
           "hex": "#37B992"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c3960cdcb01ac245426c4d2252a003dd4942a452/5552:1787",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3143,18 +2465,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11764705926179886,
-            0.6235294342041016,
-            0.45098039507865906
+            0.11764705926179886, 0.6235294342041016, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#1E9F73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:825d5e0d4f11b5c461c99684362039a7b917c6f4/5552:1786",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3162,19 +2480,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.47058823704719543,
-            0.35686275362968445
-          ],
+          "components": [0, 0.47058823704719543, 0.35686275362968445],
           "alpha": 1,
           "hex": "#00785B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:00a0b968550bae6877c54319b08ebf7c5ea33db1/5552:1785",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3183,18 +2495,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0776388868689537,
-            0.3583333194255829,
-            0.2625925838947296
+            0.0776388868689537, 0.3583333194255829, 0.2625925838947296
           ],
           "alpha": 1,
           "hex": "#145B43"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d89bf81e99ceeea8056aa8db2de4a1bfb4efb7b5/5552:1784",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3203,18 +2511,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.20392157137393951,
-            0.1764705926179886
+            0.08627451211214066, 0.20392157137393951, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#16342D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b677f25b770f831b41df2521e876991e41ebc7af/5552:1783",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3223,18 +2527,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.05098039284348488,
-            0.12156862765550613,
-            0.10588235408067703
+            0.05098039284348488, 0.12156862765550613, 0.10588235408067703
           ],
           "alpha": 1,
           "hex": "#0D1F1B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:28525f33c0f806bf19bb7308694e212a8ff20093/5552:1782",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -3244,19 +2544,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9607843160629272,
-            0.9764705896377563
-          ],
+          "components": [1, 0.9607843160629272, 0.9764705896377563],
           "alpha": 1,
           "hex": "#FFF5F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:4cdaac77f2e4307d59308f679bbb09d4d2883c6f/5552:1804",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3264,19 +2558,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9254902005195618,
-            0.9529411792755127
-          ],
+          "components": [1, 0.9254902005195618, 0.9529411792755127],
           "alpha": 1,
           "hex": "#FFECF3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:3bc2f8cc146d9f00b7713e5d7cc9ff8bcea8b5d2/5552:1802",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3284,19 +2572,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8588235378265381,
-            0.9137254953384399
-          ],
+          "components": [1, 0.8588235378265381, 0.9137254953384399],
           "alpha": 1,
           "hex": "#FFDBE9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b0ba08b359ab494c0c61a70b0f2c1e0d786b8f1e/5552:1799",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3304,19 +2586,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.7137255072593689,
-            0.8235294222831726
-          ],
+          "components": [1, 0.7137255072593689, 0.8235294222831726],
           "alpha": 1,
           "hex": "#FFB6D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f553947837d1e2c3bd4d949443a734fa98daf4c9/5552:1796",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3324,19 +2600,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.5137255191802979,
-            0.6980392336845398
-          ],
+          "components": [1, 0.5137255191802979, 0.6980392336845398],
           "alpha": 1,
           "hex": "#FF83B2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:4610bc42e4f9b7cde5dcec985d4cf916ac358b70/5552:1803",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3344,19 +2614,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.3607843220233917,
-            0.5137255191802979
-          ],
+          "components": [1, 0.3607843220233917, 0.5137255191802979],
           "alpha": 1,
           "hex": "#FF5C83"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9db013d9d17b1956c4b03dda91ef74611f767891/5552:1798",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3364,19 +2628,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.23529411852359772,
-            0.3921568691730499
-          ],
+          "components": [1, 0.23529411852359772, 0.3921568691730499],
           "alpha": 1,
           "hex": "#FF3C64"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:db5c24aade16167c29f6ea48a74785172e5f879f/5552:1801",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3385,18 +2643,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ec6c80d3aa2d1963c45595e90bc5a02b5abb879c/5552:1800",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3405,18 +2659,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6039215922355652,
-            0.05882352963089943,
-            0.1725490242242813
+            0.6039215922355652, 0.05882352963089943, 0.1725490242242813
           ],
           "alpha": 1,
           "hex": "#9A0F2C"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d6871eb7897f2849c6148754d81bcdc4b6b7d37e/5552:1797",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3425,18 +2675,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3960784375667572,
-            0.007843137718737125,
-            0.07450980693101883
+            0.3960784375667572, 0.007843137718737125, 0.07450980693101883
           ],
           "alpha": 1,
           "hex": "#650213"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8cf52a1a2f9a382c382e952262135a78326e2824/5552:1795",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3445,18 +2691,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.23529411852359772,
-            0.003921568859368563,
-            0.04313725605607033
+            0.23529411852359772, 0.003921568859368563, 0.04313725605607033
           ],
           "alpha": 1,
           "hex": "#3C010B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6b7235e37eb8bc2b89981570c334f23103a31983/5552:1794",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -3466,19 +2708,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9686274528503418,
-            0.9647058844566345
-          ],
+          "components": [1, 0.9686274528503418, 0.9647058844566345],
           "alpha": 1,
           "hex": "#FFF7F6"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8553c561ec71efb2f4ff68ffcc0f1345152b9973/5552:1815",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3486,19 +2722,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.929411768913269,
-            0.9254902005195618
-          ],
+          "components": [1, 0.929411768913269, 0.9254902005195618],
           "alpha": 1,
           "hex": "#FFEDEC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9c0edadc55373d7b3b5f4279502ee9172de4a344/5552:1811",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3506,19 +2736,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.843137264251709,
-            0.8352941274642944
-          ],
+          "components": [1, 0.843137264251709, 0.8352941274642944],
           "alpha": 1,
           "hex": "#FFD7D5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:834ec0c4c45dd5f7b058e9a160931f5f15f19aae/5552:1814",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3526,19 +2750,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.6823529601097107,
-            0.6823529601097107
-          ],
+          "components": [1, 0.6823529601097107, 0.6823529601097107],
           "alpha": 1,
           "hex": "#FFAEAE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:e6cd9f91056549890f16ab905257ccae3dba8cef/5552:1806",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3546,19 +2764,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.5058823823928833,
-            0.48235294222831726
-          ],
+          "components": [1, 0.5058823823928833, 0.48235294222831726],
           "alpha": 1,
           "hex": "#FF817B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f29c2349abc18d18cfefd027419a81a046dae1b5/5552:1813",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3567,19 +2779,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.35686275362968445,
-              0.2666666805744171
-            ],
+            "components": [1, 0.35686275362968445, 0.2666666805744171],
             "alpha": 0.4000000059604645,
             "hex": "#FF5B44"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:f68a835977fc9496fdcb4315994e63aa1137469d/5552:1816",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -3587,19 +2793,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.3550299108028412,
-              0.2683919370174408
-            ],
+            "components": [1, 0.3550299108028412, 0.2683919370174408],
             "alpha": 1,
             "hex": "#FF5B44"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:155e3abb349db856cd3b3b1cc617fa8054313dab/5552:1810",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -3608,19 +2808,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.21176470816135406,
-            0.10588235408067703
-          ],
+          "components": [1, 0.21176470816135406, 0.10588235408067703],
           "alpha": 1,
           "hex": "#FF361B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:47142e271e6df2459cfdac9d3cb124eb665dcbdd/5552:1809",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3630,18 +2824,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8745098114013672,
-              0.1568627506494522,
-              0.05882352963089943
+              0.8745098114013672, 0.1568627506494522, 0.05882352963089943
             ],
             "alpha": 0.4000000059604645,
             "hex": "#DF280F"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:a39f0c92399e219f142a085e470c180e4ea6c5bb/5552:1817",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -3650,18 +2840,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8745098114013672,
-              0.1568627506494522,
-              0.05882352963089943
+              0.8745098114013672, 0.1568627506494522, 0.05882352963089943
             ],
             "alpha": 1,
             "hex": "#DF280F"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:5742adf60a8649f1ff01694190f15bcf1e54f615/5552:1805",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -3671,18 +2857,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6274510025978088,
-            0.14901961386203766,
-            0.08235294371843338
+            0.6274510025978088, 0.14901961386203766, 0.08235294371843338
           ],
           "alpha": 1,
           "hex": "#A02615"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:86bf67967a53e707aeb2a0f0f32237d0c52700d3/5552:1808",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3691,18 +2873,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3490196168422699,
-            0.09019608050584793,
-            0.0117647061124444
+            0.3490196168422699, 0.09019608050584793, 0.0117647061124444
           ],
           "alpha": 1,
           "hex": "#591703"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9813c1ae93d38a61820b28997ec48cc293bdc95f/5552:1807",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3711,18 +2889,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2078431397676468,
-            0.054901961237192154,
-            0.007843137718737125
+            0.2078431397676468, 0.054901961237192154, 0.007843137718737125
           ],
           "alpha": 1,
           "hex": "#350E02"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0c22406f468a9bbe90a742d53d42818ab1660903/5552:1812",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -3732,19 +2906,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9882352948188782,
-            0.8980392217636108
-          ],
+          "components": [1, 0.9882352948188782, 0.8980392217636108],
           "alpha": 1,
           "hex": "#FFFCE5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:aea058c4e38b4337b49fdd5ec6cfaf0be891a92f/5552:1821",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3752,19 +2920,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9764705896377563,
-            0.7686274647712708
-          ],
+          "components": [1, 0.9764705896377563, 0.7686274647712708],
           "alpha": 1,
           "hex": "#FFF9C4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:84c77dbfedefb2f5a72a890caf7946c8b7abaef4/5552:1823",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3772,19 +2934,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9686274528503418,
-            0.6549019813537598
-          ],
+          "components": [1, 0.9686274528503418, 0.6549019813537598],
           "alpha": 1,
           "hex": "#FFF7A7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:37135961bc98b6fbdf701a2d64387e81d00d2f93/5552:1820",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3792,19 +2948,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.95686274766922,
-            0.5372549295425415
-          ],
+          "components": [1, 0.95686274766922, 0.5372549295425415],
           "alpha": 1,
           "hex": "#FFF489"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:417cb079746b4475fcb89d2c95c2a8f2c71f04a8/5552:1826",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3812,19 +2962,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9372549057006836,
-            0.34117648005485535
-          ],
+          "components": [1, 0.9372549057006836, 0.34117648005485535],
           "alpha": 1,
           "hex": "#FFEF57"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0e36f21c1eb3120ed1fe0bce42d4720d556dc22a/5552:1819",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3833,18 +2977,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.8627451062202454,
-            0.239215686917305
+            0.9882352948188782, 0.8627451062202454, 0.239215686917305
           ],
           "alpha": 1,
           "hex": "#FCDC3D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6cefa0ee4792f5776d0ab2289ba16258e4a54ca2/5552:1827",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3853,18 +2993,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9686274528503418,
-            0.7490196228027344,
-            0.08627451211214066
+            0.9686274528503418, 0.7490196228027344, 0.08627451211214066
           ],
           "alpha": 1,
           "hex": "#F7BF16"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6e1122d348cb0dea22cda69bf31dcaff2a2ccb7f/5552:1818",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3873,18 +3009,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8196078538894653,
-            0.6196078658103943,
-            0.027450980618596077
+            0.8196078538894653, 0.6196078658103943, 0.027450980618596077
           ],
           "alpha": 1,
           "hex": "#D19E07"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ac552022accb920e8c7416feb48bde2f403bb35c/5552:1824",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3893,18 +3025,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5058823823928833,
-            0.3843137323856354,
-            0.03529411926865578
+            0.5058823823928833, 0.3843137323856354, 0.03529411926865578
           ],
           "alpha": 1,
           "hex": "#816209"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c59c8d5a1dc7ff1ceca2eefcf482d72ff274d64b/5552:1822",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3912,19 +3040,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.32549020648002625,
-            0.24313725531101227,
-            0
-          ],
+          "components": [0.32549020648002625, 0.24313725531101227, 0],
           "alpha": 1,
           "hex": "#533E00"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:effe8b4f0ca88fc0e226e40ccc369104eb891c5f/5552:1828",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3932,19 +3054,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.1921568661928177,
-            0.14509804546833038,
-            0
-          ],
+          "components": [0.1921568661928177, 0.14509804546833038, 0],
           "alpha": 1,
           "hex": "#312500"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:4a7d3e853c6e7786d68825b80065e713809b1053/5552:1825",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -3954,19 +3070,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9607843160629272,
-            0.9843137264251709,
-            1
-          ],
+          "components": [0.9607843160629272, 0.9843137264251709, 1],
           "alpha": 1,
           "hex": "#F5FBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:29502f640095d5fd4bb72fb94eeab6f38d277641/5552:1837",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3974,19 +3084,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9215686321258545,
-            0.9647058844566345,
-            1
-          ],
+          "components": [0.9215686321258545, 0.9647058844566345, 1],
           "alpha": 1,
           "hex": "#EBF6FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:623d2b62739901dac0532f76b3c5bf1838085510/5552:1829",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -3994,19 +3098,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.7490196228027344,
-            0.8901960849761963,
-            1
-          ],
+          "components": [0.7490196228027344, 0.8901960849761963, 1],
           "alpha": 1,
           "hex": "#BFE3FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6fe83295c345ea1a08e8a6d1d18c36f7ba18cdfa/5552:1839",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4015,18 +3113,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.545098066329956,
-            0.7960784435272217,
-            0.9921568632125854
+            0.545098066329956, 0.7960784435272217, 0.9921568632125854
           ],
           "alpha": 1,
           "hex": "#8BCBFD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ef848afd37ff78a3dec080288e1bda7088048dbb/5552:1830",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4034,19 +3128,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.3803921639919281,
-            0.7254902124404907,
-            1
-          ],
+          "components": [0.3803921639919281, 0.7254902124404907, 1],
           "alpha": 1,
           "hex": "#61B9FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c979c3d7252a9fa7059c5ad76790bbfdababd1d1/5552:1835",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4054,19 +3142,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.5568627715110779,
-            0.9372549057006836
-          ],
+          "components": [0, 0.5568627715110779, 0.9372549057006836],
           "alpha": 1,
           "hex": "#008EEF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:eaef0062d45784de3131b1141b27506c72a24930/5552:1832",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4074,19 +3156,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.3607843220233917,
-            1
-          ],
+          "components": [0, 0.3607843220233917, 1],
           "alpha": 1,
           "hex": "#005CFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55911673a8ecd78c1b10cd53d382b7ff68b19605/5552:1838",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4095,18 +3171,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.01568627543747425,
-            0.2980392277240753,
-            0.800000011920929
+            0.01568627543747425, 0.2980392277240753, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#044CCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:766335509d8459678e695608c443d14e40d3d5a4/5552:1831",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4115,18 +3187,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.04313725605607033,
-            0.22745098173618317,
-            0.5529412031173706
+            0.04313725605607033, 0.22745098173618317, 0.5529412031173706
           ],
           "alpha": 1,
           "hex": "#0B3A8D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ed6e2dee9ecb22e7bd2ef5668f84314487e2da51/5552:1834",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4135,18 +3203,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0117647061124444,
-            0.1725490242242813,
-            0.4588235318660736
+            0.0117647061124444, 0.1725490242242813, 0.4588235318660736
           ],
           "alpha": 1,
           "hex": "#032C75"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:141ee1f779791c69940de7870af94c58164f8f16/5552:1833",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4155,18 +3219,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.007843137718737125,
-            0.10196078568696976,
-            0.2705882489681244
+            0.007843137718737125, 0.10196078568696976, 0.2705882489681244
           ],
           "alpha": 1,
           "hex": "#021A45"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0780249d743399b4ee42eb2480bd9a448f8b732e/5552:1836",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -4177,19 +3237,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 0.30000001192092896,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:88f7a75ec5b5029b1d9d2c5f79148adbd914f605/5552:1855",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4197,19 +3251,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 1,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:df039608ce704fb23149d725481966eae0435000/5552:1852",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -4219,18 +3267,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9882352948188782,
-            0.9921568632125854
+            0.9882352948188782, 0.9882352948188782, 0.9921568632125854
           ],
           "alpha": 1,
           "hex": "#FCFCFD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:26eccbd4c3cdf7b3951138a6432d8a2ad12e263d/5552:1853",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4239,18 +3283,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9764705896377563,
-            0.9764705896377563,
-            0.9921568632125854
+            0.9764705896377563, 0.9764705896377563, 0.9921568632125854
           ],
           "alpha": 1,
           "hex": "#F9F9FD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:201841acbd37debd72b70badb5e4d5203c68481f/5552:1845",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4259,18 +3299,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9686274528503418
+            0.9490196108818054, 0.9490196108818054, 0.9686274528503418
           ],
           "alpha": 1,
           "hex": "#F2F2F7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:cef0db927fe201637982109aa99d1af32e05b768/5552:1847",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4279,18 +3315,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9450980424880981
+            0.9215686321258545, 0.9215686321258545, 0.9450980424880981
           ],
           "alpha": 1,
           "hex": "#EBEBF1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:71fb555be3a14c728569112cec6f4f5a9f9b66ab/5552:1841",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4299,18 +3331,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9e780779c73acfa5a3c70c8b71ee30246f695b52/5552:1843",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4319,18 +3347,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7524305582046509,
-            0.7524305582046509,
-            0.8208333253860474
+            0.7524305582046509, 0.7524305582046509, 0.8208333253860474
           ],
           "alpha": 1,
           "hex": "#C0C0D1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1f5b46254073cb6eff1bee48dd69889d8076abff/5552:1846",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4339,18 +3363,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5647059082984924,
-            0.5647059082984924,
-            0.6392157077789307
+            0.5647059082984924, 0.5647059082984924, 0.6392157077789307
           ],
           "alpha": 1,
           "hex": "#9090A3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6c8fc692657a8d4730867d60c1e4f7377f899bce/5552:1848",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4359,18 +3379,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:89ce6a03a05cf006caf78b16a8f39be2a4e79aa7/5552:1840",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4379,18 +3395,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.29019609093666077,
-            0.29019609093666077,
-            0.35686275362968445
+            0.29019609093666077, 0.29019609093666077, 0.35686275362968445
           ],
           "alpha": 1,
           "hex": "#4A4A5B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:854436079b13a74f97b7601c754d0efa001a61b6/5552:1842",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4400,18 +3412,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.22745098173618317,
-              0.22745098173618317,
-              0.29019609093666077
+              0.22745098173618317, 0.22745098173618317, 0.29019609093666077
             ],
             "alpha": 0.6000000238418579,
             "hex": "#3A3A4A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:167e1820dfbe4725e6db027b42ceb5a9014c6735/5552:1856",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4420,18 +3428,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.22745098173618317,
-              0.22745098173618317,
-              0.29019609093666077
+              0.22745098173618317, 0.22745098173618317, 0.29019609093666077
             ],
             "alpha": 1,
             "hex": "#3A3A4A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:a625535441c5d884ddba489e3e29d825b09ec8dd/5552:1849",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -4441,18 +3445,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.12941177189350128,
-            0.125490203499794,
-            0.1764705926179886
+            0.12941177189350128, 0.125490203499794, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#21202D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:439e3c26315a280fc3dab017677fefad807f766d/5552:1850",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4461,18 +3461,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.08627451211214066,
-            0.125490203499794
+            0.08627451211214066, 0.08627451211214066, 0.125490203499794
           ],
           "alpha": 1,
           "hex": "#161620"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1514ec8348f7508663c404346b5d41bb76fa69fc/5552:1844",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4481,20 +3477,14 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.20000000298023224,
             "hex": "#000000"
           },
           "$description": "Screendimmer iOS26",
           "$extensions": {
             "com.figma.variableId": "VariableID:7a2a46ab4072af86c725b956efa3abd0d6afac55/5552:1857",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4502,19 +3492,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:32ab2d9beaeab39a289d33c85f9201693a67e02b/5552:1854",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4522,20 +3506,14 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.47999998927116394,
             "hex": "#000000"
           },
           "$description": "Screendimmer iOS26",
           "$extensions": {
             "com.figma.variableId": "VariableID:5202934cacd08e77b5388a98d279c0e5884f6140/5552:1858",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4543,19 +3521,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 1,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:750f77fd944b7330f9cd6e4ab8036ecb01b6cacf/5552:1851",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -4569,18 +3541,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.95686274766922,
-            0.9843137264251709,
-            0.9764705896377563
+            0.95686274766922, 0.9843137264251709, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#F4FBF9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7fc4fe10abfdcf3a69b5eeb4ad6c34febba285e3/5552:1979",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4589,18 +3557,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8666666746139526,
-            0.9490196108818054,
-            0.9254902005195618
+            0.8666666746139526, 0.9490196108818054, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#DDF2EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9a7037c3ab15b1dcb39776a4af69fee303878a75/5552:1978",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4609,18 +3573,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.9411764740943909,
-            0.9058823585510254
+            0.800000011920929, 0.9411764740943909, 0.9058823585510254
           ],
           "alpha": 1,
           "hex": "#CCF0E7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c6baa87538954f69183fa4011661bf19de8774f5/5552:1977",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4629,18 +3589,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6c2c8538c62924a180dad1b3d54a40099f299545/5552:1976",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4649,18 +3605,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:bd8891179ebf58ed6e512097609c889c8cc39e5d/5552:1975",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4669,18 +3621,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1411764770746231,
-            0.5882353186607361,
-            0.5529412031173706
+            0.1411764770746231, 0.5882353186607361, 0.5529412031173706
           ],
           "alpha": 1,
           "hex": "#24968D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8a1c0f06e698f26331f25abd15955a2f5d6370b8/5552:1974",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4688,20 +3636,14 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$description": "Seagreen",
         "$extensions": {
           "com.figma.variableId": "VariableID:aa80e244cf894230da8539976f50ad85c99d971a/5552:1973",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4710,18 +3652,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:61815eacc9cd20941ac95a12dd5cea656503097c/5552:1972",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4730,18 +3668,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b2ea2201579e5f403d1486dc569051579b27e17c/5552:1971",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4750,18 +3684,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.007843137718737125,
-            0.2235294133424759,
-            0.2235294133424759
+            0.007843137718737125, 0.2235294133424759, 0.2235294133424759
           ],
           "alpha": 1,
           "hex": "#023939"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:34d0d07d8dab2db79588e673d4ead841fa9dc615/5552:1970",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4769,19 +3699,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.20392157137393951,
-            0.24313725531101227
-          ],
+          "components": [0, 0.20392157137393951, 0.24313725531101227],
           "alpha": 1,
           "hex": "#00343E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:eed2549e38dc9f2115e3edaee9cbfe7acb70da1e/5552:1969",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4789,20 +3713,14 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.06666667014360428,
-            0.0784313753247261
-          ],
+          "components": [0, 0.06666667014360428, 0.0784313753247261],
           "alpha": 1,
           "hex": "#001114"
         },
         "$description": "Noir Green",
         "$extensions": {
           "com.figma.variableId": "VariableID:bf434ffe62ee0afc7a8f20ad0f0eea51841e935a/5552:1980",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -4813,19 +3731,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 0.800000011920929,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:4271618ec8d667324598897247f501d8a2d7e529/5552:2074",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -4833,19 +3745,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              1,
-              1
-            ],
+            "components": [1, 1, 1],
             "alpha": 1,
             "hex": "#FFFFFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:0a2ed12b144c66fd5e02892cd2f38bb2ca64d92b/5552:2073",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -4855,18 +3761,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.9803921580314636,
-            0.9803921580314636
+            0.9803921580314636, 0.9803921580314636, 0.9803921580314636
           ],
           "alpha": 1,
           "hex": "#FAFAFA"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d794300df8752766d808fee88d96a6cb4dbd99a0/5552:2072",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4875,18 +3777,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9725490212440491,
-            0.9725490212440491,
-            0.9725490212440491
+            0.9725490212440491, 0.9725490212440491, 0.9725490212440491
           ],
           "alpha": 1,
           "hex": "#F8F8F8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7c239d6a893c102375d3acdf4f94a9e4deaa4d41/5552:2071",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4895,18 +3793,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:fbf121f2d836ddf02ee03a8bffc0e8a5d5148ae3/5552:2070",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4915,18 +3809,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d2ced02c1c4ce7d4936841279aa0d225c1ed11ec/5552:2069",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4935,18 +3825,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:98d58800060f1a8d4c3cbe1bc513c58945ba70e4/5552:2068",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4955,18 +3841,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ebec85cb6837f974e76cec0f561f157f3085b873/5552:2067",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4975,18 +3857,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:64b1989952893e3183cb16d0516148218a07f288/5552:2066",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -4995,18 +3873,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.38823530077934265,
-            0.38823530077934265,
-            0.4000000059604645
+            0.38823530077934265, 0.38823530077934265, 0.4000000059604645
           ],
           "alpha": 1,
           "hex": "#636366"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:72e8d120c2c6e70e1414bb0c4e91975e19ce6bda/5552:2065",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5015,18 +3889,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2823529541492462,
-            0.2823529541492462,
-            0.29019609093666077
+            0.2823529541492462, 0.2823529541492462, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#48484A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:766b9bd4a60490bdaf0ff930942f2944de3527a3/5552:2064",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5035,18 +3905,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a2e8c4f27f4f50b8965e01c3ac01d4f836354c59/5552:2063",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5055,18 +3921,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1725490242242813,
-            0.1725490242242813,
-            0.18039216101169586
+            0.1725490242242813, 0.1725490242242813, 0.18039216101169586
           ],
           "alpha": 1,
           "hex": "#2C2C2E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:02f1a88d5b8fe839a66d12db37e9826427b44b4f/5552:2062",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5075,18 +3937,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10980392247438431,
-            0.11764705926179886
+            0.10980392247438431, 0.10980392247438431, 0.11764705926179886
           ],
           "alpha": 1,
           "hex": "#1C1C1E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:590bc1b2dcb676b3fdd2ab82aa0e19cf493d4abb/5552:2061",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5095,19 +3953,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.05000000074505806,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:f9701d39b786424fce60f7aea4ab00547523e73c/5552:2077",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -5115,19 +3967,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.10000000149011612,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:f245f101a1ff9981cddc6ef5bfdbae2b1d81dfab/5552:2078",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -5135,19 +3981,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b472f18179ab446282a9cfcfa058469bfa528751/5552:2075",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -5155,19 +3995,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.5,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:c806e6a76d9ad25c958081198c3316b2417a4b84/5552:2076",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -5175,19 +4009,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 1,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:6203c0169bd780b9bf062d88a9bafdf0796de04e/5552:2060",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -5199,18 +4027,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.929411768913269,
-            0.9215686321258545
+            0.9882352948188782, 0.929411768913269, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#FCEDEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c42c9489c4dcf5115e297a0d570479bafa257137/5552:2002",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5218,19 +4042,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8705882430076599,
-            0.8588235378265381
-          ],
+          "components": [1, 0.8705882430076599, 0.8588235378265381],
           "alpha": 1,
           "hex": "#FFDEDB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:454c65625e8a052cb24289fcb38aee55d1bfc922/5552:2001",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5239,18 +4057,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9411764740943909,
-            0.7803921699523926,
-            0.772549033164978
+            0.9411764740943909, 0.7803921699523926, 0.772549033164978
           ],
           "alpha": 1,
           "hex": "#F0C7C5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5dee8c16ea80f09bc9523dfdb2623617a8b35629/5552:2000",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5259,18 +4073,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.886274516582489,
-            0.6352941393852234,
-            0.6470588445663452
+            0.886274516582489, 0.6352941393852234, 0.6470588445663452
           ],
           "alpha": 1,
           "hex": "#E2A2A5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ed1865053b7cfc1b00244ff93b7895c6228e393a/5552:1999",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5279,18 +4089,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8039215803146362,
-            0.5098039507865906,
-            0.5333333611488342
+            0.8039215803146362, 0.5098039507865906, 0.5333333611488342
           ],
           "alpha": 1,
           "hex": "#CD8288"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a1bbe1997abecdffd9dd27a4b1629c786b590d9e/5552:1998",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5299,18 +4105,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7137255072593689,
-            0.4274509847164154,
-            0.45098039507865906
+            0.7137255072593689, 0.4274509847164154, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#B66D73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:bc9a6d38b04bfef3fe9e821bacea0c2bc466b934/5552:1997",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5319,18 +4121,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.250980406999588,
-            0.2862745225429535
+            0.5568627715110779, 0.250980406999588, 0.2862745225429535
           ],
           "alpha": 1,
           "hex": "#8E4049"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:544f3e8e8afe4608d2ca17ec14ed6f20067a4c5b/5552:1996",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5339,18 +4137,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5176470875740051,
-            0.2666666805744171,
-            0.29019609093666077
+            0.5176470875740051, 0.2666666805744171, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#84444A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:470424c2ebee51b83b5e2d21e870a03844036306/5552:1995",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5359,18 +4153,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.41960784792900085,
-            0.1921568661928177,
-            0.21176470816135406
+            0.41960784792900085, 0.1921568661928177, 0.21176470816135406
           ],
           "alpha": 1,
           "hex": "#6B3136"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62d4a3da6788677a85c40fbae5fb34cdc9c46df2/5552:1994",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5378,19 +4168,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.3607843220233917,
-            0,
-            0.13333334028720856
-          ],
+          "components": [0.3607843220233917, 0, 0.13333334028720856],
           "alpha": 1,
           "hex": "#5C0022"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:c68f36aa93c3aff829b88b06fb1ca1f297a05dd1/5552:1993",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5398,19 +4182,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.1411764770746231,
-            0,
-            0.05098039284348488
-          ],
+          "components": [0.1411764770746231, 0, 0.05098039284348488],
           "alpha": 1,
           "hex": "#24000D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:dc2d8a4deb13b13fa1b5db1989e7b63780c30547/5552:1992",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -5421,18 +4199,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.9843137264251709,
-            0.9764705896377563
+            0.9921568632125854, 0.9843137264251709, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#FDFBF9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1a09367ad46cdc4592c9ebeba0473dedb96acfe0/5552:2013",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5441,18 +4215,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.95686274766922,
-            0.9411764740943909
+            0.9803921580314636, 0.95686274766922, 0.9411764740943909
           ],
           "alpha": 1,
           "hex": "#FAF4F0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5186cf5a0b3ffed0d27f663426d5e8f62c92d35f/5552:2012",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5461,9 +4231,7 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.9176470637321472,
-            0.8941176533699036
+            0.9647058844566345, 0.9176470637321472, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#F6EAE4"
@@ -5471,9 +4239,7 @@
         "$description": "Classic Beige",
         "$extensions": {
           "com.figma.variableId": "VariableID:6590d77b4de2c74f675179634f03d03a2b8833e0/5552:2011",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5482,18 +4248,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8588235378265381,
-            0.8039215803146362,
-            0.772549033164978
+            0.8588235378265381, 0.8039215803146362, 0.772549033164978
           ],
           "alpha": 1,
           "hex": "#DBCDC5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ef3cc71083e94fd28a3f2c8e7e5465602a6f9176/5552:2010",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5502,18 +4264,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7960784435272217,
-            0.7098039388656616,
-            0.6666666865348816
+            0.7960784435272217, 0.7098039388656616, 0.6666666865348816
           ],
           "alpha": 1,
           "hex": "#CBB5AA"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2f8be37edb8fe0d2f16e44635d9ac55d2e23d38d/5552:2009",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5522,18 +4280,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7098039388656616,
-            0.6313725709915161,
-            0.5921568870544434
+            0.7098039388656616, 0.6313725709915161, 0.5921568870544434
           ],
           "alpha": 1,
           "hex": "#B5A197"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:33eb45c9cccdc9f607ed8a28486f78369d09ca75/5552:2008",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5542,18 +4296,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6235294342041016,
-            0.5529412031173706,
-            0.5176470875740051
+            0.6235294342041016, 0.5529412031173706, 0.5176470875740051
           ],
           "alpha": 1,
           "hex": "#9F8D84"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a10d75f6849b5b4f4fd7346be7df7e19b0bc235f/5552:2007",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5562,18 +4312,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5372549295425415,
-            0.4745098054409027,
-            0.4431372582912445
+            0.5372549295425415, 0.4745098054409027, 0.4431372582912445
           ],
           "alpha": 1,
           "hex": "#897971"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:cc547a3c7594fc73c09f63a6bfc228a4ca6b435b/5552:2006",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5582,18 +4328,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.3960784375667572,
-            0.3686274588108063
+            0.45098039507865906, 0.3960784375667572, 0.3686274588108063
           ],
           "alpha": 1,
           "hex": "#73655E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:dd8830bab3b10b8a32fa054edae10fb482688d8c/5552:2005",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5602,18 +4344,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3686274588108063,
-            0.32156863808631897,
-            0.2980392277240753
+            0.3686274588108063, 0.32156863808631897, 0.2980392277240753
           ],
           "alpha": 1,
           "hex": "#5E524C"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1736c467c709a08cc199f80eca1f44bb503ffecc/5552:2004",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5622,18 +4360,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.29019609093666077,
-            0.24705882370471954,
-            0.22745098173618317
+            0.29019609093666077, 0.24705882370471954, 0.22745098173618317
           ],
           "alpha": 1,
           "hex": "#4A3F3A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d456b16160aca5c81399b57473085ec76915aeed/5552:2003",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -5644,18 +4378,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2e2b5b366990ea6cfc16803758f41ffe11b1a3e2/5552:2059",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5664,18 +4394,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:940125b24d466d56479286e386bb1ccef61b5611/5552:2058",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5684,18 +4410,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8039215803146362,
-            0.8588235378265381,
-            0.95686274766922
+            0.8039215803146362, 0.8588235378265381, 0.95686274766922
           ],
           "alpha": 1,
           "hex": "#CDDBF4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d6a17fa17daf97574f54c3eaaff697cef0139be9/5552:2057",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5704,18 +4426,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6627451181411743,
-            0.7529411911964417,
-            0.9372549057006836
+            0.6627451181411743, 0.7529411911964417, 0.9372549057006836
           ],
           "alpha": 1,
           "hex": "#A9C0EF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:d9b278eaa4dfc61d38071e43e0234ed49bd84e5a/5552:2056",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5724,18 +4442,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4901960790157318,
-            0.6431372761726379,
-            0.9098039269447327
+            0.4901960790157318, 0.6431372761726379, 0.9098039269447327
           ],
           "alpha": 1,
           "hex": "#7DA4E8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:cee899205158f9bcf857b2729a3c9be9b6a8baab/5552:2055",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5744,18 +4458,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.27843138575553894,
-            0.5176470875740051,
-            0.8823529481887817
+            0.27843138575553894, 0.5176470875740051, 0.8823529481887817
           ],
           "alpha": 1,
           "hex": "#4784E1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6b7f69b9f5cee9539111e076e60e73a5fd4788d3/5552:2054",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5764,18 +4474,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:df6f47e13fdd4c9db05213cc34b7230e772da1a7/5552:2053",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5784,18 +4490,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.09803921729326248,
-            0.3333333432674408,
-            0.6627451181411743
+            0.09803921729326248, 0.3333333432674408, 0.6627451181411743
           ],
           "alpha": 1,
           "hex": "#1955A9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:272d20285293d055a713a18447db03fd14c86ff7/5552:2052",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5804,18 +4506,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08235294371843338,
-            0.24705882370471954,
-            0.49803921580314636
+            0.08235294371843338, 0.24705882370471954, 0.49803921580314636
           ],
           "alpha": 1,
           "hex": "#153F7F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:70b793de2557bea3fdf72603b28a413cfb7e968a/5552:2051",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5824,18 +4522,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.1921568661928177,
-            0.3529411852359772
+            0.08627451211214066, 0.1921568661928177, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#16315A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:69351684da0e11eb8e84bf8782d476088a7553ae/5552:2050",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5844,18 +4538,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08235294371843338,
-            0.14901961386203766,
-            0.250980406999588
+            0.08235294371843338, 0.14901961386203766, 0.250980406999588
           ],
           "alpha": 1,
           "hex": "#152640"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:aebfb3d26b82bdc09b569db4d68abf60066e1f07/5552:2049",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -5866,18 +4556,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:bde376ba3ee513ac64b4fab7b1bb0df51c21740b/5552:1991",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5886,18 +4572,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8627451062202454,
-            0.9529411792755127,
-            0.9098039269447327
+            0.8627451062202454, 0.9529411792755127, 0.9098039269447327
           ],
           "alpha": 1,
           "hex": "#DCF3E8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:974fc2df153c89ec4060d9e497fe5a9862998f16/5552:1990",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5906,18 +4588,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7882353067398071,
-            0.9411764740943909,
-            0.8666666746139526
+            0.7882353067398071, 0.9411764740943909, 0.8666666746139526
           ],
           "alpha": 1,
           "hex": "#C9F0DD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:9b39dadbf93f64135e2dddc81b2981bae8a120f4/5552:1989",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5926,18 +4604,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7254902124404907,
-            0.9058823585510254,
-            0.8078431487083435
+            0.7254902124404907, 0.9058823585510254, 0.8078431487083435
           ],
           "alpha": 1,
           "hex": "#B9E7CE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:67fce4b9f31f59bc1b5f6db3d0f7f83f3fa46cde/5552:1988",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5946,18 +4620,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5333333611488342,
-            0.8549019694328308,
-            0.7019608020782471
+            0.5333333611488342, 0.8549019694328308, 0.7019608020782471
           ],
           "alpha": 1,
           "hex": "#88DAB3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6577c03939fe45aee424d4149d47bf70a2919355/5552:1987",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5966,18 +4636,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2801666557788849,
-            0.8199999928474426,
-            0.593269944190979
+            0.2801666557788849, 0.8199999928474426, 0.593269944190979
           ],
           "alpha": 1,
           "hex": "#47D197"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:3b4085a1094a2019e689bb34d2918a9f82377438/5552:1986",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -5986,18 +4652,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1568627506494522,
-            0.7058823704719543,
-            0.5098039507865906
+            0.1568627506494522, 0.7058823704719543, 0.5098039507865906
           ],
           "alpha": 1,
           "hex": "#28B482"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f88c50802ab59c0619985065cdb4ded79a364102/5552:1985",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6005,19 +4667,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:12f24b34c6b753bcc239aab1796cf39df5eae6de/5552:1984",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6025,19 +4681,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.34583333134651184,
-            0.26429539918899536
-          ],
+          "components": [0, 0.34583333134651184, 0.26429539918899536],
           "alpha": 1,
           "hex": "#005843"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:40dbacc04b96afc5d9d5b7a1c12bbed125c34dac/5552:1983",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6046,18 +4696,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.05098039284348488,
-            0.27450981736183167,
-            0.21568627655506134
+            0.05098039284348488, 0.27450981736183167, 0.21568627655506134
           ],
           "alpha": 1,
           "hex": "#0D4637"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f15c86979dc81ca15cd817b9c0b65c836acf8232/5552:1982",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6066,18 +4712,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.20392157137393951,
-            0.1764705926179886
+            0.10980392247438431, 0.20392157137393951, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#1C342D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:4ab849a818fe51ca06cad91f386c569ae7034387/5552:1981",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -6088,18 +4730,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:2de8e4757924f0cbd399cb36d2d88b486e49b212/5552:2047",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6108,18 +4746,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.8666666746139526,
-            0.8666666746139526
+            0.9882352948188782, 0.8666666746139526, 0.8666666746139526
           ],
           "alpha": 1,
           "hex": "#FCDDDD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:ba6886ab368e102f31fee761ab3788b17e4a416c/5552:2046",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6128,18 +4762,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.8039215803146362,
-            0.8039215803146362
+            0.9803921580314636, 0.8039215803146362, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#FACDCD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:6b71bac1329da580371fc087c05de66963e40376/5552:2045",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6148,18 +4778,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.6745098233222961,
-            0.6745098233222961
+            0.9843137264251709, 0.6745098233222961, 0.6745098233222961
           ],
           "alpha": 1,
           "hex": "#FBACAC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b47d0d51b498c71311e166ad2f30062f936fa846/5552:2044",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6168,18 +4794,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.5333333611488342,
-            0.5333333611488342
+            0.9647058844566345, 0.5333333611488342, 0.5333333611488342
           ],
           "alpha": 1,
           "hex": "#F68888"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:1754f7b0b98a38169d11ed7814a2738cb9def1e2/5552:2043",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6188,18 +4810,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9300000071525574,
-            0.29760000109672546,
-            0.29760000109672546
+            0.9300000071525574, 0.29760000109672546, 0.29760000109672546
           ],
           "alpha": 1,
           "hex": "#ED4C4C"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:03c1b4562f3222e414df3b5730c93db305c3341c/5552:2042",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6209,18 +4827,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8352941274642944,
-              0.14509804546833038,
-              0.14509804546833038
+              0.8352941274642944, 0.14509804546833038, 0.14509804546833038
             ],
             "alpha": 0.4000000059604645,
             "hex": "#D52525"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:1630a6af8fe1661ef75aa20095f61e12ef8103cc/5552:2048",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -6229,18 +4843,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8352941274642944,
-              0.14509804546833038,
-              0.14509804546833038
+              0.8352941274642944, 0.14509804546833038, 0.14509804546833038
             ],
             "alpha": 1,
             "hex": "#D52525"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:b6672aa9af52eaba97ed6f81a4b0f3234aaef571/5552:2041",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -6250,18 +4860,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6980392336845398,
-            0.11764705926179886,
-            0.11764705926179886
+            0.6980392336845398, 0.11764705926179886, 0.11764705926179886
           ],
           "alpha": 1,
           "hex": "#B21E1E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:08d3914002f721e0549e9da5e588c93a6b8567c5/5552:2040",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6270,18 +4876,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.47843137383461,
-            0.07450980693101883,
-            0.07450980693101883
+            0.47843137383461, 0.07450980693101883, 0.07450980693101883
           ],
           "alpha": 1,
           "hex": "#7A1313"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:68b6d8b656ad8cd50c33fdd54b4ecb88e8948b69/5552:2039",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6290,18 +4892,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.33000001311302185,
-            0.08250000327825546,
-            0.08250000327825546
+            0.33000001311302185, 0.08250000327825546, 0.08250000327825546
           ],
           "alpha": 1,
           "hex": "#541515"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:791402524271a5d9a273711435c13e2eea0f79ef/5552:2038",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6310,18 +4908,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.250980406999588,
-            0.10196078568696976,
-            0.10196078568696976
+            0.250980406999588, 0.10196078568696976, 0.10196078568696976
           ],
           "alpha": 1,
           "hex": "#401A1A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:a56f262898eb8ef0425bfe0db391a43f17bb70d1/5552:2037",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -6332,18 +4926,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7fadd7537df85c5ad5eae08f103243b783b4e191/5552:2024",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6352,18 +4942,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.95686274766922,
-            0.8784313797950745
+            0.9921568632125854, 0.95686274766922, 0.8784313797950745
           ],
           "alpha": 1,
           "hex": "#FDF4E0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:0f6d2071a5aa8484476495d29735dd0d2314c6dc/5552:2023",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6371,19 +4957,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.929411768913269,
-            0.7843137383460999
-          ],
+          "components": [1, 0.929411768913269, 0.7843137383460999],
           "alpha": 1,
           "hex": "#FFEDC8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:cf0d46fba708040d024d217ccb7ea053d22a2fd7/5552:2022",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6392,18 +4972,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.8823529481887817,
-            0.6627451181411743
+            0.9882352948188782, 0.8823529481887817, 0.6627451181411743
           ],
           "alpha": 1,
           "hex": "#FCE1A9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:3aa195522c5a3c2ea178e91c599c9827fd1d4065/5552:2021",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6412,18 +4988,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9803921580314636,
-            0.8235294222831726,
-            0.501960813999176
+            0.9803921580314636, 0.8235294222831726, 0.501960813999176
           ],
           "alpha": 1,
           "hex": "#FAD280"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:944334a3c37b6f72f4bc098baec47f9aa134b51b/5552:2020",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6432,18 +5004,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7cf0e8c452c05056a06fa08ead39b3db17897a2a/5552:2019",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6452,18 +5020,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.5921568870544434,
-            0.062745101749897
+            0.8509804010391235, 0.5921568870544434, 0.062745101749897
           ],
           "alpha": 1,
           "hex": "#D99710"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:b71c63c1811ccb624cace33196c15214d32ff2ef/5552:2018",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6472,18 +5036,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7019608020782471,
-            0.48235294222831726,
-            0.027450980618596077
+            0.7019608020782471, 0.48235294222831726, 0.027450980618596077
           ],
           "alpha": 1,
           "hex": "#B37B07"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:5344ecf0814a33b925abe3c4a710d1ddc0c2f2dd/5552:2017",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6492,18 +5052,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.501960813999176,
-            0.35686275362968445,
-            0.054901961237192154
+            0.501960813999176, 0.35686275362968445, 0.054901961237192154
           ],
           "alpha": 1,
           "hex": "#805B0E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:bbdecc4ed1e645b3d233a13bf204e3a2cdd38c96/5552:2016",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6512,18 +5068,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.37254902720451355,
-            0.2705882489681244,
-            0.05882352963089943
+            0.37254902720451355, 0.2705882489681244, 0.05882352963089943
           ],
           "alpha": 1,
           "hex": "#5F450F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:05a528aee263618114e8f377efd773bb23b03c6e/5552:2015",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6532,18 +5084,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.239215686917305,
-            0.18039216101169586,
-            0.05882352963089943
+            0.239215686917305, 0.18039216101169586, 0.05882352963089943
           ],
           "alpha": 1,
           "hex": "#3D2E0F"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:eaa2fdc215ae5580959d9cff84ae122a3760909e/5552:2014",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }
@@ -6553,19 +5101,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9490196108818054,
-            0.9490196108818054
-          ],
+          "components": [1, 0.9490196108818054, 0.9490196108818054],
           "alpha": 1,
           "hex": "#FFF2F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:85f2218d275c14406d38a380396fc06c3e5499e2/5552:2035",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6573,19 +5115,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9176470637321472,
-            0.8784313797950745
-          ],
+          "components": [1, 0.9176470637321472, 0.8784313797950745],
           "alpha": 1,
           "hex": "#FFEAE0"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:00a5b20d58f88d078ba3bde3de456476f512bf24/5552:2034",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6593,19 +5129,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8666666746139526,
-            0.800000011920929
-          ],
+          "components": [1, 0.8666666746139526, 0.800000011920929],
           "alpha": 1,
           "hex": "#FFDDCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:3c7f3a4253f359054581d8310834c7341c6525e8/5552:2033",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6613,19 +5143,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.7333333492279053,
-            0.6000000238418579
-          ],
+          "components": [1, 0.7333333492279053, 0.6000000238418579],
           "alpha": 1,
           "hex": "#FFBB99"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:7ee0880e10de091b02c69600cdcb8d23f4b98e93/5552:2032",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6633,19 +5157,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.5960784554481506,
-            0.4000000059604645
-          ],
+          "components": [1, 0.5960784554481506, 0.4000000059604645],
           "alpha": 1,
           "hex": "#FF9866"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:19b65efa5b85c598ae9485f2cc50b3d92ae71643/5552:2031",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6653,19 +5171,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.4627451002597809,
-            0.20000000298023224
-          ],
+          "components": [1, 0.4627451002597809, 0.20000000298023224],
           "alpha": 1,
           "hex": "#FF7633"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:3b1c86e0c887ffd89d48b59be7e77efef67effe1/5552:2030",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6675,18 +5187,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9254902005195618,
-              0.3803921639919281,
-              0.16470588743686676
+              0.9254902005195618, 0.3803921639919281, 0.16470588743686676
             ],
             "alpha": 0.4000000059604645,
             "hex": "#EC612A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:79e661ca16f19d57ced2464224a4fffd3b5ca499/5552:2036",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         },
@@ -6694,19 +5202,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.3294117748737335,
-              0
-            ],
+            "components": [1, 0.3294117748737335, 0],
             "alpha": 1,
             "hex": "#FF5400"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:90e742619c18601e63f2485d750bb6187961aa71/5552:2029",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.isOverride": true
           }
         }
@@ -6715,19 +5217,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.800000011920929,
-            0.26274511218070984,
-            0
-          ],
+          "components": [0.800000011920929, 0.26274511218070984, 0],
           "alpha": 1,
           "hex": "#CC4300"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:13bb94ed08ba9a3e6d094ebd4b4448712b326dde/5552:2028",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6735,19 +5231,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.6000000238418579,
-            0.19607843458652496,
-            0
-          ],
+          "components": [0.6000000238418579, 0.19607843458652496, 0],
           "alpha": 1,
           "hex": "#993200"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:8857828ebb83de183cd88ad7f18c7f381ccb61a0/5552:2027",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6756,18 +5246,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.4000000059604645,
-            0.14509804546833038,
-            0.019607843831181526
+            0.4000000059604645, 0.14509804546833038, 0.019607843831181526
           ],
           "alpha": 1,
           "hex": "#662505"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:769eadf226099aa704339d5238af6da1672f7c03/5552:2026",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       },
@@ -6776,18 +5262,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3019607961177826,
-            0.11764705926179886,
-            0.0313725508749485
+            0.3019607961177826, 0.11764705926179886, 0.0313725508749485
           ],
           "alpha": 1,
           "hex": "#4D1E08"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:f99ed5fc4b384e0e16c1821f25bc8ea4d2f3731a/5552:2025",
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.isOverride": true
         }
       }

--- a/packages/dnb-eufemia/src/style/themes/figma/dnb-light.tokens.json
+++ b/packages/dnb-eufemia/src/style/themes/figma/dnb-light.tokens.json
@@ -5,20 +5,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1280",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-page-background"
           },
@@ -35,20 +28,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1283",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action"
           },
@@ -65,20 +51,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:706",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover"
           },
@@ -96,19 +75,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.9529411792755127,
-            0.9254902005195618
+            0.8470588326454163, 0.9529411792755127, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#D8F3EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11711",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle"
           },
@@ -126,19 +100,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:708",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed"
           },
@@ -156,19 +125,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7372549176216125,
-            0.9098039269447327,
-            0.8627451062202454
+            0.7372549176216125, 0.9098039269447327, 0.8627451062202454
           ],
           "alpha": 1,
           "hex": "#BCE8DC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11713",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle"
           },
@@ -186,19 +150,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:2187",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus"
           },
@@ -216,19 +175,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus-subtle"
           },
@@ -246,19 +200,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled"
           },
@@ -276,19 +225,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:13725",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-inverse"
           },
@@ -306,19 +250,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17036",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-inverse"
           },
@@ -336,19 +275,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.007843137718737125,
-            0.2235294133424759,
-            0.2235294133424759
+            0.007843137718737125, 0.2235294133424759, 0.2235294133424759
           ],
           "alpha": 1,
           "hex": "#023939"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17069",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-inverse"
           },
@@ -366,19 +300,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17070",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-inverse"
           },
@@ -396,19 +325,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11718",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-ondark"
           },
@@ -426,19 +350,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56032:1390",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-ondark"
           },
@@ -456,19 +375,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3792",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-ondark"
           },
@@ -486,19 +400,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55892:2104",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-ondark"
           },
@@ -516,19 +425,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3877",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-ondark"
           },
@@ -546,19 +450,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2823529541492462,
-            0.2823529541492462,
-            0.29019609093666077
+            0.2823529541492462, 0.2823529541492462, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#48484A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1906",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled-ondark"
           },
@@ -576,19 +475,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11719",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative"
           },
@@ -606,19 +500,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11722",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative-hover-subtle"
           },
@@ -636,19 +525,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected"
           },
@@ -666,19 +550,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8941176533699036,
-            0.9333333373069763,
-            0.843137264251709
+            0.8941176533699036, 0.9333333373069763, 0.843137264251709
           ],
           "alpha": 1,
           "hex": "#E4EED7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11723",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle"
           },
@@ -696,19 +575,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.9529411792755127,
-            0.9254902005195618
+            0.8470588326454163, 0.9529411792755127, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#D8F3EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1727",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-ondark"
           },
@@ -726,19 +600,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.05098039284348488,
-            0.27450981736183167,
-            0.21568627655506134
+            0.05098039284348488, 0.27450981736183167, 0.21568627655506134
           ],
           "alpha": 1,
           "hex": "#0D4637"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1728",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle-ondark"
           },
@@ -755,20 +624,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1287",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral"
           },
@@ -785,20 +647,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1289",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-static"
           },
@@ -816,19 +671,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9725490212440491,
-            0.9725490212440491,
-            0.9725490212440491
+            0.9725490212440491, 0.9725490212440491, 0.9725490212440491
           ],
           "alpha": 1,
           "hex": "#F8F8F8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1290",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-subtle"
           },
@@ -846,19 +696,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1294",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-base"
           },
@@ -876,19 +721,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37606",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-bold"
           },
@@ -906,19 +746,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-alternative"
           },
@@ -935,20 +770,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1302",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info"
           },
@@ -966,19 +794,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.95686274766922,
-            0.9254902005195618
+            0.9490196108818054, 0.95686274766922, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#F2F4EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1304",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info-subtle"
           },
@@ -995,20 +818,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1296",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive"
           },
@@ -1026,19 +842,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1299",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive-subtle"
           },
@@ -1056,19 +867,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1307",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning"
           },
@@ -1086,19 +892,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1310",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning-subtle"
           },
@@ -1116,19 +917,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1313",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error"
           },
@@ -1146,19 +942,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1318",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error-subtle"
           },
@@ -1176,19 +967,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1324",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing"
           },
@@ -1206,19 +992,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:19893",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing-subtle"
           },
@@ -1237,19 +1018,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1327",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action"
           },
@@ -1266,19 +1041,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:923",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover"
           },
@@ -1296,18 +1065,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:924",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed"
           },
@@ -1325,18 +1090,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:721",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-focus"
           },
@@ -1354,18 +1115,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:925",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled"
           },
@@ -1383,18 +1140,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-inverse"
           },
@@ -1412,18 +1165,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17057",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-inverse"
           },
@@ -1441,18 +1190,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17062",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-inverse"
           },
@@ -1470,18 +1215,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1331",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-selected"
           },
@@ -1499,18 +1240,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1344",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-ondark"
           },
@@ -1528,18 +1265,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1118",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-ondark"
           },
@@ -1557,18 +1290,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1120",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-ondark"
           },
@@ -1586,18 +1315,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1907",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled-ondark"
           },
@@ -1614,19 +1339,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:722",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-alternative-ondark"
           },
@@ -1644,18 +1363,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1316",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral"
           },
@@ -1673,18 +1388,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:57035:13480",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-onlight"
           },
@@ -1702,18 +1413,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1318",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-alternative"
           },
@@ -1730,19 +1437,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1321",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-inverse"
           },
@@ -1759,19 +1460,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1322",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-ondark"
           },
@@ -1789,18 +1484,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1324",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle"
           },
@@ -1818,18 +1509,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1326",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle-ondark"
           },
@@ -1847,18 +1534,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive"
           },
@@ -1875,19 +1558,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.3294117748737335,
-            0
-          ],
+          "components": [1, 0.3294117748737335, 0],
           "alpha": 1,
           "hex": "#FF5400"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87730",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive-inverse"
           },
@@ -1905,18 +1582,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.501960813999176,
-            0.35686275362968445,
-            0.054901961237192154
+            0.501960813999176, 0.35686275362968445, 0.054901961237192154
           ],
           "alpha": 1,
           "hex": "#805B0E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54378:4457",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning"
           },
@@ -1934,18 +1607,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87731",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning-inverse"
           },
@@ -1962,19 +1631,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1330",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive"
           },
@@ -1992,18 +1655,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1568627506494522,
-            0.7058823704719543,
-            0.5098039507865906
+            0.1568627506494522, 0.7058823704719543, 0.5098039507865906
           ],
           "alpha": 1,
           "hex": "#28B482"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87732",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive-inverse"
           },
@@ -2022,20 +1681,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1332",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action"
           },
@@ -2052,20 +1704,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:723",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover"
           },
@@ -2083,19 +1728,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:724",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed"
           },
@@ -2113,19 +1753,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:725",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-focus"
           },
@@ -2143,19 +1778,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:929",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled"
           },
@@ -2173,19 +1803,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1333",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-inverse"
           },
@@ -2203,19 +1828,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17059",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-inverse"
           },
@@ -2233,19 +1853,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17060",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-inverse"
           },
@@ -2263,19 +1878,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1334",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected"
           },
@@ -2293,19 +1903,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.9529411792755127,
-            0.9254902005195618
+            0.8470588326454163, 0.9529411792755127, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#D8F3EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1726",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected-ondark"
           },
@@ -2323,19 +1928,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53696:1314",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-ondark"
           },
@@ -2352,20 +1952,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1902",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-alternative-ondark"
           },
@@ -2383,19 +1976,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1119",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-ondark"
           },
@@ -2413,19 +2001,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1121",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-ondark"
           },
@@ -2443,19 +2026,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1908",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled-ondark"
           },
@@ -2473,19 +2051,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1335",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral"
           },
@@ -2503,19 +2076,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:16166",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-static"
           },
@@ -2532,20 +2100,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1337",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-inverse"
           },
@@ -2562,20 +2123,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1338",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-ondark"
           },
@@ -2593,19 +2147,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1340",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-alternative"
           },
@@ -2623,19 +2172,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1341",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-destructive"
           },
@@ -2652,20 +2196,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1993",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info"
           },
@@ -2683,19 +2220,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.95686274766922,
-            0.9254902005195618
+            0.9490196108818054, 0.95686274766922, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#F2F4EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1990",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info-subtle"
           },
@@ -2712,20 +2244,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1988",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive"
           },
@@ -2743,19 +2268,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive-subtle"
           },
@@ -2773,19 +2293,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1992",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning"
           },
@@ -2803,19 +2318,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning-subtle"
           },
@@ -2833,19 +2343,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1989",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error"
           },
@@ -2863,19 +2368,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1991",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error-subtle"
           },
@@ -2893,19 +2393,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1321",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing"
           },
@@ -2923,19 +2418,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1985",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing-subtle"
           },
@@ -2954,19 +2444,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:712",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action"
           },
@@ -2984,18 +2468,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12503",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative"
           },
@@ -3012,19 +2492,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:726",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover"
           },
@@ -3042,18 +2516,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0784313753247261,
-            0.3333333432674408,
-            0.3529411852359772
+            0.0784313753247261, 0.3333333432674408, 0.3529411852359772
           ],
           "alpha": 1,
           "hex": "#14555A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:727",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed"
           },
@@ -3071,18 +2541,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6980",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-inverse"
           },
@@ -3100,18 +2566,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17064",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-inverse"
           },
@@ -3129,18 +2591,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17063",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-inverse"
           },
@@ -3158,18 +2616,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:729",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus"
           },
@@ -3187,18 +2641,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12504",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus-subtle"
           },
@@ -3216,18 +2666,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:931",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled"
           },
@@ -3245,18 +2691,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0313725508749485,
-            0.2705882489681244,
-            0.3019607961177826
+            0.0313725508749485, 0.2705882489681244, 0.3019607961177826
           ],
           "alpha": 1,
           "hex": "#08454D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:714",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected"
           },
@@ -3274,18 +2716,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.9529411792755127,
-            0.9254902005195618
+            0.8470588326454163, 0.9529411792755127, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#D8F3EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected-ondark"
           },
@@ -3303,18 +2741,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12973",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-ondark"
           },
@@ -3332,18 +2766,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1917",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative-ondark"
           },
@@ -3361,18 +2791,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6470588445663452,
-            0.8823529481887817,
-            0.8235294222831726
+            0.6470588445663452, 0.8823529481887817, 0.8235294222831726
           ],
           "alpha": 1,
           "hex": "#A5E1D2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6981",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-ondark"
           },
@@ -3390,18 +2816,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3607843220233917,
-            0.7411764860153198,
-            0.6784313917160034
+            0.3607843220233917, 0.7411764860153198, 0.6784313917160034
           ],
           "alpha": 1,
           "hex": "#5CBDAD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6982",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-ondark"
           },
@@ -3419,18 +2841,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.38823530077934265,
-            0.38823530077934265,
-            0.4000000059604645
+            0.38823530077934265, 0.38823530077934265, 0.4000000059604645
           ],
           "alpha": 1,
           "hex": "#636366"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1909",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled-ondark"
           },
@@ -3448,18 +2866,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:718",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral"
           },
@@ -3476,19 +2890,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:719",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-ondark"
           },
@@ -3506,18 +2914,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:720",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-subtle"
           },
@@ -3535,18 +2939,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37609",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-bold"
           },
@@ -3564,18 +2964,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4988",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-alternative"
           },
@@ -3592,19 +2988,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:722",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-info"
           },
@@ -3621,19 +3011,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54483:254295",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-positive"
           },
@@ -3651,18 +3035,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:723",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-warning"
           },
@@ -3680,18 +3060,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:724",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-error"
           },
@@ -3709,18 +3085,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-marketing"
           },
@@ -3741,18 +3113,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8470588326454163,
-              0.9529411792755127,
-              0.9254902005195618
+              0.8470588326454163, 0.9529411792755127, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#D8F3EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6395",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted"
             },
@@ -3770,18 +3138,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8470588326454163,
-              0.9529411792755127,
-              0.9254902005195618
+              0.8470588326454163, 0.9529411792755127, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#D8F3EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6397",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted-static"
             },
@@ -3799,18 +3163,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 1,
             "hex": "#A5E1D2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6398",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle"
             },
@@ -3828,18 +3188,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 1,
             "hex": "#A5E1D2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6400",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle-static"
             },
@@ -3857,18 +3213,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.29019609093666077,
-              0.5803921818733215,
-              0.5529412031173706
+              0.29019609093666077, 0.5803921818733215, 0.5529412031173706
             ],
             "alpha": 1,
             "hex": "#4A948D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6401",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base"
             },
@@ -3886,18 +3238,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.29019609093666077,
-              0.5803921818733215,
-              0.5529412031173706
+              0.29019609093666077, 0.5803921818733215, 0.5529412031173706
             ],
             "alpha": 1,
             "hex": "#4A948D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6405",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base-static"
             },
@@ -3915,18 +3263,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 1,
             "hex": "#14555A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6406",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold"
             },
@@ -3944,9 +3288,7 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 1,
             "hex": "#14555A"
@@ -3954,9 +3296,7 @@
           "$description": "Standard background color for \"ondark\" components",
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6408",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold-static"
             },
@@ -3973,19 +3313,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 1,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6409",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense"
             },
@@ -4002,19 +3336,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 1,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6412",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense-static"
             },
@@ -4034,18 +3362,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8627451062202454,
-              0.9529411792755127,
-              0.9098039269447327
+              0.8627451062202454, 0.9529411792755127, 0.9098039269447327
             ],
             "alpha": 1,
             "hex": "#DCF3E8"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6413",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted"
             },
@@ -4063,18 +3387,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8627451062202454,
-              0.9529411792755127,
-              0.9098039269447327
+              0.8627451062202454, 0.9529411792755127, 0.9098039269447327
             ],
             "alpha": 1,
             "hex": "#DCF3E8"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6414",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted-static"
             },
@@ -4092,18 +3412,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7254902124404907,
-              0.9058823585510254,
-              0.8078431487083435
+              0.7254902124404907, 0.9058823585510254, 0.8078431487083435
             ],
             "alpha": 1,
             "hex": "#B9E7CE"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6415",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle"
             },
@@ -4121,18 +3437,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7254902124404907,
-              0.9058823585510254,
-              0.8078431487083435
+              0.7254902124404907, 0.9058823585510254, 0.8078431487083435
             ],
             "alpha": 1,
             "hex": "#B9E7CE"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6416",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle-static"
             },
@@ -4150,18 +3462,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.2801666557788849,
-              0.8199999928474426,
-              0.593269944190979
+              0.2801666557788849, 0.8199999928474426, 0.593269944190979
             ],
             "alpha": 1,
             "hex": "#47D197"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6417",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base"
             },
@@ -4179,18 +3487,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.2801666557788849,
-              0.8199999928474426,
-              0.593269944190979
+              0.2801666557788849, 0.8199999928474426, 0.593269944190979
             ],
             "alpha": 1,
             "hex": "#47D197"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6418",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base-static"
             },
@@ -4207,19 +3511,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.48235294222831726,
-              0.3686274588108063
-            ],
+            "components": [0, 0.48235294222831726, 0.3686274588108063],
             "alpha": 1,
             "hex": "#007B5E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6419",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold"
             },
@@ -4236,19 +3534,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.48235294222831726,
-              0.3686274588108063
-            ],
+            "components": [0, 0.48235294222831726, 0.3686274588108063],
             "alpha": 1,
             "hex": "#007B5E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6420",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold-static"
             },
@@ -4266,18 +3558,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.05098039284348488,
-              0.27450981736183167,
-              0.21568627655506134
+              0.05098039284348488, 0.27450981736183167, 0.21568627655506134
             ],
             "alpha": 1,
             "hex": "#0D4637"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6421",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense"
             },
@@ -4295,18 +3583,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.05098039284348488,
-              0.27450981736183167,
-              0.21568627655506134
+              0.05098039284348488, 0.27450981736183167, 0.21568627655506134
             ],
             "alpha": 1,
             "hex": "#0D4637"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6422",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense-static"
             },
@@ -4326,18 +3610,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9490196108818054,
-              0.95686274766922,
-              0.9254902005195618
+              0.9490196108818054, 0.95686274766922, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#F2F4EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6429",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted"
             },
@@ -4355,18 +3635,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9490196108818054,
-              0.95686274766922,
-              0.9254902005195618
+              0.9490196108818054, 0.95686274766922, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#F2F4EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6430",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted-static"
             },
@@ -4384,18 +3660,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7372549176216125,
-              0.8980392217636108,
-              0.6745098233222961
+              0.7372549176216125, 0.8980392217636108, 0.6745098233222961
             ],
             "alpha": 1,
             "hex": "#BCE5AC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6431",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle"
             },
@@ -4413,18 +3685,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7372549176216125,
-              0.8980392217636108,
-              0.6745098233222961
+              0.7372549176216125, 0.8980392217636108, 0.6745098233222961
             ],
             "alpha": 1,
             "hex": "#BCE5AC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6432",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle-static"
             },
@@ -4442,18 +3710,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.5018489956855774,
-              0.7291666865348816,
-              0.46484375
+              0.5018489956855774, 0.7291666865348816, 0.46484375
             ],
             "alpha": 1,
             "hex": "#80BA77"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6433",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base"
             },
@@ -4471,18 +3735,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.5018489956855774,
-              0.7291666865348816,
-              0.46484375
+              0.5018489956855774, 0.7291666865348816, 0.46484375
             ],
             "alpha": 1,
             "hex": "#80BA77"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6434",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base-static"
             },
@@ -4500,18 +3760,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.364705890417099,
-              0.4627451002597809,
-              0.3137255012989044
+              0.364705890417099, 0.4627451002597809, 0.3137255012989044
             ],
             "alpha": 1,
             "hex": "#5D7650"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6435",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold"
             },
@@ -4529,18 +3785,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.364705890417099,
-              0.4627451002597809,
-              0.3137255012989044
+              0.364705890417099, 0.4627451002597809, 0.3137255012989044
             ],
             "alpha": 1,
             "hex": "#5D7650"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6436",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold-static"
             },
@@ -4558,18 +3810,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.23137255012989044,
-              0.27843138575553894,
-              0.21176470816135406
+              0.23137255012989044, 0.27843138575553894, 0.21176470816135406
             ],
             "alpha": 1,
             "hex": "#3B4736"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6437",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense"
             },
@@ -4587,18 +3835,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.23137255012989044,
-              0.27843138575553894,
-              0.21176470816135406
+              0.23137255012989044, 0.27843138575553894, 0.21176470816135406
             ],
             "alpha": 1,
             "hex": "#3B4736"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6438",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense-static"
             },
@@ -4620,20 +3864,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:565",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action"
               },
@@ -4650,20 +3887,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12974",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-hover"
               },
@@ -4681,8 +3911,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -4690,10 +3919,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1579",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive"
               },
@@ -4711,8 +3937,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -4720,10 +3945,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1580",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover"
               },
@@ -4741,19 +3963,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9882352948188782,
-                0.9333333373069763,
-                0.9333333373069763
+                0.9882352948188782, 0.9333333373069763, 0.9333333373069763
               ],
               "alpha": 1,
               "hex": "#FCEEEE"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1833",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover-subtle"
               },
@@ -4771,8 +3988,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -4780,10 +3996,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1589",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed"
               },
@@ -4801,19 +4014,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9882352948188782,
-                0.8666666746139526,
-                0.8666666746139526
+                0.9882352948188782, 0.8666666746139526, 0.8666666746139526
               ],
               "alpha": 1,
               "hex": "#FCDDDD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1837",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed-subtle"
               },
@@ -4832,19 +4040,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1755",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral"
               },
@@ -4862,8 +4064,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.007843137718737125,
-                0.2235294133424759,
+                0.007843137718737125, 0.2235294133424759,
                 0.2235294133424759
               ],
               "alpha": 1,
@@ -4871,9 +4072,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17051",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-inverse"
               },
@@ -4891,8 +4090,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.007843137718737125,
-                0.2235294133424759,
+                0.007843137718737125, 0.2235294133424759,
                 0.2235294133424759
               ],
               "alpha": 1,
@@ -4900,9 +4098,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1756",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-ondark"
               },
@@ -4919,19 +4115,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:572",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action"
               },
@@ -4948,19 +4138,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12975",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover"
               },
@@ -4978,18 +4162,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6470588445663452,
-                0.8823529481887817,
-                0.8235294222831726
+                0.6470588445663452, 0.8823529481887817, 0.8235294222831726
               ],
               "alpha": 1,
               "hex": "#A5E1D2"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17038",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-inverse"
               },
@@ -5007,18 +4187,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6470588445663452,
-                0.8823529481887817,
-                0.8235294222831726
+                0.6470588445663452, 0.8823529481887817, 0.8235294222831726
               ],
               "alpha": 1,
               "hex": "#A5E1D2"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17039",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-inverse"
               },
@@ -5036,18 +4212,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6470588445663452,
-                0.8823529481887817,
-                0.8235294222831726
+                0.6470588445663452, 0.8823529481887817, 0.8235294222831726
               ],
               "alpha": 1,
               "hex": "#A5E1D2"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17049",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-ondark"
               },
@@ -5065,18 +4237,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6470588445663452,
-                0.8823529481887817,
-                0.8235294222831726
+                0.6470588445663452, 0.8823529481887817, 0.8235294222831726
               ],
               "alpha": 1,
               "hex": "#A5E1D2"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17050",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-ondark"
               },
@@ -5093,19 +4261,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4155",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-disabled"
               },
@@ -5122,19 +4284,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2246",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-destructive"
               },
@@ -5152,8 +4308,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5161,9 +4316,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1824",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive"
               },
@@ -5181,8 +4334,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5190,9 +4342,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1825",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-hover"
               },
@@ -5210,8 +4360,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5219,9 +4368,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1826",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-pressed"
               },
@@ -5240,20 +4387,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2038",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral"
               },
@@ -5271,8 +4411,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.007843137718737125,
-                0.2235294133424759,
+                0.007843137718737125, 0.2235294133424759,
                 0.2235294133424759
               ],
               "alpha": 1,
@@ -5280,10 +4419,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2040",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-ondark"
               },
@@ -5300,20 +4436,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:573",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action"
               },
@@ -5330,20 +4459,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12976",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-hover"
               },
@@ -5360,20 +4482,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4290",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-disabled"
               },
@@ -5390,20 +4505,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2247",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-destructive"
               },
@@ -5421,8 +4529,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5430,10 +4537,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1829",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive"
               },
@@ -5451,8 +4555,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5460,10 +4563,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1827",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-hover"
               },
@@ -5481,8 +4581,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5490,10 +4589,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1828",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-pressed"
               },
@@ -5512,19 +4608,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:4984",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action"
               },
@@ -5541,19 +4631,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0.4470588266849518,
-                0.4470588266849518
-              ],
+              "components": [0, 0.4470588266849518, 0.4470588266849518],
               "alpha": 1,
               "hex": "#007272"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12977",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-hover"
               },
@@ -5571,8 +4655,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5580,9 +4663,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1832",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive"
               },
@@ -5600,8 +4681,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5609,9 +4689,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1830",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-hover"
               },
@@ -5629,8 +4707,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5638,9 +4715,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1831",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-pressed"
               },
@@ -5658,18 +4733,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.0784313753247261,
-                0.3333333432674408,
-                0.3529411852359772
+                0.0784313753247261, 0.3333333432674408, 0.3529411852359772
               ],
               "alpha": 0.4000000059604645,
               "hex": "#14555A"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:60162:6172",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-selected"
               },
@@ -5691,8 +4762,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.20000000298023224,
-                0.20000000298023224,
+                0.20000000298023224, 0.20000000298023224,
                 0.20000000298023224
               ],
               "alpha": 1,
@@ -5700,10 +4770,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17800",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-tooltip-background-neutral"
               },
@@ -5725,18 +4792,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9803921580314636,
-                0.9803921580314636,
-                0.9803921580314636
+                0.9803921580314636, 0.9803921580314636, 0.9803921580314636
               ],
               "alpha": 1,
               "hex": "#FAFAFA"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17801",
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-table-background-neutral-alternative"
               },
@@ -5756,19 +4819,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:55039:23608",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-dimmer-background"
             },
@@ -5788,18 +4845,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.20000000298023224,
-              0.20000000298023224,
-              0.20000000298023224
+              0.20000000298023224, 0.20000000298023224, 0.20000000298023224
             ],
             "alpha": 1,
             "hex": "#333333"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56059:1770",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-switch-action-disabled-ondark"
             },
@@ -5819,18 +4872,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.800000011920929,
-              0.800000011920929,
-              0.800000011920929
+              0.800000011920929, 0.800000011920929, 0.800000011920929
             ],
             "alpha": 1,
             "hex": "#CCCCCC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56898:675",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-progressbar-neutral-onsubtle"
             },
@@ -5853,9 +4902,7 @@
         "$value": 48,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3882",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-xx-large"
           },
@@ -5873,9 +4920,7 @@
         "$value": 34,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3883",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-x-large"
           },
@@ -5893,9 +4938,7 @@
         "$value": 26,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3884",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-large"
           },
@@ -5913,9 +4956,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3885",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-lead"
           },
@@ -5933,9 +4974,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3886",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis"
           },
@@ -5953,9 +4992,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3887",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis-medium"
           },
@@ -5973,9 +5010,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3888",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small"
           },
@@ -5993,9 +5028,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3889",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small-medium"
           },
@@ -6013,9 +5046,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3890",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small"
           },
@@ -6033,9 +5064,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3891",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small-medium"
           },
@@ -6055,9 +5084,7 @@
         "$value": 56,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3901",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-xx-large"
           },
@@ -6075,9 +5102,7 @@
         "$value": 40,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3902",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-x-large"
           },
@@ -6095,9 +5120,7 @@
         "$value": 32,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3903",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-large"
           },
@@ -6115,9 +5138,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3904",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-lead"
           },
@@ -6135,9 +5156,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3905",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis"
           },
@@ -6155,9 +5174,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3906",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis-medium"
           },
@@ -6175,9 +5192,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3907",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small"
           },
@@ -6195,9 +5210,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3908",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small-medium"
           },
@@ -6215,9 +5228,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3909",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small"
           },
@@ -6235,9 +5246,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3910",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small-medium"
           },
@@ -6257,9 +5266,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3926",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-xx-large"
           },
@@ -6278,9 +5285,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3927",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-x-large"
           },
@@ -6299,9 +5304,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3928",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-large"
           },
@@ -6320,9 +5323,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3929",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-lead"
           },
@@ -6341,9 +5342,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3930",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis"
           },
@@ -6362,9 +5361,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3931",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis-medium"
           },
@@ -6383,9 +5380,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3932",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small"
           },
@@ -6404,9 +5399,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3933",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small-medium"
           },
@@ -6425,9 +5418,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3934",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small"
           },
@@ -6446,9 +5437,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3935",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small-medium"
           },
@@ -6469,9 +5458,7 @@
         "$value": "DNB",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3940",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-heading"
           },
@@ -6490,9 +5477,7 @@
         "$value": "DNB",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3941",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-body"
           },
@@ -6514,9 +5499,7 @@
       "$value": 0,
       "$extensions": {
         "com.figma.variableId": "VariableID:60016:38685",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-0"
         },
@@ -6534,9 +5517,7 @@
       "$value": 2,
       "$extensions": {
         "com.figma.variableId": "VariableID:59988:11383",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xs"
         },
@@ -6554,9 +5535,7 @@
       "$value": 4,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:10833",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-sm"
         },
@@ -6574,9 +5553,7 @@
       "$value": 8,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17818",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-md"
         },
@@ -6594,9 +5571,7 @@
       "$value": 16,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17819",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-lg"
         },
@@ -6614,9 +5589,7 @@
       "$value": 24,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17820",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xl"
         },
@@ -6634,9 +5607,7 @@
       "$value": 9999,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17822",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-full"
         },

--- a/packages/dnb-eufemia/src/style/themes/figma/dnbcarnegie-light.tokens.json
+++ b/packages/dnb-eufemia/src/style/themes/figma/dnbcarnegie-light.tokens.json
@@ -5,20 +5,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1280",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-page-background"
           },
@@ -35,20 +28,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1283",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action"
           },
@@ -66,19 +52,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:706",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover"
           },
@@ -95,20 +76,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 0.05000000074505806,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11711",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle"
           },
@@ -125,20 +99,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:708",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed"
           },
@@ -155,20 +122,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 0.10000000149011612,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11713",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle"
           },
@@ -186,19 +146,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:2187",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus"
           },
@@ -216,19 +171,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus-subtle"
           },
@@ -246,19 +196,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled"
           },
@@ -276,19 +221,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:13725",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-inverse"
           },
@@ -306,19 +246,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17036",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-inverse"
           },
@@ -335,20 +270,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17069",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-inverse"
           },
@@ -366,19 +294,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17070",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-inverse"
           },
@@ -395,20 +318,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11718",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-ondark"
           },
@@ -425,20 +341,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56032:1390",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-ondark"
           },
@@ -455,20 +364,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 0.30000001192092896,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3792",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-ondark"
           },
@@ -485,20 +387,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55892:2104",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-ondark"
           },
@@ -515,20 +410,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 0.5,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3877",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-ondark"
           },
@@ -546,19 +434,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2823529541492462,
-            0.2823529541492462,
-            0.29019609093666077
+            0.2823529541492462, 0.2823529541492462, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#48484A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1906",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled-ondark"
           },
@@ -575,20 +458,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11719",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative"
           },
@@ -606,19 +482,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11722",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative-hover-subtle"
           },
@@ -635,20 +506,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected"
           },
@@ -666,19 +530,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.9176470637321472,
-            0.8941176533699036
+            0.9647058844566345, 0.9176470637321472, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#F6EAE4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11723",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle"
           },
@@ -695,20 +554,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1727",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-ondark"
           },
@@ -725,20 +577,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1728",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle-ondark"
           },
@@ -755,20 +600,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1287",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral"
           },
@@ -785,20 +623,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1289",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-static"
           },
@@ -816,19 +647,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9725490212440491,
-            0.9725490212440491,
-            0.9725490212440491
+            0.9725490212440491, 0.9725490212440491, 0.9725490212440491
           ],
           "alpha": 1,
           "hex": "#F8F8F8"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1290",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-subtle"
           },
@@ -846,19 +672,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1294",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-base"
           },
@@ -876,19 +697,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37606",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-bold"
           },
@@ -906,19 +722,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-alternative"
           },
@@ -935,20 +746,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1302",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info"
           },
@@ -966,19 +770,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1304",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info-subtle"
           },
@@ -995,20 +794,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1296",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive"
           },
@@ -1026,19 +818,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1299",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive-subtle"
           },
@@ -1056,19 +843,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1307",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning"
           },
@@ -1086,19 +868,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1310",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning-subtle"
           },
@@ -1116,19 +893,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1313",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error"
           },
@@ -1146,19 +918,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1318",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error-subtle"
           },
@@ -1176,19 +943,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1324",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing"
           },
@@ -1206,19 +968,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:19893",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing-subtle"
           },
@@ -1237,19 +994,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1327",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action"
           },
@@ -1266,19 +1017,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:923",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover"
           },
@@ -1295,19 +1040,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:924",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed"
           },
@@ -1325,18 +1064,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:721",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-focus"
           },
@@ -1354,18 +1089,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:925",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled"
           },
@@ -1382,19 +1113,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-inverse"
           },
@@ -1411,19 +1136,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17057",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-inverse"
           },
@@ -1440,19 +1159,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17062",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-inverse"
           },
@@ -1470,18 +1183,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1331",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-selected"
           },
@@ -1498,19 +1207,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1344",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-ondark"
           },
@@ -1527,19 +1230,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1118",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-ondark"
           },
@@ -1556,19 +1253,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1120",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-ondark"
           },
@@ -1586,18 +1277,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1907",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled-ondark"
           },
@@ -1614,19 +1301,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:722",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-alternative-ondark"
           },
@@ -1643,19 +1324,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1316",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral"
           },
@@ -1672,19 +1347,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:57035:13480",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-onlight"
           },
@@ -1702,18 +1371,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1318",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-alternative"
           },
@@ -1730,19 +1395,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1321",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-inverse"
           },
@@ -1759,19 +1418,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1322",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-ondark"
           },
@@ -1789,18 +1442,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1324",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle"
           },
@@ -1818,18 +1467,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1326",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle-ondark"
           },
@@ -1847,18 +1492,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive"
           },
@@ -1875,19 +1516,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.3294117748737335,
-            0
-          ],
+          "components": [1, 0.3294117748737335, 0],
           "alpha": 1,
           "hex": "#FF5400"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87730",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive-inverse"
           },
@@ -1905,18 +1540,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.501960813999176,
-            0.35686275362968445,
-            0.054901961237192154
+            0.501960813999176, 0.35686275362968445, 0.054901961237192154
           ],
           "alpha": 1,
           "hex": "#805B0E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54378:4457",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning"
           },
@@ -1934,18 +1565,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87731",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning-inverse"
           },
@@ -1962,19 +1589,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1330",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive"
           },
@@ -1992,18 +1613,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.1568627506494522,
-            0.7058823704719543,
-            0.5098039507865906
+            0.1568627506494522, 0.7058823704719543, 0.5098039507865906
           ],
           "alpha": 1,
           "hex": "#28B482"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87732",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive-inverse"
           },
@@ -2022,20 +1639,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1332",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action"
           },
@@ -2052,20 +1662,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:723",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover"
           },
@@ -2082,20 +1685,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:724",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed"
           },
@@ -2113,19 +1709,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:725",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-focus"
           },
@@ -2143,19 +1734,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:929",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled"
           },
@@ -2172,20 +1758,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1333",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-inverse"
           },
@@ -2202,20 +1781,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17059",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-inverse"
           },
@@ -2232,20 +1804,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17060",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-inverse"
           },
@@ -2262,20 +1827,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1334",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected"
           },
@@ -2293,19 +1851,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9215686321258545
+            0.9215686321258545, 0.9215686321258545, 0.9215686321258545
           ],
           "alpha": 1,
           "hex": "#EBEBEB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1726",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected-ondark"
           },
@@ -2322,20 +1875,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53696:1314",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-ondark"
           },
@@ -2352,20 +1898,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1902",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-alternative-ondark"
           },
@@ -2382,20 +1921,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1119",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-ondark"
           },
@@ -2412,20 +1944,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1121",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-ondark"
           },
@@ -2443,19 +1968,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1908",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled-ondark"
           },
@@ -2472,20 +1992,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1335",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral"
           },
@@ -2502,20 +2015,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:16166",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-static"
           },
@@ -2532,20 +2038,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1337",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-inverse"
           },
@@ -2562,20 +2061,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1338",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-ondark"
           },
@@ -2593,19 +2085,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.45098039507865906,
-            0.45098039507865906,
-            0.45098039507865906
+            0.45098039507865906, 0.45098039507865906, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#737373"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1340",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-alternative"
           },
@@ -2623,19 +2110,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1341",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-destructive"
           },
@@ -2652,20 +2134,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1993",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info"
           },
@@ -2683,19 +2158,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1990",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info-subtle"
           },
@@ -2712,20 +2182,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1988",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive"
           },
@@ -2743,19 +2206,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.95686274766922,
-            0.9490196108818054
+            0.9215686321258545, 0.95686274766922, 0.9490196108818054
           ],
           "alpha": 1,
           "hex": "#EBF4F2"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive-subtle"
           },
@@ -2773,19 +2231,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1992",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning"
           },
@@ -2803,19 +2256,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9843137264251709,
-            0.9647058844566345,
-            0.9254902005195618
+            0.9843137264251709, 0.9647058844566345, 0.9254902005195618
           ],
           "alpha": 1,
           "hex": "#FBF6EC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning-subtle"
           },
@@ -2833,19 +2281,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1989",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error"
           },
@@ -2863,19 +2306,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9882352948188782,
-            0.9333333373069763,
-            0.9333333373069763
+            0.9882352948188782, 0.9333333373069763, 0.9333333373069763
           ],
           "alpha": 1,
           "hex": "#FCEEEE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1991",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error-subtle"
           },
@@ -2893,19 +2331,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1321",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing"
           },
@@ -2923,19 +2356,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9607843160629272
+            0.9490196108818054, 0.9490196108818054, 0.9607843160629272
           ],
           "alpha": 1,
           "hex": "#F2F2F5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1985",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing-subtle"
           },
@@ -2954,19 +2382,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:712",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action"
           },
@@ -2983,19 +2405,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12503",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative"
           },
@@ -3012,19 +2428,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:726",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover"
           },
@@ -3042,18 +2452,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.2823529541492462,
-            0.2823529541492462,
-            0.29019609093666077
+            0.2823529541492462, 0.2823529541492462, 0.29019609093666077
           ],
           "alpha": 1,
           "hex": "#48484A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:727",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed"
           },
@@ -3070,19 +2476,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6980",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-inverse"
           },
@@ -3099,19 +2499,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17064",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-inverse"
           },
@@ -3129,18 +2523,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5568627715110779,
-            0.5568627715110779,
-            0.5764706134796143
+            0.5568627715110779, 0.5568627715110779, 0.5764706134796143
           ],
           "alpha": 1,
           "hex": "#8E8E93"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17063",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-inverse"
           },
@@ -3158,18 +2548,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.15360000729560852,
-            0.41471999883651733,
-            0.8064000010490417
+            0.15360000729560852, 0.41471999883651733, 0.8064000010490417
           ],
           "alpha": 1,
           "hex": "#276ACE"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:729",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus"
           },
@@ -3187,18 +2573,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8823529481887817,
-            0.9137254953384399,
-            0.9764705896377563
+            0.8823529481887817, 0.9137254953384399, 0.9764705896377563
           ],
           "alpha": 1,
           "hex": "#E1E9F9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12504",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus-subtle"
           },
@@ -3216,18 +2598,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:931",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled"
           },
@@ -3244,19 +2622,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:714",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected"
           },
@@ -3274,18 +2646,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.6941176652908325,
-            0.6941176652908325,
-            0.7098039388656616
+            0.6941176652908325, 0.6941176652908325, 0.7098039388656616
           ],
           "alpha": 1,
           "hex": "#B1B1B5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected-ondark"
           },
@@ -3302,19 +2670,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12973",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-ondark"
           },
@@ -3332,18 +2694,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1917",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative-ondark"
           },
@@ -3360,19 +2718,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6981",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-ondark"
           },
@@ -3389,19 +2741,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6982",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-ondark"
           },
@@ -3419,18 +2765,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.38823530077934265,
-            0.38823530077934265,
-            0.4000000059604645
+            0.38823530077934265, 0.38823530077934265, 0.4000000059604645
           ],
           "alpha": 1,
           "hex": "#636366"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1909",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled-ondark"
           },
@@ -3448,18 +2790,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8588235378265381,
-            0.8039215803146362,
-            0.772549033164978
+            0.8588235378265381, 0.8039215803146362, 0.772549033164978
           ],
           "alpha": 1,
           "hex": "#DBCDC5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:718",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral"
           },
@@ -3476,19 +2814,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:719",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-ondark"
           },
@@ -3506,18 +2838,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9647058844566345,
-            0.9176470637321472,
-            0.8941176533699036
+            0.9647058844566345, 0.9176470637321472, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#F6EAE4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:720",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-subtle"
           },
@@ -3534,19 +2862,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0,
-            0
-          ],
+          "components": [0, 0, 0],
           "alpha": 1,
           "hex": "#000000"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37609",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-bold"
           },
@@ -3564,18 +2886,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.800000011920929,
-            0.800000011920929,
-            0.800000011920929
+            0.800000011920929, 0.800000011920929, 0.800000011920929
           ],
           "alpha": 1,
           "hex": "#CCCCCC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4988",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-alternative"
           },
@@ -3592,19 +2910,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.4470588266849518,
-            0.4470588266849518
-          ],
+          "components": [0, 0.4470588266849518, 0.4470588266849518],
           "alpha": 1,
           "hex": "#007272"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:722",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-info"
           },
@@ -3621,19 +2933,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.48235294222831726,
-            0.3686274588108063
-          ],
+          "components": [0, 0.48235294222831726, 0.3686274588108063],
           "alpha": 1,
           "hex": "#007B5E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54483:254295",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-positive"
           },
@@ -3651,18 +2957,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9921568632125854,
-            0.7333333492279053,
-            0.1921568661928177
+            0.9921568632125854, 0.7333333492279053, 0.1921568661928177
           ],
           "alpha": 1,
           "hex": "#FDBB31"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:723",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-warning"
           },
@@ -3680,18 +2982,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8352941274642944,
-            0.14509804546833038,
-            0.14509804546833038
+            0.8352941274642944, 0.14509804546833038, 0.14509804546833038
           ],
           "alpha": 1,
           "hex": "#D52525"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:724",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-error"
           },
@@ -3709,18 +3007,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.20000000298023224,
-            0.20000000298023224,
-            0.20000000298023224
+            0.20000000298023224, 0.20000000298023224, 0.20000000298023224
           ],
           "alpha": 1,
           "hex": "#333333"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-marketing"
           },
@@ -3741,18 +3035,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9921568632125854,
-              0.9843137264251709,
-              0.9764705896377563
+              0.9921568632125854, 0.9843137264251709, 0.9764705896377563
             ],
             "alpha": 1,
             "hex": "#FDFBF9"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6395",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted"
             },
@@ -3770,18 +3060,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9921568632125854,
-              0.9843137264251709,
-              0.9764705896377563
+              0.9921568632125854, 0.9843137264251709, 0.9764705896377563
             ],
             "alpha": 1,
             "hex": "#FDFBF9"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6397",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted-static"
             },
@@ -3799,18 +3085,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9647058844566345,
-              0.9176470637321472,
-              0.8941176533699036
+              0.9647058844566345, 0.9176470637321472, 0.8941176533699036
             ],
             "alpha": 1,
             "hex": "#F6EAE4"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6398",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle"
             },
@@ -3828,18 +3110,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.9647058844566345,
-              0.9176470637321472,
-              0.8941176533699036
+              0.9647058844566345, 0.9176470637321472, 0.8941176533699036
             ],
             "alpha": 1,
             "hex": "#F6EAE4"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6400",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle-static"
             },
@@ -3857,18 +3135,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7098039388656616,
-              0.6313725709915161,
-              0.5921568870544434
+              0.7098039388656616, 0.6313725709915161, 0.5921568870544434
             ],
             "alpha": 1,
             "hex": "#B5A197"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6401",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base"
             },
@@ -3886,18 +3160,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7098039388656616,
-              0.6313725709915161,
-              0.5921568870544434
+              0.7098039388656616, 0.6313725709915161, 0.5921568870544434
             ],
             "alpha": 1,
             "hex": "#B5A197"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6405",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base-static"
             },
@@ -3915,18 +3185,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.45098039507865906,
-              0.3960784375667572,
-              0.3686274588108063
+              0.45098039507865906, 0.3960784375667572, 0.3686274588108063
             ],
             "alpha": 1,
             "hex": "#73655E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6406",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold"
             },
@@ -3944,9 +3210,7 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.45098039507865906,
-              0.3960784375667572,
-              0.3686274588108063
+              0.45098039507865906, 0.3960784375667572, 0.3686274588108063
             ],
             "alpha": 1,
             "hex": "#73655E"
@@ -3954,9 +3218,7 @@
           "$description": "Standard background color for \"ondark\" components",
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6408",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold-static"
             },
@@ -3974,18 +3236,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.29019609093666077,
-              0.24705882370471954,
-              0.22745098173618317
+              0.29019609093666077, 0.24705882370471954, 0.22745098173618317
             ],
             "alpha": 1,
             "hex": "#4A3F3A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6409",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense"
             },
@@ -4003,18 +3261,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.29019609093666077,
-              0.24705882370471954,
-              0.22745098173618317
+              0.29019609093666077, 0.24705882370471954, 0.22745098173618317
             ],
             "alpha": 1,
             "hex": "#4A3F3A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6412",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense-static"
             },
@@ -4033,19 +3287,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.8705882430076599,
-              0.8588235378265381
-            ],
+            "components": [1, 0.8705882430076599, 0.8588235378265381],
             "alpha": 1,
             "hex": "#FFDEDB"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6413",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted"
             },
@@ -4062,19 +3310,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              1,
-              0.8705882430076599,
-              0.8588235378265381
-            ],
+            "components": [1, 0.8705882430076599, 0.8588235378265381],
             "alpha": 1,
             "hex": "#FFDEDB"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6414",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted-static"
             },
@@ -4092,18 +3334,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.886274516582489,
-              0.6352941393852234,
-              0.6470588445663452
+              0.886274516582489, 0.6352941393852234, 0.6470588445663452
             ],
             "alpha": 1,
             "hex": "#E2A2A5"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6415",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle"
             },
@@ -4121,18 +3359,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.886274516582489,
-              0.6352941393852234,
-              0.6470588445663452
+              0.886274516582489, 0.6352941393852234, 0.6470588445663452
             ],
             "alpha": 1,
             "hex": "#E2A2A5"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6416",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle-static"
             },
@@ -4150,18 +3384,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7137255072593689,
-              0.4274509847164154,
-              0.45098039507865906
+              0.7137255072593689, 0.4274509847164154, 0.45098039507865906
             ],
             "alpha": 1,
             "hex": "#B66D73"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6417",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base"
             },
@@ -4179,18 +3409,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.7137255072593689,
-              0.4274509847164154,
-              0.45098039507865906
+              0.7137255072593689, 0.4274509847164154, 0.45098039507865906
             ],
             "alpha": 1,
             "hex": "#B66D73"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6418",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base-static"
             },
@@ -4207,19 +3433,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.3607843220233917,
-              0,
-              0.13333334028720856
-            ],
+            "components": [0.3607843220233917, 0, 0.13333334028720856],
             "alpha": 1,
             "hex": "#5C0022"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6419",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold"
             },
@@ -4236,19 +3456,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.3607843220233917,
-              0,
-              0.13333334028720856
-            ],
+            "components": [0.3607843220233917, 0, 0.13333334028720856],
             "alpha": 1,
             "hex": "#5C0022"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6420",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold-static"
             },
@@ -4265,19 +3479,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.1411764770746231,
-              0,
-              0.05098039284348488
-            ],
+            "components": [0.1411764770746231, 0, 0.05098039284348488],
             "alpha": 1,
             "hex": "#24000D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6421",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense"
             },
@@ -4294,19 +3502,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.1411764770746231,
-              0,
-              0.05098039284348488
-            ],
+            "components": [0.1411764770746231, 0, 0.05098039284348488],
             "alpha": 1,
             "hex": "#24000D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6422",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense-static"
             },
@@ -4326,18 +3528,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8666666746139526,
-              0.9490196108818054,
-              0.9254902005195618
+              0.8666666746139526, 0.9490196108818054, 0.9254902005195618
             ],
             "alpha": 1,
             "hex": "#DDF2EC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6429",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted"
             },
@@ -4355,18 +3553,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8627451062202454,
-              0.9529411792755127,
-              0.9098039269447327
+              0.8627451062202454, 0.9529411792755127, 0.9098039269447327
             ],
             "alpha": 1,
             "hex": "#DCF3E8"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6430",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted-static"
             },
@@ -4384,18 +3578,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 1,
             "hex": "#A5E1D2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6431",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle"
             },
@@ -4413,18 +3603,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.6470588445663452,
-              0.8823529481887817,
-              0.8235294222831726
+              0.6470588445663452, 0.8823529481887817, 0.8235294222831726
             ],
             "alpha": 1,
             "hex": "#A5E1D2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6432",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle-static"
             },
@@ -4442,18 +3628,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.1411764770746231,
-              0.5882353186607361,
-              0.5529412031173706
+              0.1411764770746231, 0.5882353186607361, 0.5529412031173706
             ],
             "alpha": 1,
             "hex": "#24968D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6433",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base"
             },
@@ -4471,18 +3653,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.1411764770746231,
-              0.5882353186607361,
-              0.5529412031173706
+              0.1411764770746231, 0.5882353186607361, 0.5529412031173706
             ],
             "alpha": 1,
             "hex": "#24968D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6434",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base-static"
             },
@@ -4500,18 +3678,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 1,
             "hex": "#14555A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6435",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold"
             },
@@ -4529,18 +3703,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0784313753247261,
-              0.3333333432674408,
-              0.3529411852359772
+              0.0784313753247261, 0.3333333432674408, 0.3529411852359772
             ],
             "alpha": 1,
             "hex": "#14555A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6436",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold-static"
             },
@@ -4557,19 +3727,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 1,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6437",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense"
             },
@@ -4586,19 +3750,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.20392157137393951,
-              0.24313725531101227
-            ],
+            "components": [0, 0.20392157137393951, 0.24313725531101227],
             "alpha": 1,
             "hex": "#00343E"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6438",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense-static"
             },
@@ -4620,20 +3778,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:565",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action"
               },
@@ -4650,20 +3801,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12974",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-hover"
               },
@@ -4681,8 +3825,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -4690,10 +3833,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1579",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive"
               },
@@ -4711,8 +3851,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -4720,10 +3859,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1580",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover"
               },
@@ -4741,19 +3877,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9882352948188782,
-                0.9333333373069763,
-                0.9333333373069763
+                0.9882352948188782, 0.9333333373069763, 0.9333333373069763
               ],
               "alpha": 1,
               "hex": "#FCEEEE"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1833",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover-subtle"
               },
@@ -4771,8 +3902,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -4780,10 +3910,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1589",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed"
               },
@@ -4801,19 +3928,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9882352948188782,
-                0.8666666746139526,
-                0.8666666746139526
+                0.9882352948188782, 0.8666666746139526, 0.8666666746139526
               ],
               "alpha": 1,
               "hex": "#FCDDDD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1837",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed-subtle"
               },
@@ -4832,19 +3954,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1755",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral"
               },
@@ -4861,19 +3977,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17051",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-inverse"
               },
@@ -4890,19 +4000,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1756",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-ondark"
               },
@@ -4919,19 +4023,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:572",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action"
               },
@@ -4948,19 +4046,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12975",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover"
               },
@@ -4977,19 +4069,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17038",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-inverse"
               },
@@ -5006,19 +4092,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17039",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-inverse"
               },
@@ -5035,19 +4115,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17049",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-ondark"
               },
@@ -5064,19 +4138,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17050",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-ondark"
               },
@@ -5093,19 +4161,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4155",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-disabled"
               },
@@ -5122,19 +4184,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2246",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-destructive"
               },
@@ -5152,8 +4208,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5161,9 +4216,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1824",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive"
               },
@@ -5181,8 +4234,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5190,9 +4242,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1825",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-hover"
               },
@@ -5210,8 +4260,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5219,9 +4268,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1826",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-pressed"
               },
@@ -5240,20 +4287,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2038",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral"
               },
@@ -5270,20 +4310,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2040",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-ondark"
               },
@@ -5300,20 +4333,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:573",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action"
               },
@@ -5330,20 +4356,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12976",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-hover"
               },
@@ -5360,20 +4379,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4290",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-disabled"
               },
@@ -5390,20 +4402,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2247",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-destructive"
               },
@@ -5421,8 +4426,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5430,10 +4434,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1829",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive"
               },
@@ -5451,8 +4452,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5460,10 +4460,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1827",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-hover"
               },
@@ -5481,8 +4478,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5490,10 +4486,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1828",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-pressed"
               },
@@ -5512,19 +4505,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:4984",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action"
               },
@@ -5541,19 +4528,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                0,
-                0,
-                0
-              ],
+              "components": [0, 0, 0],
               "alpha": 1,
               "hex": "#000000"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12977",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-hover"
               },
@@ -5571,8 +4552,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5580,9 +4560,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1832",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive"
               },
@@ -5600,8 +4578,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8352941274642944,
-                0.14509804546833038,
+                0.8352941274642944, 0.14509804546833038,
                 0.14509804546833038
               ],
               "alpha": 1,
@@ -5609,9 +4586,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1830",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-hover"
               },
@@ -5629,8 +4604,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6980392336845398,
-                0.11764705926179886,
+                0.6980392336845398, 0.11764705926179886,
                 0.11764705926179886
               ],
               "alpha": 1,
@@ -5638,9 +4612,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1831",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-pressed"
               },
@@ -5658,18 +4630,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.5372549295425415,
-                0.4745098054409027,
-                0.4431372582912445
+                0.5372549295425415, 0.4745098054409027, 0.4431372582912445
               ],
               "alpha": 1,
               "hex": "#897971"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:60162:6172",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-selected"
               },
@@ -5691,8 +4659,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.20000000298023224,
-                0.20000000298023224,
+                0.20000000298023224, 0.20000000298023224,
                 0.20000000298023224
               ],
               "alpha": 1,
@@ -5700,10 +4667,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17800",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-tooltip-background-neutral"
               },
@@ -5725,18 +4689,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9803921580314636,
-                0.9803921580314636,
-                0.9803921580314636
+                0.9803921580314636, 0.9803921580314636, 0.9803921580314636
               ],
               "alpha": 1,
               "hex": "#FAFAFA"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17801",
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-table-background-neutral-alternative"
               },
@@ -5756,19 +4716,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:55039:23608",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-dimmer-background"
             },
@@ -5788,18 +4742,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.20000000298023224,
-              0.20000000298023224,
-              0.20000000298023224
+              0.20000000298023224, 0.20000000298023224, 0.20000000298023224
             ],
             "alpha": 1,
             "hex": "#333333"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56059:1770",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-switch-action-disabled-ondark"
             },
@@ -5819,18 +4769,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.800000011920929,
-              0.800000011920929,
-              0.800000011920929
+              0.800000011920929, 0.800000011920929, 0.800000011920929
             ],
             "alpha": 1,
             "hex": "#CCCCCC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56898:675",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-progressbar-neutral-onsubtle"
             },
@@ -5853,9 +4799,7 @@
         "$value": 56,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3882",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-xx-large"
           },
@@ -5873,9 +4817,7 @@
         "$value": 34,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3883",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-x-large"
           },
@@ -5893,9 +4835,7 @@
         "$value": 26,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3884",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-large"
           },
@@ -5913,9 +4853,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3885",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-lead"
           },
@@ -5933,9 +4871,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3886",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis"
           },
@@ -5953,9 +4889,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3887",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis-medium"
           },
@@ -5973,9 +4907,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3888",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small"
           },
@@ -5993,9 +4925,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3889",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small-medium"
           },
@@ -6013,9 +4943,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3890",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small"
           },
@@ -6033,9 +4961,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3891",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small-medium"
           },
@@ -6055,9 +4981,7 @@
         "$value": 68,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3901",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-xx-large"
           },
@@ -6075,9 +4999,7 @@
         "$value": 40,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3902",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-x-large"
           },
@@ -6095,9 +5017,7 @@
         "$value": 32,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3903",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-large"
           },
@@ -6115,9 +5035,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3904",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-lead"
           },
@@ -6135,9 +5053,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3905",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis"
           },
@@ -6155,9 +5071,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3906",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis-medium"
           },
@@ -6175,9 +5089,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3907",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small"
           },
@@ -6195,9 +5107,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3908",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small-medium"
           },
@@ -6215,9 +5125,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3909",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small"
           },
@@ -6235,9 +5143,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3910",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small-medium"
           },
@@ -6257,9 +5163,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3926",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-xx-large"
           },
@@ -6278,9 +5182,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3927",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-x-large"
           },
@@ -6299,9 +5201,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3928",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-large"
           },
@@ -6320,9 +5220,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3929",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-lead"
           },
@@ -6341,9 +5239,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3930",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis"
           },
@@ -6362,9 +5258,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3931",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis-medium"
           },
@@ -6383,9 +5277,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3932",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small"
           },
@@ -6404,9 +5296,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3933",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small-medium"
           },
@@ -6425,9 +5315,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3934",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small"
           },
@@ -6446,9 +5334,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3935",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small-medium"
           },
@@ -6469,9 +5355,7 @@
         "$value": "ABC Arizona Flare",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3940",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-heading"
           },
@@ -6490,9 +5374,7 @@
         "$value": "DNB",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3941",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-body"
           },
@@ -6514,9 +5396,7 @@
       "$value": 0,
       "$extensions": {
         "com.figma.variableId": "VariableID:60016:38685",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-0"
         },
@@ -6534,9 +5414,7 @@
       "$value": 0,
       "$extensions": {
         "com.figma.variableId": "VariableID:59988:11383",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xs"
         },
@@ -6554,9 +5432,7 @@
       "$value": 2,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:10833",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-sm"
         },
@@ -6574,9 +5450,7 @@
       "$value": 2,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17818",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-md"
         },
@@ -6594,9 +5468,7 @@
       "$value": 4,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17819",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-lg"
         },
@@ -6614,9 +5486,7 @@
       "$value": 24,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17820",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xl"
         },
@@ -6634,9 +5504,7 @@
       "$value": 9999,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17822",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-full"
         },

--- a/packages/dnb-eufemia/src/style/themes/figma/sbanken-light.tokens.json
+++ b/packages/dnb-eufemia/src/style/themes/figma/sbanken-light.tokens.json
@@ -5,20 +5,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1280",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-page-background"
           },
@@ -36,19 +29,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1283",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action"
           },
@@ -66,19 +54,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:706",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover"
           },
@@ -95,20 +78,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9450980424880981,
-            0.9215686321258545,
-            1
-          ],
+          "components": [0.9450980424880981, 0.9215686321258545, 1],
           "alpha": 1,
           "hex": "#F1EBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11711",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle"
           },
@@ -126,19 +102,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:708",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed"
           },
@@ -155,20 +126,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8784313797950745,
-            0.8156862854957581,
-            1
-          ],
+          "components": [0.8784313797950745, 0.8156862854957581, 1],
           "alpha": 1,
           "hex": "#E0D0FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11713",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle"
           },
@@ -185,20 +149,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.3607843220233917,
-            1
-          ],
+          "components": [0, 0.3607843220233917, 1],
           "alpha": 1,
           "hex": "#005CFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:2187",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus"
           },
@@ -215,20 +172,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9215686321258545,
-            0.9647058844566345,
-            1
-          ],
+          "components": [0.9215686321258545, 0.9647058844566345, 1],
           "alpha": 1,
           "hex": "#EBF6FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-focus-subtle"
           },
@@ -246,19 +196,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9450980424880981
+            0.9215686321258545, 0.9215686321258545, 0.9450980424880981
           ],
           "alpha": 1,
           "hex": "#EBEBF1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled"
           },
@@ -276,19 +221,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:13725",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-inverse"
           },
@@ -306,19 +246,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17036",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-inverse"
           },
@@ -336,19 +271,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17069",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-inverse"
           },
@@ -366,19 +296,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56487:17070",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-inverse"
           },
@@ -396,19 +321,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11718",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-ondark"
           },
@@ -426,19 +346,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56032:1390",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-ondark"
           },
@@ -456,19 +371,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.20392157137393951,
-            0.1764705926179886
+            0.08627451211214066, 0.20392157137393951, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#16342D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3792",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-hover-subtle-ondark"
           },
@@ -486,19 +396,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55892:2104",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-ondark"
           },
@@ -516,19 +421,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.05098039284348488,
-            0.12156862765550613,
-            0.10588235408067703
+            0.05098039284348488, 0.12156862765550613, 0.10588235408067703
           ],
           "alpha": 1,
           "hex": "#0D1F1B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55977:3877",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-pressed-subtle-ondark"
           },
@@ -546,19 +446,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1906",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-disabled-ondark"
           },
@@ -576,19 +471,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5647059082984924,
-            0.5647059082984924,
-            0.6392157077789307
+            0.5647059082984924, 0.5647059082984924, 0.6392157077789307
           ],
           "alpha": 1,
           "hex": "#9090A3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11719",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative"
           },
@@ -606,19 +496,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9686274528503418
+            0.9490196108818054, 0.9490196108818054, 0.9686274528503418
           ],
           "alpha": 1,
           "hex": "#F2F2F7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11722",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-action-alternative-hover-subtle"
           },
@@ -636,19 +521,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:716",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected"
           },
@@ -665,20 +545,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9450980424880981,
-            0.9215686321258545,
-            1
-          ],
+          "components": [0.9450980424880981, 0.9215686321258545, 1],
           "alpha": 1,
           "hex": "#F1EBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:11723",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle"
           },
@@ -695,20 +568,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8980392217636108,
-            1,
-            0.9686274528503418
-          ],
+          "components": [0.8980392217636108, 1, 0.9686274528503418],
           "alpha": 1,
           "hex": "#E5FFF7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1727",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-ondark"
           },
@@ -726,19 +592,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.08627451211214066,
-            0.20392157137393951,
-            0.1764705926179886
+            0.08627451211214066, 0.20392157137393951, 0.1764705926179886
           ],
           "alpha": 1,
           "hex": "#16342D"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1728",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-selected-subtle-ondark"
           },
@@ -755,20 +616,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1287",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral"
           },
@@ -785,20 +639,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1289",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-static"
           },
@@ -816,19 +663,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9686274528503418
+            0.9490196108818054, 0.9490196108818054, 0.9686274528503418
           ],
           "alpha": 1,
           "hex": "#F2F2F7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1290",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-subtle"
           },
@@ -846,19 +688,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9686274528503418
+            0.9490196108818054, 0.9490196108818054, 0.9686274528503418
           ],
           "alpha": 1,
           "hex": "#F2F2F7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1294",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-base"
           },
@@ -876,19 +713,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37606",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-bold"
           },
@@ -906,19 +738,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9490196108818054,
-            0.9490196108818054,
-            0.9686274528503418
+            0.9490196108818054, 0.9490196108818054, 0.9686274528503418
           ],
           "alpha": 1,
           "hex": "#F2F2F7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-neutral-alternative"
           },
@@ -936,19 +763,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11764705926179886,
-            0.6235294342041016,
-            0.45098039507865906
+            0.11764705926179886, 0.6235294342041016, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#1E9F73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1302",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info"
           },
@@ -965,20 +787,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9583333134651184,
-            1,
-            0.9850000143051147
-          ],
+          "components": [0.9583333134651184, 1, 0.9850000143051147],
           "alpha": 1,
           "hex": "#F4FFFB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1304",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-info-subtle"
           },
@@ -995,20 +810,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.47058823704719543,
-            0.35686275362968445
-          ],
+          "components": [0, 0.47058823704719543, 0.35686275362968445],
           "alpha": 1,
           "hex": "#00785B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1296",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive"
           },
@@ -1025,20 +833,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8980392217636108,
-            1,
-            0.9686274528503418
-          ],
+          "components": [0.8980392217636108, 1, 0.9686274528503418],
           "alpha": 1,
           "hex": "#E5FFF7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1299",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-positive-subtle"
           },
@@ -1056,19 +857,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9686274528503418,
-            0.7490196228027344,
-            0.08627451211214066
+            0.9686274528503418, 0.7490196228027344, 0.08627451211214066
           ],
           "alpha": 1,
           "hex": "#F7BF16"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1307",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning"
           },
@@ -1085,20 +881,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9882352948188782,
-            0.8980392217636108
-          ],
+          "components": [1, 0.9882352948188782, 0.8980392217636108],
           "alpha": 1,
           "hex": "#FFFCE5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1310",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-warning-subtle"
           },
@@ -1116,19 +905,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1313",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error"
           },
@@ -1145,20 +929,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8588235378265381,
-            0.9137254953384399
-          ],
+          "components": [1, 0.8588235378265381, 0.9137254953384399],
           "alpha": 1,
           "hex": "#FFDBE9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1318",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-error-subtle"
           },
@@ -1176,19 +953,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1324",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing"
           },
@@ -1205,20 +977,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9450980424880981,
-            0.9215686321258545,
-            1
-          ],
+          "components": [0.9450980424880981, 0.9215686321258545, 1],
           "alpha": 1,
           "hex": "#F1EBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:19893",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-background-marketing-subtle"
           },
@@ -1238,18 +1003,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1327",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action"
           },
@@ -1267,18 +1028,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:923",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover"
           },
@@ -1296,18 +1053,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:924",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed"
           },
@@ -1324,19 +1077,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.3607843220233917,
-            1
-          ],
+          "components": [0, 0.3607843220233917, 1],
           "alpha": 1,
           "hex": "#005CFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:721",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-focus"
           },
@@ -1354,18 +1101,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:925",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled"
           },
@@ -1383,18 +1126,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-inverse"
           },
@@ -1412,18 +1151,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17057",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-inverse"
           },
@@ -1441,18 +1176,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17062",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-inverse"
           },
@@ -1470,18 +1201,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1331",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-selected"
           },
@@ -1499,18 +1226,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1344",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-ondark"
           },
@@ -1528,18 +1251,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1118",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-hover-ondark"
           },
@@ -1557,18 +1276,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1120",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-pressed-ondark"
           },
@@ -1586,18 +1301,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5647059082984924,
-            0.5647059082984924,
-            0.6392157077789307
+            0.5647059082984924, 0.5647059082984924, 0.6392157077789307
           ],
           "alpha": 1,
           "hex": "#9090A3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1907",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-disabled-ondark"
           },
@@ -1614,19 +1325,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53777:722",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-action-alternative-ondark"
           },
@@ -1644,18 +1349,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0941176488995552,
-            0.09019608050584793,
-            0.16470588743686676
+            0.0941176488995552, 0.09019608050584793, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#18172A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1316",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral"
           },
@@ -1673,18 +1374,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0941176488995552,
-            0.09019608050584793,
-            0.16470588743686676
+            0.0941176488995552, 0.09019608050584793, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#18172A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:57035:13480",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-onlight"
           },
@@ -1702,18 +1399,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1318",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-alternative"
           },
@@ -1730,19 +1423,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1321",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-inverse"
           },
@@ -1759,19 +1446,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1322",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-ondark"
           },
@@ -1789,18 +1470,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1324",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle"
           },
@@ -1818,18 +1495,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9215686321258545,
-            0.9215686321258545,
-            0.9450980424880981
+            0.9215686321258545, 0.9215686321258545, 0.9450980424880981
           ],
           "alpha": 1,
           "hex": "#EBEBF1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1326",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-neutral-subtle-ondark"
           },
@@ -1847,18 +1520,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1328",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive"
           },
@@ -1875,19 +1544,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.3550299108028412,
-            0.2683919370174408
-          ],
+          "components": [1, 0.3550299108028412, 0.2683919370174408],
           "alpha": 1,
           "hex": "#FF5B44"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87730",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-destructive-inverse"
           },
@@ -1905,18 +1568,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5058823823928833,
-            0.3843137323856354,
-            0.03529411926865578
+            0.5058823823928833, 0.3843137323856354, 0.03529411926865578
           ],
           "alpha": 1,
           "hex": "#816209"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54378:4457",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning"
           },
@@ -1934,18 +1593,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9686274528503418,
-            0.7490196228027344,
-            0.08627451211214066
+            0.9686274528503418, 0.7490196228027344, 0.08627451211214066
           ],
           "alpha": 1,
           "hex": "#F7BF16"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87731",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-warning-inverse"
           },
@@ -1962,19 +1617,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.47058823704719543,
-            0.35686275362968445
-          ],
+          "components": [0, 0.47058823704719543, 0.35686275362968445],
           "alpha": 1,
           "hex": "#00785B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1330",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive"
           },
@@ -1992,18 +1641,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11764705926179886,
-            0.6235294342041016,
-            0.45098039507865906
+            0.11764705926179886, 0.6235294342041016, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#1E9F73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56524:87732",
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-text-positive-inverse"
           },
@@ -2023,19 +1668,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1332",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action"
           },
@@ -2053,19 +1693,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:723",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover"
           },
@@ -2083,19 +1718,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:724",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed"
           },
@@ -2112,20 +1742,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.3607843220233917,
-            1
-          ],
+          "components": [0, 0.3607843220233917, 1],
           "alpha": 1,
           "hex": "#005CFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:725",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-focus"
           },
@@ -2143,19 +1766,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:929",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled"
           },
@@ -2173,19 +1791,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1333",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-inverse"
           },
@@ -2203,19 +1816,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17059",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-inverse"
           },
@@ -2233,19 +1841,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17060",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-inverse"
           },
@@ -2263,19 +1866,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1334",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected"
           },
@@ -2293,19 +1891,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1726",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-selected-ondark"
           },
@@ -2323,19 +1916,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53696:1314",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-ondark"
           },
@@ -2352,20 +1940,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1902",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-alternative-ondark"
           },
@@ -2383,19 +1964,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1119",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-hover-ondark"
           },
@@ -2413,19 +1989,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1121",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-pressed-ondark"
           },
@@ -2443,19 +2014,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5647059082984924,
-            0.5647059082984924,
-            0.6392157077789307
+            0.5647059082984924, 0.5647059082984924, 0.6392157077789307
           ],
           "alpha": 1,
           "hex": "#9090A3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1908",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-action-disabled-ondark"
           },
@@ -2473,19 +2039,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0941176488995552,
-            0.09019608050584793,
-            0.16470588743686676
+            0.0941176488995552, 0.09019608050584793, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#18172A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1335",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral"
           },
@@ -2503,19 +2064,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.0941176488995552,
-            0.09019608050584793,
-            0.16470588743686676
+            0.0941176488995552, 0.09019608050584793, 0.16470588743686676
           ],
           "alpha": 1,
           "hex": "#18172A"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:16166",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-static"
           },
@@ -2532,20 +2088,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1337",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-inverse"
           },
@@ -2562,20 +2111,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1338",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-ondark"
           },
@@ -2593,19 +2135,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1340",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-neutral-alternative"
           },
@@ -2623,19 +2160,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53690:1341",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-destructive"
           },
@@ -2653,19 +2185,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11764705926179886,
-            0.6235294342041016,
-            0.45098039507865906
+            0.11764705926179886, 0.6235294342041016, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#1E9F73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1993",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info"
           },
@@ -2682,20 +2209,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9583333134651184,
-            1,
-            0.9850000143051147
-          ],
+          "components": [0.9583333134651184, 1, 0.9850000143051147],
           "alpha": 1,
           "hex": "#F4FFFB"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1990",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-info-subtle"
           },
@@ -2712,20 +2232,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.47058823704719543,
-            0.35686275362968445
-          ],
+          "components": [0, 0.47058823704719543, 0.35686275362968445],
           "alpha": 1,
           "hex": "#00785B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1988",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive"
           },
@@ -2742,20 +2255,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8980392217636108,
-            1,
-            0.9686274528503418
-          ],
+          "components": [0.8980392217636108, 1, 0.9686274528503418],
           "alpha": 1,
           "hex": "#E5FFF7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1987",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-positive-subtle"
           },
@@ -2773,19 +2279,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9686274528503418,
-            0.7490196228027344,
-            0.08627451211214066
+            0.9686274528503418, 0.7490196228027344, 0.08627451211214066
           ],
           "alpha": 1,
           "hex": "#F7BF16"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1992",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning"
           },
@@ -2802,20 +2303,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.9882352948188782,
-            0.8980392217636108
-          ],
+          "components": [1, 0.9882352948188782, 0.8980392217636108],
           "alpha": 1,
           "hex": "#FFFCE5"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1986",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-warning-subtle"
           },
@@ -2833,19 +2327,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1989",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error"
           },
@@ -2862,20 +2351,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            0.8588235378265381,
-            0.9137254953384399
-          ],
+          "components": [1, 0.8588235378265381, 0.9137254953384399],
           "alpha": 1,
           "hex": "#FFDBE9"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1991",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-error-subtle"
           },
@@ -2893,19 +2375,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53684:1321",
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing"
           },
@@ -2922,20 +2399,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9450980424880981,
-            0.9215686321258545,
-            1
-          ],
+          "components": [0.9450980424880981, 0.9215686321258545, 1],
           "alpha": 1,
           "hex": "#F1EBFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:62150:1985",
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-icon-marketing-subtle"
           },
@@ -2955,18 +2425,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:712",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action"
           },
@@ -2984,18 +2450,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.5647059082984924,
-            0.5647059082984924,
-            0.6392157077789307
+            0.5647059082984924, 0.5647059082984924, 0.6392157077789307
           ],
           "alpha": 1,
           "hex": "#9090A3"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12503",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative"
           },
@@ -3013,18 +2475,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.30588236451148987,
-            0.0313725508749485,
-            0.7372549176216125
+            0.30588236451148987, 0.0313725508749485, 0.7372549176216125
           ],
           "alpha": 1,
           "hex": "#4E08BC"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:726",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover"
           },
@@ -3042,18 +2500,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53780:727",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed"
           },
@@ -3071,18 +2525,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6980",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-inverse"
           },
@@ -3100,18 +2550,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17064",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-inverse"
           },
@@ -3129,18 +2575,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.21447916328907013,
-            0.7250000238418579,
-            0.5718437433242798
+            0.21447916328907013, 0.7250000238418579, 0.5718437433242798
           ],
           "alpha": 1,
           "hex": "#37B992"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56478:17063",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-inverse"
           },
@@ -3157,19 +2599,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.3607843220233917,
-            1
-          ],
+          "components": [0, 0.3607843220233917, 1],
           "alpha": 1,
           "hex": "#005CFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:729",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus"
           },
@@ -3186,19 +2622,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.9215686321258545,
-            0.9647058844566345,
-            1
-          ],
+          "components": [0.9215686321258545, 0.9647058844566345, 1],
           "alpha": 1,
           "hex": "#EBF6FF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12504",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-focus-subtle"
           },
@@ -3216,18 +2646,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53785:931",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled"
           },
@@ -3245,18 +2671,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.10980392247438431,
-            0.10588235408067703,
-            0.30588236451148987
+            0.10980392247438431, 0.10588235408067703, 0.30588236451148987
           ],
           "alpha": 1,
           "hex": "#1C1B4E"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:714",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected"
           },
@@ -3273,19 +2695,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0.8980392217636108,
-            1,
-            0.9686274528503418
-          ],
+          "components": [0.8980392217636108, 1, 0.9686274528503418],
           "alpha": 1,
           "hex": "#E5FFF7"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-selected-ondark"
           },
@@ -3303,18 +2719,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55036:12973",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-ondark"
           },
@@ -3332,18 +2744,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.7524305582046509,
-            0.7524305582046509,
-            0.8208333253860474
+            0.7524305582046509, 0.7524305582046509, 0.8208333253860474
           ],
           "alpha": 1,
           "hex": "#C0C0D1"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:56059:1917",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-alternative-ondark"
           },
@@ -3361,18 +2769,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.572549045085907,
-            0.9333333373069763,
-            0.8039215803146362
+            0.572549045085907, 0.9333333373069763, 0.8039215803146362
           ],
           "alpha": 1,
           "hex": "#92EECD"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6981",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-hover-ondark"
           },
@@ -3390,18 +2794,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.3921568691730499,
-            0.843137264251709,
-            0.7058823704719543
+            0.3921568691730499, 0.843137264251709, 0.7058823704719543
           ],
           "alpha": 1,
           "hex": "#64D7B4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55887:6982",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-pressed-ondark"
           },
@@ -3419,18 +2819,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.39834973216056824,
-            0.3943229019641876,
-            0.47083333134651184
+            0.39834973216056824, 0.3943229019641876, 0.47083333134651184
           ],
           "alpha": 1,
           "hex": "#666578"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55872:1909",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-action-disabled-ondark"
           },
@@ -3448,18 +2844,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:718",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral"
           },
@@ -3476,19 +2868,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            1,
-            1,
-            1
-          ],
+          "components": [1, 1, 1],
           "alpha": 1,
           "hex": "#FFFFFF"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:719",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-ondark"
           },
@@ -3506,18 +2892,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:720",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-subtle"
           },
@@ -3535,18 +2917,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:55045:37609",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-bold"
           },
@@ -3564,18 +2942,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8509804010391235,
-            0.8509804010391235,
-            0.8941176533699036
+            0.8509804010391235, 0.8509804010391235, 0.8941176533699036
           ],
           "alpha": 1,
           "hex": "#D9D9E4"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53837:4988",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-neutral-alternative"
           },
@@ -3593,18 +2967,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.11764705926179886,
-            0.6235294342041016,
-            0.45098039507865906
+            0.11764705926179886, 0.6235294342041016, 0.45098039507865906
           ],
           "alpha": 1,
           "hex": "#1E9F73"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:722",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-info"
           },
@@ -3621,19 +2991,13 @@
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [
-            0,
-            0.47058823704719543,
-            0.35686275362968445
-          ],
+          "components": [0, 0.47058823704719543, 0.35686275362968445],
           "alpha": 1,
           "hex": "#00785B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:54483:254295",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-positive"
           },
@@ -3651,18 +3015,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.9686274528503418,
-            0.7490196228027344,
-            0.08627451211214066
+            0.9686274528503418, 0.7490196228027344, 0.08627451211214066
           ],
           "alpha": 1,
           "hex": "#F7BF16"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:723",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-warning"
           },
@@ -3680,18 +3040,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.8470588326454163,
-            0.07450980693101883,
-            0.29411765933036804
+            0.8470588326454163, 0.07450980693101883, 0.29411765933036804
           ],
           "alpha": 1,
           "hex": "#D8134B"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:724",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-error"
           },
@@ -3709,18 +3065,14 @@
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.13333334028720856,
-            0.12941177189350128,
-            0.38823530077934265
+            0.13333334028720856, 0.12941177189350128, 0.38823530077934265
           ],
           "alpha": 1,
           "hex": "#222163"
         },
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:725",
-          "com.figma.scopes": [
-            "STROKE"
-          ],
+          "com.figma.scopes": ["STROKE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-color-stroke-marketing"
           },
@@ -3740,19 +3092,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.9450980424880981,
-              0.9215686321258545,
-              1
-            ],
+            "components": [0.9450980424880981, 0.9215686321258545, 1],
             "alpha": 1,
             "hex": "#F1EBFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6395",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted"
             },
@@ -3769,19 +3115,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.9450980424880981,
-              0.9215686321258545,
-              1
-            ],
+            "components": [0.9450980424880981, 0.9215686321258545, 1],
             "alpha": 1,
             "hex": "#F1EBFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6397",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-muted-static"
             },
@@ -3798,19 +3138,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 1,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6398",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle"
             },
@@ -3827,19 +3161,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 1,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6400",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-subtle-static"
             },
@@ -3857,18 +3185,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.4431372582912445,
-              0.16078431904315948,
-              0.886274516582489
+              0.4431372582912445, 0.16078431904315948, 0.886274516582489
             ],
             "alpha": 1,
             "hex": "#7129E2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6401",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base"
             },
@@ -3886,18 +3210,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.4431372582912445,
-              0.16078431904315948,
-              0.886274516582489
+              0.4431372582912445, 0.16078431904315948, 0.886274516582489
             ],
             "alpha": 1,
             "hex": "#7129E2"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6405",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-base-static"
             },
@@ -3915,18 +3235,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 1,
             "hex": "#4E08BC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6406",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold"
             },
@@ -3944,9 +3260,7 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 1,
             "hex": "#4E08BC"
@@ -3954,9 +3268,7 @@
           "$description": "Standard background color for \"ondark\" components",
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6408",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-bold-static"
             },
@@ -3974,18 +3286,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 1,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6409",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense"
             },
@@ -4003,18 +3311,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 1,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6412",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-first-intense-static"
             },
@@ -4033,19 +3337,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8980392217636108,
-              1,
-              0.9686274528503418
-            ],
+            "components": [0.8980392217636108, 1, 0.9686274528503418],
             "alpha": 1,
             "hex": "#E5FFF7"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6413",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted"
             },
@@ -4062,19 +3360,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8980392217636108,
-              1,
-              0.9686274528503418
-            ],
+            "components": [0.8980392217636108, 1, 0.9686274528503418],
             "alpha": 1,
             "hex": "#E5FFF7"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6414",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-muted-static"
             },
@@ -4092,18 +3384,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.572549045085907,
-              0.9333333373069763,
-              0.8039215803146362
+              0.572549045085907, 0.9333333373069763, 0.8039215803146362
             ],
             "alpha": 1,
             "hex": "#92EECD"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6415",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle"
             },
@@ -4121,18 +3409,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.572549045085907,
-              0.9333333373069763,
-              0.8039215803146362
+              0.572549045085907, 0.9333333373069763, 0.8039215803146362
             ],
             "alpha": 1,
             "hex": "#92EECD"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6416",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-subtle-static"
             },
@@ -4150,18 +3434,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.21447916328907013,
-              0.7250000238418579,
-              0.5718437433242798
+              0.21447916328907013, 0.7250000238418579, 0.5718437433242798
             ],
             "alpha": 1,
             "hex": "#37B992"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6417",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base"
             },
@@ -4179,18 +3459,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.21447916328907013,
-              0.7250000238418579,
-              0.5718437433242798
+              0.21447916328907013, 0.7250000238418579, 0.5718437433242798
             ],
             "alpha": 1,
             "hex": "#37B992"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6418",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-base-static"
             },
@@ -4207,19 +3483,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.47058823704719543,
-              0.35686275362968445
-            ],
+            "components": [0, 0.47058823704719543, 0.35686275362968445],
             "alpha": 1,
             "hex": "#00785B"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6419",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold"
             },
@@ -4236,19 +3506,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0.47058823704719543,
-              0.35686275362968445
-            ],
+            "components": [0, 0.47058823704719543, 0.35686275362968445],
             "alpha": 1,
             "hex": "#00785B"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6420",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-bold-static"
             },
@@ -4266,18 +3530,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.08627451211214066,
-              0.20392157137393951,
-              0.1764705926179886
+              0.08627451211214066, 0.20392157137393951, 0.1764705926179886
             ],
             "alpha": 1,
             "hex": "#16342D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6421",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense"
             },
@@ -4295,18 +3555,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.08627451211214066,
-              0.20392157137393951,
-              0.1764705926179886
+              0.08627451211214066, 0.20392157137393951, 0.1764705926179886
             ],
             "alpha": 1,
             "hex": "#16342D"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6422",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-second-intense-static"
             },
@@ -4325,19 +3581,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.9843137264251709,
-              0.9764705896377563,
-              1
-            ],
+            "components": [0.9843137264251709, 0.9764705896377563, 1],
             "alpha": 1,
             "hex": "#FBF9FF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6429",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted"
             },
@@ -4354,19 +3604,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.9843137264251709,
-              0.9764705896377563,
-              1
-            ],
+            "components": [0.9843137264251709, 0.9764705896377563, 1],
             "alpha": 1,
             "hex": "#FBF9FF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6430",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-muted-static"
             },
@@ -4383,19 +3627,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 1,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6431",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle"
             },
@@ -4412,19 +3650,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0.8235294222831726,
-              0.729411780834198,
-              1
-            ],
+            "components": [0.8235294222831726, 0.729411780834198, 1],
             "alpha": 1,
             "hex": "#D2BAFF"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6432",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-subtle-static"
             },
@@ -4442,18 +3674,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.5921568870544434,
-              0.3803921639919281,
-              0.9450980424880981
+              0.5921568870544434, 0.3803921639919281, 0.9450980424880981
             ],
             "alpha": 1,
             "hex": "#9761F1"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6433",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base"
             },
@@ -4471,18 +3699,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.5921568870544434,
-              0.3803921639919281,
-              0.9450980424880981
+              0.5921568870544434, 0.3803921639919281, 0.9450980424880981
             ],
             "alpha": 1,
             "hex": "#9761F1"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6434",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-base-static"
             },
@@ -4500,18 +3724,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 1,
             "hex": "#4E08BC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6435",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold"
             },
@@ -4529,18 +3749,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.30588236451148987,
-              0.0313725508749485,
-              0.7372549176216125
+              0.30588236451148987, 0.0313725508749485, 0.7372549176216125
             ],
             "alpha": 1,
             "hex": "#4E08BC"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6436",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-bold-static"
             },
@@ -4558,18 +3774,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 1,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6437",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense"
             },
@@ -4587,18 +3799,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.13333334028720856,
-              0.12941177189350128,
-              0.38823530077934265
+              0.13333334028720856, 0.12941177189350128, 0.38823530077934265
             ],
             "alpha": 1,
             "hex": "#222163"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:53820:6438",
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-decorative-third-intense-static"
             },
@@ -4621,8 +3829,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -4630,10 +3837,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:565",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action"
               },
@@ -4651,8 +3855,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -4660,10 +3863,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12974",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-hover"
               },
@@ -4681,19 +3881,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1579",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive"
               },
@@ -4711,19 +3906,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1580",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover"
               },
@@ -4740,20 +3930,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                0.9254902005195618,
-                0.9529411792755127
-              ],
+              "components": [1, 0.9254902005195618, 0.9529411792755127],
               "alpha": 1,
               "hex": "#FFECF3"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1833",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-hover-subtle"
               },
@@ -4771,8 +3954,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.6274510025978088,
-                0.14901961386203766,
+                0.6274510025978088, 0.14901961386203766,
                 0.08235294371843338
               ],
               "alpha": 1,
@@ -4780,10 +3962,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1589",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed"
               },
@@ -4800,20 +3979,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                0.8588235378265381,
-                0.9137254953384399
-              ],
+              "components": [1, 0.8588235378265381, 0.9137254953384399],
               "alpha": 1,
               "hex": "#FFDBE9"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1837",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-background-action-destructive-pressed-subtle"
               },
@@ -4832,19 +4004,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1755",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral"
               },
@@ -4862,8 +4028,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.0941176488995552,
-                0.09019608050584793,
+                0.0941176488995552, 0.09019608050584793,
                 0.16470588743686676
               ],
               "alpha": 1,
@@ -4871,9 +4036,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17051",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-inverse"
               },
@@ -4891,8 +4054,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.0941176488995552,
-                0.09019608050584793,
+                0.0941176488995552, 0.09019608050584793,
                 0.16470588743686676
               ],
               "alpha": 1,
@@ -4900,9 +4062,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:1756",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-ondark"
               },
@@ -4920,8 +4080,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -4929,9 +4088,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:572",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action"
               },
@@ -4949,8 +4106,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -4958,9 +4114,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12975",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover"
               },
@@ -4978,18 +4132,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.572549045085907,
-                0.9333333373069763,
-                0.8039215803146362
+                0.572549045085907, 0.9333333373069763, 0.8039215803146362
               ],
               "alpha": 1,
               "hex": "#92EECD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17038",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-inverse"
               },
@@ -5007,18 +4157,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.572549045085907,
-                0.9333333373069763,
-                0.8039215803146362
+                0.572549045085907, 0.9333333373069763, 0.8039215803146362
               ],
               "alpha": 1,
               "hex": "#92EECD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17039",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-inverse"
               },
@@ -5036,18 +4182,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.572549045085907,
-                0.9333333373069763,
-                0.8039215803146362
+                0.572549045085907, 0.9333333373069763, 0.8039215803146362
               ],
               "alpha": 1,
               "hex": "#92EECD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17049",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-ondark"
               },
@@ -5065,18 +4207,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.572549045085907,
-                0.9333333373069763,
-                0.8039215803146362
+                0.572549045085907, 0.9333333373069763, 0.8039215803146362
               ],
               "alpha": 1,
               "hex": "#92EECD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:56478:17050",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-hover-ondark"
               },
@@ -5093,19 +4231,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4155",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-disabled"
               },
@@ -5122,19 +4254,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2246",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-neutral-destructive"
               },
@@ -5152,18 +4278,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1824",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive"
               },
@@ -5181,18 +4303,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1825",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-hover"
               },
@@ -5209,19 +4327,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                0.3550299108028412,
-                0.2683919370174408
-              ],
+              "components": [1, 0.3550299108028412, 0.2683919370174408],
               "alpha": 1,
               "hex": "#FF5B44"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1826",
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-text-action-destructive-pressed"
               },
@@ -5240,20 +4352,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2038",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral"
               },
@@ -5271,8 +4376,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.0941176488995552,
-                0.09019608050584793,
+                0.0941176488995552, 0.09019608050584793,
                 0.16470588743686676
               ],
               "alpha": 1,
@@ -5280,10 +4384,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55892:2040",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-ondark"
               },
@@ -5301,8 +4402,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -5310,10 +4410,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:573",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action"
               },
@@ -5331,8 +4428,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -5340,10 +4436,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12976",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-hover"
               },
@@ -5360,20 +4453,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:4290",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-disabled"
               },
@@ -5390,20 +4476,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                1,
-                1
-              ],
+              "components": [1, 1, 1],
               "alpha": 1,
               "hex": "#FFFFFF"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:2247",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-neutral-destructive"
               },
@@ -5421,19 +4500,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1829",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive"
               },
@@ -5451,19 +4525,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1827",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-hover"
               },
@@ -5480,20 +4549,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                0.3550299108028412,
-                0.2683919370174408
-              ],
+              "components": [1, 0.3550299108028412, 0.2683919370174408],
               "alpha": 1,
               "hex": "#FF5B44"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1828",
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-icon-action-destructive-pressed"
               },
@@ -5513,8 +4575,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -5522,9 +4583,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:53837:4984",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action"
               },
@@ -5542,8 +4601,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.13333334028720856,
-                0.12941177189350128,
+                0.13333334028720856, 0.12941177189350128,
                 0.38823530077934265
               ],
               "alpha": 1,
@@ -5551,9 +4609,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:12977",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-hover"
               },
@@ -5571,18 +4627,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1832",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive"
               },
@@ -5600,18 +4652,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.8745098114013672,
-                0.1568627506494522,
-                0.05882352963089943
+                0.8745098114013672, 0.1568627506494522, 0.05882352963089943
               ],
               "alpha": 1,
               "hex": "#DF280F"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1830",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-hover"
               },
@@ -5628,19 +4676,13 @@
             "$type": "color",
             "$value": {
               "colorSpace": "srgb",
-              "components": [
-                1,
-                0.3550299108028412,
-                0.2683919370174408
-              ],
+              "components": [1, 0.3550299108028412, 0.2683919370174408],
               "alpha": 1,
               "hex": "#FF5B44"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55907:1831",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-action-destructive-pressed"
               },
@@ -5658,18 +4700,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.30588236451148987,
-                0.0313725508749485,
-                0.7372549176216125
+                0.30588236451148987, 0.0313725508749485, 0.7372549176216125
               ],
               "alpha": 0.4000000059604645,
               "hex": "#4E08BC"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:60162:6172",
-              "com.figma.scopes": [
-                "STROKE"
-              ],
+              "com.figma.scopes": ["STROKE"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-button-stroke-selected"
               },
@@ -5691,8 +4729,7 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.22745098173618317,
-                0.22745098173618317,
+                0.22745098173618317, 0.22745098173618317,
                 0.29019609093666077
               ],
               "alpha": 1,
@@ -5700,10 +4737,7 @@
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17800",
-              "com.figma.scopes": [
-                "FRAME_FILL",
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-tooltip-background-neutral"
               },
@@ -5725,18 +4759,14 @@
             "$value": {
               "colorSpace": "srgb",
               "components": [
-                0.9882352948188782,
-                0.9882352948188782,
-                0.9921568632125854
+                0.9882352948188782, 0.9882352948188782, 0.9921568632125854
               ],
               "alpha": 1,
               "hex": "#FCFCFD"
             },
             "$extensions": {
               "com.figma.variableId": "VariableID:55036:17801",
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.codeSyntax": {
                 "WEB": "--token-color-component-table-background-neutral-alternative"
               },
@@ -5756,19 +4786,13 @@
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "components": [
-              0,
-              0,
-              0
-            ],
+            "components": [0, 0, 0],
             "alpha": 0.30000001192092896,
             "hex": "#000000"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:55039:23608",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-dimmer-background"
             },
@@ -5788,18 +4812,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.0941176488995552,
-              0.09019608050584793,
-              0.16470588743686676
+              0.0941176488995552, 0.09019608050584793, 0.16470588743686676
             ],
             "alpha": 1,
             "hex": "#18172A"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56059:1770",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-switch-action-disabled-ondark"
             },
@@ -5819,18 +4839,14 @@
           "$value": {
             "colorSpace": "srgb",
             "components": [
-              0.8509804010391235,
-              0.8509804010391235,
-              0.8941176533699036
+              0.8509804010391235, 0.8509804010391235, 0.8941176533699036
             ],
             "alpha": 1,
             "hex": "#D9D9E4"
           },
           "$extensions": {
             "com.figma.variableId": "VariableID:56898:675",
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.codeSyntax": {
               "WEB": "--token-color-component-progressbar-neutral-onsubtle"
             },
@@ -5853,9 +4869,7 @@
         "$value": 48,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3882",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-xx-large"
           },
@@ -5873,9 +4887,7 @@
         "$value": 34,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3883",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-x-large"
           },
@@ -5893,9 +4905,7 @@
         "$value": 26,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3884",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-heading-large"
           },
@@ -5913,9 +4923,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3885",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-lead"
           },
@@ -5933,9 +4941,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3886",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis"
           },
@@ -5953,9 +4959,7 @@
         "$value": 18,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3887",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-basis-medium"
           },
@@ -5973,9 +4977,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3888",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small"
           },
@@ -5993,9 +4995,7 @@
         "$value": 16,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3889",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-small-medium"
           },
@@ -6013,9 +5013,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3890",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small"
           },
@@ -6033,9 +5031,7 @@
         "$value": 14,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3891",
-          "com.figma.scopes": [
-            "FONT_SIZE"
-          ],
+          "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-size-text-x-small-medium"
           },
@@ -6055,9 +5051,7 @@
         "$value": 56,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3901",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-xx-large"
           },
@@ -6075,9 +5069,7 @@
         "$value": 40,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3902",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-x-large"
           },
@@ -6095,9 +5087,7 @@
         "$value": 32,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3903",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-heading-large"
           },
@@ -6115,9 +5105,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3904",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-lead"
           },
@@ -6135,9 +5123,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3905",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis"
           },
@@ -6155,9 +5141,7 @@
         "$value": 24,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3906",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-basis-medium"
           },
@@ -6175,9 +5159,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3907",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small"
           },
@@ -6195,9 +5177,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3908",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-small-medium"
           },
@@ -6215,9 +5195,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3909",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small"
           },
@@ -6235,9 +5213,7 @@
         "$value": 20,
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3910",
-          "com.figma.scopes": [
-            "LINE_HEIGHT"
-          ],
+          "com.figma.scopes": ["LINE_HEIGHT"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-height-text-x-small-medium"
           },
@@ -6257,9 +5233,7 @@
         "$value": "Book Sbanken",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3926",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-xx-large"
           },
@@ -6278,9 +5252,7 @@
         "$value": "Book Sbanken",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3927",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-x-large"
           },
@@ -6299,9 +5271,7 @@
         "$value": "Book Sbanken",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3928",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-heading-large"
           },
@@ -6320,9 +5290,7 @@
         "$value": "Demi Sbanken",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3929",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-lead"
           },
@@ -6341,9 +5309,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3930",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis"
           },
@@ -6362,9 +5328,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3931",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-basis-medium"
           },
@@ -6383,9 +5347,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3932",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small"
           },
@@ -6404,9 +5366,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3933",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-small-medium"
           },
@@ -6425,9 +5385,7 @@
         "$value": "Regular",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3934",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small"
           },
@@ -6446,9 +5404,7 @@
         "$value": "Medium",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3935",
-          "com.figma.scopes": [
-            "FONT_STYLE"
-          ],
+          "com.figma.scopes": ["FONT_STYLE"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-weight-text-x-small-medium"
           },
@@ -6469,9 +5425,7 @@
         "$value": "Maison Neue",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3940",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-heading"
           },
@@ -6490,9 +5444,7 @@
         "$value": "Roboto",
         "$extensions": {
           "com.figma.variableId": "VariableID:53718:3941",
-          "com.figma.scopes": [
-            "FONT_FAMILY"
-          ],
+          "com.figma.scopes": ["FONT_FAMILY"],
           "com.figma.codeSyntax": {
             "WEB": "--token-font-family-body"
           },
@@ -6514,9 +5466,7 @@
       "$value": 0,
       "$extensions": {
         "com.figma.variableId": "VariableID:60016:38685",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-0"
         },
@@ -6534,9 +5484,7 @@
       "$value": 2,
       "$extensions": {
         "com.figma.variableId": "VariableID:59988:11383",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xs"
         },
@@ -6554,9 +5502,7 @@
       "$value": 4,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:10833",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-sm"
         },
@@ -6574,9 +5520,7 @@
       "$value": 8,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17818",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-md"
         },
@@ -6594,9 +5538,7 @@
       "$value": 16,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17819",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-lg"
         },
@@ -6614,9 +5556,7 @@
       "$value": 24,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17820",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-xl"
         },
@@ -6634,9 +5574,7 @@
       "$value": 9999,
       "$extensions": {
         "com.figma.variableId": "VariableID:59977:17822",
-        "com.figma.scopes": [
-          "CORNER_RADIUS"
-        ],
+        "com.figma.scopes": ["CORNER_RADIUS"],
         "com.figma.codeSyntax": {
           "WEB": "--token-radius-radius-full"
         },

--- a/packages/dnb-eufemia/src/style/themes/sbanken/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/properties-tailwind.css
@@ -3,7 +3,8 @@
 /* stylelint-disable-next-line scss/at-rule-no-unknown */
 @theme {
   --font-sb-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --font-sb-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica';
+  --font-sb-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
   --font-weight-sb-default: normal;
   --font-weight-sb-basis: normal;
   --font-weight-sb-regular: normal;
@@ -107,7 +108,9 @@
   --color-ca-pale-red: #ffdedb;
   --font-default: var(--font-sb-default);
   --font-heading: var(--font-sb-heading);
-  --font-monospace: 'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono';
+  --font-monospace:
+    'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace;
   --font-weight-default: normal;
   --font-weight-basis: normal;
   --font-weight-regular: normal;

--- a/packages/dnb-eufemia/src/style/themes/sbanken/properties.js
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/properties.js
@@ -2,7 +2,8 @@
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -106,7 +107,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': 'var(--sb-font-family-default)',
   '--font-family-heading': 'var(--sb-font-family-heading)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',

--- a/packages/dnb-eufemia/src/style/themes/sbanken/properties.scss
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/properties.scss
@@ -6,8 +6,8 @@
 :root {
   // Typography Family
   --sb-font-family-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --sb-font-family-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica',
-    'Arial', sans-serif;
+  --sb-font-family-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
 
   // Typography Weights
   // TODO: Do we need 3 different "normals"? Which to use when?

--- a/packages/dnb-eufemia/src/style/themes/ui/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties-tailwind.css
@@ -3,7 +3,8 @@
 /* stylelint-disable-next-line scss/at-rule-no-unknown */
 @theme {
   --font-sb-default: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  --font-sb-heading: 'MaisonNeueHeadings', 'Roboto', 'Helvetica';
+  --font-sb-heading:
+    'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif;
   --font-weight-sb-default: normal;
   --font-weight-sb-basis: normal;
   --font-weight-sb-regular: normal;
@@ -107,7 +108,9 @@
   --color-ca-pale-red: #ffdedb;
   --font-default: 'DNB', sans-serif;
   --font-heading: var(--font-family-default);
-  --font-monospace: 'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono';
+  --font-monospace:
+    'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace;
   --font-weight-default: normal;
   --font-weight-basis: normal;
   --font-weight-regular: normal;

--- a/packages/dnb-eufemia/src/style/themes/ui/properties.js
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties.js
@@ -2,7 +2,8 @@
 
 export default {
   '--sb-font-family-default': "'Roboto', 'Helvetica', 'Arial', sans-serif",
-  '--sb-font-family-heading': "'MaisonNeueHeadings', 'Roboto', 'Helvetica',",
+  '--sb-font-family-heading':
+    "'MaisonNeueHeadings', 'Roboto', 'Helvetica', 'Arial', sans-serif",
   '--sb-font-weight-default': 'normal',
   '--sb-font-weight-basis': 'normal',
   '--sb-font-weight-regular': 'normal',
@@ -106,7 +107,8 @@ export default {
   '--ca-color-pale-red': '#ffdedb',
   '--font-family-default': "'DNB', sans-serif",
   '--font-family-heading': 'var(--font-family-default)',
-  '--font-family-monospace': "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',",
+  '--font-family-monospace':
+    "'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace",
   '--font-weight-default': 'normal',
   '--font-weight-basis': 'normal',
   '--font-weight-regular': 'normal',

--- a/packages/dnb-eufemia/src/style/themes/ui/properties.scss
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties.scss
@@ -7,9 +7,9 @@
   // Typography Family
   --font-family-default: 'DNB', sans-serif;
   --font-family-heading: var(--font-family-default);
-  --font-family-monospace: 'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono',
-    'Ubuntu Monospace', 'Noto Mono', 'Oxygen Mono', 'Liberation Mono',
-    monospace;
+  --font-family-monospace:
+    'DNBMono', 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace;
 
   // Typography Weights
   --font-weight-default: normal;

--- a/packages/eufemia-starter/eslint.config.mjs
+++ b/packages/eufemia-starter/eslint.config.mjs
@@ -24,5 +24,5 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
     },
-  },
+  }
 )

--- a/tools/eufemia-llm-metadata/package.json
+++ b/tools/eufemia-llm-metadata/package.json
@@ -27,7 +27,7 @@
     "@babel/types": "7.28.5",
     "front-matter": "4.0.2",
     "fs-extra": "10.0.0",
-    "prettier": "3.0.3"
+    "prettier": "3.8.1"
   },
   "peerDependencies": {
     "gatsby": ">=5.0.0"

--- a/tools/react-live-ssr/dist/index.js
+++ b/tools/react-live-ssr/dist/index.js
@@ -1,83 +1,102 @@
-"use strict";
-var __create = Object.create;
-var __defProp = Object.defineProperty;
-var __defProps = Object.defineProperties;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropSymbols = Object.getOwnPropertySymbols;
-var __getProtoOf = Object.getPrototypeOf;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __propIsEnum = Object.prototype.propertyIsEnumerable;
-var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+'use strict'
+var __create = Object.create
+var __defProp = Object.defineProperty
+var __defProps = Object.defineProperties
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor
+var __getOwnPropDescs = Object.getOwnPropertyDescriptors
+var __getOwnPropNames = Object.getOwnPropertyNames
+var __getOwnPropSymbols = Object.getOwnPropertySymbols
+var __getProtoOf = Object.getPrototypeOf
+var __hasOwnProp = Object.prototype.hasOwnProperty
+var __propIsEnum = Object.prototype.propertyIsEnumerable
+var __defNormalProp = (obj, key, value) =>
+  key in obj
+    ? __defProp(obj, key, {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value,
+      })
+    : (obj[key] = value)
 var __spreadValues = (a, b) => {
   for (var prop in b || (b = {}))
-    if (__hasOwnProp.call(b, prop))
-      __defNormalProp(a, prop, b[prop]);
+    if (__hasOwnProp.call(b, prop)) __defNormalProp(a, prop, b[prop])
   if (__getOwnPropSymbols)
     for (var prop of __getOwnPropSymbols(b)) {
-      if (__propIsEnum.call(b, prop))
-        __defNormalProp(a, prop, b[prop]);
+      if (__propIsEnum.call(b, prop)) __defNormalProp(a, prop, b[prop])
     }
-  return a;
-};
-var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+  return a
+}
+var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b))
 var __objRest = (source, exclude) => {
-  var target = {};
+  var target = {}
   for (var prop in source)
     if (__hasOwnProp.call(source, prop) && exclude.indexOf(prop) < 0)
-      target[prop] = source[prop];
+      target[prop] = source[prop]
   if (source != null && __getOwnPropSymbols)
     for (var prop of __getOwnPropSymbols(source)) {
       if (exclude.indexOf(prop) < 0 && __propIsEnum.call(source, prop))
-        target[prop] = source[prop];
+        target[prop] = source[prop]
     }
-  return target;
-};
+  return target
+}
 var __export = (target, all) => {
   for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
+    __defProp(target, name, { get: all[name], enumerable: true })
+}
 var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === "object" || typeof from === "function") {
+  if ((from && typeof from === 'object') || typeof from === 'function') {
     for (let key of __getOwnPropNames(from))
       if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+        __defProp(to, key, {
+          get: () => from[key],
+          enumerable:
+            !(desc = __getOwnPropDesc(from, key)) || desc.enumerable,
+        })
   }
-  return to;
-};
-var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
-  // If the importer is in node compatibility mode or this is not an ESM
-  // file that has been converted to a CommonJS file using a Babel-
-  // compatible transform (i.e. "__esModule" has not been set), then set
-  // "default" to the CommonJS "module.exports" for node compatibility.
-  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
-  mod
-));
-var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+  return to
+}
+var __toESM = (mod, isNodeMode, target) => (
+  (target = mod != null ? __create(__getProtoOf(mod)) : {}),
+  __copyProps(
+    // If the importer is in node compatibility mode or this is not an ESM
+    // file that has been converted to a CommonJS file using a Babel-
+    // compatible transform (i.e. "__esModule" has not been set), then set
+    // "default" to the CommonJS "module.exports" for node compatibility.
+    isNodeMode || !mod || !mod.__esModule
+      ? __defProp(target, 'default', { value: mod, enumerable: true })
+      : target,
+    mod
+  )
+)
+var __toCommonJS = (mod) =>
+  __copyProps(__defProp({}, '__esModule', { value: true }), mod)
 var __async = (__this, __arguments, generator) => {
   return new Promise((resolve, reject) => {
     var fulfilled = (value) => {
       try {
-        step(generator.next(value));
+        step(generator.next(value))
       } catch (e) {
-        reject(e);
+        reject(e)
       }
-    };
+    }
     var rejected = (value) => {
       try {
-        step(generator.throw(value));
+        step(generator.throw(value))
       } catch (e) {
-        reject(e);
+        reject(e)
       }
-    };
-    var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
-    step((generator = generator.apply(__this, __arguments)).next());
-  });
-};
+    }
+    var step = (x) =>
+      x.done
+        ? resolve(x.value)
+        : Promise.resolve(x.value).then(fulfilled, rejected)
+    step((generator = generator.apply(__this, __arguments)).next())
+  })
+}
 
 // src/index.ts
-var src_exports = {};
+var src_exports = {}
 __export(src_exports, {
   Editor: () => Editor_default,
   LiveContext: () => LiveContext_default,
@@ -87,112 +106,124 @@ __export(src_exports, {
   LiveProvider: () => LiveProvider_default,
   generateElement: () => generateElement,
   renderElementAsync: () => renderElementAsync,
-  withLive: () => withLive
-});
-module.exports = __toCommonJS(src_exports);
+  withLive: () => withLive,
+})
+module.exports = __toCommonJS(src_exports)
 
 // src/components/Editor/index.tsx
-var import_prism_react_renderer = require("prism-react-renderer");
-var import_react = require("react");
-var import_jsx_runtime = require("react/jsx-runtime");
+var import_prism_react_renderer = require('prism-react-renderer')
+var import_react = require('react')
+var import_jsx_runtime = require('react/jsx-runtime')
 
 // -- useEditable: inline replacement for use-editable package --
 var _ue_observerSettings = {
   characterData: true,
   characterDataOldValue: true,
   childList: true,
-  subtree: true
-};
-var _ue_getCurrentRange = () => window.getSelection().getRangeAt(0);
+  subtree: true,
+}
+var _ue_getCurrentRange = () => window.getSelection().getRangeAt(0)
 var _ue_setCurrentRange = (range) => {
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-};
+  const selection = window.getSelection()
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
 var _ue_isUndoRedoKey = (event) =>
-  (event.metaKey || event.ctrlKey) && !event.altKey && event.code === "KeyZ";
+  (event.metaKey || event.ctrlKey) &&
+  !event.altKey &&
+  event.code === 'KeyZ'
 var _ue_toString = (element) => {
-  const queue = [element.firstChild];
-  let content = "";
-  let node;
+  const queue = [element.firstChild]
+  let content = ''
+  let node
   while ((node = queue.pop())) {
     if (node.nodeType === Node.TEXT_NODE) {
-      content += node.textContent;
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === "BR") {
-      content += "\n";
+      content += node.textContent
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      node.nodeName === 'BR'
+    ) {
+      content += '\n'
     }
-    if (node.nextSibling) queue.push(node.nextSibling);
-    if (node.firstChild) queue.push(node.firstChild);
+    if (node.nextSibling) queue.push(node.nextSibling)
+    if (node.firstChild) queue.push(node.firstChild)
   }
-  if (content[content.length - 1] !== "\n") content += "\n";
-  return content;
-};
+  if (content[content.length - 1] !== '\n') content += '\n'
+  return content
+}
 var _ue_setStart = (range, node, offset) => {
-  if (offset < node.textContent.length) range.setStart(node, offset);
-  else range.setStartAfter(node);
-};
+  if (offset < node.textContent.length) range.setStart(node, offset)
+  else range.setStartAfter(node)
+}
 var _ue_setEnd = (range, node, offset) => {
-  if (offset < node.textContent.length) range.setEnd(node, offset);
-  else range.setEndAfter(node);
-};
+  if (offset < node.textContent.length) range.setEnd(node, offset)
+  else range.setEndAfter(node)
+}
 var _ue_getPosition = (element) => {
-  const range = _ue_getCurrentRange();
-  const extent = !range.collapsed ? range.toString().length : 0;
-  const untilRange = document.createRange();
-  untilRange.setStart(element, 0);
-  untilRange.setEnd(range.startContainer, range.startOffset);
-  let content = untilRange.toString();
-  const position = content.length;
-  const lines = content.split("\n");
-  const line = lines.length - 1;
-  content = lines[line];
-  return { position, extent, content, line };
-};
+  const range = _ue_getCurrentRange()
+  const extent = !range.collapsed ? range.toString().length : 0
+  const untilRange = document.createRange()
+  untilRange.setStart(element, 0)
+  untilRange.setEnd(range.startContainer, range.startOffset)
+  let content = untilRange.toString()
+  const position = content.length
+  const lines = content.split('\n')
+  const line = lines.length - 1
+  content = lines[line]
+  return { position, extent, content, line }
+}
 var _ue_makeRange = (element, start, end) => {
-  if (start <= 0) start = 0;
-  if (!end || end < 0) end = start;
-  const range = document.createRange();
-  const queue = [element.firstChild];
-  let current = 0;
-  let node;
-  let position = start;
+  if (start <= 0) start = 0
+  if (!end || end < 0) end = start
+  const range = document.createRange()
+  const queue = [element.firstChild]
+  let current = 0
+  let node
+  let position = start
   while ((node = queue[queue.length - 1])) {
     if (node.nodeType === Node.TEXT_NODE) {
-      const length = node.textContent.length;
+      const length = node.textContent.length
       if (current + length >= position) {
-        const offset = position - current;
+        const offset = position - current
         if (position === start) {
-          _ue_setStart(range, node, offset);
-          if (end !== start) { position = end; continue; }
-          else break;
+          _ue_setStart(range, node, offset)
+          if (end !== start) {
+            position = end
+            continue
+          } else break
         } else {
-          _ue_setEnd(range, node, offset);
-          break;
+          _ue_setEnd(range, node, offset)
+          break
         }
       }
-      current += node.textContent.length;
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === "BR") {
+      current += node.textContent.length
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      node.nodeName === 'BR'
+    ) {
       if (current + 1 >= position) {
         if (position === start) {
-          _ue_setStart(range, node, 0);
-          if (end !== start) { position = end; continue; }
-          else break;
+          _ue_setStart(range, node, 0)
+          if (end !== start) {
+            position = end
+            continue
+          } else break
         } else {
-          _ue_setEnd(range, node, 0);
-          break;
+          _ue_setEnd(range, node, 0)
+          break
         }
       }
-      current++;
+      current++
     }
-    queue.pop();
-    if (node.nextSibling) queue.push(node.nextSibling);
-    if (node.firstChild) queue.push(node.firstChild);
+    queue.pop()
+    if (node.nextSibling) queue.push(node.nextSibling)
+    if (node.firstChild) queue.push(node.firstChild)
   }
-  return range;
-};
+  return range
+}
 var useEditable = (elementRef, onChange, opts) => {
-  if (!opts) opts = {};
-  const unblock = (0, import_react.useState)([])[1];
+  if (!opts) opts = {}
+  const unblock = (0, import_react.useState)([])[1]
   const state = (0, import_react.useState)(() => {
     const s = {
       observer: null,
@@ -201,446 +232,564 @@ var useEditable = (elementRef, onChange, opts) => {
       queue: [],
       history: [],
       historyAt: -1,
-      position: null
-    };
-    if (typeof MutationObserver !== "undefined") {
-      s.observer = new MutationObserver((batch) => { s.queue.push(...batch); });
+      position: null,
     }
-    return s;
-  })[0];
+    if (typeof MutationObserver !== 'undefined') {
+      s.observer = new MutationObserver((batch) => {
+        s.queue.push(...batch)
+      })
+    }
+    return s
+  })[0]
   var _ue_editInsert = (element, append, deleteOffset) => {
-    let range = _ue_getCurrentRange();
-    range.deleteContents();
-    range.collapse();
-    const position = _ue_getPosition(element);
-    const offset = deleteOffset || 0;
-    const start = position.position + (offset < 0 ? offset : 0);
-    const end = position.position + (offset > 0 ? offset : 0);
-    range = _ue_makeRange(element, start, end);
-    range.deleteContents();
-    if (append) range.insertNode(document.createTextNode(append));
-    _ue_setCurrentRange(_ue_makeRange(element, start + append.length));
-  };
+    let range = _ue_getCurrentRange()
+    range.deleteContents()
+    range.collapse()
+    const position = _ue_getPosition(element)
+    const offset = deleteOffset || 0
+    const start = position.position + (offset < 0 ? offset : 0)
+    const end = position.position + (offset > 0 ? offset : 0)
+    range = _ue_makeRange(element, start, end)
+    range.deleteContents()
+    if (append) range.insertNode(document.createTextNode(append))
+    _ue_setCurrentRange(_ue_makeRange(element, start + append.length))
+  }
   var _ue_editUpdate = (element, content) => {
-    const position = _ue_getPosition(element);
-    const prevContent = _ue_toString(element);
-    position.position += content.length - prevContent.length;
-    state.position = position;
-    state.onChange(content, position);
-  };
-  if (typeof navigator !== "object") return;
-  (0, import_react.useLayoutEffect)(() => {
-    state.onChange = onChange;
-    if (!elementRef.current || opts.disabled) return;
-    state.disconnected = false;
-    state.observer.observe(elementRef.current, _ue_observerSettings);
+    const position = _ue_getPosition(element)
+    const prevContent = _ue_toString(element)
+    position.position += content.length - prevContent.length
+    state.position = position
+    state.onChange(content, position)
+  }
+  if (typeof navigator !== 'object') return
+  ;(0, import_react.useLayoutEffect)(() => {
+    state.onChange = onChange
+    if (!elementRef.current || opts.disabled) return
+    state.disconnected = false
+    state.observer.observe(elementRef.current, _ue_observerSettings)
     if (state.position) {
-      const { position, extent } = state.position;
-      _ue_setCurrentRange(_ue_makeRange(elementRef.current, position, position + extent));
-    }
-    return () => { state.observer.disconnect(); };
-  });
-  (0, import_react.useLayoutEffect)(() => {
-    if (!elementRef.current || opts.disabled) {
-      state.history.length = 0;
-      state.historyAt = -1;
-      return;
-    }
-    const element = elementRef.current;
-    if (state.position) {
-      element.focus();
-      const { position, extent } = state.position;
-      _ue_setCurrentRange(_ue_makeRange(element, position, position + extent));
-    }
-    const prevWhiteSpace = element.style.whiteSpace;
-    const prevContentEditable = element.contentEditable;
-    let hasPlaintextSupport = true;
-    try { element.contentEditable = "plaintext-only"; }
-    catch (_error) { element.contentEditable = "true"; hasPlaintextSupport = false; }
-    if (prevWhiteSpace !== "pre") element.style.whiteSpace = "pre-wrap";
-    if (opts.indentation) {
-      element.style.tabSize = element.style.MozTabSize = "" + opts.indentation;
-    }
-    const indentPattern = " ".repeat(opts.indentation || 0);
-    const indentRe = new RegExp("^(?:" + indentPattern + ")");
-    const blanklineRe = new RegExp("^(?:" + indentPattern + ")*(" + indentPattern + ")$");
-    let _trackStateTimestamp = 0;
-    const trackState = (ignoreTimestamp) => {
-      if (!elementRef.current || !state.position) return;
-      const content = _ue_toString(element);
-      const position = _ue_getPosition(element);
-      const timestamp = new Date().valueOf();
-      const lastEntry = state.history[state.historyAt];
-      if ((!ignoreTimestamp && timestamp - _trackStateTimestamp < 500) ||
-          (lastEntry && lastEntry[1] === content)) {
-        _trackStateTimestamp = timestamp;
-        return;
-      }
-      const at = ++state.historyAt;
-      state.history[at] = [position, content];
-      state.history.splice(at + 1);
-      if (at > 500) { state.historyAt--; state.history.shift(); }
-    };
-    const disconnect = () => { state.observer.disconnect(); state.disconnected = true; };
-    const flushChanges = () => {
-      state.queue.push(...state.observer.takeRecords());
-      const position = _ue_getPosition(element);
-      if (state.queue.length) {
-        disconnect();
-        const content = _ue_toString(element);
-        state.position = position;
-        let mutation;
-        let i = 0;
-        while ((mutation = state.queue.pop())) {
-          if (mutation.oldValue !== null) mutation.target.textContent = mutation.oldValue;
-          for (i = mutation.removedNodes.length - 1; i >= 0; i--)
-            mutation.target.insertBefore(mutation.removedNodes[i], mutation.nextSibling);
-          for (i = mutation.addedNodes.length - 1; i >= 0; i--)
-            if (mutation.addedNodes[i].parentNode)
-              mutation.target.removeChild(mutation.addedNodes[i]);
-        }
-        state.onChange(content, position);
-      }
-    };
-    const onKeyDown = (event) => {
-      if (event.defaultPrevented || event.target !== element) return;
-      if (state.disconnected) { event.preventDefault(); return unblock([]); }
-      if (_ue_isUndoRedoKey(event)) {
-        event.preventDefault();
-        let history;
-        if (!event.shiftKey) {
-          const at = --state.historyAt;
-          history = state.history[at];
-          if (!history) state.historyAt = 0;
-        } else {
-          const at = ++state.historyAt;
-          history = state.history[at];
-          if (!history) state.historyAt = state.history.length - 1;
-        }
-        if (history) { disconnect(); state.position = history[0]; state.onChange(history[1], history[0]); }
-        return;
-      } else { trackState(); }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        const position = _ue_getPosition(element);
-        const match = /\S/g.exec(position.content);
-        const index = match ? match.index : position.content.length;
-        const text = "\n" + position.content.slice(0, index);
-        _ue_editInsert(element, text);
-      } else if ((!hasPlaintextSupport || opts.indentation) && event.key === "Backspace") {
-        event.preventDefault();
-        const range = _ue_getCurrentRange();
-        if (!range.collapsed) { _ue_editInsert(element, "", 0); }
-        else {
-          const position = _ue_getPosition(element);
-          const match = blanklineRe.exec(position.content);
-          _ue_editInsert(element, "", match ? -match[1].length : -1);
-        }
-      } else if (opts.indentation && event.key === "Tab") {
-        event.preventDefault();
-        const position = _ue_getPosition(element);
-        const start = position.position - position.content.length;
-        const content = _ue_toString(element);
-        const newContent = event.shiftKey
-          ? content.slice(0, start) + position.content.replace(indentRe, "") + content.slice(start + position.content.length)
-          : content.slice(0, start) + (opts.indentation ? " ".repeat(opts.indentation) : "\t") + content.slice(start);
-        _ue_editUpdate(element, newContent);
-      }
-      if (event.repeat) flushChanges();
-    };
-    const onKeyUp = (event) => {
-      if (event.defaultPrevented || event.isComposing) return;
-      if (!_ue_isUndoRedoKey(event)) trackState();
-      flushChanges();
-      element.focus();
-    };
-    const onSelect = (event) => {
-      state.position = window.getSelection().rangeCount && event.target === element
-        ? _ue_getPosition(element) : null;
-    };
-    const onPaste = (event) => {
-      event.preventDefault();
-      trackState(true);
-      _ue_editInsert(element, event.clipboardData.getData("text/plain"));
-      trackState(true);
-      flushChanges();
-    };
-    document.addEventListener("selectstart", onSelect);
-    window.addEventListener("keydown", onKeyDown);
-    element.addEventListener("paste", onPaste);
-    element.addEventListener("keyup", onKeyUp);
-    return () => {
-      document.removeEventListener("selectstart", onSelect);
-      window.removeEventListener("keydown", onKeyDown);
-      element.removeEventListener("paste", onPaste);
-      element.removeEventListener("keyup", onKeyUp);
-      element.style.whiteSpace = prevWhiteSpace;
-      element.contentEditable = prevContentEditable;
-    };
-  }, [elementRef.current, opts.disabled, opts.indentation]);
-};
-// -- end useEditable --
-var CodeEditor = (props) => {
-  const _a = props, {
-    code: origCode,
-    className,
-    style,
-    tabMode="indentation",
-    theme: origTheme,
-    prism,
-    language,
-    disabled,
-    onChange,
-    editorRef
-  } = _a, rest = __objRest(_a, [
-    "code",
-    "className",
-    "style",
-    "tabMode",
-    "theme",
-    "prism",
-    "language",
-    "disabled",
-    "onChange",
-    "editorRef"
-  ]);
-  const _editorRef = editorRef || (0, import_react.useRef)(null);
-  const [code, setCode] = (0, import_react.useState)(origCode || "");
-  const { theme } = props;
-  (0, import_react.useEffect)(() => {
-    setCode(origCode);
-  }, [origCode]);
-  useEditable(_editorRef, (text) => setCode(text.slice(0, -1)), {
-    disabled,
-    indentation: tabMode === "indentation" ? 2 : void 0
-  });
-  (0, import_react.useEffect)(() => {
-    if (onChange) {
-      onChange(code);
-    }
-  }, [code]);
-  return /* @__PURE__ */ (0, import_jsx_runtime.jsx)("div", { className, style, children: /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
-    import_prism_react_renderer.Highlight,
-    {
-      prism: prism || import_prism_react_renderer.Prism,
-      code,
-      theme: origTheme || import_prism_react_renderer.themes.nightOwl,
-      language,
-      children: ({
-        className: _className,
-        tokens,
-        getLineProps,
-        getTokenProps,
-        style: _style
-      }) => /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
-        "pre",
-        __spreadProps(__spreadValues({
-          className: _className,
-          style: __spreadValues(__spreadValues({
-            margin: 0,
-            outline: "none",
-            padding: 10,
-            fontFamily: "inherit"
-          }, theme && typeof theme.plain === "object" ? theme.plain : {}), _style),
-          ref: _editorRef,
-          spellCheck: "false"
-        }, rest), {
-          children: tokens.map((line, lineIndex) => /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("span", __spreadProps(__spreadValues({}, getLineProps({ line })), { children: [
-            line.filter((token) => !token.empty).map((token, tokenIndex) => /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
-              "span",
-              __spreadValues({}, getTokenProps({ token })),
-              `token-${tokenIndex}`
-            )),
-            "\n"
-          ] }), `line-${lineIndex}`))
-        })
+      const { position, extent } = state.position
+      _ue_setCurrentRange(
+        _ue_makeRange(elementRef.current, position, position + extent)
       )
     }
-  ) });
-};
-var Editor_default = CodeEditor;
+    return () => {
+      state.observer.disconnect()
+    }
+  })
+  ;(0, import_react.useLayoutEffect)(() => {
+    if (!elementRef.current || opts.disabled) {
+      state.history.length = 0
+      state.historyAt = -1
+      return
+    }
+    const element = elementRef.current
+    if (state.position) {
+      element.focus()
+      const { position, extent } = state.position
+      _ue_setCurrentRange(
+        _ue_makeRange(element, position, position + extent)
+      )
+    }
+    const prevWhiteSpace = element.style.whiteSpace
+    const prevContentEditable = element.contentEditable
+    let hasPlaintextSupport = true
+    try {
+      element.contentEditable = 'plaintext-only'
+    } catch (_error) {
+      element.contentEditable = 'true'
+      hasPlaintextSupport = false
+    }
+    if (prevWhiteSpace !== 'pre') element.style.whiteSpace = 'pre-wrap'
+    if (opts.indentation) {
+      element.style.tabSize = element.style.MozTabSize =
+        '' + opts.indentation
+    }
+    const indentPattern = ' '.repeat(opts.indentation || 0)
+    const indentRe = new RegExp('^(?:' + indentPattern + ')')
+    const blanklineRe = new RegExp(
+      '^(?:' + indentPattern + ')*(' + indentPattern + ')$'
+    )
+    let _trackStateTimestamp = 0
+    const trackState = (ignoreTimestamp) => {
+      if (!elementRef.current || !state.position) return
+      const content = _ue_toString(element)
+      const position = _ue_getPosition(element)
+      const timestamp = new Date().valueOf()
+      const lastEntry = state.history[state.historyAt]
+      if (
+        (!ignoreTimestamp && timestamp - _trackStateTimestamp < 500) ||
+        (lastEntry && lastEntry[1] === content)
+      ) {
+        _trackStateTimestamp = timestamp
+        return
+      }
+      const at = ++state.historyAt
+      state.history[at] = [position, content]
+      state.history.splice(at + 1)
+      if (at > 500) {
+        state.historyAt--
+        state.history.shift()
+      }
+    }
+    const disconnect = () => {
+      state.observer.disconnect()
+      state.disconnected = true
+    }
+    const flushChanges = () => {
+      state.queue.push(...state.observer.takeRecords())
+      const position = _ue_getPosition(element)
+      if (state.queue.length) {
+        disconnect()
+        const content = _ue_toString(element)
+        state.position = position
+        let mutation
+        let i = 0
+        while ((mutation = state.queue.pop())) {
+          if (mutation.oldValue !== null)
+            mutation.target.textContent = mutation.oldValue
+          for (i = mutation.removedNodes.length - 1; i >= 0; i--)
+            mutation.target.insertBefore(
+              mutation.removedNodes[i],
+              mutation.nextSibling
+            )
+          for (i = mutation.addedNodes.length - 1; i >= 0; i--)
+            if (mutation.addedNodes[i].parentNode)
+              mutation.target.removeChild(mutation.addedNodes[i])
+        }
+        state.onChange(content, position)
+      }
+    }
+    const onKeyDown = (event) => {
+      if (event.defaultPrevented || event.target !== element) return
+      if (state.disconnected) {
+        event.preventDefault()
+        return unblock([])
+      }
+      if (_ue_isUndoRedoKey(event)) {
+        event.preventDefault()
+        let history
+        if (!event.shiftKey) {
+          const at = --state.historyAt
+          history = state.history[at]
+          if (!history) state.historyAt = 0
+        } else {
+          const at = ++state.historyAt
+          history = state.history[at]
+          if (!history) state.historyAt = state.history.length - 1
+        }
+        if (history) {
+          disconnect()
+          state.position = history[0]
+          state.onChange(history[1], history[0])
+        }
+        return
+      } else {
+        trackState()
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        const position = _ue_getPosition(element)
+        const match = /\S/g.exec(position.content)
+        const index = match ? match.index : position.content.length
+        const text = '\n' + position.content.slice(0, index)
+        _ue_editInsert(element, text)
+      } else if (
+        (!hasPlaintextSupport || opts.indentation) &&
+        event.key === 'Backspace'
+      ) {
+        event.preventDefault()
+        const range = _ue_getCurrentRange()
+        if (!range.collapsed) {
+          _ue_editInsert(element, '', 0)
+        } else {
+          const position = _ue_getPosition(element)
+          const match = blanklineRe.exec(position.content)
+          _ue_editInsert(element, '', match ? -match[1].length : -1)
+        }
+      } else if (opts.indentation && event.key === 'Tab') {
+        event.preventDefault()
+        const position = _ue_getPosition(element)
+        const start = position.position - position.content.length
+        const content = _ue_toString(element)
+        const newContent = event.shiftKey
+          ? content.slice(0, start) +
+            position.content.replace(indentRe, '') +
+            content.slice(start + position.content.length)
+          : content.slice(0, start) +
+            (opts.indentation ? ' '.repeat(opts.indentation) : '\t') +
+            content.slice(start)
+        _ue_editUpdate(element, newContent)
+      }
+      if (event.repeat) flushChanges()
+    }
+    const onKeyUp = (event) => {
+      if (event.defaultPrevented || event.isComposing) return
+      if (!_ue_isUndoRedoKey(event)) trackState()
+      flushChanges()
+      element.focus()
+    }
+    const onSelect = (event) => {
+      state.position =
+        window.getSelection().rangeCount && event.target === element
+          ? _ue_getPosition(element)
+          : null
+    }
+    const onPaste = (event) => {
+      event.preventDefault()
+      trackState(true)
+      _ue_editInsert(element, event.clipboardData.getData('text/plain'))
+      trackState(true)
+      flushChanges()
+    }
+    document.addEventListener('selectstart', onSelect)
+    window.addEventListener('keydown', onKeyDown)
+    element.addEventListener('paste', onPaste)
+    element.addEventListener('keyup', onKeyUp)
+    return () => {
+      document.removeEventListener('selectstart', onSelect)
+      window.removeEventListener('keydown', onKeyDown)
+      element.removeEventListener('paste', onPaste)
+      element.removeEventListener('keyup', onKeyUp)
+      element.style.whiteSpace = prevWhiteSpace
+      element.contentEditable = prevContentEditable
+    }
+  }, [elementRef.current, opts.disabled, opts.indentation])
+}
+// -- end useEditable --
+var CodeEditor = (props) => {
+  const _a = props,
+    {
+      code: origCode,
+      className,
+      style,
+      tabMode = 'indentation',
+      theme: origTheme,
+      prism,
+      language,
+      disabled,
+      onChange,
+      editorRef,
+    } = _a,
+    rest = __objRest(_a, [
+      'code',
+      'className',
+      'style',
+      'tabMode',
+      'theme',
+      'prism',
+      'language',
+      'disabled',
+      'onChange',
+      'editorRef',
+    ])
+  const _editorRef = editorRef || (0, import_react.useRef)(null)
+  const [code, setCode] = (0, import_react.useState)(origCode || '')
+  const { theme } = props
+  ;(0, import_react.useEffect)(() => {
+    setCode(origCode)
+  }, [origCode])
+  useEditable(_editorRef, (text) => setCode(text.slice(0, -1)), {
+    disabled,
+    indentation: tabMode === 'indentation' ? 2 : void 0,
+  })
+  ;(0, import_react.useEffect)(() => {
+    if (onChange) {
+      onChange(code)
+    }
+  }, [code])
+  return /* @__PURE__ */ (0, import_jsx_runtime.jsx)('div', {
+    className,
+    style,
+    children: /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+      import_prism_react_renderer.Highlight,
+      {
+        prism: prism || import_prism_react_renderer.Prism,
+        code,
+        theme: origTheme || import_prism_react_renderer.themes.nightOwl,
+        language,
+        children: ({
+          className: _className,
+          tokens,
+          getLineProps,
+          getTokenProps,
+          style: _style,
+        }) =>
+          /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+            'pre',
+            __spreadProps(
+              __spreadValues(
+                {
+                  className: _className,
+                  style: __spreadValues(
+                    __spreadValues(
+                      {
+                        margin: 0,
+                        outline: 'none',
+                        padding: 10,
+                        fontFamily: 'inherit',
+                      },
+                      theme && typeof theme.plain === 'object'
+                        ? theme.plain
+                        : {}
+                    ),
+                    _style
+                  ),
+                  ref: _editorRef,
+                  spellCheck: 'false',
+                },
+                rest
+              ),
+              {
+                children: tokens.map((line, lineIndex) =>
+                  /* @__PURE__ */ (0, import_jsx_runtime.jsxs)(
+                    'span',
+                    __spreadProps(
+                      __spreadValues({}, getLineProps({ line })),
+                      {
+                        children: [
+                          line
+                            .filter((token) => !token.empty)
+                            .map((token, tokenIndex) =>
+                              /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+                                'span',
+                                __spreadValues(
+                                  {},
+                                  getTokenProps({ token })
+                                ),
+                                `token-${tokenIndex}`
+                              )
+                            ),
+                          '\n',
+                        ],
+                      }
+                    ),
+                    `line-${lineIndex}`
+                  )
+                ),
+              }
+            )
+          ),
+      }
+    ),
+  })
+}
+var Editor_default = CodeEditor
 
 // src/components/Live/LiveProvider.tsx
-var import_react5 = require("react");
+var import_react5 = require('react')
 
 // src/components/Live/LiveContext.ts
-var import_react2 = require("react");
-var LiveContext = (0, import_react2.createContext)({});
-var LiveContext_default = LiveContext;
+var import_react2 = require('react')
+var LiveContext = (0, import_react2.createContext)({})
+var LiveContext_default = LiveContext
 
 // src/utils/transpile/index.ts
-var import_react4 = __toESM(require("react"));
+var import_react4 = __toESM(require('react'))
 
 // src/utils/transpile/transform.ts
-var import_sucrase = require("sucrase");
-var defaultTransforms = ["jsx", "imports"];
+var import_sucrase = require('sucrase')
+var defaultTransforms = ['jsx', 'imports']
 function transform(opts = {}) {
-  const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
-  return (code) => (0, import_sucrase.transform)(code, { transforms }).code;
+  const transforms = Array.isArray(opts.transforms)
+    ? opts.transforms.filter(Boolean)
+    : defaultTransforms
+  return (code) => (0, import_sucrase.transform)(code, { transforms }).code
 }
 
 // src/utils/transpile/errorBoundary.tsx
-var import_react3 = __toESM(require("react"));
-var import_jsx_runtime2 = require("react/jsx-runtime");
+var import_react3 = __toESM(require('react'))
+var import_jsx_runtime2 = require('react/jsx-runtime')
 var errorBoundary = (Element, errorCallback) => {
   return class ErrorBoundary extends import_react3.Component {
     componentDidCatch(error) {
-      errorCallback(error);
+      errorCallback(error)
     }
     render() {
-      return typeof Element === "function" ? /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(Element, {}) : import_react3.default.isValidElement(Element) ? Element : null;
+      return typeof Element === 'function'
+        ? /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(Element, {})
+        : import_react3.default.isValidElement(Element)
+        ? Element
+        : null
     }
-  };
-};
-var errorBoundary_default = errorBoundary;
+  }
+}
+var errorBoundary_default = errorBoundary
 
 // src/utils/transpile/evalCode.ts
 var evalCode = (code, scope) => {
-  const scopeKeys = Object.keys(scope);
-  const scopeValues = scopeKeys.map((key) => scope[key]);
-  return new Function(...scopeKeys, code)(...scopeValues);
-};
-var evalCode_default = evalCode;
+  const scopeKeys = Object.keys(scope)
+  const scopeValues = scopeKeys.map((key) => scope[key])
+  return new Function(...scopeKeys, code)(...scopeValues)
+}
+var evalCode_default = evalCode
 
 // src/utils/transpile/compose.ts
 function compose(...functions) {
   return functions.reduce(
-    (acc, currentFn) => (...args) => acc(currentFn(...args))
-  );
+    (acc, currentFn) =>
+      (...args) =>
+        acc(currentFn(...args))
+  )
 }
 
 // src/utils/transpile/index.ts
-var jsxConst = 'const _jsxFileName = "";';
-var trimCode = (code) => code.trim().replace(/;$/, "");
-var spliceJsxConst = (code) => code.replace(jsxConst, "").trim();
-var addJsxConst = (code) => jsxConst + code;
-var wrapReturn = (code) => `return (${code})`;
-var generateElement = ({ code = "", scope = {}, enableTypeScript = true }, errorCallback) => {
-  const firstPassTransforms = ["jsx"];
-  enableTypeScript && firstPassTransforms.push("typescript");
+var jsxConst = 'const _jsxFileName = "";'
+var trimCode = (code) => code.trim().replace(/;$/, '')
+var spliceJsxConst = (code) => code.replace(jsxConst, '').trim()
+var addJsxConst = (code) => jsxConst + code
+var wrapReturn = (code) => `return (${code})`
+var generateElement = (
+  { code = '', scope = {}, enableTypeScript = true },
+  errorCallback
+) => {
+  const firstPassTransforms = ['jsx']
+  enableTypeScript && firstPassTransforms.push('typescript')
   const transformed = compose(
     addJsxConst,
-    transform({ transforms: ["imports"] }),
+    transform({ transforms: ['imports'] }),
     wrapReturn,
     spliceJsxConst,
     trimCode,
     transform({ transforms: firstPassTransforms }),
     trimCode
-  )(code);
+  )(code)
   return errorBoundary_default(
-    evalCode_default(transformed, __spreadValues({ React: import_react4.default }, scope)),
+    evalCode_default(
+      transformed,
+      __spreadValues({ React: import_react4.default }, scope)
+    ),
     errorCallback
-  );
-};
-var renderElementAsync = ({ code = "", scope = {}, enableTypeScript = true }, resultCallback, errorCallback) => {
+  )
+}
+var renderElementAsync = (
+  { code = '', scope = {}, enableTypeScript = true },
+  resultCallback,
+  errorCallback
+) => {
   const render = (element) => {
-    if (typeof element === "undefined") {
-      errorCallback(new SyntaxError("`render` must be called with valid JSX."));
+    if (typeof element === 'undefined') {
+      errorCallback(
+        new SyntaxError('`render` must be called with valid JSX.')
+      )
     } else {
-      resultCallback(errorBoundary_default(element, errorCallback));
+      resultCallback(errorBoundary_default(element, errorCallback))
     }
-  };
+  }
   if (!/render\s*\(/.test(code)) {
     return errorCallback(
-      new SyntaxError("No-Inline evaluations must call `render`.")
-    );
+      new SyntaxError('No-Inline evaluations must call `render`.')
+    )
   }
-  const transforms = ["jsx", "imports"];
-  enableTypeScript && transforms.splice(1, 0, "typescript");
-  evalCode_default(transform({ transforms })(code), __spreadProps(__spreadValues({ React: import_react4.default }, scope), { render }));
-};
+  const transforms = ['jsx', 'imports']
+  enableTypeScript && transforms.splice(1, 0, 'typescript')
+  evalCode_default(
+    transform({ transforms })(code),
+    __spreadProps(
+      __spreadValues({ React: import_react4.default }, scope),
+      { render }
+    )
+  )
+}
 
 // src/components/Live/LiveProvider.tsx
-var import_jsx_runtime3 = require("react/jsx-runtime");
+var import_jsx_runtime3 = require('react/jsx-runtime')
 function LiveProvider({
   children,
-  code = "",
-  language = "tsx",
+  code = '',
+  language = 'tsx',
   theme,
   enableTypeScript = true,
   disabled = false,
   scope,
   transformCode,
   noInline = false,
-  skipInitialRender = false
+  skipInitialRender = false,
 }) {
-  const cache = (0, import_react5.useRef)("initial");
-  const [state, setState] = (0, import_react5.useState)(() => transpileSync(code));
+  const cache = (0, import_react5.useRef)('initial')
+  const [state, setState] = (0, import_react5.useState)(() =>
+    transpileSync(code)
+  )
   function transpileSync(code2) {
     const returnObject = {
       element: void 0,
-      error: void 0
-    };
+      error: void 0,
+    }
     if (!skipInitialRender) {
       const renderElement = (element) => {
-        return returnObject.element = element;
-      };
+        return (returnObject.element = element)
+      }
       const errorCallback = (error) => {
-        return returnObject.error = String(error);
-      };
+        return (returnObject.error = String(error))
+      }
       try {
-        const transformResult = transformCode ? transformCode(code2) : code2;
+        const transformResult = transformCode
+          ? transformCode(code2)
+          : code2
         const input = {
           code: transformResult,
           scope,
-          enableTypeScript
-        };
-        if (noInline) {
-          renderElementAsync(input, renderElement, errorCallback);
-        } else {
-          renderElement(generateElement(input, errorCallback));
+          enableTypeScript,
         }
-        cache.current = code2;
+        if (noInline) {
+          renderElementAsync(input, renderElement, errorCallback)
+        } else {
+          renderElement(generateElement(input, errorCallback))
+        }
+        cache.current = code2
       } catch (e) {
-        errorCallback(e);
+        errorCallback(e)
       }
     }
-    return returnObject;
+    return returnObject
   }
   function transpileAsync(newCode) {
     return __async(this, null, function* () {
       if (cache.current === newCode) {
-        cache.current = "used";
-        return Promise.resolve();
+        cache.current = 'used'
+        return Promise.resolve()
       }
       const errorCallback = (error) => {
-        setState({ error: error.toString(), element: void 0 });
-      };
+        setState({ error: error.toString(), element: void 0 })
+      }
       try {
-        const transformResult = transformCode ? transformCode(newCode) : newCode;
+        const transformResult = transformCode
+          ? transformCode(newCode)
+          : newCode
         try {
-          const transformedCode = yield Promise.resolve(transformResult);
-          const renderElement = (element) => setState({ error: void 0, element });
-          if (typeof transformedCode !== "string") {
-            throw new Error("Code failed to transform");
+          const transformedCode = yield Promise.resolve(transformResult)
+          const renderElement = (element) =>
+            setState({ error: void 0, element })
+          if (typeof transformedCode !== 'string') {
+            throw new Error('Code failed to transform')
           }
           const input = {
             code: transformedCode,
             scope,
-            enableTypeScript
-          };
+            enableTypeScript,
+          }
           if (noInline) {
-            setState({ error: void 0, element: null });
-            renderElementAsync(input, renderElement, errorCallback);
+            setState({ error: void 0, element: null })
+            renderElementAsync(input, renderElement, errorCallback)
           } else {
-            renderElement(generateElement(input, errorCallback));
+            renderElement(generateElement(input, errorCallback))
           }
         } catch (error) {
-          return errorCallback(error);
+          return errorCallback(error)
         }
       } catch (e) {
-        errorCallback(e);
-        return Promise.resolve();
+        errorCallback(e)
+        return Promise.resolve()
       }
-    });
+    })
   }
-  const onError = (error) => setState({ error: error.toString() });
-  (0, import_react5.useEffect)(() => {
-    transpileAsync(code).catch(onError);
-  }, [code, scope, noInline, transformCode]);
+  const onError = (error) => setState({ error: error.toString() })
+  ;(0, import_react5.useEffect)(() => {
+    transpileAsync(code).catch(onError)
+  }, [code, scope, noInline, transformCode])
   const onChange = (newCode) => {
-    transpileAsync(newCode).catch(onError);
-  };
+    transpileAsync(newCode).catch(onError)
+  }
   return /* @__PURE__ */ (0, import_jsx_runtime3.jsx)(
     LiveContext_default.Provider,
     {
@@ -650,66 +799,97 @@ function LiveProvider({
         theme,
         disabled,
         onError,
-        onChange
+        onChange,
       }),
-      children
+      children,
     }
-  );
+  )
 }
-var LiveProvider_default = LiveProvider;
+var LiveProvider_default = LiveProvider
 
 // src/components/Live/LiveEditor.tsx
-var import_react6 = require("react");
-var import_jsx_runtime4 = require("react/jsx-runtime");
+var import_react6 = require('react')
+var import_jsx_runtime4 = require('react/jsx-runtime')
 function LiveEditor(props) {
-  const { code, language, theme, disabled, onChange } = (0, import_react6.useContext)(LiveContext_default);
+  const { code, language, theme, disabled, onChange } = (0,
+  import_react6.useContext)(LiveContext_default)
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(
     Editor_default,
-    __spreadValues({
-      theme,
-      code,
-      language,
-      disabled,
-      onChange
-    }, props)
-  );
+    __spreadValues(
+      {
+        theme,
+        code,
+        language,
+        disabled,
+        onChange,
+      },
+      props
+    )
+  )
 }
 
 // src/components/Live/LiveError.tsx
-var import_react7 = require("react");
-var import_jsx_runtime5 = require("react/jsx-runtime");
+var import_react7 = require('react')
+var import_jsx_runtime5 = require('react/jsx-runtime')
 function LiveError(props) {
-  const { error } = (0, import_react7.useContext)(LiveContext_default);
-  return error ? /* @__PURE__ */ (0, import_jsx_runtime5.jsx)("pre", __spreadProps(__spreadValues({}, props), { children: error })) : null;
+  const { error } = (0, import_react7.useContext)(LiveContext_default)
+  return error
+    ? /* @__PURE__ */ (0, import_jsx_runtime5.jsx)(
+        'pre',
+        __spreadProps(__spreadValues({}, props), { children: error })
+      )
+    : null
 }
 
 // src/components/Live/LivePreview.tsx
-var import_react8 = require("react");
-var import_jsx_runtime6 = require("react/jsx-runtime");
+var import_react8 = require('react')
+var import_jsx_runtime6 = require('react/jsx-runtime')
 function LivePreview(_a) {
-  var _b = _a, { Component: Component2 = "div" } = _b, rest = __objRest(_b, ["Component"]);
-  const { element: Element } = (0, import_react8.useContext)(LiveContext_default);
-  return /* @__PURE__ */ (0, import_jsx_runtime6.jsx)(Component2, __spreadProps(__spreadValues({}, rest), { children: Element ? /* @__PURE__ */ (0, import_jsx_runtime6.jsx)(Element, {}) : null }));
+  var _b = _a,
+    { Component: Component2 = 'div' } = _b,
+    rest = __objRest(_b, ['Component'])
+  const { element: Element } = (0, import_react8.useContext)(
+    LiveContext_default
+  )
+  return /* @__PURE__ */ (0, import_jsx_runtime6.jsx)(
+    Component2,
+    __spreadProps(__spreadValues({}, rest), {
+      children: Element
+        ? /* @__PURE__ */ (0, import_jsx_runtime6.jsx)(Element, {})
+        : null,
+    })
+  )
 }
-var LivePreview_default = LivePreview;
+var LivePreview_default = LivePreview
 
 // src/hoc/withLive.tsx
-var import_jsx_runtime7 = require("react/jsx-runtime");
+var import_jsx_runtime7 = require('react/jsx-runtime')
 function withLive(WrappedComponent) {
-  const WithLive = (props) => /* @__PURE__ */ (0, import_jsx_runtime7.jsx)(LiveContext_default.Consumer, { children: (live) => /* @__PURE__ */ (0, import_jsx_runtime7.jsx)(WrappedComponent, __spreadValues({ live }, props)) });
-  WithLive.displayName = "WithLive";
-  return WithLive;
+  const WithLive = (props) =>
+    /* @__PURE__ */ (0, import_jsx_runtime7.jsx)(
+      LiveContext_default.Consumer,
+      {
+        children: (live) =>
+          /* @__PURE__ */ (0, import_jsx_runtime7.jsx)(
+            WrappedComponent,
+            __spreadValues({ live }, props)
+          ),
+      }
+    )
+  WithLive.displayName = 'WithLive'
+  return WithLive
 }
 // Annotate the CommonJS export names for ESM import in node:
-0 && (module.exports = {
-  Editor,
-  LiveContext,
-  LiveEditor,
-  LiveError,
-  LivePreview,
-  LiveProvider,
-  generateElement,
-  renderElementAsync,
-  withLive
-});
+0 &&
+  (module.exports = {
+    Editor,
+    LiveContext,
+    LiveEditor,
+    LiveError,
+    LivePreview,
+    LiveProvider,
+    generateElement,
+    renderElementAsync,
+    withLive,
+  })
 //# sourceMappingURL=index.js.map

--- a/tools/react-live-ssr/dist/index.mjs
+++ b/tools/react-live-ssr/dist/index.mjs
@@ -1,157 +1,178 @@
-var __defProp = Object.defineProperty;
-var __defProps = Object.defineProperties;
-var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
-var __getOwnPropSymbols = Object.getOwnPropertySymbols;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __propIsEnum = Object.prototype.propertyIsEnumerable;
-var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __defProp = Object.defineProperty
+var __defProps = Object.defineProperties
+var __getOwnPropDescs = Object.getOwnPropertyDescriptors
+var __getOwnPropSymbols = Object.getOwnPropertySymbols
+var __hasOwnProp = Object.prototype.hasOwnProperty
+var __propIsEnum = Object.prototype.propertyIsEnumerable
+var __defNormalProp = (obj, key, value) =>
+  key in obj
+    ? __defProp(obj, key, {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value,
+      })
+    : (obj[key] = value)
 var __spreadValues = (a, b) => {
   for (var prop in b || (b = {}))
-    if (__hasOwnProp.call(b, prop))
-      __defNormalProp(a, prop, b[prop]);
+    if (__hasOwnProp.call(b, prop)) __defNormalProp(a, prop, b[prop])
   if (__getOwnPropSymbols)
     for (var prop of __getOwnPropSymbols(b)) {
-      if (__propIsEnum.call(b, prop))
-        __defNormalProp(a, prop, b[prop]);
+      if (__propIsEnum.call(b, prop)) __defNormalProp(a, prop, b[prop])
     }
-  return a;
-};
-var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+  return a
+}
+var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b))
 var __objRest = (source, exclude) => {
-  var target = {};
+  var target = {}
   for (var prop in source)
     if (__hasOwnProp.call(source, prop) && exclude.indexOf(prop) < 0)
-      target[prop] = source[prop];
+      target[prop] = source[prop]
   if (source != null && __getOwnPropSymbols)
     for (var prop of __getOwnPropSymbols(source)) {
       if (exclude.indexOf(prop) < 0 && __propIsEnum.call(source, prop))
-        target[prop] = source[prop];
+        target[prop] = source[prop]
     }
-  return target;
-};
+  return target
+}
 var __async = (__this, __arguments, generator) => {
   return new Promise((resolve, reject) => {
     var fulfilled = (value) => {
       try {
-        step(generator.next(value));
+        step(generator.next(value))
       } catch (e) {
-        reject(e);
+        reject(e)
       }
-    };
+    }
     var rejected = (value) => {
       try {
-        step(generator.throw(value));
+        step(generator.throw(value))
       } catch (e) {
-        reject(e);
+        reject(e)
       }
-    };
-    var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
-    step((generator = generator.apply(__this, __arguments)).next());
-  });
-};
+    }
+    var step = (x) =>
+      x.done
+        ? resolve(x.value)
+        : Promise.resolve(x.value).then(fulfilled, rejected)
+    step((generator = generator.apply(__this, __arguments)).next())
+  })
+}
 
 // src/components/Editor/index.tsx
-import { Highlight, Prism, themes } from "prism-react-renderer";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { jsx, jsxs } from "react/jsx-runtime";
+import { Highlight, Prism, themes } from 'prism-react-renderer'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { jsx, jsxs } from 'react/jsx-runtime'
 
 // -- useEditable: inline replacement for use-editable package --
 var _ue_observerSettings = {
   characterData: true,
   characterDataOldValue: true,
   childList: true,
-  subtree: true
-};
-var _ue_getCurrentRange = () => window.getSelection().getRangeAt(0);
+  subtree: true,
+}
+var _ue_getCurrentRange = () => window.getSelection().getRangeAt(0)
 var _ue_setCurrentRange = (range) => {
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-};
+  const selection = window.getSelection()
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
 var _ue_isUndoRedoKey = (event) =>
-  (event.metaKey || event.ctrlKey) && !event.altKey && event.code === "KeyZ";
+  (event.metaKey || event.ctrlKey) &&
+  !event.altKey &&
+  event.code === 'KeyZ'
 var _ue_toString = (element) => {
-  const queue = [element.firstChild];
-  let content = "";
-  let node;
+  const queue = [element.firstChild]
+  let content = ''
+  let node
   while ((node = queue.pop())) {
     if (node.nodeType === Node.TEXT_NODE) {
-      content += node.textContent;
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === "BR") {
-      content += "\n";
+      content += node.textContent
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      node.nodeName === 'BR'
+    ) {
+      content += '\n'
     }
-    if (node.nextSibling) queue.push(node.nextSibling);
-    if (node.firstChild) queue.push(node.firstChild);
+    if (node.nextSibling) queue.push(node.nextSibling)
+    if (node.firstChild) queue.push(node.firstChild)
   }
-  if (content[content.length - 1] !== "\n") content += "\n";
-  return content;
-};
+  if (content[content.length - 1] !== '\n') content += '\n'
+  return content
+}
 var _ue_setStart = (range, node, offset) => {
-  if (offset < node.textContent.length) range.setStart(node, offset);
-  else range.setStartAfter(node);
-};
+  if (offset < node.textContent.length) range.setStart(node, offset)
+  else range.setStartAfter(node)
+}
 var _ue_setEnd = (range, node, offset) => {
-  if (offset < node.textContent.length) range.setEnd(node, offset);
-  else range.setEndAfter(node);
-};
+  if (offset < node.textContent.length) range.setEnd(node, offset)
+  else range.setEndAfter(node)
+}
 var _ue_getPosition = (element) => {
-  const range = _ue_getCurrentRange();
-  const extent = !range.collapsed ? range.toString().length : 0;
-  const untilRange = document.createRange();
-  untilRange.setStart(element, 0);
-  untilRange.setEnd(range.startContainer, range.startOffset);
-  let content = untilRange.toString();
-  const position = content.length;
-  const lines = content.split("\n");
-  const line = lines.length - 1;
-  content = lines[line];
-  return { position, extent, content, line };
-};
+  const range = _ue_getCurrentRange()
+  const extent = !range.collapsed ? range.toString().length : 0
+  const untilRange = document.createRange()
+  untilRange.setStart(element, 0)
+  untilRange.setEnd(range.startContainer, range.startOffset)
+  let content = untilRange.toString()
+  const position = content.length
+  const lines = content.split('\n')
+  const line = lines.length - 1
+  content = lines[line]
+  return { position, extent, content, line }
+}
 var _ue_makeRange = (element, start, end) => {
-  if (start <= 0) start = 0;
-  if (!end || end < 0) end = start;
-  const range = document.createRange();
-  const queue = [element.firstChild];
-  let current = 0;
-  let node;
-  let position = start;
+  if (start <= 0) start = 0
+  if (!end || end < 0) end = start
+  const range = document.createRange()
+  const queue = [element.firstChild]
+  let current = 0
+  let node
+  let position = start
   while ((node = queue[queue.length - 1])) {
     if (node.nodeType === Node.TEXT_NODE) {
-      const length = node.textContent.length;
+      const length = node.textContent.length
       if (current + length >= position) {
-        const offset = position - current;
+        const offset = position - current
         if (position === start) {
-          _ue_setStart(range, node, offset);
-          if (end !== start) { position = end; continue; }
-          else break;
+          _ue_setStart(range, node, offset)
+          if (end !== start) {
+            position = end
+            continue
+          } else break
         } else {
-          _ue_setEnd(range, node, offset);
-          break;
+          _ue_setEnd(range, node, offset)
+          break
         }
       }
-      current += node.textContent.length;
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === "BR") {
+      current += node.textContent.length
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      node.nodeName === 'BR'
+    ) {
       if (current + 1 >= position) {
         if (position === start) {
-          _ue_setStart(range, node, 0);
-          if (end !== start) { position = end; continue; }
-          else break;
+          _ue_setStart(range, node, 0)
+          if (end !== start) {
+            position = end
+            continue
+          } else break
         } else {
-          _ue_setEnd(range, node, 0);
-          break;
+          _ue_setEnd(range, node, 0)
+          break
         }
       }
-      current++;
+      current++
     }
-    queue.pop();
-    if (node.nextSibling) queue.push(node.nextSibling);
-    if (node.firstChild) queue.push(node.firstChild);
+    queue.pop()
+    if (node.nextSibling) queue.push(node.nextSibling)
+    if (node.firstChild) queue.push(node.firstChild)
   }
-  return range;
-};
+  return range
+}
 var useEditable = (elementRef, onChange, opts) => {
-  if (!opts) opts = {};
-  const unblock = useState([])[1];
+  if (!opts) opts = {}
+  const unblock = useState([])[1]
   const state = useState(() => {
     const s = {
       observer: null,
@@ -160,227 +181,276 @@ var useEditable = (elementRef, onChange, opts) => {
       queue: [],
       history: [],
       historyAt: -1,
-      position: null
-    };
-    if (typeof MutationObserver !== "undefined") {
-      s.observer = new MutationObserver((batch) => { s.queue.push(...batch); });
+      position: null,
     }
-    return s;
-  })[0];
+    if (typeof MutationObserver !== 'undefined') {
+      s.observer = new MutationObserver((batch) => {
+        s.queue.push(...batch)
+      })
+    }
+    return s
+  })[0]
   var _ue_editInsert = (element, append, deleteOffset) => {
-    let range = _ue_getCurrentRange();
-    range.deleteContents();
-    range.collapse();
-    const position = _ue_getPosition(element);
-    const offset = deleteOffset || 0;
-    const start = position.position + (offset < 0 ? offset : 0);
-    const end = position.position + (offset > 0 ? offset : 0);
-    range = _ue_makeRange(element, start, end);
-    range.deleteContents();
-    if (append) range.insertNode(document.createTextNode(append));
-    _ue_setCurrentRange(_ue_makeRange(element, start + append.length));
-  };
+    let range = _ue_getCurrentRange()
+    range.deleteContents()
+    range.collapse()
+    const position = _ue_getPosition(element)
+    const offset = deleteOffset || 0
+    const start = position.position + (offset < 0 ? offset : 0)
+    const end = position.position + (offset > 0 ? offset : 0)
+    range = _ue_makeRange(element, start, end)
+    range.deleteContents()
+    if (append) range.insertNode(document.createTextNode(append))
+    _ue_setCurrentRange(_ue_makeRange(element, start + append.length))
+  }
   var _ue_editUpdate = (element, content) => {
-    const position = _ue_getPosition(element);
-    const prevContent = _ue_toString(element);
-    position.position += content.length - prevContent.length;
-    state.position = position;
-    state.onChange(content, position);
-  };
-  if (typeof navigator !== "object") return;
+    const position = _ue_getPosition(element)
+    const prevContent = _ue_toString(element)
+    position.position += content.length - prevContent.length
+    state.position = position
+    state.onChange(content, position)
+  }
+  if (typeof navigator !== 'object') return
   useLayoutEffect(() => {
-    state.onChange = onChange;
-    if (!elementRef.current || opts.disabled) return;
-    state.disconnected = false;
-    state.observer.observe(elementRef.current, _ue_observerSettings);
+    state.onChange = onChange
+    if (!elementRef.current || opts.disabled) return
+    state.disconnected = false
+    state.observer.observe(elementRef.current, _ue_observerSettings)
     if (state.position) {
-      const { position, extent } = state.position;
-      _ue_setCurrentRange(_ue_makeRange(elementRef.current, position, position + extent));
+      const { position, extent } = state.position
+      _ue_setCurrentRange(
+        _ue_makeRange(elementRef.current, position, position + extent)
+      )
     }
-    return () => { state.observer.disconnect(); };
-  });
+    return () => {
+      state.observer.disconnect()
+    }
+  })
   useLayoutEffect(() => {
     if (!elementRef.current || opts.disabled) {
-      state.history.length = 0;
-      state.historyAt = -1;
-      return;
+      state.history.length = 0
+      state.historyAt = -1
+      return
     }
-    const element = elementRef.current;
+    const element = elementRef.current
     if (state.position) {
-      element.focus();
-      const { position, extent } = state.position;
-      _ue_setCurrentRange(_ue_makeRange(element, position, position + extent));
+      element.focus()
+      const { position, extent } = state.position
+      _ue_setCurrentRange(
+        _ue_makeRange(element, position, position + extent)
+      )
     }
-    const prevWhiteSpace = element.style.whiteSpace;
-    const prevContentEditable = element.contentEditable;
-    let hasPlaintextSupport = true;
-    try { element.contentEditable = "plaintext-only"; }
-    catch (_error) { element.contentEditable = "true"; hasPlaintextSupport = false; }
-    if (prevWhiteSpace !== "pre") element.style.whiteSpace = "pre-wrap";
+    const prevWhiteSpace = element.style.whiteSpace
+    const prevContentEditable = element.contentEditable
+    let hasPlaintextSupport = true
+    try {
+      element.contentEditable = 'plaintext-only'
+    } catch (_error) {
+      element.contentEditable = 'true'
+      hasPlaintextSupport = false
+    }
+    if (prevWhiteSpace !== 'pre') element.style.whiteSpace = 'pre-wrap'
     if (opts.indentation) {
-      element.style.tabSize = element.style.MozTabSize = "" + opts.indentation;
+      element.style.tabSize = element.style.MozTabSize =
+        '' + opts.indentation
     }
-    const indentPattern = " ".repeat(opts.indentation || 0);
-    const indentRe = new RegExp("^(?:" + indentPattern + ")");
-    const blanklineRe = new RegExp("^(?:" + indentPattern + ")*(" + indentPattern + ")$");
-    let _trackStateTimestamp = 0;
+    const indentPattern = ' '.repeat(opts.indentation || 0)
+    const indentRe = new RegExp('^(?:' + indentPattern + ')')
+    const blanklineRe = new RegExp(
+      '^(?:' + indentPattern + ')*(' + indentPattern + ')$'
+    )
+    let _trackStateTimestamp = 0
     const trackState = (ignoreTimestamp) => {
-      if (!elementRef.current || !state.position) return;
-      const content = _ue_toString(element);
-      const position = _ue_getPosition(element);
-      const timestamp = new Date().valueOf();
-      const lastEntry = state.history[state.historyAt];
-      if ((!ignoreTimestamp && timestamp - _trackStateTimestamp < 500) ||
-          (lastEntry && lastEntry[1] === content)) {
-        _trackStateTimestamp = timestamp;
-        return;
+      if (!elementRef.current || !state.position) return
+      const content = _ue_toString(element)
+      const position = _ue_getPosition(element)
+      const timestamp = new Date().valueOf()
+      const lastEntry = state.history[state.historyAt]
+      if (
+        (!ignoreTimestamp && timestamp - _trackStateTimestamp < 500) ||
+        (lastEntry && lastEntry[1] === content)
+      ) {
+        _trackStateTimestamp = timestamp
+        return
       }
-      const at = ++state.historyAt;
-      state.history[at] = [position, content];
-      state.history.splice(at + 1);
-      if (at > 500) { state.historyAt--; state.history.shift(); }
-    };
-    const disconnect = () => { state.observer.disconnect(); state.disconnected = true; };
+      const at = ++state.historyAt
+      state.history[at] = [position, content]
+      state.history.splice(at + 1)
+      if (at > 500) {
+        state.historyAt--
+        state.history.shift()
+      }
+    }
+    const disconnect = () => {
+      state.observer.disconnect()
+      state.disconnected = true
+    }
     const flushChanges = () => {
-      state.queue.push(...state.observer.takeRecords());
-      const position = _ue_getPosition(element);
+      state.queue.push(...state.observer.takeRecords())
+      const position = _ue_getPosition(element)
       if (state.queue.length) {
-        disconnect();
-        const content = _ue_toString(element);
-        state.position = position;
-        let mutation;
-        let i = 0;
+        disconnect()
+        const content = _ue_toString(element)
+        state.position = position
+        let mutation
+        let i = 0
         while ((mutation = state.queue.pop())) {
-          if (mutation.oldValue !== null) mutation.target.textContent = mutation.oldValue;
+          if (mutation.oldValue !== null)
+            mutation.target.textContent = mutation.oldValue
           for (i = mutation.removedNodes.length - 1; i >= 0; i--)
-            mutation.target.insertBefore(mutation.removedNodes[i], mutation.nextSibling);
+            mutation.target.insertBefore(
+              mutation.removedNodes[i],
+              mutation.nextSibling
+            )
           for (i = mutation.addedNodes.length - 1; i >= 0; i--)
             if (mutation.addedNodes[i].parentNode)
-              mutation.target.removeChild(mutation.addedNodes[i]);
+              mutation.target.removeChild(mutation.addedNodes[i])
         }
-        state.onChange(content, position);
+        state.onChange(content, position)
       }
-    };
+    }
     const onKeyDown = (event) => {
-      if (event.defaultPrevented || event.target !== element) return;
-      if (state.disconnected) { event.preventDefault(); return unblock([]); }
-      if (_ue_isUndoRedoKey(event)) {
-        event.preventDefault();
-        let history;
-        if (!event.shiftKey) {
-          const at = --state.historyAt;
-          history = state.history[at];
-          if (!history) state.historyAt = 0;
-        } else {
-          const at = ++state.historyAt;
-          history = state.history[at];
-          if (!history) state.historyAt = state.history.length - 1;
-        }
-        if (history) { disconnect(); state.position = history[0]; state.onChange(history[1], history[0]); }
-        return;
-      } else { trackState(); }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        const position = _ue_getPosition(element);
-        const match = /\S/g.exec(position.content);
-        const index = match ? match.index : position.content.length;
-        const text = "\n" + position.content.slice(0, index);
-        _ue_editInsert(element, text);
-      } else if ((!hasPlaintextSupport || opts.indentation) && event.key === "Backspace") {
-        event.preventDefault();
-        const range = _ue_getCurrentRange();
-        if (!range.collapsed) { _ue_editInsert(element, "", 0); }
-        else {
-          const position = _ue_getPosition(element);
-          const match = blanklineRe.exec(position.content);
-          _ue_editInsert(element, "", match ? -match[1].length : -1);
-        }
-      } else if (opts.indentation && event.key === "Tab") {
-        event.preventDefault();
-        const position = _ue_getPosition(element);
-        const start = position.position - position.content.length;
-        const content = _ue_toString(element);
-        const newContent = event.shiftKey
-          ? content.slice(0, start) + position.content.replace(indentRe, "") + content.slice(start + position.content.length)
-          : content.slice(0, start) + (opts.indentation ? " ".repeat(opts.indentation) : "\t") + content.slice(start);
-        _ue_editUpdate(element, newContent);
+      if (event.defaultPrevented || event.target !== element) return
+      if (state.disconnected) {
+        event.preventDefault()
+        return unblock([])
       }
-      if (event.repeat) flushChanges();
-    };
+      if (_ue_isUndoRedoKey(event)) {
+        event.preventDefault()
+        let history
+        if (!event.shiftKey) {
+          const at = --state.historyAt
+          history = state.history[at]
+          if (!history) state.historyAt = 0
+        } else {
+          const at = ++state.historyAt
+          history = state.history[at]
+          if (!history) state.historyAt = state.history.length - 1
+        }
+        if (history) {
+          disconnect()
+          state.position = history[0]
+          state.onChange(history[1], history[0])
+        }
+        return
+      } else {
+        trackState()
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        const position = _ue_getPosition(element)
+        const match = /\S/g.exec(position.content)
+        const index = match ? match.index : position.content.length
+        const text = '\n' + position.content.slice(0, index)
+        _ue_editInsert(element, text)
+      } else if (
+        (!hasPlaintextSupport || opts.indentation) &&
+        event.key === 'Backspace'
+      ) {
+        event.preventDefault()
+        const range = _ue_getCurrentRange()
+        if (!range.collapsed) {
+          _ue_editInsert(element, '', 0)
+        } else {
+          const position = _ue_getPosition(element)
+          const match = blanklineRe.exec(position.content)
+          _ue_editInsert(element, '', match ? -match[1].length : -1)
+        }
+      } else if (opts.indentation && event.key === 'Tab') {
+        event.preventDefault()
+        const position = _ue_getPosition(element)
+        const start = position.position - position.content.length
+        const content = _ue_toString(element)
+        const newContent = event.shiftKey
+          ? content.slice(0, start) +
+            position.content.replace(indentRe, '') +
+            content.slice(start + position.content.length)
+          : content.slice(0, start) +
+            (opts.indentation ? ' '.repeat(opts.indentation) : '\t') +
+            content.slice(start)
+        _ue_editUpdate(element, newContent)
+      }
+      if (event.repeat) flushChanges()
+    }
     const onKeyUp = (event) => {
-      if (event.defaultPrevented || event.isComposing) return;
-      if (!_ue_isUndoRedoKey(event)) trackState();
-      flushChanges();
-      element.focus();
-    };
+      if (event.defaultPrevented || event.isComposing) return
+      if (!_ue_isUndoRedoKey(event)) trackState()
+      flushChanges()
+      element.focus()
+    }
     const onSelect = (event) => {
-      state.position = window.getSelection().rangeCount && event.target === element
-        ? _ue_getPosition(element) : null;
-    };
+      state.position =
+        window.getSelection().rangeCount && event.target === element
+          ? _ue_getPosition(element)
+          : null
+    }
     const onPaste = (event) => {
-      event.preventDefault();
-      trackState(true);
-      _ue_editInsert(element, event.clipboardData.getData("text/plain"));
-      trackState(true);
-      flushChanges();
-    };
-    document.addEventListener("selectstart", onSelect);
-    window.addEventListener("keydown", onKeyDown);
-    element.addEventListener("paste", onPaste);
-    element.addEventListener("keyup", onKeyUp);
+      event.preventDefault()
+      trackState(true)
+      _ue_editInsert(element, event.clipboardData.getData('text/plain'))
+      trackState(true)
+      flushChanges()
+    }
+    document.addEventListener('selectstart', onSelect)
+    window.addEventListener('keydown', onKeyDown)
+    element.addEventListener('paste', onPaste)
+    element.addEventListener('keyup', onKeyUp)
     return () => {
-      document.removeEventListener("selectstart", onSelect);
-      window.removeEventListener("keydown", onKeyDown);
-      element.removeEventListener("paste", onPaste);
-      element.removeEventListener("keyup", onKeyUp);
-      element.style.whiteSpace = prevWhiteSpace;
-      element.contentEditable = prevContentEditable;
-    };
-  }, [elementRef.current, opts.disabled, opts.indentation]);
-};
+      document.removeEventListener('selectstart', onSelect)
+      window.removeEventListener('keydown', onKeyDown)
+      element.removeEventListener('paste', onPaste)
+      element.removeEventListener('keyup', onKeyUp)
+      element.style.whiteSpace = prevWhiteSpace
+      element.contentEditable = prevContentEditable
+    }
+  }, [elementRef.current, opts.disabled, opts.indentation])
+}
 // -- end useEditable --
 var CodeEditor = (props) => {
-  const _a = props, {
-    code: origCode,
-    className,
-    style,
-    tabMode="indentation",
-    theme: origTheme,
-    prism,
-    language,
-    disabled,
-    onChange,
-    editorRef
-  } = _a, rest = __objRest(_a, [
-    "code",
-    "className",
-    "style",
-    "tabMode",
-    "theme",
-    "prism",
-    "language",
-    "disabled",
-    "onChange",
-    "editorRef"
-  ]);
-  const _editorRef = editorRef || useRef(null);
-  const [code, setCode] = useState(origCode || "");
-  const { theme } = props;
+  const _a = props,
+    {
+      code: origCode,
+      className,
+      style,
+      tabMode = 'indentation',
+      theme: origTheme,
+      prism,
+      language,
+      disabled,
+      onChange,
+      editorRef,
+    } = _a,
+    rest = __objRest(_a, [
+      'code',
+      'className',
+      'style',
+      'tabMode',
+      'theme',
+      'prism',
+      'language',
+      'disabled',
+      'onChange',
+      'editorRef',
+    ])
+  const _editorRef = editorRef || useRef(null)
+  const [code, setCode] = useState(origCode || '')
+  const { theme } = props
   useEffect(() => {
-    setCode(origCode);
-  }, [origCode]);
+    setCode(origCode)
+  }, [origCode])
   useEditable(_editorRef, (text) => setCode(text.slice(0, -1)), {
     disabled,
-    indentation: tabMode === "indentation" ? 2 : void 0
-  });
+    indentation: tabMode === 'indentation' ? 2 : void 0,
+  })
   useEffect(() => {
     if (onChange) {
-      onChange(code);
+      onChange(code)
     }
-  }, [code]);
-  return /* @__PURE__ */ jsx("div", { className, style, children: /* @__PURE__ */ jsx(
-    Highlight,
-    {
+  }, [code])
+  return /* @__PURE__ */ jsx('div', {
+    className,
+    style,
+    children: /* @__PURE__ */ jsx(Highlight, {
       prism: prism || Prism,
       code,
       theme: origTheme || themes.nightOwl,
@@ -390,278 +460,357 @@ var CodeEditor = (props) => {
         tokens,
         getLineProps,
         getTokenProps,
-        style: _style
-      }) => /* @__PURE__ */ jsx(
-        "pre",
-        __spreadProps(__spreadValues({
-          className: _className,
-          style: __spreadValues(__spreadValues({
-            margin: 0,
-            outline: "none",
-            padding: 10,
-            fontFamily: "inherit"
-          }, theme && typeof theme.plain === "object" ? theme.plain : {}), _style),
-          ref: _editorRef,
-          spellCheck: "false"
-        }, rest), {
-          children: tokens.map((line, lineIndex) => /* @__PURE__ */ jsxs("span", __spreadProps(__spreadValues({}, getLineProps({ line })), { children: [
-            line.filter((token) => !token.empty).map((token, tokenIndex) => /* @__PURE__ */ jsx(
-              "span",
-              __spreadValues({}, getTokenProps({ token })),
-              `token-${tokenIndex}`
-            )),
-            "\n"
-          ] }), `line-${lineIndex}`))
-        })
-      )
-    }
-  ) });
-};
-var Editor_default = CodeEditor;
+        style: _style,
+      }) =>
+        /* @__PURE__ */ jsx(
+          'pre',
+          __spreadProps(
+            __spreadValues(
+              {
+                className: _className,
+                style: __spreadValues(
+                  __spreadValues(
+                    {
+                      margin: 0,
+                      outline: 'none',
+                      padding: 10,
+                      fontFamily: 'inherit',
+                    },
+                    theme && typeof theme.plain === 'object'
+                      ? theme.plain
+                      : {}
+                  ),
+                  _style
+                ),
+                ref: _editorRef,
+                spellCheck: 'false',
+              },
+              rest
+            ),
+            {
+              children: tokens.map((line, lineIndex) =>
+                /* @__PURE__ */ jsxs(
+                  'span',
+                  __spreadProps(
+                    __spreadValues({}, getLineProps({ line })),
+                    {
+                      children: [
+                        line
+                          .filter((token) => !token.empty)
+                          .map((token, tokenIndex) =>
+                            /* @__PURE__ */ jsx(
+                              'span',
+                              __spreadValues({}, getTokenProps({ token })),
+                              `token-${tokenIndex}`
+                            )
+                          ),
+                        '\n',
+                      ],
+                    }
+                  ),
+                  `line-${lineIndex}`
+                )
+              ),
+            }
+          )
+        ),
+    }),
+  })
+}
+var Editor_default = CodeEditor
 
 // src/components/Live/LiveProvider.tsx
 import {
   useEffect as useEffect2,
   useState as useState2,
-  useRef as useRef2
-} from "react";
+  useRef as useRef2,
+} from 'react'
 
 // src/components/Live/LiveContext.ts
-import { createContext } from "react";
-var LiveContext = createContext({});
-var LiveContext_default = LiveContext;
+import { createContext } from 'react'
+var LiveContext = createContext({})
+var LiveContext_default = LiveContext
 
 // src/utils/transpile/index.ts
-import React2 from "react";
+import React2 from 'react'
 
 // src/utils/transpile/transform.ts
-import { transform as _transform } from "sucrase";
-var defaultTransforms = ["jsx", "imports"];
+import { transform as _transform } from 'sucrase'
+var defaultTransforms = ['jsx', 'imports']
 function transform(opts = {}) {
-  const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
-  return (code) => _transform(code, { transforms }).code;
+  const transforms = Array.isArray(opts.transforms)
+    ? opts.transforms.filter(Boolean)
+    : defaultTransforms
+  return (code) => _transform(code, { transforms }).code
 }
 
 // src/utils/transpile/errorBoundary.tsx
-import React, { Component } from "react";
-import { jsx as jsx2 } from "react/jsx-runtime";
+import React, { Component } from 'react'
+import { jsx as jsx2 } from 'react/jsx-runtime'
 var errorBoundary = (Element, errorCallback) => {
   return class ErrorBoundary extends Component {
     componentDidCatch(error) {
-      errorCallback(error);
+      errorCallback(error)
     }
     render() {
-      return typeof Element === "function" ? /* @__PURE__ */ jsx2(Element, {}) : React.isValidElement(Element) ? Element : null;
+      return typeof Element === 'function'
+        ? /* @__PURE__ */ jsx2(Element, {})
+        : React.isValidElement(Element)
+        ? Element
+        : null
     }
-  };
-};
-var errorBoundary_default = errorBoundary;
+  }
+}
+var errorBoundary_default = errorBoundary
 
 // src/utils/transpile/evalCode.ts
 var evalCode = (code, scope) => {
-  const scopeKeys = Object.keys(scope);
-  const scopeValues = scopeKeys.map((key) => scope[key]);
-  return new Function(...scopeKeys, code)(...scopeValues);
-};
-var evalCode_default = evalCode;
+  const scopeKeys = Object.keys(scope)
+  const scopeValues = scopeKeys.map((key) => scope[key])
+  return new Function(...scopeKeys, code)(...scopeValues)
+}
+var evalCode_default = evalCode
 
 // src/utils/transpile/compose.ts
 function compose(...functions) {
   return functions.reduce(
-    (acc, currentFn) => (...args) => acc(currentFn(...args))
-  );
+    (acc, currentFn) =>
+      (...args) =>
+        acc(currentFn(...args))
+  )
 }
 
 // src/utils/transpile/index.ts
-var jsxConst = 'const _jsxFileName = "";';
-var trimCode = (code) => code.trim().replace(/;$/, "");
-var spliceJsxConst = (code) => code.replace(jsxConst, "").trim();
-var addJsxConst = (code) => jsxConst + code;
-var wrapReturn = (code) => `return (${code})`;
-var generateElement = ({ code = "", scope = {}, enableTypeScript = true }, errorCallback) => {
-  const firstPassTransforms = ["jsx"];
-  enableTypeScript && firstPassTransforms.push("typescript");
+var jsxConst = 'const _jsxFileName = "";'
+var trimCode = (code) => code.trim().replace(/;$/, '')
+var spliceJsxConst = (code) => code.replace(jsxConst, '').trim()
+var addJsxConst = (code) => jsxConst + code
+var wrapReturn = (code) => `return (${code})`
+var generateElement = (
+  { code = '', scope = {}, enableTypeScript = true },
+  errorCallback
+) => {
+  const firstPassTransforms = ['jsx']
+  enableTypeScript && firstPassTransforms.push('typescript')
   const transformed = compose(
     addJsxConst,
-    transform({ transforms: ["imports"] }),
+    transform({ transforms: ['imports'] }),
     wrapReturn,
     spliceJsxConst,
     trimCode,
     transform({ transforms: firstPassTransforms }),
     trimCode
-  )(code);
+  )(code)
   return errorBoundary_default(
-    evalCode_default(transformed, __spreadValues({ React: React2 }, scope)),
+    evalCode_default(
+      transformed,
+      __spreadValues({ React: React2 }, scope)
+    ),
     errorCallback
-  );
-};
-var renderElementAsync = ({ code = "", scope = {}, enableTypeScript = true }, resultCallback, errorCallback) => {
+  )
+}
+var renderElementAsync = (
+  { code = '', scope = {}, enableTypeScript = true },
+  resultCallback,
+  errorCallback
+) => {
   const render = (element) => {
-    if (typeof element === "undefined") {
-      errorCallback(new SyntaxError("`render` must be called with valid JSX."));
+    if (typeof element === 'undefined') {
+      errorCallback(
+        new SyntaxError('`render` must be called with valid JSX.')
+      )
     } else {
-      resultCallback(errorBoundary_default(element, errorCallback));
+      resultCallback(errorBoundary_default(element, errorCallback))
     }
-  };
+  }
   if (!/render\s*\(/.test(code)) {
     return errorCallback(
-      new SyntaxError("No-Inline evaluations must call `render`.")
-    );
+      new SyntaxError('No-Inline evaluations must call `render`.')
+    )
   }
-  const transforms = ["jsx", "imports"];
-  enableTypeScript && transforms.splice(1, 0, "typescript");
-  evalCode_default(transform({ transforms })(code), __spreadProps(__spreadValues({ React: React2 }, scope), { render }));
-};
+  const transforms = ['jsx', 'imports']
+  enableTypeScript && transforms.splice(1, 0, 'typescript')
+  evalCode_default(
+    transform({ transforms })(code),
+    __spreadProps(__spreadValues({ React: React2 }, scope), { render })
+  )
+}
 
 // src/components/Live/LiveProvider.tsx
-import { jsx as jsx3 } from "react/jsx-runtime";
+import { jsx as jsx3 } from 'react/jsx-runtime'
 function LiveProvider({
   children,
-  code = "",
-  language = "tsx",
+  code = '',
+  language = 'tsx',
   theme,
   enableTypeScript = true,
   disabled = false,
   scope,
   transformCode,
   noInline = false,
-  skipInitialRender = false
+  skipInitialRender = false,
 }) {
-  const cache = useRef2("initial");
-  const [state, setState] = useState2(() => transpileSync(code));
+  const cache = useRef2('initial')
+  const [state, setState] = useState2(() => transpileSync(code))
   function transpileSync(code2) {
     const returnObject = {
       element: void 0,
-      error: void 0
-    };
+      error: void 0,
+    }
     if (!skipInitialRender) {
       const renderElement = (element) => {
-        return returnObject.element = element;
-      };
+        return (returnObject.element = element)
+      }
       const errorCallback = (error) => {
-        return returnObject.error = String(error);
-      };
+        return (returnObject.error = String(error))
+      }
       try {
-        const transformResult = transformCode ? transformCode(code2) : code2;
+        const transformResult = transformCode
+          ? transformCode(code2)
+          : code2
         const input = {
           code: transformResult,
           scope,
-          enableTypeScript
-        };
-        if (noInline) {
-          renderElementAsync(input, renderElement, errorCallback);
-        } else {
-          renderElement(generateElement(input, errorCallback));
+          enableTypeScript,
         }
-        cache.current = code2;
+        if (noInline) {
+          renderElementAsync(input, renderElement, errorCallback)
+        } else {
+          renderElement(generateElement(input, errorCallback))
+        }
+        cache.current = code2
       } catch (e) {
-        errorCallback(e);
+        errorCallback(e)
       }
     }
-    return returnObject;
+    return returnObject
   }
   function transpileAsync(newCode) {
     return __async(this, null, function* () {
       if (cache.current === newCode) {
-        cache.current = "used";
-        return Promise.resolve();
+        cache.current = 'used'
+        return Promise.resolve()
       }
       const errorCallback = (error) => {
-        setState({ error: error.toString(), element: void 0 });
-      };
+        setState({ error: error.toString(), element: void 0 })
+      }
       try {
-        const transformResult = transformCode ? transformCode(newCode) : newCode;
+        const transformResult = transformCode
+          ? transformCode(newCode)
+          : newCode
         try {
-          const transformedCode = yield Promise.resolve(transformResult);
-          const renderElement = (element) => setState({ error: void 0, element });
-          if (typeof transformedCode !== "string") {
-            throw new Error("Code failed to transform");
+          const transformedCode = yield Promise.resolve(transformResult)
+          const renderElement = (element) =>
+            setState({ error: void 0, element })
+          if (typeof transformedCode !== 'string') {
+            throw new Error('Code failed to transform')
           }
           const input = {
             code: transformedCode,
             scope,
-            enableTypeScript
-          };
+            enableTypeScript,
+          }
           if (noInline) {
-            setState({ error: void 0, element: null });
-            renderElementAsync(input, renderElement, errorCallback);
+            setState({ error: void 0, element: null })
+            renderElementAsync(input, renderElement, errorCallback)
           } else {
-            renderElement(generateElement(input, errorCallback));
+            renderElement(generateElement(input, errorCallback))
           }
         } catch (error) {
-          return errorCallback(error);
+          return errorCallback(error)
         }
       } catch (e) {
-        errorCallback(e);
-        return Promise.resolve();
+        errorCallback(e)
+        return Promise.resolve()
       }
-    });
+    })
   }
-  const onError = (error) => setState({ error: error.toString() });
+  const onError = (error) => setState({ error: error.toString() })
   useEffect2(() => {
-    transpileAsync(code).catch(onError);
-  }, [code, scope, noInline, transformCode]);
+    transpileAsync(code).catch(onError)
+  }, [code, scope, noInline, transformCode])
   const onChange = (newCode) => {
-    transpileAsync(newCode).catch(onError);
-  };
-  return /* @__PURE__ */ jsx3(
-    LiveContext_default.Provider,
-    {
-      value: __spreadProps(__spreadValues({}, state), {
-        code,
-        language,
-        theme,
-        disabled,
-        onError,
-        onChange
-      }),
-      children
-    }
-  );
-}
-var LiveProvider_default = LiveProvider;
-
-// src/components/Live/LiveEditor.tsx
-import { useContext } from "react";
-import { jsx as jsx4 } from "react/jsx-runtime";
-function LiveEditor(props) {
-  const { code, language, theme, disabled, onChange } = useContext(LiveContext_default);
-  return /* @__PURE__ */ jsx4(
-    Editor_default,
-    __spreadValues({
-      theme,
+    transpileAsync(newCode).catch(onError)
+  }
+  return /* @__PURE__ */ jsx3(LiveContext_default.Provider, {
+    value: __spreadProps(__spreadValues({}, state), {
       code,
       language,
+      theme,
       disabled,
-      onChange
-    }, props)
-  );
+      onError,
+      onChange,
+    }),
+    children,
+  })
+}
+var LiveProvider_default = LiveProvider
+
+// src/components/Live/LiveEditor.tsx
+import { useContext } from 'react'
+import { jsx as jsx4 } from 'react/jsx-runtime'
+function LiveEditor(props) {
+  const { code, language, theme, disabled, onChange } = useContext(
+    LiveContext_default
+  )
+  return /* @__PURE__ */ jsx4(
+    Editor_default,
+    __spreadValues(
+      {
+        theme,
+        code,
+        language,
+        disabled,
+        onChange,
+      },
+      props
+    )
+  )
 }
 
 // src/components/Live/LiveError.tsx
-import { useContext as useContext2 } from "react";
-import { jsx as jsx5 } from "react/jsx-runtime";
+import { useContext as useContext2 } from 'react'
+import { jsx as jsx5 } from 'react/jsx-runtime'
 function LiveError(props) {
-  const { error } = useContext2(LiveContext_default);
-  return error ? /* @__PURE__ */ jsx5("pre", __spreadProps(__spreadValues({}, props), { children: error })) : null;
+  const { error } = useContext2(LiveContext_default)
+  return error
+    ? /* @__PURE__ */ jsx5(
+        'pre',
+        __spreadProps(__spreadValues({}, props), { children: error })
+      )
+    : null
 }
 
 // src/components/Live/LivePreview.tsx
-import { useContext as useContext3 } from "react";
-import { jsx as jsx6 } from "react/jsx-runtime";
+import { useContext as useContext3 } from 'react'
+import { jsx as jsx6 } from 'react/jsx-runtime'
 function LivePreview(_a) {
-  var _b = _a, { Component: Component2 = "div" } = _b, rest = __objRest(_b, ["Component"]);
-  const { element: Element } = useContext3(LiveContext_default);
-  return /* @__PURE__ */ jsx6(Component2, __spreadProps(__spreadValues({}, rest), { children: Element ? /* @__PURE__ */ jsx6(Element, {}) : null }));
+  var _b = _a,
+    { Component: Component2 = 'div' } = _b,
+    rest = __objRest(_b, ['Component'])
+  const { element: Element } = useContext3(LiveContext_default)
+  return /* @__PURE__ */ jsx6(
+    Component2,
+    __spreadProps(__spreadValues({}, rest), {
+      children: Element ? /* @__PURE__ */ jsx6(Element, {}) : null,
+    })
+  )
 }
-var LivePreview_default = LivePreview;
+var LivePreview_default = LivePreview
 
 // src/hoc/withLive.tsx
-import { jsx as jsx7 } from "react/jsx-runtime";
+import { jsx as jsx7 } from 'react/jsx-runtime'
 function withLive(WrappedComponent) {
-  const WithLive = (props) => /* @__PURE__ */ jsx7(LiveContext_default.Consumer, { children: (live) => /* @__PURE__ */ jsx7(WrappedComponent, __spreadValues({ live }, props)) });
-  WithLive.displayName = "WithLive";
-  return WithLive;
+  const WithLive = (props) =>
+    /* @__PURE__ */ jsx7(LiveContext_default.Consumer, {
+      children: (live) =>
+        /* @__PURE__ */ jsx7(
+          WrappedComponent,
+          __spreadValues({ live }, props)
+        ),
+    })
+  WithLive.displayName = 'WithLive'
+  return WithLive
 }
 export {
   Editor_default as Editor,
@@ -672,6 +821,6 @@ export {
   LiveProvider_default as LiveProvider,
   generateElement,
   renderElementAsync,
-  withLive
-};
+  withLive,
+}
 //# sourceMappingURL=index.mjs.map

--- a/tools/react-live-ssr/src/useEditable.ts
+++ b/tools/react-live-ssr/src/useEditable.ts
@@ -56,7 +56,9 @@ const setCurrentRange = (range: Range): void => {
 }
 
 const isUndoRedoKey = (event: KeyboardEvent): boolean =>
-  (event.metaKey || event.ctrlKey) && !event.altKey && event.code === 'KeyZ'
+  (event.metaKey || event.ctrlKey) &&
+  !event.altKey &&
+  event.code === 'KeyZ'
 
 /** Walk the DOM tree of an element and extract its text content. */
 const toString = (element: HTMLElement): string => {
@@ -321,8 +323,9 @@ export const useEditable = (
     }
 
     if (opts!.indentation) {
-      element.style.tabSize = (element.style as Record<string, string>)
-        .MozTabSize = '' + opts!.indentation
+      element.style.tabSize = (
+        element.style as Record<string, string>
+      ).MozTabSize = '' + opts!.indentation
     }
 
     const indentPattern = ' '.repeat(opts!.indentation || 0)
@@ -472,9 +475,7 @@ export const useEditable = (
             position.content.replace(indentRe, '') +
             content.slice(start + position.content.length)
           : content.slice(0, start) +
-            (opts!.indentation
-              ? ' '.repeat(opts!.indentation)
-              : '\t') +
+            (opts!.indentation ? ' '.repeat(opts!.indentation) : '\t') +
             content.slice(start)
         editUpdate(element, newContent)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,7 +4467,7 @@ __metadata:
     postcss: "npm:8.4.32"
     postcss-preset-env: "npm:9.6.0"
     postcss-selector-parser: "npm:7.1.0"
-    prettier: "npm:3.0.3"
+    prettier: "npm:3.8.1"
     prettier-package-json: "npm:2.8.0"
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
@@ -14928,7 +14928,7 @@ __metadata:
     github-slugger: "npm:1.4.0"
     jest: "npm:30.0.5"
     mdast-util-to-string: "npm:^2"
-    prettier: "npm:3.0.3"
+    prettier: "npm:3.8.1"
     prettier-package-json: "npm:2.8.0"
     prism-react-renderer: "npm:2.0.5"
     process: "npm:0.11.10"
@@ -16710,7 +16710,7 @@ __metadata:
     front-matter: "npm:4.0.2"
     fs-extra: "npm:10.0.0"
     markdown-tables-utils: "workspace:*"
-    prettier: "npm:3.0.3"
+    prettier: "npm:3.8.1"
   peerDependencies:
     gatsby: ">=5.0.0"
   languageName: unknown
@@ -29129,12 +29129,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.3":
-  version: 3.0.3
-  resolution: "prettier@npm:3.0.3"
+"prettier@npm:3.8.1":
+  version: 3.8.1
+  resolution: "prettier@npm:3.8.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/ccf1ead9794b017be6b42d0873f459070beef2069eb393c8b4c0d11aa3430acefc54f6d5f44a5b7ce9af05ad8daf694b912f0aa2808d1c22dfa86e61e9d563f8
+  checksum: 10/3da1cf8c1ef9bea828aa618553696c312e951f810bee368f6887109b203f18ee869fe88f66e65f9cf60b7cb1f2eae859892c860a300c062ff8ec69c381fc8dbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
prettier 3.0.3 → 3.5+: Bug fixes and improved formatting for TypeScript, CSS, and MDX. Notably, v3.1+ fixed several SCSS formatting issues and v3.3+ improved TypeScript satisfies / decorator handling. Since Eufemia uses all of those, we'd get more correct auto-formatting. No breaking changes within v3.x.