### PR TITLE
chore(eslint): add no-inline-type-exports rule

### DIFF
--- a/packages/dnb-eufemia/eslint.config.mjs
+++ b/packages/dnb-eufemia/eslint.config.mjs
@@ -447,6 +447,12 @@ export default [
           allowlist: [],
         },
       ],
+      'component-types/no-inline-type-exports': [
+        'warn',
+        {
+          threshold: 5,
+        },
+      ],
     },
   },
   {

--- a/packages/dnb-eufemia/scripts/eslint/plugins/component-types/__tests__/no-inline-type-exports.test.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/component-types/__tests__/no-inline-type-exports.test.ts
@@ -1,0 +1,127 @@
+import { RuleTester } from 'eslint'
+import rule from '../rules/no-inline-type-exports'
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+tester.run('no-inline-type-exports', rule, {
+  valid: [
+    // Under threshold (4 types in a .tsx file)
+    {
+      code: `
+        export type FooProps = { a: string }
+        export type FooSize = 'small' | 'large'
+        export type FooVariant = 'primary' | 'secondary'
+        export type FooEvent = { value: string }
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+    },
+    // Exactly at threshold (5 types, threshold is 5)
+    {
+      code: `
+        export type A = string
+        export type B = string
+        export type C = string
+        export type D = string
+        export type E = string
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+    },
+    // Any number of types in a .ts file (non-component file)
+    {
+      code: `
+        export type A = string
+        export type B = string
+        export type C = string
+        export type D = string
+        export type E = string
+        export type F = string
+        export type G = string
+      `,
+      filename: '/src/components/foo/types.ts',
+    },
+    // Test files are ignored
+    {
+      code: `
+        export type A = string
+        export type B = string
+        export type C = string
+        export type D = string
+        export type E = string
+        export type F = string
+      `,
+      filename: '/src/components/foo/__tests__/Foo.test.tsx',
+    },
+    // Stories are ignored
+    {
+      code: `
+        export type A = string
+        export type B = string
+        export type C = string
+        export type D = string
+        export type E = string
+        export type F = string
+      `,
+      filename: '/src/components/foo/Foo.stories.tsx',
+    },
+    // Custom threshold: 10
+    {
+      code: `
+        export type A = string
+        export type B = string
+        export type C = string
+        export type D = string
+        export type E = string
+        export type F = string
+        export type G = string
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+      options: [{ threshold: 10 }],
+    },
+  ],
+
+  invalid: [
+    // Over threshold (6 types in a .tsx file)
+    {
+      code: `
+        export type FooProps = { a: string }
+        export type FooSize = 'small' | 'large'
+        export type FooVariant = 'primary' | 'secondary'
+        export type FooEvent = { value: string }
+        export type FooAllProps = FooProps & { extra: boolean }
+        export type FooOnChange = (event: FooEvent) => void
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+      errors: [{ messageId: 'tooManyInlineTypes' }],
+    },
+    // Interfaces count too
+    {
+      code: `
+        export interface FooProps { a: string }
+        export interface FooEvent { value: string }
+        export type FooSize = 'small' | 'large'
+        export type FooVariant = 'primary' | 'secondary'
+        export type FooAllProps = FooProps & { extra: boolean }
+        export type FooOnChange = (event: FooEvent) => void
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+      errors: [{ messageId: 'tooManyInlineTypes' }],
+    },
+    // Custom threshold: 2
+    {
+      code: `
+        export type FooProps = { a: string }
+        export type FooSize = 'small' | 'large'
+        export type FooVariant = 'primary' | 'secondary'
+      `,
+      filename: '/src/components/foo/Foo.tsx',
+      options: [{ threshold: 2 }],
+      errors: [{ messageId: 'tooManyInlineTypes' }],
+    },
+  ],
+})

--- a/packages/dnb-eufemia/scripts/eslint/plugins/component-types/index.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/component-types/index.js
@@ -1,7 +1,9 @@
 const requireComponentPrefix = require('./rules/require-component-prefix')
+const noInlineTypeExports = require('./rules/no-inline-type-exports')
 
 module.exports = {
   rules: {
     'require-component-prefix': requireComponentPrefix,
+    'no-inline-type-exports': noInlineTypeExports,
   },
 }

--- a/packages/dnb-eufemia/scripts/eslint/plugins/component-types/rules/no-inline-type-exports.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/component-types/rules/no-inline-type-exports.js
@@ -1,0 +1,106 @@
+/**
+ * ESLint rule: no-inline-type-exports
+ *
+ * Enforces that component files (.tsx) with many exported type definitions
+ * move those types into a separate `types.ts` file. This keeps component
+ * files focused on rendering logic and makes types easier to find and reuse.
+ *
+ * The threshold is configurable (default: 5 exported types). When a .tsx
+ * file exceeds the threshold, this rule reports an error suggesting the
+ * types be moved to a sibling types.ts file.
+ *
+ * Files named `types.ts` are always allowed to export any number of types.
+ */
+
+const DEFAULT_THRESHOLD = 5
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow exporting too many type definitions from component .tsx files — move them to types.ts',
+    },
+    messages: {
+      tooManyInlineTypes:
+        'This file exports {{ count }} type definitions (threshold: {{ threshold }}). Move shared types to a sibling `types.ts` file.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          threshold: {
+            type: 'integer',
+            minimum: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename()
+
+    // Only apply to .tsx files (component files)
+    if (!filename.endsWith('.tsx')) {
+      return {}
+    }
+
+    // Skip test files and stories
+    if (
+      filename.includes('__tests__') ||
+      filename.includes('.test.') ||
+      filename.includes('.spec.') ||
+      filename.includes('.stories.')
+    ) {
+      return {}
+    }
+
+    const options = context.options[0] || {}
+    const threshold = options.threshold || DEFAULT_THRESHOLD
+
+    const exportedTypes = []
+
+    return {
+      ExportNamedDeclaration(node) {
+        // Case 1: export type X = ...
+        if (
+          node.declaration &&
+          node.declaration.type === 'TSTypeAliasDeclaration'
+        ) {
+          exportedTypes.push(node)
+        }
+
+        // Case 2: export interface X { ... }
+        if (
+          node.declaration &&
+          node.declaration.type === 'TSInterfaceDeclaration'
+        ) {
+          exportedTypes.push(node)
+        }
+
+        // Case 3: export type { X, Y } (re-exports count too)
+        if (node.exportKind === 'type' && node.specifiers) {
+          for (const specifier of node.specifiers) {
+            exportedTypes.push(specifier)
+          }
+        }
+      },
+
+      'Program:exit'() {
+        if (exportedTypes.length > threshold) {
+          // Report on the first exported type to point the developer
+          // to the start of the issue
+          context.report({
+            node: exportedTypes[0],
+            messageId: 'tooManyInlineTypes',
+            data: {
+              count: String(exportedTypes.length),
+              threshold: String(threshold),
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/component-types/rules/no-inline-type-exports.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/component-types/rules/no-inline-type-exports.js
@@ -14,6 +14,7 @@
 
 const DEFAULT_THRESHOLD = 5
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',


### PR DESCRIPTION
Add a new ESLint rule `component-types/no-inline-type-exports` that warns when a .tsx component file exports more than 5 type definitions inline. Complex components should move shared types to a sibling types.ts file for better organization and reusability.

The rule:
- Only applies to .tsx files (component files)
- Skips test files, stories, and .d.ts files
- Has a configurable threshold (default: 5)
- Counts exported type aliases, interfaces, and re-exports
- Set to warn (not error) to allow gradual adoption

