### PR TITLE
chore: suppress expected Eufemia warnings in Stat test console output

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/__tests__/Amount.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Amount.test.tsx
@@ -13,17 +13,23 @@ import Stat from '../Stat'
 import Amount from '../Amount'
 
 describe('Stat.Amount', () => {
-  it('emits a deprecation warning when used', () => {
-    const log = spyOnEufemiaWarn()
+  let log: ReturnType<typeof spyOnEufemiaWarn>
 
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
+
+  it('emits a deprecation warning when used', () => {
     render(<Stat.Amount value={100} />)
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining('Eufemia'),
       expect.stringContaining('Stat.Amount is deprecated')
     )
-
-    log.mockRestore()
   })
 
   it('renders plain amount by default without currency', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
@@ -1,9 +1,18 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 
 describe('Stat.Currency', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
   it('renders currency by default', () => {
     render(<Stat.Currency value={12345.67} />)
 

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
+import {
+  axeComponent,
+  spyOnEufemiaWarn,
+} from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 
 describe('Stat.Currency', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Info.test.tsx
@@ -7,6 +7,16 @@ import {
 import Stat from '../Stat'
 
 describe('Stat.Info', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
+
   it('renders info content and class', () => {
     render(<Stat.Info>Some additional content</Stat.Info>)
 
@@ -29,8 +39,6 @@ describe('Stat.Info', () => {
   })
 
   it('supports deprecated default variant and maps to plain', () => {
-    const log = spyOnEufemiaWarn()
-
     render(
       <Stat.Info variant="default">Some additional content</Stat.Info>
     )
@@ -43,8 +51,6 @@ describe('Stat.Info', () => {
       expect.stringContaining('Eufemia'),
       expect.stringContaining('variant="default" is deprecated')
     )
-
-    log.mockRestore()
   })
 
   it('supports prominent variant', () => {
@@ -109,21 +115,15 @@ describe('Stat.Info', () => {
   })
 
   it('warns when used outside Stat.Root', () => {
-    const log = spyOnEufemiaWarn()
-
     render(<Stat.Info>Details</Stat.Info>)
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining('Eufemia'),
       expect.stringContaining('Stat.Info should be used inside Stat.Root')
     )
-
-    log.mockRestore()
   })
 
   it('does not warn when used inside Stat.Root', () => {
-    const log = spyOnEufemiaWarn()
-
     render(
       <Stat.Root>
         <Stat.Label>Revenue</Stat.Label>
@@ -137,8 +137,6 @@ describe('Stat.Info', () => {
       expect.stringContaining('Eufemia'),
       expect.stringContaining('Stat.Info should be used inside Stat.Root')
     )
-
-    log.mockRestore()
   })
 
   it('forwards data-* and aria-* attributes to the DOM element', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
+import {
+  axeComponent,
+  spyOnEufemiaWarn,
+} from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 import Provider from '../../../shared/Provider'
 import SharedContext from '../../../shared/Context'

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
@@ -1,11 +1,20 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 import Provider from '../../../shared/Provider'
 import SharedContext from '../../../shared/Context'
 
 describe('Stat.Inline', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
   it('renders horizontal inline layout with defaults', () => {
     render(
       <Stat.Inline>
@@ -172,28 +181,22 @@ describe('Stat.Inline', () => {
   })
 
   it('warns when used outside Stat.Root', () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
-
     render(
       <Stat.Inline>
         <Stat.Trend>+1.2%</Stat.Trend>
       </Stat.Inline>
     )
 
-    const didWarn = spy.mock.calls.some((call) =>
+    const didWarn = log.mock.calls.some((call) =>
       call
         .map((entry) => String(entry))
         .join(' ')
         .includes('Stat.Inline should be used inside Stat.Root')
     )
     expect(didWarn).toBe(true)
-
-    spy.mockRestore()
   })
 
   it('does not warn when used inside Stat.Root', () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
-
     render(
       <Stat.Root>
         <Stat.Label>Revenue</Stat.Label>
@@ -205,15 +208,13 @@ describe('Stat.Inline', () => {
       </Stat.Root>
     )
 
-    const didWarn = spy.mock.calls.some((call) =>
+    const didWarn = log.mock.calls.some((call) =>
       call
         .map((entry) => String(entry))
         .join(' ')
         .includes('Stat.Inline should be used inside Stat.Root')
     )
     expect(didWarn).toBe(false)
-
-    spy.mockRestore()
   })
 
   it('forwards data-* and aria-* attributes to the DOM element', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
+import {
+  axeComponent,
+  spyOnEufemiaWarn,
+} from '../../../core/jest/jestSetup'
 import Provider from '../../../shared/Provider'
 import Stat from '../Stat'
 import NumberComponent from '../Number'

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
@@ -1,11 +1,20 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
 import Provider from '../../../shared/Provider'
 import Stat from '../Stat'
 import NumberComponent from '../Number'
 
 describe('Stat.Number', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
   it('declares _supportsSpacingProps', () => {
     expect(NumberComponent._supportsSpacingProps).toBe(true)
   })

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
+import {
+  axeComponent,
+  spyOnEufemiaWarn,
+} from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 
 describe('Stat.Percent', () => {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
@@ -1,9 +1,18 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
 import Stat from '../Stat'
 
 describe('Stat.Percent', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
   it('renders percent with separate auxiliary percent sign', () => {
     render(<Stat.Percent value={0.1234} signDisplay="always" />)
 

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
+import {
+  axeComponent,
+  spyOnEufemiaWarn,
+} from '../../../core/jest/jestSetup'
 import Provider from '../../../shared/Provider'
 import Stat from '../Stat'
 

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Stat.integration.test.tsx
@@ -1,10 +1,19 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { axeComponent } from '../../../core/jest/jestSetup'
+import { axeComponent, spyOnEufemiaWarn } from '../../../core/jest/jestSetup'
 import Provider from '../../../shared/Provider'
 import Stat from '../Stat'
 
 describe('Stat integration', () => {
+  let log: ReturnType<typeof spyOnEufemiaWarn>
+
+  beforeEach(() => {
+    log = spyOnEufemiaWarn()
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+  })
   it('renders full composition with semantic dl/dt/dd markup', () => {
     render(
       <Stat.Root>


### PR DESCRIPTION
Add describe-level spyOnEufemiaWarn() to Stat test files that produce expected console.log noise from deprecation warnings and "should be used inside Stat.Root" messages. Refactor per-test warning spies to use the shared describe-level spy where applicable.

Affected files:
- Amount.test.tsx (Stat.Amount deprecation warnings)
- Number.test.tsx (Stat.Info outside Root warnings)
- Stat.integration.test.tsx (Stat.Info/Content outside Root)
- Inline.test.tsx (Stat.Inline outside Root)
- Info.test.tsx (Stat.Info outside Root + deprecated variant)
- Percent.test.tsx (Stat.Info outside Root)
- Currency.test.tsx (Stat.Info outside Root)

