### PR TITLE
chore(Forms): use `interface` over `type` for performance in docgen

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -352,13 +352,15 @@ export type ErrorProp<Value> = MessageProp<
   | Array<string | React.ReactElement | Error | FormError>
 >
 
-export type UseFieldProps<
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+interface UseFieldPropsInterface<
   Value = unknown,
   EmptyValue = undefined | unknown,
   ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
   ExtraValue extends
     ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
-> = {
+> extends DataValueReadWriteComponentProps<Value, EmptyValue>,
+    AriaAttributes {
   // - HTML Element Attributes
   /**
    * ID added to the actual field component, and linked to the label via for-attribute
@@ -494,8 +496,15 @@ export type UseFieldProps<
    * For internal use only.
    */
   valueType?: string | number | boolean | Array<string | number | boolean>
-} & DataValueReadWriteComponentProps<Value, EmptyValue> &
-  AriaAttributes
+}
+
+export type UseFieldProps<
+  Value = unknown,
+  EmptyValue = undefined | unknown,
+  ErrorMessages extends DefaultErrorMessages = DefaultErrorMessages,
+  ExtraValue extends
+    ProvideAdditionalEventArgs = ProvideAdditionalEventArgs,
+> = UseFieldPropsInterface<Value, EmptyValue, ErrorMessages, ExtraValue>
 
 export type FieldProps<
   Value = unknown,
@@ -528,7 +537,9 @@ export type FieldPropsWithExtraValue<
 > &
   DataValueWriteProps<Value, EmptyValue, ExtraValue>
 
-export type ValueProps<Value = unknown> = {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+interface ValuePropsInterface<Value = unknown>
+  extends DataValueReadComponentProps<Value> {
   /**
    * Field label to show above the data value.
    */
@@ -593,7 +604,9 @@ export type ValueProps<Value = unknown> = {
    * Transforms the given props `value` before any other step gets entered.
    */
   fromExternal?: (external: Value) => Value
-} & DataValueReadComponentProps<Value>
+}
+
+export type ValueProps<Value = unknown> = ValuePropsInterface<Value>
 
 export type Path = string
 export type PathStrict = `/${string}`


### PR DESCRIPTION
Fixes an issue cause by this change #6778
It causes docgen (used by Storybook) to use a lot of memory, so it may crash. And if it not crashes, it slows down the performance.

More details:
The issue is that `type = { ... } & Base` forces react-docgen-typescript to structurally expand intersection types recursively, while `interface extends` uses nominal/lazy resolution. The fix: keep the exported name as `type` (satisfying your ESLint rule) but use an internal `interface` for the actual type body, so react-docgen gets the efficient resolution path.

Related PR #7331