### PR TITLE
feat(List): add `to`, `element`and `elementProps` to List.Item.Action

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAction.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAction.tsx
@@ -23,7 +23,7 @@ export type ItemActionProps = {
   element?: AnchorProps['element']
   target?: string
   rel?: string
-} & Omit<ItemContentProps, 'title'>
+} & Omit<ItemContentProps, 'title' | 'element'>
 
 function ItemAction(props: ItemActionProps) {
   const {

--- a/packages/dnb-eufemia/src/components/list/ItemAction.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAction.tsx
@@ -10,9 +10,7 @@ import type { IconIcon } from '../icon/Icon'
 
 export type ItemActionIconPosition = 'left' | 'right'
 
-export type ItemActionProps<
-  E extends React.ElementType = 'a',
-> = {
+export type ItemActionProps<E extends React.ElementType = 'a'> = {
   id?: string
   variant?: ListVariant
   selected?: boolean
@@ -154,7 +152,9 @@ function ItemAction<E extends React.ElementType = 'a'>(
         <Anchor
           noStyle
           ref={anchorRef}
-          {...(href != null ? { href: isInactive ? undefined : href } : {})}
+          {...(href != null
+            ? { href: isInactive ? undefined : href }
+            : {})}
           to={isInactive ? undefined : to}
           element={element}
           target={target}

--- a/packages/dnb-eufemia/src/components/list/ItemAction.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAction.tsx
@@ -3,14 +3,16 @@ import { ListVariant, ListContext } from './ListContext'
 import ItemContent, { ItemContentProps } from './ItemContent'
 import React, { useCallback, useContext, useRef } from 'react'
 import IconPrimary from '../IconPrimary'
-import Anchor, { AnchorProps } from '../Anchor'
+import Anchor from '../Anchor'
 import ItemIcon from './ItemIcon'
 import ItemTitle from './ItemTitle'
 import type { IconIcon } from '../icon/Icon'
 
 export type ItemActionIconPosition = 'left' | 'right'
 
-export type ItemActionProps = {
+export type ItemActionProps<
+  E extends React.ElementType = 'a',
+> = {
   id?: string
   variant?: ListVariant
   selected?: boolean
@@ -20,12 +22,24 @@ export type ItemActionProps = {
   title?: React.ReactNode
   href?: string
   to?: string
-  element?: AnchorProps['element']
+  element?: E
+  elementProps?: Omit<
+    React.ComponentPropsWithoutRef<E>,
+    | 'href'
+    | 'to'
+    | 'target'
+    | 'rel'
+    | 'children'
+    | 'tabIndex'
+    | 'aria-disabled'
+  >
   target?: string
   rel?: string
 } & Omit<ItemContentProps, 'title' | 'element'>
 
-function ItemAction(props: ItemActionProps) {
+function ItemAction<E extends React.ElementType = 'a'>(
+  props: ItemActionProps<E>
+) {
   const {
     className,
     onClick,
@@ -41,6 +55,7 @@ function ItemAction(props: ItemActionProps) {
     href,
     to,
     element,
+    elementProps,
     target,
     rel,
     ...rest
@@ -146,6 +161,7 @@ function ItemAction(props: ItemActionProps) {
           rel={rel}
           tabIndex={-1}
           aria-disabled={isInactive ? true : undefined}
+          {...elementProps}
         >
           {content}
         </Anchor>

--- a/packages/dnb-eufemia/src/components/list/ItemAction.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAction.tsx
@@ -3,7 +3,7 @@ import { ListVariant, ListContext } from './ListContext'
 import ItemContent, { ItemContentProps } from './ItemContent'
 import React, { useCallback, useContext, useRef } from 'react'
 import IconPrimary from '../IconPrimary'
-import Anchor from '../Anchor'
+import Anchor, { AnchorProps } from '../Anchor'
 import ItemIcon from './ItemIcon'
 import ItemTitle from './ItemTitle'
 import type { IconIcon } from '../icon/Icon'
@@ -19,6 +19,8 @@ export type ItemActionProps = {
   icon?: IconIcon
   title?: React.ReactNode
   href?: string
+  to?: string
+  element?: AnchorProps['element']
   target?: string
   rel?: string
 } & Omit<ItemContentProps, 'title'>
@@ -37,6 +39,8 @@ function ItemAction(props: ItemActionProps) {
     icon,
     title,
     href,
+    to,
+    element,
     target,
     rel,
     ...rest
@@ -102,7 +106,7 @@ function ItemAction(props: ItemActionProps) {
   const actionClassName = classnames(
     'dnb-list__item__action',
     chevronPosition === 'left' && 'dnb-list__item--chevron-left',
-    href && 'dnb-list__item__action--href',
+    (href || to) && 'dnb-list__item__action--href',
     className
   )
 
@@ -116,7 +120,7 @@ function ItemAction(props: ItemActionProps) {
     </>
   )
 
-  if (href) {
+  if (href || to) {
     return (
       <ItemContent
         className={actionClassName}
@@ -135,7 +139,9 @@ function ItemAction(props: ItemActionProps) {
         <Anchor
           noStyle
           ref={anchorRef}
-          href={isInactive ? undefined : href}
+          {...(href != null ? { href: isInactive ? undefined : href } : {})}
+          to={isInactive ? undefined : to}
+          element={element}
           target={target}
           rel={rel}
           tabIndex={-1}

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -331,6 +331,16 @@ export const ItemActionProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  to: {
+    doc: 'Use this prop only if you are using a router Link component as the `element` that uses the `to` property to declare the navigation url.',
+    type: 'string',
+    status: 'optional',
+  },
+  element: {
+    doc: 'Define what HTML or React element should be used for the link (e.g. `element={Link}` for React Router). Only applicable when `href` or `to` is set.',
+    type: 'React.Element',
+    status: 'optional',
+  },
   target: {
     doc: 'Link target (e.g. `_blank` for new tab). Only applicable when `href` is set.',
     type: 'string',

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -342,7 +342,7 @@ export const ItemActionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   elementProps: {
-    doc: 'Additional props forwarded to the `element` component (e.g. `{ replace: true, state: { from: "list" } }` for React Router Link). Only applicable when `element` is set.',
+    doc: 'Additional props forwarded to the `element` component (e.g. `{ replace: true, state: { from: "list" } }` for React Router Link).',
     type: 'object',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -341,6 +341,11 @@ export const ItemActionProperties: PropertiesTableProps = {
     type: 'React.Element',
     status: 'optional',
   },
+  elementProps: {
+    doc: 'Additional props forwarded to the `element` component (e.g. `{ replace: true, state: { from: "list" } }` for React Router Link). Only applicable when `element` is set.',
+    type: 'object',
+    status: 'optional',
+  },
   target: {
     doc: 'Link target (e.g. `_blank` for new tab). Only applicable when `href` is set.',
     type: 'string',

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
@@ -583,7 +583,11 @@ describe('ItemAction', () => {
   describe('element and to', () => {
     const MockLink = React.forwardRef<
       HTMLAnchorElement,
-      { to: string; children: React.ReactNode; preventScrollReset?: boolean}
+      {
+        to: string
+        children: React.ReactNode
+        preventScrollReset?: boolean
+      }
     >(({ to, children, ...rest }, ref) => (
       <a href={to} ref={ref} {...rest}>
         {children}
@@ -699,7 +703,9 @@ describe('ItemAction', () => {
         <ItemAction
           element={MockLink}
           to="/route"
-          elementProps={{ 'data-replace': 'true' } as Record<string, unknown>}
+          elementProps={
+            { 'data-replace': 'true' } as Record<string, unknown>
+          }
         >
           Content
         </ItemAction>

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
@@ -583,7 +583,7 @@ describe('ItemAction', () => {
   describe('element and to', () => {
     const MockLink = React.forwardRef<
       HTMLAnchorElement,
-      { to: string; children: React.ReactNode }
+      { to: string; children: React.ReactNode; preventScrollReset?: boolean}
     >(({ to, children, ...rest }, ref) => (
       <a href={to} ref={ref} {...rest}>
         {children}
@@ -692,6 +692,22 @@ describe('ItemAction', () => {
 
       expect(clickSpy).toHaveBeenCalled()
       clickSpy.mockRestore()
+    })
+
+    it('forwards elementProps to the anchor element', () => {
+      render(
+        <ItemAction
+          element={MockLink}
+          to="/route"
+          elementProps={{ 'data-replace': 'true' } as Record<string, unknown>}
+        >
+          Content
+        </ItemAction>
+      )
+
+      const anchor = document.querySelector('a')
+
+      expect(anchor?.getAttribute('data-replace')).toBe('true')
     })
   })
 })

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAction.test.tsx
@@ -579,4 +579,119 @@ describe('ItemAction', () => {
       expect(handleClick).not.toHaveBeenCalled()
     })
   })
+
+  describe('element and to', () => {
+    const MockLink = React.forwardRef<
+      HTMLAnchorElement,
+      { to: string; children: React.ReactNode }
+    >(({ to, children, ...rest }, ref) => (
+      <a href={to} ref={ref} {...rest}>
+        {children}
+      </a>
+    ))
+    MockLink.displayName = 'MockLink'
+
+    it('renders with a custom router Link component via element and to', () => {
+      render(
+        <ItemAction element={MockLink} to="/route">
+          Router link
+        </ItemAction>
+      )
+
+      const anchor = document.querySelector('a')
+
+      expect(anchor).toBeInTheDocument()
+      expect(anchor?.getAttribute('href')).toBe('/route')
+      expect(anchor?.textContent).toContain('Router link')
+    })
+
+    it('applies --href modifier class when to is provided', () => {
+      render(
+        <ItemAction element={MockLink} to="/route">
+          Content
+        </ItemAction>
+      )
+
+      const element = document.querySelector(
+        '.dnb-list__item__action--href'
+      )
+
+      expect(element).toBeInTheDocument()
+    })
+
+    it('has role="link" when to is provided', () => {
+      render(
+        <ItemAction element={MockLink} to="/route">
+          Content
+        </ItemAction>
+      )
+
+      const element = document.querySelector('.dnb-list__item__action')
+
+      expect(element?.getAttribute('role')).toBe('link')
+    })
+
+    it('does not forward to when disabled', () => {
+      render(
+        <ItemAction element={MockLink} to="/route" disabled>
+          Content
+        </ItemAction>
+      )
+
+      const anchor = document.querySelector('a')
+
+      expect(anchor).not.toHaveAttribute('href')
+      expect(anchor?.getAttribute('aria-disabled')).toBe('true')
+    })
+
+    it('does not forward to when pending', () => {
+      render(
+        <ItemAction element={MockLink} to="/route" pending>
+          Content
+        </ItemAction>
+      )
+
+      const anchor = document.querySelector('a')
+
+      expect(anchor).not.toHaveAttribute('href')
+    })
+
+    it('triggers anchor click on Enter key when using to', () => {
+      render(
+        <ItemAction element={MockLink} to="/route">
+          Content
+        </ItemAction>
+      )
+
+      const listItem = document.querySelector(
+        '.dnb-list__item__action--href'
+      )
+      const anchor = listItem?.querySelector('a')
+      const clickSpy = jest.spyOn(anchor as HTMLAnchorElement, 'click')
+
+      fireEvent.keyDown(listItem as Element, { key: 'Enter' })
+
+      expect(clickSpy).toHaveBeenCalled()
+      clickSpy.mockRestore()
+    })
+
+    it('triggers anchor click on Space key when using to', () => {
+      render(
+        <ItemAction element={MockLink} to="/route">
+          Content
+        </ItemAction>
+      )
+
+      const listItem = document.querySelector(
+        '.dnb-list__item__action--href'
+      )
+      const anchor = listItem?.querySelector('a')
+      const clickSpy = jest.spyOn(anchor as HTMLAnchorElement, 'click')
+
+      fireEvent.keyDown(listItem as Element, { key: ' ' })
+
+      expect(clickSpy).toHaveBeenCalled()
+      clickSpy.mockRestore()
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -294,6 +294,10 @@
         grid-row: 1 / -1; // Center vertically
         text-decoration: none;
         color: inherit;
+
+        &:visited {
+          color: inherit;
+        }
       }
 
       // Handle action states

--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -294,10 +294,6 @@
         grid-row: 1 / -1; // Center vertically
         text-decoration: none;
         color: inherit;
-
-        &:visited {
-          color: inherit;
-        }
       }
 
       // Handle action states
@@ -382,6 +378,10 @@
       a {
         cursor: not-allowed;
       }
+    }
+
+    &__action--href a:visited {
+      color: inherit;
     }
     &__pending {
       position: absolute;


### PR DESCRIPTION
## Summary
- Add `element`, `to`, and `elementProps` props to `List.Item.Action`, enabling React Router client-side navigation
- Follows the established pattern used by `Anchor`, `Button`, and `BreadcrumbItem`
- Without this, using `href` always causes a full page reload
- `elementProps` is fully typed — it infers allowed props from the `element` component
- Add `a:visited { color: inherit }` to the action href anchor CSS reset to prevent browser default visited-link styling

### Usage
```tsx
import { Link } from 'react-router-dom'

<List.Item.Action
  element={Link}
  to="/my-route"
  title="Go somewhere"
  elementProps={{ replace: true, state: { from: 'list' } }}
/>
```

## Test plan
- [x] All 57 existing + new ItemAction tests pass
- [x] Verify client-side navigation works with React Router in a consumer app
- [x] Verify `href` (without `element`/`to`) still works as before
- [x] Verify disabled/pending states prevent navigation with `to`
- [ ] Verify `elementProps` provides correct type inference for the given `element`