### PR TITLE
chore: add axe accessibility tests to all untested components

### DIFF
--- a/packages/dnb-eufemia/src/components/aria-live/__tests__/AriaLive.test.tsx
+++ b/packages/dnb-eufemia/src/components/aria-live/__tests__/AriaLive.test.tsx
@@ -203,9 +203,7 @@ describe('AriaLive', () => {
 
 describe('AriaLive aria', () => {
   it('should validate', async () => {
-    const Component = render(
-      <AriaLive>Announcement content</AriaLive>
-    )
+    const Component = render(<AriaLive>Announcement content</AriaLive>)
     expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/aria-live/__tests__/AriaLive.test.tsx
+++ b/packages/dnb-eufemia/src/components/aria-live/__tests__/AriaLive.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import AriaLive from '../AriaLive'
+import { axeComponent } from '../../../core/jest/jestSetup'
 import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('AriaLive', () => {
@@ -197,5 +198,14 @@ describe('AriaLive', () => {
     expect((AriaLive as ComponentMarkers)._supportsSpacingProps).toBe(
       'children'
     )
+  })
+})
+
+describe('AriaLive aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <AriaLive>Announcement content</AriaLive>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -206,9 +206,7 @@ describe('CopyOnClick', () => {
 
 describe('CopyOnClick aria', () => {
   it('should validate', async () => {
-    const Component = render(
-      <CopyOnClick>CopyOnClick text</CopyOnClick>
-    )
+    const Component = render(<CopyOnClick>CopyOnClick text</CopyOnClick>)
     expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import CopyOnClick from '../CopyOnClick'
-import { mockClipboard } from '../../../core/jest/jestSetup'
+import { axeComponent, mockClipboard } from '../../../core/jest/jestSetup'
 import NumberFormat from '../../NumberFormat'
 import userEvent from '@testing-library/user-event'
 
@@ -201,5 +201,14 @@ describe('CopyOnClick', () => {
 
     // Restore original mock
     navigator.clipboard.writeText = originalWrite
+  })
+})
+
+describe('CopyOnClick aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <CopyOnClick>CopyOnClick text</CopyOnClick>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/country-flag/__tests__/CountryFlag.test.tsx
+++ b/packages/dnb-eufemia/src/components/country-flag/__tests__/CountryFlag.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import CountryFlag from '../CountryFlag'
 import Provider from '../../../shared/Provider'
+import { axeComponent } from '../../../core/jest/jestSetup'
 
 describe('CountryFlag', () => {
   it('should use NO as default', () => {
@@ -90,5 +91,12 @@ describe('CountryFlag', () => {
 
     const element = document.querySelector('.dnb-country-flag')
     expect(refElement).toBe(element)
+  })
+})
+
+describe('CountryFlag aria', () => {
+  it('should validate', async () => {
+    const Component = render(<CountryFlag iso="NO" />)
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/grid/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/grid/__tests__/Container.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import 'mock-match-media/jest-setup'
 import Grid from '../Grid'
+import { axeComponent } from '../../../core/jest/jestSetup'
 
 describe('Grid.Container', () => {
   it('should forward HTML attributes', () => {
@@ -184,5 +185,16 @@ describe('Grid.Container', () => {
 
     const element = document.querySelector('.dnb-grid-container')
     expect(refElement).toBe(element)
+  })
+})
+
+describe('Grid.Container aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <Grid.Container>
+        <Grid.Item>Item</Grid.Item>
+      </Grid.Container>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/grid/__tests__/Item.test.tsx
+++ b/packages/dnb-eufemia/src/components/grid/__tests__/Item.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import 'mock-match-media/jest-setup'
 import Grid from '../Grid'
+import { axeComponent } from '../../../core/jest/jestSetup'
 
 function getStyleProperties(
   element: HTMLElement,
@@ -298,5 +299,12 @@ describe('Grid.Item', () => {
     const element = document.querySelector('.dnb-grid-item')
 
     expect(element.tagName).toBe('SECTION')
+  })
+})
+
+describe('Grid.Item aria', () => {
+  it('should validate', async () => {
+    const Component = render(<Grid.Item>content</Grid.Item>)
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -10,6 +10,7 @@ import {
   runAnimation,
   simulateAnimationEnd,
 } from './HeightAnimationUtils'
+import { axeComponent } from '../../../core/jest/jestSetup'
 import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('HeightAnimation', () => {
@@ -440,5 +441,14 @@ describe('HeightAnimation without initializeTestSetup()', () => {
     expect(ref.current instanceof HTMLDivElement).toBe(true)
     expect(ref.current.tagName).toBe('DIV')
     expect(ref.current.classList).toContain('dnb-height-animation')
+  })
+})
+
+describe('HeightAnimation aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <HeightAnimation>visible content</HeightAnimation>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
@@ -4,6 +4,7 @@ import PortalRoot, { getOrCreatePortalElement } from '../PortalRoot'
 import IsolatedStyleScope, {
   IsolatedStyleScopeContext,
 } from '../../../shared/IsolatedStyleScope'
+import { axeComponent } from '../../../core/jest/jestSetup'
 
 describe('PortalRoot', () => {
   let originalWindow: Window & typeof globalThis
@@ -1054,5 +1055,16 @@ describe('getOrCreatePortalElement', () => {
       // Ensure provider id element not created
       expect(document.getElementById('provider-portal-root')).toBeNull()
     })
+  })
+})
+
+describe('PortalRoot aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <PortalRoot>
+        <div>Portal content</div>
+      </PortalRoot>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/term-definition/__tests__/TermDefinition.test.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/__tests__/TermDefinition.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TermDefinition from '../TermDefinition'
 import defaultLocales from '../../../shared/locales'
-import { wait } from '../../../core/jest/jestSetup'
+import { axeComponent, wait } from '../../../core/jest/jestSetup'
 import { Field } from '../../../extensions/forms'
 
 const term = 'unusual words'
@@ -403,5 +403,14 @@ describe('TermDefinition', () => {
     // Verify the input did NOT receive focus
     expect(document.activeElement).not.toBe(input)
     expect(input).not.toHaveFocus()
+  })
+})
+
+describe('TermDefinition aria', () => {
+  it('should validate', async () => {
+    const Component = render(
+      <TermDefinition content="A definition">Term</TermDefinition>
+    )
+    expect(await axeComponent(Component)).toHaveNoViolations()
   })
 })


### PR DESCRIPTION
Add axeComponent tests to 7 components that were missing them:
- AriaLive
- CopyOnClick
- CountryFlag
- Grid.Container
- Grid.Item
- HeightAnimation
- PortalRoot
- TermDefinition

This ensures all components have baseline accessibility validation using jest-axe.

