### PR TITLE
chore: replace hardcoded media queries with breakpoint mixins

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
@@ -261,7 +261,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -375,7 +375,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/dropdown/style/dnb-dropdown.scss
+++ b/packages/dnb-eufemia/src/components/dropdown/style/dnb-dropdown.scss
@@ -134,7 +134,7 @@
     width: auto;
   }
 
-  @media screen and (max-width: 40em) {
+  @include utilities.allBelow(small) {
     &--action-menu &__trigger.dnb-button {
       padding-left: 0.5rem;
       padding-right: 0.5rem;
@@ -149,7 +149,7 @@
     }
   }
 
-  @media screen and (max-width: 40em) {
+  @include utilities.allBelow(small) {
     &--action-menu &__shell &__text {
       width: 0;
       padding: 0;
@@ -365,7 +365,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/global-error/style/dnb-global-error.scss
+++ b/packages/dnb-eufemia/src/components/global-error/style/dnb-global-error.scss
@@ -34,7 +34,7 @@
 
     padding: var(--spacing-large);
 
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       padding: 0 var(--spacing-x-small);
     }
 
@@ -62,7 +62,7 @@
   }
 
   h1 {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       // margin-top: 0;
       font-size: var(--font-size-large);
     }

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -597,7 +597,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
+++ b/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
@@ -317,7 +317,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
@@ -279,7 +279,7 @@
   }
 
   .dnb-responsive-component & {
-    @media screen and (max-width: 40em) {
+    @include utilities.allBelow(small) {
       display: flex;
       flex-direction: column;
       align-items: flex-start;


### PR DESCRIPTION
Replace 10 hardcoded @media screen and (max-width: 40em) queries with @include utilities.allBelow(small) across 7 component SCSS files:
- dropdown, autocomplete, input, slider, textarea, date-picker, global-error

Height-based queries (drawer, dialog) are left as-is since the mixin only supports width-based breakpoints.

