### PR TITLE
chore: standardize media query syntax in dialog SCSS

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -1527,7 +1527,7 @@ html:not([data-visual-test]) .dnb-dialog--hide {
   margin-top: 1.5rem;
 }
 @supports (-webkit-touch-callout: none) {
-  @media (max-height: 40em) {
+  @media screen and (max-height: 40em) {
     .dnb-dialog .dnb-scroll-view {
       max-height: 82vh;
     }

--- a/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
@@ -289,7 +289,7 @@
   // Fix for iOS on iPhone
   // Because Safari includes the navigation bar on the height
   @include utilities.isSafariMobile() {
-    @media (max-height: 40em) {
+    @media screen and (max-height: 40em) {
       .dnb-scroll-view {
         max-height: 82vh;
       }


### PR DESCRIPTION
Add missing 'screen and' prefix to the viewport height query in dnb-dialog.scss to match the convention used by the breakpoint mixins and all other viewport-based media queries in the codebase.

