### PR TITLE
chore: convert px values to rem in component SCSS

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2484,7 +2484,7 @@ html[data-whatinput=keyboard] .dnb-radio__input:not([disabled]):not(:checked):no
 .dnb-date-picker {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
+  --date-picker-day-horizontal-spacing: 0.25rem;
   display: inline-flex;
   align-items: center;
   column-gap: var(--spacing-small);
@@ -2811,7 +2811,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker__portal {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
+  --date-picker-day-horizontal-spacing: 0.25rem;
   --popover-z-index: calc(var(--modal-z-index) + 10);
   line-height: var(--date-picker-input-height);
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -8,7 +8,7 @@
 .dnb-date-picker {
   --date-picker-input-height: 2rem;
   --date-picker-day-width: 2rem;
-  --date-picker-day-horizontal-spacing: 4px;
+  --date-picker-day-horizontal-spacing: 0.25rem;
 
   display: inline-flex;
   align-items: center;
@@ -404,7 +404,7 @@
     // make variables available inside the portal
     --date-picker-input-height: 2rem;
     --date-picker-day-width: 2rem;
-    --date-picker-day-horizontal-spacing: 4px;
+    --date-picker-day-horizontal-spacing: 0.25rem;
 
     // Over modal, but below tooltip
     --popover-z-index: calc(var(--modal-z-index) + 10);

--- a/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
+++ b/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
@@ -86,7 +86,7 @@
     display: flex;
     flex-direction: column;
 
-    max-width: calc(var(--prose-max-width) - 64px);
+    max-width: calc(var(--prose-max-width) - 4rem);
     padding: calc(var(--inner-space) * 2) 0 calc(var(--inner-space) * 2);
   }
   &--no-max-width &__content {

--- a/packages/dnb-eufemia/src/components/term-definition/style/dnb-term-definition.scss
+++ b/packages/dnb-eufemia/src/components/term-definition/style/dnb-term-definition.scss
@@ -16,7 +16,7 @@
       text-decoration: underline;
       text-decoration-style: dotted;
       text-decoration-color: var(--anchor-color);
-      text-decoration-thickness: 2.5px;
+      text-decoration-thickness: 0.15625rem;
       text-underline-offset: 0.3125em;
     }
   }

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -987,7 +987,7 @@ button.dnb-button::-moz-focus-inner {
   --upload-background--active: lightgray;
   --upload-border: gray;
   --upload-border--active: black;
-  --upload-border-width: 2px;
+  --upload-border-width: 0.125rem;
   --upload-list-border: black;
   --upload-icon--default: black;
   --upload-icon--warning: red;

--- a/packages/dnb-eufemia/src/components/upload/style/dnb-upload.scss
+++ b/packages/dnb-eufemia/src/components/upload/style/dnb-upload.scss
@@ -10,7 +10,7 @@
   --upload-background--active: lightgray;
   --upload-border: gray;
   --upload-border--active: black;
-  --upload-border-width: 2px;
+  --upload-border-width: 0.125rem;
   --upload-list-border: black;
   --upload-icon--default: black;
   --upload-icon--warning: red;


### PR DESCRIPTION
Convert hardcoded px values to rem where the value represents a spacing or size that should scale with the document font size:

- date-picker: 4px → 0.25rem (day horizontal spacing)
- upload: 2px → 0.125rem (border width)
- term-definition: 2.5px → 0.15625rem (decoration thickness)
- popover: 64px → 4rem (max-width calc offset)

Intentional px values are preserved where documented (input file centering, popover margin for font-size resilience, browser-specific fixes, 1px hairlines/borders, animation transforms).

