### PR TITLE
break: remove internal _innerRef prop, use native ref

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -120,8 +120,6 @@ export type InputMaskedProps = Omit<
      * `shift` (default) moves to the next slot, `replace` keeps the cursor in place.
      */
     overwriteMode?: InputMaskedOverwriteMode | null
-    /** @internal */
-    _innerRef?: React.Ref<HTMLInputElement>
     onSubmit?: InputMaskedEventHandler
     onFocus?: InputMaskedEventHandler
     onBlur?: InputMaskedEventHandler
@@ -187,7 +185,6 @@ function InputMasked({ ref, ...restProps }: InputMaskedProps) {
     const propsWithRef = {
       ...restProps,
       ref,
-      _innerRef: restProps._innerRef ?? ref,
     }
 
     return extendPropsWithContext(
@@ -218,7 +215,6 @@ const defaultProps = {
   showMask: false,
   allowOverflow: false,
   overwriteMode: null,
-  _innerRef: null,
   onChange: null,
   onSubmit: null,
   onFocus: null,

--- a/packages/dnb-eufemia/src/components/input-masked/hooks/useFilteredProps.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/hooks/useFilteredProps.tsx
@@ -23,7 +23,6 @@ export const useFilteredProps = () => {
     showMask,
     allowOverflow,
     overwriteMode,
-    _innerRef,
 
     // Get rest of possible attributes
     ...attributes

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -200,11 +200,6 @@ export type InputProps = Omit<
      */
     inputElement?: InputElement
     /**
-     * Internal ref alias used by wrappers such as InputMasked.
-     * @internal
-     */
-    _innerRef?: React.Ref<HTMLInputElement>
-    /**
      * If set to `true`, the Input's internal "__shell" and "__border" class element will be omitted.
      * @internal
      */
@@ -597,7 +592,6 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     selectAll, //eslint-disable-line
     inputElement: _inputElement, //eslint-disable-line
     ref: _ref, //eslint-disable-line
-    _innerRef, //eslint-disable-line
     inputState: _inputState, //eslint-disable-line
 
     onSubmit, //eslint-disable-line


### PR DESCRIPTION
Remove the _innerRef prop from Input and InputMasked components. InputMasked already receives ref as a regular prop and threads it through context — the _innerRef alias was redundant.

This simplifies the ref handling and prepares for React 19 where ref is a first-class prop on all components.

BREAKING CHANGE: _innerRef is removed from InputProps and InputMaskedProps. Use the standard ref prop instead.

