### PR TITLE
fix(Icon): replace alt='no-alt' with empty string for data:image icons

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -473,7 +473,7 @@ export function prerenderIcon(
   let { icon } = props as Omit<IconProps, 'icon'> & { icon: IconType }
 
   if (typeof icon === 'string' && /^data:image\//.test(icon)) {
-    return () => <img src={String(icon)} alt={alt || 'no-alt'} />
+    return () => <img src={String(icon)} alt={alt || ''} />
   }
 
   if (typeof icon === 'function') {

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -241,6 +241,22 @@ describe('Icon component', () => {
     const Comp = render(<Icon {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
+
+  it('should render data:image icon with empty alt when no alt is provided', () => {
+    const dataUri = 'data:image/png;base64,abc123'
+    render(<Icon icon={dataUri} />)
+
+    const img = document.querySelector('img')
+    expect(img).toHaveAttribute('alt', '')
+  })
+
+  it('should render data:image icon with provided alt text', () => {
+    const dataUri = 'data:image/png;base64,abc123'
+    render(<Icon icon={dataUri} alt="Custom alt" />)
+
+    const img = document.querySelector('img')
+    expect(img).toHaveAttribute('alt', 'Custom alt')
+  })
 })
 
 describe('Icon scss', () => {


### PR DESCRIPTION
Screen readers would announce 'no-alt' as the alt text for data:image icons. Now uses an empty string instead to make the image decorative and silent for assistive technologies.

