### PR TITLE
refactor: centralize z-index scale with CSS custom properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -252,6 +252,45 @@ This allows usage like:
 
 The `tokens-tailwind.css` files are available for all themes: `ui`, `sbanken`, and `carnegie`.
 
+## Z-Index Scale \{#z-index\}
+
+Eufemia defines a centralized z-index scale using CSS Custom Properties. This ensures consistent layering across all components and makes the stacking order discoverable and adjustable from a single place.
+
+The following tokens are defined on `:root` and control the stacking order of Eufemia components:
+
+| Token                  | Default value | Usage                                   |
+| ---------------------- | ------------- | --------------------------------------- |
+| `--z-index-section`    | `1`           | Content sections                        |
+| `--z-index-dropdown`   | `100`         | Inline dropdowns, drawer-lists          |
+| `--z-index-popover`    | `1000`        | Popovers, floating elements             |
+| `--z-index-tooltip`    | `1100`        | Tooltips (always above popovers)        |
+| `--z-index-modal`      | `3000`        | Dialogs, drawers, full overlays         |
+
+Each component also exposes its own CSS Custom Property that references the centralized token. This preserves backward compatibility for consumers who override the component-level property directly.
+
+| Component | Component property    | References              |
+| --------- | --------------------- | ----------------------- |
+| Section   | `--section-z-index`   | `var(--z-index-section)`  |
+| Popover   | `--popover-z-index`   | `var(--z-index-popover)`  |
+| Tooltip   | `--tooltip-z-index`   | `var(--z-index-tooltip)`  |
+| Modal     | `--modal-z-index`     | `var(--z-index-modal)`    |
+
+You can override the global z-index scale to adjust the layering for your application:
+
+```css
+:root {
+  --z-index-modal: 9999;
+}
+```
+
+Or override a single component's z-index:
+
+```css
+:root {
+  --modal-z-index: 5000;
+}
+```
+
 ## Known styling and CSS issues
 
 - Safari, both on mobile and desktop, has a problem where we combine `border-radius` with the usage of `inset` in a `box-shadow`. The solution for now is to not use `inset`, which results in an outer border. This is not ideal as we don't follow the UX guidelines for these browsers. We have a SASS function handling this for us: `@mixin fakeBorder`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -258,22 +258,22 @@ Eufemia defines a centralized z-index scale using CSS Custom Properties. This en
 
 The following tokens are defined on `:root` and control the stacking order of Eufemia components:
 
-| Token                  | Default value | Usage                                   |
-| ---------------------- | ------------- | --------------------------------------- |
-| `--z-index-section`    | `1`           | Content sections                        |
-| `--z-index-dropdown`   | `100`         | Inline dropdowns, drawer-lists          |
-| `--z-index-popover`    | `1000`        | Popovers, floating elements             |
-| `--z-index-tooltip`    | `1100`        | Tooltips (always above popovers)        |
-| `--z-index-modal`      | `3000`        | Dialogs, drawers, full overlays         |
+| Token                | Default value | Usage                            |
+| -------------------- | ------------- | -------------------------------- |
+| `--z-index-section`  | `1`           | Content sections                 |
+| `--z-index-dropdown` | `100`         | Inline dropdowns, drawer-lists   |
+| `--z-index-popover`  | `1000`        | Popovers, floating elements      |
+| `--z-index-tooltip`  | `1100`        | Tooltips (always above popovers) |
+| `--z-index-modal`    | `3000`        | Dialogs, drawers, full overlays  |
 
 Each component also exposes its own CSS Custom Property that references the centralized token. This preserves backward compatibility for consumers who override the component-level property directly.
 
-| Component | Component property    | References              |
-| --------- | --------------------- | ----------------------- |
-| Section   | `--section-z-index`   | `var(--z-index-section)`  |
-| Popover   | `--popover-z-index`   | `var(--z-index-popover)`  |
-| Tooltip   | `--tooltip-z-index`   | `var(--z-index-tooltip)`  |
-| Modal     | `--modal-z-index`     | `var(--z-index-modal)`    |
+| Component | Component property  | References               |
+| --------- | ------------------- | ------------------------ |
+| Section   | `--section-z-index` | `var(--z-index-section)` |
+| Popover   | `--popover-z-index` | `var(--z-index-popover)` |
+| Tooltip   | `--tooltip-z-index` | `var(--z-index-tooltip)` |
+| Modal     | `--modal-z-index`   | `var(--z-index-modal)`   |
 
 You can override the global z-index scale to adjust the layering for your application:
 

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -104,7 +104,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -112,7 +112,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -960,7 +960,7 @@ button.dnb-button::-moz-focus-inner {
  *
  */
 :root {
-  --section-z-index: 1;
+  --section-z-index: var(--z-index-section);
 }
 
 .dnb-section {

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -104,7 +104,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -244,7 +244,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -116,7 +116,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -1163,7 +1163,7 @@ button.dnb-button::-moz-focus-inner {
   }
 }
 :root {
-  --modal-z-index: 3000;
+  --modal-z-index: var(--z-index-modal);
   --modal-animation-duration: 300ms;
 }
 

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -1164,7 +1164,7 @@ button.dnb-button::-moz-focus-inner {
   }
 }
 :root {
-  --modal-z-index: 3000;
+  --modal-z-index: var(--z-index-modal);
   --modal-animation-duration: 300ms;
 }
 

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -112,7 +112,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -960,7 +960,7 @@ button.dnb-button::-moz-focus-inner {
  *
  */
 :root {
-  --section-z-index: 1;
+  --section-z-index: var(--z-index-section);
 }
 
 .dnb-section {

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -118,7 +118,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -112,7 +112,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -112,7 +112,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -1159,7 +1159,7 @@ button.dnb-button::-moz-focus-inner {
   }
 }
 :root {
-  --modal-z-index: 3000;
+  --modal-z-index: var(--z-index-modal);
   --modal-animation-duration: 300ms;
 }
 

--- a/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
@@ -7,7 +7,7 @@
 @use './modal-mixins.scss';
 
 :root {
-  --modal-z-index: 3000;
+  --modal-z-index: var(--z-index-modal);
   --modal-animation-duration: 300ms;
 }
 

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`NumberFormat scss has to match style dependencies css 1`] = `
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
+++ b/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
@@ -1,7 +1,7 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 :root {
-  --popover-z-index: 1000;
+  --popover-z-index: var(--z-index-popover);
 }
 
 .dnb-popover {

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Section scss has to match style dependencies css 1`] = `
  * Utilities
  */
 :root {
-  --section-z-index: 1;
+  --section-z-index: var(--z-index-section);
 }
 
 .dnb-section {

--- a/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
@@ -6,7 +6,7 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 :root {
-  --section-z-index: 1;
+  --section-z-index: var(--z-index-section);
 }
 
 .dnb-section {

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {
@@ -960,7 +960,7 @@ button.dnb-button::-moz-focus-inner {
  *
  */
 :root {
-  --section-z-index: 1;
+  --section-z-index: var(--z-index-section);
 }
 
 .dnb-section {

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -115,7 +115,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -108,7 +108,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -302,7 +302,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Tooltip scss has to match style dependencies css 1`] = `
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
+++ b/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
@@ -6,7 +6,7 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -131,7 +131,7 @@ p > .dnb-icon {
  * Utilities
  */
 :root {
-  --tooltip-z-index: 1100;
+  --tooltip-z-index: var(--z-index-tooltip);
 }
 
 .dnb-tooltip {

--- a/packages/dnb-eufemia/src/style/core/z-index.scss
+++ b/packages/dnb-eufemia/src/style/core/z-index.scss
@@ -1,0 +1,21 @@
+/*
+ * Z-Index Scale
+ *
+ * Centralized z-index token definitions for layering control.
+ * Components should reference these variables instead of hardcoding values.
+ *
+ * Layers (low to high):
+ *   section     →    1  (content sections)
+ *   dropdown    →  100  (inline dropdowns, drawer-lists)
+ *   popover     → 1000  (popovers, floating elements)
+ *   tooltip     → 1100  (tooltips, always above popovers)
+ *   modal       → 3000  (dialogs, drawers, full overlays)
+ */
+
+:root {
+  --z-index-section: 1;
+  --z-index-dropdown: 100;
+  --z-index-popover: 1000;
+  --z-index-tooltip: 1100;
+  --z-index-modal: 3000;
+}

--- a/packages/dnb-eufemia/src/style/dnb-ui-core.scss
+++ b/packages/dnb-eufemia/src/style/dnb-ui-core.scss
@@ -6,6 +6,7 @@
 // core imports
 @use 'sass:meta';
 @use './core/scopes.scss' as scopes;
+@use './core/z-index.scss';
 
 @include scopes.globalReset();
 


### PR DESCRIPTION
Add src/style/core/z-index.scss with a centralized z-index token scale:
  --z-index-section:  1
  --z-index-dropdown: 100
  --z-index-popover:  1000
  --z-index-tooltip:  1100
  --z-index-modal:    3000

Component-level custom properties (--modal-z-index, --popover-z-index, --tooltip-z-index, --section-z-index) now reference the centralized tokens via var() instead of hardcoded numeric values.

This makes the z-index layering system discoverable and adjustable from a single place while preserving backward compatibility for consumers who override the component-level custom properties.

