### PR TITLE
chore(lint): add stylelint plugin to detect unused @use imports

### DIFF
--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -5,7 +5,8 @@
   ],
   "plugins": [
     "stylelint-scss",
-    "./scripts/stylelint/plugins/token-name-policy"
+    "./scripts/stylelint/plugins/token-name-policy",
+    "./scripts/stylelint/plugins/no-unused-use"
   ],
   "rules": {
     "scss/at-mixin-argumentless-call-parentheses": "always",
@@ -40,6 +41,7 @@
           "carnegie": "carnegie"
         }
       }
-    ]
+    ],
+    "eufemia/no-unused-use": true
   }
 }

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-unused-use.test.ts
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-unused-use.test.ts
@@ -1,0 +1,174 @@
+import stylelint from 'stylelint'
+const noUnusedUsePlugin = require('../no-unused-use')
+
+const lintWithRule = async (code: string) => {
+  const result = await stylelint.lint({
+    code,
+    codeFilename: 'test.scss',
+    customSyntax: 'postcss-scss',
+    config: {
+      plugins: [noUnusedUsePlugin],
+      rules: {
+        [noUnusedUsePlugin.ruleName]: true,
+      },
+    },
+  })
+
+  return result.results?.[0]?.warnings || []
+}
+
+describe('no-unused-use', () => {
+  it('should report unused @use with explicit namespace', async () => {
+    const warnings = await lintWithRule(`
+      @use '../../../../style/core/utilities.scss' as utilities;
+
+      .dnb-dialog {
+        --dialog-radius: 0.125rem;
+      }
+    `)
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('utilities')
+    expect(warnings[0].text).toContain('unused')
+  })
+
+  it('should not report @use with namespace that is used in @include', async () => {
+    const warnings = await lintWithRule(`
+      @use '../../../../style/core/utilities.scss' as utilities;
+
+      .dnb-dialog {
+        @include utilities.fakeBorder($color: red);
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report @use with namespace used in a value via function call', async () => {
+    const warnings = await lintWithRule(`
+      @use '../mixins.scss' as mixins;
+
+      .foo {
+        color: mixins.get-color('primary');
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report @use with namespace used via variable access', async () => {
+    const warnings = await lintWithRule(`
+      @use '../vars.scss' as vars;
+
+      .foo {
+        color: vars.$primary-color;
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report @use without explicit alias (side-effect import)', async () => {
+    const warnings = await lintWithRule(`
+      @use './dnb-dialog.scss';
+
+      .foo {
+        color: red;
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report @use with as * (global import)', async () => {
+    const warnings = await lintWithRule(`
+      @use './properties.scss' as *;
+
+      .foo {
+        color: red;
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should report multiple unused @use statements', async () => {
+    const warnings = await lintWithRule(`
+      @use '../a.scss' as a;
+      @use '../b.scss' as b;
+
+      .foo {
+        color: red;
+      }
+    `)
+
+    expect(warnings).toHaveLength(2)
+  })
+
+  it('should report only the unused one when one is used and one is not', async () => {
+    const warnings = await lintWithRule(`
+      @use '../a.scss' as a;
+      @use '../b.scss' as b;
+
+      .foo {
+        @include a.mixin();
+      }
+    `)
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('b')
+  })
+
+  it('should detect namespace used in selector via placeholder', async () => {
+    const warnings = await lintWithRule(`
+      @use '../reset.scss' as reset;
+
+      .foo {
+        @extend reset.%placeholder;
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should detect namespace used in at-rule params', async () => {
+    const warnings = await lintWithRule(`
+      @use '../utilities.scss' as utilities;
+
+      @include utilities.media('small') {
+        .foo {
+          color: red;
+        }
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not flag @use used in property name', async () => {
+    const warnings = await lintWithRule(`
+      @use '../tokens.scss' as tokens;
+
+      .foo {
+        #{tokens.$prop}: red;
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report @use with namespace used in @forward with', async () => {
+    const warnings = await lintWithRule(`
+      @use '../utilities.scss' as utilities;
+      @use './other.scss';
+
+      .foo {
+        color: red;
+      }
+    `)
+
+    // utilities is unused since @forward is excluded from checking
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('utilities')
+  })
+})

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/no-unused-use.js
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/no-unused-use.js
@@ -19,9 +19,7 @@ const meta = {
  * - `@use 'path'`         → null (side-effect / implicit namespace — skip)
  */
 const getExplicitNamespace = (params) => {
-  const match = params.match(
-    /^(['"]).*?\1\s+as\s+(\S+)\s*;?\s*$/
-  )
+  const match = params.match(/^(['"]).*?\1\s+as\s+(\S+)\s*;?\s*$/)
 
   if (!match) {
     return null
@@ -88,9 +86,13 @@ const isNamespaceUsed = (root, namespace) => {
 
 const ruleFunction = (primary) => {
   return (root, result) => {
-    const validOptions = stylelint.utils.validateOptions(result, RULE_NAME, {
-      actual: primary,
-    })
+    const validOptions = stylelint.utils.validateOptions(
+      result,
+      RULE_NAME,
+      {
+        actual: primary,
+      }
+    )
 
     if (!validOptions) {
       return

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/no-unused-use.js
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/no-unused-use.js
@@ -1,0 +1,126 @@
+const stylelint = require('stylelint')
+
+const RULE_NAME = 'eufemia/no-unused-use'
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+  unusedUse: (namespace, path) =>
+    `Unexpected unused @use "${path}" with namespace "${namespace}". Either use the namespace or remove the @use statement.`,
+})
+
+const meta = {
+  url: 'https://github.com/dnbexperience/eufemia',
+}
+
+/**
+ * Extracts the namespace from a @use at-rule.
+ *
+ * - `@use 'path' as foo` → "foo"
+ * - `@use 'path' as *`   → null (global — cannot be checked)
+ * - `@use 'path'`         → null (side-effect / implicit namespace — skip)
+ */
+const getExplicitNamespace = (params) => {
+  const match = params.match(
+    /^(['"]).*?\1\s+as\s+(\S+)\s*;?\s*$/
+  )
+
+  if (!match) {
+    return null
+  }
+
+  const namespace = match[2].replace(/;$/, '')
+
+  if (namespace === '*') {
+    return null
+  }
+
+  return namespace
+}
+
+/**
+ * Extracts the module path string from @use params.
+ */
+const getModulePath = (params) => {
+  const match = params.match(/^(['"])(.*?)\1/)
+  return match ? match[2] : params
+}
+
+/**
+ * Checks whether a namespace is referenced anywhere in the file
+ * after the @use statement.
+ *
+ * A namespace is "used" if `<namespace>.` appears in any of:
+ * - `@include namespace.mixin`
+ * - `namespace.$variable`
+ * - `namespace.function()`
+ * - `meta.load-css` with the namespace
+ */
+const isNamespaceUsed = (root, namespace) => {
+  const pattern = `${namespace}.`
+  let found = false
+
+  root.walk((node) => {
+    if (found) {
+      return
+    }
+
+    const textToSearch = []
+
+    if (node.type === 'decl') {
+      textToSearch.push(node.prop, node.value)
+    } else if (node.type === 'atrule') {
+      if (node.name !== 'use' && node.name !== 'forward') {
+        textToSearch.push(node.params)
+      }
+    } else if (node.type === 'rule') {
+      textToSearch.push(node.selector)
+    }
+
+    for (const text of textToSearch) {
+      if (text && text.includes(pattern)) {
+        found = true
+        return
+      }
+    }
+  })
+
+  return found
+}
+
+const ruleFunction = (primary) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, RULE_NAME, {
+      actual: primary,
+    })
+
+    if (!validOptions) {
+      return
+    }
+
+    root.walkAtRules('use', (atRule) => {
+      const namespace = getExplicitNamespace(atRule.params)
+
+      if (!namespace) {
+        return
+      }
+
+      if (!isNamespaceUsed(root, namespace)) {
+        const modulePath = getModulePath(atRule.params)
+
+        stylelint.utils.report({
+          message: messages.unusedUse(namespace, modulePath),
+          node: atRule,
+          result,
+          ruleName: RULE_NAME,
+        })
+      }
+    })
+  }
+}
+
+ruleFunction.ruleName = RULE_NAME
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction)
+module.exports.ruleName = RULE_NAME
+module.exports.messages = messages

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1205,11 +1205,11 @@ exports[`Button scss has to match theme css for ui 1`] = `
 *
 */
 /*
-* Button mixins
+* Button theme
 *
 */
 /*
-* Button theme
+* Button mixins
 *
 */
 .dnb-button--tertiary {

--- a/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/button/style/themes/dnb-button-theme-ui.scss
@@ -4,7 +4,6 @@
 */
 
 @use '../../../../style/core/utilities.scss' as utilities;
-@use './button-mixins.scss' as button-mixins;
 
 // Because the tertiary button has so much code,
 // we slice the shareable parts out in a separate file

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -8,14 +8,6 @@ exports[`DatePicker scss should match default theme snapshot 1`] = `
 /*
  * Utilities
  */
-/*
-* DatePicker theme
-*
-*/
-/*
-* Button mixins
-*
-*/
 .dnb-date-picker__container {
   box-shadow: var(--shadow-sharp);
   border-radius: 0.25rem;

--- a/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/themes/dnb-date-picker-theme-ui.scss
@@ -4,7 +4,6 @@
 */
 
 @use '../../../../style/core/utilities.scss' as utilities;
-@use '../../../button/style/themes/button-mixins.scss' as button-mixins;
 
 .dnb-date-picker {
   &__container {

--- a/packages/dnb-eufemia/src/components/textarea/style/themes/dnb-textarea-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/themes/dnb-textarea-theme-sbanken.scss
@@ -3,8 +3,6 @@
 *
 */
 
-@use '../../../../style/core/utilities.scss' as utilities;
-
 .dnb-textarea {
   --textarea-border-radius--focus: 1.5rem;
 

--- a/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/toggle-button/style/themes/dnb-toggle-button-theme-sbanken.scss
@@ -3,8 +3,6 @@
 *
 */
 
-@use '../../../../style/core/utilities.scss' as utilities;
-
 .dnb-toggle-button {
   &__button {
     --button-color-bg--default: var(--sb-color-white);

--- a/packages/dnb-eufemia/src/extensions/vipps-wallet-button/style/dnb-vipps-wallet-button.scss
+++ b/packages/dnb-eufemia/src/extensions/vipps-wallet-button/style/dnb-vipps-wallet-button.scss
@@ -3,8 +3,6 @@
  *
  */
 
-@use '../../../style/core/utilities.scss' as utilities;
-
 .dnb-vipps-wallet-button.dnb-button--primary {
   &,
   &.dnb-button--surface-dark {


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/7357#discussion_r3053472338

Add custom stylelint rule "eufemia/no-unused-use" that flags @use statements with explicit namespace aliases that are never referenced in the file body. This catches dead imports like:

  @use "utilities.scss" as utilities;
  // utilities. never used

The rule only flags @use with explicit "as <namespace>" (not "as *" or bare @use) to avoid false positives on side-effect imports.

Also removes 5 unused @use imports found across the codebase.

