### PR TITLE
feat(Portal): add carnegie theme color for Layout footer

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -25,6 +25,9 @@
   .eufemia-theme__sbanken {
     --footer-bg: var(--sb-color-purple);
   }
+  .eufemia-theme__carnegie {
+    --footer-bg: var(--ca-color-ocean-green);
+  }
 }
 
 .portalStyle {

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -26,7 +26,7 @@
     --footer-bg: var(--sb-color-purple);
   }
   .eufemia-theme__carnegie {
-    --footer-bg: var(--ca-color-ocean-green);
+    --footer-bg: var(--ca-color-burgundy-red);
   }
 }
 


### PR DESCRIPTION
From:

<img width="1315" height="909" alt="Screenshot 2026-04-09 at 14 14 20" src="https://github.com/user-attachments/assets/cd2d817f-3a1a-4d29-9811-a59cfe8361e6" />


To:

<img width="1314" height="865" alt="Screenshot 2026-04-09 at 14 16 48" src="https://github.com/user-attachments/assets/11c4f82f-f351-4d13-b88b-46d9b4de11d9" />
