### PR TITLE
feat(Portal): tokenize Card text color and add theme support

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
@@ -2,6 +2,19 @@
 @use './../parts/PortalStyle.mixins.scss';
 
 .liItemStyle {
+  --card-selected-bg: var(--color-mint-green);
+  --card-hover-bg: var(--color-mint-green-50);
+
+  :global(.eufemia-theme__sbanken) & {
+    --card-selected-bg: var(--sb-color-violet-light-2);
+    --card-hover-bg: var(--sb-color-violet-light-3);
+  }
+
+  :global(.eufemia-theme__carnegie) & {
+    --card-selected-bg: var(--ca-color-pale-green);
+    --card-hover-bg: var(--ca-color-pale-green);
+  }
+
   list-style-type: none;
   width: calc(33.333333% - 1rem);
 
@@ -16,12 +29,12 @@
   }
 
   &.is-selected a {
-    background-color: var(--color-mint-green);
+    background-color: var(--card-selected-bg);
   }
 
   a:focus,
   a:hover {
-    background-color: var(--color-mint-green-50);
+    background-color: var(--card-hover-bg);
   }
 
   /* mobile view */
@@ -72,7 +85,7 @@
 
   height: 100%;
 
-  color: rgb(0 0 0 / 75%);
+  color: var(--color-black-80);
   text-decoration: none;
   text-align: center;
   font-weight: var(--font-weight-basis);

--- a/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
@@ -12,8 +12,8 @@
   }
 
   :global(.eufemia-theme__carnegie) & {
-    --card-selected-bg: var(--ca-color-pale-green);
-    --card-hover-bg: var(--ca-color-pale-green);
+    --card-selected-bg: var(--ca-color-pale-red);
+    --card-hover-bg: var(--ca-color-classic-beige);
   }
 
   list-style-type: none;

--- a/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/Card.module.scss
@@ -5,6 +5,7 @@
   --card-selected-bg: var(--color-mint-green);
   --card-hover-bg: var(--color-mint-green-50);
 
+  /* stylelint-disable no-descending-specificity */
   :global(.eufemia-theme__sbanken) & {
     --card-selected-bg: var(--sb-color-violet-light-2);
     --card-hover-bg: var(--sb-color-violet-light-3);
@@ -36,6 +37,7 @@
   a:hover {
     background-color: var(--card-hover-bg);
   }
+  /* stylelint-enable no-descending-specificity */
 
   /* mobile view */
   @include utilities.allBelow(small) {


### PR DESCRIPTION
Replace hardcoded rgb(0 0 0 / 75%) with --color-black-80 token. Add local card tokens for selected/hover states with sbanken and carnegie overrides.

