### PR TITLE
feat(lint): enable scss/dimension-no-non-numeric-values rule

### DIFF
--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -31,6 +31,7 @@
     "selector-id-pattern": null,
     "number-max-precision": null,
     "at-rule-disallowed-list": ["import"],
+    "scss/dimension-no-non-numeric-values": true,
     "eufemia/token-name-policy": [
       true,
       {

--- a/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
+++ b/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
@@ -188,8 +188,8 @@
     svg {
       vertical-align: baseline;
       transform: scale($icon-scale) var(--anchor-icon-position);
-      font-size: #{math.div(1, $icon-scale)}em;
-      width: #{$icon-scale}em;
+      font-size: math.div(1, $icon-scale) * 1em;
+      width: $icon-scale * 1em;
       height: 1em;
       pointer-events: none;
     }

--- a/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/code/style/code-mixins.scss
@@ -15,7 +15,7 @@
   }
   padding: calc(0.25em / #{$code-scale});
 
-  font-size: #{$code-scale}em;
+  font-size: $code-scale * 1em;
   text-decoration: inherit;
   line-height: calc(var(--line-height-xx-small--em) / #{$code-scale});
 


### PR DESCRIPTION
Enable the rule that prevents interpolation-based dimension values like `#{$value}em` and requires proper Sass math `$value * 1em`.

Fix 2 violations:
- anchor-mixins.scss: font-size and width
- code-mixins.scss: font-size

