### PR TITLE
fix(Portal): tokenize hardcoded colors in PortalStyle and Layout

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -58,7 +58,7 @@
 
         font-style: italic;
 
-        border-top: solid 1px #c4c4c4;
+        border-top: solid 1px var(--color-black-border);
       }
 
       img:not([width]) {
@@ -185,7 +185,7 @@
       font-style: italic;
       text-align: center;
 
-      border-top: solid 1px #c4c4c4;
+      border-top: solid 1px var(--color-black-border);
 
       p {
         margin: 0;

--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
@@ -16,6 +16,14 @@
 .home-background {
   min-height: 100dvh;
   background-color: var(--color-emerald-green);
+
+  :global(.eufemia-theme__sbanken) & {
+    background-color: var(--sb-color-purple);
+  }
+
+  :global(.eufemia-theme__carnegie) & {
+    background-color: var(--ca-color-ocean-green);
+  }
 }
 
 [skip-isolation] #gatsby-noscript {
@@ -28,8 +36,8 @@
   padding: 1.25rem;
   text-align: center;
 
-  color: black;
-  background-color: white;
+  color: var(--color-black);
+  background-color: var(--color-white);
 }
 
 .dnb-live-preview {

--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
@@ -22,7 +22,7 @@
   }
 
   :global(.eufemia-theme__carnegie) & {
-    background-color: var(--ca-color-ocean-green);
+    background-color: var(--ca-color-burgundy-red);
   }
 }
 


### PR DESCRIPTION
Replace #c4c4c4 borders with --color-black-border token. Replace hardcoded black/white with --color-black and --color-white tokens. Add sbanken and carnegie theme overrides for home background.

