### PR TITLE
chore: replace React.FC with function signature in FormStatus

### DIFF
--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -568,7 +568,7 @@ FormStatusComponent.displayName = 'FormStatus'
 const FormStatus = React.memo(
   FormStatusComponent
 ) as React.MemoExoticComponent<
-  React.FC<FormStatusProps & { ref?: React.Ref<HTMLElement> }>
+  (props: FormStatusProps & { ref?: React.Ref<HTMLElement> }) => React.ReactNode
 >
 
 withComponentMarkers(FormStatus, { _supportsSpacingProps: true })

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -568,7 +568,9 @@ FormStatusComponent.displayName = 'FormStatus'
 const FormStatus = React.memo(
   FormStatusComponent
 ) as React.MemoExoticComponent<
-  (props: FormStatusProps & { ref?: React.Ref<HTMLElement> }) => React.ReactNode
+  (
+    props: FormStatusProps & { ref?: React.Ref<HTMLElement> }
+  ) => React.ReactNode
 >
 
 withComponentMarkers(FormStatus, { _supportsSpacingProps: true })


### PR DESCRIPTION
React.FC is discouraged in modern React. Replace the type assertion with an explicit function signature type.

