### PR TITLE
chore: remove redundant `labelDirection="vertical"` after default change

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
@@ -1,4 +1,3 @@
-import { Provider } from '@dnb/eufemia/shared'
 import { DatePicker, Flex, Space } from '@dnb/eufemia/src'
 import { isSameDay } from 'date-fns'
 import {
@@ -31,8 +30,7 @@ export default function Page() {
 const DatePickerScreenshotTestSizes = () => {
   return (
     <Space data-visual-test="date-picker-sizes">
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <DatePicker
             label="DatePicker"
             date={new Date('2022/06/10')}
@@ -56,8 +54,7 @@ const DatePickerScreenshotTestSizes = () => {
             date={new Date('2022/06/10')}
             showInput
           />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Space>
   )
 }
@@ -65,12 +62,10 @@ const DatePickerScreenshotTestSizes = () => {
 const DatePickerScreenshotTestDisabled = () => {
   return (
     <Space data-visual-test="date-picker-disabled">
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <DatePicker disabled />
           <DatePicker showInput disabled />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Space>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
@@ -31,29 +31,29 @@ const DatePickerScreenshotTestSizes = () => {
   return (
     <Space data-visual-test="date-picker-sizes">
       <Flex.Vertical>
-          <DatePicker
-            label="DatePicker"
-            date={new Date('2022/06/10')}
-            showInput
-          />
-          <DatePicker
-            size="small"
-            label="DatePicker"
-            date={new Date('2022/06/10')}
-            showInput
-          />
-          <DatePicker
-            size="medium"
-            label="DatePicker"
-            date={new Date('2022/06/10')}
-            showInput
-          />
-          <DatePicker
-            size="large"
-            label="DatePicker"
-            date={new Date('2022/06/10')}
-            showInput
-          />
+        <DatePicker
+          label="DatePicker"
+          date={new Date('2022/06/10')}
+          showInput
+        />
+        <DatePicker
+          size="small"
+          label="DatePicker"
+          date={new Date('2022/06/10')}
+          showInput
+        />
+        <DatePicker
+          size="medium"
+          label="DatePicker"
+          date={new Date('2022/06/10')}
+          showInput
+        />
+        <DatePicker
+          size="large"
+          label="DatePicker"
+          date={new Date('2022/06/10')}
+          showInput
+        />
       </Flex.Vertical>
     </Space>
   )
@@ -63,8 +63,8 @@ const DatePickerScreenshotTestDisabled = () => {
   return (
     <Space data-visual-test="date-picker-disabled">
       <Flex.Vertical>
-          <DatePicker disabled />
-          <DatePicker showInput disabled />
+        <DatePicker disabled />
+        <DatePicker showInput disabled />
       </Flex.Vertical>
     </Space>
   )

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -21,7 +21,7 @@ import {
   Input,
 } from '../..'
 import { Anchor, Flex, Li, Ol, P, Section, Space } from '../../../'
-import { Context, Provider } from '../../../shared'
+import { Context } from '../../../shared'
 import { SubmitButton } from '../../input/Input'
 import { format } from '../../number-format/NumberUtils'
 import type {
@@ -812,8 +812,7 @@ export function DataSuffix() {
 
   return (
     <WideStyle>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Autocomplete
+      <Autocomplete
           lang="nb"
           value={0}
           data={numbers}
@@ -821,9 +820,7 @@ export function DataSuffix() {
           icon={null}
           showSubmitButton
           label="From account"
-          labelDirection="vertical"
         />
-      </Provider>
     </WideStyle>
   )
 }
@@ -983,7 +980,6 @@ export const Memo = () => {
     return (
       <Autocomplete
         label={label}
-        labelDirection="vertical"
         value={value}
         data={['Up', 'Right', 'Down', 'Left']}
         onChange={(e) => {

--- a/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -813,14 +813,14 @@ export function DataSuffix() {
   return (
     <WideStyle>
       <Autocomplete
-          lang="nb"
-          value={0}
-          data={numbers}
-          size="medium"
-          icon={null}
-          showSubmitButton
-          label="From account"
-        />
+        lang="nb"
+        value={0}
+        data={numbers}
+        size="medium"
+        icon={null}
+        showSubmitButton
+        label="From account"
+      />
     </WideStyle>
   )
 }

--- a/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
@@ -57,8 +57,7 @@ const ChangeLocale = () => {
 export const DatePickerSandbox = () => (
   <Wrapper>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <DatePicker
+      <DatePicker
           label="Linked Range DatePicker:"
           startDate="2019-01-15"
           endDate="2020-11-02"
@@ -98,7 +97,6 @@ export const DatePickerSandbox = () => (
           showResetButton
           showSubmitButton
         />
-      </Provider>
     </Box>
     <Box>
       <DatePicker
@@ -161,12 +159,7 @@ export const DatePickerSandbox = () => (
       />
     </Box>
     <Box>
-      <Provider
-        formElement={{
-          labelDirection: 'vertical',
-        }}
-      >
-        <FieldBlock label="Legend:">
+      <FieldBlock label="Legend:">
           <Flex.Vertical>
             <DatePicker
               label="Date Picker 1"
@@ -225,8 +218,7 @@ export const DatePickerSandbox = () => (
               ]}
             />
           </Flex.Vertical>
-        </FieldBlock>
-      </Provider>
+      </FieldBlock>
     </Box>
     <Box>
       <FieldBlock label="Legend:">
@@ -288,8 +280,7 @@ export const DatePickerSandbox = () => (
       />
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <Input label="Input Default" />
           <DatePicker
             label="DatePicker Default"
@@ -297,12 +288,10 @@ export const DatePickerSandbox = () => (
             showInput={true}
           />
           <Input label="Input Default" />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <Input size="small" label="Input Small" />
           <DatePicker
             size="small"
@@ -311,12 +300,10 @@ export const DatePickerSandbox = () => (
             showInput={true}
           />
           <Input size="small" label="Input Small" />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <Input size="medium" label="Input Medium" />
           <DatePicker
             size="medium"
@@ -325,12 +312,10 @@ export const DatePickerSandbox = () => (
             showInput={true}
           />
           <Input size="medium" label="Input Medium" />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Flex.Vertical>
+      <Flex.Vertical>
           <Input size="large" label="Input Large" />
           <DatePicker
             size="large"
@@ -339,8 +324,7 @@ export const DatePickerSandbox = () => (
             showInput={true}
           />
           <Input size="large" label="Input Large" />
-        </Flex.Vertical>
-      </Provider>
+      </Flex.Vertical>
     </Box>
   </Wrapper>
 )

--- a/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/stories/DatePicker.stories.tsx
@@ -58,45 +58,45 @@ export const DatePickerSandbox = () => (
   <Wrapper>
     <Box>
       <DatePicker
-          label="Linked Range DatePicker:"
-          startDate="2019-01-15"
-          endDate="2020-11-02"
-          range={true}
-          showInput={true}
-          onOpen={(props) => {
-            console.log('onOpen', props)
-          }}
-          onDaysRender={(days) => {
-            return days.map((dateObject) => {
-              if (isWeekend(dateObject.date)) {
-                dateObject.isInactive = true
-                dateObject.className = 'dnb-date-picker__day--weekend'
-              }
-              return dateObject
-            })
-          }}
-          onClose={(props) => {
-            console.log('onClose', props)
-          }}
-          onChange={(props) => {
-            console.log('onChange', props)
-          }}
-          onType={(props) => {
-            console.log('onType', props)
-          }}
-          onSubmit={(props) => {
-            console.log('onSubmit', props)
-          }}
-          onCancel={(props) => {
-            console.log('onCancel', props)
-          }}
-          onReset={(props) => {
-            console.log('onReset', props)
-          }}
-          showCancelButton
-          showResetButton
-          showSubmitButton
-        />
+        label="Linked Range DatePicker:"
+        startDate="2019-01-15"
+        endDate="2020-11-02"
+        range={true}
+        showInput={true}
+        onOpen={(props) => {
+          console.log('onOpen', props)
+        }}
+        onDaysRender={(days) => {
+          return days.map((dateObject) => {
+            if (isWeekend(dateObject.date)) {
+              dateObject.isInactive = true
+              dateObject.className = 'dnb-date-picker__day--weekend'
+            }
+            return dateObject
+          })
+        }}
+        onClose={(props) => {
+          console.log('onClose', props)
+        }}
+        onChange={(props) => {
+          console.log('onChange', props)
+        }}
+        onType={(props) => {
+          console.log('onType', props)
+        }}
+        onSubmit={(props) => {
+          console.log('onSubmit', props)
+        }}
+        onCancel={(props) => {
+          console.log('onCancel', props)
+        }}
+        onReset={(props) => {
+          console.log('onReset', props)
+        }}
+        showCancelButton
+        showResetButton
+        showSubmitButton
+      />
     </Box>
     <Box>
       <DatePicker
@@ -160,64 +160,64 @@ export const DatePickerSandbox = () => (
     </Box>
     <Box>
       <FieldBlock label="Legend:">
-          <Flex.Vertical>
-            <DatePicker
-              label="Date Picker 1"
-              right="small"
-              date="1981-01-15"
-              title="My Button"
-            />
-            <DatePicker
-              label="Date Picker 2:"
-              alignPicker="right"
-              date={new Date()}
-            />
-            <DatePicker
-              label="Date Picker 3:"
-              showInput
-              alignPicker="right"
-              maskPlaceholder="dd/mm/yyyy"
-              firstDay="sunday"
-              returnFormat="dd/MM/yyyy"
-              date="1981-01-15"
-              data-foo="bar"
-              onOpen={(props) => {
-                console.log('onOpen', props.event)
-              }}
-              onClose={(props) => {
-                console.log('onClose', props.event)
-              }}
-              onChange={(props) => {
-                console.log('onChange', props.event)
-              }}
-            />
-            <DatePicker
-              label="Hidden Nav:"
-              showInput
-              hideNavigation={true}
-              hideDays={true}
-              submitButtonText="OK"
-              cancelButtonText="Cancel"
-              dateFormat="dd/MM/yyyy"
-              range={true}
-              returnFormat="yyyy/MM/dd"
-              onChange={({ date }) => {
-                console.log('onChange', date)
-              }}
-              shortcuts={[
-                {
-                  title: 'Set date period',
-                  startDate: '1981-01-15',
-                  endDate: '1981-02-15',
-                },
-                {
-                  title: 'This month',
-                  startDate: startOfMonth(new Date()),
-                  endDate: lastDayOfMonth(new Date()),
-                },
-              ]}
-            />
-          </Flex.Vertical>
+        <Flex.Vertical>
+          <DatePicker
+            label="Date Picker 1"
+            right="small"
+            date="1981-01-15"
+            title="My Button"
+          />
+          <DatePicker
+            label="Date Picker 2:"
+            alignPicker="right"
+            date={new Date()}
+          />
+          <DatePicker
+            label="Date Picker 3:"
+            showInput
+            alignPicker="right"
+            maskPlaceholder="dd/mm/yyyy"
+            firstDay="sunday"
+            returnFormat="dd/MM/yyyy"
+            date="1981-01-15"
+            data-foo="bar"
+            onOpen={(props) => {
+              console.log('onOpen', props.event)
+            }}
+            onClose={(props) => {
+              console.log('onClose', props.event)
+            }}
+            onChange={(props) => {
+              console.log('onChange', props.event)
+            }}
+          />
+          <DatePicker
+            label="Hidden Nav:"
+            showInput
+            hideNavigation={true}
+            hideDays={true}
+            submitButtonText="OK"
+            cancelButtonText="Cancel"
+            dateFormat="dd/MM/yyyy"
+            range={true}
+            returnFormat="yyyy/MM/dd"
+            onChange={({ date }) => {
+              console.log('onChange', date)
+            }}
+            shortcuts={[
+              {
+                title: 'Set date period',
+                startDate: '1981-01-15',
+                endDate: '1981-02-15',
+              },
+              {
+                title: 'This month',
+                startDate: startOfMonth(new Date()),
+                endDate: lastDayOfMonth(new Date()),
+              },
+            ]}
+          />
+        </Flex.Vertical>
       </FieldBlock>
     </Box>
     <Box>
@@ -281,49 +281,49 @@ export const DatePickerSandbox = () => (
     </Box>
     <Box>
       <Flex.Vertical>
-          <Input label="Input Default" />
-          <DatePicker
-            label="DatePicker Default"
-            date={new Date()}
-            showInput={true}
-          />
-          <Input label="Input Default" />
+        <Input label="Input Default" />
+        <DatePicker
+          label="DatePicker Default"
+          date={new Date()}
+          showInput={true}
+        />
+        <Input label="Input Default" />
       </Flex.Vertical>
     </Box>
     <Box>
       <Flex.Vertical>
-          <Input size="small" label="Input Small" />
-          <DatePicker
-            size="small"
-            label="DatePicker Small"
-            date={new Date()}
-            showInput={true}
-          />
-          <Input size="small" label="Input Small" />
+        <Input size="small" label="Input Small" />
+        <DatePicker
+          size="small"
+          label="DatePicker Small"
+          date={new Date()}
+          showInput={true}
+        />
+        <Input size="small" label="Input Small" />
       </Flex.Vertical>
     </Box>
     <Box>
       <Flex.Vertical>
-          <Input size="medium" label="Input Medium" />
-          <DatePicker
-            size="medium"
-            label="DatePicker Medium"
-            date={new Date()}
-            showInput={true}
-          />
-          <Input size="medium" label="Input Medium" />
+        <Input size="medium" label="Input Medium" />
+        <DatePicker
+          size="medium"
+          label="DatePicker Medium"
+          date={new Date()}
+          showInput={true}
+        />
+        <Input size="medium" label="Input Medium" />
       </Flex.Vertical>
     </Box>
     <Box>
       <Flex.Vertical>
-          <Input size="large" label="Input Large" />
-          <DatePicker
-            size="large"
-            label="DatePicker Large"
-            date={new Date()}
-            showInput={true}
-          />
-          <Input size="large" label="Input Large" />
+        <Input size="large" label="Input Large" />
+        <DatePicker
+          size="large"
+          label="DatePicker Large"
+          date={new Date()}
+          showInput={true}
+        />
+        <Input size="large" label="Input Large" />
       </Flex.Vertical>
     </Box>
   </Wrapper>

--- a/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
@@ -246,7 +246,6 @@ export const DialogSandbox = () => (
       >
         <ProgressIndicator
           showDefaultLabel
-          labelDirection="vertical"
           top="large"
           bottom="large"
           size="large"
@@ -262,7 +261,6 @@ export const DialogSandbox = () => (
       >
         <ProgressIndicator
           showDefaultLabel
-          labelDirection="vertical"
           top="large"
           bottom="large"
           size="large"

--- a/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
@@ -170,7 +170,6 @@ function FillContent() {
       consectetur massa lobortis diam netus congue a nibh dolor faucibus
       vivamus taciti neque accumsan urna varius dis egestas
       <Dropdown
-        labelDirection="vertical"
         label="Dropdown"
         data={dropdownData}
         right
@@ -218,7 +217,6 @@ function FillContent() {
       nostra leo cum consequat sit ridiculus ad inceptos cras facilisis
       pretium natoque libero nulla interdum pellentesque viverra turpis
       <Dropdown
-        labelDirection="vertical"
         label="Dropdown"
         data={dropdownData}
         right
@@ -289,7 +287,6 @@ function FillContent() {
       inceptos volutpat phasellus ornare nisi tortor lobortis ligula
       ultricies ante proin
       <Dropdown
-        labelDirection="vertical"
         label="Dropdown"
         data={dropdownData}
         right

--- a/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/stories/Drawer.stories.tsx
@@ -169,12 +169,7 @@ function FillContent() {
       This is the drawer text. Triggered by a tertiary button. Hac eleifend
       consectetur massa lobortis diam netus congue a nibh dolor faucibus
       vivamus taciti neque accumsan urna varius dis egestas
-      <Dropdown
-        label="Dropdown"
-        data={dropdownData}
-        right
-        skipPortal
-      />
+      <Dropdown label="Dropdown" data={dropdownData} right skipPortal />
       montes tempus tortor mi aptent enim cursus venenatis cras ornare nisl
       pretium tincidunt et imperdiet sapien luctus vel volutpat risus dui
       himenaeos nec est turpis ridiculus posuere sollicitudin nostra
@@ -216,11 +211,7 @@ function FillContent() {
       quisque tellus consectetur fringilla curae praesent nullam vulputate
       nostra leo cum consequat sit ridiculus ad inceptos cras facilisis
       pretium natoque libero nulla interdum pellentesque viverra turpis
-      <Dropdown
-        label="Dropdown"
-        data={dropdownData}
-        right
-      />
+      <Dropdown label="Dropdown" data={dropdownData} right />
       vestibulum maecenas molestie dolor morbi vehicula ultrices diam quis
       velit etiam dictum feugiat sed lacinia placerat euismod magna sapien
       luctus eget tempus rutrum faucibus et suspendisse aliquam felis
@@ -286,11 +277,7 @@ function FillContent() {
       dolor fusce nostra orci turpis velit fames a porttitor quis mi rutrum
       inceptos volutpat phasellus ornare nisi tortor lobortis ligula
       ultricies ante proin
-      <Dropdown
-        label="Dropdown"
-        data={dropdownData}
-        right
-      />
+      <Dropdown label="Dropdown" data={dropdownData} right />
     </P>
   )
 }

--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -18,7 +18,6 @@ import {
 } from '../..'
 import { Dialog, Flex, Icon, Link, P } from '../../..'
 import type { DrawerListDataArray } from '../../../fragments/DrawerList'
-import { Provider } from '../../../shared'
 import { Field, Form } from '../../../extensions/forms'
 import { bank } from '../../../icons'
 
@@ -374,12 +373,7 @@ const DropdownStory = () => {
         <DropdownStatesSync />
       </Box>
       <Box>
-        <Provider
-          formElement={{
-            labelDirection: 'vertical',
-          }}
-        >
-          <Dropdown
+        <Dropdown
             label="Vertical A (function):"
             title="Default option"
             data={() => {
@@ -399,17 +393,10 @@ const DropdownStory = () => {
             iconPosition="left"
             data={dropdownData}
           />
-        </Provider>
       </Box>
       <Box>
-        <Provider
-          formElement={{
-            labelDirection: 'vertical',
-          }}
-        >
-          <Dropdown label="Vertical A:" data={dropdownData} />
+        <Dropdown label="Vertical A:" data={dropdownData} />
           <Dropdown label="Vertical B:" data={dropdownData} top="small" />
-        </Provider>
       </Box>
       <Box>
         <Form.Handler
@@ -465,7 +452,6 @@ const DropdownStory = () => {
       <Box>
         <Dropdown
           label="Label vertical:"
-          labelDirection="vertical"
           title={<>Custom title {'🔥'}</>}
           data={dropdownData}
           onChange={({ data }) => {
@@ -482,9 +468,7 @@ const DropdownStory = () => {
         </p>
       </Box>
       <Box>
-        <Provider formElement={{ labelDirection: 'vertical' }}>
-          <Dropdown label="Vertical:" data={dropdownData} />
-        </Provider>
+        <Dropdown label="Vertical:" data={dropdownData} />
       </Box>
       <Box>
         <span className="dnb-p">Eros semper</span>
@@ -738,8 +722,7 @@ function DropdownStatesSync() {
   }
 
   return (
-    <Provider formElement={{ labelDirection: 'vertical' }}>
-      <Flex.Vertical>
+    <Flex.Vertical>
         <>{JSON.stringify(state)}</>
         <Dropdown
           data={dropdownDataScrollable}
@@ -754,8 +737,7 @@ function DropdownStatesSync() {
         title="Dropdown 2"
         onChange={handleOnChange}
       /> */}
-      </Flex.Vertical>
-    </Provider>
+    </Flex.Vertical>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/stories/Dropdown.stories.tsx
@@ -374,29 +374,29 @@ const DropdownStory = () => {
       </Box>
       <Box>
         <Dropdown
-            label="Vertical A (function):"
-            title="Default option"
-            data={() => {
-              return dropdownData
-            }}
-            right
-            status="Status message"
-            onChange={({ attributes }) => {
-              console.log('onChange', attributes)
-            }}
-            data-attr={123}
-            iconPosition="left"
-          />
-          <Dropdown
-            title="Default option"
-            label="Vertical B:"
-            iconPosition="left"
-            data={dropdownData}
-          />
+          label="Vertical A (function):"
+          title="Default option"
+          data={() => {
+            return dropdownData
+          }}
+          right
+          status="Status message"
+          onChange={({ attributes }) => {
+            console.log('onChange', attributes)
+          }}
+          data-attr={123}
+          iconPosition="left"
+        />
+        <Dropdown
+          title="Default option"
+          label="Vertical B:"
+          iconPosition="left"
+          data={dropdownData}
+        />
       </Box>
       <Box>
         <Dropdown label="Vertical A:" data={dropdownData} />
-          <Dropdown label="Vertical B:" data={dropdownData} top="small" />
+        <Dropdown label="Vertical B:" data={dropdownData} top="small" />
       </Box>
       <Box>
         <Form.Handler
@@ -723,14 +723,14 @@ function DropdownStatesSync() {
 
   return (
     <Flex.Vertical>
-        <>{JSON.stringify(state)}</>
-        <Dropdown
-          data={dropdownDataScrollable}
-          defaultValue={0}
-          title="Dropdown 1"
-          onChange={handleOnChange}
-        />
-        {/* <Dropdown
+      <>{JSON.stringify(state)}</>
+      <Dropdown
+        data={dropdownDataScrollable}
+        defaultValue={0}
+        title="Dropdown 1"
+        onChange={handleOnChange}
+      />
+      {/* <Dropdown
         top
         data={dropdownDataScrollable}
         defaultValue={1}

--- a/packages/dnb-eufemia/src/components/global-status/stories/GlobalStatus.stories.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/stories/GlobalStatus.stories.tsx
@@ -41,7 +41,6 @@ export const ComponentAsLabel = () => {
 
       <Provider
         formElement={{
-          labelDirection: 'vertical',
           globalStatus: { id: 'test' },
         }}
       >
@@ -85,7 +84,6 @@ export const CustomGlobalStatusMessage = () => {
 
       <Provider
         formElement={{
-          labelDirection: 'vertical',
           globalStatus: { id: 'test-test', message: 'Hva skjer nå' },
         }}
       >
@@ -229,8 +227,7 @@ const InputWithError = () => {
             }}
             right="small"
           />
-          <Provider formElement={{ labelDirection: 'vertical' }}>
-            <Flex.Vertical>
+          <Flex.Vertical>
               <Switch
                 status={haveAnErrorMessage3 ? 'Error Message #3' : null}
                 onChange={({ checked }) => {
@@ -244,8 +241,7 @@ const InputWithError = () => {
                   setErrorMessage4(checked)
                 }}
               />
-            </Flex.Vertical>
-          </Provider>
+          </Flex.Vertical>
         </FieldBlock>
       </Form.Handler>
       <GlobalStatus id="form-status" autoScroll={false} top="small" />

--- a/packages/dnb-eufemia/src/components/global-status/stories/GlobalStatus.stories.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/stories/GlobalStatus.stories.tsx
@@ -228,19 +228,19 @@ const InputWithError = () => {
             right="small"
           />
           <Flex.Vertical>
-              <Switch
-                status={haveAnErrorMessage3 ? 'Error Message #3' : null}
-                onChange={({ checked }) => {
-                  setErrorMessage3(checked)
-                }}
-                bottom="small"
-              />
-              <Switch
-                status={haveAnErrorMessage4 ? 'Error Message #4' : null}
-                onChange={({ checked }) => {
-                  setErrorMessage4(checked)
-                }}
-              />
+            <Switch
+              status={haveAnErrorMessage3 ? 'Error Message #3' : null}
+              onChange={({ checked }) => {
+                setErrorMessage3(checked)
+              }}
+              bottom="small"
+            />
+            <Switch
+              status={haveAnErrorMessage4 ? 'Error Message #4' : null}
+              onChange={({ checked }) => {
+                setErrorMessage4(checked)
+              }}
+            />
           </Flex.Vertical>
         </FieldBlock>
       </Form.Handler>

--- a/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
@@ -33,9 +33,7 @@ export function Sandbox() {
   const [locale, setLocale] = React.useState<InternalLocale>('nb-NO')
   return (
     <Wrapper>
-      <Provider
-        locale={locale}
-      >
+      <Provider locale={locale}>
         <Form.Handler>
           <ToggleButton.Group
             value={locale}

--- a/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/stories/InputMasked.stories.tsx
@@ -35,9 +35,6 @@ export function Sandbox() {
     <Wrapper>
       <Provider
         locale={locale}
-        formElement={{
-          labelDirection: 'vertical',
-        }}
       >
         <Form.Handler>
           <ToggleButton.Group

--- a/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
@@ -19,7 +19,6 @@ import {
 
 import { format } from '../../number-format/NumberUtils'
 import { FieldBlock, Form } from '../../../extensions/forms'
-import { Provider } from '../../../shared'
 
 export default {
   title: 'Eufemia/Components/Input',
@@ -38,8 +37,7 @@ export const InputSandbox = () => {
     <CustomStyle>
       <Wrapper>
         <Box>
-          <Provider formElement={{ labelDirection: 'vertical' }}>
-            <Flex.Vertical>
+          <Flex.Vertical>
               <Input value="Plain" />
               <Input value="Search" type="search" />
               <Input value="Search" size="medium" type="search" />
@@ -82,7 +80,6 @@ export const InputSandbox = () => {
                 align="right"
               />
             </Flex.Vertical>
-          </Provider>
         </Box>
         <Box>
           <Input
@@ -96,8 +93,7 @@ export const InputSandbox = () => {
         </Box>
         <Box>
           🚀
-          <Provider formElement={{ labelDirection: 'vertical' }}>
-            <Form.Handler>
+          <Form.Handler>
               <FieldBlock label="Long label labwl Adipiscing mauris dis proin nec Condimentum egestas class blandit netus non a suscipit id urna:">
                 <Flex.Vertical>
                   <Input
@@ -110,22 +106,15 @@ export const InputSandbox = () => {
                   <Input label="Input C:" />
                 </Flex.Vertical>
               </FieldBlock>
-            </Form.Handler>
-          </Provider>
+          </Form.Handler>
         </Box>
         <Box>
-          <Provider
-            formElement={{
-              labelDirection: 'vertical',
-            }}
-          >
-            <FieldBlock label="Vertical label:">
+          <FieldBlock label="Vertical label:">
               <Flex.Horizontal>
                 <Input label="Input label A:" right="small" />
                 <Input label="Input label B:" />
               </Flex.Horizontal>
-            </FieldBlock>
-          </Provider>
+          </FieldBlock>
         </Box>
         <Box>
           <FieldBlock label="Legend:">
@@ -136,21 +125,18 @@ export const InputSandbox = () => {
           </FieldBlock>
         </Box>
         <Box>
-          <Provider formElement={{ labelDirection: 'vertical' }}>
-            <FieldBlock label="Legend:">
+          <FieldBlock label="Legend:">
               <Flex.Vertical>
                 <Input label="Vertical 1:" />
                 <Input label="Vertical 2:" stretch top="small" />
               </Flex.Vertical>
-            </FieldBlock>
-          </Provider>
+          </FieldBlock>
         </Box>
         <Box>
           <Input
             label="Vertical label:"
             value="Stretch me ..."
             stretch
-            labelDirection="vertical"
           />
         </Box>
         <Box>

--- a/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
@@ -38,48 +38,48 @@ export const InputSandbox = () => {
       <Wrapper>
         <Box>
           <Flex.Vertical>
-              <Input value="Plain" />
-              <Input value="Search" type="search" />
-              <Input value="Search" size="medium" type="search" />
-              <Input value="Search" size="large" type="search" />
-              <Input
-                value="Value Eu pretium sit magnis suscipit cursus dis proin rutrum elementum"
-                icon="calendar"
-                align="right"
-              />
-              <Input
-                placeholder="Placeholder Eu pretium sit magnis suscipit cursus dis proin rutrum elementum"
-                iconPosition="right"
-                icon="calendar"
-                align="right"
-              />
-              <Input
-                size="medium"
-                value="Value"
-                icon="calendar"
-                align="right"
-              />
-              <Input
-                size="medium"
-                placeholder="Placeholder"
-                iconPosition="right"
-                icon="calendar"
-                align="right"
-              />
-              <Input
-                size="large"
-                value="Value"
-                icon="calendar"
-                align="right"
-              />
-              <Input
-                size="large"
-                placeholder="Placeholder"
-                iconPosition="right"
-                icon="calendar"
-                align="right"
-              />
-            </Flex.Vertical>
+            <Input value="Plain" />
+            <Input value="Search" type="search" />
+            <Input value="Search" size="medium" type="search" />
+            <Input value="Search" size="large" type="search" />
+            <Input
+              value="Value Eu pretium sit magnis suscipit cursus dis proin rutrum elementum"
+              icon="calendar"
+              align="right"
+            />
+            <Input
+              placeholder="Placeholder Eu pretium sit magnis suscipit cursus dis proin rutrum elementum"
+              iconPosition="right"
+              icon="calendar"
+              align="right"
+            />
+            <Input
+              size="medium"
+              value="Value"
+              icon="calendar"
+              align="right"
+            />
+            <Input
+              size="medium"
+              placeholder="Placeholder"
+              iconPosition="right"
+              icon="calendar"
+              align="right"
+            />
+            <Input
+              size="large"
+              value="Value"
+              icon="calendar"
+              align="right"
+            />
+            <Input
+              size="large"
+              placeholder="Placeholder"
+              iconPosition="right"
+              icon="calendar"
+              align="right"
+            />
+          </Flex.Vertical>
         </Box>
         <Box>
           <Input
@@ -94,26 +94,26 @@ export const InputSandbox = () => {
         <Box>
           🚀
           <Form.Handler>
-              <FieldBlock label="Long label labwl Adipiscing mauris dis proin nec Condimentum egestas class blandit netus non a suscipit id urna:">
-                <Flex.Vertical>
-                  <Input
-                    ref={myRef}
-                    label="Input A:"
-                    placeholder="Placeholder text"
-                  />
+            <FieldBlock label="Long label labwl Adipiscing mauris dis proin nec Condimentum egestas class blandit netus non a suscipit id urna:">
+              <Flex.Vertical>
+                <Input
+                  ref={myRef}
+                  label="Input A:"
+                  placeholder="Placeholder text"
+                />
 
-                  <Input label="Input B:" placeholder="Placeholder text" />
-                  <Input label="Input C:" />
-                </Flex.Vertical>
-              </FieldBlock>
+                <Input label="Input B:" placeholder="Placeholder text" />
+                <Input label="Input C:" />
+              </Flex.Vertical>
+            </FieldBlock>
           </Form.Handler>
         </Box>
         <Box>
           <FieldBlock label="Vertical label:">
-              <Flex.Horizontal>
-                <Input label="Input label A:" right="small" />
-                <Input label="Input label B:" />
-              </Flex.Horizontal>
+            <Flex.Horizontal>
+              <Input label="Input label A:" right="small" />
+              <Input label="Input label B:" />
+            </Flex.Horizontal>
           </FieldBlock>
         </Box>
         <Box>
@@ -126,18 +126,14 @@ export const InputSandbox = () => {
         </Box>
         <Box>
           <FieldBlock label="Legend:">
-              <Flex.Vertical>
-                <Input label="Vertical 1:" />
-                <Input label="Vertical 2:" stretch top="small" />
-              </Flex.Vertical>
+            <Flex.Vertical>
+              <Input label="Vertical 1:" />
+              <Input label="Vertical 2:" stretch top="small" />
+            </Flex.Vertical>
           </FieldBlock>
         </Box>
         <Box>
-          <Input
-            label="Vertical label:"
-            value="Stretch me ..."
-            stretch
-          />
+          <Input label="Vertical label:" value="Stretch me ..." stretch />
         </Box>
         <Box>
           Text

--- a/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
+++ b/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
@@ -91,7 +91,6 @@ export const ModalSandbox = () => (
       >
         <ProgressIndicator
           showDefaultLabel
-          labelDirection="vertical"
           top="large"
           bottom="large"
           size="large"
@@ -107,7 +106,6 @@ export const ModalSandbox = () => (
       >
         <ProgressIndicator
           showDefaultLabel
-          labelDirection="vertical"
           top="large"
           bottom="large"
           size="large"

--- a/packages/dnb-eufemia/src/components/radio/stories/Radio.stories.tsx
+++ b/packages/dnb-eufemia/src/components/radio/stories/Radio.stories.tsx
@@ -8,7 +8,6 @@ import { Wrapper, Box } from 'storybook-utils/helpers'
 import { Radio, FormLabel, Button, HelpButton, GlobalStatus } from '../..'
 
 import { Flex } from '../../..'
-import { Provider } from '../../../shared'
 import { Form } from '../../../extensions/forms'
 
 export default {
@@ -162,9 +161,9 @@ export const RadioButtonSandbox = () => (
     </Box>
     <Box>
       <Radio.Group label="Vertical with Provider:">
-          <Radio label="First" value="first" />
-          <Radio label="Second" value="second" />
-          <Radio label="Third" value="third" checked />
+        <Radio label="First" value="first" />
+        <Radio label="Second" value="second" />
+        <Radio label="Third" value="third" checked />
       </Radio.Group>
     </Box>
     <Box>
@@ -216,36 +215,34 @@ const RadioGroupsWithStatus = () => {
   return (
     <Form.Handler>
       <Radio.Group
-          label="Group A label:"
-          value={currentValueForGroupA}
-          onChange={({ value }) => {
-            console.log('onChange A', value)
-            setValueForGroupA(value)
-          }}
-        >
-          <Radio label="First" value="first" />
-          <Radio label="Second" value="second" />
-          <Radio label="Third" value="third" />
-        </Radio.Group>
-        <Radio.Group
-          label="Group B label:"
-          value={currentValueForGroupB}
-          onChange={({ value }) => {
-            console.log('onChange B', value)
-          }}
-        >
-          <Radio label="First" value="first" />
-          <Radio label="Second" value="second" />
-          <Radio label="Third" value="third" />
-        </Radio.Group>
-        <Button
-          onClick={() => {
-            setValueForGroupB(
-              shuffleArray(['first', 'second', 'third'])[0]
-            )
-          }}
-          text="Set New State"
-        />
+        label="Group A label:"
+        value={currentValueForGroupA}
+        onChange={({ value }) => {
+          console.log('onChange A', value)
+          setValueForGroupA(value)
+        }}
+      >
+        <Radio label="First" value="first" />
+        <Radio label="Second" value="second" />
+        <Radio label="Third" value="third" />
+      </Radio.Group>
+      <Radio.Group
+        label="Group B label:"
+        value={currentValueForGroupB}
+        onChange={({ value }) => {
+          console.log('onChange B', value)
+        }}
+      >
+        <Radio label="First" value="first" />
+        <Radio label="Second" value="second" />
+        <Radio label="Third" value="third" />
+      </Radio.Group>
+      <Button
+        onClick={() => {
+          setValueForGroupB(shuffleArray(['first', 'second', 'third'])[0])
+        }}
+        text="Set New State"
+      />
     </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/components/radio/stories/Radio.stories.tsx
+++ b/packages/dnb-eufemia/src/components/radio/stories/Radio.stories.tsx
@@ -153,7 +153,6 @@ export const RadioButtonSandbox = () => (
       <Radio.Group
         label="Vertical group with error:"
         layoutDirection="column"
-        labelDirection="vertical"
         status="Error message Potenti viverra facilisi blandit sodales lorem est fusce pulvinar a imperdiet quis mi parturient mattis feugiat tellus ipsum magnis rutrum"
       >
         <Radio label="First" value="first" />
@@ -162,16 +161,14 @@ export const RadioButtonSandbox = () => (
       </Radio.Group>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Radio.Group label="Vertical with Provider:">
+      <Radio.Group label="Vertical with Provider:">
           <Radio label="First" value="first" />
           <Radio label="Second" value="second" />
           <Radio label="Third" value="third" checked />
-        </Radio.Group>
-      </Provider>
+      </Radio.Group>
     </Box>
     <Box>
-      <Radio.Group label="Vertical label:" labelDirection="vertical">
+      <Radio.Group label="Vertical label:">
         <Radio label="First" value="first" />
         <Radio label="Second" value="second" />
         <Radio label="Third" value="third" checked />
@@ -180,7 +177,6 @@ export const RadioButtonSandbox = () => (
     <Box>
       <Radio.Group
         label="Group with error:"
-        labelDirection="vertical"
         labelPosition="left" // for every radio button
         status="Error message left position Potenti viverra facilisi blandit sodales lorem est fusce pulvinar a imperdiet quis mi parturient mattis feugiat tellus ipsum magnis rutrum"
       >
@@ -219,8 +215,7 @@ const RadioGroupsWithStatus = () => {
 
   return (
     <Form.Handler>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Radio.Group
+      <Radio.Group
           label="Group A label:"
           value={currentValueForGroupA}
           onChange={({ value }) => {
@@ -251,7 +246,6 @@ const RadioGroupsWithStatus = () => {
           }}
           text="Set New State"
         />
-      </Provider>
     </Form.Handler>
   )
 }

--- a/packages/dnb-eufemia/src/components/skeleton/stories/Skeleton.stories.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/stories/Skeleton.stories.tsx
@@ -103,8 +103,8 @@ export const SkeletonSandbox = () => {
               <Checkbox label="Checkbox:" left />
               <Switch label="Switch:" left />
               <Radio label="Radio:" left />
-              <Input top labelDirection="vertical" label="Input" />
-              <Textarea top labelDirection="vertical" label="Textarea" />
+              <Input top label="Input" />
+              <Textarea top label="Textarea" />
             </Box>
 
             <Box>

--- a/packages/dnb-eufemia/src/components/slider/stories/Slider.stories.tsx
+++ b/packages/dnb-eufemia/src/components/slider/stories/Slider.stories.tsx
@@ -65,7 +65,6 @@ export function Marker() {
             },
           }}
           label="Label with some text"
-          labelDirection="vertical"
           min={-40}
           max={100}
           stretch

--- a/packages/dnb-eufemia/src/components/textarea/stories/Textarea.stories.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/stories/Textarea.stories.tsx
@@ -6,7 +6,6 @@
 import React from 'react'
 import { Wrapper, Box } from 'storybook-utils/helpers'
 
-import Provider from '../../../shared/Provider'
 import { Textarea, GlobalStatus, Flex } from '../..'
 import { FieldBlock } from '../../../extensions/forms'
 import Input from '../../input/Input'
@@ -67,9 +66,7 @@ export const TextareaSandbox = () => (
       </Flex.Stack>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <Textarea value="Text" label="Label:" suffix="123" />
-      </Provider>
+      <Textarea value="Text" label="Label:" suffix="123" />
     </Box>
     <Box>
       <Textarea
@@ -87,8 +84,7 @@ export const TextareaSandbox = () => (
       />
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <FieldBlock label="Legend:">
+      <FieldBlock label="Legend:">
           <Flex.Vertical>
             <Textarea
               label="Vertical label:"
@@ -104,12 +100,10 @@ export const TextareaSandbox = () => (
             scelerisque sapien erat"
             />
           </Flex.Vertical>
-        </FieldBlock>
-      </Provider>
+      </FieldBlock>
     </Box>
     <Box>
-      <Provider formElement={{ labelDirection: 'vertical' }}>
-        <FieldBlock label="Legend:">
+      <FieldBlock label="Legend:">
           <Flex.Vertical>
             <Textarea
               label="Vertical:"
@@ -125,8 +119,7 @@ export const TextareaSandbox = () => (
             scelerisque sapien erat"
             />
           </Flex.Vertical>
-        </FieldBlock>
-      </Provider>
+      </FieldBlock>
     </Box>
     <Box>
       <Textarea
@@ -188,7 +181,6 @@ export const TextareaSandbox = () => (
       <Textarea
         stretch
         label="Stretched label:"
-        labelDirection="vertical"
         value="Nec litora inceptos vestibulum id interdum donec gravida nostra
               lacinia bibendum hendrerit porttitor volutpat nam duis nisl
               scelerisque sapien erat"

--- a/packages/dnb-eufemia/src/components/textarea/stories/Textarea.stories.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/stories/Textarea.stories.tsx
@@ -85,40 +85,40 @@ export const TextareaSandbox = () => (
     </Box>
     <Box>
       <FieldBlock label="Legend:">
-          <Flex.Vertical>
-            <Textarea
-              label="Vertical label:"
-              value="Nec litora inceptos vestibulum id interdum donec gravida nostra
+        <Flex.Vertical>
+          <Textarea
+            label="Vertical label:"
+            value="Nec litora inceptos vestibulum id interdum donec gravida nostra
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
-              right="small"
-            />
-            <Textarea
-              label="Vertical label:"
-              value="Nec litora inceptos vestibulum id interdum donec gravida nostra
+            right="small"
+          />
+          <Textarea
+            label="Vertical label:"
+            value="Nec litora inceptos vestibulum id interdum donec gravida nostra
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
-            />
-          </Flex.Vertical>
+          />
+        </Flex.Vertical>
       </FieldBlock>
     </Box>
     <Box>
       <FieldBlock label="Legend:">
-          <Flex.Vertical>
-            <Textarea
-              label="Vertical:"
-              value="Nec litora inceptos vestibulum id interdum donec gravida nostra
+        <Flex.Vertical>
+          <Textarea
+            label="Vertical:"
+            value="Nec litora inceptos vestibulum id interdum donec gravida nostra
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
-            />
-            <Textarea
-              top="small"
-              label="Vertical:"
-              value="Nec litora inceptos vestibulum id interdum donec gravida nostra
+          />
+          <Textarea
+            top="small"
+            label="Vertical:"
+            value="Nec litora inceptos vestibulum id interdum donec gravida nostra
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
-            />
-          </Flex.Vertical>
+          />
+        </Flex.Vertical>
       </FieldBlock>
     </Box>
     <Box>

--- a/packages/dnb-eufemia/src/components/toggle-button/stories/ToggleButton.stories.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/stories/ToggleButton.stories.tsx
@@ -97,7 +97,7 @@ export const ToggleButtonSandbox = () => (
 
     <Box>
       <Provider
-        formElement={{ labelDirection: 'vertical', disabled: true }}
+        formElement={{ disabled: true }}
       >
         <ToggleButton.Group>
           <ToggleButton
@@ -275,7 +275,6 @@ export const ToggleButtonSandbox = () => (
       <ToggleButton.Group
         label="Vertical group with error:"
         layoutDirection="column"
-        labelDirection="vertical"
         status="Error message Potenti viverra facilisi blandit sodales lorem est fusce pulvinar a imperdiet quis mi parturient mattis feugiat tellus ipsum magnis rutrum"
       >
         <ToggleButton text="First" value="first" />

--- a/packages/dnb-eufemia/src/components/toggle-button/stories/ToggleButton.stories.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/stories/ToggleButton.stories.tsx
@@ -96,9 +96,7 @@ export const ToggleButtonSandbox = () => (
     </Box>
 
     <Box>
-      <Provider
-        formElement={{ disabled: true }}
-      >
+      <Provider formElement={{ disabled: true }}>
         <ToggleButton.Group>
           <ToggleButton
             text="First"

--- a/packages/dnb-eufemia/src/elements/stories/OtherElements.stories.tsx
+++ b/packages/dnb-eufemia/src/elements/stories/OtherElements.stories.tsx
@@ -16,7 +16,6 @@ import {
   Flex,
 } from '../../components'
 import { H1, H2, P, Hr, Link, Span, Div, Img } from '..'
-import { Provider } from '../../shared'
 
 export default {
   title: 'Eufemia/Elements/Other',
@@ -152,8 +151,7 @@ export const Textarea = () => (
   <Wrapper className="dnb-spacing">
     <CustomStyles>
       <Box>
-        <Provider formElement={{ labelDirection: 'vertical' }}>
-          <Flex.Vertical>
+        <Flex.Vertical>
             <label className="dnb-form-label" htmlFor="hendrerit">
               Label for the textarea:
             </label>
@@ -166,8 +164,7 @@ export const Textarea = () => (
             nostra lacinia bibendum hendrerit porttitor volutpat nam duis
             nisl scelerisque sapien erat"
             />
-          </Flex.Vertical>
-        </Provider>
+        </Flex.Vertical>
         <p className="dnb-p">I have to be on the grid!</p>
       </Box>
       <Box>
@@ -201,8 +198,7 @@ export const Textarea = () => (
         <p className="dnb-p">I have to be on the grid!</p>
       </Box>
       <Box>
-        <Provider formElement={{ labelDirection: 'vertical' }}>
-          <Flex.Vertical>
+        <Flex.Vertical>
             <label className="dnb-form-label" htmlFor="vestibulum">
               Label:
             </label>
@@ -214,9 +210,8 @@ export const Textarea = () => (
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
             />
-          </Flex.Vertical>
-          <FormStatus text="Message to the user" />
-        </Provider>
+        </Flex.Vertical>
+        <FormStatus text="Message to the user" />
         <p className="dnb-p">I have to be on the grid!</p>
       </Box>
       <Box>

--- a/packages/dnb-eufemia/src/elements/stories/OtherElements.stories.tsx
+++ b/packages/dnb-eufemia/src/elements/stories/OtherElements.stories.tsx
@@ -152,18 +152,18 @@ export const Textarea = () => (
     <CustomStyles>
       <Box>
         <Flex.Vertical>
-            <label className="dnb-form-label" htmlFor="hendrerit">
-              Label for the textarea:
-            </label>
-            <textarea
-              className="dnb-textarea"
-              id="hendrerit"
-              rows={5}
-              cols={33}
-              defaultValue="Nec litora inceptos vestibulum id interdum donec gravida
+          <label className="dnb-form-label" htmlFor="hendrerit">
+            Label for the textarea:
+          </label>
+          <textarea
+            className="dnb-textarea"
+            id="hendrerit"
+            rows={5}
+            cols={33}
+            defaultValue="Nec litora inceptos vestibulum id interdum donec gravida
             nostra lacinia bibendum hendrerit porttitor volutpat nam duis
             nisl scelerisque sapien erat"
-            />
+          />
         </Flex.Vertical>
         <p className="dnb-p">I have to be on the grid!</p>
       </Box>
@@ -199,17 +199,17 @@ export const Textarea = () => (
       </Box>
       <Box>
         <Flex.Vertical>
-            <label className="dnb-form-label" htmlFor="vestibulum">
-              Label:
-            </label>
-            <textarea
-              id="vestibulum"
-              className="dnb-textarea status--error"
-              cols={33}
-              defaultValue="Nec litora inceptos vestibulum id interdum donec gravida nostra
+          <label className="dnb-form-label" htmlFor="vestibulum">
+            Label:
+          </label>
+          <textarea
+            id="vestibulum"
+            className="dnb-textarea status--error"
+            cols={33}
+            defaultValue="Nec litora inceptos vestibulum id interdum donec gravida nostra
             lacinia bibendum hendrerit porttitor volutpat nam duis nisl
             scelerisque sapien erat"
-            />
+          />
         </Flex.Vertical>
         <FormStatus text="Message to the user" />
         <p className="dnb-p">I have to be on the grid!</p>

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -32,7 +32,7 @@ export const DrawerListProperties: PropertiesTableProps = {
     status: 'optional',
   },
   labelDirection: {
-    doc: "The direction of the label. If set to 'horizontal', the label will be positioned horizontally next to the input element. If set to 'vertical', the label will be positioned vertically above the input element.",
+    doc: "Use `labelDirection=\"horizontal\"` to change the label layout direction. Defaults to `vertical`.",
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -32,7 +32,7 @@ export const DrawerListProperties: PropertiesTableProps = {
     status: 'optional',
   },
   labelDirection: {
-    doc: "Use `labelDirection=\"horizontal\"` to change the label layout direction. Defaults to `vertical`.",
+    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/shared/stories/Experiments.stories.tsx
+++ b/packages/dnb-eufemia/src/shared/stories/Experiments.stories.tsx
@@ -36,14 +36,14 @@ export const ExperimentsSandbox = () => (
     <Wrapper>
       <Box>
         <PhoneRow label="Phone number">
-            <Flex.Horizontal>
-              <Dropdown
-                title="Country code"
-                value={0}
-                data={['+47', '+48', '+49']}
-              />
-              <Input placeholder="Your phone number" />
-            </Flex.Horizontal>
+          <Flex.Horizontal>
+            <Dropdown
+              title="Country code"
+              value={0}
+              data={['+47', '+48', '+49']}
+            />
+            <Input placeholder="Your phone number" />
+          </Flex.Horizontal>
         </PhoneRow>
       </Box>
       <Box>

--- a/packages/dnb-eufemia/src/shared/stories/Experiments.stories.tsx
+++ b/packages/dnb-eufemia/src/shared/stories/Experiments.stories.tsx
@@ -35,12 +35,7 @@ export const ExperimentsSandbox = () => (
   <Center>
     <Wrapper>
       <Box>
-        <Provider
-          formElement={{
-            labelDirection: 'vertical',
-          }}
-        >
-          <PhoneRow label="Phone number">
+        <PhoneRow label="Phone number">
             <Flex.Horizontal>
               <Dropdown
                 title="Country code"
@@ -49,8 +44,7 @@ export const ExperimentsSandbox = () => (
               />
               <Input placeholder="Your phone number" />
             </Flex.Horizontal>
-          </PhoneRow>
-        </Provider>
+        </PhoneRow>
       </Box>
       <Box>
         <Provider


### PR DESCRIPTION
Since PR #7349 changed the default labelDirection to vertical, remove now-redundant explicit labelDirection="vertical" props and Provider formElement={{ labelDirection: "vertical" }} wrappers from stories and visual tests.

Also update DrawerListDocs to mention the vertical default.

