### PR TITLE
docs: add TSDoc to undocumented public prop interfaces

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/types.ts
+++ b/packages/dnb-eufemia/src/components/accordion/types.ts
@@ -1,6 +1,7 @@
 import type { AccordionProps } from './Accordion'
 
 export type AccordionGroupProps = AccordionProps & {
+  /** If `true`, all accordions can be collapsed at once (none expanded). Defaults to `false`. */
   allowCloseAll?: boolean
   /**
    * Determines how many accordions can be expanded at once.
@@ -13,6 +14,7 @@ export type AccordionGroupProps = AccordionProps & {
    * Default: `undefined`
    */
   expandedId?: string
+  /** Ref that exposes a function to programmatically collapse all expanded accordions. Call `.current()` to trigger. */
   collapseAllHandleRef?: React.RefObject<() => void>
 }
 

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
@@ -64,11 +64,17 @@ export type NumberFormatChildren =
   | (() => React.ReactNode)
 export type NumberFormatProps = {
   id?: string
+  /** The numeric or string value to format. */
   value?: NumberFormatValue
+  /** BCP 47 locale string for formatting, e.g. `nb-NO`, `en-US`. Defaults to context locale. */
   locale?: string
+  /** Content placed before the formatted value. Can be a string or React element. */
   prefix?: NumberFormatPrefix
+  /** Content placed after the formatted value. Can be a string or React element. */
   suffix?: NumberFormatSuffix
+  /** Formats the value as a currency. Pass `true` for locale default or a currency code string (e.g. `NOK`, `USD`). */
   currency?: NumberFormatCurrency
+  /** How to display the currency: `code` (NOK), `name` (Norwegian krone), `symbol` (kr), or `narrowSymbol`. */
   currencyDisplay?:
     | 'code'
     | 'name'
@@ -76,31 +82,52 @@ export type NumberFormatProps = {
     | 'narrowSymbol'
     | ''
     | false
+  /** Position of the currency symbol relative to the value: `auto`, `before`, or `after`. */
   currencyPosition?: NumberFormatCurrencyPosition
+  /** Compact number display. `short` (e.g., 1.2K), `long` (e.g., 1.2 thousand), or `true` for short. */
   compact?: NumberFormatCompact
+  /** Formats the value as a Norwegian bank account number (11 digits with spaces). */
   ban?: boolean
+  /** Formats the value as a Norwegian national identity number (11 digits with space). */
   nin?: boolean
+  /** Formats the value as a phone number with spaces. */
   phone?: boolean
+  /** Formats the value as a Norwegian organization number (9 digits with spaces). */
   org?: boolean
+  /** Formats the value as a percentage. */
   percent?: boolean
+  /** Wraps the formatted value in a clickable link: `tel` for phone or `sms` for SMS. */
   link?: NumberFormatLink
+  /** If `true`, renders the value in monospace font for tabular alignment. */
   monospace?: boolean
+  /** Additional `Intl.NumberFormat` options for custom formatting. */
   options?: NumberFormatOptions
+  /** Fixed number of decimal digits to display. */
   decimals?: NumberFormatDecimals
+  /** If `true`, selects the entire value text on click. */
   selectAll?: boolean
+  /** If `true`, keeps the value text selected at all times after click. */
   alwaysSelectAll?: boolean
+  /** If `true`, copies the selected value to clipboard on selection. */
   copySelection?: boolean
+  /** If `true`, strips formatting characters (spaces, currency symbols) from the copied value. */
   cleanCopyValue?: boolean
+  /** Rounding strategy: `omit` (truncate), `half-even` (banker's rounding), or `half-up`. */
   rounding?: 'omit' | 'half-even' | 'half-up'
+  /** Controls display of positive/negative signs: `auto`, `always`, `exceptZero`, `negative`, `never`. */
   signDisplay?: NumberFormatSignDisplay
+  /** If `true`, strips trailing zeroes from decimal values. */
   clean?: boolean
+  /** Screen-reader-only label for the formatted value for accessibility. */
   srLabel?: React.ReactNode
+  /** HTML element to render as. Defaults to `span`. */
   element?: NumberFormatElement
+  /** Tooltip content shown on hover over the formatted value. */
   tooltip?: NumberFormatTooltip
+  /** If `true`, renders a skeleton loading placeholder instead of the value. */
   skeleton?: SkeletonShow
   className?: string
   children?: NumberFormatChildren
-  // Additional props used in stories
   style?: React.CSSProperties
   lang?: string
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -6,10 +6,15 @@ import type { FieldProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 type BooleanProps = {
+  /** Custom label text shown when the value is `true`. Defaults to localized "Yes". */
   trueText?: string
+  /** Custom label text shown when the value is `false`. Defaults to localized "No". */
   falseText?: string
+  /** The visual variant of the toggle field: `checkbox`, `checkbox-button`, `button`, or `buttons`. */
   variant?: ToggleFieldProps['variant']
+  /** The size of the toggle. Available sizes: `small`, `medium` (default), `large`. */
   size?: ToggleFieldProps['size']
+  /** Callback fired when the toggle is clicked. */
   onClick?: ToggleFieldProps['onClick']
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -28,30 +28,49 @@ import * as z from 'zod'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FieldNumberProps = FieldProps<number, undefined | number> & {
+  /** Ref to the underlying input element. */
   ref?: React.RefObject<HTMLInputElement>
+  /** Additional CSS class applied to the inner input element. */
   inputClassName?: string
+  /** Formats the value as a currency. Pass `true` for locale default or a currency code string. */
   currency?: InputMaskedProps['asCurrency']
+  /** How to display the currency symbol: `code` (e.g., USD), `symbol` (e.g., $), `narrowSymbol`, or `name`. */
   currencyDisplay?: 'code' | 'symbol' | 'narrowSymbol' | 'name' | false
+  /** Formats the value as a percentage. */
   percent?: InputMaskedProps['asPercent']
+  /** Input mask configuration for the underlying masked input. */
   mask?: InputMaskedProps['mask']
+  /** Step increment/decrement value for the step controls. Defaults to `1`. */
   step?: number
+  /** Initial value when the field is empty and the user clicks a step control. */
   startWith?: number
-  // Formatting
+  /** Maximum number of decimal digits allowed. Defaults to `12`. */
   decimalLimit?: number
+  /** If `true`, allows negative numbers. Defaults to `true`. */
   allowNegative?: boolean
+  /** If `true`, disallows leading zeroes (e.g. `007`). */
   disallowLeadingZeroes?: boolean
+  /** Text or function returning text to display before the number value. */
   prefix?: string | ((value: number) => string)
+  /** Text or function returning text to display after the number value. */
   suffix?: string | ((value: number) => string)
-  // Validation
-  minimum?: number // aka greater than or equal to
-  maximum?: number // aka less than or equal to
-  exclusiveMinimum?: number // aka greater than
-  exclusiveMaximum?: number // aka less than
+  /** Minimum allowed value (inclusive, i.e. greater than or equal to). */
+  minimum?: number
+  /** Maximum allowed value (inclusive, i.e. less than or equal to). */
+  maximum?: number
+  /** Exclusive minimum (value must be strictly greater than this). */
+  exclusiveMinimum?: number
+  /** Exclusive maximum (value must be strictly less than this). */
+  exclusiveMaximum?: number
+  /** Value must be a multiple of this number. */
   multipleOf?: number
-  // Styling
+  /** The size of the input. Available sizes: `small`, `medium` (default), `large`. */
   size?: InputSize
+  /** Defines the width of the field block container. */
   width?: FieldBlockWidth
+  /** Text alignment inside the input: `left`, `center`, or `right`. */
   align?: InputAlign
+  /** If `true`, shows increment/decrement step control buttons. */
   showStepControls?: boolean
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -24,47 +24,77 @@ import type { FieldProps, Schema } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FieldStringProps = FieldProps<string, undefined | string> & {
-  // - Shared props
+  /** Renders a multiline textarea instead of a single-line input. */
   multiline?: boolean
+  /** Additional CSS class applied to the inner input element. */
   inputClassName?: string
+  /** Ref to the underlying input or textarea element. */
   ref?: React.RefObject<HTMLInputElement | HTMLTextAreaElement>
+  /** Defines the width of the field block container. */
   width?: FieldBlockWidth
+  /** The size of the input. Available sizes: `small`, `medium` (default), `large`. */
   size?: InputProps['size'] | TextareaProps['size']
+  /** If set to `true` the placeholder will remain visible when the field has focus. */
   keepPlaceholder?: InputProps['keepPlaceholder']
 
   // - Validation
+  /** Minimum number of characters required. Triggers a validation error if the value is shorter. */
   minLength?: number
+  /** Maximum number of characters allowed. Triggers a validation error if the value is longer. */
   maxLength?: number
+  /** Regex pattern string the value must match. Triggers a validation error on mismatch. */
   pattern?: string
 
   // - Input props
+  /** HTML input type attribute, e.g. `text`, `password`, `search`. Defaults to `text`. */
   type?: InputProps['type']
+  /** Text alignment inside the input: `left`, `center`, or `right`. */
   align?: InputProps['align']
+  /** If `true`, all text in the input is selected on focus. */
   selectAll?: InputProps['selectAll']
+  /** If `true`, shows a clear button inside the input. */
   clear?: boolean
+  /** Input mask configuration for masked input patterns. */
   mask?: InputMaskedProps['mask']
+  /** If `true`, allows typing beyond the defined mask boundaries. */
   allowOverflow?: InputMaskedProps['allowOverflow']
+  /** Icon displayed on the left side of the input. Accepts icon name strings. */
   leftIcon?: string
+  /** Icon displayed on the right side of the input. Accepts icon name strings. */
   rightIcon?: string
+  /** Custom React element rendered as a submit button inside the input. */
   submitElement?: InputProps['submitElement']
+  /** If `true`, capitalizes the first letter of the input value. */
   capitalize?: boolean
+  /** If `true`, trims leading and trailing whitespace from the value on blur. */
   trim?: boolean
 
   // - Textarea props
+  /** Number of visible text rows for the textarea (when `multiline` is true). */
   rows?: TextareaProps['rows']
+  /** Maximum number of rows the textarea can grow to when `autoResize` is enabled. */
   autoResizeMaxRows?: TextareaProps['autoResizeMaxRows']
+  /** If `true`, the textarea height adjusts automatically to its content. */
   autoResize?: TextareaProps['autoResize']
+  /** Displays a character counter. Pass a number to set the max count, or a config object. */
   characterCounter?: Omit<TextCounterProps, 'text'> | number
 
   // - Html props
+  /** HTML `autocomplete` attribute for browser autofill hints. */
   autoComplete?: HTMLInputElement['autocomplete']
+  /** Hint for the virtual keyboard type on touch devices, e.g. `numeric`, `email`, `tel`. */
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode']
+  /** Controls browser autocorrect behavior. */
   autoCorrect?: React.HTMLAttributes<HTMLInputElement>['autoCorrect']
+  /** Controls browser spell-checking behavior. */
   spellCheck?: React.HTMLAttributes<HTMLInputElement>['spellCheck']
+  /** If `true`, the input receives focus when the component mounts. */
   autoFocus?: React.HTMLAttributes<HTMLInputElement>['autoFocus']
+  /** Controls text auto-capitalization on touch devices. */
   autoCapitalize?: React.HTMLAttributes<HTMLInputElement>['autoCapitalize']
 
   // - Events
+  /** Callback fired when a key is pressed while the input has focus. */
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/ButtonRow/ButtonRow.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/ButtonRow/ButtonRow.tsx
@@ -4,6 +4,7 @@ import { Space } from '../../../../components'
 import type { ComponentProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
+/** Props for the Form.ButtonRow component which provides consistent spacing for form action buttons. */
 export type FormButtonRowProps = ComponentProps & {
   children?: React.ReactNode
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
@@ -11,7 +11,9 @@ import type { ComponentProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FormMainHeadingProps = ComponentProps & {
+  /** The heading level to render (h2–h6). Defaults to `2`. */
   level?: HeadingLevel
+  /** Configuration for an inline help button shown next to the heading. */
   help?: HelpProps
   children?: React.ReactNode
 } & Omit<React.HTMLProps<HTMLElement>, 'size'>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
@@ -11,7 +11,9 @@ import type { ComponentProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FormSubHeadingProps = ComponentProps & {
+  /** The heading level to render (h2–h6). Defaults to `3`. */
   level?: HeadingLevel
+  /** Configuration for an inline help button shown next to the heading. */
   help?: HelpProps
   children?: React.ReactNode
 } & Omit<React.HTMLProps<HTMLElement>, 'size'>

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
@@ -30,22 +30,39 @@ export type IterateArrayProps = Omit<
     | 'validateContinuously'
     | 'schema'
   > & {
+    /** Render function or React nodes for each array item. When a function, receives `(value, index, arrayItems)`. */
     children: ElementChild | Array<ElementChild>
+    /** JSON Pointer path to the array data in the form data context. */
     path?: Path
+    /** JSON Pointer sub-path within each array item for value access. */
     itemPath?: Path
+    /** Maximum number of items to render from the array. */
     limit?: number
+    /** If `true`, renders array items in reverse order. */
     reverse?: boolean
+    /** JSON Pointer path to a counter value that tracks the number of items. */
     countPath?: Path
+    /** Maximum value the counter at `countPath` can reach. */
     countPathLimit?: number
+    /** Minimum number of items required. Triggers a validation error if fewer. */
     minItems?: number
+    /** Maximum number of items allowed. Triggers a validation error if more. */
     maxItems?: number
+    /** Custom validator function called when the array value changes. */
     onChangeValidator?: Validator<Value>
+    /** If `true`, renders children without a Flex container wrapper. */
     withoutFlex?: boolean
+    /** If `true`, animates item additions and removals. */
     animate?: boolean
+    /** Content to display when the array is empty. */
     placeholder?: React.ReactNode
+    /** Controls the initial display mode for items: `view`, `edit`, or `auto`. */
     containerMode?: ContainerMode
+    /** If `true`, at least one item is required. */
     required?: boolean
+    /** Custom error messages for validation states. */
     errorMessages?: DefaultErrorMessages
+    /** Transform function applied to each item before updating the count path. */
     countPathTransform?: (params: { value: any; index: number }) => any
 
     // internal


### PR DESCRIPTION
Add JSDoc/TSDoc comments to exported prop types that lacked IDE intellisense documentation:

- Field.String (FieldStringProps): all 30+ properties documented
- Field.Number (FieldNumberProps): all 25+ properties documented
- Field.Boolean (BooleanProps): all 6 properties documented
- NumberFormat (NumberFormatProps): all 30+ properties documented
- AccordionGroup (AccordionGroupProps): 2 missing props documented
- Form.SubHeading (FormSubHeadingProps): level and help props
- Form.MainHeading (FormMainHeadingProps): level and help props
- Form.ButtonRow (FormButtonRowProps): type-level doc added
- Iterate.Array (IterateArrayProps): all 17 properties documented

