### PR TITLE
docs(v11): improve v11-info.mdx readability for migration

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1245,7 +1245,7 @@ The following properties have been renamed from snake_case to camelCase:
 #### TypeScript types
 
 - Replace `OnChangeEventProps` with `SliderOnChangeParams`.
-- Replace `ThumbStateEnums` with `ThumbState`.
+- Replace `ThumbStateEnums` with `SliderThumbState`.
 
 ### [Timeline](/uilib/components/timeline/)
 
@@ -2190,10 +2190,10 @@ Several component types that accepted `(...args: any[]) => any` for render funct
 
 ## Theming
 
-- Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`
-- Replace import from path `style/themes/theme-sbanken/` with `style/themes/sbanken/`
-- Replace import from path `style/themes/theme-eiendom/` with `style/themes/eiendom/`
-- Replace import from path `style/themes/theme-carnegie/` with `style/themes/carnegie/`
+- Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`.
+- Replace import from path `style/themes/theme-sbanken/` with `style/themes/sbanken/`.
+- Replace import from path `style/themes/theme-eiendom/` with `style/themes/eiendom/`.
+- Replace import from path `style/themes/theme-carnegie/` with `style/themes/carnegie/`.
 
 ## Props Type Exports
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -120,7 +120,7 @@ The largest category of changes in v11 is the rename of **all snake_case propert
 - Events: `on_change` → `onChange`, `on_click` → `onClick`
 - Translations: `Autocomplete.no_options` → `Autocomplete.noOptions`
 
-You can use your editor's find-and-replace or a codemod to handle most of these. Since each snake_case property maps to a specific camelCase name, we recommend using the per-component find-and-replace lists below rather than a generic regex.
+You can use your editor's find-and-replace to handle most of these. Since each snake_case property maps to a specific camelCase name, we recommend using the per-component lists below rather than a generic regex.
 
 > **Note:** Some renames are not just snake_case conversions — they also change the name itself (e.g. `triangle_position` → `arrowPosition`, `opened` → `open`, `on_show` → `onOpen`). These are listed individually per component below and require manual attention.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -854,10 +854,6 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 - Replace `card_status` with `cardStatus`.
 - Replace `raw_data` with `rawData`.
 
-#### Translations
-
-- Remove translation `PaymentCard.text_card_number` as it's not supported anymore.
-
 #### `cardStatus` property
 
 - Replace value `not_active` with `notActive`.
@@ -866,6 +862,7 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 
 #### Translations
 
+- Remove translation `PaymentCard.text_card_number` as it's not supported anymore.
 - Replace `PaymentCard.text_blocked` with `PaymentCard.textBlocked`.
 - Replace `PaymentCard.text_expired` with `PaymentCard.textExpired`.
 - Replace `PaymentCard.text_not_active` with `PaymentCard.textNotActive`.
@@ -1352,7 +1349,7 @@ In addition to the behavioral changes above, the following properties have been 
 - Remove `on_item_render`. No longer has any other function than each step's `title` property.
 - Remove step item `on_render`. No longer has any other function than the `title` property.
 - Remove `sidebarId`. No longer has any sidebar. If an id is needed, use the `id` property.
-- Remove `step_title_extended`. Only `step_title` is needed.
+- Remove `step_title_extended`. Only `stepTitle` is needed.
 - Replace `is_current` with `isCurrent`.
 - Replace `status_state` with `statusState`.
 - Replace `statusState`'s value `warn` with `warning`.
@@ -1454,7 +1451,6 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `status_id` with `statusId`.
 - Replace `status_anchor_url` with `statusAnchorUrl`.
 - Replace `status_anchor_label` with `statusAnchorLabel`.
-- Replace `status_id` with `statusId`.
 - Replace `buffer_delay` with `bufferDelay`.
 - Replace `on_close`'s `status_id` with `statusId`.
 - Replace `autoclose` with `autoClose`.
@@ -1584,9 +1580,6 @@ The following functions have been removed from `@dnb/eufemia/shared/helpers`:
 
 - `insertElementBeforeSelection` – Unused helper for inserting DOM elements before a text selection.
 - `convertStatusToStateOnly` – Trivial helper. Replace `convertStatusToStateOnly(status, state)` with `status ? state : null`.
-
-The following functions have been removed from `@dnb/eufemia/shared/helpers`:
-
 - `isEdge` / `IS_EDGE` – Edge is now Chromium-based, making these detections obsolete.
 
 #### Removed HOCs and conversion utilities
@@ -1892,7 +1885,7 @@ The JSX usage (`<Wizard.Provider value={...}>`) remains the same — no changes 
 
 #### Properties
 
-- Replace `filterSubmitData` with rather using the `filterData` in the second event parameter in the `onSubmit` or `onChange` events.
+- Replace `filterSubmitData` by using the `filterData` function in the second event parameter of the `onSubmit` or `onChange` events.
 
 ## SCSS mixin renames
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -119,14 +119,8 @@ The largest category of changes in v11 is the rename of **all snake_case propert
 - Properties: `selected_key` → `selectedKey`, `label_direction` → `labelDirection`
 - Events: `on_change` → `onChange`, `on_click` → `onClick`
 - Translations: `Autocomplete.no_options` → `Autocomplete.noOptions`
-- CSS classes: `dnb-date-picker--opened` → `dnb-date-picker--open`
 
-You can use your editor's find-and-replace or a codemod to handle these. For a regex-based approach:
-
-```
-Find:    (on_|\_)([a-z])
-Replace: (match based on camelCase conversion)
-```
+You can use your editor's find-and-replace or a codemod to handle most of these. Since each snake_case property maps to a specific camelCase name, we recommend using the per-component find-and-replace lists below rather than a generic regex.
 
 > **Note:** Some renames are not just snake_case conversions — they also change the name itself (e.g. `triangle_position` → `arrowPosition`, `opened` → `open`, `on_show` → `onOpen`). These are listed individually per component below and require manual attention.
 
@@ -526,6 +520,10 @@ The following properties have been renamed from snake_case to camelCase:
 - Find and remove `scrollToHashHandler`. Smooth hash scrolling is now supported by all major browsers.
 - Replace `inner_ref` with `ref`.
 
+#### Styling
+
+- Replace CSS class `dnb-anchor--contrast` with `dnb-anchor--surface-dark`.
+
 ### [Input](/uilib/components/input/)
 
 **Removals:**
@@ -644,6 +642,7 @@ New props added:
 
 #### Deprecations and removals
 
+- `MultiInputMask` has been removed as a public component. If you were importing it directly, use `InputMasked` instead.
 - `show_guide` has been removed. If you need to communicate an expected format, pass an example using the regular `placeholder` prop (e.g. `placeholder="00 00 00"`) or provide helper text next to the field.
 - `keep_char_positions` has been removed.
 - `placeholder_char` has been removed.
@@ -813,6 +812,7 @@ New props added:
 
 #### Properties
 
+- Replace `isCollapsed` with `collapsed`.
 - Replace `styleType` (or `style_type`) with `backgroundColor`.
 - The `spacing` prop type has changed from `SectionSpacing` to `SpaceTypeAll | SpaceTypeMedia`. All previously valid string values still work, but if you imported `SectionSpacing` to type your Breadcrumb spacing, update to use the new types.
 
@@ -987,6 +987,7 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `custom_content` with `customContent`.
+- Replace `class` with `className`.
 - Replace `inner_ref` with `ref`.
 
 #### Events
@@ -1163,7 +1164,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `tabs_style` with `tabsStyle`.
 - Replace `tabs_spacing` or `tabsSpacing` with `tabsInnerSpace`. The `tabsSpacing` prop has been removed – use `tabsInnerSpace` instead.
 - Replace `nav_button_edge` with `navButtonEdge`.
-- Replace `preventRerender` with `preventRerender`.
+- Replace `prevent_rerender` with `preventRerender`.
 - Replace `on_change` with `onChange`.
 - Replace `on_click` with `onClick`.
 - Replace `on_mouse_enter` with `onMouseEnter`.
@@ -1627,6 +1628,7 @@ The following SCSS mixins have been removed:
 ### General
 
 - `Form.Card` no longer enables `outset` by default.
+- `Form.ButtonRow` no longer has automatic horizontal alignment styles when placed next to a `Card`. If you relied on this spacing, add explicit spacing (e.g. via `left` or `Space`).
 - `Card.Provider` / `Form.Card.Provider` has been removed (including `disableCardBreakout`).
 - Replace `Form.useErrorMessage` with your error messages as an object in the `errorMessages` property (e.g., with a `useMemo` hook).
 - Replace `Form.useError` with `Form.useValidation`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -735,20 +735,23 @@ New props added:
 - The deprecated `onStateUpdate` prop has been removed. Use `onChange` instead.
 - The deprecated `attributes` prop has been removed. Use spread props instead.
 - Replace `expandBehaviour` with `expandBehavior`.
-- Replace `on_state_update` with `onStateUpdate`.
 - Replace `expanded_ssr` with `expandedSsr`.
 - Replace `heading_level` with `headingLevel`.
 - Replace `icon_size` with `iconSize`.
 - Replace `single_container` with `singleContainer`.
 - Replace `left_component` with `leftComponent`.
 - Replace `flush_remembered_state` with `flushRememberedState`.
-- Replace `on_change` with `onChange`.
 - Replace `icon_position` with `iconPosition`.
 - Replace `prevent_rerender_conditional` with `preventRerenderConditional`.
 - Replace `remember_state` with `rememberState`.
 - Replace `prevent_rerender` with `preventRerender`.
 - Replace `no_animation` with `noAnimation`.
 - Replace `prerender` with `keepInDOM`.
+
+#### Events
+
+- Replace `on_change` with `onChange`.
+- Replace `on_state_update` with `onStateUpdate`.
 
 ### [Accordion.Group](/uilib/components/accordion/)
 
@@ -784,15 +787,15 @@ New props added:
 
 ### [P](/uilib/elements/paragraph/)
 
-- Replace class `.dnb-p--medium` with `.dnb-t__weight--medium`
-- Replace class `.dnb-p--bold` with `.dnb-t__weight--bold`
-- Replace class `.dnb-p__size--xx-large` with `.dnb-t__size--xx-large` and `.dnb-t__line-height--xx-large`
-- Replace class `.dnb-p__size--x-large` with `.dnb-t__size--x-large` and `.dnb-t__line-height--x-large`
-- Replace class `.dnb-p__size--large` with `.dnb-t__size--large` and `.dnb-t__line-height--large`
-- Replace class `.dnb-p__size--basis` with `.dnb-t__size--basis` and `.dnb-t__line-height--basis`
-- Replace class `.dnb-p__size--medium` with `.dnb-t__size--medium` and `.dnb-t__line-height--medium`
-- Replace class `.dnb-p--small` or `.dnb-p__size--small` with `.dnb-t__size--small` and `.dnb-t__line-height--small`
-- Replace class `.dnb-p--x-small` or `.dnb-p__size--x-small` with `.dnb-t__size--x-small` and `.dnb-t__line-height--x-small`
+- Replace class `.dnb-p--medium` with `.dnb-t__weight--medium`.
+- Replace class `.dnb-p--bold` with `.dnb-t__weight--bold`.
+- Replace class `.dnb-p__size--xx-large` with `.dnb-t__size--xx-large` and `.dnb-t__line-height--xx-large`.
+- Replace class `.dnb-p__size--x-large` with `.dnb-t__size--x-large` and `.dnb-t__line-height--x-large`.
+- Replace class `.dnb-p__size--large` with `.dnb-t__size--large` and `.dnb-t__line-height--large`.
+- Replace class `.dnb-p__size--basis` with `.dnb-t__size--basis` and `.dnb-t__line-height--basis`.
+- Replace class `.dnb-p__size--medium` with `.dnb-t__size--medium` and `.dnb-t__line-height--medium`.
+- Replace class `.dnb-p--small` or `.dnb-p__size--small` with `.dnb-t__size--small` and `.dnb-t__line-height--small`.
+- Replace class `.dnb-p--x-small` or `.dnb-p__size--x-small` with `.dnb-t__size--x-small` and `.dnb-t__line-height--x-small`.
 
 #### Properties
 
@@ -905,8 +908,11 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
-- Replace `on_change` with `onChange`.
 - Replace `children` with `label`.
+
+#### Events
+
+- Replace `on_change` with `onChange`.
 
 #### TypeScript types
 
@@ -923,10 +929,13 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 - Replace `status_state` with `statusState`.
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `status_props` with `statusProps`.
+- Replace `status_no_animation` with `statusNoAnimation`.
+
+#### Events
+
 - Replace `on_change` with `onChange`.
 - Replace `on_change_end` with `onChangeEnd`.
 - Replace `on_state_update` with `onStateUpdate`.
-- Replace `status_no_animation` with `statusNoAnimation`.
 
 ### [Logo](/uilib/components/logo/)
 
@@ -1328,12 +1337,12 @@ In addition to the behavioral changes above, the following properties have been 
 
 #### TypeScript types
 
-- Replace `formatReturnValue` with `FormatReturnValue`.
-- Replace `formatValue` with `FormatValue`.
-- Replace `formatOptionParams` with `FormatOptionParams`.
-- Replace `formatReturnType` with `FormatReturnType`.
-- Replace `formatTypes` with `FormatTypes`.
-- Replace `formatCurrencyPosition` with `FormatCurrencyPosition`.
+- Replace `formatReturnValue` with `NumberFormatReturnValue`.
+- Replace `formatValue` with `NumberFormatValue`.
+- Replace `formatOptionParams` with `NumberFormatOptionParams`.
+- Replace `formatReturnType` with `NumberFormatReturnType`.
+- Replace `formatTypes` with `NumberFormatType`.
+- Replace `formatCurrencyPosition` with `NumberFormatCurrencyPosition`.
 
 ### [StepIndicator](/uilib/components/step-indicator/)
 
@@ -1452,7 +1461,6 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `status_anchor_url` with `statusAnchorUrl`.
 - Replace `status_anchor_label` with `statusAnchorLabel`.
 - Replace `buffer_delay` with `bufferDelay`.
-- Replace `on_close`'s `status_id` with `statusId`.
 - Replace `autoclose` with `autoClose`.
 - Replace `autoscroll` with `autoScroll`.
 
@@ -1462,7 +1470,7 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `on_open` with `onOpen`.
 - Replace `on_show` with `onShow`.
 - Replace `on_hide` with `onHide`.
-- Replace `on_close` with `onClose`.
+- Replace `on_close` with `onClose`. The `status_id` callback parameter has been renamed to `statusId`.
 
 #### Translations
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -546,9 +546,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `input_state` with `inputState`.
 - Replace `submit_button_title` with `submitButtonTitle`.
 - Replace `clear_button_title` with `clearButtonTitle`.
-- Replace `clear` with `showClearButton`.
 - Replace `keep_placeholder` with `keepPlaceholder`.
-- Replace `input_class` with `inputClassName`.
 - Replace `input_attributes` with `inputAttributes`.
 - Replace `input_element` with `inputElement`.
 - Replace `icon_size` with `iconSize`.
@@ -1247,10 +1245,10 @@ The following properties have been renamed from snake_case to camelCase:
 - The `onBlur` and `onFocus` events fire now only once per user interaction, not on every internal input blur.
 - The visible date segments are no longer native `input` elements. They are now exposed as section elements with `role="spinbutton"`. If you have Jest or DOM tests that query `input` or assert old input-specific ARIA attributes, update them to target the visible date picker field/segments instead.
 - Find `partialDate`, `partialStartDate` and `partialEndDate` and remove it.
-- Find `correctInvalidDate` / `correct_invalid_date` and remove it. You may rather use [Field.Date](/uilib/extensions/forms/feature-fields/Date/) from Eufemia Forms when using `minDate` and `maxDate`, as this has built in validation. Reason for removing this is because we believe it's not good UX, or best practice to automatically change the user input. This often leads to confusion, as what they typed in, magically changes for seemingly no reason. We believe it's better to inform them about the error and let them correct it themselves.
+- Find `correctInvalidDate` / `correct_invalid_date` and remove it. Use [Field.Date](/uilib/extensions/forms/feature-fields/Date/) from Eufemia Forms instead when using `minDate` and `maxDate`, as it has built-in validation. Automatically correcting user input leads to confusion — inform users about the error and let them correct it themselves.
 - Replace `on_show` with `onOpen` and `on_hide` with `onClose` (not just a casing change — the event names changed).
 - Replace `opened` with `open`.
-- `dateFormat` and `returnFormat` does no longer support the format `YYYY-MM-DD`, use `yyyy-MM-dd` instead.
+- `dateFormat` and `returnFormat` no longer support the format `YYYY-MM-DD`. Use `yyyy-MM-dd` instead.
 
 #### Properties
 
@@ -1361,7 +1359,6 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `current_step` with `currentStep`.
 - Replace `overview_title` with `overviewTitle`.
 - Replace `step_title` with `stepTitle`.
-- Replace `current_step` with `currentStep`.
 - Replace `hide_numbers` with `hideNumbers`.
 - Replace `no_animation` with `noAnimation`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -4,15 +4,137 @@ description: 'January 23, 2026'
 order: -11
 ---
 
+import { Accordion } from '@dnb/eufemia/src'
+
 # v11
 
-This page lists the changes introduced in v11. It focuses on breaking changes, removals, and required migrations, grouped by area for clarity.
+This is the migration guide for @dnb/eufemia v11. It covers all breaking changes, removals, and required code updates.
+
+**Most changes fall into these categories:**
+
+1. **snake_case → camelCase renames** — The majority of changes are mechanical property, event, and translation key renames. These can be [automated](#automated-migration-snake_case-to-camelcase).
+2. **React 19 alignment** — `innerRef` → `ref`, `Context.Provider` → `Context`, and related updates.
+3. **Behavioral changes and removals** — API redesigns, removed features, and changed defaults. These require manual review.
+
+<Accordion title="Table of contents">
+
+- [Summary of changes](#summary-of-changes)
+- [Install](#install)
+- [Migration](#migration)
+  - [Automated migration: snake_case to camelCase](#automated-migration-snake_case-to-camelcase)
+  - [innerRef → ref](#innerref--ref)
+  - [Context.Provider → Context](#contextprovider--context)
+  - [Theme.Provider → Theme.Context](#themeprovider--themecontext)
+- [Components](#components)
+  - [labelDirection default changed to vertical](#labeldirection-default-changed-to-vertical)
+  - [Section](#section)
+  - [HelpButton](#helpbutton)
+  - [Autocomplete](#autocomplete)
+  - [Dropdown](#dropdown)
+  - [DrawerList](#drawerlist)
+  - [Anchor](#anchor)
+  - [Input](#input)
+  - [InputMasked](#inputmasked)
+  - [FormLabel](#formlabel)
+  - [Radio](#radio)
+  - [Textarea](#textarea)
+  - [Accordion](#accordion)
+  - [Tag](#tag)
+  - [Upload](#upload)
+  - [Stat](#stat)
+  - [P (paragraph)](#p)
+  - [Definition lists](#definition-lists)
+  - [Breadcrumb](#breadcrumb)
+  - [ProgressIndicator](#progressindicator)
+  - [PaymentCard](#paymentcard)
+  - [Divider (Horizontal Rule)](#divider-horizontal-rule)
+  - [Flex.Item](#flexitem)
+  - [Card](#card)
+  - [Checkbox](#checkbox)
+  - [Switch](#switch)
+  - [Logo](#logo)
+  - [Icon](#icon)
+  - [Button](#button)
+  - [Modal, Dialog and Drawer](#modal-dialog-and-drawer)
+  - [Heading](#heading)
+  - [H (heading elements)](#h-heading-elements)
+  - [Table](#table)
+  - [FormStatus](#formstatus)
+  - [Skeleton](#skeleton)
+  - [Tabs](#tabs)
+  - [Pagination](#pagination)
+  - [Slider](#slider)
+  - [Timeline](#timeline)
+  - [DatePicker](#datepicker)
+  - [NumberFormat](#numberformat)
+  - [StepIndicator](#stepindicator)
+  - [GlobalError](#globalerror)
+  - [ToggleButton](#togglebutton)
+  - [Tooltip](#tooltip)
+  - [GlobalStatus](#globalstatus)
+  - [CopyOnClick](#copyonclick)
+- [Layout](#layout)
+- [Helpers](#helpers)
+- [Eufemia Forms](#eufemia-forms)
+- [SCSS mixin renames](#scss-mixin-renames)
+- [SCSS: @import → @use](#scss-import--use)
+- [TypeScript](#typescript)
+- [Theming](#theming)
+- [Props Type Exports](#props-type-exports)
+
+</Accordion>
+
+## Summary of changes
+
+- All **snake_case** (`on_click`) events and properties have been converted to **camelCase** (`onClick`). The reason for previously using snake_case was to support Web Components – but the support was discontinued in [v10](/uilib/about-the-lib/releases/eufemia/v10-info/).
+- Replaced deprecated `<Context.Provider>` with direct `<Context>` rendering across all internal context providers (React 19).
+- Several exported TypeScript `interface` declarations have been converted to `type`. This prevents declaration merging but has no impact on standard usage.
+- All React context value types have been renamed to use a consistent `...ContextValue` suffix (e.g. `AccordionContextProps` → `AccordionContextValue`). See [TypeScript](#typescript) for the full list.
+- Event handler and render function prop types have been replaced with properly typed signatures (e.g. `(...args: any[]) => any` → `(event: AccordionChangeEvent) => void`). See [Typed event handlers](#typed-event-handlers) for the full list.
+
+## Install
+
+To upgrade to @dnb/eufemia v11 with NPM, use:
+
+```bash
+$ npm i @dnb/eufemia@11
+# or
+$ yarn add @dnb/eufemia@11
+# or
+$ pnpm add @dnb/eufemia@11
+```
 
 ## Migration
 
-v11 of @dnb/eufemia contains _breaking changes_. As a migration process, you can simply search and replace:
+v11 of @dnb/eufemia contains _breaking changes_.
 
 > Important: Upgrading to v11 requires React and React DOM v19 ([React 19 Upgrade Guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide)).
+
+### Automated migration: snake_case to camelCase
+
+The largest category of changes in v11 is the rename of **all snake_case properties, events, and translation keys to camelCase**. This affects every component and can be automated.
+
+**The pattern:**
+
+- Properties: `selected_key` → `selectedKey`, `label_direction` → `labelDirection`
+- Events: `on_change` → `onChange`, `on_click` → `onClick`
+- Translations: `Autocomplete.no_options` → `Autocomplete.noOptions`
+- CSS classes: `dnb-date-picker--opened` → `dnb-date-picker--open`
+
+You can use your editor's find-and-replace or a codemod to handle these. For a regex-based approach:
+
+```
+Find:    (on_|\_)([a-z])
+Replace: (match based on camelCase conversion)
+```
+
+> **Note:** Some renames are not just snake_case conversions — they also change the name itself (e.g. `triangle_position` → `arrowPosition`, `opened` → `open`, `on_show` → `onOpen`). These are listed individually per component below and require manual attention.
+
+The rest of this section covers changes that **cannot** be automated with a simple find-and-replace and need manual review.
+
+### Step-by-step checklist
+
+As a migration process, you can search and replace:
 
 1. Replace `innerRef` with `ref` on all Eufemia components.
 2. Replace `<Context.Provider>` with `<Context>` when using Eufemia contexts directly (React 19 deprecation).
@@ -92,27 +214,9 @@ If you use any Eufemia context objects directly (e.g. `Wizard.Provider`), update
 
 `Theme.Provider` has been removed.
 
-## Install
-
-To upgrade to @dnb/eufemia v11 with NPM, use:
-
-```bash
-$ npm i @dnb/eufemia@11
-# or
-$ yarn add @dnb/eufemia@11
-# or
-$ pnpm add @dnb/eufemia@11
-```
-
-## Summary of changes:
-
-- All **snake case** (`on_click`) events and properties has been converted to use **camel case** (`onClick`). The reason for previously using **snake case** was to support Web Components – but the support was discontinued in [v10](/uilib/about-the-lib/releases/eufemia/v10-info/).
-- Replaced deprecated `<Context.Provider>` with direct `<Context>` rendering across all internal context providers (React 19).
-- Several exported TypeScript `interface` declarations have been converted to `type`. This prevents declaration merging but has no impact on standard usage.
-- All React context value types have been renamed to use a consistent `...ContextValue` suffix (e.g. `AccordionContextProps` → `AccordionContextValue`). See [TypeScript](#typescript) for the full list.
-- Event handler and render function prop types have been replaced with properly typed signatures (e.g. `(...args: any[]) => any` → `(event: AccordionChangeEvent) => void`). See [Typed event handlers](#typed-event-handlers) for the full list.
-
 ## Components
+
+> Each component section below lists its changes. Behavioral changes and removals are called out separately where applicable. The bulk of per-component changes are snake_case → camelCase renames covered by the [automated migration](#automated-migration-snake_case-to-camelcase) section above.
 
 ### labelDirection default changed to `vertical`
 
@@ -167,9 +271,17 @@ You can also use `top` and `bottom` individually if you need different values, e
 
 ### [Autocomplete](/uilib/components/autocomplete/)
 
+**Removals and behavioral changes:**
+
 - The deprecated `onStateUpdate` prop has been removed. Use `onChange` instead.
+- Replace `input_icon` with `icon`. The `inputIcon` prop has been removed — use the `icon` prop instead (defaults to `'loupe'`).
+- Replace `opened` with `open`.
+- Replace `align_autocomplete` with `align`.
+- Replace `on_show` with `onOpen` and `on_hide` with `onClose` (not just a casing change — the event names changed).
 
 #### Properties
+
+The following properties have been renamed from snake_case to camelCase:
 
 - Replace `selected_key` with `selectedKey`.
 - Replace `default_value` with `defaultValue`.
@@ -207,7 +319,6 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `input_ref` with `inputRef`.
 - Replace `icon_size` with `iconSize`.
 - Replace `icon_position` with `iconPosition`.
-- Replace `input_icon` with `icon`. The `inputIcon` prop has been removed — use the `icon` prop instead (defaults to `'loupe'`).
 - Replace `label_sr_only` with `labelSrOnly`.
 - Replace `keep_value` with `keepValue`.
 - Replace `keep_selection` with `keepSelection`.
@@ -222,7 +333,6 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `disable_highlighting` with `disableHighlighting`.
 - Replace `show_submit_button` with `showSubmitButton`.
 - Replace `submit_element` with `submitElement`.
-- Replace `align_autocomplete` with `align`.
 - Replace `input_element` with `inputElement`.
 - Replace `search_in_word_index` with `searchInWordIndex`.
 - Replace `search_numbers` with `searchNumbers`.
@@ -232,7 +342,6 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `prevent_focus` with `preventFocus`.
 - Replace `action_menu` with `actionMenu`.
 - Replace `is_popup` with `isPopup`.
-- Replace `opened` with `open`.
 - Replace `selectall` with `selectAll`.
 
 #### Events
@@ -277,9 +386,17 @@ You can also use `top` and `bottom` individually if you need different values, e
 
 ### [Dropdown](/uilib/components/dropdown/)
 
-#### Properties
+**Removals and behavioral changes:**
 
 - The deprecated `onStateUpdate` prop has been removed. Use `onChange` instead.
+- Replace `opened` with `open`.
+- Replace `align_dropdown` with `align`.
+- Replace `on_show` with `onOpen` and `on_hide` with `onClose` (not just a casing change — the event names changed).
+
+#### Properties
+
+The following properties have been renamed from snake_case to camelCase:
+
 - Replace `selected_key` with `selectedKey`.
 - Replace `default_value` with `defaultValue`.
 - Replace `prevent_selection` with `preventSelection`.
@@ -313,13 +430,11 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `more_menu` with `moreMenu`.
-- Replace `align_dropdown` with `align`.
 - Replace `trigger_element` with `triggerElement`.
 - Replace `open_on_focus` with `openOnFocus`.
 - Replace `action_menu` with `actionMenu`.
 - Replace `is_popup` with `isPopup`.
 - Replace `prevent_focus` with `preventFocus`.
-- Replace `opened` with `open`.
 
 #### Events
 
@@ -413,10 +528,17 @@ You can also use `top` and `bottom` individually if you need different values, e
 
 ### [Input](/uilib/components/input/)
 
-#### Properties
+**Removals:**
 
 - The `inputPropTypes` export has been removed as part of the PropTypes removal. If you were importing it via `import { inputPropTypes } from '@dnb/eufemia/components/input'`, remove the import — runtime prop validation is no longer provided.
 - The deprecated `onStateUpdate` prop has been removed. Use `onChange` instead.
+- Replace `clear` with `showClearButton`.
+- Replace `input_class` with `inputClassName` (note the name change, not just casing).
+
+#### Properties
+
+The following properties have been renamed from snake_case to camelCase:
+
 - Replace `label_direction` with `labelDirection`.
 - Replace `label_sr_only` with `labelSrOnly`.
 - Replace `status_state` with `statusState`.
@@ -458,7 +580,7 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `Input.submit_button_title` with `Input.submitButtonTitle`.
 - Replace `Input.clear_button_title` with `Input.clearButtonTitle`.
 
-#### SubmitButton (do we need to document this, I don't see any docs of this, but it's exposed/exported)
+#### SubmitButton
 
 - Replace `icon_size` with `iconSize`.
 - Replace `status_state` with `statusState`.
@@ -466,6 +588,8 @@ You can also use `top` and `bottom` individually if you need different values, e
 - Replace `status_props` with `statusProps`.
 
 ### [InputMasked](/uilib/components/input-masked/)
+
+> **Major change:** The masking engine has been replaced. Read this section carefully.
 
 In v11, the InputMasked component has been rewritten to use [Maskito](https://maskito.dev/) instead of the unmaintained [text-mask](https://github.com/text-mask/text-mask) library. This brings better input handling, improved mobile keyboard support, and more reliable cursor/caret behavior. The public API (`mask`, `numberMask`, `currencyMask`, `asNumber`, `asCurrency`, `asPercent`, etc.) remains the same — the masking engine underneath has changed.
 
@@ -811,6 +935,8 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 
 ### [Logo](/uilib/components/logo/)
 
+> **Major change:** The Logo component API has been redesigned. Instead of `brand` and `variant` props, import the specific SVG component directly.
+
 #### Properties
 
 - Remove `brand` prop. Import and use the desired SVG component directly (e.g., `DnbDefault`, `SbankenDefault`, `SbankenCompact`, `SbankenHorizontal`, `CarnegieDefault`, `EiendomDefault`).
@@ -847,10 +973,13 @@ render(<Logo svg={SbankenCompact} />)
 
 ### [Button](/uilib/components/button/)
 
-#### Properties
+**Removals:**
 
 - The `variant="signal"` has been removed. Use `variant="primary"` or `variant="secondary"` instead.
 - The `buttonVariantPropType` export has been removed as part of the PropTypes removal. If you were importing it via `import { buttonVariantPropType } from '@dnb/eufemia/components/button'`, remove the import — runtime prop validation is no longer provided.
+
+#### Properties
+
 - Replace `icon_position` with `iconPosition`.
 - Replace `icon_size` with `iconSize`.
 - Replace `status_state` with `statusState`.
@@ -866,7 +995,15 @@ render(<Logo svg={SbankenCompact} />)
 
 ### [Modal](/uilib/components/modal/), [Dialog](/uilib/components/dialog/) and [Drawer](/uilib/components/drawer/)
 
+**Removals and behavioral changes:**
+
+- **Removed:** `rootId` property has been removed. Modal root elements no longer support custom IDs.
+- Replace `openState` with `open`. Replace `openState="opened"` with `open={true}` and `openState="closed"` with `open={false}`.
+- If you rely on opening and closing a modal by mounting and unmounting the component (legacy behavior), you should change to using the `open` property instead.
+
 #### Properties
+
+The following properties have been renamed from snake_case to camelCase:
 
 - Replace `class` with `className`.
 - Replace `focus_selector` with `focusSelector`.
@@ -906,10 +1043,6 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `content_ref` with `contentRef`.
 - Replace `scroll_ref` with `scrollRef`.
 - Replace `prevent_overlay_close` with `preventOverlayClose`.
-- Replace `openState` with `open`.
-- Replace `openState="opened"` with `open={true}`.
-- Replace `openState="closed"` with `open={false}`.
-- **Removed:** `rootId` property has been removed. Modal root elements no longer support custom IDs.
 
 #### TypeScript types
 
@@ -919,10 +1052,6 @@ render(<Logo svg={SbankenCompact} />)
 
 - Replace `Modal.dialog_title` with `Modal.dialogTitle`.
 - Replace `Modal.close_title` with `Modal.closeTitle`.
-
-#### Opening and closing a modal
-
-- If you rely on opening and closing a modal by mounting and unmounting the component (legacy behavior), you should change to using the `open` property instead.
 
 ### [Modal.Header](/uilib/components/modal/), [Dialog.Header](/uilib/components/dialog/) and [Drawer.Header](/uilib/components/drawer/)
 
@@ -954,8 +1083,8 @@ render(<Logo svg={SbankenCompact} />)
 
 #### Properties
 
-- Replace `debug_counter` with debugCounter`.
-- Replace `skip_correction` with skipCorrection`.
+- Replace `debug_counter` with `debugCounter`.
+- Replace `skip_correction` with `skipCorrection`.
 
 ### [H (heading elements)](/uilib/elements/heading/)
 
@@ -1112,12 +1241,20 @@ render(<Logo svg={SbankenCompact} />)
 
 ### [DatePicker](/uilib/components/date-picker/)
 
-#### Properties
+**Removals and behavioral changes:**
 
 - The `onBlur` and `onFocus` events fire now only once per user interaction, not on every internal input blur.
 - The visible date segments are no longer native `input` elements. They are now exposed as section elements with `role="spinbutton"`. If you have Jest or DOM tests that query `input` or assert old input-specific ARIA attributes, update them to target the visible date picker field/segments instead.
 - Find `partialDate`, `partialStartDate` and `partialEndDate` and remove it.
 - Find `correctInvalidDate` / `correct_invalid_date` and remove it. You may rather use [Field.Date](/uilib/extensions/forms/feature-fields/Date/) from Eufemia Forms when using `minDate` and `maxDate`, as this has built in validation. Reason for removing this is because we believe it's not good UX, or best practice to automatically change the user input. This often leads to confusion, as what they typed in, magically changes for seemingly no reason. We believe it's better to inform them about the error and let them correct it themselves.
+- Replace `on_show` with `onOpen` and `on_hide` with `onClose` (not just a casing change — the event names changed).
+- Replace `opened` with `open`.
+- `dateFormat` and `returnFormat` does no longer support the format `YYYY-MM-DD`, use `yyyy-MM-dd` instead.
+
+#### Properties
+
+In addition to the behavioral changes above, the following properties have been renamed from snake_case to camelCase:
+
 - Replace `start_date` with `startDate`.
 - Replace `end_date` with `endDate`.
 - Replace `start_month` with `startMonth`.
@@ -1167,8 +1304,6 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `is_valid_start_date` with `isValidStartDate`.
 - Replace `is_valid_end_date` with `isValidEndDate`.
 - Replace the `shortcuts` property `close_on_select` with `closeOnSelect`.
-- Replace `opened` with `open`.
-- `dateFormat` and `returnFormat` does no longer support the format `YYYY-MM-DD`, use `yyyy-MM-dd` instead.
 
 #### Styling
 
@@ -1206,7 +1341,9 @@ render(<Logo svg={SbankenCompact} />)
 
 ### [StepIndicator](/uilib/components/step-indicator/)
 
-#### Properties
+> **Major change:** This component has been redesigned. The sidebar variant has been removed entirely.
+
+#### Removals
 
 - Major redesign of component. There is now only one variant (instead of two).
 - Remove `StepIndicatorRenderCallback` type. Not needed anymore.
@@ -1484,6 +1621,8 @@ The following SCSS mixins have been removed:
 - **`componentReset`** (`style/core/scopes.scss`) — applied core CSS reset rules to a single component. Use the global Eufemia CSS reset instead.
 
 ## Eufemia Forms
+
+> This section covers changes specific to `@dnb/eufemia/extensions/forms`. Many of these are **behavioral changes and removals** that require manual review.
 
 ### General
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -283,7 +283,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `prevent_close` with `preventClose`.
 - Replace `keep_open` with `keepOpen`.
 - Replace `independent_width` with `independentWidth`.
-- Replace `fixed_postion` with `fixedPosition`.
+- Replace `fixed_position` with `fixedPosition`.
 - Replace `enable_body_lock` with `enableBodyLock`.
 - Replace `align_drawer` with `alignDrawer`.
 - Replace `list_class` with `listClass`.
@@ -397,7 +397,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `prevent_close` with `preventClose`.
 - Replace `keep_open` with `keepOpen`.
 - Replace `independent_width` with `independentWidth`.
-- Replace `fixed_postion` with `fixedPosition`.
+- Replace `fixed_position` with `fixedPosition`.
 - Replace `enable_body_lock` with `enableBodyLock`.
 - Replace `align_drawer` with `alignDrawer`.
 - Replace `list_class` with `listClass`.
@@ -464,7 +464,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `prevent_close` with `preventClose`.
 - Replace `keep_open` with `keepOpen`.
 - Replace `independent_width` with `independentWidth`.
-- Replace `fixed_postion` with `fixedPosition`.
+- Replace `fixed_position` with `fixedPosition`.
 - Replace `enable_body_lock` with `enableBodyLock`.
 - Replace `align_drawer` with `alignDrawer`.
 - Replace `list_class` with `listClass`.
@@ -845,7 +845,7 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 
 #### Translations
 
-- Replace translation `ProgressIndicator.indicator_label` with `ProgressInidicator.indicatorLabel`.
+- Replace translation `ProgressIndicator.indicator_label` with `ProgressIndicator.indicatorLabel`.
 
 ### [PaymentCard](/uilib/extensions/payment-card/)
 
@@ -1238,7 +1238,7 @@ The following properties have been renamed from snake_case to camelCase:
 
 - Replace `TimelineItem.alt_label_completed` with `TimelineItem.altLabelCompleted`.
 - Replace `TimelineItem.alt_label_current` with `TimelineItem.altLabelCurrent`.
-- Replace `TimelineItem.alt_label_upoming` with `TimelineItem.altLabelUpcoming`.
+- Replace `TimelineItem.alt_label_upcoming` with `TimelineItem.altLabelUpcoming`.
 
 ### [DatePicker](/uilib/components/date-picker/)
 
@@ -1632,7 +1632,7 @@ The following SCSS mixins have been removed:
 - `Card.Provider` / `Form.Card.Provider` has been removed (including `disableCardBreakout`).
 - Replace `Form.useErrorMessage` with your error messages as an object in the `errorMessages` property (e.g., with a `useMemo` hook).
 - Replace `Form.useError` with `Form.useValidation`.
-- Replace `Form.useLocale` with `Form.useLocation`.
+- Replace `Form.useLocale` with `Form.useTranslation`.
 - Replace `internal.error` with `error`.
 - Replace Form.Iterate label variable `{itemNr}` with `{itemNo}`.
 - Replace `Form.FieldProps` with `Field.Provider`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -247,7 +247,9 @@ If you used `<Provider formElement={{ labelDirection: 'vertical' }}>` or `labelD
 
 You can also use `top` and `bottom` individually if you need different values, e.g. `innerSpace={{ top: 'small', bottom: 'large' }}`. Note that `innerSpace="large"` (a plain string) applies padding on **all four sides**, not just top/bottom.
 
-3. Replace `inner_ref` with `ref`.
+3. Replace `variant`'s value `info` with `information`.
+
+4. Replace `inner_ref` with `ref`.
 
 #### Types
 
@@ -373,10 +375,7 @@ The following properties have been renamed from snake_case to camelCase:
 
 #### DrawerListDataArrayObject
 
-- Replace `selected_value` with `selectedValue`.
-- Replace `suffix_value` with `suffixValue`.
-- Replace `search_content` with `searchContent`.
-- Replace `class_name` with `className`.
+See [DrawerList > DrawerListDataArrayObject](#drawerlistdataarrayobject-2) for the property renames.
 
 ### [Dropdown](/uilib/components/dropdown/)
 
@@ -445,10 +444,7 @@ The following properties have been renamed from snake_case to camelCase:
 
 #### DrawerListDataArrayObject
 
-- Replace `selected_value` with `selectedValue`.
-- Replace `suffix_value` with `suffixValue`.
-- Replace `search_content` with `searchContent`.
-- Replace `class_name` with `className`.
+See [DrawerList > DrawerListDataArrayObject](#drawerlistdataarrayobject-2) for the property renames.
 
 ### [DrawerList](/uilib/components/fragments/drawer-list/)
 
@@ -836,9 +832,12 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 - Replace `indicator_label` with `indicatorLabel`.
 - Replace `label_direction` with `labelDirection`.
 - Replace `show_label` with `showDefaultLabel`.
-- Replace `on_complete` with `onComplete`.
 - Replace `class` with `className`.
 - Replace `children` with `label`.
+
+#### Events
+
+- Replace `on_complete` with `onComplete`.
 
 #### Styling
 
@@ -1032,9 +1031,6 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `open_state` with `openState`.
 - Replace `direct_dom_return` with `directDomReturn`.
 - Replace `omit_trigger_button` with `omitTriggerButton`.
-- Replace `on_open` with `onOpen`.
-- Replace `on_close` with `onClose`.
-- Replace `on_close_prevent` with `onClosePrevent`.
 - Replace `open_modal` with `openModal`.
 - Replace `close_modal` with `closeModal`.
 - Replace `trigger_attributes` with `triggerAttributes`.
@@ -1048,6 +1044,13 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `content_ref` with `contentRef`.
 - Replace `scroll_ref` with `scrollRef`.
 - Replace `prevent_overlay_close` with `preventOverlayClose`.
+- Replace `confirmType`'s value `info` with `information` on Dialog.
+
+#### Events
+
+- Replace `on_open` with `onOpen`.
+- Replace `on_close` with `onClose`.
+- Replace `on_close_prevent` with `onClosePrevent`.
 
 #### TypeScript types
 
@@ -1141,6 +1144,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `text_id` with `textId`.
 - Replace `width_selector` with `widthSelector`.
 - Replace `width_element` with `widthElement`.
+- Replace `state`'s value `info` with `information`.
 - Replace `state`'s value `warn` with `warning`.
 - Replace `variant`'s value `flat` with `plain`.
 
@@ -1169,13 +1173,16 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `tabs_spacing` or `tabsSpacing` with `tabsInnerSpace`. The `tabsSpacing` prop has been removed – use `tabsInnerSpace` instead.
 - Replace `nav_button_edge` with `navButtonEdge`.
 - Replace `prevent_rerender` with `preventRerender`.
+- Replace `focus_key` with `focusKey`.
+- Replace `no_border` with `noBorder`.
+- Replace `prerender` with `keepInDOM`.
+
+#### Events
+
 - Replace `on_change` with `onChange`.
 - Replace `on_click` with `onClick`.
 - Replace `on_mouse_enter` with `onMouseEnter`.
 - Replace `on_focus` with `onFocus`.
-- Replace `focus_key` with `focusKey`.
-- Replace `no_border` with `noBorder`.
-- Replace `prerender` with `keepInDOM`.
 
 #### Styling
 
@@ -1230,6 +1237,10 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `on_click` with `onClick`.
 
 ### [Slider](/uilib/components/slider/)
+
+#### Properties
+
+- Replace `statusState`'s value `info` with `information`.
 
 #### TypeScript types
 
@@ -1296,6 +1307,10 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `prevent_close` with `preventClose`.
 - Replace `no_animation` with `noAnimation`.
 - Replace `align_picker` with `alignPicker`.
+- Replace the `shortcuts` property `close_on_select` with `closeOnSelect`.
+
+#### Events
+
 - Replace `on_days_render` with `onDaysRender`.
 - Replace `on_change` with `onChange`.
 - Replace `on_type` with `onType`.
@@ -1304,11 +1319,15 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `on_submit` with `onSubmit`.
 - Replace `on_cancel` with `onCancel`.
 - Replace `on_reset` with `onReset`.
+
+#### Event return object
+
+The following properties on the event callback return object have been renamed:
+
 - Replace `days_between` with `daysBetween`.
 - Replace `is_valid` with `isValid`.
 - Replace `is_valid_start_date` with `isValidStartDate`.
 - Replace `is_valid_end_date` with `isValidEndDate`.
-- Replace the `shortcuts` property `close_on_select` with `closeOnSelect`.
 
 #### Styling
 
@@ -1361,6 +1380,7 @@ In addition to the behavioral changes above, the following properties have been 
 - Remove `step_title_extended`. Only `stepTitle` is needed.
 - Replace `is_current` with `isCurrent`.
 - Replace `status_state` with `statusState`.
+- Replace `statusState`'s value `info` with `information`.
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `current_step` with `currentStep`.
 - Replace `overview_title` with `overviewTitle`.
@@ -1461,6 +1481,7 @@ In addition to the behavioral changes above, the following properties have been 
 - Replace `status_anchor_url` with `statusAnchorUrl`.
 - Replace `status_anchor_label` with `statusAnchorLabel`.
 - Replace `buffer_delay` with `bufferDelay`.
+- Replace `state`'s value `info` with `information`.
 - Replace `autoclose` with `autoClose`.
 - Replace `autoscroll` with `autoScroll`.
 
@@ -1550,7 +1571,7 @@ In addition to the behavioral changes above, the following properties have been 
 #### Properties
 
 - Replace `spacing` with `gap` on all Flex components.
-- `rowGap` no longer accepts value `true`. Replace `true` with `undefined` or remove the property to get the same behavior.
+- `rowGap` no longer accepts value `true`. Remove the property to get the same behavior.
 
 ### Removal of FormRow and FormSet
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1629,9 +1629,9 @@ The following TypeScript types have also been removed:
 
 These were previously used to support dual snake_case/camelCase prop naming. Since v11 uses camelCase exclusively, they are no longer needed.
 
-#### Updated SCSS mixin: `IS_FF`
+#### Updated SCSS mixin: `isFirefox` (formerly `IS_FF`)
 
-The `IS_FF()` SCSS mixin now uses `@supports (-moz-appearance: none)` instead of the deprecated `@-moz-document url-prefix()` hack. No changes needed if you use the mixin — it works the same way.
+The `IS_FF` SCSS mixin has been renamed to `isFirefox` (see [SCSS mixin renames](#scss-mixin-renames)). Its implementation now uses `@supports (-moz-appearance: none)` instead of the deprecated `@-moz-document url-prefix()` hack. The behavior is unchanged.
 
 #### Removed SCSS mixins
 


### PR DESCRIPTION
Deploy preview https://docs-improve-v11-info-readab.eufemia-e25.pages.dev/uilib/about-the-lib/releases/eufemia/v11-info/#v11

- Add Accordion-based table of contents for navigation
- Move Summary section before Install for better flow
- Add intro with categorized overview of change types
- Add 'Automated migration: snake_case to camelCase' section explaining the global rename pattern and automation guidance
- Add 'Step-by-step checklist' subheading for clarity
- Separate behavioral changes/removals from mechanical renames in key component sections (Autocomplete, Dropdown, Input, InputMasked, DatePicker, Button, Logo, Modal, StepIndicator)
- Add contextual intro notes to Components and Eufemia Forms sections
- Fix missing backticks in Heading section
- Remove internal dev comment from SubmitButton heading
- Remove duplicated content that was moved to behavioral sections

