### PR TITLE
refactor(Accordion): type onInit callback with AccordionInstance

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -39,7 +39,7 @@ import { AccordionStore, Store, rememberWarning } from './AccordionStore'
 import { accordionDefaultProps, type AccordionGroupProps } from './types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
-export type { AccordionGroupProps } from './types'
+export type { AccordionGroupProps, AccordionInstance } from './types'
 export { accordionDefaultProps } from './types'
 
 export type AccordionVariant = 'plain' | 'default' | 'outlined' | 'filled'

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -17,13 +17,16 @@ import { createSpacingClasses } from '../space/SpacingHelper'
 import Context from '../../shared/Context'
 import AccordionGroupContext from './AccordionProviderContext'
 
-import type { AccordionGroupProps as AccordionGroupBaseProps } from './types'
+import type {
+  AccordionGroupProps as AccordionGroupBaseProps,
+  AccordionInstance,
+} from './types'
 import { accordionDefaultProps } from './types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type AccordionGroupProps = React.HTMLProps<HTMLElement> &
   AccordionGroupBaseProps & {
-    onInit?: (accordion: Record<string, unknown>) => void
+    onInit?: (accordion: AccordionInstance) => void
   }
 
 const AccordionGroup = (props: AccordionGroupProps) => {

--- a/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionProviderContext.ts
@@ -5,6 +5,7 @@
 
 import React from 'react'
 import type { AccordionGroupProps } from './AccordionGroup'
+import type { AccordionInstance } from './types'
 
 type AccordionGroupContextProps = {
   expanded?: boolean
@@ -14,7 +15,7 @@ type AccordionGroupContextProps = {
   flushRememberedState?: boolean
   expandedId?: string
   onChange?: (...params: unknown[]) => void
-  onInit?: (accordion: Record<string, unknown>) => void
+  onInit?: (accordion: AccordionInstance) => void
   collapseAccordionCallbacks?: React.RefObject<(() => void)[]>
   collapseAllHandleRef?: React.RefObject<() => void>
   expandBehavior?: AccordionGroupProps['expandBehavior']

--- a/packages/dnb-eufemia/src/components/accordion/types.ts
+++ b/packages/dnb-eufemia/src/components/accordion/types.ts
@@ -1,5 +1,13 @@
 import type { AccordionProps } from './Accordion'
 
+export type AccordionInstance = {
+  _id: string
+  close: () => void
+  setExpandedState: (expanded: boolean) => void
+  state: { expanded: boolean; group?: string }
+  props: AccordionProps
+}
+
 export type AccordionGroupProps = AccordionProps & {
   /** If `true`, all accordions can be collapsed at once (none expanded). Defaults to `false`. */
   allowCloseAll?: boolean


### PR DESCRIPTION
Add AccordionInstance type to types.ts defining the shape of the accordion instance object (props, state, close, setExpandedState). Replace Record<string, unknown> in onInit callback in AccordionGroup and AccordionProviderContext.

