### PR TITLE
refactor(Modal): type modal stack entries and callback instances

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -38,13 +38,14 @@ import {
   addToIndex,
   removeFromIndex,
 } from './helpers'
+import type { ModalStackEntry } from './helpers'
 import { getThemeClasses } from '../../shared/Theme'
 import { Context } from '../../shared'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
-    __modalStack: any[]
+    __modalStack: ModalStackEntry[]
   }
 }
 
@@ -102,7 +103,7 @@ export default function ModalContent(props: ModalContentProps) {
   const triggeredByEventRef = useRef<React.SyntheticEvent>(undefined)
 
   // Stable identity for the modal stack
-  const selfRef = useRef<any>(null)
+  const selfRef = useRef<ModalStackEntry>(null)
   if (!selfRef.current) {
     selfRef.current = {
       _id: idProp,

--- a/packages/dnb-eufemia/src/components/modal/helpers.ts
+++ b/packages/dnb-eufemia/src/components/modal/helpers.ts
@@ -1,6 +1,17 @@
+import type React from 'react'
 import { warn, processChildren } from '../../shared/component-helper'
 
-export function getListOfModalRoots(): any[] {
+export type ModalStackEntry = {
+  _id: string
+  _scrollRef: React.RefObject<HTMLElement | null>
+  _contentRef: React.RefObject<HTMLElement | null>
+  _iiLocal?: {
+    activate: (target?: HTMLElement | null) => void
+    revert: () => void
+  }
+}
+
+export function getListOfModalRoots(): ModalStackEntry[] {
   if (typeof window !== 'undefined') {
     try {
       const stack = window.__modalStack || []
@@ -13,7 +24,7 @@ export function getListOfModalRoots(): any[] {
   return []
 }
 
-export function getModalRoot(index?: number): any {
+export function getModalRoot(index?: number): ModalStackEntry | null {
   if (typeof window !== 'undefined') {
     try {
       const stack = window.__modalStack || []
@@ -34,7 +45,7 @@ export function getModalRoot(index?: number): any {
   return null
 }
 
-export function addToIndex(elem) {
+export function addToIndex(elem: ModalStackEntry) {
   if (typeof window !== 'undefined') {
     try {
       if (!Array.isArray(window.__modalStack)) {
@@ -47,7 +58,7 @@ export function addToIndex(elem) {
   }
 }
 
-export function removeFromIndex(elem) {
+export function removeFromIndex(elem: ModalStackEntry) {
   if (typeof window !== 'undefined') {
     try {
       if (!Array.isArray(window.__modalStack)) {

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -3,6 +3,11 @@ import type { CloseButtonProps } from './parts/CloseButton'
 import type { ButtonProps } from '../button/Button'
 import type { ModalRootProps } from './ModalRoot'
 
+export type ModalCallbackInstance = {
+  _id: string
+  props: ModalProps
+}
+
 export type ModalFullscreen = 'auto' | boolean
 export type ModalAlignContent = 'left' | 'center' | 'centered' | 'right'
 export type ModalContainerPlacement = 'left' | 'right' | 'top' | 'bottom'
@@ -107,7 +112,7 @@ export type ModalProps = ModalRootProps & {
    */
   openModal?: (
     open?: (e: Event) => void,
-    instance?: any
+    instance?: ModalCallbackInstance
   ) => () => void | void
 
   /**
@@ -115,7 +120,7 @@ export type ModalProps = ModalRootProps & {
    */
   closeModal?: (
     close?: ModalCloseHandler,
-    instance?: any
+    instance?: ModalCallbackInstance
   ) => () => void | void
 
   /**


### PR DESCRIPTION
Replace any types in modal helpers with ModalStackEntry for the internal modal stack (__modalStack), and ModalCallbackInstance for the openModal/ closeModal instance parameter. Type getListOfModalRoots, getModalRoot, addToIndex, and removeFromIndex with proper types.

