### PR TITLE
chore(Forms): move Ajv error handling to instance for tree shaking capability

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { FormError, JsonObject } from '../utils'
-import type { Ajv } from '../utils/ajv'
+import type { AjvInstance } from '../utils/ajv'
 import type {
   GlobalErrorMessagesWithPaths,
   SubmitState,
@@ -213,7 +213,7 @@ export type ContextState = {
   hasVisibleError: boolean
   formState: SubmitState
   activeSubmitButtonId?: string
-  getAjvInstance?: () => Ajv
+  getAjvInstance?: () => AjvInstance
   contextErrorMessages: GlobalErrorMessagesWithPaths
   schema: Schema
   path?: Path

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -8,13 +8,13 @@ import React, {
 } from 'react'
 import type { JsonObject } from '../../utils/json-pointer'
 import pointer from '../../utils/json-pointer'
-import type { z, Ajv, FormError } from '../../utils'
+import type { z, FormError } from '../../utils'
+import type { AjvInstance } from '../../utils/ajv'
 import {
   isZodSchema,
   createZodValidator,
   zodErrorsToFormErrors,
 } from '../../utils'
-import { ajvErrorsToFormErrors } from '../../utils/ajvErrors'
 import type {
   GlobalErrorMessagesWithPaths,
   SubmitState,
@@ -111,7 +111,7 @@ export type DataContextProviderProps<Data extends JsonObject> =
     /**
      * Custom Ajv instance, if you want to use your own
      */
-    ajvInstance?: Ajv
+    ajvInstance?: AjvInstance
     /**
      * Custom error messages for the whole data set
      */
@@ -265,7 +265,7 @@ export default function Provider<Data extends JsonObject>(
   const translation = useTranslation().Field
 
   // - Ajv (lazy initialization)
-  const ajvRef = useRef<Ajv>(undefined)
+  const ajvRef = useRef<AjvInstance>(undefined)
   const getAjvInstance = useCallback(() => {
     if (!ajvRef.current) {
       ajvRef.current = ajvInstance
@@ -345,7 +345,10 @@ export default function Provider<Data extends JsonObject>(
           const ajvValidator = validator as ValidateFunction
           const ajvErrors = ajvValidator.errors
           if (ajvErrors && ajvErrors.length) {
-            errors = ajvErrorsToFormErrors(ajvErrors, sectionData)
+            errors = getAjvInstance()?.ajvErrorsToFormErrors(
+              ajvErrors,
+              sectionData
+            )
           }
         }
 
@@ -516,7 +519,7 @@ export default function Provider<Data extends JsonObject>(
           )
         } else {
           // These are AJV errors, use the existing conversion
-          errorsRef.current = ajvErrorsToFormErrors(
+          errorsRef.current = getAjvInstance()?.ajvErrorsToFormErrors(
             errors as ErrorObject<string, Record<string, unknown>>[],
             internalDataRef.current
           )

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -6,7 +6,7 @@ import {
   createZodValidator,
   zodErrorsToOneFormError,
 } from '../utils'
-import { ajvErrorsToOneFormError } from '../utils/ajvErrors'
+import type { AjvInstance } from '../utils/ajv'
 import type * as z from 'zod'
 import type {
   FieldPropsGeneric,
@@ -44,9 +44,7 @@ export type UseFieldValidationParams<Value> = {
   emptyValue: unknown
   required: boolean
   hasDataContext: boolean
-  getAjvInstanceDataContext: () => {
-    compile: (schema: unknown) => ValidateFunction
-  }
+  getAjvInstanceDataContext: () => AjvInstance
   setFieldEventListener: (
     identifier: Identifier,
     event: string,
@@ -712,7 +710,7 @@ export default function useFieldValidation<Value>({
             const zodError = validationResult as z.ZodError<unknown>
             error = zodErrorsToOneFormError(zodError.issues)
           } else {
-            error = ajvErrorsToOneFormError(
+            error = getAjvInstance()?.ajvErrorsToOneFormError(
               (schemaValidatorRef.current as ValidateFunction).errors,
               value
             )

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajv.ts
@@ -1,14 +1,23 @@
 import Ajv from 'ajv/dist/2020.js'
 import ajvErrors from 'ajv-errors'
+import {
+  ajvErrorsToFormErrors,
+  ajvErrorsToOneFormError,
+} from './ajvErrors'
 
 export { Ajv }
+
+export type AjvInstance = Ajv & {
+  ajvErrorsToFormErrors: typeof ajvErrorsToFormErrors
+  ajvErrorsToOneFormError: typeof ajvErrorsToOneFormError
+}
 
 /**
  * Creates or enhances an Ajv instance.
  * If no instance is provided, a new one is created with allErrors option enabled.
  * The ajv-errors plugin is added to the instance if it hasn't been added yet.
  */
-export function makeAjvInstance(instance?: Ajv): Ajv {
+export function makeAjvInstance(instance?: Ajv): AjvInstance {
   return enhanceAjvInstance(instance || new Ajv({ allErrors: true }))
 }
 
@@ -18,11 +27,14 @@ export function makeAjvInstance(instance?: Ajv): Ajv {
  * @param instance - Optional custom instance of Ajv.
  * @returns The created or provided instance of Ajv.
  */
-export function enhanceAjvInstance(instance?: Ajv): Ajv {
+export function enhanceAjvInstance(instance?: Ajv): AjvInstance {
   if (!instance['__ajvErrors__']) {
     ajvErrors(instance)
     instance['__ajvErrors__'] = true
   }
 
-  return instance
+  instance['ajvErrorsToFormErrors'] = ajvErrorsToFormErrors
+  instance['ajvErrorsToOneFormError'] = ajvErrorsToOneFormError
+
+  return instance as AjvInstance
 }


### PR DESCRIPTION
Our own `ajvErrorsToFormErrors` and `ajvErrorsToOneFormError` functions where still a part of the bundle, even when no Ajv was used. 

Related PR #7389 and [comment](https://github.com/dnbexperience/eufemia/pull/7389#issuecomment-4241900456).

<img width="329" height="218" alt="Screenshot 2026-04-14 at 09 08 27" src="https://github.com/user-attachments/assets/d73566d8-d658-463e-b826-e3d77eab5c26" />
