### PR TITLE
refactor(FormStatus): type icon props with React.SVGProps

### DIFF
--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -157,37 +157,33 @@ export type FormStatusProps = {
 > &
   SpacingProps
 
-export type ErrorIconProps = {
+export type ErrorIconProps = React.SVGProps<SVGSVGElement> & {
   /**
    * The `title` attribute in the status.
    */
   title?: string
   state?: FormStatusState
-  [key: string]: any
 }
-export type WarnIconProps = {
+export type WarnIconProps = React.SVGProps<SVGSVGElement> & {
   /**
    * The `title` attribute in the status.
    */
   title?: string
   state?: FormStatusState
-  [key: string]: any
 }
-export type InfoIconProps = {
+export type InfoIconProps = React.SVGProps<SVGSVGElement> & {
   /**
    * The `title` attribute in the status.
    */
   title?: string
   state?: FormStatusState
-  [key: string]: any
 }
-export type MarketingIconProps = {
+export type MarketingIconProps = React.SVGProps<SVGSVGElement> & {
   /**
    * The `title` attribute in the status.
    */
   title?: string
   state?: FormStatusState
-  [key: string]: any
 }
 
 export type FormStatusIcon =

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -219,13 +219,13 @@ describe('Icon component', () => {
   it('should detect medium size from a direct function icon with minified name', () => {
     // Direct function (not wrapped in JSX) with short name — tests the
     // typeof icon === 'function' branch in calcSize
-    const e = (props?: Record<string, unknown>) => (
+    const e = (props?: unknown) => (
       <svg
         width={24}
         height={24}
         viewBox="0 0 24 24"
         fill="none"
-        {...props}
+        {...(props as Record<string, unknown>)}
       >
         <path d="M12 2a10 10 0 100 20 10 10 0 000-20z" />
       </svg>


### PR DESCRIPTION
Replace [key: string]: any index signatures in ErrorIconProps, WarnIconProps, InfoIconProps, and MarketingIconProps with React.SVGProps<SVGSVGElement> intersection type.

