### PR TITLE
fix: replace RefObject<any> with proper function type in modal

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -131,7 +131,9 @@ export default function ModalContent(props: ModalContentProps) {
   // Sync modalContentCloseRef
   useEffect(() => {
     if (modalContentCloseRef) {
-      const mutableRef = modalContentCloseRef as React.RefObject<any>
+      const mutableRef = modalContentCloseRef as React.RefObject<
+        typeof setModalContentState
+      >
       mutableRef.current = setModalContentState
     }
   }, [modalContentCloseRef, setModalContentState])

--- a/packages/dnb-eufemia/src/components/modal/ModalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalRoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ModalContent from './ModalContent'
-import type { ModalContentProps } from './types'
+import type { ModalContentProps, ModalContentCloseHandler } from './types'
 import PortalRoot from '../PortalRoot'
 
 declare global {
@@ -25,7 +25,7 @@ export type ModalRootProps = {
     | ((props: ModalContentProps) => React.ReactNode)
 
   /** For internal use only */
-  modalContentCloseRef?: React.RefObject<any>
+  modalContentCloseRef?: React.RefObject<ModalContentCloseHandler | null>
 } & ModalContentProps
 
 export default function ModalRoot({

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -26,6 +26,10 @@ export type ModalCloseHandlerParams = {
   triggeredBy: ModalTriggeredBy
   triggeredByEvent?: Event
 }
+export type ModalContentCloseHandler = (
+  event: React.SyntheticEvent | Event,
+  options: { triggeredBy?: string }
+) => void
 export type ModalCloseHandler = (params?: ModalCloseHandlerParams) => void
 
 export type ModalProps = ModalRootProps & {
@@ -317,7 +321,7 @@ export type ModalContentProps = {
   contentRef?: React.RefObject<HTMLElement>
   scrollRef?: React.RefObject<HTMLElement>
   open?: boolean
-  modalContentCloseRef?: React.RefObject<any>
+  modalContentCloseRef?: React.RefObject<ModalContentCloseHandler | null>
 }
 
 export type ModalTriggerAttributes = ButtonProps


### PR DESCRIPTION
- Add ModalContentCloseHandler type for the close ref callback
- modalContentCloseRef: RefObject<any> → RefObject<ModalContentCloseHandler | null>

