### PR TITLE
refactor(GlobalStatusProvider): replace [key: string]: any with unknown

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
@@ -21,13 +21,13 @@ type StatusProps = {
   items?: (StatusItem | string)[] | string
   item?: StatusItem | string
   bufferDelay?: number
-  [key: string]: any
+  [key: string]: unknown
 }
 
 type StatusItem = {
   itemId?: string
-  text?: any
-  [key: string]: any
+  text?: ReactNode
+  [key: string]: unknown
 }
 
 export type GlobalStatusResult = {


### PR DESCRIPTION
Replace [key: string]: any index signatures in StatusProps and StatusItem with [key: string]: unknown for stricter internal type safety. Also type StatusItem.text as ReactNode instead of any.

