### PR TITLE
chore: stop AI agents from auto-updating changelog files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@
 - Write concise code and add comments only when they clarify intent.
 - Gather all required information from the documentation before using it as a reference.
 - Do not make assumptions or infer missing details unless explicitly instructed to do so.
-- Update `EUFEMIA_CHANGELOG.mdx` whenever a new component is added or a significant visual change is made to an existing component.
-- For Eufemia Forms changes, also `/forms/changelog.mdx` when relevant.
+- Do NOT update changelog files (such as `EUFEMIA_CHANGELOG.mdx` or `changelog.mdx`) unless the user explicitly asks you to. Changelog entries should be written by humans.
 
 ## Code Style Rules
 


### PR DESCRIPTION
As we most likely do not want to have entries in our changelog files, based on previous PR experiences.