### PR TITLE
chore(Currency): fix inconsistent quoting in currencyDisplay type array

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/CurrencyDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/CurrencyDocs.ts
@@ -13,7 +13,7 @@ export const CurrencyProperties: PropertiesTableProps = {
   },
   currencyDisplay: {
     doc: 'Defines the currency display style. When set to `code`, the currency code is rendered before the amount. Defaults to `narrowSymbol`.',
-    type: ['"code"', 'symbol', 'narrowSymbol', '"name"', 'false'],
+    type: ['"code"', '"symbol"', '"narrowSymbol"', '"name"', 'false'],
     status: 'optional',
   },
   ...props,


### PR DESCRIPTION
Fixed 'symbol' and 'narrowSymbol' to use proper quoted string literals ('"symbol"' and '"narrowSymbol"') matching the pattern used by all other Docs.ts type arrays.

