### PR TITLE
chore(Switch): remove incorrect (required) from title JSDoc

### DIFF
--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -59,7 +59,7 @@ export type SwitchProps = {
    */
   labelSrOnly?: boolean
   /**
-   * <em>(required)</em> the `title` of the input - describing it a bit further for accessibility reasons.
+   * The `title` of the input - describing it a bit further for accessibility reasons.
    */
   title?: string
   /**


### PR DESCRIPTION
The title prop is optional (title?: string) and SwitchDocs.ts correctly lists it as optional. The JSDoc incorrectly stated it was required.

