### PR TITLE
chore(PhoneNumber): use union type for countries prop

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumberDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumberDocs.ts
@@ -6,7 +6,7 @@ import { FieldProperties } from '../../Field/FieldDocs'
 export const PhoneNumberProperties: PropertiesTableProps = {
   countries: {
     doc: 'List only a certain set of countries: `Scandinavia`, `Nordic`, `Europe` or `Prioritized`(all countries [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCountry/#filter-or-prioritize-country-listing)). Defaults to `Prioritized`.',
-    type: 'string',
+    type: ['"Scandinavia"', '"Nordic"', '"Europe"', '"Prioritized"'],
     status: 'optional',
   },
   filterCountries: {


### PR DESCRIPTION
Changed type from generic 'string' to specific union of allowed values matching the CountryFilterSet TS type: Scandinavia, Nordic, Europe, Prioritized.

