### PR TITLE
chore(Button): add missing surface prop documentation

### DIFF
--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -27,7 +27,7 @@ export const ButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
   surface: {
-    doc: 'Used to override the `surface` value from `Theme.Context`. Changes component style based on background. Defaults to `"default"` if there is no `Theme.Context`.',
+    doc: 'Used to override the `surface` value from `Theme.Context`. Changes component style based on background. Defaults to `undefined` if there is no `Theme.Context`.',
     type: ['"default"', '"dark"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -26,6 +26,11 @@ export const ButtonProperties: PropertiesTableProps = {
     type: ['"primary"', '"secondary"', '"tertiary"', '"unstyled"'],
     status: 'optional',
   },
+  surface: {
+    doc: 'Used to override the `surface` value from `Theme.Context`. Changes component style based on background. Defaults to `"default"` if there is no `Theme.Context`.',
+    type: ['"default"', '"dark"'],
+    status: 'optional',
+  },
   size: {
     doc: 'The size of the button. There is `default`, `small`, `medium`  and `large`. The `tertiary` button officially supports only default and large. Changing the size mainly affects spacing, but the large tertiary button also has a larger font size.',
     type: ['"default"', '"small"', '"medium"', '"large"'],


### PR DESCRIPTION
The surface prop exists in Button's TS type with JSDoc but was missing from ButtonDocs.ts. Added it with the correct ThemeSurface union type.

