### PR TITLE
chore(FieldBlock): align internal labelSize type with TS definition

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
@@ -73,7 +73,7 @@ export const FieldBlockProperties: PropertiesTableProps = {
   ...FieldBlockSharedProperties,
   labelSize: {
     doc: 'Define one of the following [heading sizes](/uilib/elements/heading/): `medium` or `large`.',
-    type: ['string', 'false'],
+    type: ['"medium"', '"large"'],
     status: 'optional',
   },
   labelHeight: {


### PR DESCRIPTION
The internal FieldBlockProperties override used ['string', 'false'] for labelSize, but the TS type is 'medium' | 'large'. Aligned with the shared definition which correctly uses ['"medium"', '"large"'].

