### PR TITLE
chore(Section): add missing element prop documentation

### DIFF
--- a/packages/dnb-eufemia/src/components/section/SectionDocs.ts
+++ b/packages/dnb-eufemia/src/components/section/SectionDocs.ts
@@ -56,6 +56,11 @@ export const SectionProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  element: {
+    doc: 'Define what HTML element should be used. Defaults to `<section>`.',
+    type: ['string', 'React.Element'],
+    status: 'optional',
+  },
   ref: {
     doc: 'By providing a React Ref we can get the internally used element (DOM). E.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
     type: 'React.RefObject',


### PR DESCRIPTION
The element prop (DynamicElement) exists in Section's TS type with JSDoc but was missing from SectionDocs.ts.

Not sure if we should document this property? It's not marked as internal or private in JSDoc

