### PR TITLE
chore(Bring): document snake_case types as external API contracts

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -30,6 +30,11 @@ export type SupportedCountries = (typeof supportedCountryCodes)[number]
 export const unsupportedCountryMessage =
   'Postal code verification is not supported for {countryCode}.'
 
+/**
+ * Mirrors the Bring Address API response format.
+ * Property names use snake_case to match the external API contract.
+ * @see https://developer.bring.com/api/address/
+ */
 export type AddressResolverData = {
   addresses: {
     street_name: string

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -39,6 +39,11 @@ type AutofillHandlerConfig = HandlerConfig & {
 export const unsupportedCountryCodeMessage =
   'Postal code verification is not supported for {countryCode}.'
 
+/**
+ * Mirrors the Bring Postal Code API response format.
+ * Property names use snake_case to match the external API contract.
+ * @see https://developer.bring.com/api/postal-code/
+ */
 export type PostalCodeResolverData = {
   postal_codes: { postal_code: string; city: string }[]
 }


### PR DESCRIPTION
The PostalCodeResolverData and AddressResolverData types intentionally use snake_case property names to match the Bring postal/address API response format. Added JSDoc comments to clarify this is by design.

