### PR TITLE
chore(Popover): fix missing quotes in autoAlignMode type array

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/PopoverDocs.ts
+++ b/packages/dnb-eufemia/src/components/popover/PopoverDocs.ts
@@ -207,7 +207,7 @@ export const PopoverProperties: PropertiesTableProps = {
   },
   autoAlignMode: {
     doc: "Control when the popover automatically flips its placement to fit within the viewport. `initial` (default): Flip placement only on initial open when there's limited space. `scroll`: Flip placement on initial open and during scroll events. `never`: Never automatically flip placement, always use the specified `placement` property.",
-    type: ['"initial"', '"scroll"', 'never'],
+    type: ['"initial"', '"scroll"', '"never"'],
     defaultValue: 'initial',
     status: 'optional',
   },


### PR DESCRIPTION
'never' was missing inner double-quotes, inconsistent with the other values in the same array.

