### PR TITLE
chore(NumberFormat): fix missing quotes in signDisplay type array

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
@@ -68,7 +68,7 @@ export const NumberFormatProperties: PropertiesTableProps = {
   },
   signDisplay: {
     doc: 'When to display the sign for the number. Use `auto` (default) for negative numbers only, `always` to always display sign, `exceptZero` for positive and negative numbers but not zero, `negative` for negative numbers only including negative zero, or `never` to never display sign.',
-    type: ['"auto"', '"always"', 'exceptZero', '"negative"', 'never'],
+    type: ['"auto"', '"always"', '"exceptZero"', '"negative"', '"never"'],
     status: 'optional',
   },
   prefix: {


### PR DESCRIPTION
'exceptZero' and 'never' were missing inner double-quotes, inconsistent with the other values in the same array.

