### PR TITLE
chore(Heading): clean up JSDoc for text and size props

### DIFF
--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -70,12 +70,12 @@ export type HeadingProps = {
   group?: string
 
   /**
-   * <em>(required)</em> a heading, can be text or React.ReactNode.
+   * A heading, can be text or React.ReactNode.
    */
   text?: React.ReactNode
 
   /**
-   * Define the typography <a href="/uilib/typography/font-size">font-size</a> by a size <em>type</em>, e.g. `x-large`. Defaults to the predefined heading sizes.
+   * Define the typography font-size by a size type, e.g. `x-large`. Defaults to the predefined heading sizes.
    */
   size?: HeadingSize
   level?: HeadingLevel


### PR DESCRIPTION
Removed incorrect '<em>(required)</em>' from text prop JSDoc (prop is optional). Replaced HTML tags in size JSDoc with plain text for consistency with other component JSDoc.

