### PR TITLE
chore(FieldBlock): use union type for layout prop

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
@@ -43,7 +43,7 @@ export const FieldBlockSharedProperties: PropertiesTableProps = {
   },
   layout: {
     doc: 'Layout for the label and input. Can be `horizontal` or `vertical`.',
-    type: 'string',
+    type: ['"horizontal"', '"vertical"'],
     status: 'optional',
   },
   layoutOptions: {


### PR DESCRIPTION
Changed from generic 'string' to specific union matching the TS type: 'vertical' | 'horizontal'.

