### PR TITLE
chore(Input): use union type for align prop

### DIFF
--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -8,7 +8,7 @@ export const InputProperties: PropertiesTableProps = {
   },
   align: {
     doc: 'Defines the text alignment of the input. Can be `left`, `right` or `center`. Defaults to `left`.',
-    type: 'string',
+    type: ['"left"', '"center"', '"right"'],
     status: 'optional',
   },
   label: {


### PR DESCRIPTION
Changed from generic 'string' to specific union matching the InputAlign TS type: 'left' | 'center' | 'right'.

