### PR TITLE
chore(Section): list specific variant values in type

### DIFF
--- a/packages/dnb-eufemia/src/components/section/SectionDocs.ts
+++ b/packages/dnb-eufemia/src/components/section/SectionDocs.ts
@@ -3,7 +3,14 @@ import type { PropertiesTableProps } from '../../shared/types'
 export const SectionProperties: PropertiesTableProps = {
   variant: {
     doc: 'Defines the semantic purpose and subsequently the style of the visual helper.',
-    type: 'string',
+    type: [
+      '"error"',
+      '"information"',
+      '"warning"',
+      '"success"',
+      '"divider"',
+      'string',
+    ],
     status: 'optional',
   },
   breakout: {


### PR DESCRIPTION
Changed from generic 'string' to list the known SectionVariants union values (error, information, warning, success, divider) alongside generic string, matching the TS type SectionVariants | string.

