### PR TITLE
chore(DrawerList): use union type for direction prop

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -28,7 +28,7 @@ export const DrawerListProperties: PropertiesTableProps = {
   },
   direction: {
     doc: "Defines the direction of how the drawer-list shows the options list. Can be 'bottom' or 'top'. Defaults to 'auto'.",
-    type: 'string',
+    type: ['"auto"', '"top"', '"bottom"'],
     status: 'optional',
   },
   labelDirection: {


### PR DESCRIPTION
Changed from generic 'string' to specific union matching the TS type: 'auto' | 'top' | 'bottom'.

