### PR TITLE
chore(ViewContainer): use specific union types

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainerDocs.ts
@@ -8,7 +8,7 @@ export const ViewContainerProperties: PropertiesTableProps = {
   },
   variant: {
     doc: 'Defines the variant of the container. Can be `outline`, `filled` or `basic`. Defaults to `outline`.',
-    type: 'string',
+    type: ['"outline"', '"filled"', '"basic"'],
     status: 'optional',
   },
   toolbar: {
@@ -18,7 +18,7 @@ export const ViewContainerProperties: PropertiesTableProps = {
   },
   toolbarVariant: {
     doc: 'Use variants to render the toolbar differently. Currently there are the `minimumOneItem` and `custom` variants. See the info section for more info.',
-    type: 'string',
+    type: ['"minimumOneItem"', '"custom"'],
     status: 'optional',
   },
   '[FlexVertical](/uilib/layout/flex/container/properties)': {


### PR DESCRIPTION
Replace generic 'string' with union types for variant and toolbarVariant properties.

