### PR TITLE
chore(Element): use union type for skeletonMethod and fix doc typo form→code

### DIFF
--- a/packages/dnb-eufemia/src/elements/ElementDocs.ts
+++ b/packages/dnb-eufemia/src/elements/ElementDocs.ts
@@ -26,8 +26,8 @@ export const ElementProperties: PropertiesTableProps = {
     status: 'optional',
   },
   skeletonMethod: {
-    doc: 'Can be `shape`, `font` or `form`. Defaults to `font`.',
-    type: 'string',
+    doc: 'Can be `shape`, `font` or `code`. Defaults to `font`.',
+    type: ['"shape"', '"font"', '"code"'],
     status: 'optional',
   },
 }


### PR DESCRIPTION
The TS type is 'shape' | 'font' | 'code' but docs incorrectly said 'form'.

