### PR TITLE
chore(ChildrenWithAge): correct mode type from 'number' to union type

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
@@ -3,7 +3,7 @@ import type { PropertiesTableProps } from '../../../../shared/types'
 export const ChildrenWithAgeProperties: PropertiesTableProps = {
   mode: {
     doc: '`summary` for a `Value.*` version, `edit` for an editable field version. Defaults to `edit`.',
-    type: 'number',
+    type: ['"edit"', '"summary"'],
     status: 'optional',
   },
   enableAdditionalQuestions: {


### PR DESCRIPTION
The TS type is 'edit' | 'summary', not number.

