### PR TITLE
chore: correct filter type from 'string' to 'function' in CountDocs.ts

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/CountDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/CountDocs.ts
@@ -13,7 +13,7 @@ export const CountProperties: PropertiesTableProps = {
   },
   filter: {
     doc: 'A filter function to filter the data before counting.',
-    type: 'string',
+    type: 'function',
     status: 'optional',
   },
 }


### PR DESCRIPTION
The TS type is (item: unknown) => boolean, not string.

