### PR TITLE
fix(StyleIsolation): handle `:global(html[attr]) &` when used in CSS module

### DIFF
--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
@@ -1265,6 +1265,38 @@ describe('isolated-style-scope-plugin', () => {
           { runAsCssModule: true, scopeHash: 'test-scope' }
         )
       })
+
+      it('should scope class after :global(html[data-attr])', async () => {
+        return await run(
+          ':global(html[data-visual-test]) .someClass { color: red; }',
+          'html[data-visual-test] :global(.test-scope) .someClass { color: red; }',
+          { runAsCssModule: true, scopeHash: 'test-scope' }
+        )
+      })
+
+      it('should scope class with pseudo-element after :global(html[data-attr])', async () => {
+        return await run(
+          ':global(html[data-visual-test]) .someClass::after { color: red; }',
+          'html[data-visual-test] :global(.test-scope) .someClass::after { color: red; }',
+          { runAsCssModule: true, scopeHash: 'test-scope' }
+        )
+      })
+
+      it('should not scope :global(html) alone', async () => {
+        return await run(
+          ':global(html) { color: red; }',
+          ':global(html) { color: red; }',
+          { runAsCssModule: true, scopeHash: 'test-scope' }
+        )
+      })
+
+      it('should scope class after :global(body[data-attr])', async () => {
+        return await run(
+          ':global(body[data-theme]) .someClass { color: red; }',
+          'body[data-theme] :global(.test-scope) .someClass { color: red; }',
+          { runAsCssModule: true, scopeHash: 'test-scope' }
+        )
+      })
     })
   })
 

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
@@ -252,6 +252,52 @@ const postcssIsolateStyle = (opts = {}) => {
                 }
               }
 
+              // 5b. handle `:global(html[...])` or `:global(body[...])` —
+              // extract the html/body (with attrs/pseudos) out of :global()
+              // so the scope is inserted after html/body, not before it.
+              if (
+                group.nodes[i]?.type === 'pseudo' &&
+                group.nodes[i].value === ':global' &&
+                group.nodes[i].nodes?.length === 1
+              ) {
+                const innerSelector = group.nodes[i].nodes[0]
+                const firstInner = innerSelector.nodes?.[0]
+                if (
+                  firstInner?.type === 'tag' &&
+                  ['html', 'body'].includes(firstInner.value)
+                ) {
+                  // Extract all nodes from :global(...) and place them
+                  // directly into the group at position i
+                  const extractedNodes = [...innerSelector.nodes]
+                  group.nodes.splice(i, 1, ...extractedNodes)
+
+                  // Now skip past the html/body tag and its attrs/pseudos
+                  i++ // skip html/body tag
+                  while (
+                    group.nodes[i] &&
+                    (group.nodes[i].type === 'pseudo' ||
+                      group.nodes[i].type === 'attribute')
+                  ) {
+                    i++
+                  }
+                  // skip body after html if present
+                  if (
+                    group.nodes[i]?.type === 'combinator' &&
+                    group.nodes[i + 1]?.type === 'tag' &&
+                    group.nodes[i + 1].value === 'body'
+                  ) {
+                    i += 2
+                    while (
+                      group.nodes[i] &&
+                      (group.nodes[i].type === 'pseudo' ||
+                        group.nodes[i].type === 'attribute')
+                    ) {
+                      i++
+                    }
+                  }
+                }
+              }
+
               // now skip an initial html (and optional body) just like before
               if (
                 group.nodes[i]?.type === 'tag' &&


### PR DESCRIPTION
Found while working on #7429 – so its needed for further progress.