### PR TITLE
chore: show data-visual-test ID in visual diff report

### DIFF
--- a/tools/jest-image-snapshot-reporter/jest-reporter.js
+++ b/tools/jest-image-snapshot-reporter/jest-reporter.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const ansiHTML = require('ansi-html-community')
 
-function extractDataVisualTestId(testFilePath, title) {
+function extractTestMetadata(testFilePath, title) {
   try {
     const content = fs.readFileSync(testFilePath, 'utf-8')
 
@@ -10,20 +10,22 @@ function extractDataVisualTestId(testFilePath, title) {
     const titleIndex = content.search(new RegExp(escapedTitle))
 
     if (titleIndex === -1) {
-      return null
+      return { dataVisualTestId: null, lineNumber: null }
     }
+
+    // Count lines up to the match to get the line number
+    const lineNumber = content.substring(0, titleIndex).split('\n').length
 
     // Search forward from the it() title to find data-visual-test in the same block
     const searchContent = content.substring(titleIndex, titleIndex + 2000)
     const match = searchContent.match(/data-visual-test="([^"]+)"/)
 
-    if (match) {
-      return match[1]
+    return {
+      dataVisualTestId: match ? match[1] : null,
+      lineNumber,
     }
-
-    return null
   } catch (e) {
-    return null
+    return { dataVisualTestId: null, lineNumber: null }
   }
 }
 
@@ -62,18 +64,20 @@ class JestReporter {
                 failureMessage.replace(cwd, '').replace(/\n/g, '<br />')
               )
 
-              const dataVisualTestId = extractDataVisualTestId(
+              const { dataVisualTestId, lineNumber } = extractTestMetadata(
                 testFilePath,
                 title
               )
 
               reports.push({
+                testFilePath,
                 relativeTestFilePath,
                 message,
                 relativeImgPath,
                 absoluteImgPath,
                 fullName,
                 dataVisualTestId,
+                lineNumber,
               })
             }
           })
@@ -108,8 +112,10 @@ class JestReporter {
             message,
             absoluteImgPath,
             relativeImgPath,
+            testFilePath,
             relativeTestFilePath,
             dataVisualTestId,
+            lineNumber,
           },
           i
         ) => {
@@ -146,7 +152,7 @@ class JestReporter {
               <dl class="dnb-dl">
                 <dt class="dnb-lead">${fullName}</dt>
                 <dd>
-                  <p class="dnb-lead"><code>${relativeTestFilePath}</code></p>
+                  <p class="dnb-lead"><a href="vscode://file${testFilePath}${lineNumber ? ':' + lineNumber : ''}"><code>${relativeTestFilePath}${lineNumber ? ':' + lineNumber : ''}</code></a></p>
                   ${visualTestIdHtml}
                   <p>${message}</p>
                   ${image}

--- a/tools/jest-image-snapshot-reporter/jest-reporter.js
+++ b/tools/jest-image-snapshot-reporter/jest-reporter.js
@@ -2,6 +2,31 @@ const fs = require('fs')
 const path = require('path')
 const ansiHTML = require('ansi-html-community')
 
+function extractDataVisualTestId(testFilePath, title) {
+  try {
+    const content = fs.readFileSync(testFilePath, 'utf-8')
+
+    const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const titleIndex = content.search(new RegExp(escapedTitle))
+
+    if (titleIndex === -1) {
+      return null
+    }
+
+    // Search forward from the it() title to find data-visual-test in the same block
+    const searchContent = content.substring(titleIndex, titleIndex + 2000)
+    const match = searchContent.match(/data-visual-test="([^"]+)"/)
+
+    if (match) {
+      return match[1]
+    }
+
+    return null
+  } catch (e) {
+    return null
+  }
+}
+
 class JestReporter {
   onRunComplete(contexts, { testResults, numFailedTests }) {
     if (numFailedTests === 0) {
@@ -20,7 +45,7 @@ class JestReporter {
           .filter(({ status }) => {
             return status === 'failed'
           })
-          .forEach(({ failureDetails, fullName }) => {
+          .forEach(({ failureDetails, fullName, title }) => {
             const failureMessage = failureDetails[0].matcherResult?.message
 
             if (failureMessage) {
@@ -37,12 +62,18 @@ class JestReporter {
                 failureMessage.replace(cwd, '').replace(/\n/g, '<br />')
               )
 
+              const dataVisualTestId = extractDataVisualTestId(
+                testFilePath,
+                title
+              )
+
               reports.push({
                 relativeTestFilePath,
                 message,
                 relativeImgPath,
                 absoluteImgPath,
                 fullName,
+                dataVisualTestId,
               })
             }
           })
@@ -78,6 +109,7 @@ class JestReporter {
             absoluteImgPath,
             relativeImgPath,
             relativeTestFilePath,
+            dataVisualTestId,
           },
           i
         ) => {
@@ -105,12 +137,17 @@ class JestReporter {
             `
             : ''
 
+          const visualTestIdHtml = dataVisualTestId
+            ? /* jsx */ `<p><b><code class="copy-id" onclick="navigator.clipboard.writeText('${dataVisualTestId}').then(() => { this.classList.add('copied'); setTimeout(() => this.classList.remove('copied'), 1000) })">data-visual-test="${dataVisualTestId}"</code></b></p>`
+            : ''
+
           return /* jsx */ `
             <li>
               <dl class="dnb-dl">
                 <dt class="dnb-lead">${fullName}</dt>
                 <dd>
                   <p class="dnb-lead"><code>${relativeTestFilePath}</code></p>
+                  ${visualTestIdHtml}
                   <p>${message}</p>
                   ${image}
                 </dd>
@@ -161,6 +198,23 @@ class JestReporter {
           transform: scale(2) translate3d(25%, 25%, 0);
           position: relative;
           z-index: 1;
+        }
+
+        .copy-id {
+          cursor: pointer;
+          user-select: all;
+          position: relative;
+        }
+
+        .copy-id:hover {
+          background-color: var(--color-mint-green-25);
+        }
+
+        .copy-id.copied::after {
+          content: 'Copied!';
+          margin-left: 0.5rem;
+          color: var(--color-sea-green);
+          white-space: nowrap;
         }
       </style>
     </head>


### PR DESCRIPTION
Make it easier to find related test:

<img width="764" height="363" alt="Screenshot 2026-04-15 at 09 08 23" src="https://github.com/user-attachments/assets/66f0fe9b-7729-4670-9796-57e9decbc7d8" />

Also, when clicking on it:

<img width="310" height="93" alt="Screenshot 2026-04-15 at 09 10 47" src="https://github.com/user-attachments/assets/82f5991d-ab83-47a3-b380-72da48a45fed" />

Also, make the file clickable so it opens in the code editor on the exact line:

<img width="764" height="280" alt="Screenshot 2026-04-15 at 09 17 53" src="https://github.com/user-attachments/assets/75e3dcca-b2c8-45fe-90dd-4eb19951807f" />
