### PR TITLE
refactor: rename extendPropsWithContextInClassComponent to extendExistingPropsWithContext

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx'
 import Context from '../../shared/Context'
 import {
   warn,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   removeUndefinedProps,
   validateDOMAttributes,
   processChildren,
@@ -255,12 +255,9 @@ function Button({ ref, ...restProps }: ButtonProps) {
     null
   )
 
-  // use only the props from context, who are available here anyway
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     {
       ...buttonDefaultProps,
-      // Strip undefined values so they fall through to defaults,
-      // preserving the legacy React defaultProps behavior.
       ...removeUndefinedProps({ ...restProps }),
     },
     buttonDefaultProps,

--- a/packages/dnb-eufemia/src/components/modal/parts/CloseButton.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/CloseButton.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import clsx from 'clsx'
-import { extendPropsWithContextInClassComponent } from '../../../shared/component-helper'
+import { extendExistingPropsWithContext } from '../../../shared/component-helper'
 import Button from '../../button/Button'
 import Context from '../../../shared/Context'
 import type { ButtonProps } from '../../button/Button'
@@ -27,7 +27,7 @@ function CloseButton(props: CloseButtonProps) {
     iconPosition = 'left',
     className = null,
     ...buttonProps
-  } = extendPropsWithContextInClassComponent(
+  } = extendExistingPropsWithContext(
     props,
     {
       closeTitle: null,

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
@@ -13,7 +13,7 @@ import {
   warn,
   validateDOMAttributes,
   convertJsxToString,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   extendDeep,
   detectOutsideClick,
   isTouchDevice,
@@ -357,10 +357,7 @@ function NumberFormat(ownProps: NumberFormatAllProps) {
   const translations = context.getTranslation?.(propsWithDefaults)
     ?.NumberFormat as Record<string, string> | undefined
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in numberFormatDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     propsWithDefaults,
     numberFormatDefaultProps,
     translations as Record<string, unknown>,

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -8,7 +8,7 @@ import PaginationContext from './PaginationContext'
 import PaginationProvider from './PaginationProvider'
 import {
   validateDOMAttributes,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import { createSpacingClasses } from '../space/SpacingHelper'
@@ -308,10 +308,7 @@ const PaginationInstance = React.memo(function PaginationInstance(
   const ctx = useContext(PaginationContext)
   const contentRef = useRef<HTMLDivElement | null>(null)
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in paginationDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     ownProps,
     paginationDefaultProps,
     ctx.getTranslation(ownProps).Pagination,

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -7,7 +7,7 @@ import React, { useContext, useRef, useState, useCallback } from 'react'
 import clsx from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
@@ -299,24 +299,19 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
     [isPlainGroup, callOnChange]
   )
 
-  // Strip undefined values so they fall through to defaults,
-  // preserving the legacy React defaultProps behavior.
   const resolvedProps = {
     ...radioDefaultProps,
     ...removeUndefinedProps({ ...ownProps }),
   }
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in radioDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const contextProps = extendPropsWithContextInClassComponent(
+  const contextProps = extendExistingPropsWithContext(
     resolvedProps,
     radioDefaultProps,
     groupContext as Record<string, unknown>
   )
 
   // use only the props from context, who are available here anyway
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     resolvedProps,
     radioDefaultProps,
     contextProps,

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -6,7 +6,7 @@ import React, { useContext, useRef, useState, useCallback } from 'react'
 import clsx from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
@@ -159,10 +159,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
     ...removeUndefinedProps({ ...ownProps }),
   }
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in radioGroupDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     resolvedProps,
     radioGroupDefaultProps,
     pickFormElementProps(context?.formElement),

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
@@ -1,14 +1,11 @@
 /**
  * Web Skeleton Component
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 
 import React from 'react'
 import clsx from 'clsx'
 import {
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   removeUndefinedProps,
   validateDOMAttributes,
 } from '../../shared/component-helper'
@@ -68,7 +65,7 @@ export type SkeletonProps = {
 
 const skeletonDefaultProps = {
   show: null,
-  skeleton: null, // only to make sure we process extendPropsWithContextInClassComponent
+  skeleton: null,
   noAnimation: null,
   figure: null,
   ariaBusy: null,
@@ -86,11 +83,9 @@ function Skeleton(props: SkeletonProps) {
 
   const getProps = React.useCallback(
     (propsToExtend = props, ctx = context) => {
-      return extendPropsWithContextInClassComponent(
+      return extendExistingPropsWithContext(
         {
           ...skeletonDefaultProps,
-          // Strip undefined values so they fall through to defaults,
-          // preserving the legacy React defaultProps behavior.
           ...removeUndefinedProps({ ...propsToExtend }),
         },
         skeletonDefaultProps,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
   warn,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
@@ -234,17 +234,14 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     ...removeUndefinedProps({ ...ownProps }),
   }
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in toggleButtonDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const contextProps = extendPropsWithContextInClassComponent(
+  const contextProps = extendExistingPropsWithContext(
     resolvedProps,
     toggleButtonDefaultProps,
     groupContext as Record<string, unknown>
   )
 
   // use only the props from context, who are available here anyway
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     resolvedProps,
     toggleButtonDefaultProps,
     contextProps,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -7,7 +7,7 @@ import React, { useContext, useRef, useState, useCallback } from 'react'
 import clsx from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
@@ -144,10 +144,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
     ...removeUndefinedProps({ ...ownProps }),
   }
 
-  // Uses extendPropsWithContextInClassComponent (onlyMergeExistingProps: true)
-  // to prevent context props not defined in toggleButtonGroupDefaultProps from
-  // leaking into the component and potentially reaching DOM attributes.
-  const props = extendPropsWithContextInClassComponent(
+  const props = extendExistingPropsWithContext(
     resolvedProps,
     toggleButtonGroupDefaultProps,
     (

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
@@ -1,8 +1,5 @@
 /**
  * Web PaymentCard Component
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 import React, { useContext } from 'react'
 import clsx from 'clsx'
@@ -10,7 +7,7 @@ import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
 import {
   validateDOMAttributes,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import { createSpacingClasses } from '../../components/space/SpacingHelper'
@@ -138,12 +135,9 @@ const paymentCardDefaultProps = {
 function PaymentCard(props: PaymentCardProps) {
   const context = useContext(Context)
 
-  // use only the props from context, who are available here anyway
-  const extendedProps = extendPropsWithContextInClassComponent(
+  const extendedProps = extendExistingPropsWithContext(
     {
       ...paymentCardDefaultProps,
-      // Strip undefined values so they fall through to defaults,
-      // preserving the legacy React defaultProps behavior.
       ...removeUndefinedProps({ ...props }),
     },
     paymentCardDefaultProps,
@@ -225,11 +219,9 @@ function PaymentCardContent({
   variant: PaymentCardVariant
 }) {
   const { translation } = useContext(Context)
-  const translations = extendPropsWithContextInClassComponent(
+  const translations = extendExistingPropsWithContext(
     {
       ...translationDefaultPropsProps,
-      // Strip undefined values so they fall through to defaults,
-      // preserving the legacy React defaultProps behavior.
       ...removeUndefinedProps({ ...props }),
     },
     translationDefaultPropsProps,

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -15,7 +15,7 @@ export * from './legacy/component-helper-legacy'
 export { InteractionInvalidation } from './helpers/InteractionInvalidation'
 export {
   extendPropsWithContext,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
 } from './helpers/extendPropsWithContext'
 export { assignPropsWithContext } from './helpers/assignPropsWithContext'
 export { filterProps } from './helpers/filterProps'

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/extendPropsWithContext.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/extendPropsWithContext.test.ts
@@ -1,6 +1,6 @@
 import {
   extendPropsWithContext,
-  extendPropsWithContextInClassComponent,
+  extendExistingPropsWithContext,
 } from '../extendPropsWithContext'
 
 describe('extendPropsWithContext', () => {
@@ -104,13 +104,13 @@ describe('extendPropsWithContext', () => {
   })
 })
 
-describe('extendPropsWithContextInClassComponent', () => {
+describe('extendExistingPropsWithContext', () => {
   it('should use context if not defined in props but in default', () => {
     const defaultProps = { foo: 'should exist' }
-    const props = { ...defaultProps } // Thats how ClassComponents include defaultProps
+    const props = { ...defaultProps }
     const context1 = { foo: 'use this value' }
 
-    const result = extendPropsWithContextInClassComponent(
+    const result = extendExistingPropsWithContext(
       props,
       defaultProps,
       context1
@@ -123,10 +123,10 @@ describe('extendPropsWithContextInClassComponent', () => {
 
   it('should use props if defined in props, but not in default', () => {
     const defaultProps = {}
-    const props = { ...defaultProps, foo: 'use this value' } // Thats how ClassComponents include defaultProps
+    const props = { ...defaultProps, foo: 'use this value' }
     const context1 = { foo: 'bar' }
 
-    const result = extendPropsWithContextInClassComponent(
+    const result = extendExistingPropsWithContext(
       props,
       defaultProps,
       context1
@@ -139,10 +139,10 @@ describe('extendPropsWithContextInClassComponent', () => {
 
   it('should use context if props and default are the same', () => {
     const defaultProps = { foo: 'same' }
-    const props = { ...defaultProps, foo: 'same' } // Thats how ClassComponents include defaultProps
+    const props = { ...defaultProps, foo: 'same' }
     const context1 = { foo: 'use context' }
 
-    const result = extendPropsWithContextInClassComponent(
+    const result = extendExistingPropsWithContext(
       props,
       defaultProps,
       context1

--- a/packages/dnb-eufemia/src/shared/helpers/extendPropsWithContext.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/extendPropsWithContext.ts
@@ -24,7 +24,13 @@ export function extendPropsWithContext<Props>(
   }
 }
 
-export function extendPropsWithContextInClassComponent<Props>(
+/**
+ * Like extendPropsWithContext, but only merges context values
+ * for props that already exist on the props object.
+ * This prevents unknown context keys from leaking into
+ * the component and potentially reaching DOM attributes.
+ */
+export function extendExistingPropsWithContext<Props>(
   props: Props,
   defaults: DefaultsProps = {},
   ...contexts: Contexts


### PR DESCRIPTION
Builds upon https://github.com/dnbexperience/eufemia/pull/7309

Remove class component references from function name, comments,
and test descriptions now that all components are functional.

The function behavior is preserved as it prevents unknown context
keys from leaking into components and reaching DOM attributes.
This is not class-component-specific - it's needed by any component
that receives raw context objects.

Changes:
- Rename extendPropsWithContextInClassComponent → extendExistingPropsWithContext
- Add JSDoc describing the function's actual purpose
- Remove 'legacy component' headers from Skeleton and PaymentCard
- Remove 'legacy React defaultProps behavior' comments
- Remove 'ClassComponents' references from test descriptions
- Remove 'onlyMergeExistingProps' implementation comments