### PR TITLE
fix(GlobalStatus): prevent unintended visibility when show defaults to auto

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -337,7 +337,10 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
     useState<GlobalStatusResult>(() => {
       const provider = GlobalStatusProvider.create(ownProps.id)
       providerRef.current = provider
-      const status = provider.init(ownProps)
+      const status = provider.init({
+        ...ownProps,
+        show: ownProps.show ?? 'auto',
+      })
       globalStatusRef.current = status
       return status
     })
@@ -383,12 +386,12 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
           hadContentRef.current &&
           !hasContent(status) &&
           props.show !== true) ||
-        (typeof status.show !== 'undefined' && !status.show)
+        (typeof status.show !== 'undefined' && status.show !== true)
       ) {
         setIsActive(false)
       } else if (
         props.show === true ||
-        (typeof status.show !== 'undefined' && status.show)
+        (typeof status.show !== 'undefined' && status.show === true)
       ) {
         hadContentRef.current = hasContent(status)
 

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -1095,6 +1095,62 @@ describe('GlobalStatus component', () => {
     expect(element).not.toHaveClass('dnb-global-status--error')
     expect(closeButton.textContent).toContain('Lukk')
   })
+
+  it('should not become visible when rendered without show prop', () => {
+    render(<GlobalStatus id="auto-show-test" autoScroll={false} />)
+
+    const wrapper = document.getElementById('auto-show-test')
+    expect(wrapper).toHaveAttribute('aria-live', 'off')
+    expect(
+      wrapper.querySelector('.dnb-global-status__content')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not become visible after a provider update when show is auto', async () => {
+    render(
+      <>
+        <GlobalStatus id="provider-update-test" autoScroll={false} />
+        <GlobalStatus.Add
+          id="provider-update-test"
+          statusId="temp-status"
+          text="temporary"
+        />
+      </>
+    )
+
+    simulateAnimationEnd()
+
+    render(
+      <GlobalStatus.Remove
+        id="provider-update-test"
+        statusId="temp-status"
+      />
+    )
+
+    await waitFor(() => {
+      const wrapper = document.getElementById('provider-update-test')
+      expect(wrapper).toHaveAttribute('aria-live', 'off')
+    })
+  })
+
+  it('should render with error state when show is true but state prop is not explicitly set', () => {
+    render(
+      <GlobalStatus
+        show={true}
+        autoScroll={false}
+        noAnimation={true}
+        id="state-default-test"
+        text="Failure text"
+        title="Custom Title"
+      />
+    )
+
+    const wrapper = document.getElementById('state-default-test')
+    expect(wrapper).toHaveAttribute('aria-live', 'assertive')
+
+    const status = wrapper.querySelector('.dnb-global-status')
+    expect(status).toHaveClass('dnb-global-status--error')
+  })
 })
 
 describe('GlobalStatus scss', () => {


### PR DESCRIPTION
Issue: https://v11.eufemia-e25.pages.dev/uilib/components/global-status/demos/
Deploy preview: https://fix-global-status-show-auto.eufemia-e25.pages.dev/uilib/components/global-status/demos/

Two issues from the class-to-functional conversion:

1. provider.init() received raw ownProps (show: undefined) instead of
   props with defaults (show: 'auto'). The provider add method sets
   show to true when undefined.

2. The onUpdate callback used truthy/falsy checks instead of strict
   boolean checks. The old class component used isTrue() which only
   returns true for literal true/1. Since 'auto' is truthy, it
   incorrectly triggered setIsActive(true) when any provider update
   occurred.