### PR TITLE
break(Theme)!: remove `propMapping`

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dropdown, Switch } from '@dnb/eufemia/src'
+import { Dropdown } from '@dnb/eufemia/src'
 import { Context } from '@dnb/eufemia/src/shared'
 import {
   getThemes,
@@ -32,23 +32,6 @@ export default function ChangeStyleTheme({ label = null, ...rest } = {}) {
         })
       }}
       {...rest}
-    />
-  )
-}
-
-ChangeStyleTheme.PropMapping = PropMapping
-
-function PropMapping({ enabled, ...props }) {
-  const { propMapping } = getTheme()
-  return (
-    <Switch
-      top
-      label="Toggle Color Mapping"
-      checked={propMapping === 'basis' || enabled}
-      onChange={({ checked }) => {
-        setTheme({ propMapping: checked ? 'basis' : null })
-      }}
-      {...props}
     />
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -730,6 +730,10 @@ If you use any Eufemia context objects directly (e.g. `Wizard.Provider`), update
 
 `Theme.Provider` has been removed.
 
+### Theme `propMapping` removed
+
+The `propMapping` prop has been removed from the `Theme` component. If you relied on it, use CSS custom properties directly on your theme wrapper instead.
+
 ## Components
 
 > Each component section below lists its changes. Behavioral changes and removals are called out separately where applicable. The bulk of per-component changes are snake_case → camelCase renames covered by the [automated migration](#automated-migration-snake_case-to-camelcase) section above.

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
@@ -88,27 +88,3 @@ export const ThemeSurfaceInitial = () => (
     </Section>
   </ComponentBox>
 )
-
-export const ThemeMapping = () => (
-  <ComponentBox>
-    {() => {
-      const MyMapping = styled.div`
-        .eufemia-theme__sbanken.eufemia-theme__prop-mapping--my-mapping {
-          --color-sea-green: var(--sb-color-purple-alternative);
-        }
-      `
-      const CustomComponent = styled(P)`
-        color: var(--color-sea-green);
-      `
-      return (
-        <MyMapping>
-          <Theme name="sbanken">
-            <Theme propMapping="my-mapping">
-              <CustomComponent>Text with custom color</CustomComponent>
-            </Theme>
-          </Theme>
-        </MyMapping>
-      )
-    }}
-  </ComponentBox>
-)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
@@ -4,7 +4,6 @@ showTabs: true
 
 import {
   ThemeBasis,
-  ThemeMapping,
   ThemeSurfaceDark,
   ThemeSurfaceInitial,
 } from 'Docs/uilib/usage/customisation/theming/theme/Examples'
@@ -15,10 +14,6 @@ import ChangeStyleTheme from '../../../../../../core/ChangeStyleTheme'
 ### Basis example
 
 <ThemeBasis />
-
-### Basis example `propMapping`
-
-<ThemeMapping />
 
 ### Surface dark
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -48,62 +48,6 @@ From CSS you can use it as so:
 }
 ```
 
-### Mapping of properties with `propMapping`
-
-In order to change or map CSS properties, you can make use of the `propMapping` solution.
-
-```tsx
-import { Theme, useTheme } from '@dnb/eufemia/shared'
-
-const Component = () => {
-  const theme = useTheme()
-  const { name, propMapping } = theme || {}
-  return 'My Component'
-}
-
-render(
-  <Theme name="sbanken">
-    <App>
-      <Theme propMapping="my-class">
-        <MyComponent />
-      </Theme>
-    </App>
-  </Theme>
-)
-```
-
-The main motivation of this feature is to provide a set of maps you can use in your app (if possible). But it lets you create your own sets as well. To do so:
-
-1. Define an area in your app – it could be your component – and give it a declarative name:
-
-```tsx
-import { Theme } from '@dnb/eufemia/shared'
-
-render(
-  <Theme propMapping="my-maps">
-    <MyComponent />
-  </Theme>
-)
-```
-
-2. Define the needed properties:
-
-**CSS**
-
-```css
-.eufemia-theme__theme-name.eufemia-theme__prop-mapping--my-maps {
-  --color-sea-green: var(--sb-color-purple-alternative);
-}
-```
-
-**SCSS**
-
-```scss
-.eufemia-theme__theme-name.eufemia-theme__prop-mapping--my-maps {
-  --color-sea-green: var(--sb-color-purple-alternative);
-}
-```
-
 ### Theme.Context
 
 You can use `Theme.Context` to provide theme properties to children without adding a wrapper element. This is useful in cases where you don't want to add an extra DOM element, but still want to provide theme context to the children.
@@ -153,7 +97,7 @@ const Component = ({ className ...props }) => {
 render(
   <Theme name="theme-name">
     <App>
-      <Theme propMapping="my-maps" element={Component}>
+      <Theme name="sbanken" element={Component}>
         ...
       </Theme>
     </App>

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -25,7 +25,7 @@ export default function PortalToolsMenu({
   hideWhenMediaLarge = false,
   ...props
 }: Props) {
-  const { skeleton, theme } = React.useContext(Context)
+  const { skeleton } = React.useContext(Context)
 
   return (
     <Drawer
@@ -91,13 +91,6 @@ export default function PortalToolsMenu({
             </Anchor>
           </P>
         </Space>
-
-        {theme.name === 'sbanken' && (
-          <Space top="large">
-            <H2 size="small">Map colors</H2>
-            <ChangeStyleTheme.PropMapping enabled={theme.propMapping} />
-          </Space>
-        )}
 
         <Space top="large">
           <H2 size="small">Helper grid lines</H2>

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -15,7 +15,6 @@ import useMediaQuery from './useMediaQuery'
 export type ThemeNames = 'ui' | 'eiendom' | 'sbanken' | 'carnegie'
 export type ThemeVariants = string
 export type ThemeSizes = 'basis'
-export type PropMapping = string
 export type ContrastMode = boolean
 /**
  * Controls the color scheme. Use `'dark'` or `'light'` to set explicitly, or `'auto'` to follow the user's system preference. Defaults to `undefined`.
@@ -31,7 +30,6 @@ export type ThemeProps = {
   name?: ThemeNames
   variant?: ThemeVariants
   size?: ThemeSizes
-  propMapping?: PropMapping
   contrastMode?: ContrastMode
   colorScheme?: ThemeColorScheme
   surface?: ThemeSurface
@@ -49,7 +47,6 @@ export default function Theme(themeProps: ThemeAllProps) {
     name,
     variant,
     size,
-    propMapping,
     contrastMode,
     colorScheme,
     surface,
@@ -73,7 +70,6 @@ export default function Theme(themeProps: ThemeAllProps) {
       name,
       variant,
       size,
-      propMapping,
       contrastMode,
       colorScheme: activeColorScheme,
       surface,
@@ -140,15 +136,13 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     return className
   }
 
-  const { name, variant, size, propMapping, contrastMode, colorScheme } =
-    theme
+  const { name, variant, size, contrastMode, colorScheme } = theme
 
   return clsx(
     className,
     'eufemia-theme',
     name && `eufemia-theme__${name}`,
     name && variant && `eufemia-theme__${name}--${variant}`,
-    propMapping && `eufemia-theme__prop-mapping--${propMapping}`,
     contrastMode && 'eufemia-theme__contrast-mode',
     colorScheme && `eufemia-theme__color-scheme--${colorScheme}`,
     size && `eufemia-theme__size--${size}`

--- a/packages/dnb-eufemia/src/shared/ThemeDocs.ts
+++ b/packages/dnb-eufemia/src/shared/ThemeDocs.ts
@@ -16,11 +16,6 @@ export const ThemeProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  propMapping: {
-    doc: 'Defines a specific CSS class so you get a declarative way of mapping CSS properties. A set of predefined maps will be available (WIP).',
-    type: 'string',
-    status: 'optional',
-  },
   contrastMode: {
     doc: 'When a component supports a contrast style, it will be used instead for the dedicated area.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -66,16 +66,6 @@ describe('Theme', () => {
     ])
   })
 
-  it('sets prop-mapping as HTML classes', () => {
-    render(<Theme propMapping="basis">content</Theme>)
-
-    const element = document.querySelector('.eufemia-theme')
-    expect(Array.from(element.classList)).toEqual([
-      'eufemia-theme',
-      'eufemia-theme__prop-mapping--basis',
-    ])
-  })
-
   it('sets contrast-mode as HTML classes', () => {
     render(<Theme contrastMode>content</Theme>)
 


### PR DESCRIPTION
Based on #7505
Motivation: Now with tokens I think we should not provide this extra tool anymore.