### PR TITLE
fix(Tabs): fix false overflow detection when tab title contains extra elements

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -514,9 +514,38 @@ function TabsComponent(ownProps: TabsProps) {
     if (!tablistRef.current) {
       return false
     }
-    return (
-      tablistRef.current.scrollWidth - 1 > tablistRef.current.offsetWidth
+
+    const tablistElem = tablistRef.current
+
+    /**
+     * Safari Desktop adds one pixel "on zoom" level 1
+     * therefore we just remove it here
+     */
+    let tolerance = 1
+
+    /**
+     * Components placed in a tab title (e.g. Badge) may add
+     * margin-right to the button for absolute positioning.
+     * On the last tab, this trailing margin inflates
+     * scrollWidth beyond the actual visible content.
+     * Subtract the net trailing margin from the last snap
+     * and its button to avoid false overflow detection.
+     */
+    const lastSnap = tablistElem.querySelector(
+      '.dnb-tabs__button__snap:last-of-type'
     )
+    if (lastSnap) {
+      const lastButton = lastSnap.querySelector('.dnb-tabs__button')
+      if (lastButton) {
+        const buttonMargin =
+          parseFloat(window.getComputedStyle(lastButton).marginRight) || 0
+        const snapMargin =
+          parseFloat(window.getComputedStyle(lastSnap).marginRight) || 0
+        tolerance += Math.max(0, buttonMargin + snapMargin)
+      }
+    }
+
+    return tablistElem.scrollWidth - tolerance > tablistElem.offsetWidth
   }
 
   const setLeftPosition = (scrollLeft: number) => {

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -695,6 +695,46 @@ describe('A single Tab component', () => {
     expect(second).toHaveAttribute('data-tab-key', 'second_key')
     expect(third).toHaveAttribute('data-tab-key', 'third_key')
   })
+
+  it('should not show scroll nav buttons when last tab margin accounts for overflow', () => {
+    const getComputedStyleOrig = window.getComputedStyle
+
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((element) => {
+        const style = getComputedStyleOrig(element)
+        if ((element as Element).classList.contains('dnb-tabs__button')) {
+          return { ...style, marginRight: '16' } as CSSStyleDeclaration
+        }
+        return style
+      })
+
+    render(
+      <Tabs {...props} data={tablistData}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const tablist = document.querySelector('.dnb-tabs__tabs__tablist')
+
+    // scrollWidth slightly exceeds offsetWidth, but within the margin tolerance
+    Object.defineProperty(tablist, 'scrollWidth', {
+      value: 117,
+      configurable: true,
+    })
+    Object.defineProperty(tablist, 'offsetWidth', {
+      value: 100,
+      configurable: true,
+    })
+
+    fireEvent(window, new Event('resize'))
+
+    expect(document.querySelector('.dnb-tabs__tabs')).not.toHaveClass(
+      'dnb-tabs--has-scrollbar'
+    )
+
+    jest.restoreAllMocks()
+  })
 })
 
 describe('Tabs scss', () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1776242936801599
Deploy preview: https://fix-tabs-scroll-nav-button-o-ae9y.eufemia-e25.pages.dev/uilib/components/tabs/demos/#tabs-with-badge-notification
Deploy preview v11 for comparison: https://v11.eufemia-e25.pages.dev/uilib/components/tabs/#tabs-with-badge-notification

Components placed in a tab title (e.g. Badge) may add margin-right to the button for absolute positioning. On the last tab, this trailing margin inflates scrollWidth beyond the actual visible content, causing checkHasScrollbar() to return true and the scroll navigation buttons to appear even when all tabs fit.

Fix checkHasScrollbar() to subtract the net trailing margin from the last snap and its button from the scrollWidth comparison.

Port of fix from main branch.
https://github.com/dnbexperience/eufemia/pull/7503

