### PR TITLE
chore(docs): add v10 support timeline to v11 migration guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -25,6 +25,7 @@ This is the migration guide for @dnb/eufemia v11. It covers all breaking changes
 <Accordion title="Table of contents">
 
 - [Summary of changes](#summary-of-changes)
+- [v10 support timeline](#v10-support-timeline)
 - [Install](#install)
 - [Migration](#migration)
   - [Automated migration: snake_case to camelCase](#automated-migration-snake_case-to-camelcase)
@@ -128,6 +129,16 @@ These components are new in v11:
 
 - **[Menu](/uilib/components/menu/)** — A context menu component that replaces Dropdown's `actionMenu` and `moreMenu` props. Supports `Menu.Button`, `Menu.List`, `Menu.Action`, `Menu.Accordion`, `Menu.Header`, and `Menu.Divider` sub-components.
 - **[List](/uilib/components/list/)** — A layout component for displaying structured lists with support for icons, titles, content, and accordion behavior.
+
+## v10 support timeline
+
+After the v11 release, **v10 will continue to receive critical bug fixes and security patches for 6 months**. During this period:
+
+- **Critical bugs** and **security vulnerabilities** will be patched in v10.
+- **New features** will only be added to v11.
+- **Non-critical bug fixes** will only target v11.
+
+After the 6-month window, v10 will no longer receive updates. We recommend starting your migration early to avoid last-minute pressure.
 
 ## Install
 


### PR DESCRIPTION
Should we add any info regarding v10 support timeline?