### PR TITLE
chore(types): fix React 19 type compatibility for createPortal returns

### DIFF
--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -52,9 +52,7 @@ export function PortalRootProvider(
   return <PortalRootContext value={value}>{children}</PortalRootContext>
 }
 
-function PortalRootInstance(
-  props: PortalRootProps = {}
-): React.JSX.Element {
+function PortalRootInstance(props: PortalRootProps = {}): React.ReactNode {
   const {
     id: idProp,
     insideSelector: insideSelectorProp,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
@@ -151,7 +151,11 @@ function usePreventSubmit() {
   }, [handleSubmit, setFieldEventListener])
 }
 
-function PrerenderPortal({ children }) {
+function PrerenderPortal({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactNode {
   if (typeof document !== 'undefined') {
     return createPortal(children, document.body)
   }


### PR DESCRIPTION
Update return types from React.JSX.Element to React.ReactNode for components that use createPortal, which returns ReactPortal (not assignable to JSX.Element in React 19 types).

Also type PrerenderPortal children prop.

