### PR TITLE
chore: fix two inaccuracies in v11 migration guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -2522,7 +2522,7 @@ A new `detectCountryCode` utility is exported from `@dnb/eufemia/extensions/form
 
 #### Properties
 
-- The `radio-list` variant has been removed. Use [List](/uilib/components/list/) with `variant="radio"` for custom list-based radio layouts ([example](/uilib/extensions/forms/base-fields/Selection/#radio-with-list-composition)).
+- The `radio-list` variant has been removed. Use a composition pattern with [List](/uilib/components/list/) to build custom radio layouts ([example](/uilib/extensions/forms/base-fields/Selection/#radio-with-list-composition)).
 
 #### `autocompleteProps` property
 
@@ -2811,7 +2811,7 @@ Affected components and props:
 | Prop                      | Before                    | After                                          |
 | ------------------------- | ------------------------- | ---------------------------------------------- |
 | `onChange`                | `(...args: any[]) => any` | `(event: AccordionChangeEvent) => void`        |
-| `onInit` (AccordionGroup) | `(...args: any[]) => any` | `(accordion: Record<string, unknown>) => void` |
+| `onInit` (AccordionGroup) | `(...args: any[]) => any` | `(accordion: AccordionInstance) => void` |
 
 #### Tabs
 


### PR DESCRIPTION
- Field.Selection: remove incorrect 'variant="radio"' on List; the replacement is a composition pattern, not a List prop
- AccordionGroup.onInit: fix type from Record<string, unknown> to AccordionInstance to match actual code

