### PR TITLE
chore(StyleLint): add no-unresolved-component-vars rule

### DIFF
--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -7,7 +7,9 @@
     "stylelint-scss",
     "./scripts/stylelint/plugins/token-name-policy.cjs",
     "./scripts/stylelint/plugins/no-unused-use.cjs",
-    "./scripts/stylelint/plugins/no-unresolved-component-vars.cjs"
+    "./scripts/stylelint/plugins/no-unresolved-component-vars.cjs",
+    "./scripts/stylelint/plugins/var-syntax.cjs",
+    "./scripts/stylelint/plugins/no-undefined-custom-properties.cjs"
   ],
   "rules": {
     "scss/at-mixin-argumentless-call-parentheses": "always",
@@ -44,6 +46,8 @@
       }
     ],
     "eufemia/no-unused-use": true,
-    "eufemia/no-unresolved-component-vars": true
+    "eufemia/no-unresolved-component-vars": true,
+    "eufemia/var-syntax": true,
+    "eufemia/no-undefined-custom-properties": true
   }
 }

--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -6,7 +6,8 @@
   "plugins": [
     "stylelint-scss",
     "./scripts/stylelint/plugins/token-name-policy.cjs",
-    "./scripts/stylelint/plugins/no-unused-use.cjs"
+    "./scripts/stylelint/plugins/no-unused-use.cjs",
+    "./scripts/stylelint/plugins/no-unresolved-component-vars.cjs"
   ],
   "rules": {
     "scss/at-mixin-argumentless-call-parentheses": "always",
@@ -42,6 +43,7 @@
         }
       }
     ],
-    "eufemia/no-unused-use": true
+    "eufemia/no-unused-use": true,
+    "eufemia/no-unresolved-component-vars": true
   }
 }

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-undefined-custom-properties.test.ts
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-undefined-custom-properties.test.ts
@@ -1,0 +1,225 @@
+import stylelint from 'stylelint'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+const noUndefinedCustomPropertiesPlugin = require('../no-undefined-custom-properties.cjs')
+
+/**
+ * Create a temporary directory structure that mimics the src/ tree,
+ * so the rule can find declared custom properties.
+ */
+const makeTempSrcDir = () => {
+  const rootDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'dnb-undefined-props-')
+  )
+  const srcDir = path.join(rootDir, 'src')
+  const styleDir = path.join(srcDir, 'components', 'button', 'style')
+  fs.mkdirSync(styleDir, { recursive: true })
+
+  return {
+    rootDir,
+    srcDir,
+    styleDir,
+    writeSrcFile: (relativePath: string, content: string) => {
+      const filePath = path.join(srcDir, relativePath)
+      const dir = path.dirname(filePath)
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(filePath, content, 'utf-8')
+      return filePath
+    },
+    cleanup: () => fs.rmSync(rootDir, { recursive: true, force: true }),
+  }
+}
+
+const lintWithRule = async ({
+  code,
+  codeFilename,
+}: {
+  code: string
+  codeFilename: string
+}) => {
+  const result = await stylelint.lint({
+    code,
+    codeFilename,
+    customSyntax: 'postcss-scss',
+    config: {
+      plugins: [noUndefinedCustomPropertiesPlugin],
+      rules: {
+        [noUndefinedCustomPropertiesPlugin.ruleName]: true,
+      },
+    },
+  })
+
+  return result.results?.[0]?.warnings || []
+}
+
+describe('no-undefined-custom-properties', () => {
+  let tempDir: ReturnType<typeof makeTempSrcDir>
+
+  beforeEach(() => {
+    tempDir = makeTempSrcDir()
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  it('should not flag var() references to properties declared in the same file', async () => {
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        --button-color: red;
+        color: var(--button-color);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not flag var() references to properties declared in another file', async () => {
+    tempDir.writeSrcFile(
+      'style/themes/ui/tokens.scss',
+      `:root {
+        --token-color-primary: blue;
+      }`
+    )
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        color: var(--token-color-primary);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag var() references to properties not declared anywhere', async () => {
+    tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        --button-color: red;
+      }`
+    )
+    const filePath = tempDir.writeSrcFile(
+      'components/card/style/dnb-card.scss',
+      `.dnb-card {
+        color: var(--nonexistent-property);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--nonexistent-property')
+  })
+
+  it('should not flag var() with a fallback value', async () => {
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        color: var(--nonexistent-property, red);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag multiple undefined references in one declaration', async () => {
+    tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        --button-color: red;
+      }`
+    )
+    const filePath = tempDir.writeSrcFile(
+      'components/card/style/dnb-card.scss',
+      `.dnb-card {
+        border: var(--undefined-a) solid var(--undefined-b);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(2)
+  })
+
+  it('should not flag declarations without var()', async () => {
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button { color: red; }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should find declarations across different component directories', async () => {
+    tempDir.writeSrcFile(
+      'components/accordion/style/dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-bg: white;
+      }`
+    )
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        background: var(--accordion-bg);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should catch typos in property names', async () => {
+    tempDir.writeSrcFile(
+      'components/button/style/dnb-button.scss',
+      `.dnb-button {
+        --button-background: blue;
+      }`
+    )
+    const filePath = tempDir.writeSrcFile(
+      'components/button/style/themes/dnb-button-theme-ui.scss',
+      `.dnb-button {
+        background: var(--button-backgroud);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--button-backgroud')
+  })
+})

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-unresolved-component-vars.test.ts
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/no-unresolved-component-vars.test.ts
@@ -1,0 +1,481 @@
+import stylelint from 'stylelint'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+const noUnresolvedComponentVarsPlugin = require('../no-unresolved-component-vars.cjs')
+
+const makeTempStyleDir = () => {
+  const rootDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'dnb-unresolved-vars-')
+  )
+  const styleDir = path.join(rootDir, 'style')
+  const themesDir = path.join(styleDir, 'themes')
+  fs.mkdirSync(themesDir, { recursive: true })
+
+  return {
+    rootDir,
+    styleDir,
+    themesDir,
+    writeStyleFile: (filename: string, content: string) => {
+      const filePath = path.join(styleDir, filename)
+      fs.writeFileSync(filePath, content, 'utf-8')
+      return filePath
+    },
+    writeThemeFile: (filename: string, content: string) => {
+      const filePath = path.join(themesDir, filename)
+      fs.writeFileSync(filePath, content, 'utf-8')
+      return filePath
+    },
+    cleanup: () => fs.rmSync(rootDir, { recursive: true, force: true }),
+  }
+}
+
+const lintWithRule = async ({
+  code,
+  codeFilename,
+  ruleOptions = {},
+}: {
+  code: string
+  codeFilename: string
+  ruleOptions?: Record<string, any>
+}) => {
+  const result = await stylelint.lint({
+    code,
+    codeFilename,
+    customSyntax: 'postcss-scss',
+    config: {
+      plugins: [noUnresolvedComponentVarsPlugin],
+      rules: {
+        [noUnresolvedComponentVarsPlugin.ruleName]: [true, ruleOptions],
+      },
+    },
+  })
+
+  return result.results?.[0]?.warnings || []
+}
+
+describe('no-unresolved-component-vars', () => {
+  let tempDir: ReturnType<typeof makeTempStyleDir>
+
+  beforeEach(() => {
+    tempDir = makeTempStyleDir()
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  it('should not flag references to declared properties in the same file', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-color-text--default: red;
+        --accordion-color-text: var(--accordion-color-text--default);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not flag references to properties declared in a sibling theme file', async () => {
+    tempDir.writeThemeFile(
+      'dnb-accordion-theme-ui.scss',
+      `.dnb-accordion {
+        --accordion-color-text--default: blue;
+        --accordion-color-bg--default: white;
+      }`
+    )
+    const filePath = tempDir.writeStyleFile(
+      'dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-color-text: var(--accordion-color-text--default);
+        --accordion-color-bg: var(--accordion-color-bg--default);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag references to undeclared component-scoped properties (typo)', async () => {
+    tempDir.writeThemeFile(
+      'dnb-accordion-theme-ui.scss',
+      `.dnb-accordion {
+        --accordion-color-border--default: gray;
+      }`
+    )
+    const filePath = tempDir.writeStyleFile(
+      'dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-color-border: var(--accordion-color-boder--default);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--accordion-color-boder--default')
+  })
+
+  it('should flag references from theme files to undeclared properties', async () => {
+    tempDir.writeStyleFile(
+      'dnb-button.scss',
+      `.dnb-button {
+        --button-color-text: var(--button-color-text--default);
+      }`
+    )
+    const themeFilePath = tempDir.writeThemeFile(
+      'dnb-button-theme-ui.scss',
+      `.dnb-button {
+        --button-color-text--default: green;
+        --button-color-bg: var(--button-color-backgrond--default);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(themeFilePath, 'utf-8'),
+      codeFilename: themeFilePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--button-color-backgrond--default')
+  })
+
+  it('should not flag references to global/token variables', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-font: var(--font-family-default);
+        --accordion-easing: var(--easing-default);
+        --accordion-bg: var(--color-white);
+        --accordion-token: var(--token-color-text-action);
+        color: var(--line-height-basis);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not flag cross-component references from other components', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-input.scss',
+      `.dnb-input {
+        --input-color: red;
+        border-radius: var(--button-border-radius);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // --button- is not a prefix derived from files in this style dir
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not flag non-component-prefixed variables', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-section.scss',
+      `.dnb-section {
+        --section-color: red;
+        --breakout: var(--breakout--small, var(--breakout--fallback));
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // --breakout- does not match the --section- component prefix
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag unresolved references from a component named in the filename', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-misc.scss',
+      `.dnb-misc {
+        --misc-only-one: red;
+        color: var(--misc-unresolved);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // --misc- prefix is derived from dnb-misc.scss filename
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--misc-unresolved')
+  })
+
+  it('should flag typo in component property name', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-card.scss',
+      `.dnb-card {
+        --card-color: red;
+        --card-border: blue;
+        background: var(--card-colr);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--card-colr')
+  })
+
+  it('should not flag var() with fallback values (intentionally optional)', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-widget.scss',
+      `.dnb-widget {
+        --widget-color: blue;
+        --widget-size: large;
+        border: var(--widget-colr, red);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // Has a CSS fallback value → intentionally optional
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag var() without fallback for undeclared properties', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-widget.scss',
+      `.dnb-widget {
+        --widget-color: blue;
+        --widget-size: large;
+        border: var(--widget-colr);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--widget-colr')
+  })
+
+  it('should not flag var() references to foundation variables (--dnb-*, --sbanken-*, --carnegie-*)', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-accordion.scss',
+      `.dnb-accordion {
+        --accordion-one: red;
+        --accordion-two: green;
+        color: var(--dnb-color-sea-green);
+        background: var(--sbanken-color-magenta);
+        border-color: var(--carnegie-color-dark);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should support custom globalPrefixes option', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-test.scss',
+      `.dnb-test {
+        --test-a: one;
+        --test-b: two;
+        color: var(--test-typo);
+        background: var(--custom-global-thing);
+      }`
+    )
+
+    // Without the custom prefix, --custom-global-thing would not be
+    // flagged because --custom- doesn't match the --test- component prefix.
+    // But --test-typo should be flagged regardless.
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+      ruleOptions: {
+        globalPrefixes: [
+          '--token-',
+          '--color-',
+          '--font-',
+          '--line-height-',
+          '--spacing-',
+          '--easing-',
+          '--b-',
+          '--dnb-',
+          '--sbanken-',
+          '--sb-',
+          '--carnegie-',
+          '--eiendom-',
+          '--custom-global-',
+        ],
+      },
+    })
+
+    // Only --test-typo is flagged; --custom-global-thing is skipped
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--test-typo')
+  })
+
+  it('should handle multiple var() references on the same declaration', async () => {
+    tempDir.writeThemeFile(
+      'dnb-box-theme.scss',
+      `.dnb-box {
+        --box-color-ok: green;
+        --box-size-ok: 1rem;
+      }`
+    )
+    const filePath = tempDir.writeStyleFile(
+      'dnb-box.scss',
+      `.dnb-box {
+        border: var(--box-widht) solid var(--box-color-ok);
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--box-widht')
+  })
+
+  it('should not flag var() references for files without dnb- prefix in name', async () => {
+    // File doesn't follow dnb-<name>.scss convention — no component prefix derived
+    const randomDir = path.join(tempDir.rootDir, 'random')
+    fs.mkdirSync(randomDir, { recursive: true })
+    const filePath = path.join(randomDir, 'random.scss')
+    fs.writeFileSync(
+      filePath,
+      `.random { color: var(--random-missing-thing); }`,
+      'utf-8'
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag inner nested var() without its own fallback', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-panel.scss',
+      `.dnb-panel {
+        --panel-one: a;
+        --panel-two: b;
+        color: var(--panel-one, var(--panel-tree));
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // The outer var has a fallback so --panel-one is skipped,
+    // but the inner var(--panel-tree) has no fallback itself
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--panel-tree')
+  })
+
+  it('should not flag state variants when base variable is declared', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-button.scss',
+      `.dnb-button {
+        --button-color-underline: none;
+        --button-border-inset: inset;
+        --button-border-width: 1px;
+
+        &:active {
+          --button-color-underline: var(--button-color-underline--active);
+          --button-border-inset: var(--button-border-inset--active);
+          --button-border-width: var(--button-border-width--active);
+        }
+
+        &:focus {
+          --button-color-underline: var(--button-color-underline--focus);
+        }
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // --button-color-underline is declared, so --button-color-underline--active is valid
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should still flag state variants with typo in base name', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-button.scss',
+      `.dnb-button {
+        --button-color-underline: none;
+
+        &:active {
+          --button-color-underline: var(--button-color-underlne--active);
+        }
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    // --button-color-underlne is NOT declared (typo), so --active variant is flagged
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--button-color-underlne--active')
+  })
+
+  it('should handle empty var references gracefully', async () => {
+    const filePath = tempDir.writeStyleFile(
+      'dnb-empty.scss',
+      `.dnb-empty {
+        --empty-a: one;
+        --empty-b: two;
+        color: red;
+      }`
+    )
+
+    const warnings = await lintWithRule({
+      code: fs.readFileSync(filePath, 'utf-8'),
+      codeFilename: filePath,
+    })
+
+    expect(warnings).toHaveLength(0)
+  })
+})

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/var-syntax.test.ts
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/var-syntax.test.ts
@@ -1,0 +1,75 @@
+import stylelint from 'stylelint'
+const varSyntaxPlugin = require('../var-syntax.cjs')
+
+const lint = async (code: string) => {
+  const result = await stylelint.lint({
+    code,
+    customSyntax: 'postcss-scss',
+    config: {
+      plugins: [varSyntaxPlugin],
+      rules: {
+        [varSyntaxPlugin.ruleName]: true,
+      },
+    },
+  })
+
+  return result.results?.[0]?.warnings || []
+}
+
+describe('var-syntax', () => {
+  it('should accept valid var(--property) syntax', async () => {
+    const warnings = await lint(`.foo { color: var(--my-color); }`)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should accept var() with fallback', async () => {
+    const warnings = await lint(`.foo { color: var(--my-color, red); }`)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should accept nested var() calls', async () => {
+    const warnings = await lint(
+      `.foo { color: var(--primary, var(--fallback)); }`
+    )
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag var(-foo) with single dash', async () => {
+    const warnings = await lint(`.foo { color: var(-my-color); }`)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('-my-color')
+  })
+
+  it('should flag var(---foo) with triple dash', async () => {
+    const warnings = await lint(`.foo { color: var(---my-color); }`)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('---my-color')
+  })
+
+  it('should flag var(foo) with no dashes', async () => {
+    const warnings = await lint(`.foo { color: var(mycolor); }`)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('mycolor')
+  })
+
+  it('should flag multiple invalid vars in the same declaration', async () => {
+    const warnings = await lint(`.foo { background: var(-a) var(---b); }`)
+    expect(warnings).toHaveLength(2)
+  })
+
+  it('should not flag declarations without var()', async () => {
+    const warnings = await lint(`.foo { color: red; }`)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should accept var() with whitespace before the property name', async () => {
+    const warnings = await lint(`.foo { color: var(  --my-color  ); }`)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should flag var() with single dash and whitespace', async () => {
+    const warnings = await lint(`.foo { color: var(  -bad  ); }`)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('-bad')
+  })
+})

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/no-undefined-custom-properties.cjs
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/no-undefined-custom-properties.cjs
@@ -1,0 +1,193 @@
+const stylelint = require('stylelint')
+const fs = require('fs')
+const path = require('path')
+
+const RULE_NAME = 'eufemia/no-undefined-custom-properties'
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+  undefinedProperty: (name) =>
+    `Unexpected undefined custom property "${name}". No declaration found in any SCSS source file.`,
+})
+
+const meta = {
+  url: 'https://github.com/dnbexperience/eufemia',
+}
+
+const VAR_REGEX = /var\(\s*(--[a-z0-9-]+)\s*([,)])/gi
+const VAR_REGEX_SINGLE = /var\(\s*(--[a-z0-9-]+)\s*([,)])/i
+const DECL_REGEX = /(^|\s|{|;)(--[a-z0-9-]+)\s*:/gim
+
+/**
+ * Cache of all declared custom properties across the source tree.
+ * Keyed by the resolved srcRoot path, persists for the process lifetime.
+ */
+const projectDeclarationsCache = new Map()
+
+/**
+ * Recursively find all .scss files under `dir`.
+ */
+const findScssFiles = (dir) => {
+  const results = []
+
+  if (!fs.existsSync(dir)) {
+    return results
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      results.push(...findScssFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.scss')) {
+      results.push(fullPath)
+    }
+  }
+
+  return results
+}
+
+/**
+ * Resolve the `src/` root from a file path.
+ * Looks for a directory named `src` in the file's ancestor chain.
+ */
+const resolveSrcRoot = (filePath) => {
+  const parts = filePath.replace(/\\/g, '/').split('/')
+  const srcIndex = parts.lastIndexOf('src')
+
+  if (srcIndex === -1) {
+    return null
+  }
+
+  return parts.slice(0, srcIndex + 1).join('/')
+}
+
+/**
+ * Build (and cache) the set of all custom property declarations
+ * found in every .scss file under `srcRoot`.
+ */
+const getProjectDeclarations = (srcRoot) => {
+  if (projectDeclarationsCache.has(srcRoot)) {
+    return projectDeclarationsCache.get(srcRoot)
+  }
+
+  const declarations = new Set()
+  const scssFiles = findScssFiles(srcRoot)
+
+  for (const file of scssFiles) {
+    const content = fs.readFileSync(file, 'utf-8')
+    let match
+
+    while ((match = DECL_REGEX.exec(content)) !== null) {
+      declarations.add(match[2])
+    }
+  }
+
+  projectDeclarationsCache.set(srcRoot, declarations)
+  return declarations
+}
+
+/**
+ * Check if `varName` is a state variant of a declared base variable.
+ *
+ * Convention: --component-property--state (double-dash separator).
+ * If --component-property is declared, --component-property--state
+ * is assumed valid (set by themes or specific variants at runtime).
+ */
+const isStateVariantOfDeclared = (varName, declarations) => {
+  const doubleDashIndex = varName.indexOf('--', 2)
+
+  if (doubleDashIndex === -1) {
+    return false
+  }
+
+  const baseName = varName.substring(0, doubleDashIndex)
+  return declarations.has(baseName)
+}
+
+const ruleFunction = (primary) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(
+      result,
+      RULE_NAME,
+      {
+        actual: primary,
+        possible: [true],
+      }
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const filePath = root.source?.input?.file || ''
+
+    if (!filePath) {
+      return
+    }
+
+    const srcRoot = resolveSrcRoot(filePath)
+
+    if (!srcRoot || !fs.existsSync(srcRoot)) {
+      return
+    }
+
+    const allDeclarations = getProjectDeclarations(srcRoot)
+
+    if (allDeclarations.size === 0) {
+      return
+    }
+
+    root.walkDecls((decl) => {
+      const value = decl.value
+
+      if (!value || !value.includes('var(')) {
+        return
+      }
+
+      const references = value.match(VAR_REGEX)
+
+      if (!references) {
+        return
+      }
+
+      for (const ref of references) {
+        const singleMatch = ref.match(VAR_REGEX_SINGLE)
+        const varName = singleMatch?.[1]
+        const delimiter = singleMatch?.[2]
+
+        if (!varName) {
+          continue
+        }
+
+        // Skip var() references with a CSS fallback value
+        if (delimiter === ',') {
+          continue
+        }
+
+        if (allDeclarations.has(varName)) {
+          continue
+        }
+
+        // Skip state variants (--foo--hover) when the base (--foo) is declared
+        if (isStateVariantOfDeclared(varName, allDeclarations)) {
+          continue
+        }
+
+        stylelint.utils.report({
+          result,
+          ruleName: RULE_NAME,
+          node: decl,
+          message: messages.undefinedProperty(varName),
+        })
+      }
+    })
+  }
+}
+
+ruleFunction.ruleName = RULE_NAME
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction)
+module.exports.ruleName = RULE_NAME
+module.exports.messages = messages

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/no-unresolved-component-vars.cjs
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/no-unresolved-component-vars.cjs
@@ -1,0 +1,290 @@
+const stylelint = require('stylelint')
+const fs = require('fs')
+const path = require('path')
+
+const RULE_NAME = 'eufemia/no-unresolved-component-vars'
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+  unresolvedVar: (ref, styleDir) =>
+    `Unexpected unknown custom property "${ref}". No declaration found in "${styleDir}".`,
+})
+
+const meta = {
+  url: 'https://github.com/dnbexperience/eufemia',
+}
+
+/**
+ * Well-known global variable prefixes that are declared outside component
+ * style directories (theme properties, design tokens, etc.).
+ * References starting with these are never flagged.
+ */
+const DEFAULT_GLOBAL_PREFIXES = [
+  '--token-',
+  '--color-',
+  '--font-',
+  '--line-height-',
+  '--spacing-',
+  '--easing-',
+  '--b-',
+  '--dnb-',
+  '--sbanken-',
+  '--sb-',
+  '--carnegie-',
+  '--eiendom-',
+]
+
+const VAR_REFERENCE_REGEX = /var\(\s*(--[a-z0-9-]+)\s*([,)])/gi
+const SINGLE_VAR_REFERENCE_REGEX = /var\(\s*(--[a-z0-9-]+)\s*([,)])/i
+
+/**
+ * Cache for style-directory scans, keyed by absolute style-root path.
+ * Persists for the lifetime of the Node process (module-level state).
+ */
+const declarationCache = new Map()
+
+/**
+ * Given a file path, return the "style root" directory.
+ *
+ * Convention:
+ *   - If the file lives inside a `themes/` subdirectory of a `style/` dir,
+ *     return the `style/` dir.
+ *   - If the file lives directly in a `style/` dir, return that dir.
+ *   - Otherwise fall back to the file's own directory.
+ */
+const resolveStyleRoot = (filePath) => {
+  const normalizedPath = (filePath || '').replace(/\\/g, '/')
+  const dir = path.dirname(normalizedPath)
+
+  // e.g. .../style/themes/foo.scss → style root is .../style
+  const themeMatch = dir.match(/^(.+\/style)\/themes\/?$/i)
+  if (themeMatch) {
+    return themeMatch[1]
+  }
+
+  // e.g. .../style/foo.scss → already at style root
+  if (path.basename(dir) === 'style') {
+    return dir
+  }
+
+  // fallback: use the file's directory
+  return dir
+}
+
+/**
+ * Recursively find all .scss files under `dir`.
+ */
+const findScssFiles = (dir) => {
+  const results = []
+
+  if (!fs.existsSync(dir)) {
+    return results
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      results.push(...findScssFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.scss')) {
+      results.push(fullPath)
+    }
+  }
+
+  return results
+}
+
+/**
+ * Extract all custom property declarations from SCSS source text.
+ * Returns a Set of property names.
+ */
+const extractDeclarations = (content) => {
+  const declarations = new Set()
+  const regex = /(^|\s|{|;)(--[a-z0-9-]+)\s*:/gim
+  let match
+
+  while ((match = regex.exec(content)) !== null) {
+    declarations.add(match[2])
+  }
+
+  return declarations
+}
+
+/**
+ * Build (and cache) the set of all custom property declarations found
+ * in every .scss file under `styleRoot`, along with the component
+ * prefixes derived from `dnb-<name>.scss` filenames.
+ */
+const getStyleRootData = (styleRoot) => {
+  if (declarationCache.has(styleRoot)) {
+    return declarationCache.get(styleRoot)
+  }
+
+  const allDeclarations = new Set()
+  const componentPrefixes = []
+  const scssFiles = findScssFiles(styleRoot)
+
+  for (const file of scssFiles) {
+    const content = fs.readFileSync(file, 'utf-8')
+
+    for (const decl of extractDeclarations(content)) {
+      allDeclarations.add(decl)
+    }
+
+    // Derive component prefix from dnb-<name>.scss filenames
+    const basename = path.basename(file, '.scss')
+    const prefixMatch = basename.match(/^dnb-(.+?)(?:-theme-.+)?$/)
+
+    if (prefixMatch) {
+      const prefix = `--${prefixMatch[1]}-`
+
+      if (!componentPrefixes.includes(prefix)) {
+        componentPrefixes.push(prefix)
+      }
+    }
+  }
+
+  const data = { allDeclarations, componentPrefixes }
+  declarationCache.set(styleRoot, data)
+  return data
+}
+
+/**
+ * Check if `varName` is a state variant of a declared base variable.
+ *
+ * Convention: --component-property--state (double-dash separator).
+ * If --component-property is declared, --component-property--state
+ * is assumed valid (set by themes or specific variants).
+ */
+const isStateVariantOfDeclared = (varName, declarations) => {
+  const doubleDashIndex = varName.indexOf('--', 2)
+
+  if (doubleDashIndex === -1) {
+    return false
+  }
+
+  const baseName = varName.substring(0, doubleDashIndex)
+  return declarations.has(baseName)
+}
+
+const ruleFunction = (primary, secondaryOptions = {}) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(
+      result,
+      RULE_NAME,
+      {
+        actual: primary,
+        possible: [true],
+      }
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const globalPrefixes =
+      secondaryOptions.globalPrefixes || DEFAULT_GLOBAL_PREFIXES
+
+    const filePath = root.source?.input?.file || ''
+
+    if (!filePath) {
+      return
+    }
+
+    const styleRoot = resolveStyleRoot(filePath)
+
+    // Bail out if the style root directory does not exist on disk
+    // (e.g. virtual files during testing without a fixture directory).
+    if (!fs.existsSync(styleRoot)) {
+      return
+    }
+
+    const { allDeclarations, componentPrefixes } =
+      getStyleRootData(styleRoot)
+
+    if (allDeclarations.size === 0 || componentPrefixes.length === 0) {
+      return
+    }
+
+    const isComponentScoped = (varName) => {
+      // Skip well-known globals
+      for (const gp of globalPrefixes) {
+        if (varName.startsWith(gp)) {
+          return false
+        }
+      }
+
+      // Check if it matches a detected component prefix
+      for (const cp of componentPrefixes) {
+        if (varName.startsWith(cp)) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    const relativeStyleDir = path.relative(
+      path.resolve(filePath, '../../..'),
+      styleRoot
+    )
+
+    root.walkDecls((decl) => {
+      const value = decl.value
+
+      if (!value || !value.includes('var(')) {
+        return
+      }
+
+      const references = value.match(VAR_REFERENCE_REGEX)
+
+      if (!references) {
+        return
+      }
+
+      for (const ref of references) {
+        const singleMatch = ref.match(SINGLE_VAR_REFERENCE_REGEX)
+        const varName = singleMatch?.[1]
+        const delimiter = singleMatch?.[2]
+
+        if (!varName) {
+          continue
+        }
+
+        // Skip var() references that have a CSS fallback value —
+        // these are intentionally optional (e.g. set via JS at runtime)
+        if (delimiter === ',') {
+          continue
+        }
+
+        if (!isComponentScoped(varName)) {
+          continue
+        }
+
+        if (allDeclarations.has(varName)) {
+          continue
+        }
+
+        // Skip state variants (--foo--hover) when the base (--foo) is declared
+        if (isStateVariantOfDeclared(varName, allDeclarations)) {
+          continue
+        }
+
+        stylelint.utils.report({
+          result,
+          ruleName: RULE_NAME,
+          node: decl,
+          message: messages.unresolvedVar(varName, relativeStyleDir),
+        })
+      }
+    })
+  }
+}
+
+ruleFunction.ruleName = RULE_NAME
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction)
+module.exports.ruleName = RULE_NAME
+module.exports.messages = messages
+module.exports.meta = meta

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/var-syntax.cjs
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/var-syntax.cjs
@@ -1,0 +1,84 @@
+const stylelint = require('stylelint')
+
+const RULE_NAME = 'eufemia/var-syntax'
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+  invalidSyntax: (raw) =>
+    `Invalid custom property syntax "${raw}". Variables must start with exactly two dashes, e.g. var(--my-property).`,
+})
+
+const meta = {
+  url: 'https://github.com/dnbexperience/eufemia',
+}
+
+/**
+ * Matches all var() references.
+ * Group 1: the first argument (property name), trimmed.
+ */
+const VAR_REGEX = /var\(\s*([^\s,)]+)/gi
+const VAR_REGEX_SINGLE = /var\(\s*([^\s,)]+)/i
+
+/**
+ * A valid custom property name starts with exactly two dashes,
+ * followed by at least one non-dash character: --foo, --my-var, etc.
+ */
+const VALID_PROPERTY_NAME = /^--[^-]/
+
+const ruleFunction = (primary) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(
+      result,
+      RULE_NAME,
+      {
+        actual: primary,
+        possible: [true],
+      }
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    root.walkDecls((decl) => {
+      const value = decl.value
+
+      if (!value || !value.includes('var(')) {
+        return
+      }
+
+      const matches = value.match(VAR_REGEX)
+
+      if (!matches) {
+        return
+      }
+
+      for (const match of matches) {
+        const singleMatch = match.match(VAR_REGEX_SINGLE)
+        const propertyName = singleMatch?.[1]
+
+        if (!propertyName) {
+          continue
+        }
+
+        if (VALID_PROPERTY_NAME.test(propertyName)) {
+          continue
+        }
+
+        stylelint.utils.report({
+          result,
+          ruleName: RULE_NAME,
+          node: decl,
+          message: messages.invalidSyntax(propertyName),
+        })
+      }
+    })
+  }
+}
+
+ruleFunction.ruleName = RULE_NAME
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction)
+module.exports.ruleName = RULE_NAME
+module.exports.messages = messages

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1058,6 +1058,7 @@ legend.dnb-form-label {
   color: var(--input-color-text);
   display: inline-flex;
   align-items: center;
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
+++ b/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
@@ -81,6 +81,7 @@
   }
 
   &__multiple &__item {
+    /* stylelint-disable-next-line eufemia/no-undefined-custom-properties -- set via JS at runtime */
     transition: transform 400ms var(--easing-default)
       calc(var(--delay) * 50ms);
     transform: translateX(-1rem);

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1189,6 +1189,7 @@ legend.dnb-form-label {
   color: var(--input-color-text);
   display: inline-flex;
   align-items: center;
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/components/flex/style/flex-item.scss
+++ b/packages/dnb-eufemia/src/components/flex/style/flex-item.scss
@@ -30,6 +30,7 @@
   }
 
   // Handle column spans
+  /* stylelint-disable eufemia/no-undefined-custom-properties -- responsive values set via JS at runtime */
   &--responsive {
     --sizeCount--default: 12;
     --span--default: var(--small);
@@ -43,6 +44,7 @@
     .dnb-flex-container[data-media-key='large'] & {
       --span: var(--large, var(--medium));
     }
+    /* stylelint-enable eufemia/no-undefined-custom-properties */
 
     --flex-basis: calc(
       100% / var(--sizeCount, var(--sizeCount--default)) *

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1058,6 +1058,7 @@ legend.dnb-form-label {
   color: var(--input-color-text);
   display: inline-flex;
   align-items: center;
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1054,6 +1054,7 @@ legend.dnb-form-label {
   color: var(--input-color-text);
   display: inline-flex;
   align-items: center;
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -65,7 +65,7 @@
   display: inline-flex;
   align-items: center;
 
-  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars, eufemia/no-undefined-custom-properties -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -65,6 +65,7 @@
   display: inline-flex;
   align-items: center;
 
+  /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- set via JS at runtime */
   font-size: var(--input-font-small);
   line-height: var(--input-height);
   text-align: left;

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/style/dnb-upload.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/style/dnb-upload.scss
@@ -4,7 +4,9 @@
       --outset-left: calc(var(--spacing-medium));
       --outset-right: calc(var(--spacing-medium));
 
+      /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- declared in components/upload */
       margin-left: var(--upload-border-width);
+      /* stylelint-disable-next-line eufemia/no-unresolved-component-vars -- declared in components/upload */
       margin-right: var(--upload-border-width);
       &::before {
         z-index: 0;

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -43,6 +43,7 @@ fieldset.dnb-forms-field-block {
     }
     @include utilities.allAbove(x-small) {
       &-custom {
+        /* stylelint-disable-next-line eufemia/no-undefined-custom-properties -- set via JS at runtime */
         width: calc(var(--dnb-forms-field-block-width));
       }
       &-small {
@@ -230,6 +231,7 @@ fieldset.dnb-forms-field-block {
         width: 100%;
       }
       &-custom {
+        /* stylelint-disable-next-line eufemia/no-undefined-custom-properties -- set via JS at runtime */
         --field-block-content-width: calc(
           var(--dnb-forms-field-block-content-width)
         );

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
@@ -127,12 +127,14 @@
 
       // Design for a business card without Visa support
       &-business-no-visa {
+        /* stylelint-disable-next-line eufemia/no-undefined-custom-properties -- set via JS at runtime */
         background-color: var(--dnb-payment-bg-business-no-visa);
         color: var(--color-white);
       }
 
       // Design for a business card with Visa support
       &-business-with-visa {
+        /* stylelint-disable-next-line eufemia/no-undefined-custom-properties -- set via JS at runtime */
         background-color: var(--dnb-payment-bg-business-with-visa);
         color: var(--color-white);
       }


### PR DESCRIPTION
Motivaiton: https://github.com/dnbexperience/eufemia/pull/7529#discussion_r3093397266

This could perhaps be a bit "over engineering", but will also reduce issues and need for thorough PR reviews

Add a custom Stylelint plugin that detects references to undeclared
CSS custom properties within component style directories. This catches
typos like --accordion-color-boder--default (missing 'r' in border).

The plugin:
- Derives component prefixes from dnb-<name>.scss filenames
- Scans all .scss files in the style/ directory (including themes/)
- Flags var() references to component-scoped properties that have no
  matching declaration
- Skips global variables (tokens, colors, fonts, foundation vars, etc.)
- Skips cross-component references (different prefix than the component)
- Skips var() with CSS fallback values (intentionally optional)
- Skips state variants (--foo--active) when the base (--foo) is declared

Includes 19 unit tests and zero inline disable comments needed.
