### PR TITLE
docs: remove `en-NO` documentation

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ChangeLocale.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeLocale.tsx
@@ -9,7 +9,6 @@ export const languageDisplayNames = {
   'nb-NO': { label: 'Norsk' },
   'sv-SE': { label: 'Svenska' },
   'da-DK': { label: 'Dansk' },
-  'en-NO': { label: 'English (NO)' },
   'en-GB': { label: 'English (GB)' },
   'en-US': { label: 'English (US)' },
 }

--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -38,16 +38,10 @@ export const translations = mergeTranslations(
   translationsWithoutEnUS,
   enUS
 )
-const allSupportedTranslationsKey: InternalLocale[] = [
-  ...(Object.keys(coreTranslations) as InternalLocale[]),
-  ...(Object.keys(translations) as InternalLocale[]),
-  'en-NO',
+export const supportedTranslationsKey = [
+  ...Object.keys(coreTranslations),
+  ...Object.keys(translations),
 ]
-
-export const supportedTranslationsKey: InternalLocale[] =
-  allSupportedTranslationsKey.filter((locale, index, list) => {
-    return list.indexOf(locale) === index
-  })
 
 // This ensures we processes also the css prop during build
 // More into in the docs: https://emotion.sh/docs/ssr#gatsby

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -71,16 +71,6 @@ Here are the available options for the `rounding` property:
 - `half-even`: Round to the nearest even number.
 - `half-up` (default): Round up if the fractional part is 0.5 or greater; otherwise, round down.
 
-## Handling en-NO
-
-`en-NO` (English – Norway) is a valid BCP 47 locale and is commonly sent by devices configured with English language and Norway region.
-
-If region-aware formatting is supported, accept en-NO and use it for date, time, and number formatting.
-
-If only specific English locales are supported (e.g. en-GB), explicitly map en-NO to the closest supported locale.
-
-Locale handling must be explicit and consistent across the application.
-
 ## Value Components
 
 The formatting helpers power several `Value.*` components:

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/Examples.tsx
@@ -67,7 +67,6 @@ export const Numbers = () => (
           <Tr noWrap>
             <Th>Variation</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -78,9 +77,6 @@ export const Numbers = () => (
             <Td>Default</Td>
             <Td>
               <NumberFormat locale="nb-NO" value={1234567.89} />
-            </Td>
-            <Td>
-              <NumberFormat locale="en-NO" value={1234567.89} />
             </Td>
             <Td>
               <NumberFormat locale="en-GB" value={1234567.89} />
@@ -97,13 +93,6 @@ export const Numbers = () => (
             <Td>
               <NumberFormat
                 locale="nb-NO"
-                value={1234567.89}
-                decimals={0}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                locale="en-NO"
                 value={1234567.89}
                 decimals={0}
               />
@@ -141,13 +130,6 @@ export const Numbers = () => (
             </Td>
             <Td>
               <NumberFormat
-                locale="en-NO"
-                value={1234567.89}
-                decimals={3}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
                 locale="en-GB"
                 value={1234567.89}
                 decimals={3}
@@ -174,9 +156,6 @@ export const Numbers = () => (
               <NumberFormat locale="nb-NO" value={-1234567.89} />
             </Td>
             <Td>
-              <NumberFormat locale="en-NO" value={-1234567.89} />
-            </Td>
-            <Td>
               <NumberFormat locale="en-GB" value={-1234567.89} />
             </Td>
             <Td>
@@ -191,13 +170,6 @@ export const Numbers = () => (
             <Td>
               <NumberFormat
                 locale="nb-NO"
-                signDisplay="exceptZero"
-                value={1234567.89}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                locale="en-NO"
                 signDisplay="exceptZero"
                 value={1234567.89}
               />
@@ -230,9 +202,6 @@ export const Numbers = () => (
               <NumberFormat locale="nb-NO">invalid</NumberFormat>
             </Td>
             <Td>
-              <NumberFormat locale="en-NO">invalid</NumberFormat>
-            </Td>
-            <Td>
               <NumberFormat locale="en-GB">invalid</NumberFormat>
             </Td>
             <Td>
@@ -256,7 +225,6 @@ export const NumbersCompact = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -268,14 +236,6 @@ export const NumbersCompact = () => (
             <Td>
               <NumberFormat
                 locale="nb-NO"
-                compact
-                decimals={1}
-                value={123456}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                locale="en-NO"
                 compact
                 decimals={1}
                 value={123456}
@@ -311,14 +271,6 @@ export const NumbersCompact = () => (
             <Td>
               <NumberFormat
                 locale="nb-NO"
-                compact="long"
-                decimals={2}
-                value={1234567.89}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                locale="en-NO"
                 compact="long"
                 decimals={2}
                 value={1234567.89}
@@ -363,7 +315,6 @@ export const Percentage = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -374,9 +325,6 @@ export const Percentage = () => (
             <Td>Default</Td>
             <Td>
               <NumberFormat locale="nb-NO" percent value={12.34} />
-            </Td>
-            <Td>
-              <NumberFormat locale="en-NO" percent value={12.34} />
             </Td>
             <Td>
               <NumberFormat locale="en-GB" percent value={12.34} />
@@ -393,14 +341,6 @@ export const Percentage = () => (
             <Td>
               <NumberFormat
                 locale="nb-NO"
-                percent
-                decimals={3}
-                value={3}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                locale="en-NO"
                 percent
                 decimals={3}
                 value={3}
@@ -445,7 +385,6 @@ export const AmountAndCurrency = () => (
           <Tr noWrap>
             <Th>Variation</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -456,9 +395,6 @@ export const AmountAndCurrency = () => (
             <Td>Default</Td>
             <Td>
               <NumberFormat currency locale="nb-NO" value={-1358} />
-            </Td>
-            <Td>
-              <NumberFormat currency locale="en-NO" value={-1358} />
             </Td>
             <Td>
               <NumberFormat currency locale="en-GB" value={-1358} />
@@ -476,14 +412,6 @@ export const AmountAndCurrency = () => (
               <NumberFormat
                 currency
                 locale="nb-NO"
-                value={-1358}
-                currencyDisplay="symbol"
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency
-                locale="en-NO"
                 value={-1358}
                 currencyDisplay="symbol"
               />
@@ -526,14 +454,6 @@ export const AmountAndCurrency = () => (
             <Td>
               <NumberFormat
                 currency="EUR"
-                locale="en-NO"
-                value={-1358}
-                currencyDisplay="narrowSymbol"
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency="EUR"
                 locale="en-GB"
                 value={-1358}
                 currencyDisplay="narrowSymbol"
@@ -562,14 +482,6 @@ export const AmountAndCurrency = () => (
               <NumberFormat
                 currency
                 locale="nb-NO"
-                value={-1358}
-                currencyDisplay="name"
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency
-                locale="en-NO"
                 value={-1358}
                 currencyDisplay="name"
               />
@@ -612,14 +524,6 @@ export const AmountAndCurrency = () => (
             <Td>
               <NumberFormat
                 currency
-                locale="en-NO"
-                value={-1358}
-                currencyDisplay="code"
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency
                 locale="en-GB"
                 value={-1358}
                 currencyDisplay="code"
@@ -655,14 +559,6 @@ export const AmountAndCurrency = () => (
             <Td>
               <NumberFormat
                 currency
-                locale="en-NO"
-                value={-1358}
-                decimals={0}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency
                 locale="en-GB"
                 value={-1358}
                 decimals={0}
@@ -691,14 +587,6 @@ export const AmountAndCurrency = () => (
               <NumberFormat
                 currency
                 locale="nb-NO"
-                value={-1358}
-                decimals={3}
-              />
-            </Td>
-            <Td>
-              <NumberFormat
-                currency
-                locale="en-NO"
                 value={-1358}
                 decimals={3}
               />
@@ -742,7 +630,6 @@ export const DateStyles = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -754,13 +641,6 @@ export const DateStyles = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30"
-                dateStyle="full"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30"
                 dateStyle="full"
               />
@@ -798,13 +678,6 @@ export const DateStyles = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30"
-                dateStyle="long"
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30"
                 dateStyle="long"
@@ -836,13 +709,6 @@ export const DateStyles = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30"
-                dateStyle="medium"
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30"
                 dateStyle="medium"
@@ -868,13 +734,6 @@ export const DateStyles = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30"
-                dateStyle="short"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30"
                 dateStyle="short"
               />
@@ -915,7 +774,6 @@ export const DateAndTime = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -927,14 +785,6 @@ export const DateAndTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30T09:12"
-                dateStyle="full"
-                timeStyle="short"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30T09:12"
                 dateStyle="full"
                 timeStyle="short"
@@ -977,14 +827,6 @@ export const DateAndTime = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30T09:12"
-                dateStyle="long"
-                timeStyle="short"
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30T09:12"
                 dateStyle="long"
@@ -1020,14 +862,6 @@ export const DateAndTime = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30T09:12"
-                dateStyle="medium"
-                timeStyle="short"
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30T09:12"
                 dateStyle="medium"
@@ -1056,14 +890,6 @@ export const DateAndTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30T09:12"
-                dateStyle="short"
-                timeStyle="short"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30T09:12"
                 dateStyle="short"
                 timeStyle="short"
@@ -1108,7 +934,6 @@ export const DateWithoutYear = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -1120,14 +945,6 @@ export const DateWithoutYear = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30"
-                dateStyle="full"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30"
                 dateStyle="full"
                 hideYear
@@ -1170,14 +987,6 @@ export const DateWithoutYear = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30"
-                dateStyle="long"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30"
                 dateStyle="long"
@@ -1213,14 +1022,6 @@ export const DateWithoutYear = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30"
-                dateStyle="medium"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30"
                 dateStyle="medium"
@@ -1249,14 +1050,6 @@ export const DateWithoutYear = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30"
-                dateStyle="short"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30"
                 dateStyle="short"
                 hideYear
@@ -1301,7 +1094,6 @@ export const DateWithoutYearAndTime = () => (
           <Tr noWrap>
             <Th>Style</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -1313,15 +1105,6 @@ export const DateWithoutYearAndTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30T09:12"
-                dateStyle="full"
-                timeStyle="short"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30T09:12"
                 dateStyle="full"
                 timeStyle="short"
@@ -1369,15 +1152,6 @@ export const DateWithoutYearAndTime = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30T09:12"
-                dateStyle="long"
-                timeStyle="short"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30T09:12"
                 dateStyle="long"
@@ -1417,15 +1191,6 @@ export const DateWithoutYearAndTime = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                value="2026-01-30T09:12"
-                dateStyle="medium"
-                timeStyle="short"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 value="2026-01-30T09:12"
                 dateStyle="medium"
@@ -1457,15 +1222,6 @@ export const DateWithoutYearAndTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                value="2026-01-30T09:12"
-                dateStyle="short"
-                timeStyle="short"
-                hideYear
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 value="2026-01-30T09:12"
                 dateStyle="short"
                 timeStyle="short"
@@ -1514,7 +1270,6 @@ export const RelativeTime = () => (
           <Tr noWrap>
             <Th>Description</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -1526,16 +1281,6 @@ export const RelativeTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                relativeTime
-                relativeTimeReference={() =>
-                  new Date('2026-02-06T12:00:00Z')
-                }
-                value="2026-02-06T11:59:30Z"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 relativeTime
                 relativeTimeReference={() =>
                   new Date('2026-02-06T12:00:00Z')
@@ -1588,16 +1333,6 @@ export const RelativeTime = () => (
             </Td>
             <Td>
               <DateFormat
-                locale="en-NO"
-                relativeTime
-                relativeTimeReference={() =>
-                  new Date('2026-02-06T12:00:00Z')
-                }
-                value="2026-02-06T11:00:00Z"
-              />
-            </Td>
-            <Td>
-              <DateFormat
                 locale="en-GB"
                 relativeTime
                 relativeTimeReference={() =>
@@ -1632,16 +1367,6 @@ export const RelativeTime = () => (
             <Td>
               <DateFormat
                 locale="nb-NO"
-                relativeTime
-                relativeTimeReference={() =>
-                  new Date('2026-02-06T12:00:00Z')
-                }
-                value="2026-02-06T15:00:00Z"
-              />
-            </Td>
-            <Td>
-              <DateFormat
-                locale="en-NO"
                 relativeTime
                 relativeTimeReference={() =>
                   new Date('2026-02-06T12:00:00Z')
@@ -1694,7 +1419,6 @@ export const DurationStrings = () => (
           <Tr noWrap>
             <Th>Duration</Th>
             <Th>nb-NO</Th>
-            <Th>en-NO</Th>
             <Th>en-GB</Th>
             <Th>sv-SE</Th>
             <Th>da-DK</Th>
@@ -1705,9 +1429,6 @@ export const DurationStrings = () => (
             <Td>PT2H30M</Td>
             <Td>
               <DateFormat locale="nb-NO" value="PT2H30M" />
-            </Td>
-            <Td>
-              <DateFormat locale="en-NO" value="PT2H30M" />
             </Td>
             <Td>
               <DateFormat locale="en-GB" value="PT2H30M" />
@@ -1723,9 +1444,6 @@ export const DurationStrings = () => (
             <Td>P1DT2H30M</Td>
             <Td>
               <DateFormat locale="nb-NO" value="P1DT2H30M" />
-            </Td>
-            <Td>
-              <DateFormat locale="en-NO" value="P1DT2H30M" />
             </Td>
             <Td>
               <DateFormat locale="en-GB" value="P1DT2H30M" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/for-formatting.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/for-formatting.mdx
@@ -12,6 +12,8 @@ This page shows the canonical number, currency and date layouts that the compone
 
 For detailed prop lists, see the [NumberFormat](/uilib/components/number-format) component and the [DateFormat](/uilib/components/date-format) component.
 
+The tables below focus on the locales most commonly used at DNB (`nb-NO`, `en-GB`, `sv-SE` and `da-DK`), but Eufemia supports many more region/locale combinations. Any valid [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) locale supported by the browser's `Intl` APIs – for example `en-NO` (English – Norway) or `en-US` – can be passed to the `locale` prop and will be formatted accordingly.
+
 ---
 
 ## Phone number

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -132,7 +132,6 @@ const ChangeLocale = () => {
   return (
     <Field.Selection value={locale} onChange={(value) => setLocale(value)}>
       <Field.Option value="nb-NO" title="Norsk" />
-      <Field.Option value="en-NO" title="English (NO)" />
       <Field.Option value="sv-SE" title="Svenska" />
       <Field.Option value="da-DK" title="Dansk" />
       <Field.Option value="en-GB" title="English (GB)" />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/provider-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/provider-info.mdx
@@ -79,7 +79,6 @@ const ChangeLocale = () => {
   return (
     <Field.Selection value={locale} onChange={(value) => setLocale(value)}>
       <Field.Option value="nb-NO" title="Norsk" />
-      <Field.Option value="en-NO" title="English (NO)" />
       <Field.Option value="sv-SE" title="Svenska" />
       <Field.Option value="da-DK" title="Dansk" />
       <Field.Option value="en-GB" title="English (GB)" />
@@ -126,7 +125,6 @@ const ChangeLocale = () => {
       onChange={(value) => setCurrentLocale(value)}
     >
       <Field.Option value="nb-NO" title="Norsk" />
-      <Field.Option value="en-NO" title="English (NO)" />
       <Field.Option value="en-GB" title="English (GB)" />
     </Field.Selection>
   )


### PR DESCRIPTION
`en-NO` is unpredictable. Some parts resolve to en (e.g. date formatting, language) others resolve to no (e.g. number formatting)

- This creates a mixed and unreliable output that depends on runtime and environment.
- It breaks the expectation of a locale.
- Accessibility issues (screen readers).
- Makes it more complex to maintain internal additional code formatting for phone number, bank account number etc.
- Also, the same applies to en-SE or en-DK etc.
- **NB:** Technically we still support it as before.

