### PR TITLE
chore: improve design tokens filter

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
@@ -6,11 +6,11 @@ import { Td, Th, Tooltip, Tr } from '@dnb/eufemia/src'
 import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 import {
-  countTokensByAudience,
+  tokenModifierOrder,
   tokenNamingPolicy,
   tokenSections,
+  type TokenModifier,
   type TokenRow,
-  type TokenAudience,
   type TokenSectionId,
 } from '../../../../../../uilib/utils/designTokens'
 
@@ -20,11 +20,6 @@ const isDev =
 
 const MDXCode = basicComponents.code
 const MDXParagraph = basicComponents.p
-const defaultVisibleAudiences: TokenAudience[] = [
-  'base',
-  'state',
-  'advanced',
-]
 type TokenType = 'color' | 'spacing'
 type DecorativeVariant = 'non-static' | 'static'
 const defaultVisibleTypes: TokenType[] = ['color']
@@ -41,10 +36,23 @@ const renderInlineCodeList = (values: readonly string[]) => {
   ))
 }
 
-const audienceLabels: Record<TokenAudience, string> = {
+const modifierLabels: Record<TokenModifier, string> = {
+  hover: 'Hover',
+  pressed: 'Pressed',
+  focus: 'Focus',
+  disabled: 'Disabled',
+  inverse: 'Inverse',
+  ondark: 'On dark',
+  onlight: 'On light',
+  onsubtle: 'On subtle',
+  subtle: 'Subtle',
+  bold: 'Bold',
   base: 'Base',
-  state: 'State',
-  advanced: 'Advanced',
+  muted: 'Muted',
+  intense: 'Intense',
+  alternative: 'Alternative',
+  destructive: 'Destructive',
+  static: 'Static',
 }
 
 const decorativeGroupLabels: Record<string, string> = {
@@ -56,12 +64,6 @@ const decorativeGroupLabels: Record<string, string> = {
 const decorativeVariantLabels: Record<DecorativeVariant, string> = {
   'non-static': 'Non-static',
   static: 'Static',
-}
-
-const audienceSortOrder: Record<TokenAudience, number> = {
-  base: 0,
-  state: 1,
-  advanced: 2,
 }
 
 const decorativeGroupSortOrder: Record<string, number> = {
@@ -181,32 +183,6 @@ const sortTokensByDefault = (
   })
 }
 
-const sortTokensByUsageThenGroup = (tokens: TokenRow[]) => {
-  return [...tokens].sort((a, b) => {
-    const usageCompare =
-      audienceSortOrder[a.audience] - audienceSortOrder[b.audience]
-
-    if (usageCompare !== 0) {
-      return usageCompare
-    }
-
-    const groupCompare = collator.compare(
-      getGroupLabel(a),
-      getGroupLabel(b)
-    )
-
-    if (groupCompare !== 0) {
-      return groupCompare
-    }
-
-    return collator.compare(a.name, b.name)
-  })
-}
-
-const isGroupFirstSection = (section: TokenSectionId) => {
-  return section === 'decorative' || section === 'component'
-}
-
 const sortTokensByGroup = (
   tokens: TokenRow[],
   section: TokenSectionId,
@@ -223,26 +199,6 @@ const sortTokensByGroup = (
 
       result = groupOrderA - groupOrderB
     }
-
-    if (result === 0) {
-      result = collator.compare(getGroupLabel(a), getGroupLabel(b))
-    }
-
-    if (result === 0) {
-      result = collator.compare(a.name, b.name)
-    }
-
-    return direction === 'desc' ? result * -1 : result
-  })
-}
-
-const sortTokensByAudience = (
-  tokens: TokenRow[],
-  direction: 'asc' | 'desc'
-) => {
-  return [...tokens].sort((a, b) => {
-    let result =
-      audienceSortOrder[a.audience] - audienceSortOrder[b.audience]
 
     if (result === 0) {
       result = collator.compare(getGroupLabel(a), getGroupLabel(b))
@@ -275,24 +231,16 @@ const sortTokensByName = (
   })
 }
 
-const getAudienceFilterConfig = (
-  section: TokenSectionId
-): {
-  options: TokenAudience[]
-  defaultValue: TokenAudience[]
-} => {
-  switch (section) {
-    case 'decorative':
-      return {
-        options: ['advanced'],
-        defaultValue: [],
-      }
-    default:
-      return {
-        options: ['base', 'state', 'advanced'],
-        defaultValue: defaultVisibleAudiences,
-      }
-  }
+const getAvailableModifiers = (tokens: TokenRow[]): TokenModifier[] => {
+  const available = new Set<TokenModifier>()
+
+  tokens.forEach((token) => {
+    token.modifiers.forEach((modifier) => {
+      available.add(modifier)
+    })
+  })
+
+  return tokenModifierOrder.filter((modifier) => available.has(modifier))
 }
 
 export function TokenTypeFilter({
@@ -314,6 +262,7 @@ export function TokenTypeFilter({
         }}
         optionsLayout="horizontal"
         variant="button"
+        size="medium"
         emptyValue={[]}
         bottom="medium"
       >
@@ -345,16 +294,12 @@ export function TokenSectionOverview() {
       <thead>
         <Tr>
           <Th>Section</Th>
-          <Th>Base</Th>
-          <Th>State</Th>
-          <Th>Advanced</Th>
+          <Th>Tokens</Th>
           <Th>Usage</Th>
         </Tr>
       </thead>
       <tbody>
         {tokenSections.map((section) => {
-          const counts = countTokensByAudience(section.tokens)
-
           return (
             <Tr key={section.id}>
               <Td>
@@ -364,15 +309,13 @@ export function TokenSectionOverview() {
                   {section.title}
                 </Anchor>
               </Td>
-              <Td>{counts.base}</Td>
-              <Td>{counts.state}</Td>
-              <Td>{counts.advanced}</Td>
+              <Td>{section.tokens.length}</Td>
               <Td>
                 {section.id === 'component'
                   ? 'For internal use only.'
                   : section.id === 'decorative'
                     ? 'For advanced custom decorative needs.'
-                    : 'For external use. Prefer base tokens; advanced tokens carry semantic intent and may change across themes.'}
+                    : 'For external use. Use the filters in each section to narrow tokens to the variants you need.'}
               </Td>
             </Tr>
           )
@@ -439,10 +382,13 @@ export function TokenSectionTable({
   const sectionTokens = sectionData?.tokens || []
   const sectionTitle = sectionData?.title || section
 
-  const audienceFilterConfig = getAudienceFilterConfig(section)
-  const [visibleAudiences, setVisibleAudiences] = React.useState<
-    TokenAudience[]
-  >(audienceFilterConfig.defaultValue)
+  const availableModifiers = React.useMemo(
+    () => getAvailableModifiers(sectionTokens),
+    [sectionTokens]
+  )
+  const [activeModifiers, setActiveModifiers] = React.useState<
+    TokenModifier[]
+  >([])
   const decorativeGroups = React.useMemo(() => {
     if (section !== 'decorative') {
       return []
@@ -457,15 +403,11 @@ export function TokenSectionTable({
   const { sortState, sortHandler, activeSortName } = useHandleSortState(
     {
       group: {
-        active: isGroupFirstSection(section),
-        direction: isGroupFirstSection(section) ? 'asc' : 'off',
+        active: true,
+        direction: 'asc',
       },
       name: {
         direction: 'off',
-      },
-      usage: {
-        active: !isGroupFirstSection(section),
-        direction: isGroupFirstSection(section) ? 'off' : 'asc',
       },
     },
     {
@@ -487,15 +429,14 @@ export function TokenSectionTable({
         )
       }
 
-      return visibleAudiences.includes(token.audience)
-    })
+      if (activeModifiers.length === 0) {
+        return true
+      }
 
-    if (activeSortName === 'usage') {
-      return sortTokensByAudience(
-        filteredTokens,
-        sortState.usage.reversed ? 'desc' : 'asc'
+      return activeModifiers.every((modifier) =>
+        token.modifiers.includes(modifier)
       )
-    }
+    })
 
     if (activeSortName === 'group') {
       return sortTokensByGroup(
@@ -512,10 +453,6 @@ export function TokenSectionTable({
       )
     }
 
-    if (!isGroupFirstSection(section)) {
-      return sortTokensByUsageThenGroup(filteredTokens)
-    }
-
     return sortTokensByDefault(filteredTokens, section)
   }, [
     activeSortName,
@@ -523,8 +460,7 @@ export function TokenSectionTable({
     sectionTokens,
     sortState.group.reversed,
     sortState.name.reversed,
-    sortState.usage.reversed,
-    visibleAudiences,
+    activeModifiers,
     visibleDecorativeGroups,
     visibleDecorativeVariants,
   ])
@@ -545,6 +481,7 @@ export function TokenSectionTable({
             }}
             optionsLayout="horizontal"
             variant="button"
+            size="medium"
             emptyValue={[]}
             bottom="medium"
           >
@@ -567,6 +504,7 @@ export function TokenSectionTable({
             }}
             optionsLayout="horizontal"
             variant="button"
+            size="medium"
             emptyValue={[]}
             bottom="medium"
           >
@@ -580,27 +518,33 @@ export function TokenSectionTable({
             />
           </Field.ArraySelection>
         </>
-      ) : (
+      ) : availableModifiers.length > 0 ? (
         <Field.ArraySelection
-          label={`Show ${sectionTitle.toLowerCase()} token types`}
-          value={visibleAudiences}
+          label={`Filter ${sectionTitle.toLowerCase()} tokens`}
+          help={{
+            title: 'Filters',
+            content:
+              'Select one or more modifiers to narrow the list. Tokens must include all selected modifiers to appear.',
+          }}
+          value={activeModifiers}
           onChange={(value) => {
-            setVisibleAudiences((value as TokenAudience[]) || [])
+            setActiveModifiers((value as TokenModifier[]) || [])
           }}
           optionsLayout="horizontal"
           variant="button"
+          size="medium"
           emptyValue={[]}
           bottom="medium"
         >
-          {audienceFilterConfig.options.map((audience) => (
+          {availableModifiers.map((modifier) => (
             <Field.Option
-              key={audience}
-              value={audience}
-              title={audienceLabels[audience]}
+              key={modifier}
+              value={modifier}
+              title={modifierLabels[modifier]}
             />
           ))}
         </Field.ArraySelection>
-      )}
+      ) : null}
 
       {visibleTokens.length === 0 ? (
         <MDXParagraph>
@@ -637,47 +581,8 @@ export function TokenSectionTable({
                     />
                   </Th>
                 </>
-              ) : isGroupFirstSection(section) ? (
-                <>
-                  <Th
-                    noWrap
-                    sortable
-                    active={sortState.group.active}
-                    reversed={sortState.group.reversed}
-                  >
-                    <Th.SortButton
-                      text="Group"
-                      title="Sort by group"
-                      onClick={sortHandler.group}
-                    />
-                  </Th>
-                  <Th
-                    noWrap
-                    sortable
-                    active={sortState.usage.active}
-                    reversed={sortState.usage.reversed}
-                  >
-                    <Th.SortButton
-                      text="Usage"
-                      title="Sort by usage"
-                      onClick={sortHandler.usage}
-                    />
-                  </Th>
-                </>
               ) : (
                 <>
-                  <Th
-                    noWrap
-                    sortable
-                    active={sortState.usage.active}
-                    reversed={sortState.usage.reversed}
-                  >
-                    <Th.SortButton
-                      text="Usage"
-                      title="Sort by usage"
-                      onClick={sortHandler.usage}
-                    />
-                  </Th>
                   <Th
                     noWrap
                     sortable
@@ -708,14 +613,8 @@ export function TokenSectionTable({
                     <Td>{getGroupLabel(token)}</Td>
                     <Td>{getTokenLabel(token)}</Td>
                   </>
-                ) : isGroupFirstSection(section) ? (
-                  <>
-                    <Td>{getGroupLabel(token)}</Td>
-                    <Td>{audienceLabels[token.audience]}</Td>
-                  </>
                 ) : (
                   <>
-                    <Td>{audienceLabels[token.audience]}</Td>
                     <Td>{getGroupLabel(token)}</Td>
                   </>
                 )}

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
@@ -138,14 +138,6 @@ Tokens are organized into sections. Each section covers a specific surface:
 
 See the [Tokens](/uilib/usage/customisation/theming/design-tokens/tokens) tab for the full catalog.
 
-## Token audiences
-
-Not all tokens are intended for the same use cases:
-
-- **Base** – Part of the intended external semantic surface, such as `action` or `action-inverse`.
-- **State** – Semantic interaction states, such as `action-hover` or `action-focus`.
-- **Advanced** – Contextual or decorative tokens, such as `action-ondark`, `action-onlight` or `action-subtle`.
-
 ## Naming contract
 
 <TokenNamingRules />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/tokens.mdx
@@ -23,7 +23,7 @@ import {
 ### Tips
 
 - Hover over the value of a token in the tables below to see its **Eufemia Foundation** name.
-- You can also filter tokens by type using the filter buttons above the tables.
+- Use the filter buttons above each table to narrow tokens by modifier (for example `inverse`, `ondark`, `subtle`, `bold` or `static`). Multiple modifiers combine with `AND`.
 - You can sort the tables by clicking the column headers. Click again to reverse the sort order.
 
 ## Background

--- a/packages/dnb-design-system-portal/src/uilib/utils/__tests__/designTokens.test.ts
+++ b/packages/dnb-design-system-portal/src/uilib/utils/__tests__/designTokens.test.ts
@@ -1,7 +1,7 @@
 import {
   buildThemeTokenEntries,
   buildTokenSections,
-  classifyTokenAudience,
+  extractTokenModifiers,
 } from '../designTokens'
 
 describe('design token docs data', () => {
@@ -26,76 +26,54 @@ describe('design token docs data', () => {
         path: ['color', 'background', 'action'],
         section: 'background',
         group: 'action',
-        audience: 'base',
+        modifiers: [],
         reference: '#007272',
         foundationReference: null,
       },
     ])
   })
 
-  it('classifies base, state and advanced tokens for usage', () => {
+  it('extracts known modifiers from a token path', () => {
     expect(
-      classifyTokenAudience(
-        '--token-color-background-action',
-        'background'
-      )
-    ).toBe('base')
+      extractTokenModifiers(['color', 'background', 'action'])
+    ).toEqual([])
 
     expect(
-      classifyTokenAudience(
-        '--token-color-background-action-inverse',
-        'background'
-      )
-    ).toBe('base')
+      extractTokenModifiers(['color', 'background', 'action', 'hover'])
+    ).toEqual(['hover'])
 
     expect(
-      classifyTokenAudience(
-        '--token-color-background-action-hover',
-        'background'
-      )
-    ).toBe('state')
+      extractTokenModifiers([
+        'color',
+        'background',
+        'action',
+        'hover',
+        'subtle',
+        'ondark',
+      ])
+    ).toEqual(['hover', 'subtle', 'ondark'])
 
     expect(
-      classifyTokenAudience(
-        '--token-color-background-action-focus',
-        'background'
-      )
-    ).toBe('state')
+      extractTokenModifiers([
+        'color',
+        'decorative',
+        'first',
+        'subtle',
+        'static',
+      ])
+    ).toEqual(['subtle', 'static'])
 
     expect(
-      classifyTokenAudience(
-        '--token-color-background-action-ondark',
-        'background'
-      )
-    ).toBe('advanced')
+      extractTokenModifiers(['color', 'text', 'neutral', 'bold'])
+    ).toEqual(['bold'])
 
     expect(
-      classifyTokenAudience(
-        '--token-color-decorative-first-subtle',
-        'decorative'
-      )
-    ).toBe('advanced')
-
-    expect(
-      classifyTokenAudience(
-        '--token-color-component-button-background-action',
-        'component'
-      )
-    ).toBe('base')
-
-    expect(
-      classifyTokenAudience(
-        '--token-color-component-button-background-action-hover',
-        'component'
-      )
-    ).toBe('state')
-
-    expect(
-      classifyTokenAudience(
-        '--token-color-component-button-background-action-ondark',
-        'component'
-      )
-    ).toBe('advanced')
+      extractTokenModifiers([
+        'color',
+        'background',
+        'action-hover-subtle-ondark',
+      ])
+    ).toEqual(['hover', 'subtle', 'ondark'])
   })
 
   it('merges the same token across themes into one row', () => {
@@ -175,7 +153,7 @@ describe('design token docs data', () => {
         path: ['color', 'text', 'neutral'],
         section: 'text',
         group: 'neutral',
-        audience: 'base',
+        modifiers: [],
         references: {
           uiLight: '#121212',
           uiDark: '#fafafa',

--- a/packages/dnb-design-system-portal/src/uilib/utils/designTokens.ts
+++ b/packages/dnb-design-system-portal/src/uilib/utils/designTokens.ts
@@ -40,7 +40,44 @@ export type ThemeName =
   | 'sbankenLight'
   | 'sbankenDark'
   | 'carnegie'
-export type TokenAudience = 'base' | 'state' | 'advanced'
+export type TokenModifier =
+  | 'hover'
+  | 'pressed'
+  | 'focus'
+  | 'disabled'
+  | 'inverse'
+  | 'ondark'
+  | 'onlight'
+  | 'onsubtle'
+  | 'subtle'
+  | 'bold'
+  | 'base'
+  | 'muted'
+  | 'intense'
+  | 'alternative'
+  | 'destructive'
+  | 'static'
+
+export const tokenModifierOrder: readonly TokenModifier[] = [
+  'hover',
+  'pressed',
+  'focus',
+  'disabled',
+  'inverse',
+  'ondark',
+  'onlight',
+  'onsubtle',
+  'subtle',
+  'bold',
+  'base',
+  'muted',
+  'intense',
+  'alternative',
+  'destructive',
+  'static',
+]
+
+const tokenModifierSet = new Set<string>(tokenModifierOrder)
 
 type FigmaValue = {
   alpha?: number
@@ -73,7 +110,7 @@ export type TokenRow = {
   path: string[]
   section: TokenSectionId
   group: string
-  audience: TokenAudience
+  modifiers: TokenModifier[]
   references: Record<ThemeName, string>
   foundationReferences: Record<ThemeName, string | null>
 }
@@ -96,7 +133,7 @@ type TokenEntry = {
   path: string[]
   section: TokenSectionId
   group: string
-  audience: TokenAudience
+  modifiers: TokenModifier[]
   reference: string
   foundationReference: string | null
 }
@@ -158,35 +195,31 @@ export const humanizeTokenSegment = (value: string) => {
     .join(' ')
 }
 
-const stateSegments = new Set(['hover', 'pressed', 'focus', 'disabled'])
+export const extractTokenModifiers = (
+  path: readonly string[]
+): TokenModifier[] => {
+  const seen = new Set<TokenModifier>()
+  const ordered: TokenModifier[] = []
 
-const advancedSegments = new Set([
-  'ondark',
-  'onlight',
-  'onsubtle',
-  'subtle',
-  'static',
-])
+  path.forEach((segment) => {
+    segment
+      .split('-')
+      .filter(Boolean)
+      .forEach((part) => {
+        if (!tokenModifierSet.has(part)) {
+          return
+        }
 
-export const classifyTokenAudience = (
-  tokenName: string,
-  section: TokenSectionId
-): TokenAudience => {
-  if (section === 'decorative') {
-    return 'advanced'
-  }
+        const modifier = part as TokenModifier
 
-  const segments = tokenName.split('-').filter(Boolean)
+        if (!seen.has(modifier)) {
+          seen.add(modifier)
+          ordered.push(modifier)
+        }
+      })
+  })
 
-  if (segments.some((segment) => stateSegments.has(segment))) {
-    return 'state'
-  }
-
-  if (segments.some((segment) => advancedSegments.has(segment))) {
-    return 'advanced'
-  }
-
-  return 'base'
+  return ordered
 }
 
 export const buildThemeTokenEntries = (
@@ -210,7 +243,7 @@ export const buildThemeTokenEntries = (
           path: nextPath,
           section,
           group: nextPath[2] || 'general',
-          audience: classifyTokenAudience(name, section),
+          modifiers: extractTokenModifiers(nextPath),
           reference: readTokenReference(value),
           foundationReference: readFoundationReference(value),
         },
@@ -255,7 +288,7 @@ export const buildTokenSections = (
         path: entry.path,
         section: entry.section,
         group: entry.group,
-        audience: entry.audience,
+        modifiers: entry.modifiers,
         references: {
           uiLight: theme === 'uiLight' ? entry.reference : 'n/a',
           uiDark: theme === 'uiDark' ? entry.reference : 'n/a',
@@ -309,19 +342,3 @@ export const buildTokenSections = (
 }
 
 export const tokenSections = buildTokenSections()
-
-export const countTokensByAudience = (
-  tokens: TokenRow[]
-): Record<TokenAudience, number> => {
-  return tokens.reduce(
-    (acc, token) => {
-      acc[token.audience] += 1
-      return acc
-    },
-    {
-      base: 0,
-      state: 0,
-      advanced: 0,
-    } as Record<TokenAudience, number>
-  )
-}


### PR DESCRIPTION
When I search for design tokens, I don't find the base/advanced filter helpful. But rather want to quickly see e.g. all "On dark" tokens. Therefore, I think it makes more sense to add this kind of filter system.

Preview: https://chore-design-tokens-filter-i.eufemia-e25.pages.dev/uilib/usage/customisation/theming/design-tokens/tokens/#background