### PR TITLE
refactor: remove @ts-nocheck from all NumberFormat utils and add proper TypeScript types

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/utils/cleanNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/cleanNumber.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Clean numbers for separators.
  * https://en.wikipedia.org/wiki/Decimal_separator
@@ -8,16 +5,22 @@
 
 import { escapeRegexChars } from '../../../shared/component-helper'
 import { NUMBER_CHARS } from './constants'
+import type { NumberFormatValue } from './types'
 
 export function cleanNumber(
-  num,
+  num: NumberFormatValue | null | undefined,
   {
     decimalSeparator = null,
     thousandsSeparator = null,
     prefix = null,
     suffix = null,
+  }: {
+    decimalSeparator?: string | null
+    thousandsSeparator?: string | null
+    prefix?: string | null
+    suffix?: string | null
   } = {}
-) {
+): NumberFormatValue | null | undefined {
   if (
     typeof num === 'number' ||
     typeof num === 'undefined' ||

--- a/packages/dnb-eufemia/src/components/number-format/utils/compact.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/compact.ts
@@ -1,9 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Helpers to configure the `Intl.NumberFormat` compact notation.
  */
+
+import type { NumberFormatValue } from './types'
+import type { InternalNumberFormatOptions } from './types'
 
 /**
  * Helper for getting a consistent compact format.
@@ -15,39 +15,44 @@ export function handleCompactBeforeDisplay({
   compact,
   decimals = 0,
   opts,
-} = {}) {
+}: {
+  value: NumberFormatValue
+  locale: string | null
+  compact: boolean | 'short' | 'long' | null
+  decimals?: number | string | null
+  opts: InternalNumberFormatOptions
+}) {
   if (!canHandleCompact({ value, compact })) {
     return // stop here
   }
 
-  value = parseInt(Math.abs(value), 10)
+  value = parseInt(String(Math.abs(Number(value))), 10)
   opts.notation = 'compact'
 
   // For numbers under 1M we do
   if (compact === true && locale && /(no|nb|nn)$/i.test(locale)) {
     opts.compactDisplay = Math.abs(value) < 1000000 ? 'long' : 'short'
-  } else {
-    opts.compactDisplay = compact !== true ? compact : 'short'
+  } else if (compact === 'long' || compact === 'short') {
+    opts.compactDisplay = compact
   }
 
   if (typeof opts.maximumSignificantDigits === 'undefined') {
-    if (isNaN(parseFloat(decimals))) {
-      decimals = 0
-    } else {
-      decimals = parseFloat(decimals)
+    let decimalCount = parseFloat(String(decimals))
+    if (isNaN(decimalCount)) {
+      decimalCount = 0
     }
 
     // This formula ensures we always get the same amount decimals
     const ref = String(value).length % 3
     if (ref === 2) {
-      decimals += 1
+      decimalCount += 1
     } else if (ref === 0) {
-      decimals += 2
+      decimalCount += 2
     }
 
     // Firefox issue?
     // If we do not define "maximumSignificantDigits" Firefox does not show any decimals at all
-    opts.maximumSignificantDigits = decimals + 1
+    opts.maximumSignificantDigits = decimalCount + 1
   }
 }
 
@@ -55,7 +60,15 @@ export function handleCompactBeforeDisplay({
  * Helper for getting a consistent compact format.
  * Mutates the given `opts` object.
  */
-export function handleCompactBeforeAria({ value, compact, opts }) {
+export function handleCompactBeforeAria({
+  value,
+  compact,
+  opts,
+}: {
+  value: NumberFormatValue
+  compact: boolean | 'short' | 'long' | null
+  opts: InternalNumberFormatOptions
+}) {
   if (!canHandleCompact({ value, compact })) {
     return // stop here
   }
@@ -66,8 +79,14 @@ export function handleCompactBeforeAria({ value, compact, opts }) {
 /**
  * Checks if we should/can handle the compact format.
  */
-export function canHandleCompact({ value, compact }) {
-  if (compact && Math.abs(value) >= 1000) {
+export function canHandleCompact({
+  value,
+  compact,
+}: {
+  value: NumberFormatValue
+  compact: boolean | 'short' | 'long' | null
+}): boolean {
+  if (compact && Math.abs(Number(value)) >= 1000) {
     return true
   }
 

--- a/packages/dnb-eufemia/src/components/number-format/utils/constants.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/constants.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+import type { NumberFormatValue } from './types'
 
 export const NUMBER_CHARS = '\\-0-9,.'
 
@@ -12,7 +11,9 @@ export const NUMBER_MINUS = '-|−|‐|‒|–|—|―'
 // this is used to format a number that is not absent
 export const ABSENT_VALUE_FORMAT = '–'
 
-export function isAbsent(value) {
+export function isAbsent(
+  value: NumberFormatValue | null | undefined
+): boolean {
   return (
     value === null ||
     value === undefined ||

--- a/packages/dnb-eufemia/src/components/number-format/utils/currencyDisplay.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/currencyDisplay.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Helpers for currency sign display lookup and fallback handling.
  */
@@ -10,20 +7,36 @@ import {
   CURRENCY_DISPLAY,
   CURRENCY_FALLBACK_DISPLAY,
 } from '../../../shared/defaults'
+import type { CurrencyDisplayValue } from './types'
+
+const validCurrencyDisplayValues: ReadonlySet<string> =
+  new Set<CurrencyDisplayValue>(['code', 'name', 'symbol', 'narrowSymbol'])
+
+function isCurrencyDisplayValue(
+  value: string
+): value is CurrencyDisplayValue {
+  return validCurrencyDisplayValues.has(value)
+}
 
 /**
  * Will return currency display value based on navigator/browser and locale.
  */
 export function getFallbackCurrencyDisplay(
-  locale = null,
-  currencyDisplay = null
-) {
+  locale: string | null = null,
+  currencyDisplay: string | boolean | null = null
+): CurrencyDisplayValue {
   // If currencyDisplay is not defined and locale is "no", use narrowSymbol
   if (!currencyDisplay && (!locale || /(no|nb|nn)$/i.test(locale))) {
     currencyDisplay = CURRENCY_DISPLAY
   }
 
-  return currencyDisplay || CURRENCY_FALLBACK_DISPLAY // code, name, symbol
+  const value = String(currencyDisplay || '')
+
+  if (isCurrencyDisplayValue(value)) {
+    return value
+  }
+
+  return CURRENCY_FALLBACK_DISPLAY
 }
 
 export { CURRENCY, CURRENCY_DISPLAY, CURRENCY_FALLBACK_DISPLAY }

--- a/packages/dnb-eufemia/src/components/number-format/utils/currencyPosition.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/currencyPosition.ts
@@ -1,19 +1,19 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+import type { FormatPartItem, PartFormatter } from './types'
+import type { NumberFormatCurrencyPosition } from './types'
 
 /**
  * Changes the currency sign position.
  * For Norway, the position defaults to "after".
  */
 export const currencyPositionFormatter = (
-  existingFormatter,
-  callback,
-  position = null
-) => {
+  existingFormatter: PartFormatter | null | undefined,
+  callback: (item: FormatPartItem) => string,
+  position: NumberFormatCurrencyPosition | null = null
+): PartFormatter => {
   let count = 0
   let countCurrency = -1
 
-  return (item) => {
+  return (item: FormatPartItem): FormatPartItem => {
     // Ensure we do not overwrite a given formatter, but run it as well
     if (typeof existingFormatter === 'function') {
       item = existingFormatter(item)

--- a/packages/dnb-eufemia/src/components/number-format/utils/decimals.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/decimals.ts
@@ -1,14 +1,14 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Decimal helpers (rounding, formatting fraction digits).
  */
 
+import type { NumberFormatValue } from './types'
+import type { InternalNumberFormatOptions } from './types'
+
 /**
  * Rounds the number to the nearest even number.
  */
-export function roundHalfEven(num, decimalPlaces = 2) {
+export function roundHalfEven(num: number, decimalPlaces = 2): number {
   const multiplier = Math.pow(10, decimalPlaces)
   const adjustedNum = num * multiplier
   const floored = Math.floor(adjustedNum)
@@ -29,8 +29,13 @@ export function roundHalfEven(num, decimalPlaces = 2) {
 /**
  * Fill format decimals.
  */
-export const formatDecimals = (value, decimals, rounding, opts = {}) => {
-  decimals = parseFloat(decimals)
+export const formatDecimals = (
+  value: NumberFormatValue,
+  decimals: number | string | null,
+  rounding: string | boolean | null | undefined,
+  opts: InternalNumberFormatOptions = {}
+): NumberFormatValue => {
+  decimals = parseFloat(String(decimals))
 
   // Mutate the given options
   if (decimals >= 0) {
@@ -42,11 +47,11 @@ export const formatDecimals = (value, decimals, rounding, opts = {}) => {
     const decimalPlaces = decimals || opts.maximumFractionDigits
     if (rounding === 'omit' || rounding === true) {
       const factor = Math.pow(10, decimalPlaces)
-      value = Math.trunc(value * factor) / factor
+      value = Math.trunc(Number(value) * factor) / factor
     } else {
       switch (rounding) {
         case 'half-even': {
-          value = roundHalfEven(value, decimalPlaces)
+          value = roundHalfEven(Number(value), decimalPlaces)
 
           break
         }
@@ -60,7 +65,10 @@ export const formatDecimals = (value, decimals, rounding, opts = {}) => {
 /**
  * Find the amount of decimals.
  */
-export const countDecimals = (value, decimalSeparator = '.') => {
+export const countDecimals = (
+  value: NumberFormatValue,
+  decimalSeparator = '.'
+): number => {
   if (
     typeof value === 'number' &&
     Math.floor(value.valueOf()) === value.valueOf()

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatBankAccountNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatBankAccountNumber.ts
@@ -1,32 +1,33 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Norwegian Bank Account Number formatter.
  */
 
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { formatWith } from './formatCore'
+import type { NumberFormatValue, FormattedParts } from './types'
 
-const formatBankAccountNumberParts = (number, locale = null) => {
+const formatBankAccountNumberParts = (
+  number: NumberFormatValue,
+  locale: string | null = null
+): FormattedParts => {
   if (isAbsent(number)) {
     return { number: ABSENT_VALUE_FORMAT, aria: ABSENT_VALUE_FORMAT }
   }
   // cleanup
-  number = String(number).replace(/[^0-9]/g, '')
+  const num = String(number).replace(/[^0-9]/g, '')
 
-  let display = number
-  let aria = null
+  let display = num
+  let aria: string | null = null
 
   switch (locale) {
     default: {
       // Get 2000 12 34567
-      display = number
+      display = num
         .split(/([0-9]{4})([0-9]{2})([0-9]{1,})/)
         .filter((s) => s)
         .join(' ')
 
-      aria = number
+      aria = num
         .split(/([0-9]{2})/)
         .filter((s) => s)
         .join(' ')

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Shared format plumbing used by the variant formatters
  * (`formatPlainNumber`, `formatPercent`, `formatCurrency`, etc.).
@@ -18,11 +15,20 @@ import {
   handleCompactBeforeAria,
 } from './compact'
 import locales from '../../../shared/locales'
+import type {
+  NumberFormatValue,
+  NumberFormatReturnValue,
+  NumberFormatFunction,
+  NumberFormatOptionParams,
+  InternalNumberFormatOptions,
+  FormatPartItem,
+  FormattedParts,
+} from './types'
 
 /**
  * Normalises locale (handles `null` + `auto`).
  */
-export function resolveLocale(locale) {
+export function resolveLocale(locale: string | null): string {
   if (!locale) {
     return LOCALE
   }
@@ -40,8 +46,14 @@ export function resolveLocale(locale) {
  * Parses the `options` argument (may be a JSON string) and mixes in
  * `signDisplay` when provided.
  */
-export function prepareFormatOptions({ options, signDisplay }) {
-  const opts =
+export function prepareFormatOptions({
+  options,
+  signDisplay,
+}: {
+  options: string | InternalNumberFormatOptions | null
+  signDisplay: NumberFormatOptionParams['signDisplay'] | null
+}): InternalNumberFormatOptions {
+  const opts: InternalNumberFormatOptions =
     (typeof options === 'string' && options[0] === '{'
       ? JSON.parse(options)
       : options) || {}
@@ -70,15 +82,24 @@ export function buildReturn({
   opts,
   cleanCopyValue,
   invalidAriaText,
-}) {
+}: {
+  value: NumberFormatValue
+  locale: string
+  display: string
+  aria: string
+  type: string
+  opts: InternalNumberFormatOptions
+  cleanCopyValue: boolean | null
+  invalidAriaText: string | null
+}): NumberFormatReturnValue {
   let cleanedValue
 
   if (cleanCopyValue) {
     cleanedValue = formatNumber(
-      opts.style === 'percent' ? value / 100 : value,
+      opts.style === 'percent' ? Number(value) / 100 : value,
       locale,
       opts,
-      (item) => {
+      (item: FormatPartItem) => {
         switch (item.type) {
           case 'group':
           case 'literal':
@@ -117,8 +138,13 @@ export function applyDecimalsForPlain({
   decimals,
   rounding,
   opts,
-}) {
-  if (parseFloat(decimals) >= 0) {
+}: {
+  value: NumberFormatValue
+  decimals: number | string | null
+  rounding: string | boolean | null | undefined
+  opts: InternalNumberFormatOptions
+}): NumberFormatValue {
+  if (parseFloat(String(decimals)) >= 0) {
     return formatDecimals(value, decimals, rounding, opts)
   } else if (typeof opts.maximumFractionDigits === 'undefined') {
     // if no decimals are set, opts.maximumFractionDigits is set
@@ -138,17 +164,26 @@ export {
   handleCompactBeforeAria,
 }
 
-import type { NumberFormatFunction } from './types'
-
 /**
  * Creates a public variant formatter given a type tag and a raw
  * `(number, locale) => { number, aria }` function. The returned function
  * accepts `(value, options)` and returns either a formatted string or –
  * when `returnAria: true` – the full `NumberFormatReturnValue` object.
  */
-export function formatWith(type, formatterFn): NumberFormatFunction {
-  return (
-    value,
+export function formatWith(
+  type: string,
+  formatterFn: (value: NumberFormatValue, locale: string) => FormattedParts
+): NumberFormatFunction {
+  function formatter(
+    value: NumberFormatValue | null | undefined,
+    options: NumberFormatOptionParams & { returnAria: true }
+  ): NumberFormatReturnValue
+  function formatter(
+    value: NumberFormatValue | null | undefined,
+    options?: NumberFormatOptionParams
+  ): string
+  function formatter(
+    value: NumberFormatValue | null | undefined,
     {
       locale: inputLocale = null,
       clean = null,
@@ -157,8 +192,8 @@ export function formatWith(type, formatterFn): NumberFormatFunction {
       returnAria = false,
       invalidAriaText = null,
       cleanCopyValue = null,
-    } = {}
-  ) => {
+    }: NumberFormatOptionParams = {}
+  ): string | NumberFormatReturnValue {
     value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
     const locale = resolveLocale(inputLocale)
@@ -193,4 +228,6 @@ export function formatWith(type, formatterFn): NumberFormatFunction {
       invalidAriaText,
     })
   }
+
+  return formatter
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
@@ -1,9 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import type {
-  NumberFormatFunction,
   NumberFormatOptionParams,
+  NumberFormatReturnValue,
+  NumberFormatValue,
+  FormatPartItem,
+  PartFormatter,
 } from './types'
 /**
  * Formatter for currency numbers.
@@ -27,8 +27,16 @@ import { currencyPositionFormatter } from './currencyPosition'
 import { getFallbackCurrencyDisplay, CURRENCY } from './currencyDisplay'
 import { alignCurrencySymbol } from './formatNumber'
 
-export const formatCurrency: NumberFormatFunction = (
-  value,
+export function formatCurrency(
+  value: NumberFormatValue | null | undefined,
+  options: NumberFormatOptionParams & { returnAria: true }
+): NumberFormatReturnValue
+export function formatCurrency(
+  value: NumberFormatValue | null | undefined,
+  options?: NumberFormatOptionParams
+): string
+export function formatCurrency(
+  value: NumberFormatValue | null | undefined,
   {
     locale: inputLocale = null,
     clean = false,
@@ -45,7 +53,7 @@ export const formatCurrency: NumberFormatFunction = (
     invalidAriaText = null,
     cleanCopyValue = null,
   }: NumberFormatOptionParams = {}
-) => {
+): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
   const locale = resolveLocale(inputLocale)
@@ -56,11 +64,11 @@ export const formatCurrency: NumberFormatFunction = (
   }
 
   opts.currency =
-    opts.currency || (currency === true ? CURRENCY : currency)
+    opts.currency || (currency === true ? CURRENCY : currency || undefined)
 
   handleCompactBeforeDisplay({ value, locale, compact, decimals, opts })
 
-  if (parseFloat(decimals) >= 0) {
+  if (parseFloat(String(decimals)) >= 0) {
     value = formatDecimals(value, decimals, rounding, opts)
   } else if (decimals === null) {
     decimals = 2
@@ -69,7 +77,11 @@ export const formatCurrency: NumberFormatFunction = (
 
   // cleanup, but only if it did not got cleaned up already
   const cleanedNumber =
-    decimals >= 0 ? value : clean ? cleanNumber(value) : value
+    parseFloat(String(decimals)) >= 0
+      ? value
+      : clean
+        ? cleanNumber(value)
+        : value
 
   if (currencyDisplay === false || currencyDisplay === '') {
     omitCurrencySign = true
@@ -85,15 +97,15 @@ export const formatCurrency: NumberFormatFunction = (
   if (
     typeof opts.minimumFractionDigits === 'undefined' &&
     String(value).indexOf('.') === -1 &&
-    cleanedNumber % 1 === 0
+    Number(cleanedNumber) % 1 === 0
   ) {
     opts.minimumFractionDigits = 0 // to enforce Norwegian style
   }
 
-  let formatter
+  let formatter: PartFormatter | null = null
 
   if (omitCurrencySign) {
-    formatter = (item) => {
+    formatter = (item: FormatPartItem) => {
       switch (item.type) {
         case 'literal':
           item.value = item.value === ' ' ? '' : item.value
@@ -117,11 +129,11 @@ export const formatCurrency: NumberFormatFunction = (
     resolvedPosition = 'after'
   }
 
-  let currencySuffix = null
+  let currencySuffix: string | null = null
   if (resolvedPosition) {
     formatter = currencyPositionFormatter(
       formatter,
-      ({ value: currencyValue }) => {
+      ({ value: currencyValue }: FormatPartItem) => {
         return (currencySuffix = alignCurrencySymbol(
           currencyValue.trim(),
           currencyDisplay

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNationalIdentityNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNationalIdentityNumber.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Norwegian National Identity Number formatter.
  */
@@ -8,21 +5,25 @@
 import { IS_WIN } from '../../../shared/helpers'
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { formatWith } from './formatCore'
+import type { NumberFormatValue, FormattedParts } from './types'
 
-const formatNationalIdentityNumberParts = (number, locale = null) => {
+const formatNationalIdentityNumberParts = (
+  number: NumberFormatValue,
+  locale: string | null = null
+): FormattedParts => {
   if (isAbsent(number)) {
     return { number: ABSENT_VALUE_FORMAT, aria: ABSENT_VALUE_FORMAT }
   }
   // cleanup
-  number = String(number).replace(/[^0-9]/g, '')
+  const num = String(number).replace(/[^0-9]/g, '')
 
-  let display = number
-  let aria = null
+  let display = num
+  let aria: string | null = null
 
   switch (locale) {
     default: {
       // Get 180892 12345
-      display = number
+      display = num
         .split(/([0-9]{6})/)
         .filter((s) => s)
         .join(' ')

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Core number formatting helpers used by all NumberFormat variants.
  */
@@ -10,30 +7,58 @@ import { warn, escapeRegexChars } from '../../../shared/component-helper'
 import { IS_MAC } from '../../../shared/helpers'
 import { ABSENT_VALUE_FORMAT, NUMBER_MINUS } from './constants'
 import { getFallbackCurrencyDisplay } from './currencyDisplay'
+import type {
+  NumberFormatValue,
+  FormatPartItem,
+  PartFormatter,
+  InternalNumberFormatOptions,
+} from './types'
+
+/**
+ * Strips custom properties (e.g. `decimals`) so the object
+ * is compatible with the native `Intl.NumberFormatOptions` type.
+ */
+function toIntlOptions({
+  decimals: _decimals,
+  ...rest
+}: InternalNumberFormatOptions): Intl.NumberFormatOptions {
+  return rest
+}
 
 /**
  * For internal usage.
  * Returns an array that contains all the parts of the given number
  * `[{ value, type }]`.
  */
-export function formatToParts({ number, locale = null, options = null }) {
+export function formatToParts({
+  number,
+  locale = null,
+  options = null,
+}: {
+  number: NumberFormatValue
+  locale?: string | null
+  options?: InternalNumberFormatOptions | null
+}): FormatPartItem[] {
   if (
     typeof Intl !== 'undefined' &&
     typeof Intl.NumberFormat === 'function'
   ) {
     try {
-      const inst = Intl.NumberFormat(locale || LOCALE, options || {})
+      const inst = new Intl.NumberFormat(
+        locale || LOCALE,
+        toIntlOptions(options || {})
+      )
       if (typeof inst.formatToParts === 'function') {
-        return inst.formatToParts(number)
+        return inst.formatToParts(Number(number))
       } else {
-        return [{ value: inst.format(number) }]
+        return [{ value: inst.format(Number(number)), type: 'unknown' }]
       }
     } catch (e) {
       warn(e)
     }
   }
 
-  return [{ value: number }]
+  return [{ value: String(number), type: 'unknown' }]
 }
 
 /**
@@ -41,11 +66,14 @@ export function formatToParts({ number, locale = null, options = null }) {
  * "norske kroner" ("Norwegian kroner") will be changed to "kroner" if the
  * currency display option is set to "name".
  */
-export function alignCurrencySymbol(output, currencyDisplay) {
+export function alignCurrencySymbol(
+  output: string | number,
+  currencyDisplay: string | boolean | null | undefined
+): string {
   if (typeof output === 'string' && currencyDisplay === 'name') {
     output = output.replace(/(nor[^\s]+?)\s(\w+)/i, '$2')
   }
-  return output
+  return String(output)
 }
 
 /**
@@ -56,7 +84,10 @@ export function alignCurrencySymbol(output, currencyDisplay) {
  * It only cleans if locale is Norwegian.
  * Form `-NOK 1 234` to `NOK -1 234`.
  */
-export const prepareMinus = (display, locale) => {
+export const prepareMinus = (
+  display: string,
+  locale: string | null
+): string => {
   if (!(locale && /(no|nb|nn)$/i.test(locale))) {
     return display
   }
@@ -90,8 +121,12 @@ export const prepareMinus = (display, locale) => {
  * Enhance VoiceOver support on mobile devices.
  * Numbers under 99.999 are read out correctly, but only if we remove the spaces.
  */
-export const enhanceSR = (value, aria, locale) => {
-  if (IS_MAC && Math.abs(parseFloat(value)) <= 99999) {
+export const enhanceSR = (
+  value: NumberFormatValue,
+  aria: string,
+  locale: string | null
+): string => {
+  if (IS_MAC && Math.abs(parseFloat(String(value))) <= 99999) {
     aria = String(aria).replace(/\s([0-9])/g, '$1')
   }
 
@@ -100,7 +135,7 @@ export const enhanceSR = (value, aria, locale) => {
   return aria
 }
 
-function replaceNaNWithDash(number) {
+function replaceNaNWithDash(number: string | number): string {
   const string = String(number)
   const replaced = string.replace(/NaN/, ABSENT_VALUE_FORMAT)
 
@@ -120,11 +155,11 @@ function replaceNaNWithDash(number) {
  * Calls the browser/Node.js `Intl.NumberFormat` or `Number.toLocaleString` APIs.
  */
 export const formatNumber = (
-  number,
-  locale,
-  options = {},
-  formatter = null
-) => {
+  number: NumberFormatValue,
+  locale: string | null,
+  options: InternalNumberFormatOptions = {},
+  formatter: PartFormatter | null = null
+): string => {
   try {
     if (options.currencyDisplay) {
       options.currencyDisplay = getFallbackCurrencyDisplay(
@@ -139,15 +174,25 @@ export const formatNumber = (
     if (formatter) {
       number = formatToParts({ number, locale, options })
         .map(formatter)
-        .reduce((acc, { value }) => acc + value, '')
+        .reduce((acc: string, { value }) => acc + value, '')
     } else if (
       typeof Number !== 'undefined' &&
       typeof Number.toLocaleString === 'function'
     ) {
-      number = parseFloat(number).toLocaleString(locale, options)
+      number = parseFloat(String(number)).toLocaleString(
+        locale || LOCALE,
+        toIntlOptions(options)
+      )
     }
-    if (new RegExp(`^(${NUMBER_MINUS})(0|0[^\\d]|0\\s.*)$`).test(number)) {
-      number = number.replace(new RegExp(`(${NUMBER_MINUS})0`), '0')
+    if (
+      new RegExp(`^(${NUMBER_MINUS})(0|0[^\\d]|0\\s.*)$`).test(
+        String(number)
+      )
+    ) {
+      number = String(number).replace(
+        new RegExp(`(${NUMBER_MINUS})0`),
+        '0'
+      )
     }
   } catch (e) {
     warn(

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatOrganizationNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatOrganizationNumber.ts
@@ -1,32 +1,33 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Norwegian Organization Number formatter.
  */
 
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { formatWith } from './formatCore'
+import type { NumberFormatValue, FormattedParts } from './types'
 
-const formatOrganizationNumberParts = (number, locale = null) => {
+const formatOrganizationNumberParts = (
+  number: NumberFormatValue,
+  locale: string | null = null
+): FormattedParts => {
   if (isAbsent(number)) {
     return { number: ABSENT_VALUE_FORMAT, aria: ABSENT_VALUE_FORMAT }
   }
   // cleanup
-  number = String(number).replace(/[^0-9]/g, '')
+  const num = String(number).replace(/[^0-9]/g, '')
 
-  let display = number
-  let aria = null
+  let display = num
+  let aria: string | null = null
 
   switch (locale) {
     default: {
       // Get 123 456 789
-      display = number
+      display = num
         .split(/([0-9]{3})/)
         .filter((s) => s)
         .join(' ')
 
-      aria = number
+      aria = num
         .split(/([0-9]{1})/)
         .filter((s) => s)
         .join(' ')

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
@@ -1,9 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import type {
-  NumberFormatFunction,
   NumberFormatOptionParams,
+  NumberFormatReturnValue,
+  NumberFormatValue,
 } from './types'
 /**
  * Formatter for percent numbers.
@@ -27,8 +25,16 @@ import {
 } from './formatCore'
 import { countDecimals } from './decimals'
 
-export const formatPercent: NumberFormatFunction = (
-  value,
+export function formatPercent(
+  value: NumberFormatValue | null | undefined,
+  options: NumberFormatOptionParams & { returnAria: true }
+): NumberFormatReturnValue
+export function formatPercent(
+  value: NumberFormatValue | null | undefined,
+  options?: NumberFormatOptionParams
+): string
+export function formatPercent(
+  value: NumberFormatValue | null | undefined,
   {
     locale: inputLocale = null,
     clean = false,
@@ -40,7 +46,7 @@ export const formatPercent: NumberFormatFunction = (
     invalidAriaText = null,
     cleanCopyValue = null,
   }: NumberFormatOptionParams = {}
-) => {
+): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
   const locale = resolveLocale(inputLocale)
@@ -50,7 +56,7 @@ export const formatPercent: NumberFormatFunction = (
     value = cleanNumber(value)
   }
 
-  if (parseFloat(decimals) >= 0) {
+  if (parseFloat(String(decimals)) >= 0) {
     value = formatDecimals(value, decimals, rounding, opts)
   }
 
@@ -65,7 +71,7 @@ export const formatPercent: NumberFormatFunction = (
     opts.style = 'percent'
   }
 
-  const display = formatNumber(value / 100, locale, opts)
+  const display = formatNumber(Number(value) / 100, locale, opts)
   const aria = display
 
   if (!returnAria) {

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPhoneNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPhoneNumber.ts
@@ -1,55 +1,57 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Phone-number specific formatter.
  */
 
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { formatWith } from './formatCore'
+import type { NumberFormatValue, FormattedParts } from './types'
 
-const formatPhoneNumberParts = (number, locale = null) => {
+const formatPhoneNumberParts = (
+  number: NumberFormatValue,
+  locale: string | null = null
+): FormattedParts => {
   if (isAbsent(number)) {
     return { number: ABSENT_VALUE_FORMAT, aria: ABSENT_VALUE_FORMAT }
   }
 
-  let display = number
-  let aria = null
+  let display = String(number)
+  let aria: string | null = null
+  let num: string
 
   switch (locale) {
     default: {
       let code = ''
-      number = String(number)
+      num = String(number)
         // Edge case for when a Norwegian number is given without a space after the country code
         .replace(/^(00|\+|)47([^\s])/, '+47 $2')
         .replace(/^00/, '+')
 
-      if (number.substring(0, 1) === '+') {
-        const codeAndNumber = number.match(
+      if (num.substring(0, 1) === '+') {
+        const codeAndNumber = num.match(
           // Split the number into the country code and the rest of the number
           /^\+([\d-]{1,8})\s{0,2}([\d\s-]{1,20})$/
         )
         if (codeAndNumber) {
           code = `+${codeAndNumber[1]} `
-          number = codeAndNumber[2]
+          num = codeAndNumber[2]
         }
       }
 
-      number = number.replace(/[^+\d]/g, '')
-      const length = number.length
+      num = num.replace(/[^+\d]/g, '')
+      const length = num.length
 
       // Get 800 22 222
-      if (length === 8 && number.substring(0, 1) === '8') {
+      if (length === 8 && num.substring(0, 1) === '8') {
         display =
           code +
-          number
+          num
             .split(/([\d]{3})([\d]{2})/)
             .filter((s) => s)
             .join(' ')
       } else {
         // Get 02000
         if (length < 6) {
-          display = code + number
+          display = code + num
         } else {
           if (code.includes('-')) {
             // Convert +12-3456 to +12 (3456)
@@ -59,7 +61,7 @@ const formatPhoneNumberParts = (number, locale = null) => {
           // Get 6 or 8 formatting
           display =
             code +
-            number
+            num
               .split(
                 length === 6
                   ? /^(\+[\d]{2})|([\d]{3})/
@@ -72,7 +74,7 @@ const formatPhoneNumberParts = (number, locale = null) => {
 
       aria =
         code +
-        number
+        num
           .split(/([\d]{2})/)
           .filter((s) => s)
           .join(' ')

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPlainNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPlainNumber.ts
@@ -1,9 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import type {
-  NumberFormatFunction,
   NumberFormatOptionParams,
+  NumberFormatReturnValue,
+  NumberFormatValue,
 } from './types'
 /**
  * Formatter for plain (non-currency / non-percent) numbers. Supports `compact`.
@@ -24,8 +22,16 @@ import {
   enhanceSR,
 } from './formatCore'
 
-export const formatPlainNumber: NumberFormatFunction = (
-  value,
+export function formatPlainNumber(
+  value: NumberFormatValue | null | undefined,
+  options: NumberFormatOptionParams & { returnAria: true }
+): NumberFormatReturnValue
+export function formatPlainNumber(
+  value: NumberFormatValue | null | undefined,
+  options?: NumberFormatOptionParams
+): string
+export function formatPlainNumber(
+  value: NumberFormatValue | null | undefined,
   {
     locale: inputLocale = null,
     clean = false,
@@ -38,7 +44,7 @@ export const formatPlainNumber: NumberFormatFunction = (
     invalidAriaText = null,
     cleanCopyValue = null,
   }: NumberFormatOptionParams = {}
-) => {
+): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
   const locale = resolveLocale(inputLocale)

--- a/packages/dnb-eufemia/src/components/number-format/utils/separators.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/separators.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 /**
  * Locale-aware separator lookups and currency symbol resolution.
  */
@@ -11,7 +8,7 @@ import { getFallbackCurrencyDisplay, CURRENCY } from './currencyDisplay'
 /**
  * Returns a decimal separator symbol based on the given locale.
  */
-export function getDecimalSeparator(locale = null) {
+export function getDecimalSeparator(locale: string | null = null): string {
   const separator =
     formatToParts({
       number: 1.1,
@@ -24,7 +21,9 @@ export function getDecimalSeparator(locale = null) {
 /**
  * Returns a thousands separator symbol based on the given locale.
  */
-export function getThousandsSeparator(locale = null) {
+export function getThousandsSeparator(
+  locale: string | null = null
+): string {
   return (
     formatToParts({
       number: 1000,
@@ -41,8 +40,8 @@ export function getCurrencySymbol(
   currency: string | boolean | null = null,
   display: string | boolean | null = null,
   number: string | number = 2
-) {
-  if (!currency) {
+): string {
+  if (!currency || currency === true) {
     currency = CURRENCY
   }
 

--- a/packages/dnb-eufemia/src/components/number-format/utils/types.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/types.ts
@@ -1,10 +1,55 @@
 // TypeScript types shared across the NumberFormat utilities.
 
+// The TS es2022 lib does not include 'negative' in the signDisplay
+// registry (it was added in es2023). Augment it so we can use the
+// native Intl types without widening signDisplay to `string`.
+// TODO: Remove this augmentation when tsconfig lib includes es2023.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Intl {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface NumberFormatOptionsSignDisplayRegistry {
+      negative: never
+    }
+  }
+}
+
+/** A single part returned by `Intl.NumberFormat.formatToParts()`. */
+export type FormatPartItem = {
+  type: string
+  value: string
+}
+
+/** Formatter callback that transforms individual format parts. */
+export type PartFormatter = (item: FormatPartItem) => FormatPartItem
+
+/** Valid values for the Intl currencyDisplay option. */
+export type CurrencyDisplayValue =
+  | 'code'
+  | 'name'
+  | 'symbol'
+  | 'narrowSymbol'
+
+/** Internal format options passed to `Intl.NumberFormat`. */
+export type InternalNumberFormatOptions = Omit<
+  Intl.NumberFormatOptions,
+  'currencyDisplay'
+> & {
+  decimals?: number
+  currencyDisplay?: CurrencyDisplayValue
+}
+
+/** Return value of inline part-formatters (phone, BAN, NIN, etc.). */
+export type FormattedParts = {
+  number: string
+  aria: string
+}
+
 export type NumberFormatType = 'number' | 'currency'
 export type NumberFormatCurrencyPosition = 'before' | 'after'
 export type NumberFormatReturnValue = {
   /** The given number */
-  value: number
+  value: NumberFormatValue
   /** Cleans a number from unnecessary parts */
   cleanedValue: string
   /** The formatted display number */


### PR DESCRIPTION
TS improvements in https://github.com/dnbexperience/eufemia/pull/7542

- Remove @ts-nocheck from all 15 utils/ files
- Add shared types: FormatPartItem, PartFormatter, InternalNumberFormatOptions,
  CurrencyDisplayValue, FormattedParts to types.ts
- Add proper parameter and return types to all functions
- Replace type casts with proper narrowing (String(), Number(), local variables)
- Use toIntlOptions() boundary helper instead of scattered 'as' casts
- Fix NumberFormatReturnValue.value type from number to NumberFormatValue
- 0 TypeScript errors, 464/464 tests passing