### PR TITLE
refactor: rename formatPlainNumber to formatNumber, internal formatNumber to formatNumberIntl

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -2029,7 +2029,7 @@ Notes:
 | `format(value, { percent: true })`   | `formatPercent(value)`                       |
 | `format(value, { currency: true })`  | `formatCurrency(value)`                      |
 | `format(value, { currency: 'USD' })` | `formatCurrency(value, { currency: 'USD' })` |
-| `format(value)`                      | `formatPlainNumber(value)`                   |
+| `format(value)`                      | `formatNumber(value)`                        |
 
 ```tsx
 // Before
@@ -2041,7 +2041,7 @@ import { formatPhoneNumber } from '@dnb/eufemia/components/NumberFormat'
 formatPhoneNumber(value)
 ```
 
-All variant formatters are re-exported from `@dnb/eufemia/components/NumberFormat`: `formatPlainNumber`, `formatCurrency`, `formatPercent`, `formatPhoneNumber`, `formatBankAccountNumber`, `formatNationalIdentityNumber`, `formatOrganizationNumber`.
+All variant formatters are re-exported from `@dnb/eufemia/components/NumberFormat`: `formatNumber`, `formatCurrency`, `formatPercent`, `formatPhoneNumber`, `formatBankAccountNumber`, `formatNationalIdentityNumber`, `formatOrganizationNumber`.
 
 `NumberFormatOptionParams` no longer accepts the `phone`, `ban`, `nin`, `org` or `percent` booleans; they were only used by the removed dispatcher.
 
@@ -2084,7 +2084,7 @@ const formatted = useNumberFormatWithParts(value, formatCurrency, {
 
 | Before                                                                | After                                                                            |
 | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `useNumberFormatWithParts(value)`                                     | `useNumberFormatWithParts(value, formatPlainNumber)`                             |
+| `useNumberFormatWithParts(value)`                                     | `useNumberFormatWithParts(value, formatNumber)`                                  |
 | `useNumberFormatWithParts(value, { currency: true })`                 | `useNumberFormatWithParts(value, formatCurrency)`                                |
 | `useNumberFormatWithParts(value, { percent: true })`                  | `useNumberFormatWithParts(value, formatPercent)`                                 |
 | `useNumberFormatWithParts(value, { forceCurrencyAfterAmount: true })` | `useNumberFormatWithParts(value, formatCurrency, { currencyPosition: 'after' })` |

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/events.mdx
@@ -14,11 +14,11 @@ import { InputEvents } from '@dnb/eufemia/src/components/input/InputDocs'
 You have two possibilities to manipulate the value while a user is typing. Either you handle the value with your own state, or you return a modified value in the `onChange` event listener:
 
 ```jsx
-import { formatPlainNumber } from '@dnb/eufemia/components/number-format/NumberUtils'
+import { formatNumber } from '@dnb/eufemia/components/number-format/NumberUtils'
 
 function Component() {
   const onChangeHandler = ({ value }) => {
-    return formatPlainNumber(value)
+    return formatNumber(value)
   }
 
   return <Input onChange={onChangeHandler} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -106,7 +106,7 @@ Each variant has a matching formatter function you can use outside of React (e.g
 
 ```tsx
 import {
-  formatPlainNumber,
+  formatNumber,
   formatCurrency,
   formatPercent,
   formatPhoneNumber,
@@ -118,7 +118,7 @@ import {
 
 | Formatter                      | Component variant                     |
 | ------------------------------ | ------------------------------------- |
-| `formatPlainNumber`            | `NumberFormat.Number`                 |
+| `formatNumber`                 | `NumberFormat.Number`                 |
 | `formatCurrency`               | `NumberFormat.Currency`               |
 | `formatPercent`                | `NumberFormat.Percent`                |
 | `formatPhoneNumber`            | `NumberFormat.PhoneNumber`            |
@@ -211,7 +211,7 @@ You can use the variant formatter functions without using a React Component or R
 ```ts
 import {
   formatCurrency,
-  formatPlainNumber,
+  formatNumber,
 } from '@dnb/eufemia/components/number-format/NumberUtils'
 
 // By using returnAria you get an object
@@ -221,7 +221,7 @@ const { number, aria } = formatCurrency(12345678.9, {
 })
 
 // Basic formatting
-const number = formatPlainNumber(1234)
+const number = formatNumber(1234)
 ```
 
 Each variant formatter accepts the same options as the corresponding component variant.

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -13,7 +13,7 @@ import {
   formatBankAccountNumber,
   formatCurrency,
   formatPhoneNumber,
-  formatPlainNumber,
+  formatNumber,
 } from '../../number-format/NumberUtils'
 import userEvent from '@testing-library/user-event'
 import {
@@ -1222,8 +1222,8 @@ describe('Autocomplete component', () => {
 
   it('has correct options when using searchNumbers, and searching with æøå', () => {
     const mockData = [
-      ['Åge Ørn Ærlig', formatPlainNumber('12345678901')],
-      ["Andrè Ørjåsæter O'Neill", formatPlainNumber('12345678901')],
+      ['Åge Ørn Ærlig', formatNumber('12345678901')],
+      ["Andrè Ørjåsæter O'Neill", formatNumber('12345678901')],
     ] as DrawerListData
 
     render(

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
@@ -5,7 +5,7 @@
 import {
   formatCurrency,
   formatPercent,
-  formatPlainNumber,
+  formatNumber,
   getDecimalSeparator,
   getThousandsSeparator,
 } from '../number-format/NumberUtils'
@@ -146,7 +146,7 @@ export const correctNumberValue = ({
     value = String(
       options.currency
         ? formatCurrency(value, options)
-        : formatPlainNumber(value, options)
+        : formatNumber(value, options)
     )
   }
 

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { InputProps } from '../Input'
 import Input from '../Input'
-import { formatPlainNumber } from '../../number-format/NumberUtils'
+import { formatNumber } from '../../number-format/NumberUtils'
 import { Provider } from '../../../shared'
 import {
   add_medium as AddIcon,
@@ -111,7 +111,7 @@ describe('Input component', () => {
       const [value, setValue] = React.useState(initialValue)
       return (
         <Input
-          value={String(formatPlainNumber(value))}
+          value={String(formatNumber(value))}
           onChange={({ value }) => {
             setValue(value)
           }}
@@ -122,7 +122,7 @@ describe('Input component', () => {
     render(<Controlled />)
 
     expect(document.querySelector('input').value).toBe(
-      formatPlainNumber(initialValue)
+      formatNumber(initialValue)
     )
 
     const newValue = '12345678'
@@ -131,7 +131,7 @@ describe('Input component', () => {
     })
 
     expect(document.querySelector('input').value).toBe(
-      formatPlainNumber(newValue)
+      formatNumber(newValue)
     )
   })
 

--- a/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
+++ b/packages/dnb-eufemia/src/components/input/stories/Input.stories.tsx
@@ -17,7 +17,7 @@ import {
   Flex,
 } from '../..'
 
-import { formatPlainNumber } from '../../number-format/NumberUtils'
+import { formatNumber } from '../../number-format/NumberUtils'
 import { FieldBlock, Form } from '../../../extensions/forms'
 
 export default {
@@ -462,7 +462,7 @@ export function ControlledInput() {
     event.preventDefault()
   }
 
-  console.log(formatPlainNumber(value))
+  console.log(formatNumber(value))
 
   return (
     <>
@@ -473,12 +473,12 @@ export function ControlledInput() {
         right
         onChange={onChangeHandler}
         onKeyDown={onKeyDownHandler}
-        value={formatPlainNumber(value).toString()}
+        value={formatNumber(value).toString()}
         selectAll
       />
       <input
         onChange={onChangeHandlerHtml}
-        value={formatPlainNumber(value).toString()}
+        value={formatNumber(value).toString()}
       />
     </>
   )

--- a/packages/dnb-eufemia/src/components/number-format/Number.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/Number.tsx
@@ -2,7 +2,7 @@ import type {
   NumberFormatAllProps,
   NumberFormatProps,
 } from './NumberFormatBase'
-import { formatPlainNumber } from './utils'
+import { formatNumber } from './utils'
 import { withFormatter } from './withFormatter'
 
 export type NumberFormatNumberProps = Omit<
@@ -15,7 +15,7 @@ export type NumberFormatNumberProps = Omit<
 
 const NumberFormatNumber = withFormatter<NumberFormatNumberProps>(
   'NumberFormat.Number',
-  formatPlainNumber
+  formatNumber
 )
 
 export default NumberFormatNumber

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormat.tsx
@@ -42,6 +42,7 @@ export { COPY_TOOLTIP_TIMEOUT } from './NumberFormatBase'
 
 // Re-export the variant formatters
 export {
+  formatNumber,
   formatPlainNumber,
   formatCurrency,
   formatPercent,

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
@@ -26,11 +26,7 @@ import {
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
 import Tooltip, { injectTooltipSemantic } from '../tooltip/Tooltip'
-import {
-  runIOSSelectionFix,
-  formatPlainNumber,
-  formatCurrency,
-} from './utils'
+import { runIOSSelectionFix, formatNumber, formatCurrency } from './utils'
 import type {
   NumberFormatCurrencyPosition as NumberFormatCurrencyPositionBase,
   NumberFormatOptions,
@@ -462,7 +458,7 @@ function NumberFormat(ownProps: NumberFormatAllProps) {
     __format ??
     (currency === true || typeof currency === 'string'
       ? formatCurrency
-      : formatPlainNumber)
+      : formatNumber)
   const result = formatter(value, formatOptions)
   const { cleanedValue, locale: lang } = result
   let { aria } = result

--- a/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberUtils.ts
@@ -19,7 +19,7 @@ export type {
 export {
   NUMBER_CHARS,
   NUMBER_MINUS,
-  formatNumber,
+  formatNumberIntl,
   alignCurrencySymbol,
   prepareMinus,
   enhanceSR,
@@ -29,6 +29,7 @@ export {
   roundHalfEven,
   cleanNumber,
   formatPlainNumber,
+  formatNumber,
   formatPercent,
   formatCurrency,
   formatPhoneNumber,

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -11,7 +11,7 @@ import { LOCALE } from '../../../shared/defaults'
 import * as helpers from '../../../shared/helpers'
 import {
   cleanNumber,
-  formatPlainNumber,
+  formatNumber,
   getFallbackCurrencyDisplay,
   getDecimalSeparator,
   getThousandsSeparator,
@@ -63,8 +63,8 @@ describe('Decimals format', () => {
   const num = -12345.6789
 
   it('should return default formatted number', () => {
-    expect(formatPlainNumber(num)).toBe('-12 345,6789')
-    expect(formatPlainNumber(num, { returnAria: true })).toMatchObject({
+    expect(formatNumber(num)).toBe('-12 345,6789')
+    expect(formatNumber(num, { returnAria: true })).toMatchObject({
       aria: '-12345,6789',
       cleanedValue: '-12345,6789',
       locale: 'nb-NO',
@@ -72,9 +72,7 @@ describe('Decimals format', () => {
       type: 'number',
       value: num,
     })
-    expect(
-      formatPlainNumber(String(num), { returnAria: true })
-    ).toMatchObject({
+    expect(formatNumber(String(num), { returnAria: true })).toMatchObject({
       aria: '-12345,6789',
       cleanedValue: '-12345,6789',
       locale: 'nb-NO',
@@ -83,7 +81,7 @@ describe('Decimals format', () => {
       value: String(num),
     })
     expect(
-      formatPlainNumber('', {
+      formatNumber('', {
         returnAria: true,
       })
     ).toMatchObject({
@@ -95,7 +93,7 @@ describe('Decimals format', () => {
       value: '–',
     })
     expect(
-      formatPlainNumber(null, {
+      formatNumber(null, {
         returnAria: true,
       })
     ).toMatchObject({
@@ -107,7 +105,7 @@ describe('Decimals format', () => {
       value: '–',
     })
     expect(
-      formatPlainNumber(undefined, {
+      formatNumber(undefined, {
         returnAria: true,
       })
     ).toMatchObject({
@@ -123,13 +121,13 @@ describe('Decimals format', () => {
   it('should handle unusual cases', () => {
     global.console.log = jest.fn()
 
-    expect(formatPlainNumber(num, { decimals: 0 })).toBe('-12 346')
-    expect(formatPlainNumber(num, { decimals: 1 })).toBe('-12 345,7')
-    expect(formatPlainNumber(num, { decimals: 2 })).toBe('-12 345,68')
-    expect(formatPlainNumber(num, { decimals: 3 })).toBe('-12 345,679')
-    expect(formatPlainNumber(num, { decimals: 4 })).toBe('-12 345,6789')
-    expect(formatPlainNumber(num, { decimals: 5 })).toBe('-12 345,67890')
-    expect(formatPlainNumber(num, { decimals: 6 })).toBe('-12 345,678900')
+    expect(formatNumber(num, { decimals: 0 })).toBe('-12 346')
+    expect(formatNumber(num, { decimals: 1 })).toBe('-12 345,7')
+    expect(formatNumber(num, { decimals: 2 })).toBe('-12 345,68')
+    expect(formatNumber(num, { decimals: 3 })).toBe('-12 345,679')
+    expect(formatNumber(num, { decimals: 4 })).toBe('-12 345,6789')
+    expect(formatNumber(num, { decimals: 5 })).toBe('-12 345,67890')
+    expect(formatNumber(num, { decimals: 6 })).toBe('-12 345,678900')
 
     expect(formatCurrency(num, { decimals: 0 })).toBe('-12 346 kr')
     expect(formatCurrency(num, { decimals: 1 })).toBe('-12 345,7 kr')
@@ -141,7 +139,7 @@ describe('Decimals format', () => {
     )
     expect(
       // more than 20 numbers
-      formatPlainNumber('-1.123456789123456789', {
+      formatNumber('-1.123456789123456789', {
         decimals: undefined,
       })
     ).toBe('-1,1234567891234568')
@@ -154,7 +152,7 @@ describe('Decimals format', () => {
 
   it('should render N/A when unsupported locale is given', () => {
     expect(
-      formatPlainNumber('invalid', {
+      formatNumber('invalid', {
         locale: 'something',
         returnAria: true,
       })
@@ -171,7 +169,7 @@ describe('Decimals format', () => {
   it('should render custom invalid ARIA text when given', () => {
     const customInvalidAriaText = 'my text'
     expect(
-      formatPlainNumber('invalid', {
+      formatNumber('invalid', {
         locale: 'something',
         returnAria: true,
         invalidAriaText: customInvalidAriaText,
@@ -213,21 +211,21 @@ describe('Decimals format', () => {
 
     it('half-even', () => {
       expect(
-        formatPlainNumber(2.5, {
+        formatNumber(2.5, {
           decimals: 0,
           rounding: 'half-even',
         })
       ).toBe('2')
 
       expect(
-        formatPlainNumber(3.5, {
+        formatNumber(3.5, {
           decimals: 0,
           rounding: 'half-even',
         })
       ).toBe('4')
 
       expect(
-        formatPlainNumber(-1000.415, {
+        formatNumber(-1000.415, {
           decimals: 2,
           rounding: 'half-even',
         })
@@ -244,31 +242,31 @@ describe('Decimals format', () => {
 
     it('half-up (default)', () => {
       expect(
-        formatPlainNumber(2.5, {
+        formatNumber(2.5, {
           decimals: 0,
           rounding: 'half-up',
         })
       ).toBe('3')
       expect(
-        formatPlainNumber(-2.5, {
+        formatNumber(-2.5, {
           decimals: 0,
           rounding: 'half-up',
         })
       ).toBe('-3')
       expect(
-        formatPlainNumber(2.434, {
+        formatNumber(2.434, {
           decimals: 2,
           rounding: 'half-up',
         })
       ).toBe('2,43')
       expect(
-        formatPlainNumber(2.476, {
+        formatNumber(2.476, {
           decimals: 2,
           rounding: 'half-up',
         })
       ).toBe('2,48')
       expect(
-        formatPlainNumber(2.476, {
+        formatNumber(2.476, {
           decimals: 2,
           rounding: undefined,
         })
@@ -278,39 +276,39 @@ describe('Decimals format', () => {
 
   describe('signDisplay', () => {
     it('auto (default)', () => {
-      expect(formatPlainNumber(1234)).toBe('1\u00A0234')
-      expect(formatPlainNumber(-1234)).toBe('-1\u00A0234')
-      expect(formatPlainNumber(0)).toBe('0')
+      expect(formatNumber(1234)).toBe('1\u00A0234')
+      expect(formatNumber(-1234)).toBe('-1\u00A0234')
+      expect(formatNumber(0)).toBe('0')
     })
 
     it('always', () => {
-      expect(formatPlainNumber(1234, { signDisplay: 'always' })).toBe(
+      expect(formatNumber(1234, { signDisplay: 'always' })).toBe(
         '+1\u00A0234'
       )
-      expect(formatPlainNumber(-1234, { signDisplay: 'always' })).toBe(
+      expect(formatNumber(-1234, { signDisplay: 'always' })).toBe(
         '-1\u00A0234'
       )
-      expect(formatPlainNumber(0, { signDisplay: 'always' })).toBe('+0')
+      expect(formatNumber(0, { signDisplay: 'always' })).toBe('+0')
     })
 
     it('exceptZero', () => {
-      expect(formatPlainNumber(1234, { signDisplay: 'exceptZero' })).toBe(
+      expect(formatNumber(1234, { signDisplay: 'exceptZero' })).toBe(
         '+1\u00A0234'
       )
-      expect(formatPlainNumber(-1234, { signDisplay: 'exceptZero' })).toBe(
+      expect(formatNumber(-1234, { signDisplay: 'exceptZero' })).toBe(
         '-1\u00A0234'
       )
-      expect(formatPlainNumber(0, { signDisplay: 'exceptZero' })).toBe('0')
+      expect(formatNumber(0, { signDisplay: 'exceptZero' })).toBe('0')
     })
 
     it('never', () => {
-      expect(formatPlainNumber(1234, { signDisplay: 'never' })).toBe(
+      expect(formatNumber(1234, { signDisplay: 'never' })).toBe(
         '1\u00A0234'
       )
-      expect(formatPlainNumber(-1234, { signDisplay: 'never' })).toBe(
+      expect(formatNumber(-1234, { signDisplay: 'never' })).toBe(
         '1\u00A0234'
       )
-      expect(formatPlainNumber(0, { signDisplay: 'never' })).toBe('0')
+      expect(formatNumber(0, { signDisplay: 'never' })).toBe('0')
     })
 
     it('should work with currency', () => {
@@ -333,10 +331,10 @@ describe('Decimals format', () => {
 
     it('should work with decimals', () => {
       expect(
-        formatPlainNumber(1234.56, { decimals: 2, signDisplay: 'always' })
+        formatNumber(1234.56, { decimals: 2, signDisplay: 'always' })
       ).toBe('+1\u00A0234,56')
       expect(
-        formatPlainNumber(-1234.56, { decimals: 2, signDisplay: 'always' })
+        formatNumber(-1234.56, { decimals: 2, signDisplay: 'always' })
       ).toBe('-1\u00A0234,56')
     })
   })

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react'
 import { renderHook } from '@testing-library/react'
 import useNumberFormatWithParts from '../useNumberFormatWithParts'
-import { formatCurrency, formatPercent, formatPlainNumber } from '../utils'
+import { formatCurrency, formatPercent, formatNumber } from '../utils'
 import Provider from '../../../shared/Provider'
 
 describe('useNumberFormatWithParts', () => {
@@ -88,7 +88,7 @@ describe('useNumberFormatWithParts', () => {
 
   it('will include split parts for plain numbers by default', () => {
     const { result } = renderHook(() =>
-      useNumberFormatWithParts(1234, formatPlainNumber, {
+      useNumberFormatWithParts(1234, formatNumber, {
         signDisplay: 'always',
       })
     )
@@ -160,7 +160,7 @@ describe('useNumberFormatWithParts', () => {
     )
     const { result } = renderHook(
       () =>
-        useNumberFormatWithParts(1234, formatPlainNumber, {
+        useNumberFormatWithParts(1234, formatNumber, {
           locale: 'en-GB',
         }),
       { wrapper }
@@ -183,7 +183,7 @@ describe('useNumberFormatWithParts', () => {
     expect(result.current).toBe('1 234,00 kr')
   })
 
-  it('defaults to formatPlainNumber when no formatter is supplied', () => {
+  it('defaults to formatNumber when no formatter is supplied', () => {
     const { result } = renderHook(() => useNumberFormatWithParts(1234))
 
     expect(result.current).toEqual(

--- a/packages/dnb-eufemia/src/components/number-format/index.ts
+++ b/packages/dnb-eufemia/src/components/number-format/index.ts
@@ -36,6 +36,7 @@ export { COPY_TOOLTIP_TIMEOUT } from './NumberFormatBase'
 
 // Re-export the variant formatters
 export {
+  formatNumber,
   formatPlainNumber,
   formatCurrency,
   formatPercent,

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormat.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormat.tsx
@@ -6,11 +6,11 @@ import type {
   NumberFormatReturnValue,
   NumberFormatValue,
 } from './NumberUtils'
-import { formatPlainNumber } from './utils'
+import { formatNumber } from './utils'
 
 /**
  * Shape of a variant formatter (`formatPhoneNumber`, `formatCurrency`,
- * `formatPercent`, `formatPlainNumber`, …).
+ * `formatPercent`, `formatNumber`, …).
  */
 export type NumberFormatter = {
   (
@@ -27,7 +27,7 @@ export type NumberFormatter = {
  * Format a value with an explicit formatter, picking up `locale` and
  * `NumberFormat` defaults from the Eufemia `Provider`.
  *
- * `formatter` is optional and defaults to `formatPlainNumber` for
+ * `formatter` is optional and defaults to `formatNumber` for
  * backwards compatibility with plain numeric values.
  *
  * Pass the variant formatter you need, e.g.
@@ -45,7 +45,7 @@ function useNumberFormat(
 ): string
 function useNumberFormat(
   value: NumberFormatValue,
-  formatter: NumberFormatter = formatPlainNumber,
+  formatter: NumberFormatter = formatNumber,
   options: NumberFormatOptionParams = {}
 ): NumberFormatReturnValue | string {
   const context = useContext(Context)

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.tsx
@@ -6,7 +6,7 @@ import type {
   NumberFormatReturnValue,
   NumberFormatValue,
 } from './NumberUtils'
-import { formatPlainNumber } from './utils'
+import { formatNumber } from './utils'
 import type { NumberFormatter } from './useNumberFormat'
 
 export type NumberFormatParts = {
@@ -30,7 +30,7 @@ export type NumberFormatReturnWithParts = NumberFormatReturnValue & {
  * formatted display string into structured `parts` (sign, number, currency,
  * percent) so consumers can style each piece independently.
  *
- * `formatter` defaults to `formatPlainNumber`. Pass `formatCurrency` or
+ * `formatter` defaults to `formatNumber`. Pass `formatCurrency` or
  * `formatPercent` for currency/percent output. The returned `parts` are
  * derived from the formatter's display string, so any formatter that
  * returns a `NumberFormatReturnValue` works.
@@ -47,7 +47,7 @@ function useNumberFormatWithParts(
 ): NumberFormatReturnWithParts
 function useNumberFormatWithParts(
   value: NumberFormatValue,
-  formatter: NumberFormatter = formatPlainNumber,
+  formatter: NumberFormatter = formatNumber,
   options: NumberFormatOptionParams = {}
 ): NumberFormatReturnWithParts | string {
   const context = useContext(Context)

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -1,6 +1,6 @@
 /**
  * Shared format plumbing used by the variant formatters
- * (`formatPlainNumber`, `formatPercent`, `formatCurrency`, etc.).
+ * (`formatNumber`, `formatPercent`, `formatCurrency`, etc.).
  */
 
 import { LOCALE } from '../../../shared/defaults'
@@ -8,7 +8,7 @@ import { warn } from '../../../shared/component-helper'
 import { ABSENT_VALUE_FORMAT, isAbsent } from './constants'
 import { cleanNumber } from './cleanNumber'
 import { formatDecimals } from './decimals'
-import { formatNumber, prepareMinus, enhanceSR } from './formatNumber'
+import { formatNumberIntl, prepareMinus, enhanceSR } from './formatNumber'
 import { getThousandsSeparator } from './separators'
 import {
   handleCompactBeforeDisplay,
@@ -96,7 +96,7 @@ export function buildReturn({
   let cleanedValue
 
   if (cleanCopyValue) {
-    cleanedValue = formatNumber(
+    cleanedValue = formatNumberIntl(
       opts.style === 'percent' ? Number(value) / 100 : value,
       locale,
       opts,
@@ -158,7 +158,7 @@ export function applyDecimalsForPlain({
 export {
   cleanNumber,
   formatDecimals,
-  formatNumber,
+  formatNumberIntl,
   prepareMinus,
   enhanceSR,
   handleCompactBeforeDisplay,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
@@ -15,7 +15,7 @@ import {
   buildReturn,
   cleanNumber,
   formatDecimals,
-  formatNumber,
+  formatNumberIntl,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -143,7 +143,7 @@ export function formatCurrency(
     )
   }
 
-  let display = formatNumber(cleanedNumber, locale, opts, formatter)
+  let display = formatNumberIntl(cleanedNumber, locale, opts, formatter)
   display = prepareMinus(display, locale)
 
   if (resolvedPosition && currencySuffix) {
@@ -157,7 +157,7 @@ export function formatCurrency(
   handleCompactBeforeAria({ value, compact, opts })
 
   // aria options
-  let aria = formatNumber(cleanedNumber, locale, {
+  let aria = formatNumberIntl(cleanedNumber, locale, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
     ...opts,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
@@ -154,7 +154,7 @@ function replaceNaNWithDash(number: string | number): string {
  * The main number formatter function.
  * Calls the browser/Node.js `Intl.NumberFormat` or `Number.toLocaleString` APIs.
  */
-export const formatNumber = (
+export const formatNumberIntl = (
   number: NumberFormatValue,
   locale: string | null,
   options: InternalNumberFormatOptions = {},

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
@@ -19,7 +19,7 @@ import {
   buildReturn,
   cleanNumber,
   formatDecimals,
-  formatNumber,
+  formatNumberIntl,
   prepareFormatOptions,
   resolveLocale,
 } from './formatCore'
@@ -71,7 +71,7 @@ export function formatPercent(
     opts.style = 'percent'
   }
 
-  const display = formatNumber(Number(value) / 100, locale, opts)
+  const display = formatNumberIntl(Number(value) / 100, locale, opts)
   const aria = display
 
   if (!returnAria) {

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPlainNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPlainNumber.ts
@@ -13,7 +13,7 @@ import {
   applyDecimalsForPlain,
   buildReturn,
   cleanNumber,
-  formatNumber,
+  formatNumberIntl,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -22,15 +22,15 @@ import {
   enhanceSR,
 } from './formatCore'
 
-export function formatPlainNumber(
+export function formatNumber(
   value: NumberFormatValue | null | undefined,
   options: NumberFormatOptionParams & { returnAria: true }
 ): NumberFormatReturnValue
-export function formatPlainNumber(
+export function formatNumber(
   value: NumberFormatValue | null | undefined,
   options?: NumberFormatOptionParams
 ): string
-export function formatPlainNumber(
+export function formatNumber(
   value: NumberFormatValue | null | undefined,
   {
     locale: inputLocale = null,
@@ -58,13 +58,13 @@ export function formatPlainNumber(
 
   handleCompactBeforeDisplay({ value, locale, compact, decimals, opts })
 
-  let display = formatNumber(value, locale, opts)
+  let display = formatNumberIntl(value, locale, opts)
   display = prepareMinus(display, locale)
 
   handleCompactBeforeAria({ value, compact, opts })
 
   // NVDA fix
-  let aria = formatNumber(value, locale, opts)
+  let aria = formatNumberIntl(value, locale, opts)
   aria = enhanceSR(value, aria, locale)
 
   if (!returnAria) {
@@ -82,3 +82,8 @@ export function formatPlainNumber(
     invalidAriaText,
   })
 }
+
+/**
+ * @deprecated Use `formatNumber` instead.
+ */
+export const formatPlainNumber = formatNumber

--- a/packages/dnb-eufemia/src/components/number-format/utils/index.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/index.ts
@@ -20,7 +20,7 @@ export type {
 export { NUMBER_CHARS, NUMBER_MINUS } from './constants'
 
 export {
-  formatNumber,
+  formatNumberIntl,
   alignCurrencySymbol,
   prepareMinus,
   enhanceSR,
@@ -31,7 +31,7 @@ export { formatDecimals, countDecimals, roundHalfEven } from './decimals'
 
 export { cleanNumber } from './cleanNumber'
 
-export { formatPlainNumber } from './formatPlainNumber'
+export { formatNumber, formatPlainNumber } from './formatPlainNumber'
 export { formatPercent } from './formatPercent'
 export { formatCurrency } from './formatCurrency'
 export { formatPhoneNumber } from './formatPhoneNumber'

--- a/packages/dnb-eufemia/src/components/number-format/withFormatter.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/withFormatter.tsx
@@ -9,7 +9,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
  * Create a `NumberFormat.*` variant component.
  *
  * Each variant imports only the formatter it cares about
- * (`formatCurrency`, `formatPlainNumber`, …) and passes it here.
+ * (`formatCurrency`, `formatNumber`, …) and passes it here.
  *
  * - `ThisVariantProps` narrows the public prop surface of the variant.
  * - `formatter` is injected as `__format` so `NumberFormatBase` can pick

--- a/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
@@ -1,8 +1,5 @@
 import type { NumberFormatReturnValue } from '../number-format/NumberUtils'
-import {
-  formatCurrency,
-  formatPlainNumber,
-} from '../number-format/NumberUtils'
+import { formatCurrency, formatNumber } from '../number-format/NumberUtils'
 import { clamp } from '../../shared/helpers/clamp'
 
 import type { SliderNumberFormat, SliderValue } from './types'
@@ -138,7 +135,7 @@ export const getFormattedNumber = (
     const formatter =
       options.currency === true || typeof options.currency === 'string'
         ? formatCurrency
-        : formatPlainNumber
+        : formatNumber
     return formatter(value as number, options)
   }
 

--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -5,7 +5,7 @@ import useNumberFormatWithParts from '../number-format/useNumberFormatWithParts'
 import {
   formatCurrency,
   formatPercent,
-  formatPlainNumber,
+  formatNumber,
 } from '../number-format/utils'
 import type {
   TypographySize,
@@ -138,7 +138,7 @@ function AmountBase(props: AmountProps) {
     ? formatPercent
     : isCurrency
       ? formatCurrency
-      : formatPlainNumber
+      : formatNumber
 
   const formatted = useNumberFormatWithParts(rawValue, formatter, {
     locale: resolvedLocale,

--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -5,7 +5,7 @@ import P from '../../elements/P'
 import Dl from '../../elements/Dl'
 import Dt from '../../elements/Dt'
 import Dd from '../../elements/Dd'
-import { formatPlainNumber } from '../number-format/NumberUtils'
+import { formatNumber } from '../number-format/NumberUtils'
 import { isArrayOfObjects, isArrayOfStrings } from './UploadVerify'
 import Table from '../Table'
 import Tr from '../table/TableTr'
@@ -83,7 +83,7 @@ const UploadInfo = () => {
               <Dd>
                 {String(fileSizeContent).replace(
                   '%size',
-                  formatPlainNumber(fileMaxSize).toString()
+                  formatNumber(fileMaxSize).toString()
                 )}
               </Dd>
             </Dl.Item>
@@ -182,7 +182,7 @@ function UploadInfoAcceptedFileTypesTable() {
                   {key !== '0' &&
                     String(fileSizeContent).replace(
                       '%size',
-                      formatPlainNumber(key).toString()
+                      formatNumber(key).toString()
                     )}
                 </Td>
               </Tr>

--- a/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadVerify.tsx
@@ -1,4 +1,4 @@
-import { formatPlainNumber } from '../number-format/NumberUtils'
+import { formatNumber } from '../number-format/NumberUtils'
 import type {
   UploadFile,
   UploadContextValue,
@@ -47,7 +47,7 @@ export function verifyFiles(
       ) {
         return String(errorLargeFile).replace(
           '%size',
-          formatPlainNumber(maxFileSize).toString()
+          formatNumber(maxFileSize).toString()
         )
       }
       return null

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -11,7 +11,7 @@ import type { NumberFormatOptionParams } from '../../../../components/number-for
 import {
   formatCurrency,
   formatPercent,
-  formatPlainNumber,
+  formatNumber,
 } from '../../../../components/number-format/NumberUtils'
 import type { InputAlign, InputSize } from '../../../../components/Input'
 import SharedContext from '../../../../shared/Context'
@@ -131,7 +131,7 @@ function NumberComponent(props: FieldNumberProps) {
             })
           }
 
-          return formatPlainNumber(value, formatOptions)
+          return formatNumber(value, formatOptions)
         }
 
         return z

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -21,7 +21,7 @@ import {
 import {
   formatCurrency,
   formatPercent,
-  formatPlainNumber,
+  formatNumber,
 } from '../../../../../components/number-format/NumberUtils'
 import { Provider as SharedProvider } from '../../../../../shared'
 import nbNO from '../../../constants/locales/nb-NO'
@@ -123,9 +123,7 @@ describe('Field.Number', () => {
       const alertText = statusElement.textContent
       const expectedText = nb.NumberField.errorMinimum.replace(
         '{minimum}',
-        String(
-          formatPlainNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' })
-        )
+        String(formatNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' }))
       )
       // Use regex to handle both regular and non-breaking spaces
       const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -156,9 +154,7 @@ describe('Field.Number', () => {
       const alertText = statusElement.textContent
       const expectedText = nb.NumberField.errorMaximum.replace(
         '{maximum}',
-        String(
-          formatPlainNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
-        )
+        String(formatNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' }))
       )
       // Use regex to handle both regular and non-breaking spaces
       const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -940,7 +936,7 @@ describe('Field.Number', () => {
 
       const expected = nb.NumberField.errorMinimum.replace(
         '{minimum}',
-        String(formatPlainNumber(1.5, { locale: 'nb-NO', decimals: 1 }))
+        String(formatNumber(1.5, { locale: 'nb-NO', decimals: 1 }))
       )
 
       await waitFor(() => {
@@ -960,7 +956,7 @@ describe('Field.Number', () => {
 
       const expected = nb.NumberField.errorExclusiveMinimum.replace(
         '{exclusiveMinimum}',
-        String(formatPlainNumber(1.5, { locale: 'nb-NO', decimals: 1 }))
+        String(formatNumber(1.5, { locale: 'nb-NO', decimals: 1 }))
       )
 
       await waitFor(() => {
@@ -980,7 +976,7 @@ describe('Field.Number', () => {
 
       const expected = nb.NumberField.errorExclusiveMaximum.replace(
         '{exclusiveMaximum}',
-        String(formatPlainNumber(2.75, { locale: 'nb-NO', decimals: 2 }))
+        String(formatNumber(2.75, { locale: 'nb-NO', decimals: 2 }))
       )
 
       await waitFor(() => {
@@ -1000,7 +996,7 @@ describe('Field.Number', () => {
 
       const expected = nb.NumberField.errorMultipleOf.replace(
         '{multipleOf}',
-        String(formatPlainNumber(3000, { locale: 'nb-NO' }))
+        String(formatNumber(3000, { locale: 'nb-NO' }))
       )
       // Use regex to handle both regular and non-breaking spaces
       const expectedRegex = expected.replace(/\s/g, '\\s')
@@ -1024,9 +1020,7 @@ describe('Field.Number', () => {
         target: { value: '1001' },
       })
 
-      const enFormatted = String(
-        formatPlainNumber(1000, { locale: 'en-GB' })
-      )
+      const enFormatted = String(formatNumber(1000, { locale: 'en-GB' }))
       const expected = en.NumberField.errorMaximum.replace(
         '{maximum}',
         enFormatted
@@ -2234,7 +2228,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMaximum.replace(
           '{maximum}',
           String(
-            formatPlainNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2274,7 +2268,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMaximum.replace(
           '{maximum}',
           String(
-            formatPlainNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2298,7 +2292,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMinimum.replace(
           '{minimum}',
           String(
-            formatPlainNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2322,7 +2316,7 @@ describe('Field.Number', () => {
         const alertText = statusElement.textContent
         const expectedText = nb.NumberField.errorMinimum.replace(
           '{minimum}',
-          String(formatPlainNumber(minimum, { locale: 'nb-NO' }))
+          String(formatNumber(minimum, { locale: 'nb-NO' }))
         )
         // Use regex to handle both regular and non-breaking spaces
         const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -2347,7 +2341,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMinimum.replace(
           '{minimum}',
           String(
-            formatPlainNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MIN_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2414,7 +2408,7 @@ describe('Field.Number', () => {
         ).toBeInTheDocument()
         const expected = nb.NumberField.errorMaximum.replace(
           '{maximum}',
-          String(formatPlainNumber(1000, { locale: 'nb-NO' }))
+          String(formatNumber(1000, { locale: 'nb-NO' }))
         )
         // Use regex to handle both regular and non-breaking spaces
         const expectedRegex = expected.replace(/\s/g, '\\s')
@@ -2473,7 +2467,7 @@ describe('Field.Number', () => {
         ).toBeInTheDocument()
         const expected = nb.NumberField.errorMaximum.replace(
           '{maximum}',
-          String(formatPlainNumber(1000, { locale: 'nb-NO' }))
+          String(formatNumber(1000, { locale: 'nb-NO' }))
         )
         // Use regex to handle both regular and non-breaking spaces
         const expectedRegex = expected.replace(/\s/g, '\\s')
@@ -2504,7 +2498,7 @@ describe('Field.Number', () => {
         ).toBeInTheDocument()
         const expected = nb.NumberField.errorExclusiveMaximum.replace(
           '{exclusiveMaximum}',
-          String(formatPlainNumber(1000, { locale: 'nb-NO' }))
+          String(formatNumber(1000, { locale: 'nb-NO' }))
         )
         // Use regex to handle both regular and non-breaking spaces
         const expectedRegex = expected.replace(/\s/g, '\\s')
@@ -2531,7 +2525,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMaximum.replace(
           '{maximum}',
           String(
-            formatPlainNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2557,7 +2551,7 @@ describe('Field.Number', () => {
         const expectedText = nb.NumberField.errorMaximum.replace(
           '{maximum}',
           String(
-            formatPlainNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
+            formatNumber(Number.MAX_SAFE_INTEGER, { locale: 'nb-NO' })
           )
         )
         // Use regex to handle both regular and non-breaking spaces
@@ -2583,7 +2577,7 @@ describe('Field.Number', () => {
         const alertText = statusElement.textContent
         const expectedText = nb.NumberField.errorMaximum.replace(
           '{maximum}',
-          String(formatPlainNumber(maximum, { locale: 'nb-NO' }))
+          String(formatNumber(maximum, { locale: 'nb-NO' }))
         )
         // Use regex to handle both regular and non-breaking spaces
         const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -2611,7 +2605,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMinimum.replace(
             '{minimum}',
-            String(formatPlainNumber(5, { locale: 'nb-NO' }))
+            String(formatNumber(5, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2639,7 +2633,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMaximum.replace(
             '{maximum}',
-            String(formatPlainNumber(10, { locale: 'nb-NO' }))
+            String(formatNumber(10, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2664,7 +2658,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMinimum.replace(
             '{minimum}',
-            String(formatPlainNumber(5, { locale: 'nb-NO' }))
+            String(formatNumber(5, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2696,7 +2690,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMinimum.replace(
             '{minimum}',
-            String(formatPlainNumber(10, { locale: 'nb-NO' }))
+            String(formatNumber(10, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2721,7 +2715,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMultipleOf.replace(
             '{multipleOf}',
-            String(formatPlainNumber(3, { locale: 'nb-NO' }))
+            String(formatNumber(3, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2744,7 +2738,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMinimum.replace(
             '{minimum}',
-            String(formatPlainNumber(5, { locale: 'nb-NO' }))
+            String(formatNumber(5, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2767,7 +2761,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMaximum.replace(
             '{maximum}',
-            String(formatPlainNumber(10, { locale: 'nb-NO' }))
+            String(formatNumber(10, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2790,7 +2784,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorExclusiveMinimum.replace(
             '{exclusiveMinimum}',
-            String(formatPlainNumber(5, { locale: 'nb-NO' }))
+            String(formatNumber(5, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2813,7 +2807,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorExclusiveMaximum.replace(
             '{exclusiveMaximum}',
-            String(formatPlainNumber(10, { locale: 'nb-NO' }))
+            String(formatNumber(10, { locale: 'nb-NO' }))
           )
         )
       })
@@ -2836,7 +2830,7 @@ describe('Field.Number', () => {
         ).toHaveTextContent(
           nb.NumberField.errorMultipleOf.replace(
             '{multipleOf}',
-            String(formatPlainNumber(3, { locale: 'nb-NO' }))
+            String(formatNumber(3, { locale: 'nb-NO' }))
           )
         )
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
@@ -10,7 +10,7 @@ import NumberFormatBase, {
 } from '../../../../components/number-format/NumberFormatBase'
 import { formatCurrency } from '../../../../components/number-format/utils/formatCurrency'
 import { formatPercent } from '../../../../components/number-format/utils/formatPercent'
-import { formatPlainNumber } from '../../../../components/number-format/utils/formatPlainNumber'
+import { formatNumber } from '../../../../components/number-format/utils/formatPlainNumber'
 
 import type { SpacingProps } from '../../../../shared/types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
@@ -62,7 +62,7 @@ function NumberValue(props: ValueNumberProps) {
     : numberFormatRest.currency === true ||
         typeof numberFormatRest.currency === 'string'
       ? formatCurrency
-      : formatPlainNumber
+      : formatNumber
 
   return (
     <ValueBlock

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
@@ -10,7 +10,7 @@ import { getFileIcon } from '../../../../components/upload/UploadFileListCell'
 import { BYTES_IN_A_MEGA_BYTE } from '../../../../components/upload/UploadVerify'
 import type { FieldUploadProps as FieldUploadProps } from '../../Field/Upload/Upload'
 import { transformFiles } from '../../Field/Upload/Upload'
-import { formatPlainNumber } from '../../../../components/number-format/NumberUtils'
+import { formatNumber } from '../../../../components/number-format/NumberUtils'
 import { UploadFileLink } from '../../../../components/upload/UploadFileListLink'
 import { isAsync } from '../../../../shared/helpers/isAsync'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
@@ -96,7 +96,7 @@ function getSize(size: number) {
   }
   // Converts from b (binary) to MB (decimal)
   const sizeInMb = size / BYTES_IN_A_MEGA_BYTE
-  return ` (${formatPlainNumber(sizeInMb, {
+  return ` (${formatNumber(sizeInMb, {
     decimals: 0,
   })} MB)`
 }

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
@@ -12,7 +12,7 @@ import ChildrenWithAge from '../ChildrenWithAge'
 import { translations } from '../ChildrenWithAgeTranslations'
 import type { GenerateRef } from '../../../Tools/ListAllProps'
 import nbNO from '../../../constants/locales/nb-NO'
-import { formatPlainNumber } from '../../../../../components/number-format/NumberUtils'
+import { formatNumber } from '../../../../../components/number-format/NumberUtils'
 
 describe('ChildrenWithAge', () => {
   const translationsNO = translations['nb-NO']
@@ -165,7 +165,7 @@ describe('ChildrenWithAge', () => {
 
     const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
       '{maximum}',
-      String(formatPlainNumber(9, { locale: 'nb-NO' }))
+      String(formatNumber(9, { locale: 'nb-NO' }))
     )
     // Use regex to handle both regular and non-breaking spaces
     const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -219,7 +219,7 @@ describe('ChildrenWithAge', () => {
 
     const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
       '{maximum}',
-      String(formatPlainNumber(17, { locale: 'nb-NO' }))
+      String(formatNumber(17, { locale: 'nb-NO' }))
     )
     // Use regex to handle both regular and non-breaking spaces
     const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -267,7 +267,7 @@ describe('ChildrenWithAge', () => {
 
     const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
       '{maximum}',
-      String(formatPlainNumber(1000000, { locale: 'nb-NO' }))
+      String(formatNumber(1000000, { locale: 'nb-NO' }))
     )
     // Use regex to handle both regular and non-breaking spaces
     const expectedRegex = expectedText.replace(/\s/g, '\\s')
@@ -289,7 +289,7 @@ describe('ChildrenWithAge', () => {
 
     const expectedText = nbNO['nb-NO'].NumberField.errorMaximum.replace(
       '{maximum}',
-      String(formatPlainNumber(1000000, { locale: 'nb-NO' }))
+      String(formatNumber(1000000, { locale: 'nb-NO' }))
     )
     // Use regex to handle both regular and non-breaking spaces
     const expectedRegex = expectedText.replace(/\s/g, '\\s')


### PR DESCRIPTION
- Rename public formatter formatPlainNumber -> formatNumber to align with the format<Type> naming convention (formatCurrency, formatPercent, etc.)
- Rename internal Intl wrapper formatNumber -> formatNumberIntl to free up the formatNumber name and clarify its role
- Keep deprecated formatPlainNumber alias for backwards compatibility
- Update all imports, usages, tests, and docs

