### PR TITLE
docs(v11): document Provider locales removal

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -583,6 +583,16 @@ grep -rn 'darkMode\|eufemia-theme__dark-mode' \
   --include='*.tsx' --include='*.ts' --include='*.scss' --include='*.css' src/
 ```
 
+#### 5. Provider `locales` prop silently ignored
+
+The `locales` prop on `Provider` and `Context` was removed in favor of `translations`. Passing `locales` compiles without error but is silently ignored, meaning your custom translations will not be applied.
+
+Search for old usage:
+
+```bash
+grep -rn 'locales=' --include='*.tsx' --include='*.ts' src/
+```
+
 ### Complete migration example
 
 This example shows a realistic v10 component migrated to v11, combining multiple change categories:
@@ -2385,6 +2395,22 @@ For more information on how to replace these, see [FormSet/FormRow deprecation](
 If you migrate a `FormSet` that relied on a native browser submit, such as `method="post"` with an `action`, you can use `preventDefaultOnSubmit={false}` on [Form.Handler](/uilib/extensions/forms/Form/Handler/) to keep the native submit behavior.
 
 ## Helpers
+
+### Provider/Context
+
+- The `locales` prop on `Provider` and `Context` has been removed. Use `translations` instead. Passing `locales` will be silently ignored.
+
+**Before:**
+
+```tsx
+<Provider locales={myLocales}>...</Provider>
+```
+
+**After:**
+
+```tsx
+<Provider translations={myTranslations}>...</Provider>
+```
 
 ### [Component helpers](/uilib/helpers/)
 


### PR DESCRIPTION
The locales prop on Provider and Context was removed in v11. Use translations instead. This is a silent failure - passing locales compiles without error but custom translations are silently ignored.

