### PR TITLE
chore(Context): correct Pagination type from AccordionProps to PaginationProps

### DIFF
--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -39,6 +39,7 @@ import type { TableProps } from '../components/Table'
 import type { GlobalErrorProps } from '../components/GlobalError'
 import type { ModalProps } from '../components/modal/types'
 import type { AccordionProps } from '../components/Accordion'
+import type { PaginationProps } from '../components/pagination/Pagination'
 import type { StepIndicatorProps } from '../components/StepIndicator'
 import type { FormLabelProps } from '../components/FormLabel'
 import type { InputProps } from '../components/Input'
@@ -106,7 +107,7 @@ export type ContextComponents = {
 
   Switch?: Partial<SwitchProps>
   NumberFormat?: Partial<NumberFormatAllProps>
-  Pagination?: Partial<AccordionProps>
+  Pagination?: Partial<PaginationProps>
   TermDefinition?: Partial<TermDefinitionProps>
 
   // Common props


### PR DESCRIPTION
The ContextComponents type incorrectly typed Pagination as Partial<AccordionProps> instead of Partial<PaginationProps>. This caused incorrect type checking for Provider-level Pagination configuration.

