### PR TITLE
chore: document date-fns v2 to v4 upgrade in v11 migration guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1976,7 +1976,6 @@ The following properties have been renamed from snake_case to camelCase:
   ```tsx
   import nbLocale from 'date-fns/locale/nb'
   import enLocale from 'date-fns/locale/en-GB'
-
   ;<DatePicker locale={nbLocale} />
   ```
 
@@ -1985,7 +1984,6 @@ The following properties have been renamed from snake_case to camelCase:
   ```tsx
   import { nb } from 'date-fns/locale/nb'
   import { enGB } from 'date-fns/locale/en-GB'
-
   ;<DatePicker locale={nb} />
   ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -113,6 +113,7 @@ This is the migration guide for @dnb/eufemia v11. It covers all breaking changes
 - **Ajv no longer shipped by default** — If you use JSON Schema validation, you must explicitly provide an Ajv instance. See [Ajv no longer shipped by default](#ajv-no-longer-shipped-by-default).
 - **Dropdown `actionMenu`/`moreMenu` removed** — The `actionMenu` and `moreMenu` props on Dropdown have been removed. Use the new [Menu](/uilib/components/menu/) component instead.
 - **NumberFormat split into variants** — The generic `<NumberFormat />` component and `format()` utility have been removed. Use variant sub-components like `<NumberFormat.Number />`, `<NumberFormat.Currency />`, etc. See [NumberFormat](#numberformat).
+- **`date-fns` upgraded from v2 to v4** — If you import `date-fns` functions directly (e.g. for DatePicker's `locale` prop), update your imports to use named exports. See [DatePicker](#datepicker).
 - Replaced deprecated `<Context.Provider>` with direct `<Context>` rendering across all internal context providers (React 19).
 - Several exported TypeScript `interface` declarations have been converted to `type`. This prevents declaration merging but has no impact on standard usage.
 - All React context value types have been renamed to use a consistent `...ContextValue` suffix (e.g. `AccordionContextProps` → `AccordionContextValue`). See [TypeScript](#typescript) for the full list.
@@ -1966,6 +1967,26 @@ The following properties have been renamed from snake_case to camelCase:
 
   ```tsx
   <DatePicker dateFormat="yyyy/MM/dd" returnFormat="yyyy-MM-dd" />
+  ```
+
+- The internal `date-fns` dependency has been upgraded from **v2** to **v4**. This does not affect the DatePicker API itself, but if you import `date-fns` directly in your project (e.g. to pass a `locale` to DatePicker), you need to update your imports from default exports to named exports:
+
+  **Before (date-fns v2):**
+
+  ```tsx
+  import nbLocale from 'date-fns/locale/nb'
+  import enLocale from 'date-fns/locale/en-GB'
+
+  ;<DatePicker locale={nbLocale} />
+  ```
+
+  **After (date-fns v4):**
+
+  ```tsx
+  import { nb } from 'date-fns/locale/nb'
+  import { enGB } from 'date-fns/locale/en-GB'
+
+  ;<DatePicker locale={nb} />
   ```
 
 #### Properties

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -95,7 +95,7 @@ export type DatePickerCalendarProps = Omit<
     nr: number
   ) => void
   /**
-   * To define the locale used in the calendar. Needs to be an `date-fns` locale object, like `import enLocale from 'date-fns/locale/en-GB'`. Defaults to `nb-NO`.
+   * To define the locale used in the calendar. Needs to be an `date-fns` locale object, like `import { enGB } from 'date-fns/locale/en-GB'`. Defaults to `nb-NO`.
    */
   locale?: InternalLocale
   rtl?: boolean
@@ -366,8 +366,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         newDate = !isRange
           ? currentMonth
           : nr === 0
-            ? setDate(currentMonth, 1)
-            : lastDayOfMonth(currentMonth)
+          ? setDate(currentMonth, 1)
+          : lastDayOfMonth(currentMonth)
 
         // only to make sure we navigate the calendar to the new date
       } else if (currentMonth && !isSameMonth(currentDate, currentMonth)) {
@@ -600,8 +600,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                   const dateType = day.isStartDate
                     ? 'start'
                     : day.isEndDate
-                      ? 'end'
-                      : undefined
+                    ? 'end'
+                    : undefined
                   const isSelectedDate =
                     nr === 0 ? day.isStartDate : day.isEndDate
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -366,8 +366,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         newDate = !isRange
           ? currentMonth
           : nr === 0
-          ? setDate(currentMonth, 1)
-          : lastDayOfMonth(currentMonth)
+            ? setDate(currentMonth, 1)
+            : lastDayOfMonth(currentMonth)
 
         // only to make sure we navigate the calendar to the new date
       } else if (currentMonth && !isSameMonth(currentDate, currentMonth)) {
@@ -600,8 +600,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                   const dateType = day.isStartDate
                     ? 'start'
                     : day.isEndDate
-                    ? 'end'
-                    : undefined
+                      ? 'end'
+                      : undefined
                   const isSelectedDate =
                     nr === 0 ? day.isStartDate : day.isEndDate
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
@@ -31,7 +31,7 @@ export type DatePickerCalendarNavigationProps = Omit<
   date?: Date
 
   /**
-   * To define the locale used in the calendar. Needs to be an `date-fns` locale object, like `import enLocale from 'date-fns/locale/en-GB'`. Defaults to `nb-NO`.
+   * To define the locale used in the calendar. Needs to be an `date-fns` locale object, like `import { enGB } from 'date-fns/locale/en-GB'`. Defaults to `nb-NO`.
    */
   locale?: InternalLocale
 }


### PR DESCRIPTION
Add note about date-fns upgrade under DatePicker section with before/after import examples for locale usage. Also update JSDoc comments in DatePickerCalendar and DatePickerCalendarNavigator to reflect the new named export import style.

