### PR TITLE
chore: replace Context.Provider with Context in Menu component

### DIFF
--- a/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
@@ -175,7 +175,7 @@ export default function MenuAccordion(props: MenuAccordionProps) {
 
       <HeightAnimation open={isOpen}>
         {childContextValue && (
-          <MenuContext.Provider value={childContextValue}>
+          <MenuContext value={childContextValue}>
             <ul
               ref={contentRef}
               role="group"
@@ -184,7 +184,7 @@ export default function MenuAccordion(props: MenuAccordionProps) {
             >
               {children}
             </ul>
-          </MenuContext.Provider>
+          </MenuContext>
         )}
       </HeightAnimation>
     </li>

--- a/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
@@ -228,7 +228,7 @@ export default function MenuRoot(props: MenuRootProps) {
         } = renderProps
 
         return (
-          <MenuTriggerContext.Provider
+          <MenuTriggerContext
             value={{
               active,
               triggerProps: domProps,
@@ -238,7 +238,7 @@ export default function MenuRoot(props: MenuRootProps) {
             }}
           >
             {triggerChild}
-          </MenuTriggerContext.Provider>
+          </MenuTriggerContext>
         )
       }
     : undefined
@@ -268,9 +268,7 @@ export default function MenuRoot(props: MenuRootProps) {
       {({ close }) => {
         popoverCloseRef.current = close
         return (
-          <MenuContext.Provider value={contextValue}>
-            {contentChildren}
-          </MenuContext.Provider>
+          <MenuContext value={contextValue}>{contentChildren}</MenuContext>
         )
       }}
     </Popover>

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
@@ -13,13 +13,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" icon="download">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('[role="menuitem"]')
@@ -33,14 +33,14 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
             <Menu.Action text="PNG" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -66,13 +66,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -85,13 +85,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -106,13 +106,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -127,13 +127,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -146,13 +146,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -170,14 +170,14 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
             <Menu.Action text="PNG" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector(
@@ -204,13 +204,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" disabled>
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -227,13 +227,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" className="custom">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const wrapper = document.querySelector('.dnb-menu__accordion')
@@ -255,13 +255,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" disabled>
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const wrapper = document.querySelector('.dnb-menu__accordion')
@@ -274,7 +274,7 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
@@ -282,7 +282,7 @@ describe('MenuAccordion', () => {
             <Menu.Action text="PNG" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -306,13 +306,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext({ closeAll })
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" onClick={() => null} />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     // Open accordion
@@ -364,13 +364,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext({ registerItem })
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     expect(registerItem).toHaveBeenCalled()
@@ -380,13 +380,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as">
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const indicator = document.querySelector(
@@ -409,13 +409,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" onOpenChange={onOpenChange}>
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -432,13 +432,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" onOpenChange={onOpenChange}>
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -451,13 +451,13 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion text="Export as" onOpenChange={onOpenChange}>
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')
@@ -473,7 +473,7 @@ describe('MenuAccordion', () => {
     const ctx = createMockContext()
 
     render(
-      <MenuContext.Provider value={ctx}>
+      <MenuContext value={ctx}>
         <ul role="menu">
           <Menu.Accordion
             text="Export as"
@@ -483,7 +483,7 @@ describe('MenuAccordion', () => {
             <Menu.Action text="PDF" />
           </Menu.Accordion>
         </ul>
-      </MenuContext.Provider>
+      </MenuContext>
     )
 
     const trigger = document.querySelector('.dnb-menu__accordion__trigger')

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuAction.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuAction.test.tsx
@@ -154,13 +154,13 @@ describe('MenuAction', () => {
 
       const context = createMockContext()
       render(
-        <MenuContext.Provider value={context}>
+        <MenuContext value={context}>
           <ul role="menu">
-            <MenuTriggerContext.Provider value={triggerValue}>
+            <MenuTriggerContext value={triggerValue}>
               <MenuAction text="Sub menu" />
-            </MenuTriggerContext.Provider>
+            </MenuTriggerContext>
           </ul>
-        </MenuContext.Provider>
+        </MenuContext>
       )
 
       const item = document.querySelector(

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuContent.test.tsx
@@ -14,9 +14,7 @@ function renderWithContext(
 ) {
   const context = createMockContext(contextOverrides)
   return {
-    ...render(
-      <MenuContext.Provider value={context}>{ui}</MenuContext.Provider>
-    ),
+    ...render(<MenuContext value={context}>{ui}</MenuContext>),
     context,
   }
 }

--- a/packages/dnb-eufemia/src/components/menu/__tests__/testHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/testHelpers.tsx
@@ -101,9 +101,9 @@ export function renderWithContext(
   const context = createMockContext(contextOverrides)
   return {
     ...render(
-      <MenuContext.Provider value={context}>
+      <MenuContext value={context}>
         <ul role="menu">{ui}</ul>
-      </MenuContext.Provider>
+      </MenuContext>
     ),
     context,
   }


### PR DESCRIPTION
React 19 deprecates Context.Provider in favor of rendering Context directly. Update MenuAccordion, MenuRoot, and all related test files to use the new pattern.

