### PR TITLE
refactor(Card): add support for scoped dark mode

### DIFF
--- a/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
+++ b/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
@@ -1,15 +1,12 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
-:root {
-  // Keep these outside of the .dnb-card class so they can be used globally (dnb-help-button-inline)
+.dnb-card {
   --card-outline-color: var(
     --border-color,
     var(--token-color-stroke-neutral-subtle)
   );
   --card-background-color: var(--token-color-background-neutral);
-}
 
-.dnb-card {
   &__heading {
     font-size: var(--font-size-basis);
     font-weight: var(--font-weight-medium);


### PR DESCRIPTION
In order to support scoped dark mode, we can not have design tokens in :root. But the two vars `--card-outline-color` and `--card-background-color` are actually not shared with HelpButtonInline as stated.

