### PR TITLE
chore(StyleLint): add rule for supporting scoped dark mode

### DIFF
--- a/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/token-name-policy.test.ts
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/__tests__/token-name-policy.test.ts
@@ -330,4 +330,66 @@ describe('token-name-policy stylelint rule', () => {
       temp.cleanup()
     }
   })
+
+  it('flags var(--token-...) references inside :root selector', async () => {
+    const errors = await lintWithRule({
+      code: ':root { --my-var: var(--token-color-background-neutral); }',
+      codeFilename: '/repo/src/components/card/style/dnb-card.scss',
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].text).toContain(
+      'must not be used in :root, html, or body selectors'
+    )
+  })
+
+  it('flags var(--token-...) references inside html selector', async () => {
+    const errors = await lintWithRule({
+      code: 'html { --my-var: var(--token-color-text-action); }',
+      codeFilename: '/repo/src/components/card/style/dnb-card.scss',
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].text).toContain(
+      'must not be used in :root, html, or body selectors'
+    )
+  })
+
+  it('flags var(--token-...) references inside body selector', async () => {
+    const errors = await lintWithRule({
+      code: 'body { --my-var: var(--token-color-stroke-neutral); }',
+      codeFilename: '/repo/src/components/card/style/dnb-card.scss',
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].text).toContain(
+      'must not be used in :root, html, or body selectors'
+    )
+  })
+
+  it('allows var(--token-...) references inside component selectors', async () => {
+    const errors = await lintWithRule({
+      code: '.dnb-card { --card-bg: var(--token-color-background-neutral); }',
+      codeFilename: '/repo/src/components/card/style/dnb-card.scss',
+    })
+
+    expect(
+      errors.some((e) =>
+        e.text.includes('must not be used in :root, html, or body')
+      )
+    ).toBe(false)
+  })
+
+  it('allows var(--token-...) declarations in tokens.scss files', async () => {
+    const errors = await lintWithRule({
+      code: ':root { --token-color-background-neutral: var(--dnb-greyscale-0); }',
+      codeFilename: '/repo/src/style/themes/ui/tokens.scss',
+    })
+
+    expect(
+      errors.some((e) =>
+        e.text.includes('must not be used in :root, html, or body')
+      )
+    ).toBe(false)
+  })
 })

--- a/packages/dnb-eufemia/scripts/stylelint/plugins/token-name-policy.cjs
+++ b/packages/dnb-eufemia/scripts/stylelint/plugins/token-name-policy.cjs
@@ -126,6 +126,8 @@ const messages = stylelint.utils.ruleMessages(RULE_NAME, {
     `Missing token "${prop}" in "${theme}" tokens.scss. All brand tokens.scss files must contain the same tokens.`,
   sassHexRgba: (value) =>
     `Unexpected Sass rgba hex usage "${value}". Use CSS channel notation, e.g. rgba(0 0 0 / 40%).`,
+  tokenInGlobalScope: (ref, selector) =>
+    `Unexpected token reference "${ref}" inside "${selector}". Design tokens must not be used in :root, html, or body selectors, in order to support scoped dark mode.`,
 })
 
 const normalizePath = (filePath) => {
@@ -349,7 +351,45 @@ const ruleFunction = (primary, secondaryOptions = {}) => {
       }
     }
 
+    const GLOBAL_SCOPE_SELECTOR_REGEX = /^(:root|html|body)$/i
+
     root.walkDecls((decl) => {
+      if (!shouldValidateTokenDeclarationPrefix) {
+        const ruleNode = decl.parent
+        if (
+          ruleNode?.type === 'rule' &&
+          GLOBAL_SCOPE_SELECTOR_REGEX.test(ruleNode.selector?.trim())
+        ) {
+          const tokenReferenceRegex =
+            tokenPrefix === DEFAULT_POLICY.tokenPrefix
+              ? TOKEN_REFERENCE_REGEX
+              : createTokenReferenceRegex(tokenPrefix)
+          const singleTokenReferenceRegex =
+            tokenPrefix === DEFAULT_POLICY.tokenPrefix
+              ? SINGLE_TOKEN_REFERENCE_REGEX
+              : createTokenReferenceRegex(tokenPrefix, 'i')
+          const tokenReferences =
+            decl.value?.match(tokenReferenceRegex) || []
+
+          for (const match of tokenReferences) {
+            const referenceMatch = match.match(singleTokenReferenceRegex)
+            const variableReference = referenceMatch?.[1]
+
+            if (variableReference) {
+              stylelint.utils.report({
+                result,
+                ruleName: RULE_NAME,
+                node: decl,
+                message: messages.tokenInGlobalScope(
+                  variableReference,
+                  ruleNode.selector.trim()
+                ),
+              })
+            }
+          }
+        }
+      }
+
       if (disallowSassHexRgba && SASS_HEX_RGBA_REGEX.test(decl.value)) {
         stylelint.utils.report({
           result,

--- a/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
+++ b/packages/dnb-eufemia/src/components/card/style/dnb-card.scss
@@ -1,15 +1,12 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
-:root {
-  // Keep these outside of the .dnb-card class so they can be used globally (dnb-help-button-inline)
+.dnb-card {
   --card-outline-color: var(
     --border-color,
     var(--token-color-stroke-neutral-subtle)
   );
   --card-background-color: var(--token-color-background-neutral);
-}
 
-.dnb-card {
   &__heading {
     font-size: var(--font-size-basis);
     font-weight: var(--font-weight-medium);


### PR DESCRIPTION
Based on #7576 so tests do not fail like so:

<img width="793" height="193" alt="Screenshot 2026-04-20 at 09 39 51" src="https://github.com/user-attachments/assets/1cad2810-c0bc-4686-995b-28f55eac4b6a" />
