### PR TITLE
fix(List): align grid-template-areas column count with grid columns

### DIFF
--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -52,34 +52,36 @@
 
     // On small screens, use 2-row layout so end wraps to a new line
     @include allBelow(small) {
-      --item-grid-template-areas: 'chevron-left start icon title center chevron-right'
-        'chevron-left end end end end chevron-right'
-        'footer footer footer footer footer footer';
+      --item-grid-template-areas: 'chevron-left start icon title center . chevron-right'
+        'chevron-left end end end end end chevron-right'
+        'footer footer footer footer footer footer footer';
       &:has(#{&}__start):has(#{&}__title),
       &:has(#{&}__icon) {
-        --item-grid-template-areas: 'chevron-left start icon title center chevron-right'
-          'chevron-left . . end end .'
-          'footer footer footer footer footer footer';
+        --item-grid-template-areas: 'chevron-left start icon title center . chevron-right'
+          'chevron-left . . end end end .'
+          'footer footer footer footer footer footer footer';
       }
     }
 
     // On x-small screens, use 3-row layout so end wraps to a new line
     @include allBelow(x-small) {
-      --item-grid-template-areas: 'chevron-left start icon title title chevron-right'
-        'chevron-left center center center center chevron-right'
-        'chevron-left end end end end chevron-right'
-        'footer footer footer footer footer footer';
+      --item-grid-template-areas: 'chevron-left start icon title title . chevron-right'
+        'chevron-left center center center center center chevron-right'
+        'chevron-left end end end end end chevron-right'
+        'footer footer footer footer footer footer footer';
       &:has(#{&}__start):has(#{&}__title),
       &:has(#{&}__icon) {
-        --item-grid-template-areas: 'chevron-left start icon title title chevron-right'
-          'chevron-left . . center center .' 'chevron-left . . end end .'
-          'footer footer footer footer footer footer';
+        --item-grid-template-areas: 'chevron-left start icon title title . chevron-right'
+          'chevron-left . . center center center .'
+          'chevron-left . . end end end .'
+          'footer footer footer footer footer footer footer';
       }
     }
 
     // If no center is used, adjust the grid columns
     &:not(:has(#{&}__center)) {
-      --item-grid-template-columns: auto auto auto minmax(0, 1fr) auto auto;
+      --item-grid-template-columns: auto auto auto minmax(0, 1fr) 0 auto
+        auto;
     }
 
     // Deal with the item layout


### PR DESCRIPTION
The grid-template shorthand requires area names per row to match the
number of column tracks. Three mismatches existed:

1. The :not(:has(__center)) rule reduced columns from 7 to 6 while areas
   stayed at 7, causing invalid grid-template on desktop and unwanted
   extra vertical spacing with tall footer content. Fixed by using a
   zero-width column (0) instead of removing it.

2. The small breakpoint areas had 6 names per row but 7 column tracks,
   making grid-template invalid at computed-value time.

3. The x-small breakpoint had the same 6-vs-7 mismatch.

All area templates now consistently use 7 names per row, matching the
7 column tracks at every breakpoint.