### PR TITLE
chore(Blockquote): override text color token in blockquote for dark background

### DIFF
--- a/packages/dnb-eufemia/src/elements/blockquote/style/themes/dnb-blockquote-theme-ui.scss
+++ b/packages/dnb-eufemia/src/elements/blockquote/style/themes/dnb-blockquote-theme-ui.scss
@@ -12,8 +12,13 @@
     }
   }
 
+  // Override text color token so child typography elements (paragraphs, headings)
+  // that explicitly set color: var(--token-color-text-neutral) remain readable
+  // on the dark background
   // make contrast
   &:not(.dnb-blockquote--no-background) {
+    --token-color-text-neutral: var(--color-mint-green);
+
     .dnb-anchor,
     a {
       @include anchor-mixins.useAnchorDarkSurfaceStyle();


### PR DESCRIPTION
Not sure about this, could potentially be fixed in an other way?
Alternative solution https://github.com/dnbexperience/eufemia/pull/7581

The issue:
<img width="1014" height="152" alt="Screenshot 2026-04-20 at 10 50 38" src="https://github.com/user-attachments/assets/1fb0ffba-f386-47c9-b22c-02ceadae1b33" />

The fix:
<img width="1293" height="115" alt="image" src="https://github.com/user-attachments/assets/027337b5-6c55-47e3-bd99-d32f2c412ab8" />


Deploy preview https://fix-blockquote-text-color-to.eufemia-e25.pages.dev/uilib/about-the-lib/releases/eufemia/v11-info/#v11