### PR TITLE
chore: remove outdated 'legacy component' comments

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
@@ -1,8 +1,5 @@
 /**
  * Web GlobalStatus Provider
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 
 import type { ReactNode } from 'react'

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -1,8 +1,5 @@
 /**
  * Web InputMasked Component
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'

--- a/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.tsx
@@ -1,8 +1,5 @@
 /**
  * Web Pagination Helpers
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 import React from 'react'
 import clsx from 'clsx'

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -1,8 +1,5 @@
 /**
  * Web DrawerList Helpers
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
  */
 
 import React from 'react'

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
@@ -1,8 +1,5 @@
 /**
- * Web DrawerList Component
- *
- * This is a legacy component.
- * For referencing while developing new features, please use a Functional component.
+ * Web DrawerList Portal Component
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'


### PR DESCRIPTION
Remove misleading 'This is a legacy component' comments from files that are already functional components or aren't React components at all:
- InputMasked.tsx (already uses hooks)
- DrawerListPortal.tsx (already uses hooks)
- DrawerListHelpers.ts (utility functions, not a component)
- PaginationHelpers.tsx (mixed utilities)
- GlobalStatusProvider.ts (service class, not a React component)

