### PR TITLE
refactor(Img): use design tokens

### DIFF
--- a/packages/dnb-eufemia/src/elements/img/style/themes/dnb-img-theme-ui.scss
+++ b/packages/dnb-eufemia/src/elements/img/style/themes/dnb-img-theme-ui.scss
@@ -1,7 +1,7 @@
 @mixin imgStyle() {
   &[alt]::after {
-    color: var(--color-black-80);
-    background-color: var(--color-black-8);
+    color: var(--token-color-text-neutral-onlight);
+    background-color: var(--token-color-background-neutral-base);
   }
 }
 
@@ -9,7 +9,7 @@
   @include imgStyle();
 
   &__img--error {
-    color: var(--color-black-80);
-    background-color: var(--color-black-8);
+    color: var(--token-color-text-neutral-onlight);
+    background-color: var(--token-color-background-neutral-base);
   }
 }

--- a/packages/dnb-eufemia/src/elements/img/style/themes/dnb-img-theme-ui.scss
+++ b/packages/dnb-eufemia/src/elements/img/style/themes/dnb-img-theme-ui.scss
@@ -1,6 +1,6 @@
 @mixin imgStyle() {
   &[alt]::after {
-    color: var(--token-color-text-neutral-onlight);
+    color: var(--token-color-text-neutral);
     background-color: var(--token-color-background-neutral-base);
   }
 }
@@ -9,7 +9,7 @@
   @include imgStyle();
 
   &__img--error {
-    color: var(--token-color-text-neutral-onlight);
+    color: var(--token-color-text-neutral);
     background-color: var(--token-color-background-neutral-base);
   }
 }


### PR DESCRIPTION
Replace var(--color-black-80) with var(--token-color-text-neutral-onlight) and var(--color-black-8) with var(--token-color-background-neutral-base) in alt text and error state styling.

