### PR TITLE
chore(Field.Block): replace old color tokens with design tokens

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-sbanken.scss
@@ -1,6 +1,6 @@
 .dnb-forms-field-block {
   &__label__description {
-    color: var(--sb-color-gray-dark);
+    color: var(--token-color-text-neutral-alternative);
     font-size: var(--font-size-small);
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-ui.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/dnb-field-block-theme-ui.scss
@@ -1,6 +1,6 @@
 .dnb-forms-field-block {
   &__label__description {
-    color: var(--color-black-55);
+    color: var(--token-color-text-neutral-alternative);
     font-size: var(--font-size-small);
   }
 }


### PR DESCRIPTION
Replace var(--color-black-55) and var(--sb-color-gray-dark) with var(--token-color-text-neutral-alternative) in UI and Sbanken themes for label description text color.

