### PR TITLE
refactor(Field.Password): use design tokens

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -300,24 +300,6 @@ describe('Password component', () => {
     expect(input).toHaveAttribute('autocomplete', 'current-password')
   })
 
-  it('should have submit button inside error status element when in error state', async () => {
-    render(<Field.Password value="a" required />)
-
-    const input = document.querySelector('input')
-    await userEvent.type(input, '{Backspace}')
-    fireEvent.blur(input)
-
-    const errorElement = document.querySelector(
-      '.dnb-input__status--error'
-    )
-    expect(errorElement).toBeInTheDocument()
-
-    const submitButton = errorElement.querySelector(
-      '.dnb-input__submit-button__button'
-    )
-    expect(submitButton).toBeInTheDocument()
-  })
-
   it('should be possible to set autocomplete (autofill)', () => {
     render(<Field.Password autoComplete="new-password" />)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -300,6 +300,24 @@ describe('Password component', () => {
     expect(input).toHaveAttribute('autocomplete', 'current-password')
   })
 
+  it('should have submit button inside error status element when in error state', async () => {
+    render(<Field.Password value="a" required />)
+
+    const input = document.querySelector('input')
+    await userEvent.type(input, '{Backspace}')
+    fireEvent.blur(input)
+
+    const errorElement = document.querySelector(
+      '.dnb-input__status--error'
+    )
+    expect(errorElement).toBeInTheDocument()
+
+    const submitButton = errorElement.querySelector(
+      '.dnb-input__submit-button__button'
+    )
+    expect(submitButton).toBeInTheDocument()
+  })
+
   it('should be possible to set autocomplete (autofill)', () => {
     render(<Field.Password autoComplete="new-password" />)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
@@ -1,10 +1,9 @@
 .dnb-forms-field-password {
-  // Make sure submit element receives red text color on error.
+  // Make sure submit element receives red text/icon color on error.
   .dnb-input__status--error .dnb-input__submit-button__button {
-    color: var(--token-color-text-destructive);
-
-    &:hover {
-      color: var(--token-color-text-neutral-inverse);
-    }
+    --button-color-icon--default: var(--token-color-text-destructive);
+    --button-color-text--default: var(--token-color-text-destructive);
+    --button-color-icon--hover: var(--token-color-text-neutral-inverse);
+    --button-color-text--hover: var(--token-color-text-neutral-inverse);
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
@@ -1,10 +1,10 @@
 .dnb-forms-field-password {
   // Make sure submit element receives red text color on error.
   .dnb-input__status--error .dnb-input__submit-button__button {
-    color: var(--color-fire-red);
+    color: var(--token-color-text-destructive);
 
     &:hover {
-      color: var(--color-white);
+      color: var(--token-color-text-neutral-inverse);
     }
   }
 }


### PR DESCRIPTION
Replace var(--color-fire-red) with var(--token-color-text-destructive) and var(--color-white) with var(--token-color-text-neutral-inverse) in error state submit button styling.


Preview: https://refactor-password-design-tok.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/more-fields/Password/