### PR TITLE
chore(Form.Section): replace old color tokens with design tokens

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/dnb-form-section.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/dnb-form-section.scss
@@ -1,10 +1,10 @@
 .dnb-forms-section {
   &-block {
-    --block-outline-color: var(--color-black-8);
+    --block-outline-color: var(--token-color-stroke-neutral-subtle);
     --block-outline-width: var(--card-outline-width);
 
     &--error:has(.dnb-form-status--error):not(#{&}--variant-basic) {
-      --block-outline-color: var(--color-fire-red);
+      --block-outline-color: var(--token-color-stroke-error);
       --block-outline-width: 0.0625rem;
     }
 
@@ -55,7 +55,7 @@
 
       &--filled.dnb-section {
         // Reset the background color to our own color instead of the card's outline color
-        --background-color: var(--color-lavender);
+        --background-color: var(--token-color-background-neutral-alternative);
       }
     }
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/themes/dnb-form-section-theme-ui.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/themes/dnb-form-section-theme-ui.scss
@@ -2,7 +2,7 @@
   &-block {
     &--variant-filled &__inner {
       --space: var(--spacing-small);
-      background-color: var(--color-lavender);
+      background-color: var(--token-color-background-neutral-alternative);
     }
   }
 }


### PR DESCRIPTION
Replace var(--color-black-8) with var(--token-color-stroke-neutral-subtle), var(--color-fire-red) with var(--token-color-stroke-error), and var(--color-lavender) with var(--token-color-background-neutral-alternative) in outline, error, and filled variant styling.

