### PR TITLE
chore: update v11 release date to April 21, 2026

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -1,12 +1,9 @@
-## April, 9. 2026
-
-- New component: [Menu](/uilib/components/menu) for accessible dropdown menus with composable sub-components (`Menu.Root`, `Menu.Content`, `Menu.Action`, `Menu.Divider`), keyboard navigation, and nested menu support.
-
-## March, 30. 2026
+## April, 21. 2026
 
 - [New major version 11](/uilib/about-the-lib/releases/eufemia/v11-info/)
 - [Button](/uilib/components/button): removed `variant="signal"`. Use `variant="primary"` or `variant="secondary"` instead.
 - [Card](/uilib/components/card): changed default outline to `1px` with color `#ebebeb` and changed corner radius to `24px` and changed default inner spacing on all sides to `16px`.
+- New component: [Menu](/uilib/components/menu) for accessible dropdown menus with composable sub-components (`Menu.Root`, `Menu.Content`, `Menu.Action`, `Menu.Divider`), keyboard navigation, and nested menu support.
 
 ## February, 27. 2026
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'v11'
-description: 'January 23, 2026'
+description: 'April 21, 2026'
 order: -11
 ---
 
@@ -3213,4 +3213,4 @@ const mainParams = applySpacing(props, {
 
 The output CSS classes (`dnb-space__top--large`, etc.) are unchanged, so no styling needs to be updated.
 
-_January 23, 2026_
+_April 21, 2026_


### PR DESCRIPTION
Updates the v11 release date from January 23, 2026 to April 21, 2026 in the migration guide.