### PR TITLE
chore(Field.Password): toggle visibility while input has focus

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
@@ -93,7 +93,15 @@ function Password({
     [props]
   )
 
-  const ToggleVisibilityButton = useCallback(() => {
+  const preventFocusChange = useCallback((event: React.MouseEvent) => {
+    // Prevent the button from stealing focus from the input on click.
+    // Without this, the input blurs and triggers a re-render that
+    // replaces the icon SVG between mousedown and mouseup, causing
+    // the browser to swallow the click event.
+    event.preventDefault()
+  }, [])
+
+  const toggleVisibilityButton = useMemo(() => {
     return (
       <SubmitButton
         id={idToUse + '-submit-button'}
@@ -114,6 +122,7 @@ function Password({
         }
         disabled={disabled}
         skeleton={sharedContext.skeleton}
+        onMouseDown={preventFocusChange}
         onClick={toggleVisibility}
       />
     )
@@ -125,6 +134,7 @@ function Password({
     size,
     disabled,
     sharedContext.skeleton,
+    preventFocusChange,
     toggleVisibility,
   ])
 
@@ -137,7 +147,7 @@ function Password({
       value={value}
       ref={ref}
       aria-describedby={idToUse + '-submit-button'}
-      submitElement={<ToggleVisibilityButton />}
+      submitElement={toggleVisibilityButton}
       disabled={disabled}
       size={size}
       autoComplete="current-password"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -159,6 +159,26 @@ describe('Password component', () => {
     ).not.toBe('focus')
   })
 
+  it('can toggle visibility while input has focus', async () => {
+    render(<Field.Password />)
+
+    const input = () => document.querySelector('input')
+    const button = () => document.querySelector('button')
+
+    await userEvent.click(input())
+    await userEvent.type(input(), 'password123')
+
+    // Toggle while input still has focus
+    await userEvent.click(button())
+
+    expect(input().getAttribute('type')).toBe('text')
+
+    // Toggle back while input has focus again
+    await userEvent.click(button())
+
+    expect(input().getAttribute('type')).toBe('password')
+  })
+
   it('events gets triggered on interaction', async () => {
     const onShowPassword = jest.fn()
     const onHidePassword = jest.fn()


### PR DESCRIPTION
The show/hide password button did not work when clicked while the input had focus. The ToggleVisibilityButton was defined as a component via useCallback, causing React to unmount and remount the button DOM node when the Password component re-rendered on blur. This broke the click event since the mousedown target was removed before mouseup.

Changed to useMemo returning a JSX element instead, keeping a stable DOM node across re-renders.


Issue in v11: https://v11.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/more-fields/Password/demos/
How it works in v10:
https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/more-fields/Password/demos/
Deploy preview of the fix:
https://fix-password-toggle-visibili.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/more-fields/Password/demos/
