### PR TITLE
chore(GlobalStatus): restore autoScroll={false} behavior

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -460,7 +460,10 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
 
   const scrollToStatus = useCallback(
     async (isDone: ((elem: HTMLElement) => void) | null = null) => {
-      if (typeof window === 'undefined') {
+      if (
+        typeof window === 'undefined' ||
+        propsRef.current.autoScroll === false
+      ) {
         return // stop here
       }
       try {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -543,6 +543,40 @@ describe('GlobalStatus component', () => {
     expect(scrollTo).not.toHaveBeenCalled()
   })
 
+  it('should scroll when autoScroll is true (default)', async () => {
+    const scrollTo = jest.fn()
+    jest.spyOn(window, 'scrollTo').mockImplementation(scrollTo)
+
+    const ToggleStatus = () => {
+      const [status, setStatus] = React.useState(null)
+
+      return (
+        <Switch
+          id="switch-scroll"
+          status={status}
+          statusNoAnimation={true}
+          globalStatus={{ id: 'scroll-test' }}
+          onChange={({ checked }) => {
+            setStatus(checked ? 'error-message' : null)
+          }}
+        />
+      )
+    }
+
+    render(
+      <>
+        <GlobalStatus id="scroll-test" />
+        <ToggleStatus />
+      </>
+    )
+
+    fireEvent.click(document.querySelector('input#switch-scroll'))
+
+    await refresh()
+
+    expect(scrollTo).toHaveBeenCalled()
+  })
+
   it('should close when esc key is pressed', async () => {
     const onClose = jest.fn()
     const onHide = jest.fn()

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -509,6 +509,40 @@ describe('GlobalStatus component', () => {
     })
   })
 
+  it('should not scroll when autoScroll is false', async () => {
+    const scrollTo = jest.fn()
+    jest.spyOn(window, 'scrollTo').mockImplementation(scrollTo)
+
+    const ToggleStatus = () => {
+      const [status, setStatus] = React.useState(null)
+
+      return (
+        <Switch
+          id="switch-no-scroll"
+          status={status}
+          statusNoAnimation={true}
+          globalStatus={{ id: 'no-scroll-test' }}
+          onChange={({ checked }) => {
+            setStatus(checked ? 'error-message' : null)
+          }}
+        />
+      )
+    }
+
+    render(
+      <>
+        <GlobalStatus id="no-scroll-test" autoScroll={false} />
+        <ToggleStatus />
+      </>
+    )
+
+    fireEvent.click(document.querySelector('input#switch-no-scroll'))
+
+    await refresh()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
   it('should close when esc key is pressed', async () => {
     const onClose = jest.fn()
     const onHide = jest.fn()


### PR DESCRIPTION
The class-to-functional conversion dropped the autoScroll check in scrollToStatus(). Setting autoScroll={false} was silently ignored, causing the component to always scroll into view when opened.

This restores the original guard that returns early when autoScroll is false, using propsRef to access the current value inside the memoized callback.

