### PR TITLE
chore(Autocomplete): fix indicator label direction

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -988,7 +988,12 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     drawerListRef.current.setData([
       {
         className: 'dnb-autocomplete__indicator',
-        content: <ProgressIndicator label={props.indicatorLabel} />,
+        content: (
+          <ProgressIndicator
+            label={props.indicatorLabel}
+            labelDirection="horizontal"
+          />
+        ),
         ignoreEvents: true,
         __id: 'indicator',
       },


### PR DESCRIPTION
The default labelDirection was changed to 'vertical', but existing usages with a label prop should retain horizontal layout to preserve previous appearance.

- Autocomplete: indicator ProgressIndicator now explicitly horizontal
