### PR TITLE
chore: add showDefaultLabel and horizontal labelDirection to random value examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
@@ -94,6 +94,7 @@ export const ProgressIndicatorCircularRandomExample = () => (
               type="circular"
               progress={value}
               showDefaultLabel
+              labelDirection="horizontal"
               noAnimation
             />
             <Button
@@ -244,6 +245,8 @@ export const ProgressIndicatorLinearRandomExample = () => (
             <ProgressIndicator
               type="linear"
               progress={value}
+              showDefaultLabel
+              labelDirection="horizontal"
               noAnimation
             />
             <Button

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
@@ -245,8 +245,6 @@ export const ProgressIndicatorLinearRandomExample = () => (
             <ProgressIndicator
               type="linear"
               progress={value}
-              showDefaultLabel
-              labelDirection="horizontal"
               noAnimation
             />
             <Button


### PR DESCRIPTION
Added labelDirection="horizontal" to the circular random value example and added showDefaultLabel with labelDirection="horizontal" to the linear random value example.

Preview: https://fix-progress-indicator-examp.eufemia-e25.pages.dev/uilib/components/progress-indicator/#circular-progressindicator-with-a-label-in-a-horizontal-direction
