### PR TITLE
fix(DrawerList): prevent value reset on blur for lazy-loaded data

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -2232,4 +2232,33 @@ describe('Field.PhoneNumber', () => {
       )
     })
   })
+
+  it('should not change country code on blur when value has non-default country code', async () => {
+    const onChange = jest.fn()
+
+    render(
+      <Form.Handler onChange={onChange}>
+        <Field.PhoneNumber path="/phone" value="+4612345678" noAnimation />
+      </Form.Handler>
+    )
+
+    const ccInput: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-phone-number__country-code input'
+    )
+
+    // Initial state: should show Sweden's country code (+46)
+    expect(ccInput.value).toContain('+46')
+
+    // Click on the country code input to focus
+    await userEvent.click(ccInput)
+
+    // Click outside to blur
+    await userEvent.click(document.body)
+
+    // Country code should still contain +46 (Sweden), not +47 (Norway)
+    expect(ccInput.value).toContain('+46')
+
+    // onChange should NOT have been called since we didn't change anything
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/__tests__/SelectCountry.test.tsx
@@ -773,4 +773,43 @@ describe('Field.SelectCountry', () => {
       expect(input).toHaveAttribute('aria-invalid', 'true')
     })
   })
+
+  it('should not change value on blur when initial value is SE', async () => {
+    const onChange = jest.fn()
+    const onSubmit = jest.fn()
+
+    render(
+      <Form.Handler onChange={onChange} onSubmit={onSubmit}>
+        <Field.SelectCountry path="/country" value="SE" noAnimation />
+      </Form.Handler>
+    )
+
+    const inputElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-select-country input'
+    )
+
+    // Initial state: should show Sverige
+    expect(inputElement).toHaveValue('Sverige')
+
+    // Click on the input to focus (simulates real user interaction)
+    await userEvent.click(inputElement)
+
+    // Verify it's focused and value is still correct
+    expect(inputElement).toHaveValue('Sverige')
+
+    // Click outside to blur (simulates clicking somewhere else)
+    await userEvent.click(document.body)
+
+    // Value should still be Sverige, not Norge
+    expect(inputElement).toHaveValue('Sverige')
+
+    // onChange should NOT have been called since we didn't change anything
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Focus and blur again to verify consistent behavior
+    await userEvent.click(inputElement)
+    await userEvent.click(document.body)
+    expect(inputElement).toHaveValue('Sverige')
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/__tests__/SelectCurrency.test.tsx
@@ -937,4 +937,42 @@ describe('Field.SelectCurrency', () => {
       expect(input).toHaveAttribute('aria-invalid', 'true')
     })
   })
+
+  it('should not change value on blur when initial value is SEK', async () => {
+    const onChange = jest.fn()
+
+    render(
+      <Form.Handler onChange={onChange}>
+        <Field.SelectCurrency path="/currency" value="SEK" noAnimation />
+      </Form.Handler>
+    )
+
+    const inputElement: HTMLInputElement = document.querySelector(
+      '.dnb-forms-field-select-currency input'
+    )
+
+    // Initial state: should show SEK
+    expect(inputElement).toHaveValue('Svensk krone (SEK)')
+
+    // Click on the input to focus (simulates real user interaction)
+    await userEvent.click(inputElement)
+
+    // Verify value is still correct
+    expect(inputElement).toHaveValue('Svensk krone (SEK)')
+
+    // Click outside to blur (simulates clicking somewhere else)
+    await userEvent.click(document.body)
+
+    // Value should still be SEK, not NOK
+    expect(inputElement).toHaveValue('Svensk krone (SEK)')
+
+    // onChange should NOT have been called since we didn't change anything
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Focus and blur again to verify consistent behavior
+    await userEvent.click(inputElement)
+    await userEvent.click(document.body)
+    expect(inputElement).toHaveValue('Svensk krone (SEK)')
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -378,6 +378,12 @@ export const prepareDerivedState = (
     }
     state.data = getData(props)
     state.originalData = getData(props)
+
+    // When data changes, selectedItem indices may shift.
+    // Recalculate to keep the correct item selected.
+    if (props.value != null && props.value !== 'initval') {
+      state.selectedItem = getCurrentIndex(props.value, state.originalData)
+    }
   }
 
   state.skipPortal = props.skipPortal


### PR DESCRIPTION
Fixes: Fixes https://github.com/dnbexperience/eufemia/issues/7615

When components like SelectCountry, SelectCurrency, and PhoneNumber lazy-load their full data on focus, the data change caused selectedItem indices to become stale in prepareDerivedState. This resulted in the value resetting to the first item (e.g. Norway).

Recalculate selectedItem directly in the data-change block of prepareDerivedState, co-locating the fix with the cause.

