### PR TITLE
chore(StepIndicator): use backgroundColor instead of removed variant on Section

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
@@ -118,7 +118,7 @@ export const StepIndicatorCustomized = () => (
               bottom
               {...props}
             />
-            <Section variant="lavender" innerSpace>
+            <Section backgroundColor="lavender" innerSpace>
               {children(step)}
             </Section>
           </>


### PR DESCRIPTION
The 'lavender' variant was removed from Section in v11. Using the removed variant caused the customized StepIndicator demo to render with a black background, making the text invisible.

Deploy preview: https://fix-step-indicator-customize.eufemia-e25.pages.dev/uilib/components/step-indicator/demos/#stepindicator-customized

Fixes #7616

