### PR TITLE
fix(Autocomplete): prevent dropdown from reopening after Enter key selection

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -1841,6 +1841,13 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           break
 
         case 'Enter':
+          // If the DrawerList's capture-phase keydown handler already
+          // handled this Enter event (selecting an item and closing),
+          // it will have called preventDefault. Skip to avoid reopening.
+          if (e.defaultPrevented) {
+            break
+          }
+
           e.preventDefault()
 
           if (!drawerList.open && hasFilterActive()) {
@@ -1858,7 +1865,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
               ...getEventObjects('onSubmit'),
             })
             toggleVisible()
-          } else {
+          } else if (!drawerList.open) {
             setVisible()
           }
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4165,6 +4165,76 @@ describe('Autocomplete component', () => {
     expect(input.value).toBe('The Godfather')
   })
 
+  it('should close dropdown when selecting an option with Enter after arrow key navigation', async () => {
+    render(<Autocomplete data={['AA', 'BB', 'CC']} {...mockProps} />)
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    // Open the dropdown
+    keyDownOnInput('ArrowDown')
+
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    // Navigate to first option
+    keyDownOnInput('ArrowDown')
+
+    // Press Enter to select
+    keyDownOnInput('Enter')
+
+    // Wait for all deferred callbacks
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Dropdown should stay closed
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+
+    // Value should be selected
+    expect(input.value).toBe('AA')
+  })
+
+  it('should close dropdown when selecting with Enter and openOnFocus is true', async () => {
+    render(
+      <Autocomplete data={['AA', 'BB', 'CC']} openOnFocus {...mockProps} />
+    )
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    // Focus opens the dropdown with openOnFocus
+    fireEvent.focus(input)
+
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    // Navigate to first option
+    keyDownOnInput('ArrowDown')
+
+    // Press Enter to select
+    keyDownOnInput('Enter')
+
+    // Wait for all deferred callbacks
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Dropdown should stay closed
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+
+    // Value should be selected
+    expect(input.value).toBe('AA')
+  })
+
   it('should open and search after clearing input following keyboard selection', async () => {
     const movies = [
       'The Shawshank Redemption',


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1776687208134349

Deploy preview: https://fix-autocomplete-enter-key-c.eufemia-e25.pages.dev/uilib/components/autocomplete/demos/#default-autocomplete


When the user presses Enter to select an item from the dropdown after
navigating with arrow keys, the DrawerList's capture-phase keydown handler
processes the selection and calls preventDefault(). The Autocomplete's
bubble-phase handler now checks e.defaultPrevented and skips its own
Enter handling, preventing it from inadvertently reopening the dropdown.

