### PR TITLE
chore(PaginationProvider): use useIsomorphicLayoutEffect for onEnd disptch

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
@@ -379,8 +379,10 @@ const PaginationProvider = (props: any) => {
     ]
   )
 
-  // Handle the onEnd dispatch after hasEndedInfinity becomes true
-  useEffect(() => {
+  // Handle the onEnd dispatch after hasEndedInfinity becomes true.
+  // Use useIsomorphicLayoutEffect so the callback fires before paint,
+  // matching the class component's setState callback timing.
+  useIsomorphicLayoutEffect(() => {
     if (hasEndedInfinity && endInfinityDispatchRef.current) {
       endInfinityDispatchRef.current = false
       const pageNumber = currentPageInternalRef.current + 1


### PR DESCRIPTION
The onEnd callback was dispatched via useEffect (after paint) while all other pending callbacks in the same file use useIsomorphicLayoutEffect (before paint) to match the class component's setState callback timing.

This inconsistency could cause a visible frame where the UI shows the ended state before the onEnd callback fires. Switching to useIsomorphicLayoutEffect aligns the timing with the stated design intent and the other callbacks.

