### PR TITLE
chore(v11): clean up strikethrough entries for removed props

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -970,7 +970,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `open_on_focus` with `openOnFocus`.
 - Replace `drawer_class` with `drawerClass`.
 - Replace `prevent_focus` with `preventFocus`.
-- ~~Replace `action_menu` with `actionMenu`.~~ The `actionMenu` (and `action_menu`) prop has been removed. Use the new [Menu](/uilib/components/menu/) component instead.
+- Removed: `action_menu` / `actionMenu`. Use the new [Menu](/uilib/components/menu/) component instead.
 - Replace `is_popup` with `isPopup`.
 - Replace `selectall` with `selectAll`.
 
@@ -1062,10 +1062,10 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `statusState`'s value `warn` with `warning`.
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
-- ~~Replace `more_menu` with `moreMenu`.~~ The `moreMenu` (and `more_menu`) prop has been removed. Use the new [Menu](/uilib/components/menu/) component instead.
+- Removed: `more_menu` / `moreMenu`. Use the new [Menu](/uilib/components/menu/) component instead.
 - Replace `trigger_element` with `triggerElement`.
 - Replace `open_on_focus` with `openOnFocus`.
-- ~~Replace `action_menu` with `actionMenu`.~~ The `actionMenu` (and `action_menu`) prop has been removed. Use the new [Menu](/uilib/components/menu/) component instead.
+- Removed: `action_menu` / `actionMenu`. Use the new [Menu](/uilib/components/menu/) component instead.
 - Replace `is_popup` with `isPopup`.
 - Replace `prevent_focus` with `preventFocus`.
 
@@ -1123,7 +1123,7 @@ Data object property renames: `selected_value` → `selectedValue`, `suffix_valu
 - Replace `ignore_events` with `ignoreEvents`.
 - Replace `no_animation` with `noAnimation`.
 - Replace `label_direction` with `labelDirection`.
-- ~~Replace `action_menu` with `actionMenu`.~~ The `actionMenu` (and `action_menu`) prop has been removed. Use the new [Menu](/uilib/components/menu/) component instead.
+- Removed: `action_menu` / `actionMenu`. Use the new [Menu](/uilib/components/menu/) component instead.
 - Replace `is_popup` with `isPopup`.
 - Replace `prevent_focus` with `preventFocus`.
 - Replace `opened` with `open`.


### PR DESCRIPTION
Replace confusing strikethrough pattern (~~Replace X with Y.~~ Removed.) with clearer 'Removed: X. Use Menu instead.' format for the removed actionMenu and moreMenu props in Autocomplete, Dropdown, and DrawerList sections.

