### PR TITLE
chore(Input): remove dead focusState code

### DIFF
--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -378,13 +378,6 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   const [inputState, setInputState] = useState(
     restProps.inputState || 'virgin'
   )
-  // Setter intentionally unused — calling setFocusState triggers re-renders
-  // that break timing-sensitive consumers (e.g. Autocomplete blur handling).
-  // The focusState is only read in the placeholder visibility check below.
-  const [focusState, _setFocusState] = useState<string | undefined>(
-    undefined
-  )
-
   const prevValuePropRef = useRef<string | number | null | undefined>(
     restProps.value
   )
@@ -780,7 +773,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
               />
             )}
 
-            {!hasVal && placeholder && focusState !== 'focus' && (
+            {!hasVal && placeholder && (
               <span
                 id={id + '-placeholder'}
                 className={clsx(


### PR DESCRIPTION
The focusState state variable and its setter were intentionally disabled during the class-to-functional conversion (setter prefixed with underscore, never called). Since focusState was always undefined, the condition `focusState !== 'focus'` in the placeholder check was always true — effectively dead code.

Placeholder visibility during focus is correctly handled by CSS via the data-input-state attribute, which uses the separate inputState variable.

