### PR TITLE
chore(PaginationProvider): derive startupPage from currentPage set after mount

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
@@ -453,6 +453,21 @@ const PaginationProvider = (props: any) => {
     }
   }, [props.currentPage])
 
+  // ---- Derive startupPage from currentPage when not yet set ----
+  // Mirrors v10 getDerivedStateFromProps: when startupPage is not a number
+  // (e.g. currentPage was initially null), re-derive once currentPage arrives.
+  useIsomorphicLayoutEffect(() => {
+    if (typeof startupPageRef.current !== 'number') {
+      const derived =
+        parseFloat(props.startupPage) ||
+        parseFloat(props.currentPage) ||
+        currentPageInternalRef.current
+      if (typeof derived === 'number' && !isNaN(derived)) {
+        setStartupPage(derived)
+      }
+    }
+  }, [props.startupPage, props.currentPage])
+
   // ---- Handle resetContentHandler prop ----
   useIsomorphicLayoutEffect(() => {
     if (props.resetContentHandler === true) {

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -285,6 +285,39 @@ describe('Infinity scroller', () => {
     await wait(20)
   }
 
+  it('should derive startupPage from currentPage set after mount', async () => {
+    const onStartup = jest.fn()
+
+    const MyComponent = () => {
+      const [currentPage, setCurrentPage] = React.useState(null)
+
+      React.useEffect(() => {
+        setCurrentPage(3)
+      }, [])
+
+      return (
+        <Pagination
+          mode="infinity"
+          currentPage={currentPage}
+          minWaitTime={0}
+          onStartup={({ pageNumber, setContent }) => {
+            setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)
+            onStartup({ pageNumber })
+          }}
+        />
+      )
+    }
+
+    render(<MyComponent />)
+
+    await waitForComponent()
+
+    expect(onStartup).toHaveBeenCalledTimes(1)
+    expect(onStartup).toHaveBeenCalledWith(
+      expect.objectContaining({ pageNumber: 3 })
+    )
+  })
+
   it('should load pages with intersection observer (after)', async () => {
     const action = ({ pageNumber, setContent }) => {
       setContent(pageNumber, <PageItem>{pageNumber}</PageItem>)


### PR DESCRIPTION
The class-to-functional conversion replaced getDerivedStateFromProps with a useState initializer for startupPage. The initializer only runs once, so when currentPage is initially null and set later via useEffect, startupPage remained undefined — causing the infinity table example to start from page 1 instead of the intended page 3.

Add a useIsomorphicLayoutEffect that re-derives startupPage from currentPage when it arrives, mirroring the v10 getDerivedStateFromProps behavior.

