### PR TITLE
chore(Autocomplete): re-compute selectedItem in showAllItems to avoid stale state

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -840,15 +840,24 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
   const showAllItems = useCallback(() => {
     resetFilter()
+
+    // Re-compute selectedItem from current value and data to avoid
+    // reading stale state. When updateData triggers both
+    // revalidateSelectedItem and showAllItems in the same callback
+    // cycle, the selectedItem state update from revalidateSelectedItem
+    // may not have been committed yet.
+    const selectedItem =
+      getCurrentIndex(
+        propsRef.current.value,
+        drawerListRef.current.originalData
+      ) ?? drawerListRef.current.selectedItem
+
     drawerListRef.current.setState({
       cacheHash: 'all',
     })
-    drawerListRef.current.setActiveItemAndScrollToIt(
-      drawerListRef.current.selectedItem,
-      {
-        scrollTo: false,
-      }
-    )
+    drawerListRef.current.setActiveItemAndScrollToIt(selectedItem, {
+      scrollTo: false,
+    })
   }, [resetFilter])
 
   const setSearchIndex = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { isCI } from 'repo-utils'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SharedProvider from '../../../../../shared/Provider'
 import type { JSONSchema } from '../../..'
@@ -826,6 +826,89 @@ describe('Field.PhoneNumber', () => {
         countryCodePrefix: '+44',
         phoneNumber: '9999',
       })
+    })
+
+    it('should set active item to selected country when opening dropdown with transformIn', () => {
+      type PhoneNumberDataShape = {
+        countryCode: string
+        phoneNumber: string
+        countryCodePrefix: string
+      }
+
+      const transformIn = (external: unknown) => {
+        const {
+          countryCode: iso,
+          phoneNumber,
+          countryCodePrefix: countryCode,
+        } = (external || {}) as PhoneNumberDataShape
+        return {
+          countryCode,
+          phoneNumber,
+          iso,
+        } satisfies AdditionalArgs
+      }
+
+      const transformOut = (
+        _internal: unknown,
+        additionalArgs?: unknown
+      ) => {
+        const args = additionalArgs as AdditionalArgs | undefined
+        return {
+          countryCode: args?.iso,
+          phoneNumber: args?.phoneNumber,
+          countryCodePrefix: args?.countryCode,
+        }
+      }
+
+      render(
+        <Form.Handler
+          defaultData={{
+            myField: {
+              countryCode: 'GB',
+              phoneNumber: '9123457',
+              countryCodePrefix: '+44',
+            },
+          }}
+        >
+          <Field.PhoneNumber
+            path="/myField"
+            transformIn={transformIn}
+            transformOut={transformOut}
+            noAnimation
+          />
+        </Form.Handler>
+      )
+
+      const codeElement = document.querySelector(
+        '.dnb-forms-field-phone-number__country-code input'
+      )
+
+      expect(codeElement).toHaveValue('GB (+44)')
+
+      // Simulate a real click: mouseDown opens the drawer,
+      // focus triggers handleCountryCodeFocus which calls updateData.
+      // Both must be batched to reproduce the stale selectedItem issue.
+      act(() => {
+        fireEvent.mouseDown(codeElement)
+        fireEvent.focus(codeElement)
+      })
+
+      // The dropdown should be open with all countries listed
+      const items = document.querySelectorAll('li.dnb-drawer-list__option')
+      expect(items.length).toBeGreaterThan(1)
+
+      // The selected item should be GB (+44)
+      const selectedItem = document.querySelector(
+        'li.dnb-drawer-list__option--selected'
+      )
+      expect(selectedItem.textContent).toContain('+44')
+
+      // The active/focused item should also be the selected country,
+      // not the first item in the list
+      const focusedItem = document.querySelector(
+        'li.dnb-drawer-list__option--focus'
+      )
+      expect(focusedItem.textContent).toContain('+44')
     })
 
     it('should support transformOut', async () => {


### PR DESCRIPTION
Issue:

PhoneNumber is the primary affected component because it uses a "lazy expand" pattern: the dropdown starts with a 1-item filtered list (just the default country) and expands to the full country list on focus via updateData. The bug is visible when the selected country is not the first item in the expanded list — meaning any non-Norwegian country code (since Norway is first in the prioritized list). This includes: PhoneNumber with transformIn and a foreign country (like the GB example) PhoneNumber with an initial value like value="+4412345678" Any PhoneNumber where the user first selects a different country, closes the dropdown, then reopens it With the default +47, the stale index (0) happens to be correct by coincidence, so the bug is invisible.

Experience it by going to https://v11.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/PhoneNumber/demos/#transform-in-and-out and https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/PhoneNumber/demos/#transform-in-and-out, then open the country code, then compare how the autocomplete/dropdown list looks.


<img width="2032" height="720" alt="Screenshot 2026-04-21 at 12 10 12" src="https://github.com/user-attachments/assets/f508868f-ae1f-482a-a7da-c45e3f4a7250" />


Can also be experienced here: https://v11.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/PhoneNumber/demos/#validation---pattern



When updateData triggers both revalidateSelectedItem and showAllItems
in the same callback cycle, the selectedItem state update may not have
been committed yet. This caused the dropdown to scroll to the wrong
item (index 0) instead of the actual selected item.

Re-compute selectedItem from the current value and data directly
instead of reading the potentially stale drawerListRef state.