### PR TITLE
fix(DatePicker, Field.Date): align cancel behavior with DatePicker

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -681,6 +681,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
   return (
     <DatePickerProvider
       {...props}
+      open={open}
       attributes={remainingDOMProps}
       setReturnObject={(fn) => (getReturnObject.current = fn)}
       hidePicker={hidePicker}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React, { useCallback, useContext, useMemo } from 'react'
+import React, { useCallback, useContext, useMemo, useRef } from 'react'
 import type {
   DatePickerEventAttributes,
   DatePickerAllProps,
@@ -87,6 +87,7 @@ function DatePickerProvider(props: DatePickerProviderProps) {
     returnFormat: returnFormatProp,
     children,
     onChange,
+    open,
     setReturnObject,
     hidePicker,
   } = props
@@ -127,6 +128,16 @@ function DatePickerProvider(props: DatePickerProviderProps) {
   const { hoverDate, setHoverDate } = useHoverDate()
 
   const { submittedDatesRef, setSubmittedDates } = useSubmittedDates()
+
+  // Snapshot current dates when the picker opens, so cancel reverts to the correct value
+  const prevOpenRef = useRef(open)
+  if (open && !prevOpenRef.current) {
+    setSubmittedDates({
+      startDate: dates.startDate,
+      endDate: dates.endDate,
+    })
+  }
+  prevOpenRef.current = open
 
   const getReturnObject = useCallback(
     <E,>({ event = null, ...rest }: GetReturnObjectParams<E> = {}) => {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1870,6 +1870,56 @@ describe('DatePicker component', () => {
     )
   })
 
+  it('should update submittedDates on reopen so cancel reverts to current value', async () => {
+    const { rerender } = render(
+      <DatePicker
+        date="2023-01-16"
+        showInput
+        showCancelButton
+        noAnimation
+      />
+    )
+
+    const [day, month, year] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    ) as Array<HTMLInputElement>
+
+    expect(day).toHaveValue('16')
+    expect(month).toHaveValue('01')
+    expect(year).toHaveValue('2023')
+
+    // Open the picker, then close it
+    const submitButton = document.querySelector(
+      'button.dnb-input__submit-button__button'
+    )
+    await userEvent.click(submitButton)
+    await userEvent.click(submitButton)
+
+    // Change the date via props (simulating an external value change)
+    rerender(
+      <DatePicker
+        date="2025-06-25"
+        showInput
+        showCancelButton
+        noAnimation
+      />
+    )
+
+    expect(day).toHaveValue('25')
+    expect(month).toHaveValue('06')
+    expect(year).toHaveValue('2025')
+
+    // Open picker and cancel — should keep the current value (2025-06-25)
+    await userEvent.click(submitButton)
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    expect(day).toHaveValue('25')
+    expect(month).toHaveValue('06')
+    expect(year).toHaveValue('2025')
+  })
+
   it('should empty the input fields when clicking the reset button when `date` is `undefined`', async () => {
     const onReset = jest.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -18,6 +18,7 @@ import useTranslation from '../../hooks/useTranslation'
 import type {
   DatePickerEvent,
   DatePickerProps,
+  DisplayPickerEvent,
 } from '../../../../components/DatePicker'
 import { convertStringToDate } from '../../../../components/date-picker/DatePickerCalc'
 import type { ProviderProps } from '../../../../shared/Provider'
@@ -283,6 +284,43 @@ function DateComponent(props: DateProps): React.ReactElement {
 
   const datePickerProps = pickDatePickerProps(rest)
   const initialValueRef = useRef(props.value ?? props.defaultValue)
+  const valueOnOpenRef = useRef(internalValue)
+
+  const handleOpen = useCallback(
+    (event: DatePickerEvent<DisplayPickerEvent>) => {
+      valueOnOpenRef.current = internalValue
+      datePickerProps.onOpen?.(event)
+    },
+    [internalValue, datePickerProps.onOpen]
+  )
+
+  const handleCancel = useCallback(
+    (event: DatePickerEvent<React.MouseEvent<HTMLButtonElement>>) => {
+      const revertValue = valueOnOpenRef.current
+
+      if (range) {
+        const [startDate, endDate] = parseRangeValue(revertValue)
+        handleChange({
+          startDate: startDate ?? undefined,
+          endDate: endDate ?? undefined,
+        })
+      } else {
+        handleChange({ date: revertValue ?? undefined })
+      }
+
+      datePickerProps.onCancel?.(event)
+    },
+    [handleChange, range, datePickerProps.onCancel]
+  )
+
+  const handleSubmit = useCallback(
+    (event: DatePickerEvent<React.MouseEvent<HTMLButtonElement>>) => {
+      valueOnOpenRef.current = internalValue
+      datePickerProps.onSubmit?.(event)
+    },
+    [internalValue, datePickerProps.onSubmit]
+  )
+
   const handleReset = useCallback(
     (
       event: DatePickerEvent<
@@ -422,6 +460,9 @@ function DateComponent(props: DateProps): React.ReactElement {
         onFocus={onFocus}
         onBlur={handleBlur}
         {...datePickerProps}
+        onOpen={handleOpen}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
         {...htmlAttributes}
       />
     </FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -1946,6 +1946,337 @@ describe('Field.Date', () => {
     })
   })
 
+  it('should not change value when clicking cancel after reset and typing', async () => {
+    render(<Field.Date value="2023-01-16" showInput />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+
+    // Type a new date
+    await userEvent.click(day)
+    await userEvent.keyboard('12122024')
+
+    expect(day.value).toBe('12')
+    expect(month.value).toBe('12')
+    expect(year.value).toBe('2024')
+
+    // Open picker and click reset
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="reset"]')
+    )
+
+    // Should reset to the initial value
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+
+    // Type another date
+    await userEvent.click(day)
+    await userEvent.keyboard('12122025')
+
+    expect(day.value).toBe('12')
+    expect(month.value).toBe('12')
+    expect(year.value).toBe('2025')
+
+    // Open picker and click cancel — should keep the typed value
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Should keep the typed value (2025-12-12), NOT revert to stale 2024-12-12
+    expect(day.value).toBe('12')
+    expect(month.value).toBe('12')
+    expect(year.value).toBe('2025')
+  })
+
+  it('should keep value unchanged when cancelling without changes', async () => {
+    render(<Field.Date value="2023-01-16" showInput />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+
+    // Open picker and cancel immediately
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+  })
+
+  it('should keep typed value when cancelling after typing', async () => {
+    render(<Field.Date value="2023-01-16" showInput />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    // Type a new date
+    await userEvent.click(day)
+    await userEvent.keyboard('25062025')
+
+    expect(day.value).toBe('25')
+    expect(month.value).toBe('06')
+    expect(year.value).toBe('2025')
+
+    // Open picker and cancel — should keep the typed value
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Cancel keeps the value from when the picker was opened
+    expect(day.value).toBe('25')
+    expect(month.value).toBe('06')
+    expect(year.value).toBe('2025')
+  })
+
+  it('should revert to value at open when cancelling after submit and typing', async () => {
+    render(<Field.Date value="2023-01-16" showInput showSubmitButton />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    // Type a new date
+    await userEvent.click(day)
+    await userEvent.keyboard('25062025')
+
+    // Open picker and submit
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="submit"]')
+    )
+
+    expect(day.value).toBe('25')
+    expect(month.value).toBe('06')
+    expect(year.value).toBe('2025')
+
+    // Type another date
+    await userEvent.click(day)
+    await userEvent.keyboard('01012026')
+
+    expect(day.value).toBe('01')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2026')
+
+    // Open picker and cancel — should keep the typed value (value at open)
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Cancel reverts to value when picker was opened (2026-01-01)
+    expect(day.value).toBe('01')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2026')
+  })
+
+  it('should keep typed value when cancelling after reset with no initial value', async () => {
+    render(<Field.Date showInput />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    // Type a date
+    await userEvent.click(day)
+    await userEvent.keyboard('15032025')
+
+    expect(day.value).toBe('15')
+    expect(month.value).toBe('03')
+    expect(year.value).toBe('2025')
+
+    // Open picker and reset (should clear since no initial value)
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="reset"]')
+    )
+
+    expect(day.value).toBe('dd')
+    expect(month.value).toBe('mm')
+    expect(year.value).toBe('åååå')
+
+    // Type another date
+    await userEvent.click(day)
+    await userEvent.keyboard('20102025')
+
+    expect(day.value).toBe('20')
+    expect(month.value).toBe('10')
+    expect(year.value).toBe('2025')
+
+    // Open picker and cancel — should keep the typed value
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Cancel keeps the value from when the picker was opened
+    expect(day.value).toBe('20')
+    expect(month.value).toBe('10')
+    expect(year.value).toBe('2025')
+  })
+
+  it('should keep typed value when cancelling after double reset', async () => {
+    render(<Field.Date value="2023-01-16" showInput />)
+
+    const [day, month, year]: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+
+    // Type a new date
+    await userEvent.click(day)
+    await userEvent.keyboard('12122024')
+
+    // First reset
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="reset"]')
+    )
+
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+
+    // Type another date
+    await userEvent.click(day)
+    await userEvent.keyboard('05052025')
+
+    // Second reset
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="reset"]')
+    )
+
+    expect(day.value).toBe('16')
+    expect(month.value).toBe('01')
+    expect(year.value).toBe('2023')
+
+    // Type yet another date
+    await userEvent.click(day)
+    await userEvent.keyboard('30112025')
+
+    expect(day.value).toBe('30')
+    expect(month.value).toBe('11')
+    expect(year.value).toBe('2025')
+
+    // Cancel — should keep the typed value
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Cancel keeps the value from when the picker was opened
+    expect(day.value).toBe('30')
+    expect(month.value).toBe('11')
+    expect(year.value).toBe('2025')
+  })
+
+  it('should keep typed value when cancelling after reset in range mode', async () => {
+    render(<Field.Date value="2023-01-16|2023-02-20" range showInput />)
+
+    const inputs: Array<HTMLInputElement> = Array.from(
+      document.querySelectorAll('.dnb-date-picker__input')
+    )
+    const [startDay, startMonth, startYear, endDay, endMonth, endYear] =
+      inputs
+
+    expect(startDay.value).toBe('16')
+    expect(startMonth.value).toBe('01')
+    expect(startYear.value).toBe('2023')
+    expect(endDay.value).toBe('20')
+    expect(endMonth.value).toBe('02')
+    expect(endYear.value).toBe('2023')
+
+    // Type new start date
+    await userEvent.click(startDay)
+    await userEvent.keyboard('01032024')
+
+    // Type new end date
+    await userEvent.click(endDay)
+    await userEvent.keyboard('15042024')
+
+    expect(startDay.value).toBe('01')
+    expect(startMonth.value).toBe('03')
+    expect(startYear.value).toBe('2024')
+    expect(endDay.value).toBe('15')
+    expect(endMonth.value).toBe('04')
+    expect(endYear.value).toBe('2024')
+
+    // Open picker and reset
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="reset"]')
+    )
+
+    expect(startDay.value).toBe('16')
+    expect(startMonth.value).toBe('01')
+    expect(startYear.value).toBe('2023')
+    expect(endDay.value).toBe('20')
+    expect(endMonth.value).toBe('02')
+    expect(endYear.value).toBe('2023')
+
+    // Type new dates again
+    await userEvent.click(startDay)
+    await userEvent.keyboard('10062025')
+    await userEvent.click(endDay)
+    await userEvent.keyboard('20072025')
+
+    // Open picker and cancel — should keep the typed values
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+    await userEvent.click(
+      document.querySelector('button[data-testid="cancel"]')
+    )
+
+    // Cancel keeps the values from when the picker was opened
+    expect(startDay.value).toBe('10')
+    expect(startMonth.value).toBe('06')
+    expect(startYear.value).toBe('2025')
+    expect(endDay.value).toBe('20')
+    expect(endMonth.value).toBe('07')
+    expect(endYear.value).toBe('2025')
+  })
+
   it('should be able to hide and show submit, cancel and reset buttons', async () => {
     const { rerender } = render(
       <Field.Date showSubmitButton showCancelButton showResetButton />


### PR DESCRIPTION
Cancel now correctly reverts to the value when the picker was opened,
matching DatePicker's existing semantics. Previously, cancel could
revert to a stale value from a previous picker session.

Changes:
- DatePickerProvider: snapshot submittedDates at render time when open
  transitions to true, ensuring the cancel revert target is always fresh
- DatePicker: pass open state to the provider
- Field.Date: add handleOpen, handleCancel, and handleSubmit to keep
  internalValue in sync with DatePicker's cancel/submit behavior

Tests:
- 7 Field.Date tests covering cancel edge cases (after reset, after
  typing, after submit, no initial value, double reset, range mode)
- 1 DatePicker test verifying submittedDates updates on reopen