### PR TITLE
fix(DrawerList): replace global isOpen variable with per-instance ref

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -2002,6 +2002,55 @@ describe('Dropdown markup', () => {
   })
 })
 
+describe('Dropdown multiple instances', () => {
+  it('should not delay opening a second Dropdown when a first is already open', () => {
+    jest.useFakeTimers()
+
+    const { container } = render(
+      <>
+        <Dropdown id="dropdown-a" skipPortal data={mockData} />
+        <Dropdown id="dropdown-b" skipPortal data={mockData} />
+      </>
+    )
+
+    const triggerA = container.querySelector(
+      '#dropdown-a'
+    ) as HTMLButtonElement
+    const triggerB = container.querySelector(
+      '#dropdown-b'
+    ) as HTMLButtonElement
+
+    // Open Dropdown A
+    act(() => {
+      fireEvent.click(triggerA)
+    })
+
+    // Advance past blurDelay (201ms) so the animation completes
+    act(() => {
+      jest.advanceTimersByTime(202)
+    })
+
+    // Dropdown A should now be fully open
+    expect(triggerA.getAttribute('aria-expanded')).toBe('true')
+
+    // Open Dropdown B
+    act(() => {
+      fireEvent.click(triggerB)
+    })
+
+    // Dropdown B should start opening immediately (hidden: false, open: true)
+    // without waiting an extra blurDelay caused by the global isOpen flag.
+    // Advance only 1ms — enough for synchronous mergeState, but NOT blurDelay.
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(triggerB.getAttribute('aria-expanded')).toBe('true')
+
+    jest.useRealTimers()
+  })
+})
+
 describe('Dropdown scss', () => {
   it('has to match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -165,8 +165,6 @@ const allDefaultProps = {
   ...drawerListProviderDefaultProps,
 }
 
-let isOpen = false
-
 function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   const context = useContext(Context)
 
@@ -262,6 +260,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
     alt: false,
   })
   const outsideClickRef = useRef<DetectOutsideClickClass | null>(null)
+  const isOpenRef = useRef(false)
 
   // --- Methods ---
 
@@ -978,7 +977,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       })
 
       const animationDelayHandler = () => {
-        isOpen = true
+        isOpenRef.current = true
         mergeState({ isOpen: true })
 
         if (typeof onStateComplete === 'function') {
@@ -1019,7 +1018,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       )
     }
 
-    if (isOpen && !propsRef.current.noAnimation) {
+    if (isOpenRef.current && !propsRef.current.noAnimation) {
       clearTimeout(hideTimeoutRef.current)
       hideTimeoutRef.current = setTimeout(
         handleSingleComponentCheck,
@@ -1066,7 +1065,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
         if (typeof onStateComplete === 'function') {
           onStateComplete(false)
         }
-        isOpen = false
+        isOpenRef.current = false
 
         setActiveState(false)
       }
@@ -1471,7 +1470,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       clearTimeout(scrollTimeoutRef.current)
       clearTimeout(directionTimeoutRef.current)
 
-      isOpen = false
+      isOpenRef.current = false
       removeObservers()
       setActiveState(false)
     }


### PR DESCRIPTION
The module-level `let isOpen` variable was shared across all DrawerList instances. When migrating from class component to functional component, this instance variable was incorrectly lifted to module scope.

This caused a bug where opening one Dropdown would set isOpen=true globally, and a second independent Dropdown would see that flag and unnecessarily delay its opening animation by blurDelay (201ms).

Replace with a per-instance `useRef` so each DrawerList tracks its own animation state independently.

