### PR TITLE
chore(Autocomplete): restore focus state after Enter selection so typing reopens dropdown

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -2168,7 +2168,17 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           setSkipFocusDuringChange(false)
 
           // Deferred refocus — matches class component's setState callback timing
-          _focusTimeout.current = setTimeout(() => setFocusOnInput(), 0)
+          _focusTimeout.current = setTimeout(() => {
+            setFocusOnInput()
+
+            // Sync internal focus state so subsequent typing
+            // correctly reopens the dropdown via runFilterWithSideEffects.
+            // setHidden() above set hasFocus=false/hasBlur=false, and
+            // setFocusOnInput() suppresses onInputFocusHandler to avoid
+            // double onFocus dispatch, so we restore these manually.
+            setHasFocus(true)
+            setHasBlur(false)
+          }, 0)
         }
 
         const val = getCurrentDataTitle(
@@ -2194,6 +2204,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
       focusDrawerList,
       setFocusOnInput,
       setInputValue,
+      setHasBlur,
     ]
   )
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4235,6 +4235,47 @@ describe('Autocomplete component', () => {
     expect(input.value).toBe('AA')
   })
 
+  it('should reopen dropdown with options when typing after Enter key selection', async () => {
+    render(<Autocomplete data={['AA', 'AB', 'BB']} {...mockProps} />)
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    // Open the dropdown
+    keyDownOnInput('ArrowDown')
+
+    // Navigate to first option and select with Enter
+    keyDownOnInput('ArrowDown')
+    keyDownOnInput('Enter')
+
+    // Wait for deferred refocus
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Dropdown should be closed and value selected
+    expect(input.value).toBe('AA')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+
+    // Clear and type a new search
+    await userEvent.clear(input)
+    await userEvent.type(input, 'B')
+
+    // Dropdown should reopen with matching options
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    const options = document.querySelectorAll(
+      '.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+    )
+    expect(options.length).toBe(1)
+    expect(options[0].textContent).toBe('BB')
+  })
+
   it('should open and search after clearing input following keyboard selection', async () => {
     const movies = [
       'The Shawshank Redemption',


### PR DESCRIPTION
After selecting an item with Enter, setHidden() sets hasFocus=false. The deferred refocus via setFocusOnInput() suppresses onInputFocusHandler to avoid double onFocus dispatch, but this left hasFocus=false. When the user subsequently typed, runFilterWithSideEffects checked hasFocusRef.current before calling setVisible(), so the dropdown never reopened.

Fix: after the deferred refocus in onChangeHandler, explicitly sync hasFocus and hasBlur to reflect actual DOM focus state.

Related PR: https://github.com/dnbexperience/eufemia/pull/7628

Issue:

https://github.com/user-attachments/assets/534c0e20-1e4e-47f4-8eb6-839a11407f14


Fix:

https://github.com/user-attachments/assets/e0eb1862-f5ff-43ed-80c4-428a3a6eb062

