### PR TITLE
chore: add prettier 3.8.1 to root devDependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Write code in logical blocks.
 - Keep blank lines between logical blocks to ensure better readability.
 - Follow existing Prettier and ESLint configurations, and run them on files after making changes.
+- Run Prettier using the workspace version: `yarn exec prettier --write <file>`. Do NOT use `npx prettier`, as it bypasses Yarn PnP resolution and may use a wrong version.
 - Use TypeScript for type safety.
 - Use React Hooks over class components.
 - Use camelCase for functions and variables.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "lint": "yarn workspace @dnb/eufemia lint && yarn workspace dnb-design-system-portal lint",
     "lint:styles": "yarn workspace @dnb/eufemia lint:styles && yarn workspace dnb-design-system-portal lint:styles"
   },
+  "devDependencies": {
+    "prettier": "3.8.1"
+  },
   "resolutions": {
     "lmdb": "3.5.1",
     "msgpackr": "1.11.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16741,6 +16741,8 @@ __metadata:
 "eufemia@workspace:.":
   version: 0.0.0-use.local
   resolution: "eufemia@workspace:."
+  dependencies:
+    prettier: "npm:3.8.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Prettier was only declared in workspace packages (dnb-eufemia, dnb-design-system-portal, eufemia-llm-metadata), not at the root. AI agents running `npx prettier` or `yarn exec prettier` from the repo root would bypass Yarn PnP and fall back to a stale globally cached version (3.0.3 instead of 3.8.1).

- Add prettier 3.8.1 as a root devDependency so it resolves correctly from anywhere in the monorepo.
- Add explicit formatting command to AGENTS.md instructing agents to use `yarn exec prettier --write <file>` instead of `npx prettier`.

