### PR TITLE
chore: correct Algolia exclusion pattern for release pages

### DIFF
--- a/packages/dnb-design-system-portal/src/uilib/search/__tests__/searchQuery.test.ts
+++ b/packages/dnb-design-system-portal/src/uilib/search/__tests__/searchQuery.test.ts
@@ -42,7 +42,7 @@ describe('searchQuery', () => {
       transformer(
         makeNode({
           fields: {
-            slug: '/uilib/about-the-lib/releases/eufemia/v11-info/',
+            slug: 'uilib/about-the-lib/releases/eufemia/v11-info',
           },
           frontmatter: { title: 'v11' },
         })

--- a/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
+++ b/packages/dnb-design-system-portal/src/uilib/search/searchQuery.js
@@ -9,7 +9,7 @@ const { getIndexName, runQueriesWhen } = require('./searchHelpers')
 
 require('dotenv').config()
 
-const excludedSlugPartials = ['/uilib/about-the-lib/releases/']
+const excludedSlugPartials = ['uilib/about-the-lib/releases/']
 
 const docsQuery = /* GraphQL */ `
   {


### PR DESCRIPTION
Slugs are generated without leading slashes, but the exclusion pattern had a leading slash so the includes() check never matched. Fixed the pattern and the corresponding test.

