### PR TITLE
fix(Button, Tabs, PaymentCard): remove legacy class prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -232,7 +232,7 @@ These renames change the property or event name itself, not just the casing. The
 | `onClosed` / `onOpened`                 | `onClose` / `onOpen`                   | Table                                                               |
 | `isCollapsed`                           | `collapsed`                            | Breadcrumb                                                          |
 | `expandBehaviour`                       | `expandBehavior`                       | Accordion                                                           |
-| `class`                                 | `className`                            | ProgressIndicator, Button                                           |
+| `class`                                 | `className`                            | ProgressIndicator, Button, Tabs, PaymentCard                        |
 | `contentSpacing` / `tabsSpacing`        | `contentInnerSpace` / `tabsInnerSpace` | Tabs                                                                |
 | `darkMode`                              | `colorScheme`                          | Theme                                                               |
 
@@ -1520,6 +1520,7 @@ For more context, see this [PR](https://github.com/dnbexperience/eufemia/pull/27
 - Replace `card_number` with `cardNumber`.
 - Replace `card_status` with `cardStatus`.
 - Replace `raw_data` with `rawData`.
+- The `class` prop has been removed. Use `className` instead.
 
 #### `cardStatus` property
 
@@ -1688,7 +1689,7 @@ render(<Logo svg={SbankenCompact} />)
 - Replace `status_props` with `statusProps`.
 - Replace `status_no_animation` with `statusNoAnimation`.
 - Replace `custom_content` with `customContent`.
-- Replace `class` with `className`.
+- The `class` prop has been removed. Use `className` instead.
 - Replace `inner_ref` with `ref`.
 
 #### Events
@@ -1878,6 +1879,7 @@ The following properties have been renamed from snake_case to camelCase:
 - Replace `focus_key` with `focusKey`.
 - Replace `no_border` with `noBorder`.
 - Replace `prerender` with `keepInDOM`.
+- The `class` prop has been removed. Use `className` instead.
 
 #### Events
 

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -172,7 +172,6 @@ export type ButtonProps = {
   disabled?: boolean
   ref?: React.Ref<HTMLElement>
   className?: string
-  class?: string
   children?: ButtonChildren
   /**
    * Only meant to be used for special use cases. Defaults to `button` or `a` depending if href is set or not.

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1065,14 +1065,12 @@ function TabsComponent(ownProps: TabsProps) {
     children,
     ...rest
   }: React.PropsWithChildren<Record<string, unknown>>) => {
-    const { className, class: _className } = ownProps as TabsProps & {
-      class?: string
-    }
+    const { className } = ownProps as TabsProps
     const { ...attributes } = filterProps(ownProps, tabsDefaultProps)
 
     const params: Record<string, unknown> = applySpacing(ownProps, {
       ...attributes,
-      className: clsx('dnb-tabs', className, _className),
+      className: clsx('dnb-tabs', className),
     })
 
     validateDOMAttributes(ownProps, params)

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
@@ -98,7 +98,6 @@ export type PaymentCardProps = {
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
-  class?: string
   className?: string
   children?: PaymentCardChildren
 } & Omit<React.HTMLProps<HTMLElement>, 'ref' | 'children'> &
@@ -159,7 +158,6 @@ function PaymentCard(props: PaymentCardProps) {
     locale,
     skeleton,
     className,
-    class: _className,
     children,
     ...attributes
   } = extendedProps
@@ -171,8 +169,7 @@ function PaymentCard(props: PaymentCardProps) {
       'dnb-payment-card',
       `dnb-payment-card--${variant}`,
       createSkeletonClass(null, skeleton, context),
-      className,
-      _className
+      className
     ),
     ...attributes,
   })

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/PaymentCard.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/PaymentCard.test.tsx
@@ -31,7 +31,6 @@ const defaultProps: PaymentCardProps = {
   id: 'id',
   locale: 'nb-NO',
   skeleton: true,
-  class: 'class',
   className: 'className',
   children: 'children',
 }


### PR DESCRIPTION
Motivation:

https://dnb.enterprise.slack.com/archives/CMXABCHEY/p1776797353909279?thread_ts=1719566341.830889&channel=CMXABCHEY&message_ts=1776797353.909279

The class prop was a legacy accommodation. Use className instead.

Sort of a breaking change, should we merge this into v11.0.1 or deprecate and remove in v12.0.0 😅 
I think it's fine, there's no reference to `class` property in any of our docs, just TS.

