### PR TITLE
fix(DrawerList): clip arrow to triangle shape to prevent diamond on overscroll

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -249,7 +249,7 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   width: calc(var(--drawer-list-height) / 2);
   height: calc(var(--drawer-list-height) / 2);
   transform: translateY(60%) rotate(45deg);
-  clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
+  clip-path: polygon(0% 0%, 100% 0%, 0% 100%);
   background-color: var(--drawer-list-list-background);
 }
 .dnb-drawer-list--arrow-position-left .dnb-drawer-list__arrow {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -249,6 +249,7 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
   width: calc(var(--drawer-list-height) / 2);
   height: calc(var(--drawer-list-height) / 2);
   transform: translateY(60%) rotate(45deg);
+  clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
   background-color: var(--drawer-list-list-background);
 }
 .dnb-drawer-list--arrow-position-left .dnb-drawer-list__arrow {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -313,6 +313,7 @@
       width: calc(var(--drawer-list-height) / 2);
       height: calc(var(--drawer-list-height) / 2);
       transform: translateY(60%) rotate(45deg);
+      clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
 
       background-color: var(--drawer-list-list-background);
     }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -313,7 +313,7 @@
       width: calc(var(--drawer-list-height) / 2);
       height: calc(var(--drawer-list-height) / 2);
       transform: translateY(60%) rotate(45deg);
-      clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
+      clip-path: polygon(0% 0%, 100% 0%, 0% 100%);
 
       background-color: var(--drawer-list-list-background);
     }


### PR DESCRIPTION
Motivation is to fix this:

https://github.com/user-attachments/assets/c950d1ce-6799-4851-882c-de1f9889f1a2

Deploy preview: https://fix-drawer-list-arrow-clip-p.eufemia-e25.pages.dev/uilib/components/autocomplete/demos/
