### PR TITLE
fix(Card): allow `outlineWidth` to work on nested Cards

### DIFF
--- a/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
+++ b/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
@@ -396,6 +396,38 @@ describe('Card', () => {
     expect(element).toHaveStyle('--outline-width--large: 2px')
   })
 
+  it('should support "outlineWidth" on nested cards', () => {
+    render(
+      <Card>
+        <Card outlineWidth="1rem">Content</Card>
+      </Card>
+    )
+
+    const innerCard = document.querySelectorAll('.dnb-card')[1]
+    expect(innerCard).toHaveStyle('--outline-width--small: 1rem')
+    expect(innerCard).toHaveStyle('--outline-width--medium: 1rem')
+    expect(innerCard).toHaveStyle('--outline-width--large: 1rem')
+  })
+
+  it('should use default outlineWidth on nested cards', () => {
+    render(
+      <Card>
+        <Card>Content</Card>
+      </Card>
+    )
+
+    const innerCard = document.querySelectorAll('.dnb-card')[1]
+    expect(innerCard).toHaveStyle(
+      '--outline-width--small: var(--card-outline-width)'
+    )
+    expect(innerCard).toHaveStyle(
+      '--outline-width--medium: var(--card-outline-width)'
+    )
+    expect(innerCard).toHaveStyle(
+      '--outline-width--large: var(--card-outline-width)'
+    )
+  })
+
   it('should support "dropShadow"', () => {
     render(<Card dropShadow>Content</Card>)
 

--- a/packages/dnb-eufemia/src/components/card/style/themes/dnb-card-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/card/style/themes/dnb-card-theme-ui.scss
@@ -6,7 +6,6 @@
 .dnb-card {
   // Nested Cards
   & .dnb-card {
-    --outline-width: 0.0625rem;
     --rounded-corner: 1rem;
   }
 


### PR DESCRIPTION
Remove the --outline-width override for nested cards in the UI theme, which had higher CSS specificity than the inline style variables set by the outlineWidth prop. The outline width is already correctly derived from var(--card-outline-width) via the prop default.

Closes #7655

