### PR TITLE
chore: convert class components to function components in tests/stories

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -310,17 +310,12 @@ describe('Accordion group component', () => {
 })
 
 describe('Accordion container component', () => {
-  type DidRenderProps = {
-    id: string
-  }
-  class DidRender extends React.PureComponent<DidRenderProps> {
-    override state = { mounted: false }
-    override componentDidMount() {
-      this.setState({ mounted: true })
-    }
-    override render() {
-      return <div id={this.props.id}>{String(this.state.mounted)}</div>
-    }
+  const DidRender = ({ id }: { id: string }) => {
+    const [mounted, setMounted] = React.useState(false)
+    React.useEffect(() => {
+      setMounted(true)
+    }, [])
+    return <div id={id}>{String(mounted)}</div>
   }
 
   const Increment = () => {

--- a/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
@@ -366,45 +366,37 @@ export const DialogSandbox = () => (
   </Wrapper>
 )
 
-class ModalRerenderExample extends React.PureComponent {
-  override state = {
-    title: 'Modal Title',
-    triggerText: 'Open Modal',
-  }
-  timeout: NodeJS.Timeout
+function ModalRerenderExample() {
+  const [title, setTitle] = React.useState('Modal Title')
+  const [triggerText, setTriggerText] = React.useState('Open Modal')
 
-  override componentDidMount() {
-    this.timeout = setTimeout(() => {
-      this.setState({ title: 'New Title' })
-      this.setState({ triggerText: 'New Open Modal' })
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      setTitle('New Title')
+      setTriggerText('New Open Modal')
     }, 1e3)
-  }
+    return () => clearTimeout(timeout)
+  }, [])
 
-  override componentWillUnmount() {
-    clearTimeout(this.timeout)
-  }
-
-  override render() {
-    return (
-      <Dialog
-        triggerAttributes={{
-          text: this.state.triggerText,
-        }}
-        title={this.state.title}
-      >
-        <Dialog.Body innerSpace={{ block: 'large' }}>
-          <DatePicker label="DatePicker" right />
-          <Dropdown
-            label="Dropdown"
-            data={dropdownData}
-            right
-            direction="top"
-          />
-          {/* <Switch label="Checked:" checked right /> */}
-        </Dialog.Body>
-      </Dialog>
-    )
-  }
+  return (
+    <Dialog
+      triggerAttributes={{
+        text: triggerText,
+      }}
+      title={title}
+    >
+      <Dialog.Body innerSpace={{ block: 'large' }}>
+        <DatePicker label="DatePicker" right />
+        <Dropdown
+          label="Dropdown"
+          data={dropdownData}
+          right
+          direction="top"
+        />
+        {/* <Switch label="Checked:" checked right /> */}
+      </Dialog.Body>
+    </Dialog>
+  )
 }
 
 const dropdownData = [

--- a/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
+++ b/packages/dnb-eufemia/src/components/modal/stories/Modal.stories.tsx
@@ -220,48 +220,37 @@ export const ModalV2Sandbox = () => (
   </Modal>
 )
 
-class ModalRerenderExample extends React.PureComponent {
-  override state = {
-    title: 'Modal Title',
-    triggerText: 'Open Modal',
-  }
-  timeout
+function ModalRerenderExample() {
+  const [title, setTitle] = React.useState('Modal Title')
+  const [triggerText, setTriggerText] = React.useState('Open Modal')
 
-  override componentDidMount() {
-    this.timeout = setTimeout(() => {
-      this.setState({ title: 'New Title' })
-      this.setState({ triggerText: 'New Open Modal' })
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      setTitle('New Title')
+      setTriggerText('New Open Modal')
     }, 1e3)
-  }
+    return () => clearTimeout(timeout)
+  }, [])
 
-  override componentWillUnmount() {
-    clearTimeout(this.timeout)
-  }
-
-  override render() {
-    return (
-      <Modal
-        triggerAttributes={{ text: this.state.triggerText }}
-        title={this.state.title}
-      >
-        <Modal.Content innerSpace={{ block: 'large' }}>
-          {/* <Hr /> */}
-          {/* <Box>
+  return (
+    <Modal triggerAttributes={{ text: triggerText }} title={title}>
+      <Modal.Content innerSpace={{ block: 'large' }}>
+        {/* <Hr /> */}
+        {/* <Box>
           <H2>Some content</H2>
           <Input>Focus me with Tab key</Input>
         </Box> */}
-          <DatePicker label="DatePicker" right />
-          <Dropdown
-            label="Dropdown"
-            data={dropdownData}
-            right
-            direction="top"
-          />
-          {/* <Switch label="Checked:" checked right /> */}
-        </Modal.Content>
-      </Modal>
-    )
-  }
+        <DatePicker label="DatePicker" right />
+        <Dropdown
+          label="Dropdown"
+          data={dropdownData}
+          right
+          direction="top"
+        />
+        {/* <Switch label="Checked:" checked right /> */}
+      </Modal.Content>
+    </Modal>
+  )
 }
 
 const dropdownData = [


### PR DESCRIPTION
Convert React.PureComponent class components to function components with hooks (useState + useEffect) in:
- Dialog.stories.tsx (ModalRerenderExample)
- Modal.stories.tsx (ModalRerenderExample)
- Accordion.test.tsx (DidRender)

The withComponentMarkers.test.tsx class component is intentionally kept as it tests class component support.

