### PR TITLE
fix(Anchor): add missing style.ts entry

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/style.ts
+++ b/packages/dnb-eufemia/src/components/anchor/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-anchor.scss'


### PR DESCRIPTION
All other components have a style.ts entry file that imports their SCSS. Anchor was missing this file, making it inconsistent with the rest of the component library.

Do we actually need this?