### PR TITLE
chore: recommend useRef over createRef in component docs

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -67,7 +67,7 @@ export const CheckboxProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -155,12 +155,12 @@ export const DropdownProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` you can get the internally used main element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` you can get the internally used main element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },
   buttonRef: {
-    doc: 'By providing a `React.Ref` you can get the internally used button element (DOM), e.g. `buttonRef={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` you can get the internally used button element (DOM), e.g. `buttonRef={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -138,7 +138,7 @@ export const InputProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
@@ -57,7 +57,7 @@ export const RadioProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/section/SectionDocs.ts
+++ b/packages/dnb-eufemia/src/components/section/SectionDocs.ts
@@ -69,7 +69,7 @@ export const SectionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -68,7 +68,7 @@ export const SwitchProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -98,7 +98,7 @@ export const TextareaProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used Textarea element (DOM), e.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used Textarea element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
     type: 'React.RefObject',
     status: 'optional',
   },


### PR DESCRIPTION
React 19 makes ref a regular prop. Update docs for Radio, Section, Checkbox, Input, Dropdown, Textarea, and Switch to recommend React.useRef() instead of React.createRef().