### PR TITLE
chore(Pagination): replace React.createRef with plain ref objects in createPagination

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -455,16 +455,25 @@ export const Bar = (props: PaginationProps) => (
 export const createPagination = (
   initProps: Record<string, unknown> = {}
 ): PaginationCreateReturn => {
-  const store = React.createRef<Record<string, unknown>>()
-  const rerender = React.createRef<
-    ((store: React.RefObject<Record<string, unknown>>) => void) | null
-  >()
-  const _setContent = React.createRef<
+  const store: React.RefObject<Record<string, unknown> | null> = {
+    current: null,
+  }
+  const rerender: React.RefObject<
+    | ((store: React.RefObject<Record<string, unknown> | null>) => void)
+    | null
+  > = { current: null }
+  const _setContent: React.RefObject<
     ((pageNumber: number, content: React.ReactNode) => void) | null
-  >()
-  const _resetContent = React.createRef<(() => void) | null>()
-  const _resetInfinity = React.createRef<(() => void) | null>()
-  const _endInfinity = React.createRef<(() => void) | null>()
+  > = { current: null }
+  const _resetContent: React.RefObject<(() => void) | null> = {
+    current: null,
+  }
+  const _resetInfinity: React.RefObject<(() => void) | null> = {
+    current: null,
+  }
+  const _endInfinity: React.RefObject<(() => void) | null> = {
+    current: null,
+  }
 
   const setContent = (pageNumber: number, content: React.ReactNode) => {
     if (pageNumber > 0) {


### PR DESCRIPTION
createPagination is a factory function (not a component), so useRef cannot be used. Replace React.createRef() calls with plain { current: null } objects, which is more idiomatic for non-component code and removes reliance on the class-component-oriented createRef API.

