### PR TITLE
chore(Upload): remove deprecated `cellSpacing` attribute

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -158,7 +158,7 @@ function UploadInfoAcceptedFileTypesTable() {
     >
       <caption className="dnb-sr-only">{fileTypeTableCaption}</caption>
       <thead>
-        <Tr variant="odd" cellSpacing={0}>
+        <Tr variant="odd">
           <Th>{fileTypeDescription}</Th>
           <Th>{fileSizeDescription}</Th>
         </Tr>


### PR DESCRIPTION
cellSpacing is a deprecated HTML attribute that only applies to <table> elements, not <tr>. It was being passed to a Tr component where it had no effect. Removed to clean up deprecated HTML usage.
