### PR TITLE
chore(Pagination): replace React.createRef with plain mutable objects

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -455,16 +455,28 @@ export const Bar = (props: PaginationProps) => (
 export const createPagination = (
   initProps: Record<string, unknown> = {}
 ): PaginationCreateReturn => {
-  const store = React.createRef<Record<string, unknown>>()
-  const rerender = React.createRef<
-    ((store: React.RefObject<Record<string, unknown>>) => void) | null
-  >()
-  const _setContent = React.createRef<
-    ((pageNumber: number, content: React.ReactNode) => void) | null
-  >()
-  const _resetContent = React.createRef<(() => void) | null>()
-  const _resetInfinity = React.createRef<(() => void) | null>()
-  const _endInfinity = React.createRef<(() => void) | null>()
+  const store: { current: Record<string, unknown> | null } = {
+    current: null,
+  }
+  const rerender: {
+    current:
+      | ((store: { current: Record<string, unknown> | null }) => void)
+      | null
+  } = { current: null }
+  const _setContent: {
+    current:
+      | ((pageNumber: number, content: React.ReactNode) => void)
+      | null
+  } = { current: null }
+  const _resetContent: { current: (() => void) | null } = {
+    current: null,
+  }
+  const _resetInfinity: { current: (() => void) | null } = {
+    current: null,
+  }
+  const _endInfinity: { current: (() => void) | null } = {
+    current: null,
+  }
 
   const setContent = (pageNumber: number, content: React.ReactNode) => {
     if (pageNumber > 0) {

--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
@@ -514,10 +514,12 @@ const PaginationProvider = (props: any) => {
     if (props.rerender) {
       const rerenderFn = ({
         current: store,
-      }: React.RefObject<{
-        pageNumber: number
-        content: React.ReactNode
-      } | null>) => {
+      }: {
+        current: {
+          pageNumber: number
+          content: React.ReactNode
+        } | null
+      }) => {
         if (store && store.pageNumber > 0) {
           clearTimeout(rerenderTimeoutRef.current)
           rerenderTimeoutRef.current = setTimeout(


### PR DESCRIPTION
React 19 freezes the .current property on objects returned by React.createRef(), making them immutable. The createPagination factory function uses ref-like objects outside of React components and mutates .current directly, which would break in React 19.

Replace with plain { current: null } objects that remain mutable.

