### PR TITLE
chore(Icon): replace deprecated defaultProps check with typeof function check

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -418,7 +418,7 @@ function prepareIconCore(
 
   let iconToRender = getIcon(props)
 
-  if (iconToRender && typeof iconToRender.defaultProps !== 'undefined') {
+  if (iconToRender && typeof iconToRender === 'function') {
     iconToRender = React.createElement(
       iconToRender,
       validateDOMAttributes(

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -420,17 +420,14 @@ function prepareIconCore(
 
   if (iconToRender && typeof iconToRender === 'function') {
     const iconProps: Record<string, unknown> = {}
-    if (color !== undefined) {
-      iconProps.color = color
+    if (iconParams.color !== undefined) {
+      iconProps.color = iconParams.color
     }
-    if (size !== undefined) {
-      iconProps.size = size
+    if (iconParams.width !== undefined) {
+      iconProps.width = iconParams.width
     }
-    if (width !== undefined) {
-      iconProps.width = width
-    }
-    if (height !== undefined) {
-      iconProps.height = height
+    if (iconParams.height !== undefined) {
+      iconProps.height = iconParams.height
     }
 
     iconToRender = React.createElement(

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -419,18 +419,23 @@ function prepareIconCore(
   let iconToRender = getIcon(props)
 
   if (iconToRender && typeof iconToRender === 'function') {
+    const iconProps: Record<string, unknown> = {}
+    if (color !== undefined) {
+      iconProps.color = color
+    }
+    if (size !== undefined) {
+      iconProps.size = size
+    }
+    if (width !== undefined) {
+      iconProps.width = width
+    }
+    if (height !== undefined) {
+      iconProps.height = height
+    }
+
     iconToRender = React.createElement(
       iconToRender,
-      validateDOMAttributes(
-        {},
-        {
-          color,
-          icon,
-          size,
-          width,
-          height,
-        }
-      )
+      validateDOMAttributes({}, iconProps)
     )
   }
 


### PR DESCRIPTION
React 19 removes defaultProps from function components. The check `typeof iconToRender.defaultProps !== 'undefined'` was used to detect if an icon is a component function (vs a rendered element). Replace with `typeof iconToRender === 'function'` which is the correct way to distinguish component functions from rendered JSX elements.

