### PR TITLE
chore(tests): replace React.createRef with { current: null } pattern

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -260,7 +260,9 @@ describe('Accordion group component', () => {
   })
 
   it('should close all accordions inside a group with collapseAllHandleRef', () => {
-    const collapseAll = React.createRef<() => void>()
+    const collapseAll: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     render(
       <Accordion.Group
@@ -422,7 +424,9 @@ describe('Accordion container component', () => {
   })
 
   it('will set minHeight', async () => {
-    const contentRef = React.createRef<HTMLElement>()
+    const contentRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
 
     render(<Container contentRef={contentRef} />)
 

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/Anchor.test.tsx
@@ -434,7 +434,9 @@ describe('Anchor element', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLAnchorElement>()
+    const ref: React.RefObject<HTMLAnchorElement | null> = {
+      current: null,
+    }
 
     render(
       <Anchor ref={ref} to="/url">
@@ -491,7 +493,9 @@ describe('Anchor element', () => {
   })
 
   it('gets valid element when ref is function', () => {
-    const ref: React.RefObject<HTMLAnchorElement> = React.createRef()
+    const ref: React.RefObject<HTMLAnchorElement | null> = {
+      current: null,
+    }
 
     const refFn = (elem: HTMLAnchorElement) => {
       ref.current = elem

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4018,7 +4018,7 @@ describe('Autocomplete component', () => {
   })
 
   it('gets valid element when inputRef is function', () => {
-    const ref: React.RefObject<HTMLInputElement> = React.createRef()
+    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
 
     const refFn = (elem: HTMLInputElement) => {
       ref.current = elem

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -823,7 +823,7 @@ describe('Avatar', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Avatar.Group label="label">

--- a/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
+++ b/packages/dnb-eufemia/src/components/badge/__tests__/Badge.test.tsx
@@ -315,7 +315,7 @@ describe('Badge', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(<Badge ref={ref} content="1" />)
 

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -491,7 +491,7 @@ describe('Breadcrumb', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Breadcrumb

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -185,7 +185,9 @@ describe('Button component', () => {
   })
 
   it('has set ref if ref was given', () => {
-    const ref = React.createRef<HTMLButtonElement>()
+    const ref: React.RefObject<HTMLButtonElement | null> = {
+      current: null,
+    }
     expect(ref.current).toBe(null)
     render(<Button ref={ref} />)
 

--- a/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
+++ b/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
@@ -565,7 +565,7 @@ describe('Card', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Card ref={ref}>

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -378,7 +378,7 @@ describe('Checkbox component', () => {
   })
 
   it('gets valid element when ref is function', () => {
-    const ref: React.RefObject<HTMLInputElement> = React.createRef()
+    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
 
     const refFn = (elem: HTMLInputElement) => {
       ref.current = elem

--- a/packages/dnb-eufemia/src/components/country-flag/__tests__/CountryFlag.test.tsx
+++ b/packages/dnb-eufemia/src/components/country-flag/__tests__/CountryFlag.test.tsx
@@ -73,7 +73,7 @@ describe('CountryFlag', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(<CountryFlag ref={ref} />)
 

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -108,8 +108,12 @@ describe('Dialog', () => {
   })
 
   it('will accept custom refs', () => {
-    const contentRef = React.createRef<HTMLElement>()
-    const scrollRef = React.createRef<HTMLElement>()
+    const contentRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
+    const scrollRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
 
     const MockComponent = () => {
       return (

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -460,8 +460,12 @@ describe('Drawer', () => {
   })
 
   it('will accept custom refs', () => {
-    const contentRef = React.createRef<HTMLElement>()
-    const scrollRef = React.createRef<HTMLElement>()
+    const contentRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
+    const scrollRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
 
     const MockComponent = () => {
       return (

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -1121,7 +1121,7 @@ describe('Flex.Container', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Flex.Container ref={ref}>

--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -447,7 +447,7 @@ describe('FormLabel component', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(<FormLabel ref={ref} forId="input" text="Label" />)
 

--- a/packages/dnb-eufemia/src/components/grid/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/grid/__tests__/Container.test.tsx
@@ -159,7 +159,7 @@ describe('Grid.Container', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Grid.Container ref={ref}>

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -434,7 +434,7 @@ describe('HeightAnimation without initializeTestSetup()', () => {
   })
 
   it('gets valid element when using createRef', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(<HeightAnimation ref={ref}>content</HeightAnimation>)
 

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -157,8 +157,12 @@ describe('Modal component', () => {
   })
 
   it('accepts custom refs', () => {
-    const contentRef = React.createRef<HTMLElement>()
-    const scrollRef = React.createRef<HTMLElement>()
+    const contentRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
+    const scrollRef: React.RefObject<HTMLElement | null> = {
+      current: null,
+    }
 
     const MockComponent = () => {
       return (

--- a/packages/dnb-eufemia/src/components/modal/__tests__/ModalContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/ModalContent.test.tsx
@@ -49,7 +49,7 @@ afterEach(() => {
 })
 
 const createTestProps = (): ModalContentProps => {
-  const contentRef: React.RefObject<HTMLElement> = React.createRef()
+  const contentRef: React.RefObject<HTMLElement | null> = { current: null }
 
   // Set up the content ref with a mock element that has the expected structure
   const mockElement = document.createElement('div')

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -484,7 +484,9 @@ describe('Popover', () => {
   })
 
   it('moves focus to a custom element when focusOnOpenElement is provided', async () => {
-    const focusRef = React.createRef<HTMLButtonElement>()
+    const focusRef: React.RefObject<HTMLButtonElement | null> = {
+      current: null,
+    }
 
     render(
       <Popover
@@ -1450,7 +1452,9 @@ describe('Popover', () => {
   })
 
   it('applies contentClassName and exposes a contentRef', async () => {
-    const contentRef = React.createRef<HTMLSpanElement>()
+    const contentRef: React.RefObject<HTMLSpanElement | null> = {
+      current: null,
+    }
     renderWithTrigger({
       contentClassName: 'custom-content',
       contentRef,

--- a/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
@@ -40,7 +40,7 @@ describe('PortalRoot', () => {
   })
 
   it('should handle ref forwarding', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
     render(
       <PortalRoot ref={ref}>
         <div>Content</div>
@@ -282,7 +282,7 @@ describe('PortalRoot', () => {
 
   it('should handle ref forwarding with custom id', () => {
     const customId = 'custom-portal-with-ref'
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
     render(
       <PortalRoot id={customId} ref={ref}>
         <div>Content</div>

--- a/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
@@ -306,7 +306,7 @@ describe('Section component', () => {
   })
 
   it('gets valid element when using createRef', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Section {...props} ref={ref}>

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -186,7 +186,7 @@ describe('Switch component', () => {
   })
 
   it('gets valid element when ref is function', () => {
-    const ref: React.RefObject<HTMLInputElement> = React.createRef()
+    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
 
     const refFn = (elem: HTMLInputElement) => {
       ref.current = elem

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -1028,7 +1028,9 @@ describe('TableAccordion', () => {
 
   describe('closeAllHandle', () => {
     it('should close all tr when called', () => {
-      const collapseAllHandleRef = React.createRef<() => void>()
+      const collapseAllHandleRef: React.RefObject<(() => void) | null> = {
+        current: null,
+      }
 
       render(
         <Table

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordionMode.test.tsx
@@ -934,7 +934,9 @@ describe('Table using mode="accordion" prop', () => {
 
   describe('closeAllHandle', () => {
     it('should close all tr when called', () => {
-      const collapseAllHandleRef = React.createRef<() => void>()
+      const collapseAllHandleRef: React.RefObject<(() => void) | null> = {
+        current: null,
+      }
 
       render(
         <Table

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableScrollView.test.tsx
@@ -49,7 +49,7 @@ describe('Table.ScrollView', () => {
     })
     setResizeObserver({ init, observe })
 
-    const ref = React.createRef<HTMLDivElement>()
+    const ref: React.RefObject<HTMLDivElement | null> = { current: null }
 
     render(
       <ScrollView ref={ref}>

--- a/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/Tag.test.tsx
@@ -552,7 +552,7 @@ describe('Tag', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(
       <Tag.Group label="tags">

--- a/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/__tests__/Timeline.test.tsx
@@ -377,7 +377,7 @@ describe('Timeline', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLOListElement>()
+    const ref: React.RefObject<HTMLOListElement | null> = { current: null }
 
     render(
       <Timeline

--- a/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/__tests__/VisuallyHidden.test.tsx
@@ -94,7 +94,7 @@ describe('VisuallyHidden', () => {
   })
 
   it('should forward ref', () => {
-    const ref = React.createRef<HTMLElement>()
+    const ref: React.RefObject<HTMLElement | null> = { current: null }
 
     render(<VisuallyHidden ref={ref}>Hidden text</VisuallyHidden>)
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/FieldBoundary/__tests__/FieldBoundaryProvider.test.tsx
@@ -17,8 +17,9 @@ describe('FieldBoundaryProvider', () => {
   })
 
   it('should set error in context', async () => {
-    const contextRef: React.RefObject<FieldBoundaryContextState> =
-      React.createRef()
+    const contextRef: React.RefObject<FieldBoundaryContextState | null> = {
+      current: null,
+    }
 
     const ContextConsumer = () => {
       contextRef.current = useContext(FieldBoundaryContext)
@@ -126,8 +127,9 @@ describe('FieldBoundaryProvider', () => {
   })
 
   it('should set showBoundaryErrorsRef to true when showErrors is true', async () => {
-    const contextRef: React.RefObject<FieldBoundaryContextState> =
-      React.createRef()
+    const contextRef: React.RefObject<FieldBoundaryContextState | null> = {
+      current: null,
+    }
 
     const ContextConsumer = () => {
       contextRef.current = useContext(FieldBoundaryContext)
@@ -147,8 +149,9 @@ describe('FieldBoundaryProvider', () => {
   })
 
   it('should set error in boundary context', async () => {
-    const contextRef: React.RefObject<FieldBoundaryContextState> =
-      React.createRef()
+    const contextRef: React.RefObject<FieldBoundaryContextState | null> = {
+      current: null,
+    }
 
     const ContextConsumer = () => {
       contextRef.current = useContext(FieldBoundaryContext)
@@ -200,8 +203,9 @@ describe('FieldBoundaryProvider', () => {
   })
 
   it('should set error in context with validateContinuously', async () => {
-    const contextRef: React.RefObject<FieldBoundaryContextState> =
-      React.createRef()
+    const contextRef: React.RefObject<FieldBoundaryContextState | null> = {
+      current: null,
+    }
 
     const Contexts = ({ children }) => {
       contextRef.current = useContext(FieldBoundaryContext)

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, createRef, useContext, useEffect } from 'react'
+import React, { StrictMode, useContext, useEffect } from 'react'
 import {
   act,
   fireEvent,
@@ -919,7 +919,7 @@ describe('DataContext.Provider', () => {
     const UseContext = ({
       result,
     }: {
-      result: React.RefObject<ContextState>
+      result: React.RefObject<ContextState | null>
     }) => {
       result.current = useContext(DataContext.Context)
       return null
@@ -1326,7 +1326,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should set "formState" to "pending" when "onChangeValidator" is async', async () => {
-      const result = createRef<ContextState>()
+      const result: React.RefObject<ContextState | null> = {
+        current: null,
+      }
       const onChangeValidator = async () => {
         return new Error('My error')
       }
@@ -1373,7 +1375,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should set "formState" to "pending" when "onBlurValidator" is async', async () => {
-      const result = createRef<ContextState>()
+      const result: React.RefObject<ContextState | null> = {
+        current: null,
+      }
       const onBlurValidator = async () => {
         return new Error('My error')
       }
@@ -1420,7 +1424,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should set "formState" to "pending" when when "onSubmit" is async', async () => {
-      const result = createRef<ContextState>()
+      const result: React.RefObject<ContextState | null> = {
+        current: null,
+      }
       const onSubmit = async () => null
 
       render(
@@ -1444,7 +1450,9 @@ describe('DataContext.Provider', () => {
     })
 
     it('should show submit indicator during submit when "onSubmit" is used', async () => {
-      const result = createRef<ContextState>()
+      const result: React.RefObject<ContextState | null> = {
+        current: null,
+      }
       const onSubmit = async () => null
 
       render(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -2910,7 +2910,7 @@ describe('Field.Number', () => {
   })
 
   it('gets valid element when using createRef', () => {
-    const ref = React.createRef<HTMLInputElement>()
+    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
 
     render(<Field.Number id="unique" ref={ref} />)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -324,7 +324,7 @@ describe('Password component', () => {
   })
 
   it('gets valid element when using createRef', () => {
-    const ref = React.createRef<HTMLInputElement>()
+    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
 
     render(<Field.Password ref={ref} />)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -1434,7 +1434,9 @@ describe('Form.Handler TypeScript type validation', () => {
   })
 
   it('should support ref prop', () => {
-    const formRef = React.createRef<HTMLFormElement>()
+    const formRef: React.RefObject<HTMLFormElement | null> = {
+      current: null,
+    }
 
     render(<Form.Handler ref={formRef}>...</Form.Handler>)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/Isolation.test.tsx
@@ -537,7 +537,9 @@ describe('Form.Isolation', () => {
 
   it('should call onChange on data context when local data submit is called', async () => {
     const onChange = jest.fn()
-    const commitHandleRef = React.createRef<() => void>()
+    const commitHandleRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler onChange={onChange}>
@@ -665,7 +667,9 @@ describe('Form.Isolation', () => {
 
   it('should call onCommit event when commitHandleRef is called', async () => {
     const onCommit = jest.fn()
-    const commitHandleRef = React.createRef<() => void>()
+    const commitHandleRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -719,7 +723,9 @@ describe('Form.Isolation', () => {
 
   it('should support nested paths', async () => {
     const onChange = jest.fn()
-    const commitHandleRef = React.createRef<() => void>()
+    const commitHandleRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler
@@ -1663,7 +1669,9 @@ describe('Form.Isolation', () => {
   })
 
   it('should render error when commitHandleRef is called', async () => {
-    const commitHandleRef = React.createRef<() => void>()
+    const commitHandleRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/__tests__/Section.test.tsx
@@ -101,7 +101,9 @@ describe('Form.Section', () => {
   })
 
   it('should match snapshot', () => {
-    const generateRef = React.createRef<GeneratePropsRef>()
+    const generateRef: React.RefObject<GeneratePropsRef | null> = {
+      current: null,
+    }
     render(
       <Form.Handler>
         <Tools.ListAllProps generateRef={generateRef}>
@@ -170,7 +172,9 @@ describe('Form.Section', () => {
   })
 
   it('should match schema snapshot with prop change', () => {
-    const generateRef = React.createRef<GenerateSchemaRef>()
+    const generateRef: React.RefObject<GenerateSchemaRef | null> = {
+      current: null,
+    }
     render(
       <Form.Handler>
         <Tools.GenerateSchema generateRef={generateRef}>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/__tests__/Snapshot.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/__tests__/Snapshot.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { render, screen } from '@testing-library/react'
 import { Field, Form } from '../../..'
 import userEvent from '@testing-library/user-event'
@@ -100,7 +100,7 @@ describe('Form.Snapshot', () => {
   })
 
   it('should handle sliced snapshots from outside of the form', async () => {
-    const pointerRef: React.RefObject<number> = createRef()
+    const pointerRef: React.RefObject<number | null> = { current: null }
     pointerRef.current = 0
 
     const MockHookFromOutside = () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/__tests__/SubmitConfirmation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/__tests__/SubmitConfirmation.test.tsx
@@ -15,11 +15,11 @@ describe('Form.SubmitConfirmation', () => {
     it('should keep pending state when confirmationState is "readyToBeSubmitted"', async () => {
       const onSubmit = jest.fn()
       const confirmationStateRef: React.RefObject<
-        ConfirmParams['confirmationState']
-      > = React.createRef()
+        ConfirmParams['confirmationState'] | null
+      > = { current: null }
       const submitHandlerRef: React.RefObject<
-        ConfirmParams['submitHandler']
-      > = React.createRef()
+        ConfirmParams['submitHandler'] | null
+      > = { current: null }
 
       render(
         <Form.Handler onSubmit={onSubmit}>
@@ -67,11 +67,11 @@ describe('Form.SubmitConfirmation', () => {
     it('should keep pending state when confirmationState is "readyToBeSubmitted" and onSubmit is async', async () => {
       const onSubmit = jest.fn(async () => null)
       const confirmationStateRef: React.RefObject<
-        ConfirmParams['confirmationState']
-      > = React.createRef()
+        ConfirmParams['confirmationState'] | null
+      > = { current: null }
       const submitHandlerRef: React.RefObject<
-        ConfirmParams['submitHandler']
-      > = React.createRef()
+        ConfirmParams['submitHandler'] | null
+      > = { current: null }
 
       render(
         <Form.Handler onSubmit={onSubmit}>
@@ -119,8 +119,8 @@ describe('Form.SubmitConfirmation', () => {
     describe('focus handling', () => {
       it('should set focus on submit button when submitHandler is called', async () => {
         const submitHandlerRef: React.RefObject<
-          ConfirmParams['submitHandler']
-        > = React.createRef()
+          ConfirmParams['submitHandler'] | null
+        > = { current: null }
 
         render(
           <Form.Handler>
@@ -170,8 +170,8 @@ describe('Form.SubmitConfirmation', () => {
 
       it('should set focus on submit button when cancelHandler is called', async () => {
         const cancelHandlerRef: React.RefObject<
-          ConfirmParams['cancelHandler']
-        > = React.createRef()
+          ConfirmParams['cancelHandler'] | null
+        > = { current: null }
 
         render(
           <Form.Handler>
@@ -439,8 +439,8 @@ describe('Form.SubmitConfirmation', () => {
         await new Promise((resolve) => setTimeout(resolve, 100))
       })
       const confirmationStateRef: React.RefObject<
-        ConfirmParams['confirmationState']
-      > = React.createRef()
+        ConfirmParams['confirmationState'] | null
+      > = { current: null }
 
       render(
         <Form.Handler onSubmit={onSubmit}>
@@ -633,8 +633,8 @@ describe('Form.SubmitConfirmation', () => {
   it('should call onSubmit when submitHandler is called', async () => {
     const onSubmit = jest.fn()
     const submitHandlerRef: React.RefObject<
-      ConfirmParams['submitHandler']
-    > = React.createRef()
+      ConfirmParams['submitHandler'] | null
+    > = { current: null }
 
     render(
       <Form.Handler onSubmit={onSubmit}>
@@ -658,11 +658,11 @@ describe('Form.SubmitConfirmation', () => {
 
   it('should set confirmationState to idle when cancelHandler is called', async () => {
     const confirmationStateRef: React.RefObject<
-      ConfirmParams['confirmationState']
-    > = React.createRef()
+      ConfirmParams['confirmationState'] | null
+    > = { current: null }
     const cancelHandlerRef: React.RefObject<
-      ConfirmParams['cancelHandler']
-    > = React.createRef()
+      ConfirmParams['cancelHandler'] | null
+    > = { current: null }
 
     render(
       <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/GenerateSchema.test.tsx
@@ -5,7 +5,9 @@ import type { GenerateRef } from '../GenerateSchema'
 
 describe('Tools.GenerateSchema', () => {
   it('should generate a schema', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -56,7 +58,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should return "data" with local value', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const { rerender } = render(
       <Form.Handler data={{ myString: 'my string' }}>
@@ -88,7 +92,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should return "propsOfFields" with object that contains all props', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const { rerender } = render(
       <Form.Handler data={{ nested: { myString: 'my string' } }}>
@@ -199,7 +205,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should return "propsOfValues" with object that contains all props', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const { rerender } = render(
       <Form.Handler data={{ nested: { myString: 'my string' } }}>
@@ -254,7 +262,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should generate schema with different types', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -292,7 +302,9 @@ describe('Tools.GenerateSchema', () => {
     `)
   })
 
-  const generateRef = React.createRef<GenerateRef>()
+  const generateRef: React.RefObject<GenerateRef | null> = {
+    current: null,
+  }
 
   it('should generate schema with various properties', () => {
     render(
@@ -353,7 +365,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should generate schema with nested paths', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -406,7 +420,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should generate schema with required', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -466,7 +482,9 @@ describe('Tools.GenerateSchema', () => {
   })
 
   it('should validate with generated schema', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
@@ -50,7 +50,9 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should return "propsOfFields" with object that contains all props', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const { rerender } = render(
       <Form.Handler data={{ nested: { myString: 'my string' } }}>
@@ -161,7 +163,9 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should return "propsOfValues" with object that contains all props', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const { rerender } = render(
       <Form.Handler data={{ nested: { myString: 'my string' } }}>
@@ -216,7 +220,9 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should generate list of all props with different types', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -283,7 +289,9 @@ describe('Tools.ListAllProps', () => {
     `)
   })
 
-  const generateRef = React.createRef<GenerateRef>()
+  const generateRef: React.RefObject<GenerateRef | null> = {
+    current: null,
+  }
 
   it('should generate props object with various properties', () => {
     render(
@@ -380,7 +388,9 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should generate props object with nested paths', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -451,7 +461,9 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should generate props object with required', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     render(
       <Form.Handler>
@@ -546,17 +558,15 @@ describe('Tools.ListAllProps', () => {
   })
 
   it('should filter out React elements', () => {
-    const generateRef = React.createRef<
-      GenerateRef<{
-        items: {
-          children: {
-            type: {
-              name: string
-            }
+    const generateRef: React.RefObject<GenerateRef<{
+      items: {
+        children: {
+          type: {
+            name: string
           }
         }
-      }>
-    >()
+      }
+    }> | null> = { current: null }
 
     render(
       <Form.Handler data={{ count: 2 }}>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createRef,
-  useCallback,
-  useMemo,
-  useReducer,
-  useRef,
-} from 'react'
+import React, { useCallback, useMemo, useReducer, useRef } from 'react'
 import { act, render, renderHook } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useNextRouter from '../useNextRouter'
@@ -41,7 +35,9 @@ describe('useNextRouter', () => {
     })
   }
   const getHookMock = () => {
-    const forceUpdateRef: React.RefObject<() => void> = createRef()
+    const forceUpdateRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     const useRouter = jest.fn(() => {
       const push = useCallback((href) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useCallback, useReducer } from 'react'
+import React, { useCallback, useReducer } from 'react'
 import { act, render, renderHook } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReachRouter from '../useReachRouter'
@@ -35,7 +35,9 @@ describe('useReachRouter', () => {
     })
   }
   const getHookMock = () => {
-    const forceUpdateRef: React.RefObject<() => void> = createRef()
+    const forceUpdateRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     const navigate = jest.fn((href) => {
       window.history.replaceState({}, '', href)

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useCallback, useReducer, useRef } from 'react'
+import React, { useCallback, useReducer, useRef } from 'react'
 import { act, render, renderHook } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReactRouter from '../useReactRouter'
@@ -37,7 +37,9 @@ describe('useReactRouter', () => {
     })
   }
   const getHookMock = () => {
-    const forceUpdateRef: React.RefObject<() => void> = createRef()
+    const forceUpdateRef: React.RefObject<(() => void) | null> = {
+      current: null,
+    }
 
     const get = jest.fn((key = null) => {
       if (key) {

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/__tests__/ChildrenWithAge.test.tsx
@@ -413,7 +413,9 @@ describe('ChildrenWithAge', () => {
   })
 
   it('should render with correct props', () => {
-    const generateRef = React.createRef<GenerateRef>()
+    const generateRef: React.RefObject<GenerateRef | null> = {
+      current: null,
+    }
 
     const data = {
       hasChildren: true,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -430,8 +430,9 @@ describe('DrawerList component', () => {
   })
 
   it('focused item remembered when reopening', async () => {
-    const contextRef: React.RefObject<DrawerListContextValue> =
-      React.createRef()
+    const contextRef: React.RefObject<DrawerListContextValue | null> = {
+      current: null,
+    }
 
     const ContextConsumer = () => {
       contextRef.current = React.useContext(DrawerListContext)
@@ -480,8 +481,9 @@ describe('DrawerList component', () => {
   })
 
   it('focused item set to selected item when opening', async () => {
-    const contextRef: React.RefObject<DrawerListContextValue> =
-      React.createRef()
+    const contextRef: React.RefObject<DrawerListContextValue | null> = {
+      current: null,
+    }
 
     const ContextConsumer = () => {
       contextRef.current = React.useContext(DrawerListContext)

--- a/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
@@ -31,7 +31,7 @@ describe('ScrollView', () => {
   it('should set tabindex based on children when interactive is set to auto', () => {
     setResizeObserver()
 
-    const ref = React.createRef<HTMLDivElement>()
+    const ref: React.RefObject<HTMLDivElement | null> = { current: null }
     const { rerender } = render(
       <ScrollView ref={ref} interactive="auto">
         overflow content
@@ -77,7 +77,7 @@ describe('ScrollView', () => {
     })
     setResizeObserver({ init, observe })
 
-    const ref = React.createRef<HTMLDivElement>()
+    const ref: React.RefObject<HTMLDivElement | null> = { current: null }
     render(
       <ScrollView ref={ref} interactive="auto">
         overflow content

--- a/packages/dnb-eufemia/src/shared/__tests__/IsolatedStyleScope.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/IsolatedStyleScope.test.tsx
@@ -176,7 +176,9 @@ describe('useIsolatedStyleScope', () => {
 
   it('returns the custom ref element if provided', () => {
     let scopeElement = null
-    const customRef = React.createRef<HTMLDivElement>()
+    const customRef: React.RefObject<HTMLDivElement | null> = {
+      current: null,
+    }
 
     const MockComponent = () => {
       const { getScopeElement } = useIsolatedStyleScope()

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -158,8 +158,12 @@ describe('"detectOutsideClick" should', () => {
     // Is there perhaps a better way to handle this?
     window.PointerEvent = undefined
 
-    const ignoreElementRef = React.createRef<HTMLDivElement>()
-    const wrapperElementRef = React.createRef<HTMLDivElement>()
+    const ignoreElementRef: React.RefObject<HTMLDivElement | null> = {
+      current: null,
+    }
+    const wrapperElementRef: React.RefObject<HTMLDivElement | null> = {
+      current: null,
+    }
     const onSuccess = jest.fn()
 
     const Component = () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useCombinedRef.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useCombinedRef.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { createRef } from 'react'
+import type { RefObject } from 'react'
 import useCombinedRef from '../useCombinedRef'
 
 describe('useCombinedRef', () => {
@@ -14,7 +14,7 @@ describe('useCombinedRef', () => {
   })
 
   it('should assign to an object ref', () => {
-    const objectRef = createRef<HTMLDivElement>()
+    const objectRef: RefObject<HTMLDivElement | null> = { current: null }
     const { result } = renderHook(() => useCombinedRef(objectRef))
 
     const node = document.createElement('div')
@@ -25,7 +25,7 @@ describe('useCombinedRef', () => {
 
   it('should assign to multiple refs', () => {
     const callbackRef = jest.fn()
-    const objectRef = createRef<HTMLDivElement>()
+    const objectRef: RefObject<HTMLDivElement | null> = { current: null }
     const { result } = renderHook(() =>
       useCombinedRef(callbackRef, objectRef)
     )
@@ -51,7 +51,7 @@ describe('useCombinedRef', () => {
 
   it('should handle null unset', () => {
     const callbackRef = jest.fn()
-    const objectRef = createRef<HTMLDivElement>()
+    const objectRef: RefObject<HTMLDivElement | null> = { current: null }
     const { result } = renderHook(() =>
       useCombinedRef(callbackRef, objectRef)
     )


### PR DESCRIPTION
React 19 makes ref a regular prop and createRef is no longer the recommended pattern. Replace all React.createRef() calls in test files with plain object refs: { current: null }.

Updated 48 test files across components, fragments, extensions, and shared helpers.

