### PR TITLE
chore: replace direct navigator.platform usage with platform helpers

### DIFF
--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -28,6 +28,7 @@ import {
   dispatchCustomElementEvent,
   convertJsxToString,
 } from '../../shared/component-helper'
+import { isWin, isMac } from '../../shared/helpers'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { applySpacing } from '../space/SpacingUtils'
@@ -206,16 +207,12 @@ function getResizeModifier() {
     if (typeof navigator !== 'undefined') {
       if (
         /Firefox|Edg/.test(navigator.userAgent) ||
-        (/Chrome/.test(navigator.userAgent) &&
-          /Win/.test(navigator.platform))
+        (/Chrome/.test(navigator.userAgent) && isWin())
       ) {
         return 'large'
       }
 
-      if (
-        /Safari|Chrome/.test(navigator.userAgent) &&
-        /Mac/.test(navigator.platform)
-      ) {
+      if (/Safari|Chrome/.test(navigator.userAgent) && isMac()) {
         return 'medium'
       }
     }

--- a/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
+++ b/packages/dnb-eufemia/src/shared/legacy/component-helper-legacy.tsx
@@ -5,12 +5,7 @@
  */
 
 import type React from 'react'
-import {
-  warn,
-  PLATFORM_MAC,
-  PLATFORM_WIN,
-  PLATFORM_LINUX,
-} from '../helpers'
+import { warn, isMac, isWin, isLinux } from '../helpers'
 
 /**
  * Check if device is touch device or not
@@ -45,18 +40,11 @@ export function defineNavigator() {
           (window as Window & { IS_TEST?: boolean }).IS_TEST
         )
       ) {
-        const platform =
-          (
-            navigator as Navigator & {
-              userAgentData?: { platform?: string }
-            }
-          ).userAgentData?.platform || navigator.platform
-
-        if (platform.match(new RegExp(PLATFORM_MAC)) !== null) {
+        if (isMac()) {
           document.documentElement.setAttribute('data-os', 'mac')
-        } else if (platform.match(new RegExp(PLATFORM_WIN)) !== null) {
+        } else if (isWin()) {
           document.documentElement.setAttribute('data-os', 'win')
-        } else if (platform.match(new RegExp(PLATFORM_LINUX)) !== null) {
+        } else if (isLinux()) {
           document.documentElement.setAttribute('data-os', 'linux')
         }
       } else {


### PR DESCRIPTION
Replace raw navigator.platform access in Textarea.tsx with isWin()/isMac() helpers, and refactor defineNavigator() to use isMac()/isWin()/isLinux().

These helpers already use navigator.userAgentData.platform (modern API) with navigator.platform as fallback, centralizing the deprecated API access to a single location in getPlatform().

