### PR TITLE
chore(HeightAnimation): rename internal CSS class to follow BEM convention

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -123,7 +123,9 @@ function HeightAnimation({
       {...rest}
     >
       {compensateForGap ? (
-        <div className="compensateForGap">{children}</div>
+        <div className="dnb-height-animation__compensate-for-gap">
+          {children}
+        </div>
       ) : (
         children
       )}

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -181,7 +181,7 @@ describe('HeightAnimation', () => {
       )
 
       const inner = document.querySelector(
-        '.dnb-height-animation > .compensateForGap'
+        '.dnb-height-animation > .dnb-height-animation__compensate-for-gap'
       )
       expect(inner).toBeInTheDocument()
     })
@@ -198,7 +198,9 @@ describe('HeightAnimation', () => {
       const main = document.querySelector('.dnb-height-animation')
       expect(main).toHaveStyle('margin-top: calc(2rem * -1);')
 
-      const inner = main.querySelector('.compensateForGap')
+      const inner = main.querySelector(
+        '.dnb-height-animation__compensate-for-gap'
+      )
       expect(inner).toHaveStyle('margin-top: 2rem;')
     })
   })

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.tsx
@@ -116,7 +116,9 @@ export function useHeightAnimation(
           .getPropertyValue('row-gap')
       }
       elem.style.marginTop = `calc(${gap} * -1)`
-      const inner = elem.querySelector('.compensateForGap') as HTMLElement
+      const inner = elem.querySelector(
+        '.dnb-height-animation__compensate-for-gap'
+      ) as HTMLElement
       inner.style.marginTop = gap
     }
   }, [compensateForGap])


### PR DESCRIPTION
Rename internal CSS class 'compensateForGap' to 'dnb-height-animation__compensate-for-gap' to follow the dnb- prefix and BEM naming convention.

The compensateForGap prop is unchanged. Only the internal DOM class name was corrected.

