### PR TITLE
chore: upgrade tsconfig lib to es2023 and remove Intl augmentation

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -22,7 +22,9 @@ function toIntlOptions({
   decimals: _decimals,
   ...rest
 }: InternalNumberFormatOptions): Intl.NumberFormatOptions {
-  return rest
+  // The custom `signDisplay` union includes 'negative' which is valid at
+  // runtime but not yet part of the ES2023 lib type.
+  return rest as Intl.NumberFormatOptions
 }
 
 /**

--- a/packages/dnb-eufemia/src/components/number-format/utils/types.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/types.ts
@@ -1,19 +1,5 @@
 // TypeScript types shared across the NumberFormat utilities.
 
-// The TS es2022 lib does not include 'negative' in the signDisplay
-// registry (it was added in es2023). Augment it so we can use the
-// native Intl types without widening signDisplay to `string`.
-// TODO: Remove this augmentation when tsconfig lib includes es2023.
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace Intl {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-    interface NumberFormatOptionsSignDisplayRegistry {
-      negative: never
-    }
-  }
-}
-
 /** A single part returned by `Intl.NumberFormat.formatToParts()`. */
 export type FormatPartItem = {
   type: string

--- a/packages/dnb-eufemia/src/components/number-format/utils/types.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/types.ts
@@ -19,10 +19,11 @@ export type CurrencyDisplayValue =
 /** Internal format options passed to `Intl.NumberFormat`. */
 export type InternalNumberFormatOptions = Omit<
   Intl.NumberFormatOptions,
-  'currencyDisplay'
+  'currencyDisplay' | 'signDisplay'
 > & {
   decimals?: number
   currencyDisplay?: CurrencyDisplayValue
+  signDisplay?: 'auto' | 'always' | 'exceptZero' | 'negative' | 'never'
 }
 
 /** Return value of inline part-formatters (phone, BAN, NIN, etc.). */

--- a/packages/dnb-eufemia/tsconfig.definitions.json
+++ b/packages/dnb-eufemia/tsconfig.definitions.json
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["es2022", "dom"],
+    "lib": ["es2023", "dom"],
     "skipLibCheck": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/packages/dnb-eufemia/tsconfig.json
+++ b/packages/dnb-eufemia/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "lib": ["es2022", "dom"],
+    "lib": ["es2023", "dom"],
     "types": ["node", "jest", "react", "react-dom"],
     "outDir": "./build",
     "rootDir": ".",


### PR DESCRIPTION
The Intl.NumberFormatOptionsSignDisplayRegistry augmentation for 'negative' was a workaround for es2022 missing it. Now that we target es2023, the native types include it and the augmentation can be removed.

