### PR TITLE
chore: move postcss-selector-parser to devDependencies

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -114,7 +114,6 @@
     "clsx": "2.1.1",
     "core-js-pure": "3.47.0",
     "date-fns": "4.1.0",
-    "postcss-selector-parser": "7.1.0",
     "zod": "4.1.8"
   },
   "peerDependencies": {
@@ -228,6 +227,7 @@
     "packpath": "0.1.0",
     "postcss": "8.4.32",
     "postcss-preset-env": "9.6.0",
+    "postcss-selector-parser": "7.1.0",
     "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",
     "react": "19.2.5",


### PR DESCRIPTION
postcss-selector-parser is only used in the build-time PostCSS plugin (isolated-style-scope-plugin.js), not in runtime code. It should be a devDependency, not a production dependency.

