### PR TITLE
chore: add missing style.ts entry points

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/style.ts
+++ b/packages/dnb-eufemia/src/components/popover/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-popover.scss'

--- a/packages/dnb-eufemia/src/components/term-definition/style.ts
+++ b/packages/dnb-eufemia/src/components/term-definition/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-term-definition.scss'

--- a/packages/dnb-eufemia/src/elements/blockquote/style.ts
+++ b/packages/dnb-eufemia/src/elements/blockquote/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-blockquote.scss'

--- a/packages/dnb-eufemia/src/elements/code/style.ts
+++ b/packages/dnb-eufemia/src/elements/code/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-code.scss'

--- a/packages/dnb-eufemia/src/elements/hr/style.ts
+++ b/packages/dnb-eufemia/src/elements/hr/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-hr.scss'

--- a/packages/dnb-eufemia/src/elements/img/style.ts
+++ b/packages/dnb-eufemia/src/elements/img/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-img.scss'

--- a/packages/dnb-eufemia/src/elements/label/style.ts
+++ b/packages/dnb-eufemia/src/elements/label/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-label.scss'

--- a/packages/dnb-eufemia/src/elements/lists/style.ts
+++ b/packages/dnb-eufemia/src/elements/lists/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-lists.scss'

--- a/packages/dnb-eufemia/src/elements/typography/style.ts
+++ b/packages/dnb-eufemia/src/elements/typography/style.ts
@@ -1,0 +1,6 @@
+/**
+ * Web Style Import
+ *
+ */
+
+import './style/dnb-typography.scss'


### PR DESCRIPTION
Add style.ts files to 9 components/elements that had style/ dirs with SCSS files but were missing the TypeScript entry point:
- components: popover, term-definition
- elements: blockquote, code, hr, img, label, lists, typography

This makes the pattern consistent: every component/element with a style/ directory and SCSS now has a style.ts entry point.

