### PR TITLE
chore: add missing ui.ts theme entry points

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/anchor/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-anchor-theme-ui.scss'

--- a/packages/dnb-eufemia/src/components/card/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/card/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-card-theme-ui.scss'

--- a/packages/dnb-eufemia/src/components/icon/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/icon/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-icon-theme-ui.scss'

--- a/packages/dnb-eufemia/src/components/term-definition/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/term-definition/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-term-definition-theme-ui.scss'

--- a/packages/dnb-eufemia/src/components/upload/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/upload/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-upload-theme-ui.scss'

--- a/packages/dnb-eufemia/src/elements/hr/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/elements/hr/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-hr-theme-ui.scss'

--- a/packages/dnb-eufemia/src/elements/img/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/elements/img/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-img-theme-ui.scss'

--- a/packages/dnb-eufemia/src/elements/typography/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/elements/typography/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-typography-theme-ui.scss'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-number-theme-ui.scss'

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-field-block-theme-ui.scss'

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/style/themes/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Imports the default theme
+ *
+ */
+
+import './dnb-wizard-layout-theme-ui.scss'


### PR DESCRIPTION
Add ui.ts files to 11 theme directories that had -theme-ui.scss files but were missing the TypeScript entry point. This makes the pattern consistent across all theme directories.

