### PR TITLE
chore: remove class component references from comments

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -224,7 +224,7 @@ function Accordion({
     }
   }, [])
 
-  // componentDidUpdate
+  // Sync expanded state from context
   useEffect(() => {
     if (context.flushRememberedState) {
       store.flush()

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -523,9 +523,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   >(DrawerListContext)
   const drawerList = context.drawerList
 
-  // Filter out undefined values to mimic React class component defaultProps behavior.
-  // Without this, explicit undefined values (e.g. size={undefined}) would override
-  // defaults and prevent context values from being merged.
+  // Filter out undefined values so that explicit undefined (e.g. size={undefined})
+  // does not override defaults or prevent context values from being merged.
   const filteredOwnProps = Object.fromEntries(
     Object.entries(ownProps).filter(([, v]) => v !== undefined)
   )
@@ -1785,7 +1784,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
   const setFocusOnInput = useCallback(() => {
     // Suppress onInputFocusHandler during programmatic refocus
-    // to prevent double onFocus dispatch (matching class component behavior)
+    // to prevent double onFocus dispatch
     suppressFocusHandlerRef.current = true
     focusInput()
     suppressFocusHandlerRef.current = false
@@ -2155,8 +2154,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           // Note: closingFromChangeRef is set/reset synchronously here, before
           // onCloseHandler fires asynchronously after React re-renders.
           // This means onCloseHandler always sees `false` and calls setFocusOnInput.
-          // This matches the class component behavior where onCloseHandler always
-          // refocused the input, so the guard is intentionally ineffective.
+          // onCloseHandler always refocuses the input, so the guard
+          // is intentionally ineffective.
           closingFromChangeRef.current = true
           setHidden()
 
@@ -2167,7 +2166,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           closingFromChangeRef.current = false
           setSkipFocusDuringChange(false)
 
-          // Deferred refocus — matches class component's setState callback timing
+          // Deferred refocus after state commits
           _focusTimeout.current = setTimeout(() => {
             setFocusOnInput()
 
@@ -2208,7 +2207,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     ]
   )
 
-  // Handle prop-driven state updates (replaces getDerivedStateFromProps)
+  // Handle prop-driven state updates
   if (props.disableHighlighting !== prevDisableHighlightingRef.current) {
     prevDisableHighlightingRef.current = props.disableHighlighting
     setDisableHighlighting(props.disableHighlighting)
@@ -2255,7 +2254,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     dataChangedRef.current = true
   }
 
-  // Forward inputRef (replaces componentDidMount inputRef handling)
+  // Forward inputRef
   useEffect(() => {
     if (inputRef && _refInput.current) {
       if (typeof inputRef === 'function') {
@@ -2274,13 +2273,12 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     }
   })
 
-  // Handle data changes (replaces getDerivedStateFromProps updateData + componentDidUpdate data check)
+  // Handle data changes
   useEffect(() => {
     if (dataChangedRef.current) {
       dataChangedRef.current = false
 
-      // Reset the dedup guard so updateData always runs here,
-      // matching the v11 class componentDidUpdate which had no guard.
+      // Reset the dedup guard so updateData always runs here.
       // Without this, updateData is skipped when it was already called
       // (e.g. from SelectCountry's onFocus handler) with the same data
       // reference, preventing the async setData callback chain from
@@ -2289,8 +2287,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
       updateData(props.data)
       if (drawerList.open || hasFocus) {
-        // Match class componentDidUpdate: re-run filter after updating the
-        // search index so highlight and visibility are handled consistently.
+        // Re-run filter after updating the search index so highlight
+        // and visibility are handled consistently.
         setSearchIndex({ overwriteSearchIndex: true }, () => {
           runFilterWithSideEffects(inputValueRef.current)
         })
@@ -2299,7 +2297,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.data])
 
-  // Handle value prop changes (replaces componentDidUpdate value check)
+  // Handle value prop changes
   useEffect(() => {
     if (props.value !== prevValueRef.current) {
       prevValueRef.current = props.value

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -238,7 +238,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
   const combinedRef = useCombinedRef(ref, elementRef)
 
   // Generate an id only when explicitly provided or when status/tooltip
-  // needs one for aria linking – mirrors the original class component logic.
+  // needs one for aria linking.
   const generatedId = useId(restProps.id)
   const resolvedId =
     restProps.id || restProps.status || restProps.tooltip

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
@@ -94,19 +94,19 @@ function GlobalStatusController(ownProps: GlobalStatusControllerProps) {
   const removeOnUnmountRef = useRef(props.removeOnUnmount)
   removeOnUnmountRef.current = props.removeOnUnmount
 
-  // Initialize provider (constructor equivalent)
+  // Initialize provider
   if (!providerRef.current) {
     providerRef.current = initProvider(props.id)
     prevPropsRef.current = ownProps
   }
 
-  // getDerivedStateFromProps equivalent: update provider when props change
+  // Sync provider when props change
   if (prevPropsRef.current !== ownProps) {
     providerRef.current?.update(statusIdRef.current, props)
     prevPropsRef.current = ownProps
   }
 
-  // componentDidMount + componentWillUnmount
+  // Register on mount, remove on unmount
   useMountEffect(() => {
     const { statusId } = providerRef.current.add(props)
     statusIdRef.current = statusId
@@ -162,13 +162,12 @@ function GlobalStatusRemove(ownProps: GlobalStatusRemovePropsLocal) {
     prevPropsRef.current = ownProps
   }
 
-  // getDerivedStateFromProps equivalent
+  // Sync provider when props change
   if (prevPropsRef.current !== ownProps) {
     providerRef.current?.update(props.statusId, props)
     prevPropsRef.current = ownProps
   }
 
-  // componentDidMount
   useMountEffect(() => {
     providerRef.current.remove(props.statusId, props)
   })

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -362,7 +362,6 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   const selectAllTimeoutRef =
     useRef<ReturnType<typeof setTimeout>>(undefined)
 
-  // getDerivedStateFromProps equivalent
   const initialValue = useMemo(() => {
     const v = getValue(restProps)
     if (v !== 'initval' && hasValue(v as string)) {
@@ -395,7 +394,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     context.Input
   )
 
-  // getDerivedStateFromProps: sync value from props
+  // Sync value from props
   const propValue = getValue(restProps)
   if (
     propValue !== 'initval' &&

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -367,7 +367,7 @@ function ModalComponent(ownProps: ModalAllProps) {
     _id: _id.current,
   })
 
-  // Handle open prop changes (getDerivedStateFromProps equivalent)
+  // Handle open prop changes
   const prevOpenRef = useRef<typeof open>(undefined)
   if (open !== prevOpenRef.current) {
     if (open === true) {
@@ -384,7 +384,7 @@ function ModalComponent(ownProps: ModalAllProps) {
     prevOpenRef.current = open
   }
 
-  // openBasedOnStateUpdate — mirrors class componentDidMount + componentDidUpdate with prevProps guard
+  // Open/close the modal when the open prop or parent props change
   const prevEffectOpenRef = useRef<typeof open>(undefined)
   const prevOwnPropsRef = useRef<ModalAllProps | undefined>(undefined)
   useEffect(() => {
@@ -392,7 +392,7 @@ function ModalComponent(ownProps: ModalAllProps) {
       activeElementRef.current = document.activeElement
     }
 
-    // Detect if parent provided new props (equivalent to class `prevProps !== this.props`)
+    // Detect if parent provided new props
     const isNewProps =
       prevOwnPropsRef.current !== undefined &&
       prevOwnPropsRef.current !== ownProps
@@ -416,7 +416,7 @@ function ModalComponent(ownProps: ModalAllProps) {
     }
   })
 
-  // Process side effects after render (equivalent to class setState callback)
+  // Process side effects after render
   useEffect(() => {
     if (pendingSideEffectsRef.current) {
       const { isModalActive, preventAutoFocus } =

--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
@@ -24,7 +24,7 @@ import PaginationContext from './PaginationContext'
 const PaginationProvider = (props: any) => {
   const sharedContext = useContext(Context)
 
-  // ---- Derive state from props (replaces getDerivedStateFromProps) ----
+  // ---- Derive state from props ----
   const computeDerived = useCallback(() => {
     const state: Record<string, unknown> = {}
 
@@ -380,8 +380,7 @@ const PaginationProvider = (props: any) => {
   )
 
   // Handle the onEnd dispatch after hasEndedInfinity becomes true.
-  // Use useIsomorphicLayoutEffect so the callback fires before paint,
-  // matching the class component's setState callback timing.
+  // Use useIsomorphicLayoutEffect so the callback fires before paint.
   useIsomorphicLayoutEffect(() => {
     if (hasEndedInfinity && endInfinityDispatchRef.current) {
       endInfinityDispatchRef.current = false
@@ -417,8 +416,7 @@ const PaginationProvider = (props: any) => {
   ])
 
   // ---- Run pending callbacks after state commits ----
-  // Use useIsomorphicLayoutEffect so callbacks fire before paint,
-  // matching the class component's setState callback timing.
+  // Use useIsomorphicLayoutEffect so callbacks fire before paint.
   useIsomorphicLayoutEffect(() => {
     if (pendingCallOnPageUpdateRef.current) {
       pendingCallOnPageUpdateRef.current = false
@@ -456,8 +454,8 @@ const PaginationProvider = (props: any) => {
   }, [props.currentPage])
 
   // ---- Derive startupPage from currentPage when not yet set ----
-  // Mirrors v10 getDerivedStateFromProps: when startupPage is not a number
-  // (e.g. currentPage was initially null), re-derive once currentPage arrives.
+  // When startupPage is not a number (e.g. currentPage was initially null),
+  // re-derive once currentPage arrives.
   useIsomorphicLayoutEffect(() => {
     if (typeof startupPageRef.current !== 'number') {
       const derived =
@@ -530,9 +528,8 @@ const PaginationProvider = (props: any) => {
     }
   }, [props.rerender, setContent])
 
-  // ---- componentDidMount ----
-  // Use useIsomorphicLayoutEffect to populate initial content before paint,
-  // matching the class component's componentDidMount timing.
+  // ---- Initial setup ----
+  // Use useIsomorphicLayoutEffect to populate initial content before paint.
   useIsomorphicLayoutEffect(() => {
     const {
       setContentHandler,
@@ -605,8 +602,7 @@ const PaginationProvider = (props: any) => {
   // ---- Build context value ----
   // Note: props (full object) is intentionally in the dep array here.
   // The context value must reflect the latest props for consumers,
-  // and this matches the class component behavior where context was
-  // recreated every render.
+  // and it is recreated every render.
   const contextValue = useMemo(
     () => ({
       ...sharedContext,

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -168,7 +168,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   }
   skipNextPropSync.current = false
 
-  // Helper functions matching class component methods
+  // Helper functions
   const isContextGroupOrSingle = useCallback(
     () => typeof groupContext.value !== 'undefined' && !ownProps.group,
     [groupContext.value, ownProps.group]

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -121,9 +121,8 @@ function RadioGroup(ownProps: RadioGroupProps) {
   // Track whether the internal state was just set by a change event
   const skipNextPropSync = useRef(false)
 
-  // Sync value state from props
-  // skipNextPropSync is always reset after each render opportunity,
-  // matching the class component's _listenForPropChanges pattern.
+  // Sync value state from props.
+  // skipNextPropSync is always reset after each render opportunity.
   if (ownProps.value !== prevPropsValue) {
     setPrevPropsValue(ownProps.value)
     if (!skipNextPropSync.current) {

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -411,7 +411,7 @@ function TabsComponent(ownProps: TabsProps) {
     ownProps.selectedKey
   )
 
-  // getDerivedStateFromProps equivalent
+  // Sync state from props
   if (listenForPropChangesRef.current) {
     const dataSource = ownProps.data || ownProps.children
     let currentData = data

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -294,7 +294,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     return ownProps.textareaState || 'virgin'
   })
 
-  // Sync value from props (getDerivedStateFromProps equivalent)
+  // Sync value from props
   if (
     propValue !== 'initval' &&
     propValue !== value &&

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -88,7 +88,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
   const valuesRef = useRef(values)
   valuesRef.current = values
 
-  // Sync value from props (replaces getDerivedStateFromProps)
+  // Sync value from props
   if (
     typeof ownProps.value !== 'undefined' &&
     ownProps.value !== prevPropsValue

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -176,7 +176,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   const propsRef = useRef(props)
   propsRef.current = props
 
-  // Mutable state stored in ref (mirrors this.state)
+  // Mutable state stored in ref
   const stateRef = useRef<DrawerListContextState>(null)
   if (!stateRef.current) {
     stateRef.current = {
@@ -191,11 +191,11 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   // Re-render trigger
   const [, forceUpdate] = useReducer(() => ({}), {})
 
-  // Callback queue for setState(..., callback) pattern
+  // Callback queue for deferred side effects
   const callbacksRef = useRef<(() => void)[]>([])
 
-  // Pending state updates — deferred to render time to match class component
-  // batching behavior where this.state is NOT updated between setState calls
+  // Pending state updates — deferred to render time so state is not
+  // updated between successive mergeState calls within the same cycle
   const pendingUpdatesRef = useRef<Partial<DrawerListContextState>[]>([])
 
   const mergeState = useCallback(
@@ -1458,7 +1458,6 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
 
   // --- Lifecycle effects ---
 
-  // componentDidMount
   useMountEffect(() => {
     if (propsRef.current.open) {
       setVisible()
@@ -1476,7 +1475,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
     }
   })
 
-  // componentDidUpdate: open prop changes
+  // Sync visibility when the open prop changes
   useUpdateEffect(() => {
     if (props.open !== null) {
       if (props.open) {
@@ -1487,7 +1486,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
     }
   }, [props.open, setVisible, setHidden])
 
-  // componentDidUpdate: focus on data change and recalculate scroll observer
+  // Focus and recalculate scroll observer when data changes
   const prevDataRef = useRef(props.data)
   const prevDirectionRef = useRef(stateRef.current.direction)
   useEffect(() => {
@@ -1516,7 +1515,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
 
   // --- Render ---
 
-  // API object for method chaining (replaces "return this" pattern from class component)
+  // API object for method chaining
   const selfRef = useRef<DrawerListProviderChainable>(null)
   selfRef.current = {
     setVisible,


### PR DESCRIPTION
Replace lifecycle method names and class component references in comments with self-describing intent. The codebase uses functional components with hooks throughout; these comments were leftover artifacts from the class-to-hooks migration.

Files updated:
- Accordion, Autocomplete, Button, GlobalStatusController
- Input, Modal, PaginationProvider, Radio, RadioGroup
- Tabs, Textarea, ToggleButtonGroup, DrawerListProvider

