### PR TITLE
chore: update JSDoc to remove React.createRef() references

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -95,7 +95,7 @@ export type CheckboxProps = {
    */
   onClick?: (args: CheckboxOnClickParams) => void
   /**
-   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.
+   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
    */
   ref?:
     | React.RefObject<HTMLInputElement>

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -101,7 +101,7 @@ export type DropdownProps = {
    */
   ref?: React.Ref<HTMLElement>
   /**
-   * By providing a React.ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.createRef()` or `React.useRef()`.
+   * By providing a React.ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.useRef()`.
    */
   buttonRef?: React.Ref<HTMLElement>
   /**

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -98,7 +98,7 @@ export type SwitchProps = {
   onClick?: (args: SwitchOnClickParams) => void
   onChangeEnd?: SwitchOnChange
   /**
-   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.createRef()` or `React.useRef()`.
+   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
    */
   ref?:
     | React.RefObject<HTMLInputElement>


### PR DESCRIPTION
Update prop documentation in Dropdown, Checkbox, and Switch to only reference React.useRef() instead of React.createRef() or React.useRef(). React.createRef() is not appropriate in function components.

