### PR TITLE
chore(DrawerList): rename unprefixed CSS classes to follow BEM convention

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -74,7 +74,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">th</span>e <span class="dnb-drawer-list__option__item--highlight">g</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er</span></span></span></li>`
+      /* html */ `<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">th</span>e <span class="dnb-drawer-list__option__item--highlight">g</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er <span class="dnb-drawer-list__option__item--highlight">Th</span>e <span class="dnb-drawer-list__option__item--highlight">G</span>odfa<span class="dnb-drawer-list__option__item--highlight">th</span>er</span></span></span></li>`
     )
   })
 
@@ -235,7 +235,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">BB</span> <span class="dnb-drawer-list__option__item--highlight">cc</span> ze<span class="dnb-drawer-list__option__item--highlight">thx</span></span></span></span></li>`
+      /* html */ `<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span><span class="dnb-drawer-list__option__item--highlight">BB</span> <span class="dnb-drawer-list__option__item--highlight">cc</span> ze<span class="dnb-drawer-list__option__item--highlight">thx</span></span></span></span></li>`
     )
 
     // check "invalid"
@@ -779,7 +779,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
     )
 
     // First result direction
@@ -789,7 +789,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="2" id="option-autocomplete-id-2"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span></li>'
+      '<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="2" id="option-autocomplete-id-2"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span></li>'
     )
 
     // Second result direction
@@ -799,7 +799,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
+      '<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">bb</span></span></span></span></li>'
     )
 
     // With three matches, we prioritize the second one to be on the first place
@@ -809,7 +809,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      '<li class="first-of-type first-item closest-to-top closest-to-bottom dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="3" id="option-autocomplete-id-3"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span> second</span></span></span></li>'
+      '<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option--closest-to-top dnb-drawer-list__option--closest-to-bottom dnb-drawer-list__option" role="option" tabindex="-1" aria-selected="false" data-item="3" id="option-autocomplete-id-3"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>item <span class="dnb-drawer-list__option__item--highlight">cc</span> second</span></span></span></li>'
     )
 
     // Do not find item, as there is defined a searchContent
@@ -1112,7 +1112,7 @@ describe('Autocomplete component', () => {
     expect(
       document.querySelectorAll('li.dnb-drawer-list__option')[0].outerHTML
     ).toBe(
-      /* html */ `<li class="first-of-type first-item dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>2223 33 44425</span></span></span></li>`
+      /* html */ `<li class="dnb-drawer-list__option--first-of-type dnb-drawer-list__option--first dnb-drawer-list__option dnb-drawer-list__option--focus" role="option" tabindex="-1" aria-selected="false" aria-current="true" data-item="1" id="option-autocomplete-id-1"><span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>2223 33 44425</span></span></span></li>`
     )
 
     fireEvent.change(document.querySelector('.dnb-input__input'), {
@@ -1400,7 +1400,7 @@ describe('Autocomplete component', () => {
           'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
         )[2].innerHTML
       ).toBe(
-        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item item-nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item item-nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
+        '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item dnb-drawer-list__option__item--nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item dnb-drawer-list__option__item--nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
       )
     })
   })

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -571,15 +571,19 @@ const DrawerListInstance = React.memo(function DrawerListInstance(
               hash,
               className: clsx(
                 // helper classes
-                j === 0 && i === 0 && 'first-item',
+                j === 0 && i === 0 && 'dnb-drawer-list__option--first',
                 j === renderData.length - 1 &&
                   i === data.length - 1 &&
-                  'last-item',
-                tagId === closestToTop && 'closest-to-top',
-                tagId === closestToBottom && 'closest-to-bottom',
-                i === 0 && 'first-of-type', // because of the triangle element
-                i === data.length - 1 && 'last-of-type', // because of the triangle element
-                (ignoreEventsBoolean || ignoreEvents) && 'ignore-events',
+                  'dnb-drawer-list__option--last',
+                tagId === closestToTop &&
+                  'dnb-drawer-list__option--closest-to-top',
+                tagId === closestToBottom &&
+                  'dnb-drawer-list__option--closest-to-bottom',
+                i === 0 && 'dnb-drawer-list__option--first-of-type', // because of the triangle element
+                i === data.length - 1 &&
+                  'dnb-drawer-list__option--last-of-type', // because of the triangle element
+                (ignoreEventsBoolean || ignoreEvents) &&
+                  'dnb-drawer-list__option--ignore-events',
                 className
               ),
               active: __id === activeItem,
@@ -626,8 +630,9 @@ const DrawerListInstance = React.memo(function DrawerListInstance(
               aria-labelledby={groupdId}
               className={clsx(
                 'dnb-drawer-list__group',
-                j === 0 && 'first-of-type',
-                j === renderData.length - 1 && 'last-of-type'
+                j === 0 && 'dnb-drawer-list__group--first-of-type',
+                j === renderData.length - 1 &&
+                  'dnb-drawer-list__group--last-of-type'
               )}
             >
               <li
@@ -636,8 +641,10 @@ const DrawerListInstance = React.memo(function DrawerListInstance(
                 className={clsx(
                   'dnb-drawer-list__group-title',
                   hideTitle && 'dnb-sr-only',
-                  groupdId === closestToBottom && 'closest-to-bottom',
-                  groupdId === closestToTop && 'closest-to-top'
+                  groupdId === closestToBottom &&
+                    'dnb-drawer-list__group-title--closest-to-bottom',
+                  groupdId === closestToTop &&
+                    'dnb-drawer-list__group-title--closest-to-top'
                 )}
               >
                 {groupTitle}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListItem.tsx
@@ -109,7 +109,7 @@ export function ItemContent({ hash = '', children }: ItemContentProps) {
       renderedContent = content.map((contentItem, n) => (
         <DrawerListOptionItem
           key={hash + n}
-          className={`item-nr-${n + 1}`} // "item-nr" is used by CSS
+          className={`dnb-drawer-list__option__item--nr-${n + 1}`}
         >
           {isDataObject && children.render
             ? children.render(contentItem, hash + n)

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -686,7 +686,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       getElementGroup(
         activeElement
       )?.nextElementSibling?.querySelector<HTMLLIElement>(
-        'li.dnb-drawer-list__option.first-of-type'
+        'li.dnb-drawer-list__option.dnb-drawer-list__option--first-of-type'
       )
 
     return getItemData(elem)
@@ -703,7 +703,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       getElementGroup(
         activeElement
       )?.previousElementSibling?.querySelector<HTMLLIElement>(
-        'li.dnb-drawer-list__option.last-of-type'
+        'li.dnb-drawer-list__option.dnb-drawer-list__option--last-of-type'
       )
 
     return getItemData(elem)
@@ -711,14 +711,14 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
 
   const getFirstItem = useCallback(() => {
     const elem = _refUl.current?.querySelector<HTMLLIElement>(
-      'li.dnb-drawer-list__option.first-item'
+      'li.dnb-drawer-list__option.dnb-drawer-list__option--first'
     )
     return getItemData(elem)
   }, [getItemData])
 
   const getLastItem = useCallback(() => {
     const elem = _refUl.current?.querySelector<HTMLLIElement>(
-      'li.dnb-drawer-list__option.last-item'
+      'li.dnb-drawer-list__option.dnb-drawer-list__option--last'
     )
     return getItemData(elem)
   }, [getItemData])

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -472,7 +472,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
 .dnb-drawer-list__option {
   position: relative;
 }
-.dnb-drawer-list__option.ignore-events {
+.dnb-drawer-list__option.dnb-drawer-list__option--ignore-events {
   pointer-events: none;
 }
 .dnb-drawer-list__option__inner::before {
@@ -487,7 +487,7 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
   height: var(--drawer-list-option-border-width);
   background-color: var(--token-color-decorative-first-muted);
 }
-.dnb-drawer-list__option__item.item-nr-1 {
+.dnb-drawer-list__option__item.dnb-drawer-list__option__item--nr-1 {
   font-weight: var(--font-weight-medium);
 }
 html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover[disabled] {
@@ -576,18 +576,18 @@ html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list
   color: var(--token-color-text-action-hover);
   background-color: var(--token-color-background-action-hover-subtle);
 }
-.dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list__option.dnb-drawer-list__option--last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   content: none;
 }
 .dnb-drawer-list--scroll .dnb-drawer-list__option:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   left: 0.5rem;
   right: 0.5rem;
 }
-.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-top .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.dnb-drawer-list__option--closest-to-top .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.dnb-drawer-list__option--closest-to-top .dnb-drawer-list__option__inner::before {
   border-top-left-radius: var(--drawer-list-options-border-radius);
   border-top-right-radius: var(--drawer-list-options-border-radius);
 }
-.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.closest-to-bottom .dnb-drawer-list__option__inner::before {
+.dnb-drawer-list--bottom .dnb-drawer-list__option--focus.dnb-drawer-list__option--closest-to-bottom .dnb-drawer-list__option__inner::before, .dnb-drawer-list--top .dnb-drawer-list__option--focus.dnb-drawer-list__option--closest-to-bottom .dnb-drawer-list__option__inner::before {
   border-bottom-left-radius: var(--drawer-list-options-border-radius);
   border-bottom-right-radius: var(--drawer-list-options-border-radius);
 }
@@ -597,13 +597,13 @@ html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list
 .dnb-drawer-list__arrow::before {
   box-shadow: var(--shadow-sharp);
 }
-.dnb-drawer-list--bottom:has(.dnb-drawer-list__group-title.closest-to-top) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__group-title.closest-to-bottom) .dnb-drawer-list__arrow::before {
+.dnb-drawer-list--bottom:has(.dnb-drawer-list__group-title.dnb-drawer-list__group-title--closest-to-top) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__group-title.dnb-drawer-list__group-title--closest-to-bottom) .dnb-drawer-list__arrow::before {
   background-color: var(--drawer-list-group-title-bg);
 }
-.dnb-drawer-list--bottom:has(.dnb-drawer-list__option.closest-to-top:hover) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.closest-to-bottom:hover) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom:has(.dnb-drawer-list__option.closest-to-top.dnb-drawer-list__option--focus) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.closest-to-bottom.dnb-drawer-list__option--focus) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.closest-to-top:hover ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.closest-to-bottom:hover ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.closest-to-top.dnb-drawer-list__option--focus ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.closest-to-bottom.dnb-drawer-list__option--focus ~ .dnb-drawer-list__arrow::before {
+.dnb-drawer-list--bottom:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top:hover) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom:hover) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top.dnb-drawer-list__option--focus) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom.dnb-drawer-list__option--focus) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top:hover ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom:hover ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top.dnb-drawer-list__option--focus ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom.dnb-drawer-list__option--focus ~ .dnb-drawer-list__arrow::before {
   background-color: var(--token-color-background-action-hover-subtle);
 }
-.dnb-drawer-list--bottom:has(.dnb-drawer-list__option.closest-to-top.dnb-drawer-list__option--selected) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.closest-to-bottom.dnb-drawer-list__option--selected) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.closest-to-top.dnb-drawer-list__option--selected ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.closest-to-bottom.dnb-drawer-list__option--selected ~ .dnb-drawer-list__arrow::before {
+.dnb-drawer-list--bottom:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top.dnb-drawer-list__option--selected) .dnb-drawer-list__arrow::before, .dnb-drawer-list--top:has(.dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom.dnb-drawer-list__option--selected) .dnb-drawer-list__arrow::before, .dnb-drawer-list--bottom .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-top.dnb-drawer-list__option--selected ~ .dnb-drawer-list__arrow::before, .dnb-drawer-list--top .dnb-drawer-list__option.dnb-drawer-list__option--closest-to-bottom.dnb-drawer-list__option--selected ~ .dnb-drawer-list__arrow::before {
   background-color: var(--token-color-background-selected);
 }
 .dnb-drawer-list > .dnb-form-status {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-sbanken.scss
@@ -70,7 +70,7 @@
     background: var(--drawer-list-sb-list-option-background);
     z-index: 0;
 
-    &__item.item-nr-1 {
+    &__item#{&}__item--nr-1 {
       font-weight: var(--font-weight-medium);
     }
 
@@ -105,7 +105,7 @@
         --drawer-list-sb-outside-border
       ); // Compensate for transparent right border
 
-      &.last-item {
+      &.dnb-drawer-list__option--last {
         border-bottom-color: var(--drawer-list-sb-outside-border);
       }
 
@@ -140,11 +140,11 @@
       }
     }
 
-    &.first-item &__inner::before {
+    &#{&}--first &__inner::before {
       content: none;
     }
 
-    &.last-item {
+    &#{&}--last {
       border-radius: var(--drawer-list-options-border-radius);
     }
 
@@ -196,17 +196,17 @@
     }
 
     .dnb-drawer-list__option {
-      &.last-item {
+      &#{&}--last {
         border-radius: 0;
       }
 
-      &.first-item {
+      &#{&}--first {
         border-radius: var(--drawer-list-options-border-radius-reversed);
       }
     }
 
     .dnb-drawer-list__option--selected {
-      &.first-item {
+      &.dnb-drawer-list__option--first {
         border-top-color: var(--drawer-list-sb-outside-border);
       }
     }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
@@ -36,7 +36,7 @@
   &__option {
     position: relative;
 
-    &.ignore-events {
+    &#{&}--ignore-events {
       pointer-events: none;
     }
 
@@ -57,7 +57,7 @@
       background-color: var(--token-color-decorative-first-muted);
     }
 
-    &__item.item-nr-1 {
+    &__item#{&}__item--nr-1 {
       font-weight: var(--font-weight-medium);
     }
 
@@ -178,7 +178,7 @@
     }
 
     // remove last bottom border
-    &.last-of-type:not(#{&}--focus) &__inner::before {
+    &#{&}--last-of-type:not(#{&}--focus) &__inner::before {
       content: none;
     }
   }
@@ -189,14 +189,22 @@
     right: 0.5rem;
   }
 
-  &--bottom &__option--focus.closest-to-top &__option__inner::before,
-  &--top &__option--focus.closest-to-top &__option__inner::before {
+  &--bottom
+    &__option--focus#{&}__option--closest-to-top
+    &__option__inner::before,
+  &--top
+    &__option--focus#{&}__option--closest-to-top
+    &__option__inner::before {
     border-top-left-radius: var(--drawer-list-options-border-radius);
     border-top-right-radius: var(--drawer-list-options-border-radius);
   }
 
-  &--bottom &__option--focus.closest-to-bottom &__option__inner::before,
-  &--top &__option--focus.closest-to-bottom &__option__inner::before {
+  &--bottom
+    &__option--focus#{&}__option--closest-to-bottom
+    &__option__inner::before,
+  &--top
+    &__option--focus#{&}__option--closest-to-bottom
+    &__option__inner::before {
     border-bottom-left-radius: var(--drawer-list-options-border-radius);
     border-bottom-right-radius: var(--drawer-list-options-border-radius);
   }
@@ -211,39 +219,53 @@
   }
 
   // group title arrow
-  &--bottom:has(#{&}__group-title.closest-to-top) &__arrow,
-  &--top:has(#{&}__group-title.closest-to-bottom) &__arrow {
+  &--bottom:has(#{&}__group-title#{&}__group-title--closest-to-top)
+    &__arrow,
+  &--top:has(#{&}__group-title#{&}__group-title--closest-to-bottom)
+    &__arrow {
     &::before {
       background-color: var(--drawer-list-group-title-bg);
     }
   }
 
   // hover and focus arrow
-  &--bottom:has(#{&}__option.closest-to-top:hover) &__arrow::before,
-  &--top:has(#{&}__option.closest-to-bottom:hover) &__arrow::before,
-  &--bottom:has(#{&}__option.closest-to-top#{&}__option--focus)
+  &--bottom:has(#{&}__option#{&}__option--closest-to-top:hover)
     &__arrow::before,
-  &--top:has(#{&}__option.closest-to-bottom#{&}__option--focus)
+  &--top:has(#{&}__option#{&}__option--closest-to-bottom:hover)
     &__arrow::before,
-  &--bottom &__option.closest-to-top:hover ~ &__arrow::before,
-  &--top &__option.closest-to-bottom:hover ~ &__arrow::before,
-  &--bottom &__option.closest-to-top#{&}__option--focus ~ &__arrow::before,
+  &--bottom:has(
+      #{&}__option#{&}__option--closest-to-top#{&}__option--focus
+    )
+    &__arrow::before,
+  &--top:has(
+      #{&}__option#{&}__option--closest-to-bottom#{&}__option--focus
+    )
+    &__arrow::before,
+  &--bottom &__option#{&}__option--closest-to-top:hover ~ &__arrow::before,
+  &--top &__option#{&}__option--closest-to-bottom:hover ~ &__arrow::before,
+  &--bottom
+    &__option#{&}__option--closest-to-top#{&}__option--focus
+    ~ &__arrow::before,
   &--top
-    &__option.closest-to-bottom#{&}__option--focus
+    &__option#{&}__option--closest-to-bottom#{&}__option--focus
     ~ &__arrow::before {
     background-color: var(--token-color-background-action-hover-subtle);
   }
 
   // selected arrow
-  &--bottom:has(#{&}__option.closest-to-top#{&}__option--selected)
+  &--bottom:has(
+      #{&}__option#{&}__option--closest-to-top#{&}__option--selected
+    )
     &__arrow::before,
-  &--top:has(#{&}__option.closest-to-bottom#{&}__option--selected)
+  &--top:has(
+      #{&}__option#{&}__option--closest-to-bottom#{&}__option--selected
+    )
     &__arrow::before,
   &--bottom
-    &__option.closest-to-top#{&}__option--selected
+    &__option#{&}__option--closest-to-top#{&}__option--selected
     ~ &__arrow::before,
   &--top
-    &__option.closest-to-bottom#{&}__option--selected
+    &__option#{&}__option--closest-to-bottom#{&}__option--selected
     ~ &__arrow::before {
     background-color: var(--token-color-background-selected);
   }


### PR DESCRIPTION
Rename internal CSS helper classes in DrawerList to use proper BEM naming with the dnb-drawer-list__ prefix:

- first-item → dnb-drawer-list__option--first
- last-item → dnb-drawer-list__option--last
- first-of-type → dnb-drawer-list__option--first-of-type
- last-of-type → dnb-drawer-list__option--last-of-type
- closest-to-top → dnb-drawer-list__option--closest-to-top
- closest-to-bottom → dnb-drawer-list__option--closest-to-bottom
- ignore-events → dnb-drawer-list__option--ignore-events
- item-nr-{n} → dnb-drawer-list__option__item--nr-{n}

Group elements also get proper BEM modifiers:
- first-of-type → dnb-drawer-list__group--first-of-type
- last-of-type → dnb-drawer-list__group--last-of-type
- closest-to-top → dnb-drawer-list__group-title--closest-to-top
- closest-to-bottom → dnb-drawer-list__group-title--closest-to-bottom

