### PR TITLE
chore(Tag): use correct semantic tokens for icon focus states

### DIFF
--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -1007,8 +1007,10 @@ html:not([data-whatinput=touch]) .dnb-tag--interactive.dnb-button:focus-visible:
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-  --tag-icon-background-color: var(--token-color-icon-action-focus);
-  --tag-icon-border-color: var(--token-color-icon-action-focus);
+  --tag-icon-background-color: var(
+    --token-color-background-action-focus
+  );
+  --tag-icon-border-color: var(--token-color-stroke-action-focus);
 }
 html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover[disabled] {
   cursor: not-allowed;

--- a/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
+++ b/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
@@ -51,8 +51,10 @@
           ),
         $focus-color: var(--token-color-icon-action-focus)
       ) {
-        --tag-icon-background-color: var(--token-color-icon-action-focus);
-        --tag-icon-border-color: var(--token-color-icon-action-focus);
+        --tag-icon-background-color: var(
+          --token-color-background-action-focus
+        );
+        --tag-icon-border-color: var(--token-color-stroke-action-focus);
       }
 
       @include button-mixins.buttonHover(


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.

Replace icon-category tokens with semantically correct alternatives:
- --tag-icon-background-color: use background-action-focus instead of icon-action-focus
- --tag-icon-border-color: use stroke-action-focus instead of icon-action-focus

