### PR TITLE
chore(Checkbox): use stroke tokens for border instead of background tokens

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -217,7 +217,7 @@ button .dnb-form-status__text {
   --checkbox-color-border-off: var(
     --token-color-stroke-action-alternative
   );
-  --checkbox-color-border-on: var(--token-color-background-selected);
+  --checkbox-color-border-on: var(--token-color-stroke-selected);
   --checkbox-color-gfx__indeterminate: var(
     --token-color-background-selected
   );
@@ -235,7 +235,7 @@ button .dnb-form-status__text {
     --token-color-background-neutral
   );
   --checkbox-color-border-on--disabled: var(
-    --token-color-background-action-disabled
+    --token-color-stroke-action-disabled
   );
   --checkbox-color-border-off--disabled: var(
     --token-color-stroke-action-disabled

--- a/packages/dnb-eufemia/src/components/checkbox/style/dnb-checkbox.scss
+++ b/packages/dnb-eufemia/src/components/checkbox/style/dnb-checkbox.scss
@@ -24,7 +24,7 @@
   --checkbox-color-border-off: var(
     --token-color-stroke-action-alternative
   );
-  --checkbox-color-border-on: var(--token-color-background-selected);
+  --checkbox-color-border-on: var(--token-color-stroke-selected);
   --checkbox-color-gfx__indeterminate: var(
     --token-color-background-selected
   );
@@ -44,7 +44,7 @@
     --token-color-background-neutral
   );
   --checkbox-color-border-on--disabled: var(
-    --token-color-background-action-disabled
+    --token-color-stroke-action-disabled
   );
   --checkbox-color-border-off--disabled: var(
     --token-color-stroke-action-disabled


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 

Replace background-category tokens with stroke tokens for border properties:
- --checkbox-color-border-on: use stroke-selected instead of background-selected
- --checkbox-color-border-on--disabled: use stroke-action-disabled instead of background-action-disabled

