### PR TITLE
chore(Switch): use stroke tokens for border instead of background tokens

### DIFF
--- a/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -302,7 +302,7 @@ button .dnb-form-status__text {
 }
 .dnb-switch__input:checked ~ .dnb-switch__background {
   background-color: var(--token-color-background-selected);
-  border-color: var(--token-color-background-selected);
+  border-color: var(--token-color-stroke-selected);
 }
 .dnb-switch__input {
   opacity: 0;
@@ -443,7 +443,7 @@ html[data-whatinput=keyboard] .dnb-switch__input:checked:not([disabled]):focus ~
 }
 .dnb-switch:not(.dnb-skeleton) .dnb-switch__input[disabled]:checked ~ .dnb-switch__background {
   background-color: var(--token-color-background-action-disabled);
-  border-color: var(--token-color-background-action-disabled);
+  border-color: var(--token-color-stroke-action-disabled);
 }
 .dnb-switch:not(.dnb-skeleton) .dnb-switch__input[disabled]:checked ~ .dnb-switch__button {
   background-color: var(--token-color-background-neutral);

--- a/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
@@ -145,7 +145,7 @@
 
   &__input:checked ~ &__background {
     background-color: var(--token-color-background-selected);
-    border-color: var(--token-color-background-selected);
+    border-color: var(--token-color-stroke-selected);
   }
 
   &__input {
@@ -317,7 +317,7 @@
 
   &:not(.dnb-skeleton) &__input[disabled]:checked ~ &__background {
     background-color: var(--token-color-background-action-disabled);
-    border-color: var(--token-color-background-action-disabled);
+    border-color: var(--token-color-stroke-action-disabled);
   }
   &:not(.dnb-skeleton) &__input[disabled]:checked ~ &__button {
     background-color: var(--token-color-background-neutral);


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 

Replace background-category tokens with stroke tokens for border-color:
- checked state: use stroke-selected instead of background-selected
- disabled checked state: use stroke-action-disabled instead of background-action-disabled

