### PR TITLE
chore(Autocomplete): rename CSS class to follow BEM kebab-case

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -2566,7 +2566,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
                     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
                     <span
                       onClick={disabled ? null : setVisibleAndFocusOnInput}
-                      className="dnb-autocomplete__suffixValue"
+                      className="dnb-autocomplete__suffix-value"
                     >
                       {currentDataItem?.suffixValue}
                     </span>

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -350,7 +350,7 @@ describe('Autocomplete component', () => {
       )
 
       fireEvent.click(
-        document.querySelector('.dnb-autocomplete__suffixValue')
+        document.querySelector('.dnb-autocomplete__suffix-value')
       )
 
       expect(
@@ -368,7 +368,7 @@ describe('Autocomplete component', () => {
       ).not.toContain('dnb-autocomplete--open')
 
       fireEvent.click(
-        document.querySelector('.dnb-autocomplete__suffixValue')
+        document.querySelector('.dnb-autocomplete__suffix-value')
       )
       expect(
         document.querySelector('.dnb-autocomplete').classList


### PR DESCRIPTION
Rename dnb-autocomplete__suffixValue to dnb-autocomplete__suffix-value to follow the BEM kebab-case naming convention used across all other component CSS classes.

