### PR TITLE
chore: correct SCSS mixin typo closDrawerList → closeDrawerList

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -24,7 +24,7 @@
     }
   }
 }
-@mixin closDrawerList($type: 'slide') {
+@mixin closeDrawerList($type: 'slide') {
   @if $type == 'scale' {
     animation: drawer-list-scale-out 150ms ease-out 1 forwards;
   } @else if $type == 'up' {
@@ -438,7 +438,7 @@
   }
 
   &:not(.dnb-drawer-list--open) &__list {
-    @include closDrawerList();
+    @include closeDrawerList();
   }
 }
 


### PR DESCRIPTION
Fix typo in drawer-list SCSS mixin name: 'closDrawerList' was missing the 'e' in 'close'. Renamed to 'closeDrawerList' in both the mixin definition and its single usage.

