### PR TITLE
chore: fix inconsistent JSDoc ref casing and useRef examples

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -95,7 +95,7 @@ export type CheckboxProps = {
    */
   onClick?: (args: CheckboxOnClickParams) => void
   /**
-   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?:
     | React.RefObject<HTMLInputElement>

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -67,7 +67,7 @@ export const CheckboxProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -97,11 +97,11 @@ export type DropdownProps = {
    */
   labelSrOnly?: boolean
   /**
-   * By providing a React.ref you can get the internally used main element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+   * By providing a React.Ref you can get the internally used main element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: React.Ref<HTMLElement>
   /**
-   * By providing a React.ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.useRef()`.
+   * By providing a React.Ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.useRef(null)`.
    */
   buttonRef?: React.Ref<HTMLElement>
   /**

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -155,12 +155,12 @@ export const DropdownProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` you can get the internally used main element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` you can get the internally used main element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },
   buttonRef: {
-    doc: 'By providing a `React.Ref` you can get the internally used button element (DOM), e.g. `buttonRef={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` you can get the internally used button element (DOM), e.g. `buttonRef={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -217,7 +217,7 @@ export type InputProps = Omit<
      */
     iconPosition?: ButtonIconPosition
     /**
-     * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+     * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
      */
     ref?: React.Ref<HTMLInputElement>
     readOnly?: boolean

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -138,7 +138,7 @@ export const InputProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -91,7 +91,7 @@ export type RadioProps = {
   children?: RadioChildren
   onChange?: (event: RadioChangeEvent) => void
   /**
-   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: React.Ref<HTMLInputElement>
 } & Omit<

--- a/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
@@ -57,7 +57,7 @@ export const RadioProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/section/SectionDocs.ts
+++ b/packages/dnb-eufemia/src/components/section/SectionDocs.ts
@@ -69,7 +69,7 @@ export const SectionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -98,7 +98,7 @@ export type SwitchProps = {
   onClick?: (args: SwitchOnClickParams) => void
   onChangeEnd?: SwitchOnChange
   /**
-   * By providing a React.ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?:
     | React.RefObject<HTMLInputElement>

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -68,7 +68,7 @@ export const SwitchProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -174,7 +174,7 @@ export type TextareaProps = Omit<
      */
     locale?: InternalLocale
     /**
-     * By providing a React.Ref we can get the internally used Textarea element (DOM). E.g. `ref={myRef}` by using `React.useRef()`.
+     * By providing a React.Ref we can get the internally used Textarea element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
      */
     ref?: React.Ref<HTMLTextAreaElement> | null
   }

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -98,7 +98,7 @@ export const TextareaProperties: PropertiesTableProps = {
     status: 'optional',
   },
   ref: {
-    doc: 'By providing a `React.Ref` we can get the internally used Textarea element (DOM), e.g. `ref={myRef}` by using `React.useRef()`.',
+    doc: 'By providing a `React.Ref` we can get the internally used Textarea element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },


### PR DESCRIPTION
- Fix React.ref (lowercase) → React.Ref (PascalCase) in JSDoc comments for Dropdown, Radio, Input, Checkbox, Switch components
- Fix React.useRef() → React.useRef(null) in JSDoc/Docs examples across Dropdown, Radio, Input, Checkbox, Switch, Textarea, Section
- React 19 requires useRef to have an argument

