### PR TITLE
chore(Tag): remove dead variables

### DIFF
--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -1007,9 +1007,6 @@ html:not([data-whatinput=touch]) .dnb-tag--interactive.dnb-button:focus-visible:
   --border-width: var(--focus-ring-width);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-  --tag-icon-background-color: var(
-    --token-color-background-action-focus
-  );
   --tag-icon-border-color: var(--token-color-stroke-action-focus);
 }
 html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover[disabled] {
@@ -1021,7 +1018,6 @@ html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover:not([di
   --border-width: 0.125rem;
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-  --tag-icon-background-color: var(--token-color-background-neutral);
 }
 .dnb-tag--interactive.dnb-button:active[disabled], html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:active[disabled] {
   cursor: not-allowed;
@@ -1033,9 +1029,6 @@ html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover:not([di
   --border-width: 0.0625rem;
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
-  --tag-icon-background-color: var(
-    --token-color-background-action-pressed
-  );
 }
 .dnb-tag--interactive.dnb-button[disabled] {
   color: var(--token-color-component-button-text-action-disabled);

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -968,7 +968,6 @@ button.dnb-button::-moz-focus-inner {
 *
 */
 .dnb-tag {
-  --tag-icon-background-color: var(--token-color-background-action);
   --tag-icon-border-color: var(--token-color-stroke-action);
 }
 .dnb-tag.dnb-button {
@@ -1076,7 +1075,7 @@ html:not([data-whatintent=touch]) .dnb-tag--removable.dnb-button:hover:not([disa
   stroke: var(--tag-icon-stroke);
 }
 .dnb-tag--addable {
-  --tag-icon-fill-color: var(--tag-icon-background-color);
+  --tag-icon-fill-color: var(--token-color-background-action);
   --tag-icon-stroke-color: var(--token-color-icon-neutral-inverse);
 }
 .dnb-tag--addable svg {

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -1034,7 +1034,7 @@ html:not([data-whatintent=touch]) .dnb-tag--interactive.dnb-button:hover:not([di
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
   --tag-icon-background-color: var(
-    --token-color-icon-action-pressed
+    --token-color-background-action-pressed
   );
 }
 .dnb-tag--interactive.dnb-button[disabled] {

--- a/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
+++ b/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
@@ -51,29 +51,20 @@
           ),
         $focus-color: var(--token-color-icon-action-focus)
       ) {
-        --tag-icon-background-color: var(
-          --token-color-background-action-focus
-        );
         --tag-icon-border-color: var(--token-color-stroke-action-focus);
       }
 
       @include button-mixins.buttonHover(
         $color: var(--token-color-text-action-hover),
         $border-color: var(--token-color-stroke-action-hover)
-      ) {
-        --tag-icon-background-color: var(--token-color-background-neutral);
-      }
+      );
 
       @include button-mixins.buttonActive(
         $color: var(--token-color-text-action-pressed),
         $background-color: var(
             --token-color-background-action-pressed-subtle
           )
-      ) {
-        --tag-icon-background-color: var(
-          --token-color-background-action-pressed
-        );
-      }
+      );
 
       &[disabled] {
         color: var(--token-color-component-button-text-action-disabled);

--- a/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
+++ b/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
@@ -71,7 +71,7 @@
           )
       ) {
         --tag-icon-background-color: var(
-          --token-color-icon-action-pressed
+          --token-color-background-action-pressed
         );
       }
 

--- a/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
+++ b/packages/dnb-eufemia/src/components/tag/style/dnb-tag.scss
@@ -8,7 +8,6 @@
 @use './tag-mixins.scss' as tag-mixins;
 
 .dnb-tag {
-  --tag-icon-background-color: var(--token-color-background-action);
   --tag-icon-border-color: var(--token-color-stroke-action);
 
   &.dnb-button {
@@ -91,7 +90,7 @@
   }
 
   &--addable {
-    --tag-icon-fill-color: var(--tag-icon-background-color);
+    --tag-icon-fill-color: var(--token-color-background-action);
     --tag-icon-stroke-color: var(--token-color-icon-neutral-inverse);
     svg {
       transform: rotate(45deg);


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 

Replace icon-category token with semantically correct background token for --tag-icon-background-color in active/pressed state:
- use background-action-pressed instead of icon-action-pressed

The --tag-icon-background-color feeds into the SVG circle fill, making background the correct token category.

