### PR TITLE
chore(Accordion): use stroke token for border-after-click

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`Accordion scss have to match default theme snapshot 1`] = `
     --token-color-stroke-action-pressed
   );
   --accordion-color-border--after-click: var(
-    --token-color-background-action
+    --token-color-stroke-action
   );
   --accordion-border-width--hover: 0.125rem;
   --accordion-border-width--active: 0.125rem;

--- a/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/themes/dnb-accordion-theme-ui.scss
@@ -37,7 +37,7 @@
       --token-color-stroke-action-pressed
     );
     --accordion-color-border--after-click: var(
-      --token-color-background-action
+      --token-color-stroke-action
     );
 
     // other


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 

Replace background token with stroke token for the outlined variant's border--after-click state:
- background-action → stroke-action

The border property should semantically use stroke tokens, not background tokens. The filled variant's border--default intentionally uses decorative-third-muted to match its background (seamless look), so it is left unchanged.

