### PR TITLE
chore(Field.Password): use icon token for icon color variables

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/style/dnb-password.scss
@@ -1,9 +1,9 @@
 .dnb-forms-field-password {
   // Make sure submit element receives red text/icon color on error.
   .dnb-input__status--error .dnb-input__submit-button__button {
-    --button-color-icon--default: var(--token-color-text-destructive);
+    --button-color-icon--default: var(--token-color-icon-destructive);
     --button-color-text--default: var(--token-color-text-destructive);
-    --button-color-icon--hover: var(--token-color-text-neutral-inverse);
+    --button-color-icon--hover: var(--token-color-icon-neutral-inverse);
     --button-color-text--hover: var(--token-color-text-neutral-inverse);
   }
 }


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 


Replace text tokens with icon tokens for the icon color variables:
- --button-color-icon--default: text-destructive → icon-destructive
- --button-color-icon--hover: text-neutral-inverse → icon-neutral-inverse

The icon color variables should semantically use icon tokens, not text tokens. Currently the values are identical across all themes and dark mode.

