### PR TITLE
chore(Table): rename confusing accordion CSS variable

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -800,7 +800,7 @@ html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dn
   );
   --table-accordion-outline-color: var(--token-color-stroke-selected);
   --table-accordion-outline-width: var(--focus-ring-width);
-  --table-accordion-outline-background--active: var(
+  --table-accordion-background--active: var(
     --token-color-background-selected-subtle
   );
 }
@@ -939,7 +939,7 @@ html:not([data-whatintent=touch]) .dnb-table__tr--clickable.dnb-table__tr:not(.d
 }
 
 .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active .dnb-table__td {
-  background-color: var(--table-accordion-outline-background--active);
+  background-color: var(--table-accordion-background--active);
 }
 
 .dnb-table__tr--clickable.dnb-table__tr:not(.dnb-table__tr--disabled):active .dnb-table__td .dnb-table__td__button-icon .dnb-icon {

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -37,7 +37,7 @@
   // Outline
   --table-accordion-outline-color: var(--token-color-stroke-selected);
   --table-accordion-outline-width: var(--focus-ring-width);
-  --table-accordion-outline-background--active: var(
+  --table-accordion-background--active: var(
     --token-color-background-selected-subtle
   );
 
@@ -188,7 +188,7 @@
   }
 
   &__tr--clickable#{&}__tr:not(&__tr--disabled):active &__td {
-    background-color: var(--table-accordion-outline-background--active);
+    background-color: var(--table-accordion-background--active);
 
     @include tableAccordionActiveColor();
   }

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
@@ -92,7 +92,7 @@
   // Outline
   --table-accordion-outline-color: var(--token-color-stroke-action);
   --table-accordion-outline-width: var(--table-accordion-border-width);
-  --table-accordion-outline-background--active: var(
+  --table-accordion-background--active: var(
     --token-color-background-neutral-subtle
   );
 }


### PR DESCRIPTION
Not sure if this change is correct or not, but I'm questioning the semantics used in the existing code.
Please feel free to close this PR if the existing code on main is correct 👍 


Rename --table-accordion-outline-background--active to --table-accordion-background--active.

The variable name mixed 'outline' and 'background' which was confusing — it is used as a background-color, not an outline. Removing 'outline' from the name clarifies its purpose.

