### PR TITLE
chore: show required error in ValidationRequired examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Address/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Address/Examples.tsx
@@ -102,10 +102,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.Address.Postal
-        value="Dronning Eufemias gate 30"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber/Examples.tsx
@@ -104,10 +104,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.BankAccountNumber
-        value="20001234567"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency/Examples.tsx
@@ -123,10 +123,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.Currency
-        value={42}
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date/Examples.tsx
@@ -76,9 +76,9 @@ export const ValidationRequired = () => {
     <ComponentBox>
       <Field.Date
         label="Label text"
-        value="2023-01-16"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth/Examples.tsx
@@ -94,10 +94,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.DateOfBirth
-        value="2000-05-17"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email/Examples.tsx
@@ -104,10 +104,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.Email
-        value="my-m@il.com"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
@@ -84,10 +84,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.Expiry
-        value="0826"
         label="Label text"
         onChange={(expiry) => console.log('onChange', expiry)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name/Examples.tsx
@@ -128,6 +128,7 @@ export const ValidationRequired = () => {
       <Field.Name.First
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/Examples.tsx
@@ -105,10 +105,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.NationalIdentityNumber
-        value="12345678901"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber/Examples.tsx
@@ -104,10 +104,10 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.OrganizationNumber
-        value="123456789"
         label="Label text"
         onChange={(value) => console.log('onChange', value)}
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber/Examples.tsx
@@ -116,12 +116,12 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.PhoneNumber
-        value="+47888"
         numberLabel="Label text"
         onChange={(value, { countryCode, phoneNumber, iso }) =>
           console.log('onChange', value, { countryCode, phoneNumber, iso })
         }
         required
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -129,7 +129,6 @@ export const ValidationRequired = () => {
         city={{
           required: true,
         }}
-        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity/Examples.tsx
@@ -129,6 +129,7 @@ export const ValidationRequired = () => {
         city={{
           required: true,
         }}
+        validateInitially
       />
     </ComponentBox>
   )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Password/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Password/Examples.tsx
@@ -92,11 +92,11 @@ export const ValidationRequired = () => {
   return (
     <ComponentBox>
       <Field.Password
-        value="pass"
         onChange={(value) => console.log('onChange', value)}
         onHidePassword={(event) => console.log('onHidePassword', event)}
         onShowPassword={(event) => console.log('onShowPassword', event)}
         required
+        validateInitially
       />
     </ComponentBox>
   )


### PR DESCRIPTION
Motivation: I feel like it's helpful to see the required error message when entering the demos, instead of having to manually remove the value and then blur.

Remove pre-filled value props and add validateInitially so the required validation message is actually displayed in the docs demos when first seeing it.

Affected fields: BankAccountNumber, Email, PhoneNumber, Currency, Address, NationalIdentityNumber, Name, OrganizationNumber, DateOfBirth, Date, PostalCodeAndCity, Expiry, Password
