### PR TITLE
fix(StyleIsolation): handle `:root` in multi-selector rules

### DIFF
--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
@@ -86,6 +86,14 @@ describe('isolated-style-scope-plugin', () => {
       )
     })
 
+    it('should scope :root in a multi-selector rule and keep other selectors', async () => {
+      return await run(
+        ':root, .other-selector { --color: red; }',
+        '.test-scope, .other-selector { --color: red; }',
+        { scopeHash: 'test-scope' }
+      )
+    })
+
     it('should scope attribute selectors', async () => {
       return await run(
         '[data-test] { color: red; }',
@@ -929,6 +937,14 @@ describe('isolated-style-scope-plugin', () => {
         return await run(
           ':root { --color: red; }',
           ':global(.test-scope) { --color: red; }',
+          { runAsCssModule: true, scopeHash: 'test-scope' }
+        )
+      })
+
+      it('should scope :root in a multi-selector rule and keep other selectors', async () => {
+        return await run(
+          ':root, .other-selector { --color: red; }',
+          ':global(.test-scope), .other-selector { --color: red; }',
           { runAsCssModule: true, scopeHash: 'test-scope' }
         )
       })

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
@@ -97,11 +97,16 @@ const postcssIsolateStyle = (opts = {}) => {
         }
 
         // Special‐case :root
-        if (
-          rule.selectors.length === 1 &&
-          (rule.selectors[0].trim() === ':root' ||
-            (isCssModule && rule.selectors[0].trim() === ':global :root'))
-        ) {
+        const isRootSelector = (s) => {
+          const trimmed = s.trim()
+          return (
+            trimmed === ':root' ||
+            (isCssModule && trimmed === ':global :root')
+          )
+        }
+        const hasRoot = rule.selectors.some(isRootSelector)
+
+        if (hasRoot) {
           const scopes = [scopeWithFallback]
 
           if (Array.isArray(sharedHashes)) {
@@ -112,13 +117,20 @@ const postcssIsolateStyle = (opts = {}) => {
             }
           }
 
-          // in CSS-Module mode, wrap the entire list in one :global(...)
+          // Replace :root with scope hashes, keep other selectors as-is
+          const nonRootSelectors = rule.selectors.filter(
+            (s) => !isRootSelector(s)
+          )
+
+          let scopeSelectors
           if (isCssModule) {
             const classList = scopes.map((s) => `.${s}`).join(', ')
-            rule.selector = `:global(${classList})`
+            scopeSelectors = [`:global(${classList})`]
           } else {
-            rule.selector = scopes.map((s) => `.${s}`).join(', ')
+            scopeSelectors = scopes.map((s) => `.${s}`)
           }
+
+          rule.selectors = [...scopeSelectors, ...nonRootSelectors]
           return
         }
 


### PR DESCRIPTION
So its possible to have selectors like:

```css
:root,
.second-selector {
  ...
}
```