### PR TITLE
chore(Portal): add outline and border to properties table

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -178,7 +178,7 @@ export default function PropertiesTable({
 
   return (
     <Table.ScrollView>
-      <StyledTable>
+      <StyledTable outline border>
         <thead>
           <Tr>
             <Th>Property</Th>


### PR DESCRIPTION
Much easier to consume when Portal is in dark mode.