### PR TITLE
chore: increase timeout in Wizard.Buttons test to avoid timeout flakiness

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Buttons/__tests__/Buttons.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Buttons/__tests__/Buttons.test.tsx
@@ -4,6 +4,9 @@ import userEvent from '@testing-library/user-event'
 import { Form, Wizard } from '../../..'
 
 describe('Wizard.Buttons', () => {
+  // Increase timeout for all tests in this suite due to async operations
+  jest.setTimeout(30000)
+
   const Step = ({ title }) => {
     return (
       <Wizard.Step>


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/24855520580/job/72767257632

Using a timeout is the same pattern used in the WizardContainer test file.
Not sure if it's the best way.