### PR TITLE
fix(FormLabel): render span instead of label when forId is not provided

### DIFF
--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -69,6 +69,8 @@ function FormLabel(localProps: FormLabelAllProps) {
     ? () => React.createElement(nestedNode, nestedContent['props'])
     : null
 
+  const defaultElement = nestedElement || (props.forId ? 'label' : 'span')
+
   const {
     forId,
     text,
@@ -77,7 +79,7 @@ function FormLabel(localProps: FormLabelAllProps) {
     labelDirection,
     size,
     skeleton,
-    element: Element = nestedElement || 'label',
+    element: Element = defaultElement,
     ref: refProp,
     className,
     children,

--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -182,8 +182,14 @@ describe('FormLabel component', () => {
     )
   })
 
-  it('should use label element by default', () => {
+  it('should use span element when forId is not provided', () => {
     render(<FormLabel>content</FormLabel>)
+
+    expect(document.querySelector('.dnb-form-label').tagName).toBe('SPAN')
+  })
+
+  it('should use label element when forId is provided', () => {
+    render(<FormLabel forId="input">content</FormLabel>)
 
     expect(document.querySelector('.dnb-form-label').tagName).toBe('LABEL')
   })
@@ -193,7 +199,11 @@ describe('FormLabel component', () => {
 
     function MockComponent() {
       ref = React.useRef<HTMLLabelElement | null>(null)
-      return <FormLabel ref={ref}>content</FormLabel>
+      return (
+        <FormLabel forId="input" ref={ref}>
+          content
+        </FormLabel>
+      )
     }
 
     render(<MockComponent />)
@@ -300,7 +310,7 @@ describe('FormLabel component', () => {
 
       rerender(<FormLabel />)
 
-      expect(label().tagName).toBe('LABEL')
+      expect(label().tagName).toBe('SPAN')
     })
   })
 


### PR DESCRIPTION
An unassociated <label> element is an accessibility violation. When no forId is provided, FormLabel now renders a <span> instead, while still rendering <label> when forId is set.