### PR TITLE
fix(DatePicker): use span instead of label for calendar header title

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendarNavigator.tsx
@@ -125,7 +125,7 @@ export function DatePickerCalendarNav({
           onClick={onNav}
         />
       </div>
-      <label
+      <span
         id={`${id}--title`}
         className="dnb-date-picker__header__title dnb-no-focus"
         title={title.replace(
@@ -135,7 +135,7 @@ export function DatePickerCalendarNav({
         tabIndex={-1}
       >
         {formatDate(date, { locale, options: titleFormat })}
-      </label>
+      </span>
       <div className="dnb-date-picker__header__nav">
         <CalendarNavButton
           type="next"

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1155,7 +1155,7 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      document.querySelector('label.dnb-date-picker__header__title')
+      document.querySelector('span.dnb-date-picker__header__title')
         .textContent
     ).toBe('mai 2020')
     expect(getDatePickerRoot().classList).toContain(
@@ -1171,7 +1171,7 @@ describe('DatePicker component', () => {
     )
 
     expect(
-      document.querySelector('label.dnb-date-picker__header__title')
+      document.querySelector('span.dnb-date-picker__header__title')
         .textContent
     ).toBe('april 2020')
     expect(getDatePickerRoot().classList).not.toContain(
@@ -1227,7 +1227,7 @@ describe('DatePicker component', () => {
     await userEvent.click(day)
 
     const [leftPickerTitle, rightPickerTitle] = Array.from(
-      document.querySelectorAll('label.dnb-date-picker__header__title')
+      document.querySelectorAll('span.dnb-date-picker__header__title')
     )
 
     expect(leftPickerTitle).toHaveTextContent('mai 2024')


### PR DESCRIPTION
The header title elements (showing month/year like 'mai 2019') were rendered as <label> elements without being associated with any form field, which is an accessibility violation. Changed to <span> since these are purely display text.

