### PR TITLE
fix(StepIndicator): render trigger label as span instead of label element

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -108,6 +108,7 @@ function StepIndicatorTriggerButton({
       <HeightAnimation animate={!noAnimation}>
         <div {...(triggerParams as React.HTMLProps<HTMLDivElement>)}>
           <FormLabel
+            element="span"
             aria-describedby={id}
             aria-hidden // In order to not duplicate information for screen readers
             className="dnb-step-indicator__label"

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -448,7 +448,7 @@ describe('StepIndicator in loose mode', () => {
     )
 
     expect(
-      document.querySelector('label.dnb-step-indicator__label').textContent
+      document.querySelector('span.dnb-step-indicator__label').textContent
     ).toContain('Steg 2 av 4:')
     expect(
       document.querySelector('button.dnb-step-indicator__trigger__button')
@@ -465,7 +465,7 @@ describe('StepIndicator in loose mode', () => {
       />
     )
     expect(
-      document.querySelector('label.dnb-step-indicator__label').textContent
+      document.querySelector('span.dnb-step-indicator__label').textContent
     ).toContain('Steg 2 av 4:')
     expect(
       document.querySelector('button.dnb-step-indicator__trigger__button')
@@ -665,6 +665,9 @@ describe('StepIndicator ARIA', () => {
 
     // Verify it has aria-hidden attribute
     expect(formLabel).toHaveAttribute('aria-hidden', 'true')
+
+    // Should render as a span, not a label, since it's not associated with a form field
+    expect(formLabel.tagName).toBe('SPAN')
   })
 
   it('should have aria-hidden on step item elements to avoid duplicate information', () => {


### PR DESCRIPTION
The step indicator trigger used a <label> element for the step count text (e.g. 'Step 1 of 2:'), but it was not associated with any form field. This caused Chrome's accessibility audit to flag it with 'a label is not associated with a form field'. Since the element is aria-hidden and purely visual, a <span> is the correct element.

