### PR TITLE
chore(Tools.Log): render label as span instead of label element

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
@@ -27,7 +27,7 @@ function Log({
       {...props}
     >
       {label && (
-        <FormLabel bottom>
+        <FormLabel element="span" bottom>
           <b>{label}</b>
         </FormLabel>
       )}

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Log.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Log.test.tsx
@@ -51,6 +51,10 @@ describe('Tools.Log', () => {
 
     const element = document.querySelector('output')
     expect(element.textContent).toContain('My label')
+
+    // Should render as a span, not a label, since it's not associated with a form field
+    const formLabel = element.querySelector('.dnb-form-label')
+    expect(formLabel.tagName).toBe('SPAN')
   })
 
   it('should render a placeholder when given', () => {


### PR DESCRIPTION
Tools.Log used a <label> element for its label prop (e.g. 'Data'), but it was not associated with any form field. This caused Chrome's accessibility audit to flag it with 'a label is not associated with a form field'. Since it's a visual heading for debug output, a <span> is the correct element.

