### PR TITLE
fix(Button): accept ReactNode title and convert to string internally

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -103,6 +103,7 @@ export type ButtonProps = {
   type?: string
   /**
    * Required if there is no text in the button. If `text` and `children` are undefined, setting the `title` property will automatically set `aria-label` with the same value.
+   * Accepts `React.ReactNode`. If a JSX element is provided, it will be converted to a plain string using `convertJsxToString` — only static text content is extracted. Custom components that don't render static children will result in an empty string.
    */
   title?: React.ReactNode
   /**

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx'
 import Context from '../../shared/Context'
 import {
   warn,
+  convertJsxToString,
   extendExistingPropsWithContext,
   removeUndefinedProps,
   validateDOMAttributes,
@@ -103,7 +104,7 @@ export type ButtonProps = {
   /**
    * Required if there is no text in the button. If `text` and `children` are undefined, setting the `title` property will automatically set `aria-label` with the same value.
    */
-  title?: string
+  title?: React.ReactNode
   /**
    * Defines the kind of button. Possible values are `primary`, `secondary` and `tertiary`. Defaults to `primary` (or `secondary` if icon only).
    */
@@ -185,7 +186,7 @@ export type ButtonProps = {
         Partial<
           React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>
         >,
-        'onClick'
+        'onClick' | 'title'
       >
   > &
   SpacingProps
@@ -356,6 +357,8 @@ function Button({ ref, ...restProps }: ButtonProps) {
     }
   }
 
+  const titleString = convertJsxToString(title) || undefined
+
   const params = applySpacing(props, {
     className: clsx(
       'dnb-button',
@@ -380,7 +383,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
       props.href || props.to ? '' : null,
       Element === Anchor && 'dnb-anchor--no-style'
     ),
-    title,
+    title: titleString,
     id: resolvedId,
     disabled,
     ...attributes,
@@ -425,7 +428,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
     params.type = params.type === '' ? undefined : 'button'
   }
   if (isIconOnly) {
-    params['aria-label'] = params['aria-label'] || title
+    params['aria-label'] = params['aria-label'] || titleString
   }
 
   skeletonDOMAttributes(params, skeleton, context)

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -46,6 +46,27 @@ describe('Button component', () => {
     expect(button.getAttribute('aria-label')).toBe(title)
   })
 
+  it('should convert React element title to string', () => {
+    render(
+      <Button
+        {...props}
+        title={<span>Component title</span>}
+        href={null}
+      />
+    )
+    const button = document.querySelector('button')
+
+    expect(button.getAttribute('title')).toBe('Component title')
+  })
+
+  it('should convert React element title to aria-label for icon-only button', () => {
+    render(<Button icon="bell" title={<>Icon label</>} />)
+    const button = document.querySelector('button')
+
+    expect(button.getAttribute('title')).toBe('Icon label')
+    expect(button.getAttribute('aria-label')).toBe('Icon label')
+  })
+
   it('icon only has to have some extra classes', () => {
     render(<Button icon="question" />)
     const button = document.querySelector('button')

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -14,12 +14,16 @@ import { applySpacing } from '../space/SpacingUtils'
 import type { ButtonProps } from '../button/Button'
 import Button from '../button/Button'
 
-const defaultProps: Partial<ButtonProps> = {
+export type HelpButtonInstanceProps = ButtonProps
+
+const defaultProps: Partial<HelpButtonInstanceProps> = {
   variant: 'secondary',
   iconPosition: 'left',
 }
 
-export default function HelpButtonInstance(localProps: ButtonProps) {
+export default function HelpButtonInstance(
+  localProps: HelpButtonInstanceProps
+) {
   const context = React.useContext(Context)
 
   // use only the props from context, who are available here anyway

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -14,16 +14,12 @@ import { applySpacing } from '../space/SpacingUtils'
 import type { ButtonProps } from '../button/Button'
 import Button from '../button/Button'
 
-export type HelpButtonInstanceProps = ButtonProps
-
-const defaultProps: Partial<HelpButtonInstanceProps> = {
+const defaultProps: Partial<ButtonProps> = {
   variant: 'secondary',
   iconPosition: 'left',
 }
 
-export default function HelpButtonInstance(
-  localProps: HelpButtonInstanceProps
-) {
+export default function HelpButtonInstance(localProps: ButtonProps) {
   const context = React.useContext(Context)
 
   // use only the props from context, who are available here anyway

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -473,11 +473,10 @@ function ModalComponent(ownProps: ModalAllProps) {
   }
 
   const headerTitle = rest.title || fallbackTitle
-  const title = (
+  const title =
     !usedTriggerAttributes?.text && headerTitle
       ? headerTitle || fallbackTitle
       : null
-  ) as string
 
   const TriggerButton = trigger
     ? (trigger as () => React.JSX.Element)

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -465,7 +465,7 @@ function ModalComponent(ownProps: ModalAllProps) {
     _id.current = usedTriggerAttributes.id
   }
 
-  let fallbackTitle: string
+  let fallbackTitle: React.ReactNode
   if (usedTriggerAttributes.title) {
     fallbackTitle = usedTriggerAttributes.title
   } else if (suffixContext) {

--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -14,7 +14,11 @@ import clsx from 'clsx'
 import PopoverCloseButton from './internal/PopoverCloseButton'
 import useId from '../../shared/helpers/useId'
 import useTranslation from '../../shared/useTranslation'
-import { combineDescribedBy, warn } from '../../shared/component-helper'
+import {
+  combineDescribedBy,
+  convertJsxToString,
+  warn,
+} from '../../shared/component-helper'
 import getRefElement from '../../shared/internal/getRefElement'
 import PopoverPortal from './PopoverPortal'
 import PopoverContainer from './PopoverContainer'
@@ -588,7 +592,9 @@ export default function Popover(props: PopoverProps) {
       icon={closeButtonProps?.icon ?? 'close'}
       {...closeButtonProps}
       className={clsx('dnb-popover__close', closeButtonProps?.className)}
-      title={closeButtonProps?.title || tr.closeButtonTitle}
+      title={
+        convertJsxToString(closeButtonProps?.title) || tr.closeButtonTitle
+      }
       onClick={(event) => {
         closeButtonProps?.onClick?.(event as any)
         if (event?.defaultPrevented) {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useMemo } from 'react'
 import clsx from 'clsx'
-import { convertJsxToString } from '../../../../shared/component-helper'
 import { Checkbox, HelpButton, ToggleButton } from '../../../../components'
 import type { FieldBlockProps, FieldBlockWidth } from '../../FieldBlock'
 import FieldBlock from '../../FieldBlock'
@@ -244,7 +243,7 @@ export function useCheckboxOrToggleOptions({
 
       const label = title ?? children
       const suffix = help ? (
-        <HelpButton size="small" title={convertJsxToString(help.title)}>
+        <HelpButton size="small" title={help.title}>
           {help.content}
         </HelpButton>
       ) : undefined

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -105,6 +105,30 @@ describe('ArraySelection', () => {
       expect(dialogContent).toHaveTextContent('Help content')
     })
 
+    it('renders help with convertible JSX title', () => {
+      render(
+        <Field.ArraySelection>
+          <Field.Option
+            value="option1"
+            help={{
+              title: <>Translatable title</>,
+              content: 'Help content',
+            }}
+          >
+            Option 1
+          </Field.Option>
+        </Field.ArraySelection>
+      )
+
+      const button = document.querySelector('.dnb-help-button')
+      expect(button).toHaveAttribute('aria-label', 'Translatable title')
+
+      fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+      const dialogContent = document.querySelector('.dnb-modal__content')
+      expect(dialogContent).toHaveTextContent('Help content')
+    })
+
     it('precede option title over children', async () => {
       render(
         <Field.ArraySelection>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -77,6 +77,34 @@ describe('ArraySelection', () => {
       expect(document.querySelectorAll('.dnb-help-button')).toHaveLength(1)
     })
 
+    it('renders help with React component title', () => {
+      function CustomTitle() {
+        return <>Component title</>
+      }
+
+      render(
+        <Field.ArraySelection>
+          <Field.Option
+            value="option1"
+            help={{
+              title: <CustomTitle />,
+              content: 'Help content',
+            }}
+          >
+            Option 1
+          </Field.Option>
+        </Field.ArraySelection>
+      )
+
+      const button = document.querySelector('.dnb-help-button')
+      expect(button).toHaveAttribute('aria-label', 'Hjelpetekst')
+
+      fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+      const dialogContent = document.querySelector('.dnb-modal__content')
+      expect(dialogContent).toHaveTextContent('Help content')
+    })
+
     it('precede option title over children', async () => {
       render(
         <Field.ArraySelection>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -1,9 +1,6 @@
 import React, { useMemo, useCallback } from 'react'
 import clsx from 'clsx'
-import {
-  convertJsxToString,
-  makeUniqueId,
-} from '../../../../shared/component-helper'
+import { makeUniqueId } from '../../../../shared/component-helper'
 import {
   ToggleButton,
   Dropdown,
@@ -432,7 +429,7 @@ function renderRadioItems({
 
     const label = title ?? children
     const suffix = help ? (
-      <HelpButton size="small" title={convertJsxToString(help.title)}>
+      <HelpButton size="small" title={help.title}>
         {help.content}
       </HelpButton>
     ) : undefined

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { axeComponent } from '../../../../../core/jest/jestSetup'
-import { screen, render, within, waitFor } from '@testing-library/react'
+import {
+  screen,
+  render,
+  within,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DataContext from '../../../DataContext/Context'
 import DrawerListProvider from '../../../../../fragments/drawer-list/DrawerListProvider'
@@ -431,6 +437,34 @@ describe('variants', () => {
         'aria-describedby',
         expect.stringContaining('-suffix')
       )
+    })
+
+    it('renders help with React component title', () => {
+      function CustomTitle() {
+        return <>Component title</>
+      }
+
+      render(
+        <Field.Selection variant="radio">
+          <Field.Option
+            value="foo"
+            help={{
+              title: <CustomTitle />,
+              content: 'Help content',
+            }}
+          >
+            Foo
+          </Field.Option>
+        </Field.Selection>
+      )
+
+      const button = document.querySelector('.dnb-help-button')
+      expect(button).toHaveAttribute('aria-label', 'Hjelpetekst')
+
+      fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+      const dialogContent = document.querySelector('.dnb-modal__content')
+      expect(dialogContent).toHaveTextContent('Help content')
     })
 
     it('should disable options', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -467,6 +467,30 @@ describe('variants', () => {
       expect(dialogContent).toHaveTextContent('Help content')
     })
 
+    it('renders help with convertible JSX title', () => {
+      render(
+        <Field.Selection variant="radio">
+          <Field.Option
+            value="foo"
+            help={{
+              title: <>Translatable title</>,
+              content: 'Help content',
+            }}
+          >
+            Foo
+          </Field.Option>
+        </Field.Selection>
+      )
+
+      const button = document.querySelector('.dnb-help-button')
+      expect(button).toHaveAttribute('aria-label', 'Translatable title')
+
+      fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+      const dialogContent = document.querySelector('.dnb-modal__content')
+      expect(dialogContent).toHaveTextContent('Help content')
+    })
+
     it('should disable options', () => {
       render(
         <Field.Selection variant="radio" disabled>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -17,7 +17,12 @@ export type FormSubmitButtonProps = {
   showIndicator?: boolean
 } & ComponentProps &
   Omit<ButtonProps, 'variant'> &
-  Partial<React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>> & {
+  Partial<
+    Omit<
+      React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>,
+      'title'
+    >
+  > & {
     variant?: 'send' | 'secondary'
   }
 


### PR DESCRIPTION
Motivation is so that users can provide like this to `title={<FormattedMessage id="app.greeting" defaultMessage="Hello, User!" values={{ name: 'John' }} />}`, also motivated by this https://github.com/dnbexperience/eufemia/issues/7752

Button now accepts React.ReactNode as its title prop and converts it
to a string via convertJsxToString before applying to DOM attributes
and aria-label. This removes the need for callers like HelpButton,
Selection, and ArraySelection to manually convert titles, simplifying
help button usage with translated or dynamic React component titles.