### PR TITLE
fix: add missing `dnb-page-background` helper class

### DIFF
--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -102,7 +102,11 @@ export const rootElement =
 function ThemeProvider({ children }) {
   const theme = useThemeHandler()
 
-  return <Theme {...theme}>{children}</Theme>
+  return (
+    <Theme {...theme} className="dnb-page-background">
+      {children}
+    </Theme>
+  )
 }
 
 // This ensures we actually will get skeletons enabled when defined in the url

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/classes.mdx
@@ -91,6 +91,12 @@ Visually hide an element while keeping it accessible to screen readers. (_sr_ st
 
 <Examples.ScreenReaderOnly />
 
+## Page background
+
+`dnb-page-background`
+
+Sets the page background color using the `--token-color-background-page-background` design token. Use this class on a root element (such as `body` or a wrapper) to ensure a themed background color that adapts to light and dark modes.
+
 ## Drop shadow
 
 `dnb-drop-shadow`

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -33,6 +33,7 @@ You can use the internal Eufemia easing function.
 - [dnb-spacing](/uilib/helpers/classes#spacing): Sets a default spacing on all nested HTML elements.
 - [dnb-scrollbar-appearance](/uilib/helpers/classes#scrollbar-appearance): Defines the DNB scrollbar appearance.
 - [dnb-sr-only](/uilib/helpers/classes#screen-reader-sr-only): An element that is reachable by screen readers, but is visually hidden.
+- [dnb-page-background](/uilib/helpers/classes#page-background): Sets the themed page background color.
 - [dnb-drop-shadow](/uilib/helpers/classes#drop-shadow): Adds the default drop shadow to the component.
 - [dnb-sharp-drop-shadow](/uilib/helpers/classes#sharp-drop-shadow): Adds the sharp drop shadow to the component.
 - [dnb-responsive-component](/uilib/helpers/classes#responsive-component): Makes the component react to small sized screens.

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -8,6 +8,10 @@
       outline: inherit;
     }
   }
+
+  :global(.eufemia-theme) {
+    background-color: transparent;
+  }
 }
 
 .exampleBoxStyle {

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -69,3 +69,8 @@
   line-height: var(--line-height-basis);
   word-break: normal; // because of "kr" usage together with "stretch" on a input/textarea
 }
+
+.dnb-page-background {
+  // Ensure themed body has a token color for page backgrounds
+  background-color: var(--token-color-background-page-background);
+}

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -57,6 +57,9 @@
 
   .eufemia-theme {
     @include typographyBasis();
+
+    // Ensure themed body has a token color for background
+    background-color: var(--token-color-background-page-background);
   }
 
   @content;

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -57,9 +57,6 @@
 
   .eufemia-theme {
     @include typographyBasis();
-
-    // Ensure themed body has a token color for background
-    background-color: var(--token-color-background-page-background);
   }
 
   @content;


### PR DESCRIPTION
This change ensures that when a theme is used, the application gets a themed background color. This could be an issue for apps not having a white background. But I think we then rather should find a solution when a report gets filed.

The motivation is that a themed background anyway is needed when it comes to dark mode.