### PR TITLE
fix(Popover): clamp arrow at border-radius boundary to avoid rounded corner gap

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -679,6 +679,9 @@ function PopoverContainer(props: PopoverContainerProps) {
     const marginRight = computedElementStyle
       ? parseFloat(computedElementStyle.marginRight) || 0
       : 0
+    const borderRadius = computedElementStyle
+      ? parseFloat(computedElementStyle.borderRadius) || 0
+      : 0
 
     let actualLeft = nextLeft
 
@@ -706,7 +709,7 @@ function PopoverContainer(props: PopoverContainerProps) {
 
     if (isVerticalPlacement) {
       const arrowWidth = 16
-      const arrowBoundary = arrowEdgeOffset ?? 8
+      const arrowBoundary = Math.max(arrowEdgeOffset ?? 8, borderRadius)
       const maxLeft = Math.max(0, elementWidth - arrowWidth)
       const arrowLeft = anchorX - actualLeft - arrowWidth / 2
 
@@ -741,7 +744,7 @@ function PopoverContainer(props: PopoverContainerProps) {
       arrowStyle.left = nextArrowLeft
     } else {
       const arrowHeight = 16
-      const arrowBoundary = arrowEdgeOffset ?? 8
+      const arrowBoundary = Math.max(arrowEdgeOffset ?? 8, borderRadius)
       const maxTop = Math.max(0, elementHeight - arrowHeight)
       const arrowTop = anchorY - actualTop - arrowHeight / 2
 

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -2237,6 +2237,76 @@ describe('Popover', () => {
       targetElement.remove()
     })
 
+    it('clamps arrow at border-radius boundary when element has large border-radius', async () => {
+      const targetElement = document.createElement('div')
+      document.body.appendChild(targetElement)
+
+      const windowWidthDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        'innerWidth'
+      )
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 320,
+      })
+
+      Object.defineProperty(targetElement, 'offsetWidth', {
+        configurable: true,
+        value: 24,
+      })
+      Object.defineProperty(targetElement, 'offsetHeight', {
+        configurable: true,
+        value: 40,
+      })
+
+      assignRect(
+        targetElement,
+        createRect({ left: 10, top: 120, width: 24, height: 40 })
+      )
+
+      setElementSize(220, 120)
+
+      const originalGetComputedStyle = window.getComputedStyle
+      jest.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+        const style = originalGetComputedStyle(el)
+        if (
+          el instanceof HTMLElement &&
+          el.classList.contains('dnb-popover')
+        ) {
+          return {
+            ...style,
+            borderRadius: '16px',
+          } as CSSStyleDeclaration
+        }
+        return style
+      })
+
+      render(
+        <Popover
+          open
+          noAnimation
+          placement="bottom"
+          arrowEdgeOffset={4}
+          targetElement={targetElement}
+        >
+          Clamped at border-radius
+        </Popover>
+      )
+
+      await waitFor(() => {
+        const arrow = document.querySelector(
+          '.dnb-popover__arrow'
+        ) as HTMLElement
+        expect(arrow?.style.left).toBe('16px')
+      })
+
+      jest.restoreAllMocks()
+      if (windowWidthDescriptor) {
+        Object.defineProperty(window, 'innerWidth', windowWidthDescriptor)
+      }
+      targetElement.remove()
+    })
+
     it('flips to top placement when there is limited space below', async () => {
       const targetElement = document.createElement('div')
       document.body.appendChild(targetElement)


### PR DESCRIPTION
Deploy preview: https://fix-tooltip-arrow-edge-borde.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/Boolean/demos/#checkbox---with-help
Motivation:

<img width="170" height="128" alt="Screenshot 2026-04-24 at 13 21 29" src="https://github.com/user-attachments/assets/f9e551d0-0f40-48bf-a7d5-1e75775ad7e2" />

To:


![image](https://github.com/user-attachments/assets/5667664e-7963-4bb4-b5f1-92cb2a7f8652)

From:

![image](https://github.com/user-attachments/assets/7994e97a-92b0-405a-a635-3c32af45bdbc)

To:


![image](https://github.com/user-attachments/assets/b4fecd00-5da4-4bd3-ad93-d73f24ef1c09)


When a popover (e.g. Tooltip with border-radius 1rem) is clamped to a viewport edge, the arrow could land inside the rounded corner zone, creating a visible gap. Instead of changing arrowEdgeOffset globally (which also affects arrowPosition and edgeSpacing), read the element's computed border-radius and use it as a floor for the arrow boundary: Math.max(arrowEdgeOffset ?? 8, borderRadius). This preserves default behavior and only increases the boundary when needed.

