### PR TITLE
chore(Portal): normalize frontmatter theme to array format

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
@@ -102,7 +102,7 @@ Example: `/docs/components/button.mdx`
 title: 'Button'
 description: 'The Button component should be used as the primary call-to-action in a form, or as a user interaction mechanism.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live.mdx
@@ -4,7 +4,7 @@ description: 'AriaLive is a React component and hook that helps make your web ap
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import AriaLiveInfo from 'Docs/uilib/components/aria-live/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar.mdx
@@ -2,7 +2,7 @@
 title: 'Avatar'
 description: 'The Avatar component is an identifier that makes people and companies more scannable.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb.mdx
@@ -2,7 +2,7 @@
 title: 'Breadcrumb'
 description: 'The Breadcrumb component is a bar for navigation showing current web path.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import BreadcrumbInfo from 'Docs/uilib/components/breadcrumb/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox.mdx
@@ -2,7 +2,7 @@
 title: 'Checkbox'
 description: 'The Checkbox component is shown as a square box that is ticked (checked) when activated.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import CheckboxInfo from 'Docs/uilib/components/checkbox/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click.mdx
@@ -4,7 +4,7 @@ description: 'The CopyOnClick component allows users to copy text to their clipb
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import CopyOnClickInfo from 'Docs/uilib/components/copy-on-click/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag.mdx
@@ -9,7 +9,7 @@ tabs:
     key: /uilib/components/country-flag/demos
   - title: Properties
     key: /uilib/components/country-flag/properties
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import CountryFlagInfo from 'Docs/uilib/components/country-flag/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown.mdx
@@ -2,7 +2,7 @@
 title: 'Dropdown'
 description: 'The Dropdown component is a custom-made data selection component.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import DropdownInfo from 'Docs/uilib/components/dropdown/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label.mdx
@@ -4,7 +4,7 @@ description: 'The FormLabel component represents a caption for all sorts of HTML
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import FormLabelInfo from 'Docs/uilib/components/form-label/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments.mdx
@@ -2,7 +2,7 @@
 title: 'Fragments'
 description: 'Fragments are small, low-level and reusable parts used inside other components.'
 order: -1
-theme: 'sbanken'
+theme: ['sbanken']
 accordion: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/drawer-list.mdx
@@ -2,7 +2,7 @@
 title: 'DrawerList'
 description: 'The DrawerList component is a fragment inside other components.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import DrawerListInfo from 'Docs/uilib/components/fragments/drawer-list/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view.mdx
@@ -2,7 +2,7 @@
 title: 'ScrollView'
 description: 'ScrollView is a tiny helper component helping the user controlling overflowing content horizontally or vertically'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/text-counter.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/text-counter.mdx
@@ -2,7 +2,7 @@
 title: 'TextCounter'
 description: 'The TextCounter is a component designed to provide real-time character count feedback in text input fields.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading.mdx
@@ -4,7 +4,7 @@ description: 'The Heading component is a helper to create automated semantic hea
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import HeadingInfo from 'Docs/uilib/components/heading/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation.mdx
@@ -2,7 +2,7 @@
 title: 'HeightAnimation'
 description: 'HeightAnimation is a helper component to animate from 0 to height:auto powered by CSS.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import HeightAnimationInfo from 'Docs/uilib/components/height-animation/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card.mdx
@@ -2,7 +2,7 @@
 title: 'InfoCard'
 description: 'The InfoCard is used to give the user more information than a message box. It can also be used to give useful tips.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import InfoCardInfo from 'Docs/uilib/components/info-card/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list-format.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list-format.mdx
@@ -9,7 +9,7 @@ tabs:
     key: /uilib/components/list-format/demos
   - title: Properties
     key: /uilib/components/list-format/properties
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import ListFormatInfo from 'Docs/uilib/components/list-format/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list.mdx
@@ -12,7 +12,7 @@ tabs:
     key: '/properties'
   - title: Events
     key: '/events'
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import ListInfo from 'Docs/uilib/components/list/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo.mdx
@@ -4,7 +4,7 @@ description: 'A ready to use Logo component with the needed SVGs.'
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import LogoInfo from 'Docs/uilib/components/logo/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format.mdx
@@ -13,7 +13,7 @@ tabs:
     key: /uilib/components/number-format/provider
 redirect_from:
   - /uilib/components/number
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import NumberInfo from 'Docs/uilib/components/number-format/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination.mdx
@@ -2,7 +2,7 @@
 title: 'Pagination'
 description: 'The Pagination component supports both classical pagination and infinity scrolling.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 accordion: true
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller.mdx
@@ -2,7 +2,7 @@
 title: 'InfinityScroller'
 description: 'The InfinityScroller component is a mode of the Pagination component which loads content continuously as the user scrolls down the page.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator.mdx
@@ -4,7 +4,7 @@ description: 'The ProgressIndicator component is a waiting loader / spinner to s
 showTabs: true
 redirect_from:
   - /uilib/components/progress
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import ProgressIndicatorInfo from 'Docs/uilib/components/progress-indicator/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio.mdx
@@ -2,7 +2,7 @@
 title: 'Radio'
 description: 'The Radio component is shown as a circle that is filled (checked) when activated.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import RadioInfo from 'Docs/uilib/components/radio/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content.mdx
@@ -2,7 +2,7 @@
 title: 'SkipContent'
 description: 'SkipContent gives users – using their keyboard for navigation – the option to skip over content which contains a large amount of interactive elements.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider.mdx
@@ -2,7 +2,7 @@
 title: 'Slider'
 description: 'The Slider component provides a visual indication of adjustable value.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import SliderInfo from 'Docs/uilib/components/slider/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch.mdx
@@ -3,7 +3,7 @@ title: 'Switch'
 description: 'The Switch component (toggle) is a digital on/off switch.'
 
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import SwitchInfo from 'Docs/uilib/components/switch/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table.mdx
@@ -4,7 +4,7 @@ description: 'Enhanced HTML Table element.'
 showTabs: true
 redirect_from:
   - /uilib/elements/tables
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import TableInfo from 'Docs/uilib/components/table/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag.mdx
@@ -2,7 +2,7 @@
 title: 'Tag'
 description: 'The Tag component is a compact element for displaying discrete information.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import TagInfo from 'Docs/uilib/components/tag/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition.mdx
@@ -4,7 +4,7 @@ description: 'TermDefinition renders a compact, inline explanation for a word or
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 status: 'new'
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button.mdx
@@ -2,7 +2,7 @@
 title: 'ToggleButton'
 description: 'The ToggleButton component should be used to toggle on or off a limited number of choices.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import ToggleButtonInfo from 'Docs/uilib/components/toggle-button/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload.mdx
@@ -2,7 +2,7 @@
 title: 'Upload'
 description: 'The Upload component should be used in scenarios where the user has to upload files. Files can be uploaded by clicking a button. You also have the opportunity to add descriptive texts below the title where you could put max file size, allowed file formats etc.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import UploadInfo from 'Docs/uilib/components/upload/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden.mdx
@@ -4,7 +4,7 @@ description: 'VisuallyHidden has all the styles necessary to hide it from visual
 showTabs: true
 hideTabs:
   - title: Events
-theme: 'sbanken'
+theme: ['sbanken']
 ---
 
 import VisuallyHiddenInfo from 'Docs/uilib/components/visually-hidden/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/blockquote.mdx
@@ -2,7 +2,7 @@
 title: 'Blockquote'
 description: 'The blockquote element is used to indicate the quotation of a large section of text from another source.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 hideTabs:
   - title: Events
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/heading.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/heading.mdx
@@ -2,7 +2,7 @@
 title: 'Heading'
 description: 'The heading element is used to indicate the quotation of a large section of text from another source.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 redirect_from:
   - /uilib/typography/heading
 hideTabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/ArraySelection.mdx
@@ -3,7 +3,7 @@ title: 'Field.ArraySelection'
 description: '`Field.ArraySelection` is a component for selecting between a fixed set of options using checkboxes or similar, that will produce a value in the form of an array containing the values of selected options.'
 componentType: 'base-selection'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Boolean.mdx
@@ -3,7 +3,7 @@ title: 'Field.Boolean'
 description: '`Field.Boolean` is the base component for receiving user input where the target data is of type `boolean`.'
 componentType: 'base-toggle'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Composition.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Composition.mdx
@@ -3,7 +3,7 @@ title: 'Field.Composition'
 description: '`Field.Composition` is a component for when you create a field block that contains of several existing fields.'
 componentType: 'base-composition'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate.mdx
@@ -4,7 +4,7 @@ description: '`Field.Indeterminate` component is used to display and handle the 
 componentType: 'base-toggle'
 hideInMenu: true
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number.mdx
@@ -3,7 +3,7 @@ title: 'Field.Number'
 description: '`Field.Number` is the base component for receiving user input where the target data is of type `number`.'
 componentType: 'base-input'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Selection.mdx
@@ -3,7 +3,7 @@ title: 'Field.Selection'
 description: '`Field.Selection` is a wrapper component for selecting between options using a dropdown or similar user experiences.'
 componentType: 'base-selection'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String.mdx
@@ -3,7 +3,7 @@ title: 'Field.String'
 description: '`Field.String` is the base component for receiving user input where the target data is of type `string`.'
 componentType: 'base-input'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Toggle.mdx
@@ -3,7 +3,7 @@ title: 'Field.Toggle'
 description: '`Field.Toggle` is a base component for allowing the user to toggle between two different values in the target data point.'
 componentType: 'base-toggle'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Address.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Address.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Address'
 description: '`Field.Address` is a wrapper component for the input of strings, with user experience tailored for postal and street addresses.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/BankAccountNumber.mdx
@@ -2,7 +2,7 @@
 title: 'Field.BankAccountNumber'
 description: '`Field.BankAccountNumber` is a wrapper component for the input of strings, with user experience tailored for bank account number values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Currency.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Currency'
 description: '`Field.Currency` is a wrapper component for the input of numbers, with user experience tailored for currency values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Date.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Date'
 description: '`Field.Date` is a wrapper component for the input of strings, with user experience tailored for date values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth.mdx
@@ -2,7 +2,7 @@
 title: 'Field.DateOfBirth'
 description: '`Field.DateOfBirth` is a wrapper component for the input of strings, with user experience tailored for date of birth values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 status: 'new'
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Email.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Email'
 description: '`Field.Email` is a wrapper component for the input of strings, with user experience tailored for email values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Expiry'
 description: '`Field.Expiry` is a wrapper component for the input of strings, with user experience tailored for expiry dates for payment cards.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Name.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Name'
 description: '`Field.Name` is a wrapper component for the input of strings, with user experience tailored for first name, last name and company names.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber.mdx
@@ -2,7 +2,7 @@
 title: 'Field.NationalIdentityNumber'
 description: '`Field.NationalIdentityNumber` is a wrapper component for the input of strings, with user experience tailored for national identity number values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/OrganizationNumber.mdx
@@ -2,7 +2,7 @@
 title: 'Field.OrganizationNumber'
 description: '`Field.OrganizationNumber` is a wrapper component for the input of strings, with user experience tailored for organization number values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PhoneNumber.mdx
@@ -2,7 +2,7 @@
 title: 'Field.PhoneNumber'
 description: '`Field.PhoneNumber` is a wrapper component for the input of strings, with user experience tailored for phone number values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/PostalCodeAndCity.mdx
@@ -2,7 +2,7 @@
 title: 'Field.PostalCodeAndCity'
 description: '`Field.PostalCodeAndCity` is a wrapper component for input of two separate values with user experience tailored for postal code and city values.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCountry.mdx
@@ -2,7 +2,7 @@
 title: 'Field.SelectCountry'
 description: '`Field.SelectCountry` is a wrapper component for the selection component, with options built in for selecting a country.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/SelectCurrency.mdx
@@ -2,7 +2,7 @@
 title: 'Field.SelectCurrency'
 description: '`Field.SelectCurrency` is a wrapper component for the selection component, with options built in for selecting a currency.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Password.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Password.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Password'
 description: '`Field.Password` is a wrapper component for the input of strings, with user experience tailored for passwords.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Slider.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Slider.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Slider'
 description: '`Field.Slider` is a wrapper component for the Slider to make it easier to use inside a form.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/more-fields/Upload.mdx
@@ -2,7 +2,7 @@
 title: 'Field.Upload'
 description: '`Field.Upload` is a wrapper for the Upload component to make it easier to use inside a form.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Flex'
 description: 'To make it easier to build application layout and form-views in line with defined design sketches, there are a number of components for layout.'
-theme: 'sbanken'
+theme: ['sbanken']
 showTabs: true
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/grid.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/grid.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Grid'
 description: 'To make it easier to build responsive application layouts in line with defined design sketches, there are a number of components for layout.'
-theme: 'sbanken'
+theme: ['sbanken']
 showTabs: true
 tabs:
   - title: Info

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space.mdx
@@ -2,7 +2,7 @@
 title: 'Space'
 description: 'The Space component provides margins within the provided spacing patterns.'
 showTabs: true
-theme: 'sbanken'
+theme: ['sbanken']
 tabs:
   - title: Info
     key: /info

--- a/packages/dnb-design-system-portal/src/docs_dummy/dummy.mdx
+++ b/packages/dnb-design-system-portal/src/docs_dummy/dummy.mdx
@@ -7,7 +7,7 @@ status: 'wip'
 order: 1
 icon: 'bell'
 search: 'tag'
-theme: 'tag'
+theme: ['tag']
 componentType: 'tag'
 draft: false
 fullscreen: false


### PR DESCRIPTION
All MDX files now use theme: ['value'] instead of theme: 'value', resolving the Gatsby GraphQL type inference conflict warning.

