### PR TITLE
docs: add design tokens guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
@@ -76,7 +76,7 @@ Dark mode tokens are generated into a separate `tokens-dark.scss` file per theme
 
 ```
 // DNB theme
-import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode.scss'
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css'
 
 // Sbanken theme
 import '@dnb/eufemia/style/themes/sbanken/sbanken-theme-dark-mode.scss'

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -65,71 +65,32 @@ Use the `var()` function to reference a token in your CSS:
 When writing custom component styles, you can use design tokens with the `var(--token-*)` syntax. For example:
 
 ```scss
-.my-component {
+.my-component__title--warning {
   color: var(--token-color-text-warning);
 }
 ```
 
 ### Dark surfaces
 
-Use `surface="dark"` to tell Eufemia that an area has a dark background. Components inside that area will automatically pick the right colors. The `ondark` tokens are the color values they switch to.
+Use `surface="dark"` on the [Theme](/src/docs/uilib/usage/customisation/theming/theme/) component to tell Eufemia that an area has a dark background. Components inside that area will automatically pick the right colors. The `ondark` tokens are the color values they switch to.
 
 For example, a button that normally uses `--token-color-background-action-hover` will switch to `--token-color-background-action-hover-ondark` when `surface="dark"` is active.
 
 Read more about `ondark` tokens and how to use them in custom components in the [Design Tokens](/uilib/usage/customisation/theming/design-tokens/info/#ondark-tokens) section.
 
-#### How `surface` works
-
-The `surface` prop is passed through **React context**, not through a global CSS class. When you set `surface="dark"` on a `<Theme>`, `<Theme.Context>`, or on a supporting component like [Section](/uilib/components/section/), the value is stored in the Eufemia theme context. Individual components that support dark surfaces — such as [Button](/uilib/components/button/) or [Anchor](/uilib/components/anchor/) — read the surface value from context and apply their own component-level CSS class (e.g. `dnb-button--surface-dark`, `dnb-anchor--surface-dark`).
-
-Wrap an area with `<Theme.Context>` or `<Section>` to propagate the surface context to all supporting components inside:
-
-```jsx
-<Theme.Context surface="dark">
-  <Button>I adapt automatically</Button>
-  <Anchor href="/path">So do I</Anchor>
-</Theme.Context>
-```
-
-Use `surface="initial"` to reset components back to their default behavior inside a dark surface context:
-
-```jsx
-<Section surface="dark">
-  <Button>Dark surface button</Button>
-  <Theme.Context surface="initial">
-    <Button>Default surface button</Button>
-  </Theme.Context>
-</Section>
-```
-
-## Persisting the theme with `getTheme` and `setTheme`
-
-Eufemia provides `getTheme` and `setTheme` helpers that persist theme state (including `colorScheme`) to `localStorage` under the key `eufemia-theme`.
-
-```tsx
-import { getTheme, setTheme } from '@dnb/eufemia/shared/Theme'
-
-// Read the current persisted theme
-const theme = getTheme()
-// { name: 'ui', colorScheme: 'auto', ... }
-
-// Update one or more properties (merges with existing state)
-setTheme({ colorScheme: 'dark' })
-
-// With a callback
-setTheme({ name: 'sbanken' }, (updatedTheme) => {
-  console.log(updatedTheme)
-})
-```
-
-`getTheme` also supports a `?eufemia-theme=<name>` URL query parameter, which overrides the persisted theme name. This is useful for testing or previewing themes via a link.
+Read more about the [surface](/uilib/usage/customisation/theming/theme/) property.
 
 ## Dark mode / Color scheme
 
-The [Theme](/src/docs/uilib/usage/customisation/theming/theme/) component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
+Use the `colorScheme` prop on the [Theme](/src/docs/uilib/usage/customisation/theming/theme/) component to control dark and light mode. When set to `"auto"`, it follows the user's system preference.
+
+Dark mode tokens are not included in the default theme import. You need to import them separately:
 
 ```tsx
 import { Theme } from '@dnb/eufemia/shared'
+
+// Required: import dark mode tokens
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css' // If style isolation is used
 
 render(
   <Theme colorScheme="auto">
@@ -138,35 +99,6 @@ render(
 )
 ```
 
-### Preventing dark mode flash (FOUC)
+When the `eufemia-theme__color-scheme--dark` class is active, the dark tokens override the same CSS custom property names with dark-appropriate values. For example, `--token-color-background-page-background` switches from `--dnb-greyscale-0` (white) to `--dnb-greyscale-1000` (dark).
 
-When using `colorScheme="system"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
-
-To prevent this, Eufemia provides blocking scripts that run synchronously before the browser paints. They read the stored preference from `localStorage` and apply the correct CSS classes immediately.
-
-```tsx
-import {
-  ColorSchemeHeadScript,
-  ColorSchemeBodyFirstScript,
-  ColorSchemeBodyLastScript,
-} from '@dnb/eufemia/shared/ColorSchemeScript'
-```
-
-Place them in your HTML template as follows:
-
-```tsx
-<html>
-  <head>
-    <ColorSchemeHeadScript />
-  </head>
-  <body>
-    <ColorSchemeBodyFirstScript />
-    {/* your app content */}
-    <ColorSchemeBodyLastScript />
-  </body>
-</html>
-```
-
-- **`ColorSchemeHeadScript`** — Resolves the color scheme from `localStorage` (or falls back to the system preference) and stores it on `globalThis`. Place in `<head>`.
-- **`ColorSchemeBodyFirstScript`** — Adds the resolved color-scheme class to `<body>`. Place as the first child of `<body>`.
-- **`ColorSchemeBodyLastScript`** — Swaps color-scheme classes on server-rendered `Theme` elements so they match the resolved scheme. Place as the last child of `<body>`.
+Read more about the [colorScheme](/uilib/usage/customisation/theming/theme/) property, including [preventing dark mode flash (FOUC)](/uilib/usage/customisation/theming/theme/#preventing-dark-mode-flash-fouc) for SSR considerations.

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -124,9 +124,23 @@ setTheme({ name: 'sbanken' }, (updatedTheme) => {
 
 `getTheme` also supports a `?eufemia-theme=<name>` URL query parameter, which overrides the persisted theme name. This is useful for testing or previewing themes via a link.
 
-## Preventing dark mode flash (FOUC)
+## Dark mode / Color scheme
 
-When using `colorScheme="auto"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
+The [Theme](/src/docs/uilib/usage/customisation/theming/theme/) component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme colorScheme="auto">
+    <App />
+  </Theme>
+)
+```
+
+### Preventing dark mode flash (FOUC)
+
+When using `colorScheme="system"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
 
 To prevent this, Eufemia provides blocking scripts that run synchronously before the browser paints. They read the stored preference from `localStorage` and apply the correct CSS classes immediately.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -124,21 +124,7 @@ setTheme({ name: 'sbanken' }, (updatedTheme) => {
 
 `getTheme` also supports a `?eufemia-theme=<name>` URL query parameter, which overrides the persisted theme name. This is useful for testing or previewing themes via a link.
 
-## Dark mode / Color scheme
-
-The `Theme` component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
-
-```tsx
-import { Theme } from '@dnb/eufemia/shared'
-
-render(
-  <Theme colorScheme="auto">
-    <App />
-  </Theme>
-)
-```
-
-### Preventing dark mode flash (FOUC)
+## Preventing dark mode flash (FOUC)
 
 When using `colorScheme="auto"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens.mdx
@@ -6,6 +6,8 @@ showTabs: true
 tabs:
   - title: Info
     key: /info
+  - title: Guide
+    key: /guide
   - title: Colors
     key: /colors
   - title: Radius

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/guide.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/guide.mdx
@@ -1,0 +1,263 @@
+---
+showTabs: true
+---
+
+## Guide contents
+
+- [Guide contents](#guide-contents)
+- [Choosing the right token](#choosing-the-right-token)
+- [Token selection by role](#token-selection-by-role)
+- [Token selection by state](#token-selection-by-state)
+  - [Interaction states](#interaction-states)
+  - [Status states](#status-states)
+  - [Modifiers](#modifiers)
+- [Practical examples](#practical-examples)
+  - [Custom action card](#custom-action-card)
+  - [Status banner](#status-banner)
+  - [Input-like field](#input-like-field)
+- [Patterns learned from Eufemia components](#patterns-learned-from-eufemia-components)
+  - [Use local CSS variables to simplify state handling](#use-local-css-variables-to-simplify-state-handling)
+  - [Use semantic tokens, not component tokens](#use-semantic-tokens-not-component-tokens)
+  - [Focus uses the shared action-focus tokens](#focus-uses-the-shared-action-focus-tokens)
+  - [Use decorative tokens only for decoration](#use-decorative-tokens-only-for-decoration)
+  - [Dark surfaces use `ondark` tokens](#dark-surfaces-use-ondark-tokens)
+- [Decision checklist](#decision-checklist)
+- [Common mistakes](#common-mistakes)
+
+## Choosing the right token
+
+When building application components with Eufemia design tokens, think semantically. Do not ask "which token has the same color value as the one I want?" Ask "what role does this color play in this component and state?"
+
+All Eufemia components already use design tokens. Their stylesheets are the best reference for how to apply tokens correctly. When you are unsure which token to use, inspect the Eufemia component that is closest to what you are building.
+
+## Token selection by role
+
+Every color in a component has a semantic role. Identify the role first, then pick the matching token section.
+
+| Role                 | Token section | Example                                      |
+| -------------------- | ------------- | -------------------------------------------- |
+| Readable text        | `text`        | `--token-color-text-neutral`                 |
+| Icon                 | `icon`        | `--token-color-icon-action`                  |
+| Background / fill    | `background`  | `--token-color-background-action`            |
+| Border / outline     | `stroke`      | `--token-color-stroke-action`                |
+| Focus ring           | `stroke`      | `--token-color-stroke-action-focus`          |
+| Branded / decorative | `decorative`  | `--token-color-decorative-first-bold-static` |
+
+## Token selection by state
+
+After the role, identify the interaction or status state. Tokens encode states as suffixes.
+
+### Interaction states
+
+| State    | Suffix example | When to use                         |
+| -------- | -------------- | ----------------------------------- |
+| Default  | (no suffix)    | Resting state                       |
+| Hover    | `-hover`       | Pointer over an interactive element |
+| Pressed  | `-pressed`     | Mouse down or touch active          |
+| Focus    | `-focus`       | Keyboard focus ring and background  |
+| Disabled | `-disabled`    | Non-interactive, visually muted     |
+| Selected | `-selected`    | Currently chosen item in a group    |
+
+### Status states
+
+| Status      | Suffix example | When to use                      |
+| ----------- | -------------- | -------------------------------- |
+| Error       | `-error`       | Validation failure               |
+| Destructive | `-destructive` | Dangerous or irreversible action |
+| Positive    | `-positive`    | Success or upward trend          |
+| Warning     | `-warning`     | Caution, needs attention         |
+| Information | `-info`        | Neutral informational notice     |
+
+### Modifiers
+
+| Modifier   | Meaning                                           |
+| ---------- | ------------------------------------------------- |
+| `-subtle`  | Lower-contrast variant, typically for backgrounds |
+| `-inverse` | For use on a filled action surface                |
+| `-ondark`  | For use on a dark surface                         |
+| `-static`  | Does not change with light/dark mode              |
+
+## Practical examples
+
+### Custom action card
+
+```scss
+.my-action-card {
+  background-color: var(--token-color-background-neutral);
+  color: var(--token-color-text-neutral);
+  box-shadow: inset 0 0 0 0.0625rem
+    var(--token-color-stroke-neutral-subtle);
+
+  &:hover {
+    box-shadow: 0 0 0 0.125rem var(--token-color-stroke-action-hover);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 var(--focus-ring-width)
+      var(--token-color-stroke-action-focus);
+    outline: none;
+  }
+
+  &--selected {
+    background-color: var(--token-color-background-selected-subtle);
+    box-shadow: inset 0 0 0 0.0625rem var(--token-color-stroke-selected);
+  }
+
+  &--disabled {
+    color: var(--token-color-text-action-disabled);
+    box-shadow: inset 0 0 0 0.0625rem
+      var(--token-color-stroke-action-disabled);
+  }
+}
+```
+
+### Status banner
+
+```scss
+.my-banner {
+  &--error {
+    background-color: var(--token-color-background-error-subtle);
+    color: var(--token-color-text-neutral);
+  }
+
+  &--warning {
+    background-color: var(--token-color-background-warning-subtle);
+    color: var(--token-color-text-neutral);
+  }
+
+  &--success {
+    background-color: var(--token-color-background-positive-subtle);
+    color: var(--token-color-text-neutral);
+  }
+}
+```
+
+### Input-like field
+
+```scss
+.my-field {
+  --field-border-color: var(--token-color-stroke-action);
+  --field-border-width: 0.0625rem;
+  --field-border-inset: inset;
+  --field-background: var(--token-color-background-neutral);
+  --field-text-color: var(--token-color-text-neutral);
+  --field-placeholder-color: var(--token-color-text-neutral-alternative);
+
+  color: var(--field-text-color);
+  background-color: var(--field-background);
+  box-shadow: var(--field-border-inset) 0 0 0 var(--field-border-width)
+    var(--field-border-color);
+
+  &::placeholder {
+    color: var(--field-placeholder-color);
+  }
+
+  &:hover {
+    --field-border-color: var(--token-color-stroke-action-hover);
+    --field-border-width: 0.125rem;
+    --field-border-inset: ;
+  }
+
+  &:focus {
+    --field-border-color: var(--token-color-stroke-action-pressed);
+    --field-border-width: 0.125rem;
+    --field-border-inset: ;
+  }
+
+  &--error {
+    --field-border-color: var(--token-color-stroke-error);
+  }
+
+  &[disabled] {
+    --field-border-color: var(--token-color-stroke-action-disabled);
+    --field-background: var(--token-color-background-neutral-subtle);
+    --field-placeholder-color: var(--token-color-text-action-disabled);
+  }
+}
+```
+
+## Patterns learned from Eufemia components
+
+Eufemia components already follow these patterns consistently. Use them as a reference when building your own.
+
+### Use local CSS variables to simplify state handling
+
+When multiple child elements need to react to the same state, define a local CSS variable on the parent and point it at the right token for each state. This is cleaner than repeating tokens across many selectors.
+
+Eufemia's Input component does this: it defines `--input-border-color`, `--input-background-color`, and `--input-color-text` at the component root and swaps token values for hover, focus, disabled, and error.
+
+Eufemia's Button component does the same with `--button-color-bg`, `--button-color-text`, and `--button-color-icon`, then each variant (primary, secondary, tertiary) reassigns those variables to different tokens.
+
+### Use semantic tokens, not component tokens
+
+The `--token-color-component-*` tokens are reserved for Eufemia's own components. Application code should use the semantic tokens from the `background`, `text`, `icon`, `stroke`, and `decorative` sections.
+
+Semantic tokens express shared design-system meanings such as "action text" or "neutral background". They adapt automatically across themes.
+
+### Focus uses the shared action-focus tokens
+
+For keyboard focus styling, use the action-focus family:
+
+- `--token-color-stroke-action-focus` for the focus ring
+- `--token-color-background-action-focus-subtle` for the focus background
+- `--token-color-text-action-focus` for text inside a focused element
+- `--token-color-icon-action-focus` for icons inside a focused element
+
+Every interactive Eufemia component — Button, Input, Tag, Menu, Tabs, List — uses these same tokens for focus. Your custom components should follow the same pattern.
+
+### Use decorative tokens only for decoration
+
+Decorative tokens are for branded or ornamental surfaces, not for UI states. If the color represents an error, a hover, or a selection, use the matching semantic token instead.
+
+### Dark surfaces use `ondark` tokens
+
+The `ondark` suffix identifies token variants designed for use on dark backgrounds. Eufemia components use these tokens automatically when `surface="dark"` is active — you do not need to select them yourself.
+
+When your component sits on a dark background, use the `ondark` suffixed tokens for text, icons, and strokes:
+
+```scss
+.my-component--dark {
+  color: var(--token-color-text-action-ondark);
+  border-color: var(--token-color-stroke-action-ondark);
+
+  .my-component__icon {
+    color: var(--token-color-icon-action-ondark);
+  }
+}
+```
+
+To detect the surface in React, use the `useTheme` hook:
+
+```tsx
+import { useTheme } from '@dnb/eufemia/shared'
+
+function MyComponent() {
+  const theme = useTheme()
+  const isDark = theme?.surface === 'dark'
+
+  return (
+    <div className={clsx('my-component', isDark && 'my-component--dark')}>
+      ...
+    </div>
+  )
+}
+```
+
+## Decision checklist
+
+When styling a custom component:
+
+1. What is the role of this color? (text, icon, background, stroke, decorative)
+1. What state is it in? (default, hover, focus, pressed, disabled, selected, error, etc.)
+1. Does an Eufemia component with similar behavior already exist? If yes, check which tokens it uses.
+1. Use the semantic token that matches both role and state.
+1. If multiple children share a state, introduce a local CSS variable.
+1. Never pick a token by matching hex values. Pick by semantic meaning.
+
+## Common mistakes
+
+- Picking a token because its current color value matches an old hardcoded color.
+- Using `--token-color-component-*` tokens in application code — these are internal to Eufemia components.
+- Using decorative tokens for UI states like error, hover, or disabled.
+- Hardcoding `ondark` tokens without checking the surface context.
+- Repeating the same token in many selectors instead of using a local CSS variable.

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
@@ -28,6 +28,8 @@ Design tokens are included when you import a Eufemia theme. No separate import i
 
 Read more about how to use design tokens in your own styles, and how Eufemia components use them internally, in the [Theming](/uilib/usage/customisation/theming#design-tokens) section.
 
+For practical guidance on choosing the right tokens for your application components, see the [Guide](/uilib/usage/customisation/theming/design-tokens/guide).
+
 ## Common patterns
 
 These examples show how to apply design tokens in typical UI scenarios. Each pattern uses semantic token names so the styles adapt automatically to themes and surfaces.
@@ -103,22 +105,7 @@ And the component internally moves that value to a token-based custom property, 
 
 The `ondark` suffix identifies token variants designed for use on dark backgrounds. Eufemia components use these tokens automatically when `surface="dark"` is active — you do not need to select them yourself.
 
-When building **custom components** that need to respond to dark surfaces, read the surface value from context with the `useTheme` hook and switch tokens accordingly:
-
-```tsx
-import { useTheme } from '@dnb/eufemia/shared'
-
-function MyComponent() {
-  const theme = useTheme()
-  const isDark = theme?.surface === 'dark'
-
-  return (
-    <div className={clsx('my-component', isDark && 'my-component--dark')}>
-      ...
-    </div>
-  )
-}
-```
+For practical guidance on using `ondark` tokens in your own components, see the [Guide](/uilib/usage/customisation/theming/design-tokens/guide#dark-surfaces-use-ondark-tokens).
 
 ## Tailwind CSS integration
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Theme'
+title: 'Theme component'
 description: 'The Theme component is a helper component that lets you create nested theming solutions.'
 showTabs: true
 tabs:

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -87,43 +87,6 @@ render(
 )
 ```
 
-#### `colorScheme` property (Dark mode)
-
-The `Theme` component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
-
-```tsx
-import { Theme } from '@dnb/eufemia/shared'
-
-render(
-  <Theme colorScheme="auto">
-    <App />
-  </Theme>
-)
-```
-
-Read more about [Preventing dark mode flash (FOUC)](/uilib/usage/customisation/theming/#preventing-dark-mode-flash-fouc) for SSR considerations.
-
-#### `surface` property
-
-The `surface` property can be used to adjust the component's appearance based on the background. It accepts three values: `dark`, `light`, and `initial`.
-
-- Use `dark` when the content is placed on a dark surface.
-- Use `light` for light surfaces.
-- Use `initial` to tell the components to use its default behavior.
-
-```tsx
-import { Theme } from '@dnb/eufemia/shared'
-
-render(
-  <Section surface="dark">
-    Children will use the dark surface behavior (ondark).
-    <Theme.Context surface="initial">
-      Children will use their default surface behavior
-    </Theme.Context>
-  </Section>
-)
-```
-
 ### Use your component as the wrapper element
 
 You can provide your component as the wrapper. This way no additional HTML Element will be created.
@@ -145,6 +108,122 @@ render(
   </Theme>
 )
 ```
+
+## `surface` property
+
+The `surface` property can be used to adjust the component's appearance based on the background. It accepts three values: `dark`, `light`, and `initial`.
+
+- Use `dark` when the content is placed on a dark surface.
+- Use `light` for light surfaces.
+- Use `initial` to tell the components to use its default behavior.
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Section surface="dark">
+    Children will use the dark surface behavior (ondark).
+    <Theme.Context surface="initial">
+      Children will use their default surface behavior
+    </Theme.Context>
+  </Section>
+)
+```
+
+### How `surface` works
+
+The `surface` prop is passed through **React context**, not through a global CSS class. When you set `surface="dark"` on a `<Theme>`, `<Theme.Context>`, or on a supporting component like [Section](/uilib/components/section/), the value is stored in the Eufemia theme context. Individual components that support dark surfaces — such as [Button](/uilib/components/button/) or [Anchor](/uilib/components/anchor/) — read the surface value from context and apply their own component-level CSS class (e.g. `dnb-button--surface-dark`, `dnb-anchor--surface-dark`).
+
+Wrap an area with `<Theme.Context>` or `<Section>` to propagate the surface context to all supporting components inside:
+
+```jsx
+<Theme.Context surface="dark">
+  <Button>I adapt automatically</Button>
+  <Anchor href="/path">So do I</Anchor>
+</Theme.Context>
+```
+
+Use `surface="initial"` to reset components back to their default behavior inside a dark surface context:
+
+```jsx
+<Section surface="dark">
+  <Button>Dark surface button</Button>
+  <Theme.Context surface="initial">
+    <Button>Default surface button</Button>
+  </Theme.Context>
+</Section>
+```
+
+## The `colorScheme` property (Dark mode)
+
+The `Theme` component accepts a `colorScheme` prop that controls dark and light mode.
+
+When set to `"auto"`, it follows the user's system color scheme preference unless overridden by a parent theme or application setting.
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme colorScheme="auto">
+    <App />
+  </Theme>
+)
+```
+
+## Persisting the theme with `getTheme` and `setTheme`
+
+Eufemia provides `getTheme` and `setTheme` helpers that persist theme state (including `colorScheme`) to `localStorage` under the key `eufemia-theme`.
+
+```tsx
+import { getTheme, setTheme } from '@dnb/eufemia/shared/Theme'
+
+// Read the current persisted theme
+const theme = getTheme()
+// { name: 'ui', colorScheme: 'auto', ... }
+
+// Update one or more properties (merges with existing state)
+setTheme({ colorScheme: 'dark' })
+
+// With a callback
+setTheme({ name: 'sbanken' }, (updatedTheme) => {
+  console.log(updatedTheme)
+})
+```
+
+`getTheme` also supports a `?eufemia-theme=<name>` URL query parameter, which overrides the persisted theme name. This is useful for testing or previewing themes via a link.
+
+### Preventing dark mode flash (FOUC)
+
+When using `colorScheme="system"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
+
+To prevent this, Eufemia provides blocking scripts that run synchronously before the browser paints. They read the stored preference from `localStorage` and apply the correct CSS classes immediately.
+
+```tsx
+import {
+  ColorSchemeHeadScript,
+  ColorSchemeBodyFirstScript,
+  ColorSchemeBodyLastScript,
+} from '@dnb/eufemia/shared/ColorSchemeScript'
+```
+
+Place them in your HTML template as follows:
+
+```tsx
+<html>
+  <head>
+    <ColorSchemeHeadScript />
+  </head>
+  <body>
+    <ColorSchemeBodyFirstScript />
+    {/* your app content */}
+    <ColorSchemeBodyLastScript />
+  </body>
+</html>
+```
+
+- **`ColorSchemeHeadScript`** — Resolves the color scheme from `localStorage` (or falls back to the system preference) and stores it on `globalThis`. Place in `<head>`.
+- **`ColorSchemeBodyFirstScript`** — Adds the resolved color-scheme class to `<body>`. Place as the first child of `<body>`.
+- **`ColorSchemeBodyLastScript`** — Swaps color-scheme classes on server-rendered `Theme` elements so they match the resolved scheme. Place as the last child of `<body>`.
 
 ### Hide or show parts of your component (filter)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -87,6 +87,22 @@ render(
 )
 ```
 
+#### `colorScheme` property (Dark mode)
+
+The `Theme` component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme colorScheme="auto">
+    <App />
+  </Theme>
+)
+```
+
+Read more about [Preventing dark mode flash (FOUC)](/uilib/usage/customisation/theming/#preventing-dark-mode-flash-fouc) for SSR considerations.
+
 #### `surface` property
 
 The `surface` property can be used to adjust the component's appearance based on the background. It accepts three values: `dark`, `light`, and `initial`.


### PR DESCRIPTION
The additional guide is kind of a summary of how tokens are used in Eufemia components.

Preview: https://docs-tokens-improvements.eufemia-e25.pages.dev/uilib/usage/customisation/theming/design-tokens/