### PR TITLE
chore(Portal): rename colorScheme 'auto' to 'system'

### DIFF
--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -109,7 +109,7 @@ function ThemeProvider({ children }) {
 
   return (
     <Theme
-      colorScheme={isCarnegie ? 'light' : isDev ? 'auto' : undefined}
+      colorScheme={isCarnegie ? 'light' : isDev ? 'system' : undefined}
       {...theme}
     >
       {children}

--- a/packages/dnb-design-system-portal/src/core/ToggleDarkMode.tsx
+++ b/packages/dnb-design-system-portal/src/core/ToggleDarkMode.tsx
@@ -7,7 +7,7 @@ import { setTheme } from 'gatsby-plugin-eufemia-theme-handler'
 export default function ToggleDarkMode(props) {
   const { disabled, ...rest } = props
   const [colorScheme, updateColorScheme] = React.useState(
-    () => getTheme().colorScheme || 'auto'
+    () => getTheme().colorScheme || 'system'
   )
 
   return (
@@ -22,7 +22,7 @@ export default function ToggleDarkMode(props) {
       }}
       {...rest}
     >
-      <ToggleButton value="auto">Auto</ToggleButton>
+      <ToggleButton value="system">System</ToggleButton>
       <ToggleButton value="dark">Dark</ToggleButton>
       <ToggleButton value="light">Light</ToggleButton>
     </ToggleButton.Group>

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -821,7 +821,7 @@ The `propMapping` prop has been removed from the `Theme` component. If you relie
 
 ### Theme `darkMode` → `colorScheme`
 
-The `darkMode` prop on the `Theme` component has been replaced with `colorScheme`, which accepts `'auto'`, `'light'`, or `'dark'`. The CSS class `eufemia-theme__dark-mode` has been renamed to `eufemia-theme__color-scheme--dark` (or `--light`).
+The `darkMode` prop on the `Theme` component has been replaced with `colorScheme`, which accepts `'system'`, `'light'`, or `'dark'`. The CSS class `eufemia-theme__dark-mode` has been renamed to `eufemia-theme__color-scheme--dark` (or `--light`).
 
 **Before:**
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -111,7 +111,7 @@ import { getTheme, setTheme } from '@dnb/eufemia/shared/Theme'
 
 // Read the current persisted theme
 const theme = getTheme()
-// { name: 'ui', colorScheme: 'auto', ... }
+// { name: 'ui', colorScheme: 'system', ... }
 
 // Update one or more properties (merges with existing state)
 setTheme({ colorScheme: 'dark' })
@@ -126,13 +126,13 @@ setTheme({ name: 'sbanken' }, (updatedTheme) => {
 
 ## Dark mode / Color scheme
 
-The `Theme` component accepts a `colorScheme` prop that controls dark and light mode. When set to `"auto"`, it follows the user's system preference.
+The `Theme` component accepts a `colorScheme` prop that controls dark and light mode. When set to `"system"`, it follows the user's system preference.
 
 ```tsx
 import { Theme } from '@dnb/eufemia/shared'
 
 render(
-  <Theme colorScheme="auto">
+  <Theme colorScheme="system">
     <App />
   </Theme>
 )
@@ -140,7 +140,7 @@ render(
 
 ### Preventing dark mode flash (FOUC)
 
-When using `colorScheme="auto"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
+When using `colorScheme="system"`, the resolved color scheme depends on the user's system preference, which is only available in the browser. During server-side rendering (SSR), this can cause a brief flash of the wrong color scheme before React hydrates.
 
 To prevent this, Eufemia provides blocking scripts that run synchronously before the browser paints. They read the stored preference from `localStorage` and apply the correct CSS classes immediately.
 

--- a/packages/dnb-eufemia/src/shared/ColorSchemeScript.tsx
+++ b/packages/dnb-eufemia/src/shared/ColorSchemeScript.tsx
@@ -36,7 +36,7 @@ const CLASS_PREFIX = 'eufemia-theme__color-scheme--'
  * Place this in <head>.
  */
 export function getHeadScript(scopeHash: string = getStyleScopeHash()) {
-  return `(function(){try{var t=JSON.parse(localStorage.getItem('${STORAGE_KEY}')||'{}');var s=t.colorScheme;if(s==='auto'||!s){s=matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.classList.add('${scopeHash}');if(s){globalThis.${GLOBAL_KEY}=s}}catch(e){}})()`
+  return `(function(){try{var t=JSON.parse(localStorage.getItem('${STORAGE_KEY}')||'{}');var s=t.colorScheme;if(s==='system'||!s){s=matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.classList.add('${scopeHash}');if(s){globalThis.${GLOBAL_KEY}=s}}catch(e){}})()`
 }
 
 /**

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -18,9 +18,9 @@ export type ThemeVariants = string
 export type ThemeSizes = 'basis'
 export type ContrastMode = boolean
 /**
- * Controls the color scheme. Use `'dark'` or `'light'` to set explicitly, or `'auto'` to follow the user's system preference. Defaults to `undefined`.
+ * Controls the color scheme. Use `'dark'` or `'light'` to set explicitly, or `'system'` to follow the user's system preference. Defaults to `undefined`.
  */
-export type ThemeColorScheme = 'auto' | 'light' | 'dark'
+export type ThemeColorScheme = 'system' | 'light' | 'dark'
 /**
  * Adjusts component appearance based on background. Defaults to `undefined`.
  * Use `'initial'` to reset to the component's default behavior, ignoring any parent surface context.
@@ -56,11 +56,11 @@ export default function Theme(themeProps: ThemeAllProps) {
 
   const prefersDarkColorScheme = useMediaQuery({
     query: '(prefers-color-scheme: dark)',
-    disabled: colorScheme !== 'auto',
+    disabled: colorScheme !== 'system',
   })
 
   const activeColorScheme =
-    colorScheme === 'auto'
+    colorScheme === 'system'
       ? globalThis.__eufemiaColorScheme ||
         (prefersDarkColorScheme ? 'dark' : 'light')
       : colorScheme

--- a/packages/dnb-eufemia/src/shared/__tests__/ColorSchemeScript.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/ColorSchemeScript.test.tsx
@@ -95,7 +95,7 @@ describe('ColorSchemeScript', () => {
     it('head script resolves auto via matchMedia', () => {
       const storageMock = jest
         .spyOn(Storage.prototype, 'getItem')
-        .mockReturnValue(JSON.stringify({ colorScheme: 'auto' }))
+        .mockReturnValue(JSON.stringify({ colorScheme: 'system' }))
 
       const matchMediaOriginal = window.matchMedia
       window.matchMedia = jest.fn().mockReturnValue({ matches: true })

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -96,7 +96,7 @@ describe('Theme', () => {
     ])
   })
 
-  it('sets colorScheme="auto" as HTML class', () => {
+  it('sets colorScheme="system" as HTML class', () => {
     const matchMediaOriginal = window.matchMedia
     window.matchMedia = jest.fn().mockImplementation((query) => ({
       media: query,
@@ -105,7 +105,7 @@ describe('Theme', () => {
       removeEventListener: jest.fn(),
     }))
 
-    render(<Theme colorScheme="auto">content</Theme>)
+    render(<Theme colorScheme="system">content</Theme>)
 
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual([
@@ -116,7 +116,7 @@ describe('Theme', () => {
     window.matchMedia = matchMediaOriginal
   })
 
-  it('sets colorScheme="auto" and resolves dark mode via matchMedia', () => {
+  it('sets colorScheme="system" and resolves dark mode via matchMedia', () => {
     const matchMediaOriginal = window.matchMedia
     window.matchMedia = jest.fn().mockImplementation((query) => ({
       media: query,
@@ -125,7 +125,7 @@ describe('Theme', () => {
       removeEventListener: jest.fn(),
     }))
 
-    render(<Theme colorScheme="auto">content</Theme>)
+    render(<Theme colorScheme="system">content</Theme>)
 
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual([
@@ -136,7 +136,7 @@ describe('Theme', () => {
     window.matchMedia = matchMediaOriginal
   })
 
-  it('updates colorScheme="auto" when system preference changes', () => {
+  it('updates colorScheme="system" when system preference changes', () => {
     const matchMediaOriginal = window.matchMedia
     let listener: (event: { matches: boolean }) => void = null
     let matches = false
@@ -154,7 +154,7 @@ describe('Theme', () => {
       removeEventListener: jest.fn(),
     }))
 
-    render(<Theme colorScheme="auto">content</Theme>)
+    render(<Theme colorScheme="system">content</Theme>)
 
     const element = document.querySelector('.eufemia-theme')
     expect(Array.from(element.classList)).toEqual([
@@ -541,7 +541,7 @@ describe('Portals', () => {
         removeEventListener: jest.fn(),
       }))
 
-      render(<Theme colorScheme="auto">content</Theme>)
+      render(<Theme colorScheme="system">content</Theme>)
 
       const element = document.querySelector('.eufemia-theme')
       expect(
@@ -562,7 +562,7 @@ describe('Portals', () => {
         removeEventListener: jest.fn(),
       }))
 
-      render(<Theme colorScheme="auto">content</Theme>)
+      render(<Theme colorScheme="system">content</Theme>)
 
       expect(globalThis.__eufemiaColorScheme).toBeUndefined()
 

--- a/packages/dnb-eufemia/src/style/themes/sbanken/sbanken-theme-dark-mode.scss
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/sbanken-theme-dark-mode.scss
@@ -2,7 +2,7 @@
  * Sbanken Theme – Dark Mode
  *
  * Import this file to enable dark mode token overrides for the Sbanken theme.
- * Use with the Theme component's colorScheme="dark" or colorScheme="auto".
+ * Use with the Theme component's colorScheme="dark" or colorScheme="system".
  */
 
 @use './tokens-dark.scss';

--- a/packages/dnb-eufemia/src/style/themes/ui/ui-theme-dark-mode.scss
+++ b/packages/dnb-eufemia/src/style/themes/ui/ui-theme-dark-mode.scss
@@ -2,7 +2,7 @@
  * DNB Eufemia UI Theme – Dark Mode
  *
  * Import this file to enable dark mode token overrides for the UI theme.
- * Use with the Theme component's colorScheme="dark" or colorScheme="auto".
+ * Use with the Theme component's colorScheme="dark" or colorScheme="system".
  */
 
 @use './tokens-dark.scss';


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/7742#discussion_r3142505266

Rename the ThemeColorScheme value from 'auto' to 'system' across the codebase to better communicate that it follows the OS preference.

Updates type definition, runtime logic, FOUC-prevention script, portal toggle button, tests, documentation, and SCSS comments.

