### PR TITLE
chore: use InlineImg component for font-size screenshot in accessibility intro

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/03-accessibility.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/03-accessibility.mdx
@@ -6,6 +6,8 @@ search: 'Intro - Accessibility'
 import Intro, {
   IntroFooter,
 } from 'dnb-design-system-portal/src/shared/tags/Intro'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import FontSizeScreenshot from 'Docs/uilib/intro/assets/dnb-screenshot-about-font-size.png'
 
 <Intro>
 
@@ -56,7 +58,11 @@ And all form components includes the [FormStatus](/uilib/components/form-status)
 
 ---
 
-![How it not should be](./assets/dnb-screenshot-about-font-size.png)
+<InlineImg
+  src={FontSizeScreenshot}
+  caption="How it not should be"
+  width="auto"
+/>
 
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/03-accessibility.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/03-accessibility.mdx
@@ -62,6 +62,7 @@ And all form components includes the [FormStatus](/uilib/components/form-status)
   src={FontSizeScreenshot}
   caption="How it not should be"
   width="auto"
+  className="blank x-10"
 />
 
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/04-ux-handover.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/04-ux-handover.mdx
@@ -6,6 +6,11 @@ search: 'Intro - UX handover'
 import Intro, {
   IntroFooter,
 } from 'dnb-design-system-portal/src/shared/tags/Intro'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import UxHandoverSpacing from 'Docs/uilib/intro/assets/ux-handover-spacing.png'
+import UxHandoverComponent from 'Docs/uilib/intro/assets/ux-handover-component.png'
+import UxHandoverTypography from 'Docs/uilib/intro/assets/ux-handover-typography.png'
+import UxHandoverColor from 'Docs/uilib/intro/assets/ux-handover-color.png'
 
 <Intro>
 
@@ -22,28 +27,44 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
 1. Select an area by a single _click_.
 2. _Hover_ on the next areas to see the spacing between them.
 
-![What spacing is used](./assets/ux-handover-spacing.png)
+<InlineImg
+  src={UxHandoverSpacing}
+  caption="What spacing is used"
+  width="auto"
+/>
 
 ## Components
 
 1. Select a component by a single _click_.
 2. Have a look at the _Pages_ pane on the left side.
 
-![What component is used](./assets/ux-handover-component.png)
+<InlineImg
+  src={UxHandoverComponent}
+  caption="What component is used"
+  width="auto"
+/>
 
 ## Typography
 
 1. Select a text by a single _click_.
 2. Have a look at the _Properties_ pane on the right side.
 
-![What typography is used](./assets/ux-handover-typography.png)
+<InlineImg
+  src={UxHandoverTypography}
+  caption="What typography is used"
+  width="auto"
+/>
 
 ## Color
 
 1. Select an area by a single _click_.
 2. Have a look at the _Properties_ pane on the right side. Only use the color name as the reference. Do not copy HEX codes.
 
-![What color is used](./assets/ux-handover-color.png)
+<InlineImg
+  src={UxHandoverColor}
+  caption="What color is used"
+  width="auto"
+/>
 
 <IntroFooter
   href="/uilib/intro/05-eufemia-for-developers"

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/04-ux-handover.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/04-ux-handover.mdx
@@ -31,6 +31,7 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
   src={UxHandoverSpacing}
   caption="What spacing is used"
   width="auto"
+  className="blank x-10"
 />
 
 ## Components
@@ -42,6 +43,7 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
   src={UxHandoverComponent}
   caption="What component is used"
   width="auto"
+  className="blank x-10"
 />
 
 ## Typography
@@ -53,6 +55,7 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
   src={UxHandoverTypography}
   caption="What typography is used"
   width="auto"
+  className="blank x-10"
 />
 
 ## Color
@@ -64,6 +67,7 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
   src={UxHandoverColor}
   caption="What color is used"
   width="auto"
+  className="blank x-10"
 />
 
 <IntroFooter

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.mdx
@@ -6,7 +6,9 @@ search: 'Intro - Layout'
 import Intro, {
   IntroFooter,
 } from 'dnb-design-system-portal/src/shared/tags/Intro'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
 import { LayoutExample } from 'Docs/uilib/intro/Examples'
+import UxLayoutSpacing from 'Docs/uilib/usage/assets/ux-layout-spacing.png'
 
 <Intro>
 
@@ -22,7 +24,11 @@ To get a good user experience and a professional looking result, perfect layouti
 
 Remember, everything should be in the **8px grid** (0.5rem) spacing - even it the designer sometimes are one or two pixels of, you now know what it should be.
 
-![UX layout spacing](../usage/assets/ux-layout-spacing.png)
+<InlineImg
+  src={UxLayoutSpacing}
+  caption="UX layout spacing"
+  width="auto"
+/>
 
 You may have a [look at the layout docs](/uilib/usage/layout) as well as [the spacing helpers](/uilib/usage/layout/spacing) and the [Space](/uilib/layout/space) component.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/10-layout.mdx
@@ -28,6 +28,7 @@ Remember, everything should be in the **8px grid** (0.5rem) spacing - even it th
   src={UxLayoutSpacing}
   caption="UX layout spacing"
   width="auto"
+  className="blank x-10"
 />
 
 You may have a [look at the layout docs](/uilib/usage/layout) as well as [the spacing helpers](/uilib/usage/layout/spacing) and the [Space](/uilib/layout/space) component.


### PR DESCRIPTION
Motivation: Not able to see the image here https://main.eufemia-e25.pages.dev/uilib/intro/03-accessibility/#200-you-said

But I guess perhaps this could be based on some environment stuff, as I'm able to see it here https://eufemia.dnb.no/uilib/intro/03-accessibility/#200-you-said

🤔 