### PR TITLE
chore(Pagination): replace fragile Symbol string coercion with direct React.Fragment comparison

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationHelpers.tsx
@@ -100,7 +100,7 @@ export function preparePageElement(
   Element,
   includeClassName = 'dnb-pagination__page'
 ) {
-  if (String(Element) === 'Symbol(react.fragment)') {
+  if (Element === React.Fragment) {
     return Element
   }
 


### PR DESCRIPTION
The check `String(Element) === 'Symbol(react.fragment)'` relies on the internal string representation of React symbols, which can change between React versions. Replace with a direct identity comparison `Element === React.Fragment`, which is the pattern used consistently elsewhere in the codebase (Element.tsx, PaginationInfinity.tsx, etc.).

