### PR TITLE
chore: replace deprecated Context.Provider with Context in React 19

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.tsx
@@ -217,7 +217,7 @@ export const GlobalStatusUpdate = () => (
         const [isVisible, setVisibility] = React.useState(false)
 
         return (
-          <Context.Provider
+          <Context
             value={{
               errorA,
               errorB,
@@ -229,7 +229,7 @@ export const GlobalStatusUpdate = () => (
           >
             <UpdateDemoStatus />
             <UpdateDemoTools />
-          </Context.Provider>
+          </Context>
         )
       }
 


### PR DESCRIPTION
React 19 deprecated <Context.Provider> in favor of rendering the context object directly as <Context>. Updated the GlobalStatus example in the portal to use the new pattern.

