### PR TITLE
chore: remove redundant createRef tests

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -434,16 +434,6 @@ describe('HeightAnimation without initializeTestSetup()', () => {
     expect(ref.current.tagName).toBe('DIV')
     expect(ref.current.classList).toContain('dnb-height-animation')
   })
-
-  it('gets valid element when using createRef', () => {
-    const ref: React.RefObject<HTMLElement | null> = { current: null }
-
-    render(<HeightAnimation ref={ref}>content</HeightAnimation>)
-
-    expect(ref.current instanceof HTMLDivElement).toBe(true)
-    expect(ref.current.tagName).toBe('DIV')
-    expect(ref.current.classList).toContain('dnb-height-animation')
-  })
 })
 
 describe('HeightAnimation aria', () => {

--- a/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
+++ b/packages/dnb-eufemia/src/components/section/__tests__/Section.test.tsx
@@ -304,20 +304,6 @@ describe('Section component', () => {
     expect(ref.current.tagName).toBe('SECTION')
     expect(ref.current.classList).toContain('dnb-section')
   })
-
-  it('gets valid element when using createRef', () => {
-    const ref: React.RefObject<HTMLElement | null> = { current: null }
-
-    render(
-      <Section {...props} ref={ref}>
-        content
-      </Section>
-    )
-
-    expect(ref.current instanceof HTMLElement).toBe(true)
-    expect(ref.current.tagName).toBe('SECTION')
-    expect(ref.current.classList).toContain('dnb-section')
-  })
 })
 
 describe('surface', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -2908,14 +2908,4 @@ describe('Field.Number', () => {
     const input = document.querySelector(`#${id}`)
     expect(input.tagName).toBe('INPUT')
   })
-
-  it('gets valid element when using createRef', () => {
-    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
-
-    render(<Field.Number id="unique" ref={ref} />)
-
-    const input = document.querySelector('#unique')
-    expect(input).toBeTruthy()
-    expect(input.tagName).toBe('INPUT')
-  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -322,14 +322,4 @@ describe('Password component', () => {
     expect(input).toBeTruthy()
     expect(input.tagName).toBe('INPUT')
   })
-
-  it('gets valid element when using createRef', () => {
-    const ref: React.RefObject<HTMLInputElement | null> = { current: null }
-
-    render(<Field.Password ref={ref} />)
-
-    const input = document.querySelector('.dnb-input__input')
-    expect(input).toBeTruthy()
-    expect(input.tagName).toBe('INPUT')
-  })
 })


### PR DESCRIPTION
Remove the 'gets valid element when using createRef' test from 4 files. Each test was a duplicate of the 'gets valid ref element' test that already exists using useRef. The removed tests used { current: null } (not actually React.createRef()) but were named misleadingly, and tested identical behavior to the useRef-based tests above them.

React 19 treats ref as a regular prop - a single useRef test per component is sufficient to verify ref forwarding.

Files changed:
- HeightAnimation.test.tsx
- Section.test.tsx
- Number.test.tsx
- Password.test.tsx

