### PR TITLE
chore: remove cloneElement usage in favor of context and direct rendering

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -1,5 +1,4 @@
 import React, {
-  cloneElement,
   useCallback,
   useEffect,
   useMemo,
@@ -28,7 +27,6 @@ export type TextMaskMask =
   | Array<RegExp | string>
   | false
   | typeof createNumberMask
-export type TextMaskInputElement = React.ReactElement<any>
 export type TextMaskValue = string | number
 export type TextMaskProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -37,7 +35,6 @@ export type TextMaskProps = Omit<
   mask: TextMaskMask
   inputRef?: React.Ref<HTMLInputElement> &
     React.MutableRefObject<HTMLInputElement | null>
-  inputElement?: TextMaskInputElement
   onChange?: React.ChangeEventHandler<HTMLInputElement>
   value?: TextMaskValue
   size?: number
@@ -54,7 +51,6 @@ export type TextMaskProps = Omit<
 
 export default function TextMask(props: TextMaskProps): React.JSX.Element {
   const {
-    inputElement,
     inputRef,
     mask: rawMask,
     value,
@@ -325,15 +321,7 @@ export default function TextMask(props: TextMaskProps): React.JSX.Element {
     return formatted
   }, [value, showMask, options, rawMask, ghostPlaceholder])
 
-  return inputElement ? (
-    cloneElement(inputElement, {
-      ...params,
-      defaultValue,
-      ref: setRefs,
-    })
-  ) : (
-    <input ref={setRefs} defaultValue={defaultValue} {...params} />
-  )
+  return <input ref={setRefs} defaultValue={defaultValue} {...params} />
 }
 
 function withOverflowSupport(mask: MaskitoMask): MaskitoMask {

--- a/packages/dnb-eufemia/src/components/input-masked/hooks/useInputElement.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/hooks/useInputElement.tsx
@@ -33,11 +33,6 @@ export const useInputElement = () => {
     }
   }, [refProp, isFn, ref])
 
-  // Create the actual input element
-  const inputElementRef = React.useRef<React.JSX.Element>(
-    <input ref={ref as React.Ref<HTMLInputElement>} />
-  )
-
   return useCallback(
     (
       params: Record<string, unknown>,
@@ -49,7 +44,6 @@ export const useInputElement = () => {
       return (
         <TextMask
           inputRef={ref}
-          inputElement={inputElementRef.current}
           mask={mask || createNumberMask()}
           showMask={showMask}
           allowOverflow={allowOverflow}

--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 import clsx from 'clsx'
 import type { ListVariant } from './ListContext'
-import { ListContext } from './ListContext'
+import { ListContext, ListItemHiddenContext } from './ListContext'
 import type { StackProps as FlexProps } from '../flex/Stack'
 import FlexContainer from '../flex/Stack'
 import type { SkeletonShow } from '../Skeleton'
@@ -59,25 +59,18 @@ function ListContainer(props: ListContainerProps) {
       return children
     }
 
-    const childArray = React.Children.toArray(children)
+    const childArray = Array.isArray(children)
+      ? children.flat()
+      : [children]
 
-    if (!shouldLimit) {
-      return childArray
-    }
-
-    return childArray.map((child, index) => {
-      if (index < visibleCount) {
-        return child
-      }
-
-      if (React.isValidElement<React.HTMLAttributes<HTMLElement>>(child)) {
-        return React.cloneElement(child, {
-          hidden: true,
-        })
-      }
-
-      return null
-    })
+    return childArray.map((child, index) => (
+      <ListItemHiddenContext
+        key={(child as React.ReactElement)?.key ?? index}
+        value={shouldLimit && index >= visibleCount}
+      >
+        {child}
+      </ListItemHiddenContext>
+    ))
   }, [children, hasVisibleCount, shouldLimit, visibleCount])
 
   const listContent = (

--- a/packages/dnb-eufemia/src/components/list/ItemContent.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemContent.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import clsx from 'clsx'
 import type { ListVariant } from './ListContext'
-import { ListContext } from './ListContext'
+import { ListContext, ListItemHiddenContext } from './ListContext'
 import type { FlexContainerAllProps as FlexProps } from '../flex/Container'
 import FlexContainer from '../flex/Container'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
@@ -35,6 +35,7 @@ function ItemContent(props: ItemContentProps) {
   const appliedVariant = variant ?? inheritedVariant
   const appliedSkeleton = skeleton ?? inheritedSkeleton
   const appliedDisabled = disabled ?? inheritedDisabled
+  const itemHidden = useContext(ListItemHiddenContext)
 
   const content = (
     <FlexContainer
@@ -43,6 +44,7 @@ function ItemContent(props: ItemContentProps) {
       justify="space-between"
       wrap={false}
       gap={false}
+      hidden={itemHidden || undefined}
       className={clsx(
         'dnb-list__item',
         'dnb-t__size--basis',

--- a/packages/dnb-eufemia/src/components/list/ListContext.ts
+++ b/packages/dnb-eufemia/src/components/list/ListContext.ts
@@ -12,3 +12,5 @@ export type ListContextValue = {
 export const ListContext = createContext<ListContextValue | undefined>(
   undefined
 )
+
+export const ListItemHiddenContext = createContext(false)


### PR DESCRIPTION
- list/Container.tsx: Replace cloneElement(child, { hidden: true }) with ListItemHiddenContext provider pattern. Each overflow child is wrapped in a context provider that signals hidden state, which ItemContent reads. Also replaces React.Children.toArray with direct array operations.
- list/ItemContent.tsx: Read ListItemHiddenContext and apply hidden attribute.
- list/ListContext.ts: Add ListItemHiddenContext for item visibility.
- input-masked/TextMask.tsx: Remove inputElement prop and cloneElement. Always render <input> directly since both code paths were equivalent.
- input-masked/hooks/useInputElement.tsx: Remove stored inputElement ref.

