### PR TITLE
chore: replace useRef(undefined) with useRef(null) for React 19 compatibility

### DIFF
--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -136,7 +136,7 @@ export type HeadingAllProps = HeadingProps &
 export default function Heading(props: HeadingAllProps) {
   const context = React.useContext(Context)
   const headingContext = React.useContext(HeadingContext)
-  const _ref = React.useRef(undefined)
+  const _ref = React.useRef(null)
 
   const {
     text,

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -66,7 +66,7 @@ function HelpButtonInline(props: HelpButtonInlineProps) {
       isOpen: help?.open ?? false,
     })
   const { isOpen, isUserIntent } = data || {}
-  const wasOpenRef = useRef(undefined)
+  const wasOpenRef = useRef(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   const toggleOpen = useCallback(() => {

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -128,7 +128,7 @@ function useHandleTrVariant({ variant }) {
    * Handle odd/even
    */
   const countRef = tableContext?.trCountRef.current
-  const lastRenderAliasRef = React.useRef(undefined)
+  const lastRenderAliasRef = React.useRef(null)
   const hasIncrementedRef = React.useRef(false)
 
   const increment = React.useCallback(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useSwitchContainerMode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/hooks/useSwitchContainerMode.ts
@@ -31,7 +31,7 @@ const globalCache: Record<
  * Therefore, it is imported and used in both e.g. the EditContainer and e.g. the PushButton.
  */
 export default function useSwitchContainerMode(path?: Path) {
-  const nextContainerModeRef = useRef(undefined)
+  const nextContainerModeRef = useRef(null)
   const { hasError } = useContext(FieldBoundaryContext) || {}
   const iterateItemContext = useContext(IterateItemContext)
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -126,7 +126,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   } = props
 
   const [salt, forceUpdate] = useReducer(() => ({}), {})
-  const isInternalRerenderRef = useRef(undefined)
+  const isInternalRerenderRef = useRef(null)
   useMemo(() => {
     /**
      * This is currently not used, but we keep it here for future use.


### PR DESCRIPTION
React 19 requires useRef to have an explicit initial value. Replace undefined with null in 5 instances across the codebase.

