### PR TITLE
chore(PaymentCard): rename provider--separator to use dnb- BEM prefix

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   background-color: var(--dnb-payment-bg-black-gold);
   color: var(--color-white);
 }
-.dnb-payment-card__card--design-saga .provider--separator {
+.dnb-payment-card__card--design-saga .dnb-payment-card__provider-separator {
   color: var(--dnb-payment-bg-gold);
 }
 .dnb-payment-card__card--design-saga-platinum, .dnb-payment-card__card--design-private {
@@ -247,7 +247,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
   align-items: center;
   column-gap: 1rem;
 }
-.dnb-payment-card__card__providers .provider--separator {
+.dnb-payment-card__card__providers .dnb-payment-card__provider-separator {
   width: 1px;
   height: 26px;
   background-color: currentcolor;
@@ -372,7 +372,7 @@ exports[`PaymentCard scss has to match style dependencies css 1`] = `
 .dnb-payment-card--compact .dnb-payment-card__card__providers--multiple svg {
   vertical-align: top;
 }
-.dnb-payment-card--compact .dnb-payment-card__card__providers--multiple .provider--separator {
+.dnb-payment-card--compact .dnb-payment-card__card__providers--multiple .dnb-payment-card__provider-separator {
   width: 1px;
 }
 .dnb-payment-card--compact .dnb-payment-card__overlay__content {

--- a/packages/dnb-eufemia/src/extensions/payment-card/components/CardFigure.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/components/CardFigure.tsx
@@ -53,7 +53,9 @@ function CardFigure({
           bankAxept={data.bankAxept}
           cardDesign={data.cardDesign}
         />
-        {multipleProviders && <div className="provider--separator" />}
+        {multipleProviders && (
+          <div className="dnb-payment-card__provider-separator" />
+        )}
         <TypeLogo cardType={data.cardType} cardDesign={data.cardDesign} />
       </div>
     )

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
@@ -107,7 +107,7 @@
         background-color: var(--dnb-payment-bg-black-gold);
         color: var(--color-white);
         // Specific styles for separators within the Saga card.
-        .provider--separator {
+        .dnb-payment-card__provider-separator {
           color: var(--dnb-payment-bg-gold);
         }
       }
@@ -189,7 +189,7 @@
       column-gap: 1rem;
 
       // Adds divider between provider icons
-      .provider--separator {
+      .dnb-payment-card__provider-separator {
         width: 1px;
         height: 26px;
         background-color: currentcolor;
@@ -331,7 +331,7 @@
         }
 
         // Define a fixed width for separators between provider icons
-        .provider--separator {
+        .dnb-payment-card__provider-separator {
           width: 1px;
         }
       }


### PR DESCRIPTION
Rename the CSS class from 'provider--separator' to 'dnb-payment-card__provider-separator' to follow the BEM naming convention with the dnb- prefix used across the codebase.

