### PR TITLE
fix: read key from element instead of props for React 19 compatibility

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -257,10 +257,11 @@ function wrapChildren(
       child.type['_supportsSpacingProps'] === 'children'
     ) {
       const childElement = child as React.ReactElement<any>
-      const { key, ...childProps } = childElement.props || {}
+      const childKey = childElement.key
+      const childProps = childElement.props || {}
       return React.createElement(
         childElement.type as React.ComponentType<any>,
-        { key, ...childProps },
+        { key: childKey, ...childProps },
         <FlexContainer {...props}>
           {childElement.props.children}
         </FlexContainer>

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -261,7 +261,7 @@ function wrapChildren(
       const childProps = childElement.props || {}
       return React.createElement(
         childElement.type as React.ComponentType<any>,
-        { key: childKey, ...childProps },
+        { ...childProps, key: childKey },
         <FlexContainer {...props}>
           {childElement.props.children}
         </FlexContainer>

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -676,6 +676,28 @@ describe('Flex.Container', () => {
       ).toHaveLength(1)
     })
 
+    it('should preserve key from element when wrapping with _supportsSpacingProps=children', () => {
+      const { rerender, Wrapper, TestComponent } = getMocks()
+
+      Wrapper._supportsSpacingProps = 'children'
+
+      const spy = jest.spyOn(React, 'createElement')
+
+      rerender(
+        <Flex.Vertical>
+          <Wrapper key="my-key">
+            <TestComponent />
+          </Wrapper>
+        </Flex.Vertical>
+      )
+
+      const wrapperCall = spy.mock.calls.find(([type]) => type === Wrapper)
+      expect(wrapperCall).toBeDefined()
+      expect(wrapperCall[1].key).toBe('.$my-key')
+
+      spy.mockRestore()
+    })
+
     it('should with _supportsSpacingProps=children wrap the children inside the Wrapper', () => {
       const { rerender, Wrapper } = getMocks()
 

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -691,7 +691,9 @@ describe('Flex.Container', () => {
         </Flex.Vertical>
       )
 
-      const wrapperCall = spy.mock.calls.find(([type]) => type === Wrapper)
+      const wrapperCall = spy.mock.calls.find(
+        ([type]) => type === (Wrapper as any)
+      )
       expect(wrapperCall).toBeDefined()
       expect(wrapperCall[1].key).toBe('.$my-key')
 

--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -6,6 +6,7 @@ import {
   isHeadingElement,
   getSpaceVariant,
   pickSpacingProps,
+  renderWithSpacing,
 } from '../../flex/utils'
 
 describe('isHeadingElement', () => {
@@ -92,5 +93,28 @@ describe('getSpaceVariant', () => {
     MockComponent._supportsSpacingProps = 'children'
 
     expect(getSpaceVariant(<MockComponent />)).toBe('children')
+  })
+})
+
+describe('renderWithSpacing', () => {
+  it('should preserve key from element when variant is children', () => {
+    const MockComponent = ({ children }) => <div>{children}</div>
+    MockComponent._supportsSpacingProps = 'children'
+
+    const spy = jest.spyOn(React, 'createElement')
+
+    renderWithSpacing(
+      <MockComponent key="test-key">
+        <span>child</span>
+      </MockComponent>,
+      {},
+      'children'
+    )
+
+    const call = spy.mock.calls.find(([type]) => type === MockComponent)
+    expect(call).toBeDefined()
+    expect(call[1].key).toBe('.$test-key')
+
+    spy.mockRestore()
   })
 })

--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -107,11 +107,12 @@ describe('renderWithSpacing', () => {
       <MockComponent key="test-key">
         <span>child</span>
       </MockComponent>,
-      {},
-      'children'
+      {}
     )
 
-    const call = spy.mock.calls.find(([type]) => type === MockComponent)
+    const call = spy.mock.calls.find(
+      ([type]) => type === (MockComponent as any)
+    )
     expect(call).toBeDefined()
     expect(call[1].key).toBe('.$test-key')
 

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -130,7 +130,7 @@ export function renderWithSpacing(
           return React.createElement(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             child.type as React.ComponentType<any>,
-            { key: childKey || i, ...childProps },
+            { ...childProps, key: childKey || i },
             wrapWithSpace({
               element: element as React.ReactNode,
               spaceProps,

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -123,7 +123,8 @@ export function renderWithSpacing(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (child: React.ReactElement<any>) => {
         const children = child?.props?.children
-        const { key: childKey, ...childProps } = child?.props || {}
+        const childKey = child?.key
+        const childProps = child?.props || {}
 
         return React.Children.toArray(children).map((element, i) => {
           return React.createElement(


### PR DESCRIPTION
In React 19, 'key' is no longer included in element.props. Read key directly from element.key instead of destructuring from element.props. Affects flex/utils.tsx and flex/Container.tsx.


Motiation: https://react.dev/warnings/special-props
