### PR TITLE
refactor: remove cloneElement usage from list/Container and input-masked/TextMask

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -1,5 +1,4 @@
 import React, {
-  cloneElement,
   useCallback,
   useEffect,
   useMemo,
@@ -28,7 +27,6 @@ export type TextMaskMask =
   | Array<RegExp | string>
   | false
   | typeof createNumberMask
-export type TextMaskInputElement = React.ReactElement<any>
 export type TextMaskValue = string | number
 export type TextMaskProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -37,7 +35,6 @@ export type TextMaskProps = Omit<
   mask: TextMaskMask
   inputRef?: React.Ref<HTMLInputElement> &
     React.MutableRefObject<HTMLInputElement | null>
-  inputElement?: TextMaskInputElement
   onChange?: React.ChangeEventHandler<HTMLInputElement>
   value?: TextMaskValue
   size?: number
@@ -54,7 +51,6 @@ export type TextMaskProps = Omit<
 
 export default function TextMask(props: TextMaskProps): React.JSX.Element {
   const {
-    inputElement,
     inputRef,
     mask: rawMask,
     value,
@@ -325,15 +321,7 @@ export default function TextMask(props: TextMaskProps): React.JSX.Element {
     return formatted
   }, [value, showMask, options, rawMask, ghostPlaceholder])
 
-  return inputElement ? (
-    cloneElement(inputElement, {
-      ...params,
-      defaultValue,
-      ref: setRefs,
-    })
-  ) : (
-    <input ref={setRefs} defaultValue={defaultValue} {...params} />
-  )
+  return <input ref={setRefs} defaultValue={defaultValue} {...params} />
 }
 
 function withOverflowSupport(mask: MaskitoMask): MaskitoMask {

--- a/packages/dnb-eufemia/src/components/input-masked/hooks/useInputElement.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/hooks/useInputElement.tsx
@@ -33,11 +33,6 @@ export const useInputElement = () => {
     }
   }, [refProp, isFn, ref])
 
-  // Create the actual input element
-  const inputElementRef = React.useRef<React.JSX.Element>(
-    <input ref={ref as React.Ref<HTMLInputElement>} />
-  )
-
   return useCallback(
     (
       params: Record<string, unknown>,
@@ -49,7 +44,6 @@ export const useInputElement = () => {
       return (
         <TextMask
           inputRef={ref}
-          inputElement={inputElementRef.current}
           mask={mask || createNumberMask()}
           showMask={showMask}
           allowOverflow={allowOverflow}

--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -65,19 +65,7 @@ function ListContainer(props: ListContainerProps) {
       return childArray
     }
 
-    return childArray.map((child, index) => {
-      if (index < visibleCount) {
-        return child
-      }
-
-      if (React.isValidElement<React.HTMLAttributes<HTMLElement>>(child)) {
-        return React.cloneElement(child, {
-          hidden: true,
-        })
-      }
-
-      return null
-    })
+    return childArray.slice(0, visibleCount)
   }, [children, hasVisibleCount, shouldLimit, visibleCount])
 
   const listContent = (


### PR DESCRIPTION
- list/Container: replace cloneElement+hidden with array slice
- TextMask: remove inputElement prop and cloneElement, render <input> directly
- useInputElement: remove pre-created inputElement ref

React 19 discourages cloneElement in favor of composition patterns.

