### PR TITLE
fix(HelpButtonInline): pass ReactNode title for tooltip rendering

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -115,7 +115,7 @@ function HelpButtonInline(props: HelpButtonInlineProps) {
     [isOpen, toggleOpen]
   )
 
-  const title = convertJsxToString(help?.title)
+  const titleString = convertJsxToString(help?.title)
 
   return (
     <>
@@ -123,7 +123,7 @@ function HelpButtonInline(props: HelpButtonInlineProps) {
         bounding
         size={size ?? 'small'}
         icon={HelpButtonIcon}
-        title={!isOpen && !wasOpenRef.current ? title : undefined}
+        title={!isOpen && !wasOpenRef.current ? help?.title : undefined}
         {...rest}
         id={controlId}
         className={clsx(
@@ -137,7 +137,7 @@ function HelpButtonInline(props: HelpButtonInlineProps) {
         selected={isOpen}
         aria-controls={`${controlId}-content`}
         aria-expanded={isOpen}
-        aria-label={title || undefined}
+        aria-label={titleString || undefined}
         onClick={onClickHandler}
         onKeyDown={onKeyDownHandler}
         ref={buttonRef}

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -314,6 +314,37 @@ describe('HelpButtonInline', () => {
       )
     })
 
+    it('should show tooltip when title is a React component', async () => {
+      function CustomTitle() {
+        return <>Component title</>
+      }
+
+      render(
+        <HelpButtonInline
+          help={{
+            title: <CustomTitle />,
+          }}
+        />
+      )
+
+      const button = document.querySelector('.dnb-help-button')
+      await userEvent.hover(button)
+
+      const ariaDescribedBy = await waitFor(() => {
+        const id = button.getAttribute('aria-describedby')
+        expect(id).toBeTruthy()
+        return id
+      })
+
+      const tooltipContent = await waitFor(() => {
+        const tooltip = document.querySelector(`#${ariaDescribedBy}`)
+        expect(tooltip).toBeInTheDocument()
+        return tooltip
+      })
+
+      expect(tooltipContent).toHaveTextContent('Component title')
+    })
+
     it('should have aria-label attribute', () => {
       render(
         <HelpButtonInline


### PR DESCRIPTION
Pass help.title as ReactNode directly to HelpButtonInstance instead of the stringified version. This allows the tooltip to render React components like <Translation /> correctly, showing the translated text on hover.

The aria-label continues to use convertJsxToString with a fallback to the default 'Hjelpetekst' translation for component-based titles.

Related to #7752

Reported reprod: https://stackblitz.com/edit/eufemia-starter-cznvpfx5?file=src%2FApp.tsx
Fixed reprod: X
