### PR TITLE
fix(date-picker): rename .rtl class to BEM-compliant dnb-date-picker_calendar--rtl

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -496,7 +496,10 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
   return (
     <div
-      className={clsx('dnb-date-picker__calendar', rtl && 'rtl')}
+      className={clsx(
+        'dnb-date-picker__calendar',
+        rtl && 'dnb-date-picker__calendar--rtl'
+      )}
       lang={locale}
     >
       {!hideNavigation && !onlyMonth && (

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2759,13 +2759,13 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker__day--start-date.dnb-date-picker__day--end-date::after {
   content: none;
 }
-.dnb-date-picker .rtl {
+.dnb-date-picker__calendar--rtl {
   direction: rtl;
 }
-.dnb-date-picker .rtl .dnb-date-picker__prev::before {
+.dnb-date-picker__calendar--rtl .dnb-date-picker__prev::before {
   transform: scaleX(-1);
 }
-.dnb-date-picker .rtl .dnb-date-picker__next::before {
+.dnb-date-picker__calendar--rtl .dnb-date-picker__next::before {
   transform: scaleX(-1);
 }
 .dnb-date-picker__inner > .dnb-form-status {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -319,7 +319,7 @@
     }
   }
 
-  .rtl {
+  &__calendar--rtl {
     direction: rtl;
 
     .dnb-date-picker__prev::before {


### PR DESCRIPTION
The .rtl CSS class used in the date-picker calendar lacked the dnb- prefix and did not follow BEM naming conventions. Renamed to dnb-date-picker__calendar--rtl (block__element--modifier).

