### PR TITLE
chore: fix spelling, grammar, and pattern inconsistencies

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7-info.mdx
@@ -80,7 +80,7 @@ We hope with that change we embrace [better accessibility](/uilib/usage/accessib
 ```
 
 - [Dropdown](/uilib/components/dropdown) now also works fine inside of a [Modal](/uilib/components/drawer/), taking the height of the Modal as the viewport reference.
-- **ESM** (mjs) [bundles](/uilib/usage/first-steps/bundles) to load directly in to modern browsers.
+- **ESM** (mjs) [bundles](/uilib/usage/first-steps/bundles) to load directly into modern browsers.
 
 ### Table (new features)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -22,8 +22,8 @@ For inline expandable groups, use `Menu.Accordion` instead of a nested `Menu.Roo
 
 ## Relevant links
 
-- Source code: https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/menu
-- Docs code: https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/menu
+- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/menu)
+- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/menu)
 
 ## Accessibility
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
@@ -18,8 +18,8 @@ It is used in the [Tooltip](/uilib/components/tooltip) and [DatePicker](/uilib/c
 
 ## Relevant links
 
-- Source code: https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/popover
-- Docs code: https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/popover
+- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/popover)
+- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/popover)
 
 ## Accessibility
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.mdx
@@ -25,7 +25,7 @@ import WhatIsEufemia from 'Docs/uilib/intro/assets/what-is-a-design-system.svg'
 
 ## What forms the system?
 
-Eufemia as a Design System consist of many sub-systems, like:
+Eufemia as a Design System consists of many sub-systems, like:
 
 - Color systems
 - Typography system

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/11-components-elements-extensions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/11-components-elements-extensions.mdx
@@ -36,7 +36,7 @@ Elements are basicity ready to use styled HTML elements.
 
 ## [Extensions](/uilib/extensions)
 
-Eufemia extensions are reusable parts that do not fit naturally in to a component or element, but rather has the nature of being an extended solution of Eufemia.
+Eufemia extensions are reusable parts that do not fit naturally into a component or element, but rather have the nature of being an extended solution of Eufemia.
 
 ---
 

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -78,7 +78,7 @@ export type AccordionProps = Omit<React.HTMLProps<HTMLElement>, 'ref'> &
      */
     expandedSsr?: boolean
     /**
-     * If set to `true` the content will be present, even the accordion is not expanded. Can be useful for assistive technology or SEO.
+     * If set to `true` the content will be present, even when the accordion is not expanded. Can be useful for assistive technology or SEO.
      */
     keepInDOM?: boolean
     /**

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -67,7 +67,7 @@ export const AccordionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   keepInDOM: {
-    doc: 'If set to `true` the content will be present, even the accordion is not expanded. Can be useful for assistive technology or SEO.',
+    doc: 'If set to `true` the content will be present, even when the accordion is not expanded. Can be useful for assistive technology or SEO.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -108,7 +108,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     status: 'optional',
   },
   showSubmitButton: {
-    doc: 'Use `true` to show a Autocomplete button to toggle the [DrawerList](/uilib/components/fragments/drawer-list). Defaults to `false`.',
+    doc: 'Use `true` to show an Autocomplete button to toggle the [DrawerList](/uilib/components/fragments/drawer-list). Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
+++ b/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
@@ -7,7 +7,7 @@ export const DrawerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   title: {
-    doc: 'The drawer title. Displays on the very top of the content.',
+    doc: 'The drawer title. Displays at the very top of the content.',
     type: 'React.ReactNode',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -93,7 +93,7 @@ export type FormStatusProps = {
    */
   show?: boolean
   /**
-   * The `text` appears as the status message. Beside plain text, you can send in a React component as well.
+   * The `text` appears as the status message. Besides plain text, you can send in a React component as well.
    */
   text?: FormStatusText
   /**
@@ -146,7 +146,7 @@ export type FormStatusProps = {
   shellSpace?: SpaceTypeAll
   className?: string
   /**
-   * The `text` appears as the status message. Beside plain text, you can send in a React component as well.
+   * The `text` appears as the status message. Besides plain text, you can send in a React component as well.
    */
   children?: FormStatusChildren
 } & Omit<

--- a/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
@@ -2,12 +2,12 @@ import type { PropertiesTableProps } from '../../shared/types'
 
 export const FormStatusProperties: PropertiesTableProps = {
   text: {
-    doc: 'The `text` appears as the status message. Beside plain text, you can send in a React component as well.',
+    doc: 'The `text` appears as the status message. Besides plain text, you can send in a React component as well.',
     type: 'React.ReactNode',
     status: 'optional',
   },
   children: {
-    doc: 'The `text` appears as the status message. Beside plain text, you can send in a React component as well.',
+    doc: 'The `text` appears as the status message. Besides plain text, you can send in a React component as well.',
     type: 'React.ReactNode',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusDocs.ts
@@ -105,7 +105,7 @@ export const GlobalStatusProperties: PropertiesTableProps = {
 
 export const GlobalStatusAdvancedItemProperties: PropertiesTableProps = {
   text: {
-    doc: 'The text appears as the status content. Beside plain text, you can send in a React component as well.',
+    doc: 'The text appears as the status content. Besides plain text, you can send in a React component as well.',
     type: 'string',
     status: 'required',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -12,7 +12,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     status: 'optional',
   },
   keepInDOM: {
-    doc: 'Set to `true` ensure the nested children content will be kept in the DOM. Defaults to `false`.',
+    doc: 'Set to `true` to ensure the nested children content will be kept in the DOM. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationDocs.ts
@@ -2,7 +2,7 @@ import type { PropertiesTableProps } from '../../shared/types'
 
 export const PaginationProperties: PropertiesTableProps = {
   mode: {
-    doc: 'If set to `infinity`, then the pagination bar will be now shown and but infinity scrolling will do the content presentation. For more information, check out the [Infinity Scroller](/uilib/components/pagination/infinity-scroller). Defaults to `pagination`.',
+    doc: 'If set to `infinity`, then the pagination bar will not be shown, but infinity scrolling will do the content presentation. For more information, check out the [Infinity Scroller](/uilib/components/pagination/infinity-scroller). Defaults to `pagination`.',
     type: ['"pagination"', '"infinity"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -35,7 +35,7 @@ export const SpaceProperties: PropertiesTableProps = {
     status: 'optional',
   },
   stretch: {
-    doc: 'If set to `true`, then the space element will be 100% in width.',
+    doc: 'If set to `true`, then the space element will be 100% in `width`.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
@@ -12,7 +12,7 @@ export const TabsProperties: PropertiesTableProps = {
     status: 'optional',
   },
   contentStyle: {
-    doc: 'To enable the visual helper `.dnb-section` on to the content wrapper. Use a supported modifier from the [Section component](/uilib/components/section/properties). Defaults to `null`.',
+    doc: 'To enable the visual helper `.dnb-section` onto the content wrapper. Use a supported modifier from the [Section component](/uilib/components/section/properties). Defaults to `null`.',
     type: ['"divider"', '"white"', '"transparent"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
@@ -17,7 +17,7 @@ export const UploadProperties: PropertiesTableProps = {
     status: 'optional',
   },
   acceptedFileTypes: {
-    doc: 'List of accepted file types. Either as string or [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype). When providing a list of [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype), the accepted file types will be presented in a table(see [example](/uilib/components/upload/demos/#upload-with-file-max-size-based-on-file-type)).',
+    doc: 'List of accepted file types. Either as a string or an [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype). When providing a list of [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype), the accepted file types will be presented in a table (see [example](/uilib/components/upload/demos/#upload-with-file-max-size-based-on-file-type)).',
     type: ['Array<string>', 'Array<AcceptedFileType>'],
     status: 'required',
   },


### PR DESCRIPTION
- Fix grammar errors in PaginationDocs, HeightAnimationDocs, AccordionDocs
- Fix article usage: 'a Autocomplete' → 'an Autocomplete'
- Fix subject-verb agreement: 'consist' → 'consists'
- Fix prepositions: 'in to' → 'into', 'on to' → 'onto', 'on the' → 'at the'
- Fix 'Beside' → 'Besides' in FormStatus and GlobalStatus docs
- Fix missing articles in UploadDocs
- Convert plain-text URLs to markdown links in Popover and Menu docs
- Sync JSDoc comments with Docs.ts fixes in Accordion.tsx and FormStatus.tsx

