### PR TITLE
chore: replace React.Children utilities with toChildArray helper

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 
 // Components
 import { applySpacing } from '../space/SpacingUtils'
@@ -173,7 +174,7 @@ const Avatar = (localProps: AvatarAllProps) => {
     const firstLetterUpperCase = childrenProp.charAt(0).toUpperCase()
     children = <span aria-hidden>{firstLetterUpperCase}</span>
   } else if (
-    React.Children.count(childrenProp) === 1 &&
+    toChildArray(childrenProp).length === 1 &&
     isIconComponent(childrenProp)
   ) {
     children = iconAutoSize(childrenProp)

--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext } from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../../shared/helpers/toChildArray'
 import Button from '../../button/Button'
 import Space from '../../space/Space'
 import { Context } from '../../../shared'
@@ -92,7 +93,7 @@ const DialogAction = ({
   )
 
   if (children) {
-    childrenWithCloseFunc = React.Children.map(children, (child) => {
+    childrenWithCloseFunc = toChildArray(children).map((child, i) => {
       if (React.isValidElement<any>(child) && child.type === Button) {
         const childElement = child as React.ReactElement<any>
 
@@ -100,6 +101,7 @@ const DialogAction = ({
           childElement.type as React.ComponentType<any>,
           {
             ...(childElement.props || {}),
+            key: childElement.key ?? i,
             onClick: (event) => {
               dispatchCustomElementEvent(childElement.props, 'onClick', {
                 event,

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useMemo } from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 import type { SpaceProps } from '../space/Space'
 import Space from '../space/Space'
 import { Hr } from '../../elements'
@@ -251,7 +252,7 @@ function wrapChildren(
   props: FlexContainerAllProps,
   children: React.ReactNode
 ) {
-  return React.Children.toArray(children).map((child) => {
+  return toChildArray(children).map((child) => {
     if (
       React.isValidElement<any>(child) &&
       child.type['_supportsSpacingProps'] === 'children'
@@ -275,10 +276,10 @@ function wrapChildren(
 function replaceRootFragment(children) {
   const firstChild = children[0]
   if (
-    React.Children.count(children) === 1 &&
+    toChildArray(children).length === 1 &&
     firstChild?.type === Fragment
   ) {
-    return React.Children.toArray(firstChild?.props?.children)
+    return toChildArray(firstChild?.props?.children)
   }
   return children
 }

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -695,7 +695,7 @@ describe('Flex.Container', () => {
         ([type]) => type === (Wrapper as any)
       )
       expect(wrapperCall).toBeDefined()
-      expect(wrapperCall[1].key).toBe('.$my-key')
+      expect(wrapperCall[1].key).toBe('my-key')
 
       spy.mockRestore()
     })

--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -114,7 +114,7 @@ describe('renderWithSpacing', () => {
       ([type]) => type === (MockComponent as any)
     )
     expect(call).toBeDefined()
-    expect(call[1].key).toBe('.$test-key')
+    expect(call[1].key).toBe('test-key')
 
     spy.mockRestore()
   })

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 import type { SpaceType, SpacingProps } from '../../shared/types'
 import Space from '../space/Space'
 import {
@@ -119,14 +120,14 @@ export function renderWithSpacing(
   }
 
   if (variant === 'children') {
-    return (React.Children.toArray(element) as React.ReactElement[]).map(
+    return (toChildArray(element) as React.ReactElement[]).map(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (child: React.ReactElement<any>) => {
         const children = child?.props?.children
         const childKey = child?.key
         const childProps = child?.props || {}
 
-        return React.Children.toArray(children).map((element, i) => {
+        return toChildArray(children).map((element, i) => {
           return React.createElement(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             child.type as React.ComponentType<any>,

--- a/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
+++ b/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useContext, useMemo } from 'react'
+import toChildArray from '../../shared/helpers/toChildArray'
 import { LOCALE } from '../../shared/defaults'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import type { InternalLocale } from '../../shared/Context'
@@ -80,7 +81,7 @@ function ListFormat(
     }
 
     return isListVariant
-      ? React.Children.map(valueToUse, (child: React.ReactNode, index) => {
+      ? toChildArray(valueToUse).map((child: React.ReactNode, index) => {
           return <Li key={index}>{child}</Li>
         })
       : valueToUse
@@ -179,15 +180,15 @@ export function listFormat(
 
 function replaceRootFragment(children) {
   if (children?.type === Fragment) {
-    return React.Children.toArray(children?.props?.children)
+    return toChildArray(children?.props?.children)
   }
   if (Array.isArray(children)) {
     const firstChild = children[0]
     if (
-      React.Children.count(children) === 1 &&
+      toChildArray(children).length === 1 &&
       firstChild?.type === Fragment
     ) {
-      return React.Children.toArray(firstChild?.props?.children)
+      return toChildArray(firstChild?.props?.children)
     }
     return children
   }

--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useMemo } from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 import type { ListVariant } from './ListContext'
 import { ListContext } from './ListContext'
 import type { StackProps as FlexProps } from '../flex/Stack'
@@ -59,7 +60,7 @@ function ListContainer(props: ListContainerProps) {
       return children
     }
 
-    const childArray = React.Children.toArray(children)
+    const childArray = toChildArray(children)
 
     if (!shouldLimit) {
       return childArray

--- a/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 import Popover from '../popover/Popover'
 import {
   MenuContext,
@@ -38,7 +39,7 @@ export default function MenuRoot(props: MenuRootProps) {
   let triggerChild: React.ReactElement | null = null
   const contentChildren: React.ReactNode[] = []
 
-  React.Children.forEach(children, (child) => {
+  toChildArray(children).forEach((child) => {
     if (
       !triggerChild &&
       React.isValidElement(child) &&

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import clsx from 'clsx'
+import toChildArray from '../../shared/helpers/toChildArray'
 import Space from '../space/Space'
 import type { SpacingProps } from '../../shared/types'
 import { warn } from '../../shared/component-helper'
@@ -67,9 +68,7 @@ Root._supportsSpacingProps = true
 export default Root
 
 function hasOnlySupportedChildren(children: React.ReactNode): boolean {
-  return React.Children.toArray(children).every((child) =>
-    isSupportedChild(child)
-  )
+  return toChildArray(children).every((child) => isSupportedChild(child))
 }
 
 function isSupportedChild(child: React.ReactNode): boolean {
@@ -92,9 +91,7 @@ function isSupportedChild(child: React.ReactNode): boolean {
 }
 
 function hasRequiredLabel(children: React.ReactNode): boolean {
-  return React.Children.toArray(children).some((child) =>
-    hasLabelChild(child)
-  )
+  return toChildArray(children).some((child) => hasLabelChild(child))
 }
 
 function hasLabelChild(child: React.ReactNode): boolean {
@@ -117,7 +114,7 @@ function flattenRoles(
 ): Array<'label' | 'content'> {
   const roles: Array<'label' | 'content'> = []
 
-  for (const child of React.Children.toArray(children)) {
+  for (const child of toChildArray(children)) {
     if (!React.isValidElement<Record<string, any>>(child)) {
       continue
     }

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
+import toChildArray from '../../../shared/helpers/toChildArray'
 import Td from '../TableTd'
 import { TableContext } from '../TableContext'
 import {
@@ -62,7 +63,7 @@ export function TableAccordionHead(allProps: TableAccordionHeadProps) {
   const [trIsHover, setHover] = React.useState(false)
   const [trHadClick, setHadClick] = React.useState(false)
 
-  let headerContent = React.Children.toArray(children)
+  let headerContent = toChildArray(children)
 
   const addContent = useCallback(
     (content) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -32,6 +32,7 @@ import type { ToggleButtonProps } from '../../../../components/ToggleButton'
 import type { RadioGroupProps } from '../../../../components/radio/RadioGroup'
 import type { ToggleButtonGroupProps } from '../../../../components/toggle-button/ToggleButtonGroup'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
+import toChildArray from '../../../../shared/helpers/toChildArray'
 
 type IOption = {
   title: string | React.ReactNode
@@ -273,7 +274,7 @@ function Selection(props: FieldSelectionProps) {
 
       const additionalFieldBlockProps: FieldBlockProps = {
         asFieldset:
-          hasRenderPropChildren || React.Children.count(items) > 1,
+          hasRenderPropChildren || toChildArray(items).length > 1,
         fieldsetRole: variant === 'radio' ? 'radiogroup' : 'group',
       }
       if (!size) {
@@ -472,7 +473,7 @@ function renderRadioItems({
 export function countOptions(children: React.ReactNode): number {
   let count = 0
 
-  React.Children.forEach(children, (child) => {
+  toChildArray(children).forEach((child) => {
     if (React.isValidElement(child)) {
       if (child.type === OptionField) {
         count++
@@ -495,9 +496,8 @@ export function mapOptions(
     createOption,
   }: { createOption: (props: OptionProps, i: number) => React.ReactNode }
 ) {
-  return React.Children.map(
+  return toChildArray(children).map(
     // @ts-expect-error - strictFunctionTypes
-    children,
     (child: React.ReactElement<OptionProps>, i) => {
       if (React.isValidElement(child)) {
         if (child.type === OptionField) {
@@ -525,7 +525,7 @@ export function makeOptions<T = DrawerListProps['data']>(
   children: React.ReactNode,
   transformSelection?: FieldSelectionProps['transformSelection']
 ): T {
-  return React.Children.map(children, (child) => {
+  return toChildArray(children).map((child) => {
     if (child?.['props']?.children?.type === OptionField) {
       child = child['props'].children
     }

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -28,6 +28,7 @@ import {
   findElementInChildren,
 } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
+import toChildArray from '../../../shared/helpers/toChildArray'
 import type {
   ComponentProps,
   FieldProps,
@@ -783,7 +784,7 @@ function isFragment(fragment: React.ReactNode) {
 function fragmentHasChildren(fragment: React.ReactNode) {
   return (
     React.isValidElement<{ children?: React.ReactNode }>(fragment) &&
-    React.Children.count(fragment.props.children) > 0
+    toChildArray(fragment.props.children).length > 0
   )
 }
 
@@ -792,7 +793,7 @@ function fragmentHasOnlyUndefinedChildren(fragment: React.ReactNode) {
 
   return (
     React.isValidElement<{ children?: React.ReactNode }>(fragment) &&
-    React.Children.toArray(fragment.props.children).every(isUndefined)
+    toChildArray(fragment.props.children).every(isUndefined)
   )
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
+import toChildArray from '../../../../shared/helpers/toChildArray'
 import clsx from 'clsx'
 import { Hr } from '../../../../elements'
 import { Flex, FormStatus, Space } from '../../../../components'
@@ -46,7 +47,7 @@ export default function Toolbar({
     children = children?.({ index, items, value })
   }
 
-  if (React.Children.count(children) === 0) {
+  if (toChildArray(children).length === 0) {
     return null
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import toChildArray from '../../../../shared/helpers/toChildArray'
 import WizardContext from '../Context/WizardContext'
 import WizardStepContext from '../Step/StepContext'
 import type { WizardStepProps as StepProps } from '../Step/Step'
@@ -30,78 +31,80 @@ export function IterateOverSteps({
   stepIndexRef.current = -1
   totalStepsRef.current = 0
 
-  const childrenArray = React.Children.map(children, (child) => {
-    if (React.isValidElement<any>(child)) {
-      let step = child
+  const childrenArray = toChildArray(children)
+    .map((child) => {
+      if (React.isValidElement<any>(child)) {
+        let step = child
 
-      if (child?.type !== Step && typeof child.type === 'function') {
-        step = (child.type as (props: unknown) => React.ReactElement)(
-          child.props
-        ) as React.ReactElement
+        if (child?.type !== Step && typeof child.type === 'function') {
+          step = (child.type as (props: unknown) => React.ReactElement)(
+            child.props
+          ) as React.ReactElement
 
-        if (step?.type === Step) {
-          child = step
-        }
-      }
-
-      if (child?.type === Step) {
-        const { title, inactive, keepInDOM, include, id, includeWhen } =
-          (child as React.ReactElement<any>).props || {}
-
-        if (include === false) {
-          return null
-        }
-
-        if (
-          includeWhen &&
-          !check({
-            visibleWhen: includeWhen,
-          })
-        ) {
-          return null
-        }
-
-        const index = totalStepsRef.current
-        totalStepsRef.current = totalStepsRef.current + 1
-
-        collectStepsData({
-          id,
-          index,
-          title,
-          inactive,
-          keepInDOM,
-        })
-
-        if (
-          prerenderFieldProps &&
-          typeof document !== 'undefined' &&
-          index !== activeIndexRef.current &&
-          typeof prerenderFieldPropsRef.current['step-' + index] ===
-            'undefined'
-        ) {
-          const key = `${index}-${activeIndexRef.current}`
-          prerenderFieldPropsRef.current['step-' + index] = {
-            index,
-            fn: () =>
-              React.createElement(
-                (child as React.ReactElement<StepProps>)
-                  .type as React.ComponentType<StepProps>,
-                {
-                  ...(child as React.ReactElement<StepProps>).props,
-                  key,
-                  index,
-                  prerenderFieldProps: true,
-                }
-              ),
+          if (step?.type === Step) {
+            child = step
           }
         }
 
-        return child
-      }
-    }
+        if (child?.type === Step) {
+          const { title, inactive, keepInDOM, include, id, includeWhen } =
+            (child as React.ReactElement<any>).props || {}
 
-    return child
-  })
+          if (include === false) {
+            return null
+          }
+
+          if (
+            includeWhen &&
+            !check({
+              visibleWhen: includeWhen,
+            })
+          ) {
+            return null
+          }
+
+          const index = totalStepsRef.current
+          totalStepsRef.current = totalStepsRef.current + 1
+
+          collectStepsData({
+            id,
+            index,
+            title,
+            inactive,
+            keepInDOM,
+          })
+
+          if (
+            prerenderFieldProps &&
+            typeof document !== 'undefined' &&
+            index !== activeIndexRef.current &&
+            typeof prerenderFieldPropsRef.current['step-' + index] ===
+              'undefined'
+          ) {
+            const key = `${index}-${activeIndexRef.current}`
+            prerenderFieldPropsRef.current['step-' + index] = {
+              index,
+              fn: () =>
+                React.createElement(
+                  (child as React.ReactElement<StepProps>)
+                    .type as React.ComponentType<StepProps>,
+                  {
+                    ...(child as React.ReactElement<StepProps>).props,
+                    key,
+                    index,
+                    prerenderFieldProps: true,
+                  }
+                ),
+            }
+          }
+
+          return child
+        }
+      }
+
+      return child
+    })
+    .filter(Boolean)
 
   // Ensure we never have a higher index than the available children
   // else we get a white screen

--- a/packages/dnb-eufemia/src/shared/helpers/toChildArray.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/toChildArray.ts
@@ -1,0 +1,23 @@
+import React from 'react'
+
+/**
+ * Converts React children to a flat array, filtering out null, undefined,
+ * and boolean values.
+ *
+ * Replaces the legacy React.Children utilities (toArray, map, forEach,
+ * count) which are discouraged in React 19+.
+ *
+ * Note: Fragments are kept as valid elements (not flattened), matching
+ * the behavior of React.Children.toArray.
+ */
+export default function toChildArray(
+  children: React.ReactNode
+): React.ReactNode[] {
+  if (children == null || typeof children === 'boolean') {
+    return []
+  }
+  if (Array.isArray(children)) {
+    return children.flatMap(toChildArray)
+  }
+  return [children]
+}


### PR DESCRIPTION
React 19 discourages React.Children.toArray/map/forEach/count. Replace all 26 usages across 13 production files with a new toChildArray() utility that provides the same behavior without the legacy API.

Files changed:
- Avatar, DialogAction, MenuRoot, TableAccordionHead, stat/Root
- list/Container, ListFormat, flex/Container, flex/utils
- FieldBlock, Toolbar, IterateOverSteps, Selection

The toChildArray utility flattens nested arrays and filters out null/undefined/boolean values, matching React.Children.toArray behavior without the key-prefixing side effect.

