### PR TITLE
fix(Table): recalculate sticky header offset on scroll for dynamic layouts

### DIFF
--- a/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
@@ -101,6 +101,11 @@ export const useStickyHeader = ({
             offset = scrollViewElem.scrollTop
           } else {
             offset = window.scrollY
+
+            // Recalculate table position on each scroll to handle
+            // dynamic layout changes (e.g., banners appearing above the table)
+            tableOffset = getOffsetTop(tableElem)
+            totalOffset = tableOffset - offsetTopPx
           }
 
           offset -= hasScrollbar ? offsetTopPx : totalOffset

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
@@ -202,6 +202,36 @@ describe('useStickyHeader', () => {
     )
   })
 
+  it('should recalculate table offset on scroll when layout changes dynamically', () => {
+    render(
+      <Table sticky stickyOffset="4rem">
+        <BasicTable />
+      </Table>
+    )
+
+    const tableElement = document.querySelector('table')
+    const trElem = document.querySelector('tr')
+
+    setSizes()
+
+    // Initial scroll: offset = 320 - (160 - 64) = 224
+    simulateScroll(320)
+    expect(trElem.style.getPropertyValue('--table-offset')).toEqual(
+      '224px'
+    )
+
+    // Simulate a banner appearing above the table, pushing it down by 80px
+    // (no resize event fired, only the table's offsetTop changes)
+    jest.spyOn(tableElement, 'offsetTop', 'get').mockReturnValue(240)
+
+    // On the next scroll, the new offset should be picked up automatically
+    // offset = 320 - (240 - 64) = 144
+    simulateScroll(320)
+    expect(trElem.style.getPropertyValue('--table-offset')).toEqual(
+      '144px'
+    )
+  })
+
   it('should check if .dnb-scroll-view has a vertical scrollbar and set shadow only, when css-position is used', () => {
     const { rerender } = render(
       <Table.ScrollView style={{ maxHeight: '4rem' }}>

--- a/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
+++ b/packages/dnb-eufemia/src/components/table/stories/Table.stories.tsx
@@ -1438,3 +1438,61 @@ export function Accodion() {
     </>
   )
 }
+
+export const StickyHeaderWithDynamicBanner = () => {
+  const [showBanner, setShowBanner] = React.useState(false)
+
+  return (
+    <div>
+      <Button
+        onClick={() => setShowBanner((prev) => !prev)}
+        variant="secondary"
+        style={{ marginBottom: '1rem' }}
+      >
+        {showBanner ? 'Hide' : 'Show'} error banner
+      </Button>
+
+      {showBanner && (
+        <div
+          style={{
+            padding: '1rem',
+            background: 'var(--color-fire-red)',
+            color: 'var(--color-white)',
+            marginBottom: '1rem',
+            borderRadius: '0.25rem',
+          }}
+        >
+          <P style={{ color: 'inherit' }}>
+            This is a global error message banner. It shifts the table down
+            and should not cause the sticky header to be offset
+            incorrectly.
+          </P>
+        </div>
+      )}
+
+      <Table sticky stickyOffset="0">
+        <caption className="dnb-sr-only">
+          Sticky header with dynamic banner
+        </caption>
+        <thead>
+          <Tr>
+            <Th>Column A</Th>
+            <Th>Column B</Th>
+            <Th>Column C</Th>
+            <Th>Column D</Th>
+          </Tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 30 }, (_, i) => (
+            <Tr key={i}>
+              <Td>Row {i + 1}</Td>
+              <Td>Data B{i + 1}</Td>
+              <Td>Data C{i + 1}</Td>
+              <Td>Data D{i + 1}</Td>
+            </Tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  )
+}


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777362503356789

When a global error banner or other dynamic content appears above a table with a sticky header, the header position would become offset because tableOffset was only calculated on init and window resize.

Now recalculates getOffsetTop(tableElem) on each scroll event (for the non-ScrollView case) so that dynamic layout changes like banners appearing/disappearing are handled automatically.


Issue:


https://github.com/user-attachments/assets/183b8bba-5821-4d02-b07a-1410ff03257d



Fix:


https://github.com/user-attachments/assets/956f7d2a-564a-454c-a6ae-ecd798f18ae4


