### PR TITLE
chore: replace deprecated pageXOffset/pageYOffset with scrollX/scrollY

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -1559,9 +1559,9 @@ describe('Dropdown component', () => {
         .mockImplementation(() => height)
     }
 
-    window.scrollTo = function resizeTo({ top = window.pageYOffset }) {
+    window.scrollTo = function resizeTo({ top = window.scrollY }) {
       Object.assign(this, {
-        pageYOffset: top,
+        scrollY: top,
       }).dispatchEvent(new this.Event('scroll'))
 
       // new setDirectionObserver implementation

--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -386,10 +386,8 @@ function PopoverContainer(props: PopoverContainerProps) {
       ? horizontalRect.left - containerRect.left
       : 0
 
-    const scrollY =
-      window.scrollY !== undefined ? window.scrollY : window.pageYOffset
-    const scrollX =
-      window.scrollX !== undefined ? window.scrollX : window.pageXOffset
+    const scrollY = window.scrollY
+    const scrollX = window.scrollX
     const scrollYOffset = fixedPosition ? 0 : scrollY
     const top = skipPortal
       ? relativeVerticalTop

--- a/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
@@ -20,15 +20,13 @@ export const percentToValue = (
 }
 
 export const getOffset = (node: HTMLElement) => {
-  const { pageYOffset, pageXOffset } =
-    typeof window !== 'undefined'
-      ? window
-      : { pageYOffset: 0, pageXOffset: 0 }
+  const { scrollY, scrollX } =
+    typeof window !== 'undefined' ? window : { scrollY: 0, scrollX: 0 }
   const { left, top } = node.getBoundingClientRect()
 
   return {
-    top: top + pageYOffset,
-    left: left + pageXOffset,
+    top: top + scrollY,
+    left: left + scrollX,
   }
 }
 

--- a/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableStickyHeader.tsx
@@ -100,7 +100,7 @@ export const useStickyHeader = ({
           if (scrollViewElem) {
             offset = scrollViewElem.scrollTop
           } else {
-            offset = window.pageYOffset
+            offset = window.scrollY
           }
 
           offset -= hasScrollbar ? offsetTopPx : totalOffset

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableStickyHeader.test.tsx
@@ -23,7 +23,7 @@ describe('useStickyHeader', () => {
     if (scrollElement) {
       jest.spyOn(scrollElement, 'scrollTop', 'get').mockReturnValue(y)
     } else {
-      window.pageYOffset = y
+      window.scrollY = y
     }
 
     fireEvent.scroll(scrollElement || document)

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListPortal.tsx
@@ -128,16 +128,8 @@ function DrawerListPortal({
 
       // Handle positions
       const rect = rootElem.getBoundingClientRect()
-      const scrollY = fixedPosition
-        ? 0
-        : window.scrollY !== undefined
-          ? window.scrollY
-          : window.pageYOffset
-      const scrollX = fixedPosition
-        ? 0
-        : window.scrollX !== undefined
-          ? window.scrollX
-          : window.pageXOffset
+      const scrollY = fixedPosition ? 0 : window.scrollY
+      const scrollX = fixedPosition ? 0 : window.scrollX
 
       let top = scrollY + rect.top
       let left =

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerListTestMocks.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerListTestMocks.ts
@@ -25,9 +25,9 @@ export function mockImplementationForDirectionObserver() {
           .mockImplementation(() => height)
       }
     ;(window as unknown as { scrollTo: CustomScrollTo }).scrollTo =
-      function scrollTo({ top = window.pageYOffset }) {
+      function scrollTo({ top = window.scrollY }) {
         Object.assign(window, {
-          pageYOffset: top,
+          scrollY: top,
         })
         window.dispatchEvent(new Event('scroll'))
 


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX#notes
- https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY#notes