### PR TITLE
chore: replace deprecated KeyboardEvent.which with event.key

### DIFF
--- a/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
@@ -153,11 +153,11 @@ export default function MenuRoot(props: MenuRootProps) {
   useIsomorphicLayoutEffect(() => {
     if (isOpen) {
       // Tab, Left/Up/Right/Down, PageUp/PageDown, End/Home.
-      whatInput.specificKeys([9, 37, 38, 39, 40, 33, 34, 35, 36])
+      whatInput.specificKeys(['Tab', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'PageUp', 'PageDown', 'End', 'Home'])
     }
 
     return () => {
-      whatInput.specificKeys([9])
+      whatInput.specificKeys(['Tab'])
     }
   }, [isOpen])
 

--- a/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
@@ -153,7 +153,17 @@ export default function MenuRoot(props: MenuRootProps) {
   useIsomorphicLayoutEffect(() => {
     if (isOpen) {
       // Tab, Left/Up/Right/Down, PageUp/PageDown, End/Home.
-      whatInput.specificKeys(['Tab', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'PageUp', 'PageDown', 'End', 'Home'])
+      whatInput.specificKeys([
+        'Tab',
+        'ArrowLeft',
+        'ArrowUp',
+        'ArrowRight',
+        'ArrowDown',
+        'PageUp',
+        'PageDown',
+        'End',
+        'Home',
+      ])
     }
 
     return () => {

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -743,7 +743,7 @@ function TabsComponent(ownProps: TabsProps) {
       getEventArgs({ event, focusKey: newFocusKey })
     )
 
-    whatInput.specificKeys([9, 37, 39, 33, 34, 35, 36])
+    whatInput.specificKeys(['Tab', 'ArrowLeft', 'ArrowRight', 'PageUp', 'PageDown', 'End', 'Home'])
   }
 
   // Focus tab button when focusKey changes
@@ -759,7 +759,7 @@ function TabsComponent(ownProps: TabsProps) {
     // saving the position will avoid flickering if the new tab will be done by a new page load
     saveLastPosition()
     saveLastUsedTab()
-    whatInput.specificKeys([9])
+    whatInput.specificKeys(['Tab'])
 
     // for handling openPrevTab and openNextTab
     if (mode === 'step' && parseFloat(String(newSelectedKey))) {
@@ -861,7 +861,7 @@ function TabsComponent(ownProps: TabsProps) {
 
     return () => {
       isMounted = false
-      whatInput.specificKeys([9])
+      whatInput.specificKeys(['Tab'])
       sharedStateRef.current = null
       if (typeof window !== 'undefined') {
         window.removeEventListener('resize', onResizeHandler)

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -743,7 +743,15 @@ function TabsComponent(ownProps: TabsProps) {
       getEventArgs({ event, focusKey: newFocusKey })
     )
 
-    whatInput.specificKeys(['Tab', 'ArrowLeft', 'ArrowRight', 'PageUp', 'PageDown', 'End', 'Home'])
+    whatInput.specificKeys([
+      'Tab',
+      'ArrowLeft',
+      'ArrowRight',
+      'PageUp',
+      'PageDown',
+      'End',
+      'Home',
+    ])
   }
 
   // Focus tab button when focusKey changes

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -25,7 +25,7 @@ export { getClosestParent, warn }
 init()
 
 // run component helper functions
-whatInput.specificKeys([9])
+whatInput.specificKeys(['Tab'])
 defineNavigator()
 
 /** @private */

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
@@ -3,9 +3,9 @@ import whatInput from '../whatInput'
 const dispatchMouse = () =>
   window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
 
-const dispatchKeyboard = (which = 9) =>
+const dispatchKeyboard = (key = 'Tab') =>
   window.dispatchEvent(
-    new KeyboardEvent('keydown', { which, bubbles: true })
+    new KeyboardEvent('keydown', { key, bubbles: true })
   )
 
 describe('whatInput', () => {
@@ -34,9 +34,9 @@ describe('whatInput', () => {
       'mouse'
     )
 
-    // Shift key (16) should be ignored
+    // Shift key should be ignored
     window.dispatchEvent(
-      new KeyboardEvent('keydown', { which: 16, bubbles: true })
+      new KeyboardEvent('keydown', { key: 'Shift', bubbles: true })
     )
     expect(document.documentElement.getAttribute('data-whatinput')).toBe(
       'mouse'
@@ -44,7 +44,7 @@ describe('whatInput', () => {
   })
 
   it('should respect specificKeys setting', () => {
-    whatInput.specificKeys([9])
+    whatInput.specificKeys(['Tab'])
 
     // Set to keyboard first so mouse transition is detected
     dispatchKeyboard()
@@ -53,15 +53,15 @@ describe('whatInput', () => {
       'mouse'
     )
 
-    // Key 65 ("a") should not trigger keyboard because only 9 is in specificKeys
+    // Key "a" should not trigger keyboard because only "Tab" is in specificKeys
     window.dispatchEvent(
-      new KeyboardEvent('keydown', { which: 65, bubbles: true })
+      new KeyboardEvent('keydown', { key: 'a', bubbles: true })
     )
     expect(document.documentElement.getAttribute('data-whatinput')).toBe(
       'mouse'
     )
 
-    // Tab (9) should trigger keyboard
+    // Tab should trigger keyboard
     dispatchKeyboard()
     expect(document.documentElement.getAttribute('data-whatinput')).toBe(
       'keyboard'

--- a/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
@@ -18,12 +18,7 @@ let currentIntent: InputType = 'initial'
 let currentTimestamp = Date.now()
 
 /** Keys to ignore – modifier keys that accompany pointer interactions. */
-const ignoreMap = [
-  'Shift',
-  'Control',
-  'Alt',
-  'Meta',
-]
+const ignoreMap = ['Shift', 'Control', 'Alt', 'Meta']
 
 /** When non-empty only these keys trigger "keyboard" input detection. */
 let specificMap: string[] = []

--- a/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
@@ -19,15 +19,14 @@ let currentTimestamp = Date.now()
 
 /** Keys to ignore – modifier keys that accompany pointer interactions. */
 const ignoreMap = [
-  16, // shift
-  17, // control
-  18, // alt
-  91, // left ⌘ / Windows key
-  93, // right ⌘ / Windows menu
+  'Shift',
+  'Control',
+  'Alt',
+  'Meta',
 ]
 
 /** When non-empty only these keys trigger "keyboard" input detection. */
-let specificMap: number[] = []
+let specificMap: string[] = []
 
 let isScrolling = false
 const mousePos = { x: 0, y: 0 }
@@ -112,7 +111,7 @@ function validateTouch(value: InputType): boolean {
 
 function setInput(event: Event) {
   const value = resolveInputType(event)
-  const eventKey = (event as KeyboardEvent).which
+  const eventKey = (event as KeyboardEvent).key
 
   if (value === 'keyboard' && eventKey) {
     const ignoreMatch =
@@ -192,10 +191,10 @@ function doUpdate(which: 'input' | 'intent') {
 
 /**
  * Set which specific keys should trigger "keyboard" input detection.
- * When set, only matching key codes count as keyboard input.
- * Pass e.g. `[9]` for Tab-only, or `[9, 37, 39]` for Tab + arrow keys.
+ * When set, only matching key names count as keyboard input.
+ * Pass e.g. `['Tab']` for Tab-only, or `['Tab', 'ArrowLeft', 'ArrowRight']` for Tab + arrow keys.
  */
-function specificKeys(arr: number[]) {
+function specificKeys(arr: string[]) {
   specificMap = arr
 }
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which

KeyboardEvent.which is deprecated. Replace all usage with the modern event.key string-based API.

Changes:
- whatInput.ts: ignoreMap and specificMap now use key name strings instead of numeric keycodes, and reads event.key instead of event.which
- specificKeys() signature changed from number[] to string[]
- Updated all callers in Tabs.tsx, MenuRoot.tsx, component-helper.ts
- Updated whatInput tests to use key names

