### PR TITLE
chore: remove deprecated document.execCommand copy fallback

### DIFF
--- a/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/__tests__/CopyOnClick.test.tsx
@@ -182,9 +182,6 @@ describe('CopyOnClick', () => {
       .fn()
       .mockRejectedValue(new Error('Permission denied'))
 
-    // Ensure fallback does not succeed
-    document.execCommand = jest.fn(() => false)
-
     render(<CopyOnClick>Copy me</CopyOnClick>)
 
     await userEvent.click(document.querySelector('.dnb-copy-on-click'))

--- a/packages/dnb-eufemia/src/shared/helpers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers.ts
@@ -312,59 +312,17 @@ export async function copyToClipboard(string: string) {
     }
   }
 
-  const copyFallback = () => {
+  if (typeof navigator !== 'undefined' && navigator?.clipboard) {
     try {
-      // create the focusable element
-      const elem = document.createElement('textarea')
-      elem.value = String(string)
-      elem.contentEditable = 'true'
-      elem.readOnly = false
-      elem.style.position = 'fixed'
-      elem.style.top = '-1000px'
-      document.body.appendChild(elem)
-
-      elem.select()
-
-      // NB: copy only works as a result of a user action (e.g. click events)
-      const success = document.execCommand('copy')
-
-      // Cleanup
-      document.body.removeChild(elem)
-
+      await navigator.clipboard.writeText(String(string))
       resetSelection()
-
-      if (success) {
-        return true
-      }
+      return true
     } catch (e) {
       return e
     }
-
-    return `Could not copy! Unknown reason. ${string}`
   }
 
-  let success
-
-  // eslint-disable-next-line compat/compat
-  if (typeof navigator !== 'undefined' && navigator?.clipboard) {
-    try {
-      // eslint-disable-next-line compat/compat
-      await navigator.clipboard.writeText(String(string))
-      success = true
-      resetSelection()
-    } catch (e) {
-      success = e
-      const newTry = copyFallback()
-      if (newTry === true) {
-        success = newTry
-      }
-    }
-  } else {
-    // use the fallback as the primary, because we get
-    success = copyFallback()
-  }
-
-  return success
+  return false
 }
 
 /**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand

Remove the document.execCommand('copy') fallback from copyToClipboard(). The function now uses navigator.clipboard.writeText() exclusively, which is supported in all browsers targeted by v11.

The deprecated fallback created a hidden textarea element, selected its content, and ran execCommand('copy') — none of which is needed with the modern Clipboard API.

