### PR TITLE
chore: deduplicate collator instance between Examples.tsx and designTokens.ts

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
@@ -6,6 +6,7 @@ import { Td, Th, Tooltip, Tr } from '@dnb/eufemia/src'
 import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 import {
+  collator,
   tokenModifierOrder,
   tokenNamingPolicy,
   tokenSections,
@@ -66,11 +67,6 @@ const decorativeGroupSortOrder: Record<string, number> = {
   second: 1,
   third: 2,
 }
-
-const collator = new Intl.Collator('en', {
-  numeric: true,
-  sensitivity: 'base',
-})
 
 const cellVerticalMiddle: React.CSSProperties = {
   verticalAlign: 'middle',

--- a/packages/dnb-design-system-portal/src/uilib/utils/designTokens.ts
+++ b/packages/dnb-design-system-portal/src/uilib/utils/designTokens.ts
@@ -148,7 +148,7 @@ const themeSources: Record<ThemeName, FigmaTokenGroup> = {
   carnegie: carnegieTokens as unknown as FigmaTokenGroup,
 }
 
-const collator = new Intl.Collator('en', {
+export const collator = new Intl.Collator('en', {
   numeric: true,
   sensitivity: 'base',
 })


### PR DESCRIPTION
Export the shared Intl.Collator from designTokens.ts and import it in Examples.tsx instead of declaring an identical instance.

