### PR TITLE
chore(Checkbox, Dropdown, Radio): standardize ref forwarding to use useCombinedRef

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -26,6 +26,7 @@ import {
 import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
 import useId from '../../shared/helpers/useId'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import type { SpacingProps } from '../../shared/types'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
@@ -158,15 +159,8 @@ function Checkbox(localProps: CheckboxProps) {
   const [, forceUpdate] = useReducer(() => ({}), {})
   const id = useId(idProp)
 
-  const isFn = typeof refProp === 'function'
-  const refHook = useRef<HTMLInputElement>(undefined)
-  const ref = (!isFn && refProp) || refHook
-
-  useEffect(() => {
-    if (isFn) {
-      refProp?.(ref.current)
-    }
-  }, [refProp, isFn, ref])
+  const internalRef = useRef<HTMLInputElement>(undefined)
+  const ref = useCombinedRef(refProp, internalRef)
 
   const preventChangeRef = useRef(false)
   const isCheckedRef = useRef(checked ?? false)
@@ -181,8 +175,10 @@ function Checkbox(localProps: CheckboxProps) {
   }, [checked])
 
   useEffect(() => {
-    ref.current.indeterminate = indeterminate
-  }, [indeterminate, ref])
+    if (internalRef.current) {
+      internalRef.current.indeterminate = indeterminate
+    }
+  }, [indeterminate, internalRef])
 
   const callOnChange: CheckboxProps['onChange'] = useCallback(
     (args) => {
@@ -204,13 +200,13 @@ function Checkbox(localProps: CheckboxProps) {
       callOnChange({ checked: updatedCheck, event })
 
       // help firefox and safari to have a correct state after a click
-      if (ref.current) {
-        ref.current.focus({
+      if (internalRef.current) {
+        internalRef.current.focus({
           preventScroll: true,
         })
       }
     },
-    [callOnChange, ref]
+    [callOnChange, internalRef]
   )
 
   const onChangeHandler = useCallback(

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -18,6 +18,7 @@ import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithCont
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
 import useId from '../../shared/helpers/useId'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { applySpacing } from '../space/SpacingUtils'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
@@ -232,29 +233,9 @@ const DropdownInstance = React.memo(function DropdownInstance({
   const attributesRef = useRef<Record<string, unknown>>({})
 
   // Combine internal and external refs
-  const setRootRef = useCallback(
-    (el: HTMLElement | null) => {
-      elRef.current = el
-      if (typeof externalRef === 'function') {
-        externalRef(el)
-      } else if (externalRef) {
-        externalRef.current = el
-      }
-    },
-    [externalRef]
-  )
+  const setRootRef = useCombinedRef(externalRef, elRef)
 
-  const setButtonRef = useCallback(
-    (el: HTMLElement | null) => {
-      buttonRef.current = el
-      if (typeof externalButtonRef === 'function') {
-        externalButtonRef(el)
-      } else if (externalButtonRef) {
-        externalButtonRef.current = el
-      }
-    },
-    [externalButtonRef]
-  )
+  const setButtonRef = useCombinedRef(externalButtonRef, buttonRef)
 
   // Strip undefined values so they fall through to defaults,
   // preserving the legacy React defaultProps behavior.

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -6,6 +6,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import React, { useContext, useRef, useState, useCallback } from 'react'
 import clsx from 'clsx'
 import useId from '../../shared/helpers/useId'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
@@ -434,21 +435,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   const Element = element || 'input'
 
   // Forward ref to external ref
-  const combinedRef = useCallback(
-    (el: HTMLInputElement | null) => {
-      ;(
-        inputRef as React.MutableRefObject<HTMLInputElement | null>
-      ).current = el
-      if (typeof externalRef === 'function') {
-        externalRef(el)
-      } else if (externalRef) {
-        ;(
-          externalRef as React.MutableRefObject<HTMLInputElement | null>
-        ).current = el
-      }
-    },
-    [externalRef]
-  )
+  const combinedRef = useCombinedRef(externalRef, inputRef)
 
   return (
     <span {...mainParams}>


### PR DESCRIPTION
All three components now use the shared useCombinedRef hook instead of rolling their own ref combining logic.

