### PR TITLE
feat(Forms): add `globalStatusAutoClose` prop to DataContext.Provider

### DIFF
--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -433,7 +433,7 @@ function FormStatusComponent(
       fillCache()
 
       if (state === 'error') {
-        if (show) {
+        if (show && getContent(restOwnProps)) {
           globalStatusRef.current?.update(
             statusId,
             {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -93,6 +93,13 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     globalStatusId?: string
     /**
+     * Set to `false` to keep the GlobalStatus visible after a field value changes.
+     * By default, the GlobalStatus error summary disappears when the user starts editing a field.
+     * When set to `false`, GlobalStatus stays visible until all errors are resolved.
+     * Defaults to `true`.
+     */
+    globalStatusAutoClose?: boolean
+    /**
      * Source data, will be used instead of defaultData, and leading to updates if changed after mount
      */
     data?: Data
@@ -215,6 +222,7 @@ export default function Provider<Data extends JsonObject>(
   const {
     id,
     globalStatusId = 'main',
+    globalStatusAutoClose = true,
     defaultData,
     emptyData,
     data,
@@ -1172,7 +1180,9 @@ export default function Provider<Data extends JsonObject>(
         handlePathChangeUnvalidated(path, value)
       }
 
-      showAllErrorsRef.current = false
+      if (globalStatusAutoClose) {
+        showAllErrorsRef.current = false
+      }
 
       validateData()
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -2590,6 +2590,65 @@ describe('DataContext.Provider', () => {
           })
         })
 
+        it('should keep GlobalStatus visible when globalStatusAutoClose is false', async () => {
+          jest.spyOn(window, 'scrollTo').mockImplementation()
+
+          render(
+            <>
+              <GlobalStatus id="my-status" />
+              <DataContext.Provider
+                globalStatusId="my-status"
+                globalStatusAutoClose={false}
+              >
+                <Field.String path="/myField" required />
+                <Field.String path="/otherField" required />
+                <Form.SubmitButton />
+              </DataContext.Provider>
+            </>
+          )
+
+          const [firstInput, secondInput] =
+            document.querySelectorAll('input')
+          const submitButton = document.querySelector('button')
+
+          expect(
+            document.querySelector('.dnb-global-status__title')
+          ).toBeNull()
+
+          fireEvent.click(submitButton)
+
+          await waitFor(() => {
+            expect(
+              document.querySelector('.dnb-global-status__title')
+            ).toHaveTextContent(nb.Field.errorSummaryTitle)
+          })
+
+          // Type in the first field - GlobalStatus should persist
+          await userEvent.type(firstInput, 'foo')
+          fireEvent.blur(firstInput)
+
+          expect(
+            document.querySelector('.dnb-global-status__title')
+          ).toHaveTextContent(nb.Field.errorSummaryTitle)
+
+          // Fix the second field as well - GlobalStatus should now auto-close
+          await userEvent.type(secondInput, 'bar')
+          fireEvent.blur(secondInput)
+
+          await waitFor(() => {
+            const heightAnimation = document.querySelector(
+              '.dnb-height-animation'
+            )
+            if (heightAnimation) {
+              simulateAnimationEnd(heightAnimation)
+            }
+
+            expect(
+              document.querySelector('.dnb-global-status__title')
+            ).toBeNull()
+          })
+        })
+
         it('should override GlobalStatus title when providing one', async () => {
           jest.spyOn(window, 'scrollTo').mockImplementation()
           const myTitle = 'Custom title for global status'

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -2607,8 +2607,9 @@ describe('DataContext.Provider', () => {
             </>
           )
 
-          const [firstInput, secondInput] =
+          const [firstInput, secondInput] = Array.from(
             document.querySelectorAll('input')
+          )
           const submitButton = document.querySelector('button')
 
           expect(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -33,6 +33,7 @@ const allowedProviderContextProps: Array<
   'ajvInstance',
   'errorMessages',
   'globalStatusId',
+  'globalStatusAutoClose',
   'transformIn',
   'transformOut',
   'onChange',


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777373660252399

Add a new 'globalStatusAutoClose' prop (default: true) to DataContext.Provider and Form.Handler. When set to `false`, the GlobalStatus error summary remains visible after the user starts editing fields, instead of disappearing immediately. This allows consumers to keep the GlobalStatus banner persistent until all validation errors are resolved, matching the behavior of the classic Input component approach. 

Changes: 
- DataContext.Provider: add globalStatusAutoClose prop, guard the showAllErrorsRef reset in handlePathChange 
- Form.Handler: forward globalStatusAutoClose to Provider 
- FormStatus: also check for content when deciding to update GlobalStatus, ensuring items are removed when errors resolve