### PR TITLE
chore(ListScrollView): use useCombinedRef

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import type { ScrollViewAllProps } from '../../fragments/scroll-view/ScrollView'
 import ScrollView from '../../fragments/scroll-view/ScrollView'
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import { ListContext } from './ListContext'
 import type { SkeletonShow } from '../Skeleton'
 
@@ -34,6 +35,7 @@ function ListScrollView(props: ListScrollViewProps) {
   } = props
 
   const localRef = useRef<HTMLDivElement>(null)
+  const combinedRef = useCombinedRef(ref, localRef)
   const [measuredMaxHeight, setMeasuredMaxHeight] = useState<
     string | undefined
   >(undefined)
@@ -69,19 +71,6 @@ function ListScrollView(props: ListScrollViewProps) {
       measuredHeight ? `${measuredHeight}px` : undefined
     )
   }, [hasValidMaxVisibleListItems, maxVisibleListItems, style?.maxHeight])
-
-  useLayoutEffect(() => {
-    if (!ref) {
-      return undefined
-    }
-
-    if (typeof ref === 'function') {
-      ref(localRef.current)
-      return undefined
-    }
-
-    ref.current = localRef.current
-  }, [ref])
 
   useLayoutEffect(() => {
     measureMaxHeight()
@@ -121,7 +110,7 @@ function ListScrollView(props: ListScrollViewProps) {
         className
       )}
       interactive="auto"
-      ref={localRef}
+      ref={combinedRef}
       style={scrollViewStyle}
       {...rest}
     >


### PR DESCRIPTION
Replace manual ref syncing logic with the useCombinedRef hook in:
- ListScrollView: remove useLayoutEffect that manually forwarded ref to localRef

