### PR TITLE
chore(CodeBlock, DrawerList): replace makeUniqueId with useId

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -6,6 +6,7 @@
 import React, {
   useCallback,
   useContext,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -24,7 +25,7 @@ import type {
   ThemeColorScheme,
   ThemeSurface,
 } from '@dnb/eufemia/src/shared/Theme'
-import { makeUniqueId } from '@dnb/eufemia/src/shared/component-helper'
+
 import { Context } from '@dnb/eufemia/src/shared'
 import { createSkeletonClass } from '@dnb/eufemia/src/components/skeleton/SkeletonHelper'
 import {
@@ -155,7 +156,7 @@ function prepareCode(code: string) {
 function LiveCode(props: LiveCodeProps) {
   const context = useContext(Context)
   const editorElementRef = useRef<HTMLDivElement>(null)
-  const idRef = useRef(makeUniqueId())
+  const id = useId()
 
   const [hideCode, setHideCode] = useState(props.hideCode)
   const [hidePreview, setHidePreview] = useState(props.hidePreview)
@@ -327,7 +328,7 @@ function LiveCode(props: LiveCodeProps) {
           >
             <LiveEditor
               prism={Prism}
-              id={idRef.current}
+              id={id}
               tabMode={tabMode}
               className="dnb-live-editor__editable dnb-pre"
             />

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -74,18 +74,6 @@ jest.mock('@dnb/eufemia/src/components', () => {
   }
 })
 
-// Mock makeUniqueId
-jest.mock('@dnb/eufemia/src/shared/component-helper', () => {
-  const actual = jest.requireActual(
-    '@dnb/eufemia/src/shared/component-helper'
-  )
-
-  return {
-    ...actual,
-    makeUniqueId: () => 'test-id',
-  }
-})
-
 // Mock Context
 jest.mock('@dnb/eufemia/src/shared', () => {
   const React = require('react')

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -3,10 +3,7 @@
  */
 
 import React from 'react'
-import {
-  makeUniqueId,
-  convertJsxToString,
-} from '../../shared/component-helper'
+import { convertJsxToString } from '../../shared/component-helper'
 import type {
   DrawerListDataArrayItem,
   DrawerListDataArrayObject,
@@ -329,7 +326,7 @@ export function prepareStartupState(
   const open = props.open !== null ? props.open : null
 
   const state: DrawerListContextState = {
-    id: props.id || makeUniqueId(),
+    id: props.id,
     open,
     data,
     originalData: data, // used to reset in case we reorder data etc.

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -47,6 +47,7 @@ import {
   disableBodyScroll,
   enableBodyScroll,
 } from '../../components/modal/bodyScrollLock'
+import useId from '../../shared/helpers/useId'
 
 import type { SpacingProps } from '../../shared/types'
 import type {
@@ -167,6 +168,7 @@ const allDefaultProps = {
 
 function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   const context = useContext(Context)
+  const id = useId(ownProps.id)
 
   // Apply defaults
   const props = useMemo(
@@ -184,7 +186,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
       activeItem: undefined,
       selectedItem: undefined,
       ignoreEvents: false,
-      ...prepareStartupState(props),
+      ...prepareStartupState({ ...props, id }),
     }
   }
 


### PR DESCRIPTION
- CodeBlock: use React.useId() instead of makeUniqueId in useRef
- DrawerListProvider: use Eufemia useId hook for fallback ID
- DrawerListHelpers: remove makeUniqueId import and fallback
- Remove obsolete makeUniqueId mock from CodeBlock test

