### PR TITLE
fix(ScrollView): support callback refs in useInteractive

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import type { ScrollViewAllProps } from '../../fragments/scroll-view/ScrollView'
 import ScrollView from '../../fragments/scroll-view/ScrollView'
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import { ListContext } from './ListContext'
 import type { SkeletonShow } from '../Skeleton'
 
@@ -34,6 +35,7 @@ function ListScrollView(props: ListScrollViewProps) {
   } = props
 
   const localRef = useRef<HTMLDivElement>(null)
+  const combinedRef = useCombinedRef(ref, localRef)
   const [measuredMaxHeight, setMeasuredMaxHeight] = useState<
     string | undefined
   >(undefined)
@@ -69,19 +71,6 @@ function ListScrollView(props: ListScrollViewProps) {
       measuredHeight ? `${measuredHeight}px` : undefined
     )
   }, [hasValidMaxVisibleListItems, maxVisibleListItems, style?.maxHeight])
-
-  useLayoutEffect(() => {
-    if (!ref) {
-      return undefined
-    }
-
-    if (typeof ref === 'function') {
-      ref(localRef.current)
-      return undefined
-    }
-
-    ref.current = localRef.current
-  }, [ref])
 
   useLayoutEffect(() => {
     measureMaxHeight()
@@ -121,7 +110,7 @@ function ListScrollView(props: ListScrollViewProps) {
         className
       )}
       interactive="auto"
-      ref={localRef}
+      ref={combinedRef}
       style={scrollViewStyle}
       {...rest}
     >

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
@@ -14,6 +14,7 @@ import { applySpacing } from '../../components/space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ScrollViewProps = {
@@ -61,14 +62,13 @@ function ScrollView(localProps: ScrollViewAllProps) {
   })
 
   const localRef = React.useRef<HTMLDivElement>(undefined)
-  mainParams.ref = refProp
-    ? (refProp as React.RefObject<HTMLDivElement>)
-    : localRef
+  const combinedRef = useCombinedRef(refProp, localRef)
+  mainParams.ref = combinedRef
 
   mainParams.tabIndex = useInteractive({
     interactive,
     children,
-    ref: mainParams.ref,
+    ref: localRef,
   })
 
   validateDOMAttributes(props, mainParams)

--- a/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
@@ -110,6 +110,28 @@ describe('ScrollView', () => {
     expect(observe).toHaveBeenCalledWith(ref.current)
   })
 
+  it('should attach ResizeObserver when a callback ref is used', () => {
+    const observe = jest.fn()
+    const init = jest.fn()
+    setResizeObserver({ init, observe })
+
+    let refValue: HTMLDivElement | null = null
+    const callbackRef = (el: HTMLDivElement | null) => {
+      refValue = el
+    }
+
+    render(
+      <ScrollView ref={callbackRef} interactive="auto">
+        overflow content
+      </ScrollView>
+    )
+
+    expect(refValue).toBeInstanceOf(HTMLDivElement)
+    expect(init).toHaveBeenCalledTimes(1)
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(observe).toHaveBeenCalledWith(refValue)
+  })
+
   it('should include custom classes', () => {
     render(
       <ScrollView className="custom-class">overflow content</ScrollView>


### PR DESCRIPTION
ScrollView assumed the ref passed to useInteractive would always be a ref object with .current. When a caller (e.g. ListScrollView) passes a callback ref via useCombinedRef, ref.current is undefined and ResizeObserver.observe crashes, breaking the component rendering.

Fix: ScrollView now uses useCombinedRef to merge the external ref with its own localRef, and always passes localRef to useInteractive. This ensures ResizeObserver works regardless of ref type.

Also re-applies useCombinedRef in ListScrollView (reverted in d5887ec) and adds a test for callback ref support.

