### PR TITLE
fix: prevent focus trap infinite loop with dynamically added elements

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
@@ -21,11 +21,13 @@ export class InteractionInvalidation {
   bypassElements: Array<TargetElement>
   bypassSelectors: Array<TargetSelector>
   _nodesToInvalidate: Array<HTMLElementNode>
+  _observer: MutationObserver | null
   options: InteractionInvalidationOptions
 
   constructor(options: InteractionInvalidationOptions = null) {
     this.bypassElements = []
     this.bypassSelectors = []
+    this._observer = null
     this.options = options || {}
     return this
   }
@@ -47,10 +49,15 @@ export class InteractionInvalidation {
   activate(targetElement: TargetElement | TargetSelector = null) {
     if (!this._nodesToInvalidate) {
       this._runInvalidation(targetElement)
+
+      if (!targetElement) {
+        this._observeNewElements()
+      }
     }
   }
 
   revert() {
+    this._disconnectObserver()
     this._revertInvalidation()
     this._nodesToInvalidate = null
   }
@@ -73,24 +80,7 @@ export class InteractionInvalidation {
         continue
       }
 
-      if (this.options.tabIndex !== false) {
-        const tabIndex = node.getAttribute('tabindex')
-        if (tabIndex !== null && typeof node.__tabIndex === 'undefined') {
-          node.__tabIndex = tabIndex
-        }
-        node.setAttribute('tabindex', '-1')
-      }
-
-      if (this.options.ariaHidden !== false) {
-        const ariaHidden = node.getAttribute('aria-hidden')
-        if (
-          ariaHidden !== null &&
-          typeof node.__ariaHidden === 'undefined'
-        ) {
-          node.__ariaHidden = ariaHidden
-        }
-        node.setAttribute('aria-hidden', 'true')
-      }
+      this._invalidateSingleNode(node)
     }
   }
 
@@ -210,5 +200,117 @@ export class InteractionInvalidation {
     }
 
     return undefined
+  }
+
+  _isNodeBypassed(node: HTMLElement): boolean {
+    if (this.bypassElements.includes(node)) {
+      return true
+    }
+
+    for (const bypassElement of this.bypassElements) {
+      if (bypassElement.contains(node)) {
+        return true
+      }
+    }
+
+    for (const selector of this.bypassSelectors) {
+      try {
+        const baseSelector = selector.replace(/\s+\*$/, '')
+        if (!baseSelector) {
+          continue
+        }
+
+        if (node.matches(baseSelector)) {
+          return true
+        }
+
+        if (node.closest(baseSelector)) {
+          return true
+        }
+      } catch (e) {
+        // Invalid selector, skip
+      }
+    }
+
+    return false
+  }
+
+  _invalidateSingleNode(node: HTMLElementNode) {
+    if (this.options.tabIndex !== false) {
+      const tabIndex = node.getAttribute('tabindex')
+      if (tabIndex !== null && typeof node.__tabIndex === 'undefined') {
+        node.__tabIndex = tabIndex
+      }
+      node.setAttribute('tabindex', '-1')
+    }
+
+    if (this.options.ariaHidden !== false) {
+      const ariaHidden = node.getAttribute('aria-hidden')
+      if (
+        ariaHidden !== null &&
+        typeof node.__ariaHidden === 'undefined'
+      ) {
+        node.__ariaHidden = ariaHidden
+      }
+      node.setAttribute('aria-hidden', 'true')
+    }
+  }
+
+  _observeNewElements() {
+    if (typeof MutationObserver === 'undefined') {
+      return // stop here
+    }
+
+    const skipTags = ['SCRIPT', 'STYLE', 'PATH']
+
+    this._observer = new MutationObserver((mutations) => {
+      if (!this._nodesToInvalidate) {
+        return // stop here
+      }
+
+      for (const mutation of mutations) {
+        for (const addedNode of Array.from(mutation.addedNodes)) {
+          if (addedNode.nodeType !== Node.ELEMENT_NODE) {
+            continue
+          }
+
+          const element = addedNode as HTMLElementNode
+
+          if (this._isNodeBypassed(element)) {
+            continue
+          }
+
+          if (!skipTags.includes(element.tagName)) {
+            this._invalidateSingleNode(element)
+            this._nodesToInvalidate.push(element)
+          }
+
+          const descendants = element.querySelectorAll(
+            '*'
+          ) as NodeListOf<HTMLElementNode>
+          for (const descendant of Array.from(descendants)) {
+            if (
+              !skipTags.includes(descendant.tagName) &&
+              !this._isNodeBypassed(descendant)
+            ) {
+              this._invalidateSingleNode(descendant)
+              this._nodesToInvalidate.push(descendant)
+            }
+          }
+        }
+      }
+    })
+
+    this._observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    })
+  }
+
+  _disconnectObserver() {
+    if (this._observer) {
+      this._observer.disconnect()
+      this._observer = null
+    }
   }
 }

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/InteractionInvalidation.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/InteractionInvalidation.test.ts
@@ -2,6 +2,10 @@ import { InteractionInvalidation } from '../InteractionInvalidation'
 
 let ii: InteractionInvalidation
 
+afterEach(() => {
+  ii?.revert()
+})
+
 beforeEach(() => {
   document.body.innerHTML = /* jsx */ `
 <div class="effected">
@@ -261,6 +265,140 @@ describe('InteractionInvalidation', () => {
 
       hasDefaultState('.bypass')
       hasInvalidatedState('.effected')
+    })
+  })
+
+  describe('dynamic elements (MutationObserver)', () => {
+    it('should invalidate elements added to the DOM after activation', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+
+      const dynamicButton = document.createElement('button')
+      dynamicButton.textContent = 'Close toast'
+      document.body.appendChild(dynamicButton)
+
+      // MutationObserver callbacks are microtasks
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton.getAttribute('tabindex')).toBe('-1')
+      expect(dynamicButton.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should invalidate descendants of dynamically added elements', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+
+      const container = document.createElement('div')
+      const innerButton = document.createElement('button')
+      innerButton.textContent = 'Close'
+      container.appendChild(innerButton)
+      document.body.appendChild(container)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(container.getAttribute('tabindex')).toBe('-1')
+      expect(container.getAttribute('aria-hidden')).toBe('true')
+      expect(innerButton.getAttribute('tabindex')).toBe('-1')
+      expect(innerButton.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('should not invalidate elements inside bypass selectors', async () => {
+      ii = new InteractionInvalidation()
+      ii.setBypassSelector('.bypass *')
+      ii.activate()
+
+      const dynamicButton = document.createElement('button')
+      dynamicButton.textContent = 'Allowed'
+      document.querySelector('.bypass').appendChild(dynamicButton)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton).not.toHaveAttribute('tabindex')
+      expect(dynamicButton).not.toHaveAttribute('aria-hidden')
+    })
+
+    it('should not invalidate elements inside bypass elements', async () => {
+      const bypassContainer = document.querySelector(
+        '.bypass'
+      ) as HTMLElement
+      ii = new InteractionInvalidation()
+      ii.setBypassElements([bypassContainer])
+      ii.activate()
+
+      const dynamicButton = document.createElement('button')
+      dynamicButton.textContent = 'Allowed'
+      bypassContainer.appendChild(dynamicButton)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton).not.toHaveAttribute('tabindex')
+      expect(dynamicButton).not.toHaveAttribute('aria-hidden')
+    })
+
+    it('should skip script, style, and path elements', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+
+      const script = document.createElement('script')
+      document.body.appendChild(script)
+
+      const style = document.createElement('style')
+      document.body.appendChild(style)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(script).not.toHaveAttribute('tabindex')
+      expect(script).not.toHaveAttribute('aria-hidden')
+      expect(style).not.toHaveAttribute('tabindex')
+      expect(style).not.toHaveAttribute('aria-hidden')
+    })
+
+    it('should revert dynamically added elements on revert()', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+
+      const dynamicButton = document.createElement('button')
+      document.body.appendChild(dynamicButton)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton.getAttribute('tabindex')).toBe('-1')
+
+      ii.revert()
+
+      expect(dynamicButton).not.toHaveAttribute('tabindex')
+      expect(dynamicButton).not.toHaveAttribute('aria-hidden')
+    })
+
+    it('should restore original tabindex on dynamically added elements', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+
+      const dynamicButton = document.createElement('button')
+      dynamicButton.setAttribute('tabindex', '0')
+      document.body.appendChild(dynamicButton)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton.getAttribute('tabindex')).toBe('-1')
+
+      ii.revert()
+
+      expect(dynamicButton.getAttribute('tabindex')).toBe('0')
+    })
+
+    it('should disconnect observer after revert()', async () => {
+      ii = new InteractionInvalidation()
+      ii.activate()
+      ii.revert()
+
+      const dynamicButton = document.createElement('button')
+      document.body.appendChild(dynamicButton)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(dynamicButton).not.toHaveAttribute('tabindex')
+      expect(dynamicButton).not.toHaveAttribute('aria-hidden')
     })
   })
 })


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777384168492689

Not sure about this fix, seems complicated...

[StackBlitz of the issue](https://stackblitz.com/edit/u6dlg7ok-11jwk6xi?file=package.json,src%2FApp.tsx)
[StackBlitz with the fix](https://stackblitz.com/edit/u6dlg7ok-rsgtofvq?file=src%2FApp.tsx) (Not working)

When a Dialog is open, elements added to the DOM dynamically (e.g. toast close buttons rendered via React portals) could remain focusable since InteractionInvalidation only processed elements present at activation time. This caused an infinite focus-fighting loop between the Dialog's focus trap and the portal, freezing the browser tab.

Add a MutationObserver to InteractionInvalidation that automatically invalidates any new elements added to the DOM while the invalidation is active, respecting existing bypass selectors and bypass elements.

