### PR TITLE
chore(Flex): resolve duplicate React keys in renderWithSpacing

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -114,7 +114,7 @@ describe('renderWithSpacing', () => {
       ([type]) => type === (MockComponent as any)
     )
     expect(call).toBeDefined()
-    expect(call[1].key).toBe('.$test-key')
+    expect(call[1].key).toBe('.$test-key-0')
 
     spy.mockRestore()
   })

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -130,7 +130,7 @@ export function renderWithSpacing(
           return React.createElement(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             child.type as React.ComponentType<any>,
-            { ...childProps, key: childKey || i },
+            { ...childProps, key: childKey ? `${childKey}-${i}` : i },
             wrapWithSpace({
               element: element as React.ReactNode,
               spaceProps,


### PR DESCRIPTION
When a Fragment child had multiple children, all created elements received the same key (childKey), causing React warnings about duplicate keys. Now each element gets a unique key by appending the child index: childKey-i instead of just childKey.

Motivation (`yarn test`):

```
PASS src/components/flex/__tests__/Container.test.tsx
  ● Console

    console.error
      Encountered two children with the same key, `.$.0`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

      60 |         return
      61 |       }
    > 62 |       originalError.call(console, ...args)
         |                     ^
      63 |     }
      64 |   })
      65 |

      at console.call [as error] (src/core/jest/setupJest.ts:62:21)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:6604:23
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at warnOnInvalidKey (../../node_modules/react-dom/cjs/react-dom-client.development.js:6603:13)
      at reconcileChildrenArray (../../node_modules/react-dom/cjs/react-dom-client.development.js:6672:31)
      at reconcileChildFibersImpl (../../node_modules/react-dom/cjs/react-dom-client.development.js:6993:30)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:7098:33
      at reconcileChildren (../../node_modules/react-dom/cjs/react-dom-client.development.js:9701:13)
      at beginWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:12126:13)
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:17641:22)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performWorkOnRootViaSchedulerTask (../../node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (../../node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:884:10)
      at ../../node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (../../node_modules/@testing-library/react/dist/pure.js:190:26)
      at rerender (../../node_modules/@testing-library/react/dist/pure.js:211:7)
      at Object.rerender (src/components/flex/__tests__/Container.test.tsx:805:7)

    console.error
      Encountered two children with the same key, `.$.1`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

      60 |         return
      61 |       }
    > 62 |       originalError.call(console, ...args)
         |                     ^
      63 |     }
      64 |   })
      65 |

      at console.call [as error] (src/core/jest/setupJest.ts:62:21)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:6604:23
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at warnOnInvalidKey (../../node_modules/react-dom/cjs/react-dom-client.development.js:6603:13)
      at reconcileChildrenArray (../../node_modules/react-dom/cjs/react-dom-client.development.js:6672:31)
      at reconcileChildFibersImpl (../../node_modules/react-dom/cjs/react-dom-client.development.js:6993:30)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:7098:33
      at reconcileChildren (../../node_modules/react-dom/cjs/react-dom-client.development.js:9701:13)
      at beginWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:12126:13)
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:17641:22)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performWorkOnRootViaSchedulerTask (../../node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (../../node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:884:10)
      at ../../node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (../../node_modules/@testing-library/react/dist/pure.js:190:26)
      at rerender (../../node_modules/@testing-library/react/dist/pure.js:211:7)
      at Object.rerender (src/components/flex/__tests__/Container.test.tsx:915:7)

    console.error
      Encountered two children with the same key, `.$.0`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

      60 |         return
      61 |       }
    > 62 |       originalError.call(console, ...args)
         |                     ^
      63 |     }
      64 |   })
      65 |

      at console.call [as error] (src/core/jest/setupJest.ts:62:21)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:6604:23
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at warnOnInvalidKey (../../node_modules/react-dom/cjs/react-dom-client.development.js:6603:13)
      at reconcileChildrenArray (../../node_modules/react-dom/cjs/react-dom-client.development.js:6672:31)
      at reconcileChildFibersImpl (../../node_modules/react-dom/cjs/react-dom-client.development.js:6993:30)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:7098:33
      at reconcileChildren (../../node_modules/react-dom/cjs/react-dom-client.development.js:9701:13)
      at beginWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:12126:13)
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:17641:22)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performWorkOnRootViaSchedulerTask (../../node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (../../node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:884:10)
      at ../../node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (../../node_modules/@testing-library/react/dist/pure.js:190:26)
      at rerender (../../node_modules/@testing-library/react/dist/pure.js:211:7)
      at Object.rerender (src/components/flex/__tests__/Container.test.tsx:915:7)

    console.error
      Encountered two children with the same key, `.$.1`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

      60 |         return
      61 |       }
    > 62 |       originalError.call(console, ...args)
         |                     ^
      63 |     }
      64 |   })
      65 |

      at console.call [as error] (src/core/jest/setupJest.ts:62:21)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:6604:23
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at warnOnInvalidKey (../../node_modules/react-dom/cjs/react-dom-client.development.js:6603:13)
      at reconcileChildrenArray (../../node_modules/react-dom/cjs/react-dom-client.development.js:6645:23)
      at reconcileChildFibersImpl (../../node_modules/react-dom/cjs/react-dom-client.development.js:6993:30)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:7098:33
      at reconcileChildren (../../node_modules/react-dom/cjs/react-dom-client.development.js:9702:13)
      at beginWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:12126:13)
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:17641:22)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performSyncWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:18972:7)
      at flushSyncWorkAcrossRoots_impl (../../node_modules/react-dom/cjs/react-dom-client.development.js:18814:21)
      at flushSpawnedWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:18334:9)
      at commitRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:17955:9)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16667:15)
      at performWorkOnRootViaSchedulerTask (../../node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (../../node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:884:10)
      at ../../node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (../../node_modules/@testing-library/react/dist/pure.js:190:26)
      at rerender (../../node_modules/@testing-library/react/dist/pure.js:211:7)
      at Object.rerender (src/components/flex/__tests__/Container.test.tsx:915:7)

    console.error
      Encountered two children with the same key, `.$.0`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

      60 |         return
      61 |       }
    > 62 |       originalError.call(console, ...args)
         |                     ^
      63 |     }
      64 |   })
      65 |

      at console.call [as error] (src/core/jest/setupJest.ts:62:21)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:6604:23
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at warnOnInvalidKey (../../node_modules/react-dom/cjs/react-dom-client.development.js:6603:13)
      at reconcileChildrenArray (../../node_modules/react-dom/cjs/react-dom-client.development.js:6645:23)
      at reconcileChildFibersImpl (../../node_modules/react-dom/cjs/react-dom-client.development.js:6993:30)
      at ../../node_modules/react-dom/cjs/react-dom-client.development.js:7098:33
      at reconcileChildren (../../node_modules/react-dom/cjs/react-dom-client.development.js:9702:13)
      at beginWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:12126:13)
      at runWithFiberInDEV (../../node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at performUnitOfWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:17641:22)
      at workLoopSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (../../node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performSyncWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:18972:7)
      at flushSyncWorkAcrossRoots_impl (../../node_modules/react-dom/cjs/react-dom-client.development.js:18814:21)
      at flushSpawnedWork (../../node_modules/react-dom/cjs/react-dom-client.development.js:18334:9)
      at commitRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:17955:9)
      at performWorkOnRoot (../../node_modules/react-dom/cjs/react-dom-client.development.js:16667:15)
      at performWorkOnRootViaSchedulerTask (../../node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (../../node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:884:10)
      at ../../node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (../../node_modules/@testing-library/react/dist/pure.js:190:26)
      at rerender (../../node_modules/@testing-library/react/dist/pure.js:211:7)
      at Object.rerender (src/components/flex/__tests__/Container.test.tsx:915:7)

```