### PR TITLE
chore: remove commented-out dead code

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -301,12 +301,6 @@ export const AccordionHeader = ({
           removeParts.push(part)
         }
 
-        // if (cur.type === AccordionHeaderTitle) {
-        //   defaultParts.unshift(cur)
-        // } else {
-        //   defaultParts.push(cur)
-        // }
-
         defaultParts.push(cur)
       }
     })

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -175,7 +175,6 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   const overlayOpen = Boolean(isOpen || isOverlayHovered)
 
-  // const fallbackDescriptionId = `${internalId}-sr`
   const describedById = overlayOpen ? internalId : null
 
   /**


### PR DESCRIPTION
Remove commented-out code blocks that are no longer needed:
- AccordionHeader.tsx: removed dead conditional block (replaced by simpler logic)
- TooltipWithEvents.tsx: removed unused variable declaration

