### PR TITLE
chore: remove deprecated NumberFormatProperties aggregate

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
@@ -204,20 +204,3 @@ export const NumberFormatOrganizationProperties: PropertiesTableProps = {
   ...commonProps,
   ...spacingProps,
 }
-
-/**
- * @deprecated Split per variant (`NumberFormat.Number`, `NumberFormat.Currency`, …).
- * Kept for internal usage in Stat/Forms docs that aggregate all available props.
- */
-export const NumberFormatProperties: PropertiesTableProps = {
-  ...valueProp,
-  ...localeProp,
-  ...compactProp,
-  ...currencyOnlyProps,
-  ...decimalsAndFormattingProps,
-  ...affixProps,
-  ...interactionProps,
-  ...presentationProps,
-  ...linkProp,
-  ...spacingProps,
-}

--- a/packages/dnb-eufemia/src/components/stat/CurrencyDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/CurrencyDocs.ts
@@ -1,9 +1,9 @@
 import type { PropertiesTableProps } from '../../shared/types'
-import { NumberFormatProperties } from '../number-format/NumberFormatDocs'
+import { NumberFormatCurrencyProperties } from '../number-format/NumberFormatDocs'
 import { SharedValueProperties } from './StatDocsUtils'
 
 export const CurrencyProperties: PropertiesTableProps = {
-  currencyDisplay: NumberFormatProperties.currencyDisplay,
-  currencyPosition: NumberFormatProperties.currencyPosition,
+  currencyDisplay: NumberFormatCurrencyProperties.currencyDisplay,
+  currencyPosition: NumberFormatCurrencyProperties.currencyPosition,
   ...SharedValueProperties,
 }

--- a/packages/dnb-eufemia/src/components/stat/NumberDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/NumberDocs.ts
@@ -9,9 +9,10 @@ import {
   pickNumberFormatProps,
   spacingProperties,
 } from './StatDocsUtils'
+import { NumberFormatCurrencyProperties } from '../number-format/NumberFormatDocs'
 
 export const NumberProperties: PropertiesTableProps = {
-  ...pickNumberFormatProps([
+  ...pickNumberFormatProps(NumberFormatCurrencyProperties, [
     'value',
     'currency',
     'currencyDisplay',

--- a/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/RatingDocs.ts
@@ -1,5 +1,5 @@
 import type { PropertiesTableProps } from '../../shared/types'
-import { NumberFormatProperties } from '../number-format/NumberFormatDocs'
+import { NumberFormatNumberProperties } from '../number-format/NumberFormatDocs'
 import { skeletonProperty, spacingProperties } from './StatDocsUtils'
 
 export const RatingProperties: PropertiesTableProps = {
@@ -21,7 +21,7 @@ export const RatingProperties: PropertiesTableProps = {
     defaultValue: '"stars"',
     status: 'optional',
   },
-  srLabel: NumberFormatProperties.srLabel,
+  srLabel: NumberFormatNumberProperties.srLabel,
   skeleton: skeletonProperty,
   '[Space](/uilib/layout/space/properties)': spacingProperties,
 }

--- a/packages/dnb-eufemia/src/components/stat/StatDocsUtils.ts
+++ b/packages/dnb-eufemia/src/components/stat/StatDocsUtils.ts
@@ -1,12 +1,11 @@
 import type { PropertiesTableProps } from '../../shared/types'
-import { NumberFormatProperties } from '../number-format/NumberFormatDocs'
+import { NumberFormatNumberProperties } from '../number-format/NumberFormatDocs'
 
 export const pickNumberFormatProps = (
+  source: PropertiesTableProps,
   keys: string[]
 ): PropertiesTableProps => {
-  return Object.fromEntries(
-    keys.map((key) => [key, NumberFormatProperties[key]])
-  )
+  return Object.fromEntries(keys.map((key) => [key, source[key]]))
 }
 
 export const mainSizeProperty: PropertiesTableProps[string] = {
@@ -88,7 +87,7 @@ export const spacingProperties: PropertiesTableProps[string] = {
 }
 
 export const SharedValueProperties: PropertiesTableProps = {
-  ...pickNumberFormatProps([
+  ...pickNumberFormatProps(NumberFormatNumberProperties, [
     'value',
     'decimals',
     'rounding',

--- a/packages/dnb-eufemia/src/components/stat/TextDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/TextDocs.ts
@@ -5,6 +5,7 @@ import {
   skeletonProperty,
   spacingProperties,
 } from './StatDocsUtils'
+import { NumberFormatNumberProperties } from '../number-format/NumberFormatDocs'
 
 export const TextProperties: PropertiesTableProps = {
   children: {
@@ -24,7 +25,7 @@ export const TextProperties: PropertiesTableProps = {
     defaultValue: 'false',
     status: 'optional',
   },
-  ...pickNumberFormatProps(['srLabel']),
+  ...pickNumberFormatProps(NumberFormatNumberProperties, ['srLabel']),
   skeleton: skeletonProperty,
   '[Space](/uilib/layout/space/properties)': spacingProperties,
 }

--- a/packages/dnb-eufemia/src/components/stat/TrendDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/TrendDocs.ts
@@ -1,5 +1,5 @@
 import type { PropertiesTableProps } from '../../shared/types'
-import { NumberFormatProperties } from '../number-format/NumberFormatDocs'
+import { NumberFormatNumberProperties } from '../number-format/NumberFormatDocs'
 import { skeletonProperty, spacingProperties } from './StatDocsUtils'
 
 export const TrendProperties: PropertiesTableProps = {
@@ -18,7 +18,7 @@ export const TrendProperties: PropertiesTableProps = {
     type: ['"positive"', '"negative"', '"neutral"'],
     status: 'optional',
   },
-  srLabel: NumberFormatProperties.srLabel,
+  srLabel: NumberFormatNumberProperties.srLabel,
   skeleton: skeletonProperty,
   '[Space](/uilib/layout/space/properties)': spacingProperties,
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/NumberDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/NumberDocs.ts
@@ -1,8 +1,8 @@
 import type { PropertiesTableProps } from '../../../../shared/types'
-import { NumberFormatProperties } from '../../../../components/number-format/NumberFormatDocs'
+import { NumberFormatNumberProperties } from '../../../../components/number-format/NumberFormatDocs'
 
 export const NumberProperties: PropertiesTableProps = {
-  value: NumberFormatProperties.value,
+  value: NumberFormatNumberProperties.value,
   minimum: {
     doc: 'Defines the minimum value of the rendered number. Defaults to `Number.MIN_SAFE_INTEGER`.',
     type: 'number',
@@ -18,5 +18,5 @@ export const NumberProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  ...NumberFormatProperties,
+  ...NumberFormatNumberProperties,
 }


### PR DESCRIPTION
Migrate all consumers to use per-variant documentation objects (NumberFormatNumberProperties, NumberFormatCurrencyProperties) instead of the deprecated NumberFormatProperties aggregate.

- StatDocsUtils: pickNumberFormatProps now takes a source parameter
- CurrencyDocs: uses NumberFormatCurrencyProperties
- TrendDocs, RatingDocs, TextDocs: use NumberFormatNumberProperties
- Stat/NumberDocs: uses NumberFormatCurrencyProperties (needs currency props)
- Value/Number/NumberDocs: uses NumberFormatNumberProperties
- NumberFormatDocs: removed NumberFormatProperties export


