### PR TITLE
fix(Icon): stabilize usePrepareIcon memoization to prevent infinite re-renders

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -446,14 +446,25 @@ function prepareIconCore(
 }
 
 function usePrepareIcon(props: IconAllProps, context: ContextProps) {
-  const { icon, size, width, height } = props
-
-  const cachedCalcSize = calcSize({
+  const {
     icon,
     size,
     width,
     height,
-  })
+    border,
+    color,
+    inheritColor,
+    modifier,
+    alt,
+    title,
+    skeleton,
+    className,
+  } = props
+
+  const cachedCalcSize = useMemo(
+    () => calcSize({ icon, size, width, height }),
+    [icon, size, width, height]
+  )
 
   const label = useMemo(
     () => (icon ? getIconNameFromComponent(icon) : null),
@@ -466,7 +477,26 @@ function usePrepareIcon(props: IconAllProps, context: ContextProps) {
         ...cachedCalcSize,
         label,
       }),
-    [props, context, cachedCalcSize, label]
+    // Use primitive values as dependencies instead of object references
+    // to prevent infinite re-render loops when a parent component
+    // (e.g. react-hot-toast) re-renders frequently with new prop objects
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      icon,
+      size,
+      width,
+      height,
+      border,
+      color,
+      inheritColor,
+      modifier,
+      alt,
+      title,
+      skeleton,
+      className,
+      cachedCalcSize,
+      label,
+    ]
   )
 }
 

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -3,9 +3,9 @@
  *
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import type { IconAllProps } from '../Icon'
 import Icon from '../Icon'
 import { question } from './test-files'
@@ -258,6 +258,46 @@ describe('Icon component', () => {
 
     const img = document.querySelector('img')
     expect(img).toHaveAttribute('alt', 'Custom alt')
+  })
+
+  it('should not re-render excessively when parent re-renders rapidly', () => {
+    const renderCount = jest.fn()
+
+    function IconSpy() {
+      renderCount()
+      return <Icon icon={question} />
+    }
+
+    function RapidUpdater() {
+      const [count, setCount] = useState(0)
+
+      React.useEffect(() => {
+        // Simulate rapid parent re-renders like react-hot-toast timers
+        for (let i = 1; i <= 10; i++) {
+          setTimeout(() => setCount(i), i)
+        }
+      }, [])
+
+      return (
+        <div data-count={count}>
+          <IconSpy />
+        </div>
+      )
+    }
+
+    jest.useFakeTimers()
+    render(<RapidUpdater />)
+
+    act(() => {
+      jest.advanceTimersByTime(20)
+    })
+
+    jest.useRealTimers()
+
+    // Initial render + at most 10 from timer updates.
+    // Without the memoization fix, this could runaway into hundreds
+    // of renders causing an infinite loop.
+    expect(renderCount.mock.calls.length).toBeLessThanOrEqual(12)
   })
 })
 


### PR DESCRIPTION
The useMemo in usePrepareIcon used object references (props, context, cachedCalcSize) as dependencies. Since these are new objects on every render, the memo never cached, causing prepareIconCore to run every render and produce new wrapperParams/iconParams objects. When used inside rapidly re-rendering parents like react-hot-toast, this created an infinite re-render loop.

Fix:
- Memoize calcSize result with useMemo using primitive deps
- Replace object reference deps with individual primitive prop values

Add test verifying Icon does not re-render excessively when the parent re-renders rapidly.

