### PR TITLE
fix(Icon): return stable reference from prerenderIcon for function icons

### DIFF
--- a/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/__tests__/IconPrimary.test.tsx
@@ -45,6 +45,18 @@ describe('IconPrimary component', () => {
     expect(svg.getAttribute('viewBox')).toBe('0 0 24 24')
   })
 
+  it('should not remount the SVG element on rerender', () => {
+    const { rerender } = render(<IconPrimary {...props} />)
+
+    const svgBefore = document.querySelector('svg')
+    expect(svgBefore).toBeInTheDocument()
+
+    rerender(<IconPrimary {...props} />)
+
+    const svgAfter = document.querySelector('svg')
+    expect(svgAfter).toBe(svgBefore)
+  })
+
   it('should validate with ARIA rules', async () => {
     const Comp = render(<IconPrimary {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -416,25 +416,7 @@ function prepareIconCore(
     })
   )
 
-  let iconToRender = getIcon(props)
-
-  if (iconToRender && typeof iconToRender === 'function') {
-    const iconProps: Record<string, unknown> = {}
-    if (iconParams.color !== undefined) {
-      iconProps.color = iconParams.color
-    }
-    if (iconParams.width !== undefined) {
-      iconProps.width = iconParams.width
-    }
-    if (iconParams.height !== undefined) {
-      iconProps.height = iconParams.height
-    }
-
-    iconToRender = React.createElement(
-      iconToRender,
-      validateDOMAttributes({}, iconProps)
-    )
-  }
+  const iconToRender = getIcon(props)
 
   return {
     ...props,
@@ -487,10 +469,7 @@ export function prerenderIcon(
   }
 
   if (typeof icon === 'function') {
-    return (props?: IconSVGProps) => {
-      const IconComponent = icon as React.ComponentType<IconSVGProps>
-      return <IconComponent {...props} />
-    }
+    return icon as React.ComponentType<IconSVGProps>
   }
 
   if (React.isValidElement(icon) || Array.isArray(icon)) {

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { render } from '@testing-library/react'
 import type { IconAllProps } from '../Icon'
-import Icon from '../Icon'
+import Icon, { prerenderIcon } from '../Icon'
 import { question } from './test-files'
 
 const props: IconAllProps = {
@@ -258,6 +258,26 @@ describe('Icon component', () => {
 
     const img = document.querySelector('img')
     expect(img).toHaveAttribute('alt', 'Custom alt')
+  })
+
+  it('should return stable component reference from prerenderIcon for function icons', () => {
+    const ref1 = prerenderIcon({ icon: question })
+    const ref2 = prerenderIcon({ icon: question })
+
+    expect(ref1).toBe(ref2)
+    expect(ref1).toBe(question)
+  })
+
+  it('should not remount the SVG element on rerender', () => {
+    const { rerender } = render(<Icon icon={question} />)
+
+    const svgBefore = document.querySelector('svg')
+    expect(svgBefore).toBeInTheDocument()
+
+    rerender(<Icon icon={question} />)
+
+    const svgAfter = document.querySelector('svg')
+    expect(svgAfter).toBe(svgBefore)
   })
 })
 


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777384168492689

Reported stackblitz: https://stackblitz.com/edit/u6dlg7ok-11jwk6xi?file=package.json,src%2FApp.tsx
Fixed Reported stackblitz (✅): https://stackblitz.com/edit/u6dlg7ok-sg7thrqr?file=package.json
Fixed stackblitz using only Icon (✅): https://stackblitz.com/edit/u6dlg7ok-ndyxnyzs?file=package.json


prerenderIcon was wrapping function icons in a new arrow function on every call, creating an unstable component reference. React treated each render as a different component type, causing unmount/remount cycles. Combined with libraries like react-hot-toast that react to DOM mutations, this caused infinite render loops and browser freezes.

- Return the original icon function directly from prerenderIcon instead of wrapping it in a new closure
- Remove eager function-to-element conversion in prepareIconCore; icon props (color, width, height) are already passed via iconParams spread

