### PR TITLE
chore: align prism-react-renderer to 2.4.1 in react-live-ssr

### DIFF
--- a/tools/react-live-ssr/package.json
+++ b/tools/react-live-ssr/package.json
@@ -10,7 +10,7 @@
   "jsnext:main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "dependencies": {
-    "prism-react-renderer": "2.0.5",
+    "prism-react-renderer": "2.4.1",
     "sucrase": "3.35.1"
   },
   "volta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10875,13 +10875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "clsx@npm:1.2.1"
-  checksum: 10/5ded6f61f15f1fa0350e691ccec43a28b12fb8e64c8e94715f2a937bc3722d4c3ed41d6e945c971fc4dcc2a7213a43323beaf2e1c28654af63ba70c9968a8643
-  languageName: node
-  linkType: hard
-
 "cmd-shim@npm:^5.0.0":
   version: 5.0.0
   resolution: "cmd-shim@npm:5.0.0"
@@ -26143,18 +26136,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prism-react-renderer@npm:2.0.5":
-  version: 2.0.5
-  resolution: "prism-react-renderer@npm:2.0.5"
-  dependencies:
-    "@types/prismjs": "npm:^1.26.0"
-    clsx: "npm:^1.2.1"
-  peerDependencies:
-    react: ">=16.0.0"
-  checksum: 10/f2f706c8a68af7c4d9b7d4b49fb8fcaffe7229fb28de370356941fd0080900280af8672af9a87a600f194e0ec5c1568ee217b7a14500eb6653efde3aba0dcc96
-  languageName: node
-  linkType: hard
-
 "prism-react-renderer@npm:2.4.1":
   version: 2.4.1
   resolution: "prism-react-renderer@npm:2.4.1"
@@ -26704,7 +26685,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-live-ssr@workspace:tools/react-live-ssr"
   dependencies:
-    prism-react-renderer: "npm:2.0.5"
+    prism-react-renderer: "npm:2.4.1"
     sucrase: "npm:3.35.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
So that we use the same version in react-live-ssr and the portal