### PR TITLE
chore(Tools.Log): use variant prop instead of backgroundColor for dark mode support

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/Log.tsx
@@ -21,7 +21,7 @@ function Log({
   return (
     <Section
       element="output"
-      backgroundColor="sand-yellow"
+      variant="warning"
       style={{ maxWidth: '80vw' }}
       innerSpace
       {...props}


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/extensions/forms/Form/useValidation/#check-for-errors-with-haserrors
Deploy preview: https://fix-tools-log-dark-mode-toke.eufemia-e25.pages.dev/uilib/extensions/forms/Form/useValidation/#check-for-errors-with-haserrors



