### PR TITLE
chore(Portal): prevent search autocomplete animation glitch on first interaction

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -92,6 +92,7 @@ export const SearchBarInput = () => {
       mode="async"
       showClearButton
       noScrollAnimation
+      noAnimation
       preventSelection
       disableFilter
       fixedPosition

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -139,6 +139,10 @@
     transition:
       transform 200ms,
       opacity 160ms ease-out;
+
+    &--no-animation {
+      transition: none;
+    }
   }
 
   // ul element


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/7742#issuecomment-4315919628
Deploy preview: https://fix-portal-search-animation.eufemia-e25.pages.dev/

- Add noAnimation prop to the search Autocomplete to prevent the
  drawer-list slide animation from firing on an empty container when the
  input is clicked before any search results have loaded.
- Use showIndicatorItem instead of showIndicator in the onType handler so
  the dropdown displays a loading indicator item while waiting for search
  results, rather than opening empty.
- Close the dropdown on search errors via setHidden to avoid leaving the
  indicator item visible.