### PR TITLE
chore(Portal): use token color for image-box background

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -48,7 +48,7 @@
 
       text-align: center;
 
-      background-color: rgba(255 255 255 / 60%);
+      background-color: var(--token-color-background-neutral-subtle);
 
       figcaption {
         padding-top: 0.938rem; /* 15/16  because of the border */


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/intro/11-components-elements-extensions/
Deploy preview: https://fix-portal-image-box-dark-mo.eufemia-e25.pages.dev/uilib/intro/11-components-elements-extensions/

Replace hardcoded rgba(255 255 255 / 60%) with
var(--token-color-background-neutral-subtle) so the image-box container adapts to dark mode.

