### PR TITLE
chore(Portal): replace Section backgroundColor with variant in MDX docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
@@ -12,7 +12,7 @@ import { Button, Blockquote, Section } from '@dnb/eufemia/src'
 
 If you are new to the Eufemia Library, we would recommend following an intro to the elementary parts of Eufemia.
 
-<Section backgroundColor="mint-green" innerSpace={{ block: 'large' }}>
+<Section variant="information" innerSpace={{ block: 'large' }}>
   <Button
     href="/uilib/intro"
     size="large"
@@ -49,7 +49,7 @@ More information in [Style guides - Git convention](/contribute/style-guides/git
 
 Have a look at the "before getting started" section for a description of technical details. In this section, you will find what packages are included, design decisions explained, the format of the component structure, what purpose different files have, what happens during a build, and the different development environments.
 
-<Section backgroundColor="mint-green" innerSpace={{ block: 'large' }}>
+<Section variant="information" innerSpace={{ block: 'large' }}>
   <Button
     href="/contribute/first-contribution/before-started"
     size="large"

--- a/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
@@ -69,7 +69,7 @@ After filing a report, a representative will contact you personally. If the pers
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the representative may take any action they deem appropriate, up to and including a permanent ban from our community without warning.
 
-<Section backgroundColor="mint-green" innerSpace={{ block: 'large' }}>
+<Section variant="information" innerSpace={{ block: 'large' }}>
   <Button
     href="/issue"
     size="large"

--- a/packages/dnb-design-system-portal/src/docs/uilib/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/getting-started.mdx
@@ -14,7 +14,7 @@ Welcome to Eufemia — DNB's design system for building accessible, consistent d
 
 ## Start Here
 
-<Section backgroundColor="mint-green" innerSpace>
+<Section variant="information" innerSpace>
   <Button href="/uilib/intro" size="large" text="Quick Intro" />
 </Section>
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/14-helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/14-helpers.mdx
@@ -21,7 +21,7 @@ A commonly used visual style is the DNB section divider. To make it easy to achi
 import { Section } from '@dnb/eufemia'
 
 render(
-  <Section backgroundColor="mint-green" spacing>
+  <Section variant="information" spacing>
     Visual DNB Section
   </Section>
 )


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/getting-started/#start-here
Deploy preview: https://fix-portal-mdx-section-dark.eufemia-e25.pages.dev/uilib/getting-started/#start-here

Replace backgroundColor="mint-green" with variant="information" to use token-based colors that adapt to dark mode automatically.