### PR TITLE
chore(Portal): remove unused focusRing mixin

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.mixins.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.mixins.scss
@@ -1,7 +1,3 @@
-@mixin focusRing {
-  box-shadow: 0 0 0 0.125rem var(--color-accent-yellow);
-}
-
 @mixin gridStyle {
   --grid-rgb: 204 80 72;
   --grid-opacity: 0.3;


### PR DESCRIPTION
The focusRing mixin using --color-accent-yellow was not referenced anywhere. Remove it to avoid confusion.

