### PR TITLE
fix(Dialog, Drawer, ScrollView): handle content movement when scrollbar appears and add `scrollbarGutter` property

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/info.mdx
@@ -21,4 +21,12 @@ It also is used in other floating components like [Dropdown](/uilib/components/d
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/fragments/scroll-view)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view)
 
+### Scrollbar gutter
+
+Use `scrollbarGutter="stable"` to reserve space for the scrollbar, preventing horizontal layout shifts when content dynamically changes between overflowing and non-overflowing states.
+
+This uses the CSS `scrollbar-gutter: stable` property. On systems with overlay scrollbars (such as iOS or macOS default), it has no visible effect. On systems with classic scrollbars (such as Windows and Linux), it prevents content from shifting when a scrollbar appears or disappears.
+
+[Dialog](/uilib/components/dialog) and [Drawer](/uilib/components/drawer) enable this automatically by default.
+
 <ScrollViewInfo />

--- a/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
@@ -45,6 +45,7 @@ export default function DialogContent({
   onDecline,
   declineText,
   confirmText,
+  scrollbarGutter = 'auto',
   ...rest
 }: DialogContentProps): React.JSX.Element {
   const context = useContext(ModalContext)
@@ -115,7 +116,17 @@ export default function DialogContent({
 
   return (
     <div {...contentParams}>
-      <ScrollView ref={context?.scrollRef}>
+      <ScrollView
+        ref={context?.scrollRef}
+        scrollbarGutter={
+          scrollbarGutter === 'stable' ||
+          (scrollbarGutter === 'auto' &&
+            variant === 'information' &&
+            spacing !== false)
+            ? 'stable'
+            : undefined
+        }
+      >
         <div
           tabIndex={-1}
           className="dnb-dialog__inner dnb-no-focus"

--- a/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
@@ -45,7 +45,7 @@ export default function DialogContent({
   onDecline,
   declineText,
   confirmText,
-  scrollbarGutter = 'auto',
+  scrollbarGutter,
   ...rest
 }: DialogContentProps): React.JSX.Element {
   const context = useContext(ModalContext)
@@ -119,12 +119,12 @@ export default function DialogContent({
       <ScrollView
         ref={context?.scrollRef}
         scrollbarGutter={
-          scrollbarGutter === 'stable' ||
-          (scrollbarGutter === 'auto' &&
-            variant === 'information' &&
-            spacing !== false)
-            ? 'stable'
-            : undefined
+          scrollbarGutter === false
+            ? undefined
+            : scrollbarGutter === 'stable' ||
+                (variant === 'information' && spacing !== false)
+              ? 'stable'
+              : undefined
         }
       >
         <div

--- a/packages/dnb-eufemia/src/components/dialog/DialogDocs.ts
+++ b/packages/dnb-eufemia/src/components/dialog/DialogDocs.ts
@@ -106,6 +106,11 @@ export const DialogProperties: PropertiesTableProps = {
     type: 'React.RefObject',
     status: 'optional',
   },
+  scrollbarGutter: {
+    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` for the `information` variant with spacing. Defaults to `auto`.',
+    type: ['"auto"', '"stable"'],
+    status: 'optional',
+  },
   contentRef: {
     doc: 'To get the inner content Element, pass in your own React ref.',
     type: 'React.RefObject',

--- a/packages/dnb-eufemia/src/components/dialog/DialogDocs.ts
+++ b/packages/dnb-eufemia/src/components/dialog/DialogDocs.ts
@@ -107,8 +107,8 @@ export const DialogProperties: PropertiesTableProps = {
     status: 'optional',
   },
   scrollbarGutter: {
-    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` for the `information` variant with spacing. Defaults to `auto`.',
-    type: ['"auto"', '"stable"'],
+    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. By default, it enables `stable` for the `information` variant with spacing. Set to `false` to disable.',
+    type: ['"stable"', 'false'],
     status: 'optional',
   },
   contentRef: {

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -650,6 +650,65 @@ describe('Dialog aria', () => {
   })
 })
 
+describe('scrollbarGutter', () => {
+  it('should add scrollbar-gutter class by default for information variant', () => {
+    render(
+      <Dialog {...props} open>
+        content
+      </Dialog>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+
+  it('should not add scrollbar-gutter class for confirmation variant', () => {
+    render(
+      <Dialog {...props} open variant="confirmation">
+        content
+      </Dialog>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+
+  it('should not add scrollbar-gutter class when spacing is false', () => {
+    render(
+      <Dialog {...props} open spacing={false}>
+        content
+      </Dialog>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+
+  it('should always add scrollbar-gutter class when set to stable', () => {
+    render(
+      <Dialog
+        {...props}
+        open
+        variant="confirmation"
+        scrollbarGutter="stable"
+      >
+        content
+      </Dialog>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+})
+
 describe('Dialog scss', () => {
   it('should match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -707,6 +707,19 @@ describe('scrollbarGutter', () => {
       'dnb-scroll-view--scrollbar-gutter-stable'
     )
   })
+
+  it('should not add scrollbar-gutter class when set to false', () => {
+    render(
+      <Dialog {...props} open scrollbarGutter={false}>
+        content
+      </Dialog>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
 })
 
 describe('Dialog scss', () => {

--- a/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/stories/Dialog.stories.tsx
@@ -29,7 +29,7 @@ import {
   cookie_medium,
   exclamation_triangle_medium as WarningIcon,
 } from '../../../icons'
-import { Form } from '../../../extensions/forms'
+import { Field, Form } from '../../../extensions/forms'
 
 export default {
   title: 'Eufemia/Components/Dialog',
@@ -172,6 +172,44 @@ export const DialogConfirm = () => (
     </Box>
   </Wrapper>
 )
+
+export function ToggleScroll() {
+  const [tall, setTall] = useState(false)
+
+  return (
+    <Dialog
+      open
+      verticalAlignment="top"
+      triggerAttributes={{
+        text: 'Show dialog',
+      }}
+      title="Dialog title"
+    >
+      <Flex.Stack>
+        <Field.Boolean
+          variant="button"
+          label="Tall content"
+          value={tall}
+          onChange={(value) => setTall(value as boolean)}
+        />
+
+        <Flex.Horizontal justify="flex-end">
+          <Field.Email />
+        </Flex.Horizontal>
+
+        <div
+          style={{
+            minBlockSize: tall ? '100rem' : '25rem',
+            background: 'pink',
+            placeContent: 'center',
+          }}
+        >
+          Content
+        </div>
+      </Flex.Stack>
+    </Dialog>
+  )
+}
 
 export const DialogSandbox = () => (
   <Wrapper>

--- a/packages/dnb-eufemia/src/components/dialog/types.ts
+++ b/packages/dnb-eufemia/src/components/dialog/types.ts
@@ -100,9 +100,9 @@ export type DialogContentProps = Omit<DialogActionProps, 'children'> & {
   description?: React.ReactNode
 
   /**
-   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` for the `information` variant with spacing. Defaults to `auto`.
+   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. By default, it enables `stable` for the `information` variant with spacing. Set to `false` to disable.
    */
-  scrollbarGutter?: 'auto' | 'stable'
+  scrollbarGutter?: 'stable' | false
 
   /**
    * The content of the modal.

--- a/packages/dnb-eufemia/src/components/dialog/types.ts
+++ b/packages/dnb-eufemia/src/components/dialog/types.ts
@@ -100,6 +100,11 @@ export type DialogContentProps = Omit<DialogActionProps, 'children'> & {
   description?: React.ReactNode
 
   /**
+   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` for the `information` variant with spacing. Defaults to `auto`.
+   */
+  scrollbarGutter?: 'auto' | 'stable'
+
+  /**
    * The content of the modal.
    */
   children?:

--- a/packages/dnb-eufemia/src/components/drawer/DrawerContent.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/DrawerContent.tsx
@@ -32,7 +32,7 @@ export default function DrawerContent({
   noAnimationOnMobile = false,
   minWidth: minWidthProp = null,
   maxWidth: maxWidthProp = null,
-  scrollbarGutter = 'auto',
+  scrollbarGutter,
   ...rest
 }: DrawerContentProps): React.JSX.Element {
   const context = useContext(ModalContext)
@@ -102,10 +102,11 @@ export default function DrawerContent({
       {...innerParams}
       ref={context?.scrollRef}
       scrollbarGutter={
-        scrollbarGutter === 'stable' ||
-        (scrollbarGutter === 'auto' && spacing !== false)
-          ? 'stable'
-          : undefined
+        scrollbarGutter === false
+          ? undefined
+          : scrollbarGutter === 'stable' || spacing !== false
+            ? 'stable'
+            : undefined
       }
     >
       {navigationElement ? (

--- a/packages/dnb-eufemia/src/components/drawer/DrawerContent.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/DrawerContent.tsx
@@ -32,6 +32,7 @@ export default function DrawerContent({
   noAnimationOnMobile = false,
   minWidth: minWidthProp = null,
   maxWidth: maxWidthProp = null,
+  scrollbarGutter = 'auto',
   ...rest
 }: DrawerContentProps): React.JSX.Element {
   const context = useContext(ModalContext)
@@ -97,7 +98,16 @@ export default function DrawerContent({
   )
 
   return (
-    <ScrollView {...innerParams} ref={context?.scrollRef}>
+    <ScrollView
+      {...innerParams}
+      ref={context?.scrollRef}
+      scrollbarGutter={
+        scrollbarGutter === 'stable' ||
+        (scrollbarGutter === 'auto' && spacing !== false)
+          ? 'stable'
+          : undefined
+      }
+    >
       {navigationElement ? (
         navigationElement
       ) : (

--- a/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
+++ b/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
@@ -61,4 +61,9 @@ export const DrawerProperties: PropertiesTableProps = {
     type: ['boolean', 'string'],
     status: 'optional',
   },
+  scrollbarGutter: {
+    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` when spacing is enabled. Defaults to `auto`.',
+    type: ['"auto"', '"stable"'],
+    status: 'optional',
+  },
 }

--- a/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
+++ b/packages/dnb-eufemia/src/components/drawer/DrawerDocs.ts
@@ -62,8 +62,8 @@ export const DrawerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   scrollbarGutter: {
-    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` when spacing is enabled. Defaults to `auto`.',
-    type: ['"auto"', '"stable"'],
+    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. By default, it enables `stable` when spacing is enabled. Set to `false` to disable.',
+    type: ['"stable"', 'false'],
     status: 'optional',
   },
 }

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -653,6 +653,19 @@ describe('scrollbarGutter', () => {
       'dnb-scroll-view--scrollbar-gutter-stable'
     )
   })
+
+  it('should not add scrollbar-gutter class when set to false', () => {
+    render(
+      <Drawer {...props} open scrollbarGutter={false}>
+        content
+      </Drawer>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
 })
 
 describe('Drawer scss', () => {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -614,6 +614,47 @@ describe('Drawer aria', () => {
   })
 })
 
+describe('scrollbarGutter', () => {
+  it('should add scrollbar-gutter class by default', () => {
+    render(
+      <Drawer {...props} open>
+        content
+      </Drawer>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+
+  it('should not add scrollbar-gutter class when spacing is false', () => {
+    render(
+      <Drawer {...props} open spacing={false}>
+        content
+      </Drawer>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+
+  it('should always add scrollbar-gutter class when set to stable', () => {
+    render(
+      <Drawer {...props} open spacing={false} scrollbarGutter="stable">
+        content
+      </Drawer>
+    )
+
+    const scrollView = document.querySelector('.dnb-scroll-view')
+    expect(scrollView).toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
+})
+
 describe('Drawer scss', () => {
   it('should match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))

--- a/packages/dnb-eufemia/src/components/drawer/types.ts
+++ b/packages/dnb-eufemia/src/components/drawer/types.ts
@@ -87,4 +87,9 @@ export type DrawerContentProps = {
    * Same as `noAnimation`, but gets triggered only if the viewport width is less than `40em`. Defaults to `false`.
    */
   noAnimationOnMobile?: boolean
-} & Omit<ScrollViewAllProps, 'children'>
+
+  /**
+   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` when spacing is enabled. Defaults to `auto`.
+   */
+  scrollbarGutter?: 'auto' | 'stable'
+} & Omit<ScrollViewAllProps, 'children' | 'scrollbarGutter'>

--- a/packages/dnb-eufemia/src/components/drawer/types.ts
+++ b/packages/dnb-eufemia/src/components/drawer/types.ts
@@ -89,7 +89,7 @@ export type DrawerContentProps = {
   noAnimationOnMobile?: boolean
 
   /**
-   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. When set to `auto`, it enables `stable` when spacing is enabled. Defaults to `auto`.
+   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. By default, it enables `stable` when spacing is enabled. Set to `false` to disable.
    */
-  scrollbarGutter?: 'auto' | 'stable'
+  scrollbarGutter?: 'stable' | false
 } & Omit<ScrollViewAllProps, 'children' | 'scrollbarGutter'>

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -41,7 +41,7 @@ export const ANIMATION_DURATION = 300
 
 export type ModalAllProps = ModalProps &
   SpacingProps &
-  Omit<ScrollViewAllProps, 'children'>
+  Omit<ScrollViewAllProps, 'children' | 'scrollbarGutter'>
 
 const modalDefaultProps: Partial<ModalAllProps> = {
   spacing: true,

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
@@ -23,6 +23,12 @@ export type ScrollViewProps = {
    * Default: `false`
    */
   interactive?: boolean | 'auto'
+
+  /**
+   * Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. Maps to the CSS `scrollbar-gutter` property.
+   * Default: `undefined`
+   */
+  scrollbarGutter?: 'stable'
 }
 
 export type ScrollViewAllProps = ScrollViewProps &
@@ -47,6 +53,7 @@ function ScrollView(localProps: ScrollViewAllProps) {
 
   const {
     interactive,
+    scrollbarGutter,
     children,
     className = null,
     ref: refProp,
@@ -58,7 +65,12 @@ function ScrollView(localProps: ScrollViewAllProps) {
     HTMLDivElement
   > = applySpacing(props, {
     ...(attributes as React.HTMLAttributes<unknown>),
-    className: clsx('dnb-scroll-view', className),
+    className: clsx(
+      'dnb-scroll-view',
+      scrollbarGutter === 'stable' &&
+        'dnb-scroll-view--scrollbar-gutter-stable',
+      className
+    ),
   })
 
   const localRef = React.useRef<HTMLDivElement>(undefined)

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollViewDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollViewDocs.ts
@@ -6,6 +6,11 @@ export const ScrollViewProperties: PropertiesTableProps = {
     type: ['boolean', '"auto"'],
     status: 'optional',
   },
+  scrollbarGutter: {
+    doc: 'Reserves space for the scrollbar gutter, preventing layout shifts when content overflows. Maps to the CSS `scrollbar-gutter` property. Defaults to `undefined`.',
+    type: '"stable"',
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],

--- a/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/__tests__/ScrollView.test.tsx
@@ -157,4 +157,22 @@ describe('ScrollView', () => {
   it('should have constant of _supportsSpacingProps', () => {
     expect(ScrollView['_supportsSpacingProps']).toBe(true)
   })
+
+  it('should add scrollbar-gutter class when scrollbarGutter is "stable"', () => {
+    render(
+      <ScrollView scrollbarGutter="stable">overflow content</ScrollView>
+    )
+
+    const element = document.querySelector('.dnb-scroll-view')
+    expect(element).toHaveClass('dnb-scroll-view--scrollbar-gutter-stable')
+  })
+
+  it('should not add scrollbar-gutter class when scrollbarGutter is not provided', () => {
+    render(<ScrollView>overflow content</ScrollView>)
+
+    const element = document.querySelector('.dnb-scroll-view')
+    expect(element).not.toHaveClass(
+      'dnb-scroll-view--scrollbar-gutter-stable'
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/fragments/scroll-view/style/dnb-scroll-view.scss
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/style/dnb-scroll-view.scss
@@ -13,6 +13,10 @@
   // Ensure the user still can scroll a ancestor scrollarea (body)
   overscroll-behavior: auto;
 
+  &--scrollbar-gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
   // interactive prop
   &[tabindex='0'] {
     &:focus {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1746779578744739

Deploy preview Dialog: https://feat-modal-scroll-view.eufemia-e25.pages.dev/uilib/components/dialog/demos/
Deploy preview Drawer: https://feat-modal-scroll-view.eufemia-e25.pages.dev/uilib/components/drawer/demos/


OK support for this UX enhancement feature: https://caniuse.com/mdn-css_properties_scrollbar-gutter

The reason why we can't enable it by default are such cases:
<img width="611" height="324" alt="Screenshot 2026-04-29 at 13 07 01" src="https://github.com/user-attachments/assets/8bef3b7f-c0de-48d0-984d-7724c586075c" />

But for the Dialog and Drawer I think its save to enable it by default, as long as spacing is not disabled, because then it means, there is something special/custom content.