### PR TITLE
fix(Dropdown, Autocomplete): improve outline (border) of DrawerList

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -446,14 +446,6 @@ exports[`DrawerList scss have to match default theme snapshot 1`] = `
   box-shadow: var(--shadow-sharp);
   border-radius: calc(var(--drawer-list-options-border-radius) + 0.15rem);
 }
-.dnb-drawer-list__list::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  border-radius: inherit;
-  box-shadow: 0 0 0 1px var(--token-color-stroke-neutral-subtle);
-}
 .dnb-drawer-list__options {
   border: none;
   border-radius: calc(var(--drawer-list-options-border-radius) + 0.15rem);
@@ -475,6 +467,14 @@ html[data-whatinput=mouse] .dnb-drawer-list__options--focusring {
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
+}
+.dnb-drawer-list__options::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  box-shadow: 0 0 0 1px var(--token-color-stroke-neutral-subtle);
 }
 .dnb-drawer-list__option {
   position: relative;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/dnb-drawer-list-theme-ui.scss
@@ -14,15 +14,6 @@
     border-radius: calc(
       var(--drawer-list-options-border-radius) + 0.15rem
     );
-
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      z-index: -1;
-      border-radius: inherit;
-      box-shadow: 0 0 0 1px var(--token-color-stroke-neutral-subtle);
-    }
   }
 
   // ul element
@@ -38,6 +29,15 @@
 
     &--focusring {
       @include utilities.focusRing('mouse');
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      border-radius: inherit;
+      box-shadow: 0 0 0 1px var(--token-color-stroke-neutral-subtle);
     }
   }
 


### PR DESCRIPTION
Introduced in #7759

It created a border always visible:

<img width="418" height="290" alt="Screenshot 2026-04-29 at 13 33 05" src="https://github.com/user-attachments/assets/27abcef3-017c-400c-af19-13ba287c5d64" />

By moving the border inside the ul, it should resolve the issue.

Related to #7854