### PR TITLE
fix(DatePicker): show error status when typed input violates minDate/maxDate

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -6,13 +6,19 @@
 import React, {
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react'
 
 // date-fns
-import { isValid as isValidFn, parseISO } from 'date-fns'
+import {
+  isValid as isValidFn,
+  isBefore,
+  startOfDay,
+  parseISO,
+} from 'date-fns'
 
 import clsx from 'clsx'
 import SegmentedField, {
@@ -23,7 +29,7 @@ import Button from '../button/Button'
 import Input, { SubmitButton } from '../input/Input'
 import type { InputElement, InputSize } from '../Input'
 import { warn, validateDOMAttributes } from '../../shared/component-helper'
-import { convertStringToDate } from './DatePickerCalc'
+import { convertStringToDate, isDisabled } from './DatePickerCalc'
 import DatePickerContext from './DatePickerContext'
 
 import type { FormStatusBaseProps } from '../FormStatus'
@@ -154,7 +160,9 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     getReturnObject,
     startDate,
     endDate,
-    props: { onType, label },
+    minDate: ctxMinDate,
+    maxDate: ctxMaxDate,
+    props: { onType, label, status: consumerStatus },
   } = useContext(DatePickerContext)
 
   const { inputDates, updateInputDates } = useInputDates({
@@ -164,6 +172,58 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
   const translation = useTranslation().DatePicker
   const { locale } = useContext(Context)
+
+  const [minMaxStatus, setMinMaxStatus] = useState<string | null>(null)
+
+  const getMinMaxErrorMessage = useCallback(
+    (date: Date) => {
+      if (!isDisabled(date, ctxMinDate, ctxMaxDate)) {
+        return null
+      }
+
+      const formatOptions = { locale }
+
+      if (
+        ctxMinDate &&
+        isBefore(startOfDay(date), startOfDay(ctxMinDate))
+      ) {
+        return translation.errorMinDate?.replace(
+          '%s',
+          formatDate(ctxMinDate, formatOptions)
+        )
+      }
+
+      if (ctxMaxDate) {
+        return translation.errorMaxDate?.replace(
+          '%s',
+          formatDate(ctxMaxDate, formatOptions)
+        )
+      }
+
+      return null
+    },
+    [ctxMinDate, ctxMaxDate, locale, translation]
+  )
+
+  // Clear min/max error when dates change externally (e.g. calendar selection)
+  useEffect(() => {
+    if (!minMaxStatus) {
+      return // stop here
+    }
+
+    const startIsValid =
+      !startDate ||
+      !isValidFn(startDate) ||
+      !isDisabled(startDate, ctxMinDate, ctxMaxDate)
+    const endIsValid =
+      !endDate ||
+      !isValidFn(endDate) ||
+      !isDisabled(endDate, ctxMinDate, ctxMaxDate)
+
+    if (startIsValid && endIsValid) {
+      setMinMaxStatus(null)
+    }
+  }, [startDate, endDate, ctxMinDate, ctxMaxDate, minMaxStatus])
 
   const resolvedMaskOrder =
     maskOrder || (locale === 'en-US' ? 'mm/dd/yyyy' : defaultMaskOrder)
@@ -312,6 +372,9 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         const mode =
           focusMode.current === 'start' ? 'startDate' : 'endDate'
 
+        // Check min/max validation for pasted dates
+        setMinMaxStatus(getMinMaxErrorMessage(date))
+
         {
           // Update provider dates
           updateDates({
@@ -337,7 +400,12 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         warn(error)
       }
     },
-    [resolvedMaskOrder, updateDates, updateInputDates]
+    [
+      resolvedMaskOrder,
+      updateDates,
+      updateInputDates,
+      getMinMaxErrorMessage,
+    ]
   )
 
   const buildInputs = useCallback(
@@ -608,6 +676,13 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
       isDateFullyFilledOutRef.current = fullyTyped
 
+      // Check min/max validation for fully typed valid dates
+      if (isValidDate) {
+        setMinMaxStatus(getMinMaxErrorMessage(dt))
+      } else if (!fullyTyped) {
+        setMinMaxStatus(null)
+      }
+
       // update the date
       if (isValidDate) {
         invalidDatesRef.current = {
@@ -656,6 +731,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
       dateRefs,
       temporaryDates,
       updateInputDates,
+      getMinMaxErrorMessage,
     ]
   )
 
@@ -756,6 +832,11 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
   const scopeRef = useRef<HTMLSpanElement>(null)
 
+  // Show min/max validation error only when the consumer hasn't set their own status
+  const hasMinMaxError = !consumerStatus && Boolean(minMaxStatus)
+  const inputFieldStatus = hasMinMaxError ? 'error' : status
+  const inputStatus = hasMinMaxError ? minMaxStatus : status
+
   const renderInputElement = useCallback(() => {
     return (
       <span
@@ -767,7 +848,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           id={`${id}-start`}
           _omitInputShellClass
           size={size}
-          status={!open ? status : null}
+          status={!open ? inputFieldStatus : null}
           statusState={statusState}
           inputs={buildInputs('start')}
           values={getValues('start')}
@@ -809,7 +890,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             id={`${id}-end`}
             _omitInputShellClass
             size={size}
-            status={!open ? status : null}
+            status={!open ? inputFieldStatus : null}
             statusState={statusState}
             inputs={buildInputs('end')}
             values={getValues('end')}
@@ -853,7 +934,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     disabled,
     skeleton,
     open,
-    status,
+    inputFieldStatus,
     statusState,
     attributes,
     isRange,
@@ -899,7 +980,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         disabled={disabled || skeleton}
         skeleton={skeleton}
         size={size}
-        status={!open ? status : null}
+        status={!open ? inputStatus : null}
         statusState={statusState}
         {...(statusProps as Record<string, unknown>)}
         submitElement={
@@ -912,7 +993,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             aria-label={ariaLabel}
             title={title}
             size={size}
-            status={status}
+            status={inputFieldStatus}
             statusState={statusState}
             type="button"
             icon="calendar"

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -2221,6 +2221,145 @@ describe('DatePicker component', () => {
     )
   })
 
+  it('shows error status when typed date violates minDate', async () => {
+    render(
+      <DatePicker
+        {...defaultProps}
+        range={false}
+        minDate="2019-01-15"
+        startDate="2019-01-20"
+        showInput
+      />
+    )
+
+    const dayElem = document.querySelector(
+      '.dnb-date-picker__input--day'
+    ) as HTMLInputElement
+
+    // Type a day before minDate (01 < 15)
+    await typeInField(dayElem, '10')
+    await waitFor(() => expect(dayElem).toHaveValue('10'))
+
+    const formStatus = document.querySelector('.dnb-form-status')
+    expect(formStatus).toBeInTheDocument()
+    expect(formStatus.textContent).toContain('15.01.2019')
+
+    // Type a valid day (20 >= 15)
+    await typeInField(dayElem, '20')
+    await waitFor(() => expect(dayElem).toHaveValue('20'))
+
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows error status when typed date violates maxDate', async () => {
+    render(
+      <DatePicker
+        {...defaultProps}
+        range={false}
+        maxDate="2019-02-28"
+        startDate="2019-02-15"
+        showInput
+      />
+    )
+
+    const monthElem = document.querySelector(
+      '.dnb-date-picker__input--month'
+    ) as HTMLInputElement
+
+    // Type month 03 — date becomes 2019-03-15, which is after maxDate
+    await typeInField(monthElem, '03')
+    await waitFor(() => expect(monthElem).toHaveValue('03'))
+
+    const formStatus = document.querySelector('.dnb-form-status')
+    expect(formStatus).toBeInTheDocument()
+    expect(formStatus.textContent).toContain('28.02.2019')
+
+    // Type month back to 02 — now within range
+    await typeInField(monthElem, '02')
+    await waitFor(() => expect(monthElem).toHaveValue('02'))
+
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not show min/max error when consumer provides their own status', async () => {
+    render(
+      <DatePicker
+        {...defaultProps}
+        range={false}
+        maxDate="2019-02-28"
+        startDate="2019-02-15"
+        showInput
+        status="Custom error"
+      />
+    )
+
+    const monthElem = document.querySelector(
+      '.dnb-date-picker__input--month'
+    ) as HTMLInputElement
+
+    // Type month 03 — violates maxDate
+    await typeInField(monthElem, '03')
+    await waitFor(() => expect(monthElem).toHaveValue('03'))
+
+    // The FormStatus should show the consumer's error, not the min/max error
+    const formStatusElements =
+      document.querySelectorAll('.dnb-form-status')
+    const texts = Array.from(formStatusElements).map(
+      (el) => el.textContent
+    )
+    expect(texts.some((t) => t.includes('Custom error'))).toBe(true)
+    expect(texts.some((t) => t.includes('28.02.2019'))).toBe(false)
+  })
+
+  it('shows error status for range mode when typed date violates min/max', async () => {
+    render(
+      <DatePicker
+        {...defaultProps}
+        range={true}
+        minDate="2019-01-02"
+        maxDate="2019-02-04"
+        startDate="2019-01-02"
+        endDate="2019-02-04"
+        showInput
+      />
+    )
+
+    const startDayElem = document.querySelectorAll(
+      '.dnb-date-picker__input--day'
+    )[0] as HTMLInputElement
+    const endDayElem = document.querySelectorAll(
+      '.dnb-date-picker__input--day'
+    )[1] as HTMLInputElement
+
+    // Type start day 01 — before minDate (02)
+    await typeInField(startDayElem, '01')
+    await waitFor(() => expect(startDayElem).toHaveValue('01'))
+
+    const formStatus = document.querySelector('.dnb-form-status')
+    expect(formStatus).toBeInTheDocument()
+    expect(formStatus.textContent).toContain('02.01.2019')
+
+    // Fix start day
+    await typeInField(startDayElem, '03')
+    await waitFor(() => expect(startDayElem).toHaveValue('03'))
+
+    expect(
+      document.querySelector('.dnb-form-status')
+    ).not.toBeInTheDocument()
+
+    // Type end day 05 — after maxDate (04)
+    await typeInField(endDayElem, '05')
+    await waitFor(() => expect(endDayElem).toHaveValue('05'))
+
+    const formStatusEnd = document.querySelector('.dnb-form-status')
+    expect(formStatusEnd).toBeInTheDocument()
+    expect(formStatusEnd.textContent).toContain('04.02.2019')
+  })
+
   it('has valid onType and onChange event calls', async () => {
     const onType = jest.fn()
     const onChange = jest.fn()

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -41,6 +41,8 @@ export default {
       dateFormat: 'yyyy-MM-dd', // in v1 of date-fns we were more flexible in terms of the format
       returnFormat: 'yyyy-MM-dd', // used in date-fns v1: YYYY-MM-DD
       firstDay: 'monday', // used in DatePickerCalendar to set the first day of the week
+      errorMinDate: 'Datoen kan ikke være før %s',
+      errorMaxDate: 'Datoen kan ikke være efter %s',
       submitButtonText: 'Ok',
       cancelButtonText: 'Annuller',
       resetButtonText: 'Gendan',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -40,6 +40,8 @@ export default {
       dateFormat: 'yyyy-MM-dd', // in v1 of date-fns we were more flexible in terms of the format
       returnFormat: 'yyyy-MM-dd', // used in date-fns v1: YYYY-MM-DD
       firstDay: 'monday', // used in DatePickerCalendar to set the first day of the week
+      errorMinDate: 'The date cannot be before %s',
+      errorMaxDate: 'The date cannot be after %s',
       submitButtonText: 'OK',
       cancelButtonText: 'Cancel',
       resetButtonText: 'Reset',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -39,6 +39,8 @@ export default {
       dateFormat: 'yyyy-MM-dd', // in v1 of date-fns we were more flexible in terms of the format
       returnFormat: 'yyyy-MM-dd', // used in date-fns v1: YYYY-MM-DD
       firstDay: 'monday', // used in DatePickerCalendar to set the first day of the week
+      errorMinDate: 'Datoen kan ikke være før %s',
+      errorMaxDate: 'Datoen kan ikke være etter %s',
       submitButtonText: 'Ok',
       cancelButtonText: 'Avbryt',
       resetButtonText: 'Tilbakestill',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -40,6 +40,8 @@ export default {
       dateFormat: 'yyyy-MM-dd', // in v1 of date-fns we were more flexible in terms of the format
       returnFormat: 'yyyy-MM-dd', // used in date-fns v1: YYYY-MM-DD
       firstDay: 'monday', // used in DatePickerCalendar to set the first day of the week
+      errorMinDate: 'Datumet kan inte vara före %s',
+      errorMaxDate: 'Datumet kan inte vara efter %s',
       submitButtonText: 'Okej',
       cancelButtonText: 'Stäng',
       resetButtonText: 'Återställ',


### PR DESCRIPTION
DO NOT REVIEW

If we'll do this, then I guess Field.Date should reuse this logic, instead of having it's own.

Previously, minDate/maxDate were only enforced in the calendar view (disabling out-of-range day buttons). When typing a date manually, out-of-range dates were silently accepted with no visual feedback.

Now the DatePicker shows an inline error message when a fully typed date violates minDate or maxDate constraints. The error clears automatically when the user corrects the date.

If the consumer provides their own status prop, the internal min/max error is suppressed to avoid duplicate error messages.

