### PR TITLE
feat(Provider): add `translationsLoader` for async dynamic translations

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation/info.mdx
@@ -198,6 +198,31 @@ render(
 - Partial explicit locale: merges missing keys as pointer strings, preserving existing ones.
 - Non-existent current locale (no explicit entry in your translations): the hook preserves defaults (no pointers).
 
+## Dynamically loaded translations
+
+`Form.useTranslation` works with translations loaded asynchronously via the `translationsLoader` prop on [Form.Handler](/uilib/extensions/forms/Form/Handler/) or the shared [Provider](/uilib/usage/customisation/provider/). Components render with default translations first, and re-render when the loaded translations are available.
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const translationsLoader = async (locale) => {
+  return import(`./locales/${locale}.json`)
+}
+
+const MyComponent = () => {
+  const t = Form.useTranslation()
+  return <>{t.Field.errorRequired}</>
+}
+
+render(
+  <Form.Handler translationsLoader={translationsLoader}>
+    <MyComponent />
+  </Form.Handler>
+)
+```
+
+Read more about dynamic loading in the [getting started guide](/uilib/extensions/forms/getting-started/#load-translations-dynamically).
+
 ```tsx
 import { Form } from '@dnb/eufemia/extensions/forms'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -945,6 +945,94 @@ or an object based structure:
 }
 ```
 
+### Load translations dynamically
+
+When you have many locales or large translation files, you can load them on demand using the `translationsLoader` prop. It accepts an async function that receives the current locale and returns a translations object. The loader is called on mount and whenever the locale changes.
+
+Components render with default translations immediately. When the loader resolves, translations are merged in and components re-render with the updated strings.
+
+The loader function can use any source — dynamic `import()` of `.ts`, `.js`, or `.json` files, `fetch()` calls, or any other async operation. As long as the function returns a translations object, it works.
+
+#### Using `Form.Handler`
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const translationsLoader = async (locale) => {
+  switch (locale) {
+    case 'en-GB':
+      return (await import('./locales/en-GB')).default
+    case 'sv-SE':
+      return (await import('./locales/sv-SE')).default
+    default:
+      return (await import('./locales/nb-NO')).default
+  }
+}
+
+render(
+  <Form.Handler translationsLoader={translationsLoader}>
+    <Field.PhoneNumber />
+  </Form.Handler>
+)
+```
+
+Each imported file should export a translations object with the locale key, matching the same structure as the `translations` prop:
+
+```ts
+// locales/nb-NO.ts
+export default {
+  'nb-NO': {
+    PhoneNumber: {
+      numberLabel: 'Dynamisk etikett',
+    },
+  },
+}
+```
+
+#### Using the shared `Provider`
+
+You can also load translations at the app level using the shared [Provider](/uilib/usage/customisation/provider/):
+
+```tsx
+import { Provider } from '@dnb/eufemia/shared'
+
+const translationsLoader = async (locale) => {
+  const response = await fetch(`/api/translations/${locale}`)
+  return response.json()
+}
+
+render(
+  <Provider translationsLoader={translationsLoader} locale="nb-NO">
+    Your app, including Eufemia Forms
+  </Provider>
+)
+```
+
+#### Combining with static translations
+
+The `translationsLoader` can be used alongside the `translations` prop. Static translations are available immediately, and loaded translations are merged on top:
+
+```tsx
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const staticTranslations = {
+  'nb-NO': { PhoneNumber: { countryCodeLabel: 'Landskode' } },
+}
+
+const translationsLoader = async (locale) => {
+  return (await import(`./locales/${locale}`)).default
+}
+
+render(
+  <Form.Handler
+    translations={staticTranslations}
+    translationsLoader={translationsLoader}
+  >
+    <Field.PhoneNumber />
+  </Form.Handler>
+)
+```
+
 ### How to customize translations in a form
 
 You can customize the translations in a form by using the `translations` property on the [Form.Handler](/uilib/extensions/forms/Form/Handler/).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -71,7 +71,7 @@ const translations = mergeTranslations(
 In React based apps, use the shared Eufemia provider:
 
 ```jsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 const myLocale = 'en-GB'
 
@@ -85,7 +85,7 @@ render(
 For component based locale, you can also make use of the `lang` attribute – if really needed:
 
 ```jsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 render(
   <Provider locale="en-GB">
@@ -101,7 +101,7 @@ render(
 You can easily enhance or change translated strings progressively:
 
 ```jsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 render(
   <Provider
@@ -123,8 +123,7 @@ You can even change the locale during runtime. Find more info in the [Provider d
 
 ```tsx
 import { Field } from '@dnb/eufemia/extensions/forms'
-import Provider from '@dnb/eufemia/shared/Provider'
-import Context from '@dnb/eufemia/shared/Context'
+import { Provider, Context } from '@dnb/eufemia/shared'
 
 const ChangeLocale = () => {
   const { setLocale, locale } = React.useContext(Context)
@@ -153,7 +152,7 @@ render(
 You can provide your own translations by using the shared [Provider](/uilib/usage/customisation/provider). Translation strings with several levels of depth can be given as a flat object with dot-notation, or as a nested object (cascaded).
 
 ```tsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 const nbNO = { myString: 'Min egendefinerte streng' }
 const enGB = {
@@ -358,7 +357,7 @@ Components render with default translations immediately. When the loader resolve
 The loader function can use any source — dynamic `import()` of `.ts`, `.js`, or `.json` files, `fetch()` calls, or any other async operation. As long as the function returns a translations object, it works.
 
 ```tsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 const translationsLoader = async (locale) => {
   switch (locale) {
@@ -381,7 +380,7 @@ render(
 You can combine `translationsLoader` with the static `translations` prop. Static translations are available immediately, and loaded translations are merged on top:
 
 ```tsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 
 const staticTranslations = {
   'nb-NO': { Modal: { closeTitle: 'Lukk' } },
@@ -405,10 +404,105 @@ render(
 
 The `translationsLoader` is also available on [Form.Handler](/uilib/extensions/forms/Form/Handler/) for form-scoped translations. Read more in the [Forms getting started guide](/uilib/extensions/forms/getting-started/#load-translations-dynamically).
 
+### Async translations with translationsLoader
+
+Use the `translationsLoader` prop to load translations asynchronously, for example from a CDN or a lazy import. The loader receives the current locale and should return a translations object.
+
+```tsx
+import { Provider } from '@dnb/eufemia/shared'
+
+const translationsLoader = async (locale) => {
+  const response = await fetch(`/translations/${locale}.json`)
+  return response.json()
+}
+
+render(
+  <Provider translationsLoader={translationsLoader}>
+    <MyApp />
+  </Provider>
+)
+```
+
+Because the consumer owns the loader function, you can handle loading state, errors, and retries directly inside it:
+
+```tsx
+import { Provider } from '@dnb/eufemia/shared'
+
+function App() {
+  const [translationsLoading, setTranslationsLoading] =
+    React.useState(true)
+
+  const translationsLoader = React.useCallback(async (locale) => {
+    setTranslationsLoading(true)
+
+    try {
+      const translations = await import(`../translations/${locale}.json`)
+      return translations.default
+    } catch (error) {
+      console.error('Failed to load translations', error)
+      return null
+    } finally {
+      setTranslationsLoading(false)
+    }
+  }, [])
+
+  return (
+    <Provider
+      translationsLoader={translationsLoader}
+      skeleton={translationsLoading}
+    >
+      <MyApp />
+    </Provider>
+  )
+}
+```
+
+You can also return fallback translations when an error occurs, so the UI still renders meaningful content in the correct language:
+
+```tsx
+import { Provider, useTranslation } from '@dnb/eufemia/shared'
+
+const fallbackTranslations = {
+  'nb-NO': {
+    errorMessage: 'Kunne ikke laste oversettelser',
+  },
+  'en-GB': {
+    errorMessage: 'Could not load translations',
+  },
+}
+
+const translationsLoader = async (locale) => {
+  try {
+    const response = await fetch(`/api/translations/${locale}`)
+    return response.json()
+  } catch (error) {
+    return fallbackTranslations
+  }
+}
+
+type FallbackTranslation =
+  (typeof fallbackTranslations)[keyof typeof fallbackTranslations]
+
+function ErrorBanner() {
+  const { errorMessage } = useTranslation<FallbackTranslation>()
+  if (errorMessage) {
+    return <FormStatus state="error" text={errorMessage} />
+  }
+  return null
+}
+
+render(
+  <Provider translationsLoader={translationsLoader}>
+    <ErrorBanner />
+    <MyApp />
+  </Provider>
+)
+```
+
 ## TypeScript support
 
 ```tsx
-import Provider, { Locales } from '@dnb/eufemia/shared/Provider'
+import { Provider, Locales } from '@dnb/eufemia/shared'
 
 const nbNO = {
   myString: 'Min egendefinerte streng',
@@ -442,7 +536,7 @@ Like, having the Eufemia components strings inside a JSON object/file `en.json`:
 and use it like this:
 
 ```jsx
-import EufemiaProvider from '@dnb/eufemia/shared/Provider'
+import { Provider as EufemiaProvider } from '@dnb/eufemia/shared'
 import nb from './nb.json' // Has to be an JavaScript object
 
 render(
@@ -721,7 +815,7 @@ export default {
 And add the file, like so:
 
 ```jsx
-import Provider from '@dnb/eufemia/shared/Provider'
+import { Provider } from '@dnb/eufemia/shared'
 import myTranslations from './locales/nn-NO'
 
 render(
@@ -734,8 +828,7 @@ render(
 ### Add or update the locales during runtime
 
 ```tsx
-import Provider from '@dnb/eufemia/shared/Provider'
-import Context from '@dnb/eufemia/shared/Context'
+import { Provider, Context } from '@dnb/eufemia/shared'
 
 import myTranslations from './locales/nn-NO'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -349,6 +349,62 @@ render(
 )
 ```
 
+## Load translations dynamically
+
+When you have many locales or large translation files, you can load them on demand using the `translationsLoader` prop on the [Provider](/uilib/usage/customisation/provider/). It accepts an async function that receives the current locale and returns a translations object. The loader is called on mount and whenever the locale changes.
+
+Components render with default translations immediately. When the loader resolves, translations are merged in and components re-render with the updated strings.
+
+The loader function can use any source — dynamic `import()` of `.ts`, `.js`, or `.json` files, `fetch()` calls, or any other async operation. As long as the function returns a translations object, it works.
+
+```tsx
+import Provider from '@dnb/eufemia/shared/Provider'
+
+const translationsLoader = async (locale) => {
+  switch (locale) {
+    case 'en-GB':
+      return (await import('./locales/en-GB')).default
+    case 'sv-SE':
+      return (await import('./locales/sv-SE')).default
+    default:
+      return (await import('./locales/nb-NO')).default
+  }
+}
+
+render(
+  <Provider translationsLoader={translationsLoader} locale="en-GB">
+    <MyApp>Eufemia components</MyApp>
+  </Provider>
+)
+```
+
+You can combine `translationsLoader` with the static `translations` prop. Static translations are available immediately, and loaded translations are merged on top:
+
+```tsx
+import Provider from '@dnb/eufemia/shared/Provider'
+
+const staticTranslations = {
+  'nb-NO': { Modal: { closeTitle: 'Lukk' } },
+}
+
+const translationsLoader = async (locale) => {
+  const response = await fetch(`/api/translations/${locale}`)
+  return response.json()
+}
+
+render(
+  <Provider
+    translations={staticTranslations}
+    translationsLoader={translationsLoader}
+    locale="nb-NO"
+  >
+    <MyApp>Eufemia components</MyApp>
+  </Provider>
+)
+```
+
+The `translationsLoader` is also available on [Form.Handler](/uilib/extensions/forms/Form/Handler/) for form-scoped translations. Read more in the [Forms getting started guide](/uilib/extensions/forms/getting-started/#load-translations-dynamically).
+
 ## TypeScript support
 
 ```tsx

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -196,6 +196,12 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     translations?: ContextProps['translations']
     /**
+     * Async function to load translations for a given locale.
+     * Called on mount and whenever the locale changes.
+     * The returned translations are merged with any existing translations.
+     */
+    translationsLoader?: ContextProps['translationsLoader']
+    /**
      * Make all fields required
      */
     required?: boolean
@@ -237,6 +243,7 @@ export default function Provider<Data extends JsonObject>(
     countryCode,
     locale,
     translations,
+    translationsLoader,
     required,
     errorMessages,
     isolate,
@@ -1824,6 +1831,9 @@ export default function Provider<Data extends JsonObject>(
         formElement={disabled ? { disabled: true } : undefined}
         locale={locale ? locale : undefined}
         translations={translations ? translations : undefined}
+        translationsLoader={
+          translationsLoader ? translationsLoader : undefined
+        }
       >
         {children}
       </FieldPropsProvider>

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/ProviderDocs.ts
@@ -81,6 +81,16 @@ export const ProviderProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  translations: {
+    doc: 'Provide translation strings. Can be a flat or nested object keyed by locale, e.g. `{ "nb-NO": { MyKey: "value" } }`. See [Localization](/uilib/usage/customisation/localization).',
+    type: 'object',
+    status: 'optional',
+  },
+  translationsLoader: {
+    doc: 'Async function that receives the current locale and returns a translations object. Called on mount and when the locale changes. Loaded translations are merged on top of static `translations`. See [Load translations dynamically](/uilib/usage/customisation/localization/#load-translations-dynamically).',
+    type: 'function',
+    status: 'optional',
+  },
   countryCode: {
     doc: 'Will change the country code for fields supporting `countryCode`. You can also set a path as the value, e.g. `/myCountryCodePath`.',
     type: ['ISO 3166-1 alpha-2', 'Path/JSON Pointer'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
@@ -22,6 +22,13 @@ export type FieldProviderProps = FieldProps & {
    */
   translations?: DataContextProps<JsonObject>['translations']
 
+  /**
+   * Async function to load translations for a given locale.
+   * Called on mount and whenever the locale changes.
+   * The returned translations are merged with any existing translations.
+   */
+  translationsLoader?: DataContextProps<JsonObject>['translationsLoader']
+
   /** For internal use only */
   overwriteProps?: {
     [key: Path]: FieldProps

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
@@ -70,6 +70,14 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
     sharedProviderParams.translations = mergedTranslations
   }
 
+  const translationsLoader =
+    dataContextRef.current?.props?.translationsLoader ??
+    restProps?.translationsLoader
+
+  if (translationsLoader) {
+    sharedProviderParams.translationsLoader = translationsLoader
+  }
+
   const extend = useCallback(
     <T extends FieldProps>(fieldProps: T) => {
       // Extract props from data context to be used in fields

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -48,6 +48,7 @@ const allowedProviderContextProps: Array<
   'locale',
   'countryCode',
   'translations',
+  'translationsLoader',
   'autoComplete',
   'disabled',
   'required',

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/__tests__/Handler.test.tsx
@@ -7,6 +7,7 @@ import { spyOnEufemiaWarn, wait } from '../../../../../core/jest/jestSetup'
 import type { JSONSchema, JSONSchemaType, OnSubmit } from '../../..'
 import { Form, Field, makeAjvInstance } from '../../..'
 import type { FieldStringProps as StringFieldProps } from '../../../Field/String'
+import type { ContextProps } from '../../../../../shared/Context'
 import nbNO from '../../../constants/locales/nb-NO'
 import enGB from '../../../constants/locales/en-GB'
 
@@ -1442,5 +1443,123 @@ describe('Form.Handler TypeScript type validation', () => {
 
     expect(formRef.current).toBeDefined()
     expect(formRef.current.tagName).toBe('FORM')
+  })
+
+  describe('translationsLoader', () => {
+    it('should load translations asynchronously', async () => {
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': { PhoneNumber: { numberLabel: 'Async etikett' } },
+      })
+
+      render(
+        <Form.Handler translationsLoader={loader}>
+          <Field.PhoneNumber />
+        </Form.Handler>
+      )
+
+      expect(loader).toHaveBeenCalledWith('nb-NO')
+
+      await waitFor(() => {
+        const labels = Array.from(
+          document.querySelectorAll('.dnb-form-label')
+        )
+        expect(labels[1]).toHaveTextContent('Async etikett')
+      })
+    })
+
+    it('should make loaded translations available via Form.useTranslation', async () => {
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': { myCustomKey: 'Async verdi' },
+      }) as unknown as ContextProps['translationsLoader'] & jest.Mock
+
+      const DisplayCustomKey = () => {
+        const t = Form.useTranslation()
+        return (
+          <span>
+            {(t as unknown as Record<string, string>).myCustomKey}
+          </span>
+        )
+      }
+
+      const { container } = render(
+        <Form.Handler translationsLoader={loader}>
+          <DisplayCustomKey />
+        </Form.Handler>
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'Async verdi'
+        )
+      })
+    })
+
+    it('should reload when locale changes', async () => {
+      const loader = jest.fn((locale) => {
+        if (locale === 'en-GB') {
+          return Promise.resolve({
+            'en-GB': { PhoneNumber: { numberLabel: 'Async label' } },
+          })
+        }
+        return Promise.resolve({
+          'nb-NO': { PhoneNumber: { numberLabel: 'Async etikett' } },
+        })
+      })
+
+      const { rerender } = render(
+        <Form.Handler translationsLoader={loader}>
+          <Field.PhoneNumber />
+        </Form.Handler>
+      )
+
+      await waitFor(() => {
+        const labels = Array.from(
+          document.querySelectorAll('.dnb-form-label')
+        )
+        expect(labels[1]).toHaveTextContent('Async etikett')
+      })
+
+      rerender(
+        <Form.Handler locale="en-GB" translationsLoader={loader}>
+          <Field.PhoneNumber />
+        </Form.Handler>
+      )
+
+      await waitFor(() => {
+        const labels = Array.from(
+          document.querySelectorAll('.dnb-form-label')
+        )
+        expect(labels[1]).toHaveTextContent('Async label')
+      })
+    })
+
+    it('should work alongside static translations prop', async () => {
+      const staticTranslations = {
+        'nb-NO': {
+          PhoneNumber: { countryCodeLabel: 'Statisk landskode' },
+        },
+      }
+
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': { PhoneNumber: { numberLabel: 'Async nummer' } },
+      })
+
+      render(
+        <Form.Handler
+          translations={staticTranslations}
+          translationsLoader={loader}
+        >
+          <Field.PhoneNumber />
+        </Form.Handler>
+      )
+
+      await waitFor(() => {
+        const labels = Array.from(
+          document.querySelectorAll('.dnb-form-label')
+        )
+        expect(labels[0]).toHaveTextContent('Statisk landskode')
+        expect(labels[1]).toHaveTextContent('Async nummer')
+      })
+    })
   })
 })

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -179,6 +179,13 @@ export type ContextProps = ContextComponents & {
    */
   translations?: Translations | TranslationCustomLocales
 
+  /**
+   * Async function to load translations for a given locale.
+   * Called on mount and whenever the locale changes.
+   * The returned translations are merged with any existing translations.
+   */
+  translationsLoader?: TranslationsLoader
+
   // -- For internal use --
   __context__?: Record<string, unknown>
   updateTranslation?: (
@@ -202,6 +209,7 @@ export type InternalLocale =
 export type Translations =
   | Partial<Record<InternalLocale, Translation | TranslationFlat>>
   | Partial<Record<InternalLocale, FormsTranslation>>
+export type TranslationsLoader = (locale: string) => Promise<Translations>
 export type TranslationDefaultLocales = typeof defaultLocales
 export type TranslationLocale = keyof TranslationDefaultLocales
 export type TranslationValues =

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -209,7 +209,9 @@ export type InternalLocale =
 export type Translations =
   | Partial<Record<InternalLocale, Translation | TranslationFlat>>
   | Partial<Record<InternalLocale, FormsTranslation>>
-export type TranslationsLoader = (locale: string) => Promise<Translations>
+export type TranslationsLoader = (
+  locale: InternalLocale
+) => Promise<Translations>
 export type TranslationDefaultLocales = typeof defaultLocales
 export type TranslationLocale = keyof TranslationDefaultLocales
 export type TranslationValues =

--- a/packages/dnb-eufemia/src/shared/Provider.tsx
+++ b/packages/dnb-eufemia/src/shared/Provider.tsx
@@ -3,11 +3,18 @@
  *
  */
 
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import type { ContextProps, InternalLocale } from './Context'
 import Context, { prepareContext } from './Context'
 import { prepareFormElementContext } from './helpers/filterValidProps'
 import { mergeTranslations } from './Translation'
+import { warn } from './component-helper'
 
 export type ProviderProps = {
   /**
@@ -49,6 +56,48 @@ export default function Provider<Props>(
     },
     [update]
   )
+
+  const { translationsLoader, translations: propTranslations } = localProps
+
+  const effectiveLocale =
+    localContext?.__context__?.locale ||
+    localProps.locale ||
+    nestedContext.locale
+
+  useEffect(() => {
+    if (!translationsLoader) {
+      return undefined // stop here
+    }
+
+    let cancelled = false
+
+    translationsLoader(effectiveLocale)
+      .then((loaded) => {
+        if (!cancelled && loaded) {
+          const base = propTranslations || {}
+          const merged = mergeTranslations(
+            base as Record<string, unknown>,
+            loaded as Record<string, unknown>
+          )
+
+          setLocalContext((prev) => ({
+            __context__: {
+              ...prev?.__context__,
+              translations: merged,
+            },
+          }))
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          warn('Provider: translationsLoader failed:', error)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [translationsLoader, effectiveLocale])
 
   const value = useMemo(() => {
     const { children, ...rest } = localProps

--- a/packages/dnb-eufemia/src/shared/Provider.tsx
+++ b/packages/dnb-eufemia/src/shared/Provider.tsx
@@ -13,6 +13,7 @@ import React, {
 } from 'react'
 import type { ContextProps, InternalLocale } from './Context'
 import Context, { prepareContext } from './Context'
+import { LOCALE } from './defaults'
 import { prepareFormElementContext } from './helpers/filterValidProps'
 import { mergeTranslations } from './Translation'
 import { warn } from './component-helper'
@@ -63,19 +64,24 @@ export default function Provider<Props>(
   const propTranslationsRef = useRef(propTranslations)
   propTranslationsRef.current = propTranslations
 
+  const translationsLoaderRef = useRef(translationsLoader)
+  translationsLoaderRef.current = translationsLoader
+
   const effectiveLocale =
     localContext?.__context__?.locale ||
     localProps.locale ||
-    nestedContext.locale
+    nestedContext.locale ||
+    LOCALE
 
   useEffect(() => {
-    if (!translationsLoader) {
+    const loader = translationsLoaderRef.current
+    if (!loader) {
       return undefined // stop here
     }
 
     let cancelled = false
 
-    translationsLoader(effectiveLocale)
+    loader(effectiveLocale)
       .then((loaded) => {
         if (!cancelled && loaded) {
           const base = propTranslationsRef.current || {}
@@ -101,7 +107,7 @@ export default function Provider<Props>(
     return () => {
       cancelled = true
     }
-  }, [translationsLoader, effectiveLocale])
+  }, [effectiveLocale])
 
   const value = useMemo(() => {
     const { children, ...rest } = localProps

--- a/packages/dnb-eufemia/src/shared/Provider.tsx
+++ b/packages/dnb-eufemia/src/shared/Provider.tsx
@@ -8,6 +8,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import type { ContextProps, InternalLocale } from './Context'
@@ -59,6 +60,9 @@ export default function Provider<Props>(
 
   const { translationsLoader, translations: propTranslations } = localProps
 
+  const propTranslationsRef = useRef(propTranslations)
+  propTranslationsRef.current = propTranslations
+
   const effectiveLocale =
     localContext?.__context__?.locale ||
     localProps.locale ||
@@ -74,7 +78,7 @@ export default function Provider<Props>(
     translationsLoader(effectiveLocale)
       .then((loaded) => {
         if (!cancelled && loaded) {
-          const base = propTranslations || {}
+          const base = propTranslationsRef.current || {}
           const merged = mergeTranslations(
             base as Record<string, unknown>,
             loaded as Record<string, unknown>

--- a/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
@@ -20,6 +20,7 @@ import Provider from '../Provider'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import locales from '../../shared/locales'
 import Translation from '../Translation'
+import useTranslation from '../useTranslation'
 import * as TranslationModule from '../Translation'
 import { Form } from '../../extensions/forms'
 
@@ -914,6 +915,46 @@ describe('Provider', () => {
       // Should still render with default translations
       await waitFor(() => {
         expect(container.querySelector('span').textContent).toBeTruthy()
+      })
+    })
+
+    it('should support consumer error handling inside the loader', async () => {
+      const onError = jest.fn()
+
+      const errorTranslations = {
+        'nb-NO': {
+          errorMessage: 'Kunne ikke laste oversettelser',
+        },
+      }
+
+      type ErrorTranslation =
+        (typeof errorTranslations)[keyof typeof errorTranslations]
+
+      const loader = jest.fn(async () => {
+        try {
+          throw new Error('Network error')
+        } catch (error) {
+          onError(error)
+          return errorTranslations
+        }
+      })
+
+      const DisplayError = () => {
+        const { errorMessage } = useTranslation<ErrorTranslation>()
+        return <>{errorMessage}</>
+      }
+
+      const { container } = render(
+        <Provider translationsLoader={loader}>
+          <DisplayError />
+        </Provider>
+      )
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(expect.any(Error))
+        expect(container.textContent).toBe(
+          'Kunne ikke laste oversettelser'
+        )
       })
     })
 

--- a/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
@@ -12,11 +12,12 @@ import type {
   ContextProps,
   TranslationFlat,
   Translations,
+  TranslationsLoader,
 } from '../Context'
 import Context from '../Context'
 import type { ProviderProps } from '../Provider'
 import Provider from '../Provider'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import locales from '../../shared/locales'
 import Translation from '../Translation'
 import * as TranslationModule from '../Translation'
@@ -696,6 +697,248 @@ describe('Provider', () => {
       expect(spy).toHaveBeenCalledTimes(1)
 
       spy.mockRestore()
+    })
+  })
+
+  describe('translationsLoader', () => {
+    const DisplayTitle = () => {
+      const { translation } = React.useContext(Context)
+      return <span>{translation.HelpButton?.title}</span>
+    }
+
+    it('should call the loader on mount with the current locale', async () => {
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': { HelpButton: { title: 'Async NB' } },
+      })
+
+      render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      expect(loader).toHaveBeenCalledTimes(1)
+      expect(loader).toHaveBeenCalledWith('nb-NO')
+    })
+
+    it('should render loaded translations after async load completes', async () => {
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': { HelpButton: { title: 'Async NB' } },
+      })
+
+      const { container } = render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'Async NB'
+        )
+      })
+    })
+
+    it('should call the loader again when locale changes', async () => {
+      const loader = jest.fn((locale) => {
+        if (locale === 'en-GB') {
+          return Promise.resolve({
+            'en-GB': { HelpButton: { title: 'Async EN' } },
+          })
+        }
+        return Promise.resolve({
+          'nb-NO': { HelpButton: { title: 'Async NB' } },
+        })
+      })
+
+      const ChangeLocale = () => {
+        const { setLocale } = React.useContext(Context)
+        return <button onClick={() => setLocale('en-GB')}>Switch</button>
+      }
+
+      const { container } = render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+          <ChangeLocale />
+        </Provider>
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'Async NB'
+        )
+      })
+
+      fireEvent.click(document.querySelector('button'))
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'Async EN'
+        )
+      })
+
+      expect(loader).toHaveBeenCalledWith('nb-NO')
+      expect(loader).toHaveBeenCalledWith('en-GB')
+    })
+
+    it('should cancel stale loads when locale switches quickly', async () => {
+      let resolveFirst: (v: unknown) => void
+      let resolveSecond: (v: unknown) => void
+
+      const firstPromise = new Promise((r) => {
+        resolveFirst = r
+      })
+      const secondPromise = new Promise((r) => {
+        resolveSecond = r
+      })
+
+      let callCount = 0
+      const loader = jest.fn(() => {
+        callCount++
+        return callCount === 1 ? firstPromise : secondPromise
+      }) as unknown as TranslationsLoader & jest.Mock
+
+      const ChangeLocale = () => {
+        const { setLocale } = React.useContext(Context)
+        return <button onClick={() => setLocale('en-GB')}>Switch</button>
+      }
+
+      const { container } = render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+          <ChangeLocale />
+        </Provider>
+      )
+
+      // Switch locale before first load completes
+      fireEvent.click(document.querySelector('button'))
+
+      // Resolve second (current) first
+      resolveSecond({
+        'en-GB': { HelpButton: { title: 'Second' } },
+      })
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe('Second')
+      })
+
+      // Resolve first (stale) after — should be ignored
+      resolveFirst({
+        'nb-NO': { HelpButton: { title: 'Stale' } },
+      })
+
+      // Give time for any unwanted state update
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe('Second')
+      })
+    })
+
+    it('should merge loaded translations with static translations', async () => {
+      const staticTranslations = {
+        'nb-NO': {
+          HelpButton: { title: 'Static NB' },
+        },
+      }
+
+      const loader = jest.fn().mockResolvedValue({
+        'nb-NO': {
+          Modal: { closeTitle: 'Async Close' },
+        },
+      })
+
+      const DisplayCloseTitle = () => {
+        const { translation } = React.useContext(Context)
+        return (
+          <>
+            <span id="help">{translation.HelpButton?.title}</span>
+            <span id="close">{translation.Modal?.closeTitle}</span>
+          </>
+        )
+      }
+
+      const { container } = render(
+        <Provider
+          translations={staticTranslations}
+          translationsLoader={loader}
+        >
+          <DisplayCloseTitle />
+        </Provider>
+      )
+
+      // Static translation should be present immediately
+      expect(container.querySelector('#help').textContent).toBe(
+        'Static NB'
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('#close').textContent).toBe(
+          'Async Close'
+        )
+      })
+    })
+
+    it('should handle loader errors gracefully', async () => {
+      const loader = jest
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+
+      const log = jest.spyOn(console, 'log').mockImplementation()
+
+      render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      // Wait for the async rejection to be handled
+      await waitFor(() => {
+        expect(log).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.stringContaining('translationsLoader'),
+          expect.any(Error)
+        )
+      })
+
+      log.mockRestore()
+    })
+
+    it('should handle loader returning null', async () => {
+      const loader = jest.fn().mockResolvedValue(null)
+
+      const { container } = render(
+        <Provider translationsLoader={loader}>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      // Should still render with default translations
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBeTruthy()
+      })
+    })
+
+    it('should not break when no loader is provided', () => {
+      const { container } = render(
+        <Provider>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      expect(container.querySelector('span').textContent).toBeTruthy()
+    })
+
+    it('should use locale prop for the loader call', async () => {
+      const loader = jest.fn().mockResolvedValue({
+        'en-GB': { HelpButton: { title: 'Async EN' } },
+      })
+
+      render(
+        <Provider locale="en-GB" translationsLoader={loader}>
+          <DisplayTitle />
+        </Provider>
+      )
+
+      expect(loader).toHaveBeenCalledWith('en-GB')
     })
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Provider.test.tsx
@@ -940,5 +940,162 @@ describe('Provider', () => {
 
       expect(loader).toHaveBeenCalledWith('en-GB')
     })
+
+    it('should cascade parent static translations to child before loader resolves', async () => {
+      const childLoader = jest.fn().mockResolvedValue({
+        'nb-NO': { Modal: { closeTitle: 'Child Async Close' } },
+      })
+
+      const DisplayBoth = () => {
+        const { translation } = React.useContext(Context)
+        return (
+          <>
+            <span id="help">{translation.HelpButton?.title}</span>
+            <span id="close">{translation.Modal?.closeTitle}</span>
+          </>
+        )
+      }
+
+      const { container } = render(
+        <Provider
+          translations={{
+            'nb-NO': { HelpButton: { title: 'Parent Static' } },
+          }}
+        >
+          <Provider translationsLoader={childLoader}>
+            <DisplayBoth />
+          </Provider>
+        </Provider>
+      )
+
+      // Parent static translation cascades to child immediately
+      expect(container.querySelector('#help').textContent).toBe(
+        'Parent Static'
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('#close').textContent).toBe(
+          'Child Async Close'
+        )
+      })
+    })
+
+    it('should let child loader override parent static translations', async () => {
+      const childLoader = jest.fn().mockResolvedValue({
+        'nb-NO': { HelpButton: { title: 'Child Override' } },
+      })
+
+      const { container } = render(
+        <Provider
+          translations={{
+            'nb-NO': { HelpButton: { title: 'Parent Static' } },
+          }}
+        >
+          <Provider translationsLoader={childLoader}>
+            <DisplayTitle />
+          </Provider>
+        </Provider>
+      )
+
+      // Before async load, parent value is used
+      expect(container.querySelector('span').textContent).toBe(
+        'Parent Static'
+      )
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'Child Override'
+        )
+      })
+    })
+
+    it('should handle both parent and child having independent loaders', async () => {
+      const parentLoader = jest.fn().mockResolvedValue({
+        'nb-NO': { HelpButton: { title: 'Parent Async' } },
+      })
+
+      const childLoader = jest.fn().mockResolvedValue({
+        'nb-NO': { Modal: { closeTitle: 'Child Async' } },
+      })
+
+      const DisplayChildTranslation = () => {
+        const { translation } = React.useContext(Context)
+        return <span id="close">{translation.Modal?.closeTitle}</span>
+      }
+
+      const { container } = render(
+        <Provider translationsLoader={parentLoader}>
+          <Provider translationsLoader={childLoader}>
+            <DisplayChildTranslation />
+          </Provider>
+        </Provider>
+      )
+
+      expect(parentLoader).toHaveBeenCalledWith('nb-NO')
+      expect(childLoader).toHaveBeenCalledWith('nb-NO')
+
+      await waitFor(() => {
+        expect(container.querySelector('#close').textContent).toBe(
+          'Child Async'
+        )
+      })
+    })
+
+    it('should handle race condition when parent locale changes during child load', async () => {
+      let resolveChildFirst: (v: unknown) => void
+      let resolveChildSecond: (v: unknown) => void
+
+      let childCallCount = 0
+      const childLoader = jest.fn(() => {
+        childCallCount++
+        if (childCallCount === 1) {
+          return new Promise((r) => {
+            resolveChildFirst = r
+          })
+        }
+        return new Promise((r) => {
+          resolveChildSecond = r
+        })
+      }) as unknown as TranslationsLoader & jest.Mock
+
+      const ChangeLocale = () => {
+        const { setLocale } = React.useContext(Context)
+        return <button onClick={() => setLocale('en-GB')}>Switch</button>
+      }
+
+      const { container } = render(
+        <Provider>
+          <Provider translationsLoader={childLoader}>
+            <DisplayTitle />
+            <ChangeLocale />
+          </Provider>
+        </Provider>
+      )
+
+      // Switch locale before child's first load completes
+      fireEvent.click(document.querySelector('button'))
+
+      // Resolve the second (current locale) load
+      resolveChildSecond({
+        'en-GB': { HelpButton: { title: 'EN Result' } },
+      })
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'EN Result'
+        )
+      })
+
+      // Resolve the first (stale) load — should be ignored
+      resolveChildFirst({
+        'nb-NO': { HelpButton: { title: 'Stale NB' } },
+      })
+
+      await waitFor(() => {
+        expect(container.querySelector('span').textContent).toBe(
+          'EN Result'
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/C05SQ17NEJH/p1774274656919459

Add `translationsLoader` prop to Provider that accepts an async function (locale) => Promise<Translations>. Translations are loaded on mount and locale change, merged with static translations, with cancellation guard and error handling.

In a following up PR I will use this in the Portal docs.

