### PR TITLE
chore: extract shared doc properties from component *Docs.ts files

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -1,4 +1,15 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDocProperty,
+  labelDirectionDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const AutocompleteProperties: PropertiesTableProps = {
   mode: {
@@ -187,51 +198,19 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
-  label: {
-    doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
-    type: 'React.ReactNode',
-    status: 'optional',
-  },
-  labelDirection: {
-    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: ['"horizontal"', '"vertical"'],
-    status: 'optional',
-  },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
+  label: labelDocProperty,
+  labelDirection: labelDirectionDocProperty,
+  labelSrOnly: labelSrOnlyDocProperty,
   suffix: {
     doc: 'Text describing the content of the Autocomplete more than the label. You can also send in a React component, so it gets wrapped inside the Autocomplete component.',
     type: 'React.ReactNode',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   inputRef: {
     doc: 'Use a `React.Ref` to get access to the `input` DOM element.',
     type: 'React.RefObject',
@@ -247,11 +226,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'Various',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const AutocompleteEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -1,4 +1,10 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const ButtonProperties: PropertiesTableProps = {
   type: {
@@ -96,11 +102,7 @@ export const ButtonProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   tooltip: {
     doc: 'Provide a string or a React Element to be shown as the tooltip content.',
     type: ['string', 'React.ReactNode'],
@@ -116,21 +118,9 @@ export const ButtonProperties: PropertiesTableProps = {
     type: ['"error"', '"information"'],
     status: 'optional',
   },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const ButtonEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -1,4 +1,12 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusStateDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const CheckboxProperties: PropertiesTableProps = {
   checked: {
@@ -21,11 +29,7 @@ export const CheckboxProperties: PropertiesTableProps = {
     type: ['"left"', '"right"'],
     status: 'optional',
   },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  labelSrOnly: labelSrOnlyDocProperty,
   size: {
     doc: 'The size of the checkbox. For now there is `medium` (default) and `large`.',
     type: ['"default"', '"medium"', '"large"'],
@@ -36,31 +40,15 @@ export const CheckboxProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties. See [FormStatus](/uilib/components/form-status/properties/).',
     type: 'FormStatusProps',
     status: 'optional',
   },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  globalStatus: globalStatusDocProperty,
+  skeleton: skeletonDocProperty,
   suffix: {
     doc: 'Text describing the content of the Checkbox more than the label. You can also send in a React component, so it gets wrapped inside the Checkbox component.',
     type: 'React.ReactNode',
@@ -71,11 +59,7 @@ export const CheckboxProperties: PropertiesTableProps = {
     type: 'React.RefObject',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const CheckboxEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -1,4 +1,14 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDirectionDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 const dateType = ['string', 'Date']
 
@@ -208,21 +218,13 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  labelDirection: {
-    doc: ' Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: ['"vertical"', '"horizontal"'],
-    status: 'optional',
-  },
+  labelDirection: labelDirectionDocProperty,
   suffix: {
     doc: 'Text describing the content of the DatePicker more than the label. You can also send in a React component, so it gets wrapped inside the DatePicker component.',
     type: 'React.ReactNode',
     status: 'optional',
   },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  labelSrOnly: labelSrOnlyDocProperty,
   shortcuts: {
     doc: 'Gives you the possibility to set predefined dates and date ranges so the user can select these by one click. Define either a JSON or an object with the defined shortcuts. More info is below.',
     type: 'object',
@@ -238,51 +240,27 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
   disableAutofocus: {
     doc: 'Once the date picker gets opened, there is a focus handling to ensure good accessibility. This can be disabled with this property. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  globalStatus: globalStatusDocProperty,
   tooltip: {
     doc: 'Provide a short Tooltip content that shows up on the picker button.',
     type: 'React.ReactNode',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   size: {
     doc: 'The sizes you can choose is `small` (1.5rem), `default` (2rem), `medium` (2.5rem) and `large` (3rem) are supported component sizes. Defaults to `default` / `null`.',
     type: 'string',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const DatePickerEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -1,4 +1,14 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDocProperty,
+  labelDirectionDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const DropdownEvents: PropertiesTableProps = {
   onChange: {
@@ -109,41 +119,17 @@ export const DropdownProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
+  status: statusDocProperty,
   statusState: {
     doc: "Defines the state of the status. It's two statuses `[error, information]`. Defaults to `error`.",
     type: ['"error"', '"information"'],
     status: 'optional',
   },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
-  label: {
-    doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
-    type: 'React.ReactNode',
-    status: 'optional',
-  },
-  labelDirection: {
-    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: ['"horizontal"', '"vertical"'],
-    status: 'optional',
-  },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
+  label: labelDocProperty,
+  labelDirection: labelDirectionDocProperty,
+  labelSrOnly: labelSrOnlyDocProperty,
   suffix: {
     doc: 'Text describing the content of the Dropdown more than the label. You can also send in a React component, so it gets wrapped inside the Dropdown component.',
     type: 'React.ReactNode',
@@ -164,19 +150,11 @@ export const DropdownProperties: PropertiesTableProps = {
     type: 'React.RefObject',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   '[DrawerList](/uilib/components/fragments/drawer-list/properties)': {
     doc: 'All DrawerList properties.',
     type: 'Various',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -1,4 +1,14 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const InputProperties: PropertiesTableProps = {
   value: {
@@ -11,41 +21,17 @@ export const InputProperties: PropertiesTableProps = {
     type: ['"left"', '"center"', '"right"'],
     status: 'optional',
   },
-  label: {
-    doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
-    type: 'React.ReactNode',
-    status: 'optional',
-  },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  label: labelDocProperty,
+  labelSrOnly: labelSrOnlyDocProperty,
   labelDirection: {
     doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
     type: 'string',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
   placeholder: {
     doc: 'The placeholder which shows up once the input value is empty.',
     type: 'React.ReactNode',
@@ -117,11 +103,7 @@ export const InputProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   inputAttributes: {
     doc: 'Provide the Input element with any attributes by using an Object `inputAttributes={{size:\'2\'}}` or a JSON Object `inputAttributes=\'{"size":"2"}\'`. **NB:** Keep in mind, that also every not listed component property will be sent along and set as an Input element attribute.',
     type: 'object',
@@ -152,11 +134,7 @@ export const InputProperties: PropertiesTableProps = {
     type: ['string', 'React.Element'],
     status: 'internal',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const InputEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
@@ -1,4 +1,15 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDocProperty,
+  labelDirectionDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const SliderProperties: PropertiesTableProps = {
   value: {
@@ -76,61 +87,25 @@ export const SliderProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  label: {
-    doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
-    type: 'React.ReactNode',
-    status: 'optional',
-  },
-  labelDirection: {
-    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: ['"horizontal"', '"vertical"'],
-    status: 'optional',
-  },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  label: labelDocProperty,
+  labelDirection: labelDirectionDocProperty,
+  labelSrOnly: labelSrOnlyDocProperty,
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
   suffix: {
     doc: 'Text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component.',
     type: 'React.ReactNode',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   extensions: {
     doc: 'Makes it possible to display overlays with other functionality such as a marker on the slider marking a given value.',
     type: 'object',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const SliderEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -1,4 +1,10 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const SwitchProperties: PropertiesTableProps = {
   checked: {
@@ -21,21 +27,13 @@ export const SwitchProperties: PropertiesTableProps = {
     type: ['"left"', '"right"'],
     status: 'optional',
   },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  labelSrOnly: labelSrOnlyDocProperty,
   size: {
     doc: 'The size of the switch. For now there is `medium` (default) and `large`.',
     type: ['"default"', '"medium"', '"large"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
+  status: statusDocProperty,
   statusState: {
     doc: 'Defines the state of the status. Defaults to `error`.',
     type: [
@@ -62,21 +60,13 @@ export const SwitchProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
   ref: {
     doc: 'By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.',
     type: 'React.RefObject',
     status: 'optional',
   },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const SwitchEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -1,4 +1,14 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  labelDocProperty,
+  labelDirectionDocProperty,
+  labelSrOnlyDocProperty,
+  statusDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const TextareaProperties: PropertiesTableProps = {
   value: {
@@ -26,26 +36,14 @@ export const TextareaProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  label: {
-    doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
-    type: 'React.ReactNode',
-    status: 'optional',
-  },
-  labelDirection: {
-    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: ['"horizontal"', '"vertical"'],
-    status: 'optional',
-  },
+  label: labelDocProperty,
+  labelDirection: labelDirectionDocProperty,
   suffix: {
     doc: 'Text describing the content of the Textarea more than the label. You can also send in a React component, so it gets wrapped inside the Textarea component.',
     type: 'React.ReactNode',
     status: 'optional',
   },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  labelSrOnly: labelSrOnlyDocProperty,
   autoResize: {
     doc: 'Use `true` to make the Textarea grow and shrink depending on how many lines the user has filled.',
     type: 'boolean',
@@ -66,11 +64,7 @@ export const TextareaProperties: PropertiesTableProps = {
     type: ['"small"', '"medium"', '"large"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
+  status: statusDocProperty,
   statusState: {
     doc: 'Defines the state of the status. Defaults to `error`.',
     type: [
@@ -82,16 +76,8 @@ export const TextareaProperties: PropertiesTableProps = {
     ],
     status: 'optional',
   },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
   textareaState: {
     doc: 'To control the visual focus state as a property, like `focus` or `blur`.',
     type: 'string',
@@ -102,16 +88,8 @@ export const TextareaProperties: PropertiesTableProps = {
     type: 'React.RefObject',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const TextareaEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
@@ -1,5 +1,13 @@
 import type { PropertiesTableProps } from '../../shared/types'
 import { ButtonProperties } from '../button/ButtonDocs'
+import {
+  statusDocProperty,
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const ToggleButtonProperties: PropertiesTableProps = {
   value: {
@@ -44,41 +52,17 @@ export const ToggleButtonProperties: PropertiesTableProps = {
   },
   tooltip: ButtonProperties.tooltip,
   size: ButtonProperties.size,
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
-    status: 'optional',
-  },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
   suffix: {
     doc: 'Text describing the content of the ToggleButton more than the label. You can also send in a React component, so it gets wrapped inside the ToggleButton component.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const ToggleButtonEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
@@ -1,4 +1,12 @@
 import type { PropertiesTableProps } from '../../shared/types'
+import {
+  statusStateDocProperty,
+  statusPropsDocProperty,
+  globalStatusDocProperty,
+  labelSrOnlyDocProperty,
+  skeletonDocProperty,
+  spacingDocProperty,
+} from '../../shared/sharedDocsProperties'
 
 export const ToggleButtonGroupProperties: PropertiesTableProps = {
   value: {
@@ -31,21 +39,9 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
-    status: 'optional',
-  },
-  statusProps: {
-    doc: 'Use an object to define additional FormStatus properties.',
-    type: 'object',
-    status: 'optional',
-  },
-  globalStatus: {
-    doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
-    type: 'object',
-    status: 'optional',
-  },
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
   label: {
     doc: 'Use either the `label` property or provide a custom one.',
     type: 'string',
@@ -56,11 +52,7 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     type: ['"vertical"', '"horizontal"'],
     status: 'optional',
   },
-  labelSrOnly: {
-    doc: 'Use `true` to make the label only readable by screen readers.',
-    type: 'boolean',
-    status: 'optional',
-  },
+  labelSrOnly: labelSrOnlyDocProperty,
   vertical: {
     doc: 'Will force both `direction` and `labelDirection` to be `vertical` if set to `true`.',
     type: 'boolean',
@@ -71,16 +63,8 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  skeleton: {
-    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
-    type: 'boolean',
-    status: 'optional',
-  },
-  '[Space](/uilib/layout/space/properties)': {
-    doc: 'Spacing properties like `top` or `bottom` are supported.',
-    type: ['string', 'object'],
-    status: 'optional',
-  },
+  skeleton: skeletonDocProperty,
+  '[Space](/uilib/layout/space/properties)': spacingDocProperty,
 }
 
 export const ToggleButtonGroupEvents: PropertiesTableProps = {

--- a/packages/dnb-eufemia/src/shared/sharedDocsProperties.ts
+++ b/packages/dnb-eufemia/src/shared/sharedDocsProperties.ts
@@ -1,0 +1,71 @@
+import type { PropertiesTableProps } from './types'
+
+// Shared property definitions used across multiple component *Docs.ts files.
+// Follow the pattern established in components/stat/StatDocsUtils.ts.
+
+export const skeletonDocProperty: PropertiesTableProps[string] = {
+  doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
+  type: 'boolean',
+  status: 'optional',
+}
+
+export const spacingDocProperty: PropertiesTableProps[string] = {
+  doc: 'Spacing properties like `top` or `bottom` are supported.',
+  type: ['string', 'object'],
+  status: 'optional',
+}
+
+export const statusDocProperty: PropertiesTableProps[string] = {
+  doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
+  type: ['"error"', '"information"', 'boolean'],
+  status: 'optional',
+}
+
+export const statusStateDocProperty: PropertiesTableProps[string] = {
+  doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
+  type: ['"error"', '"information"'],
+  status: 'optional',
+}
+
+export const statusPropsDocProperty: PropertiesTableProps[string] = {
+  doc: 'Use an object to define additional FormStatus properties.',
+  type: 'object',
+  status: 'optional',
+}
+
+export const globalStatusDocProperty: PropertiesTableProps[string] = {
+  doc: 'The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).',
+  type: 'object',
+  status: 'optional',
+}
+
+export const labelDocProperty: PropertiesTableProps[string] = {
+  doc: 'Prepends the Form Label component. If no ID is provided, a random ID is created.',
+  type: 'React.ReactNode',
+  status: 'optional',
+}
+
+export const labelDirectionDocProperty: PropertiesTableProps[string] = {
+  doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
+  type: ['"horizontal"', '"vertical"'],
+  status: 'optional',
+}
+
+export const labelSrOnlyDocProperty: PropertiesTableProps[string] = {
+  doc: 'Use `true` to make the label only readable by screen readers.',
+  type: 'boolean',
+  status: 'optional',
+}
+
+export const formStatusDocProperties: PropertiesTableProps = {
+  status: statusDocProperty,
+  statusState: statusStateDocProperty,
+  statusProps: statusPropsDocProperty,
+  globalStatus: globalStatusDocProperty,
+}
+
+export const formLabelDocProperties: PropertiesTableProps = {
+  label: labelDocProperty,
+  labelDirection: labelDirectionDocProperty,
+  labelSrOnly: labelSrOnlyDocProperty,
+}

--- a/packages/dnb-eufemia/src/shared/sharedDocsProperties.ts
+++ b/packages/dnb-eufemia/src/shared/sharedDocsProperties.ts
@@ -56,16 +56,3 @@ export const labelSrOnlyDocProperty: PropertiesTableProps[string] = {
   type: 'boolean',
   status: 'optional',
 }
-
-export const formStatusDocProperties: PropertiesTableProps = {
-  status: statusDocProperty,
-  statusState: statusStateDocProperty,
-  statusProps: statusPropsDocProperty,
-  globalStatus: globalStatusDocProperty,
-}
-
-export const formLabelDocProperties: PropertiesTableProps = {
-  label: labelDocProperty,
-  labelDirection: labelDirectionDocProperty,
-  labelSrOnly: labelSrOnlyDocProperty,
-}


### PR DESCRIPTION
Create shared/sharedDocsProperties.ts with reusable property definitions for skeleton, spacing, status, statusState, statusProps, globalStatus, label, labelDirection, and labelSrOnly.

Update 11 component Docs files to import from the shared module instead of duplicating identical property definitions:
- InputDocs, AutocompleteDocs, SliderDocs, DatePickerDocs, DropdownDocs, TextareaDocs, CheckboxDocs, SwitchDocs, ButtonDocs, ToggleButtonDocs, ToggleButtonGroupDocs

Properties with component-specific variations (different type values or doc text) are intentionally kept as-is in their respective files.