### PR TITLE
fix(Field.Selection, Field.ArraySelection): pass `width` to FieldBlock to prevent label truncation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -126,6 +126,9 @@ function ArraySelection(props: FieldArraySelectionProps) {
     fieldBlockProps.labelHeight = 'small'
   }
   if (width) {
+    if (width === 'stretch') {
+      fieldBlockProps.width = width
+    }
     fieldBlockProps.contentWidth = width
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -1405,6 +1405,19 @@ describe('ArraySelection', () => {
       )
     })
 
+    it('should apply width-stretch class to field block when width is stretch', () => {
+      render(
+        <Field.ArraySelection width="stretch">
+          <Field.Option value="foo">Foo</Field.Option>
+        </Field.ArraySelection>
+      )
+
+      const fieldBlock = document.querySelector('.dnb-forms-field-block')
+      expect(fieldBlock.classList).toContain(
+        'dnb-forms-field-block--width-stretch'
+      )
+    })
+
     it('should support custom width', () => {
       render(
         <Field.ArraySelection width="4rem">

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -435,7 +435,7 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
         variant="autocomplete"
         labelDescription={monthLabel}
         labelSize={labelSize}
-        width="stretch"
+        width="10.75rem"
         placeholder=""
         autocompleteProps={{
           openOnFocus: true,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -280,6 +280,9 @@ function Selection(props: FieldSelectionProps) {
         additionalFieldBlockProps.labelHeight = 'small'
       }
       if (width) {
+        if (width === 'stretch') {
+          additionalFieldBlockProps.width = width
+        }
         additionalFieldBlockProps.contentWidth = width
       }
 
@@ -342,6 +345,7 @@ function Selection(props: FieldSelectionProps) {
       }
 
       const specificFieldBlockProps: FieldBlockProps = {
+        width: width === 'stretch' ? width : undefined,
         contentWidth: width ?? 'large',
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -3166,6 +3166,32 @@ describe('Selection width', () => {
     )
   })
 
+  it('should apply width-stretch class to field block when width is stretch', () => {
+    render(
+      <Field.Selection width="stretch">
+        <Field.Option value="foo">Foo</Field.Option>
+      </Field.Selection>
+    )
+
+    const fieldBlock = document.querySelector('.dnb-forms-field-block')
+    expect(fieldBlock.classList).toContain(
+      'dnb-forms-field-block--width-stretch'
+    )
+  })
+
+  it('should apply width-stretch class to field block for radio variant', () => {
+    render(
+      <Field.Selection variant="radio" width="stretch">
+        <Field.Option value="foo">Foo</Field.Option>
+      </Field.Selection>
+    )
+
+    const fieldBlock = document.querySelector('.dnb-forms-field-block')
+    expect(fieldBlock.classList).toContain(
+      'dnb-forms-field-block--width-stretch'
+    )
+  })
+
   it('should support custom width', () => {
     render(
       <Field.Selection width="4rem">


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777373660252399

When width='stretch' was set on Field.Selection or Field.ArraySelection, only contentWidth was forwarded to FieldBlock. This meant the CSS class 'dnb-forms-field-block--width-stretch' was never applied, and the label kept its max-width constraint, causing long labels to be cut off. 

Both components now pass width='stretch' to FieldBlock, matching the pattern used by Field.String, Field.SelectCountry, and Field.SelectCurrency. This applies to all Selection variants (dropdown, autocomplete, radio, button) and ArraySelection (checkbox, button, checkbox-button).