### PR TITLE
fix(Forms): keep GlobalStatus visible until all errors are resolved

### DIFF
--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -433,7 +433,7 @@ function FormStatusComponent(
       fillCache()
 
       if (state === 'error') {
-        if (show) {
+        if (show && getContent(restOwnProps)) {
           globalStatusRef.current?.update(
             statusId,
             {

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -433,7 +433,11 @@ function FormStatusComponent(
       fillCache()
 
       if (state === 'error') {
-        if (show && getContent(restOwnProps)) {
+        const content = getContent(restOwnProps)
+
+        if (!content) {
+          globalStatusRef.current?.remove(statusId)
+        } else if (show) {
           globalStatusRef.current?.update(
             statusId,
             {
@@ -451,8 +455,6 @@ function FormStatusComponent(
               preventRestack: true, // because of the internal "close"
             }
           )
-        } else if (!getContent(restOwnProps)) {
-          globalStatusRef.current?.remove(statusId)
         }
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -303,9 +303,7 @@ export default function Provider<Data extends JsonObject>(
   const showGlobalStatusRef = useRef<boolean>(false)
   const setShowAllErrors = useCallback((showAllErrors: boolean) => {
     showAllErrorsRef.current = showAllErrors ? Date.now() : showAllErrors
-    if (showAllErrors) {
-      showGlobalStatusRef.current = true
-    }
+    showGlobalStatusRef.current = showAllErrors
     forceUpdate()
     addSetShowAllErrorsRef.current.forEach((fn) => fn?.(showAllErrors))
   }, [])

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -300,8 +300,12 @@ export default function Provider<Data extends JsonObject>(
     Array<(showAllErrors: boolean) => void>
   >([])
   const showAllErrorsRef = useRef<number | boolean>(false)
+  const showGlobalStatusRef = useRef<boolean>(false)
   const setShowAllErrors = useCallback((showAllErrors: boolean) => {
     showAllErrorsRef.current = showAllErrors ? Date.now() : showAllErrors
+    if (showAllErrors) {
+      showGlobalStatusRef.current = true
+    }
     forceUpdate()
     addSetShowAllErrorsRef.current.forEach((fn) => fn?.(showAllErrors))
   }, [])
@@ -1176,6 +1180,10 @@ export default function Provider<Data extends JsonObject>(
 
       validateData()
 
+      if (showGlobalStatusRef.current && !hasErrors()) {
+        showGlobalStatusRef.current = false
+      }
+
       const data = internalDataRef.current as Data
       const options = { filterData }
       const transformedData = transformOut
@@ -1199,6 +1207,7 @@ export default function Provider<Data extends JsonObject>(
     [
       filterData,
       handlePathChangeUnvalidated,
+      hasErrors,
       mutateDataHandler,
       onChange,
       transformOut,
@@ -1795,14 +1804,17 @@ export default function Provider<Data extends JsonObject>(
   }
 
   const show = Boolean(showAllErrorsRef.current)
+  const showGlobalStatus = show || showGlobalStatusRef.current
   const resolvedLocale = locale || sharedLocale
   const customErrorSummaryTitle =
     translations?.[resolvedLocale]?.Field?.errorSummaryTitle
   const formStatusConfig = useMemo(() => {
-    const status = show ? GlobalStatusProvider.get(globalStatusId) : null
+    const status = showGlobalStatus
+      ? GlobalStatusProvider.get(globalStatusId)
+      : null
     return {
       globalStatus: {
-        show,
+        show: showGlobalStatus,
         id: globalStatusId,
         title:
           status?.stack[0]?.title ??
@@ -1812,7 +1824,7 @@ export default function Provider<Data extends JsonObject>(
     }
   }, [
     globalStatusId,
-    show,
+    showGlobalStatus,
     customErrorSummaryTitle,
     translation.errorSummaryTitle,
   ])

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -2515,12 +2515,11 @@ describe('DataContext.Provider', () => {
             nb.StringField.errorMinLength.replace('{minLength}', '5')
           )
 
+          // GlobalStatus should remain visible since there are still errors
           await waitFor(() => {
-            simulateAnimationEnd()
-
             expect(
               document.querySelector('.dnb-global-status__title')
-            ).toBeNull()
+            ).toHaveTextContent(nb.Field.errorSummaryTitle)
           })
         })
 
@@ -2581,8 +2580,64 @@ describe('DataContext.Provider', () => {
             nb.StringField.errorMinLength.replace('{minLength}', '5')
           )
 
+          // GlobalStatus should remain visible since there are still errors
           await waitFor(() => {
-            simulateAnimationEnd()
+            expect(
+              document.querySelector('.dnb-global-status__title')
+            ).toHaveTextContent(nb.Field.errorSummaryTitle)
+          })
+        })
+
+        it('should keep GlobalStatus visible until all errors are resolved', async () => {
+          jest.spyOn(window, 'scrollTo').mockImplementation()
+
+          render(
+            <>
+              <GlobalStatus id="my-status" />
+              <DataContext.Provider globalStatusId="my-status">
+                <Field.String path="/myField" required />
+                <Field.String path="/otherField" required />
+                <Form.SubmitButton />
+              </DataContext.Provider>
+            </>
+          )
+
+          const [firstInput, secondInput] = Array.from(
+            document.querySelectorAll('input')
+          )
+          const submitButton = document.querySelector('button')
+
+          expect(
+            document.querySelector('.dnb-global-status__title')
+          ).toBeNull()
+
+          fireEvent.click(submitButton)
+
+          await waitFor(() => {
+            expect(
+              document.querySelector('.dnb-global-status__title')
+            ).toHaveTextContent(nb.Field.errorSummaryTitle)
+          })
+
+          // Type in the first field - GlobalStatus should persist
+          await userEvent.type(firstInput, 'foo')
+          fireEvent.blur(firstInput)
+
+          expect(
+            document.querySelector('.dnb-global-status__title')
+          ).toHaveTextContent(nb.Field.errorSummaryTitle)
+
+          // Fix the second field as well - GlobalStatus should now close
+          await userEvent.type(secondInput, 'bar')
+          fireEvent.blur(secondInput)
+
+          await waitFor(() => {
+            const heightAnimation = document.querySelector(
+              '.dnb-height-animation'
+            )
+            if (heightAnimation) {
+              simulateAnimationEnd(heightAnimation)
+            }
 
             expect(
               document.querySelector('.dnb-global-status__title')


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777373660252399

Issue reprod: https://stackblitz.com/edit/eufemia-starter-riyw7ywl?file=src%2FApp.tsx
Fix reprod: https://stackblitz.com/edit/eufemia-starter-zwsegemf?file=package.json

Change the default behavior so the GlobalStatus error summary remains visible after the user starts editing fields, instead of disappearing immediately. Previously, the GlobalStatus would auto-close as soon as any field value changed, even if validation errors remained.

Changes:
- Provider: remove showAllErrorsRef reset in handlePathChange so GlobalStatus stays visible while errors exist
- FormStatus: check for content when deciding to update GlobalStatus, ensuring items are removed when their errors resolve

