### PR TITLE
fix(GlobalStatus): preserve provider state when state prop is not given

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -358,7 +358,10 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
     ])
     setProviderGlobalStatus(derivedGlobalStatus)
   }
-  if (ownProps.state !== derivedGlobalStatus?.state) {
+  if (
+    'state' in ownProps &&
+    ownProps.state !== derivedGlobalStatus?.state
+  ) {
     derivedGlobalStatus = {
       ...derivedGlobalStatus,
       state: ownProps.state,

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -1095,6 +1095,36 @@ describe('GlobalStatus component', () => {
     expect(element).not.toHaveClass('dnb-global-status--error')
   })
 
+  it('should use error state from provider when no state prop is given', () => {
+    render(
+      <>
+        <GlobalStatus
+          id="provider-state-test"
+          autoScroll={false}
+          noAnimation
+        />
+        <GlobalStatus.Add
+          id="provider-state-test"
+          statusId="provider-state-1"
+          state="error"
+          text="Error from provider"
+        />
+      </>
+    )
+
+    const element = document.querySelector(
+      '#provider-state-test .dnb-global-status'
+    )
+    const section = document.querySelector(
+      '#provider-state-test .dnb-section'
+    )
+
+    expect(element).toHaveClass('dnb-global-status--error')
+    expect(element).not.toHaveClass('dnb-global-status--undefined')
+    expect(section).toHaveClass('dnb-section--error')
+    expect(section).not.toHaveClass('dnb-section--default')
+  })
+
   it('should reflect dynamic locale changes from Provider context', () => {
     const { rerender } = render(
       <Provider locale="en-GB">


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/components/global-status/demos/#to-showcase-the-automated-coupling-between-formstatus-and-globalstatus

From:

https://github.com/user-attachments/assets/0961e505-14fa-4462-a2f7-eead595c09d9

To:

https://github.com/user-attachments/assets/b3c0e81e-8735-459c-b3f1-1f0e4d4e1dbf





When GlobalStatus was rendered without an explicit state prop (e.g. via FormStatus coupling), the component overwrote the provider's state with undefined, resulting in missing background color (dnb-section--default instead of dnb-section--error).

Only override the provider state when the state prop is explicitly passed.

