### PR TITLE
refactor(Portal): use `translationsLoader` for dynamic locale loading

### DIFF
--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -115,21 +115,16 @@ function EufemiaProvider({ children }: { children: React.ReactNode }) {
   const [translationError, setTranslationError] = useState<string | null>(
     null
   )
-  const [isLoadingTranslation, setIsLoadingTranslation] = useState(false)
-
   const translationsLoader: TranslationsLoader = useCallback(
     async (locale) => {
       try {
         setTranslationError(null)
-        setIsLoadingTranslation(true)
         return await loadTranslations(locale)
       } catch (error) {
         setTranslationError(
           `Failed to load translations for locale "${locale}"`
         )
         return null
-      } finally {
-        setIsLoadingTranslation(false)
       }
     },
     []
@@ -137,7 +132,7 @@ function EufemiaProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <Provider
-      skeleton={getSkeletonEnabled() || isLoadingTranslation}
+      skeleton={getSkeletonEnabled()}
       locale={getLang()}
       translationsLoader={translationsLoader}
     >

--- a/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalProviders.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React, { useContext, useEffect } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { CacheProvider } from '@emotion/react'
 import createEmotionCache from '@emotion/cache'
 import {
@@ -12,35 +12,58 @@ import {
   Theme,
   mergeTranslations,
 } from '@dnb/eufemia/src/shared'
+import GlobalStatus from '@dnb/eufemia/src/components/global-status/GlobalStatus'
 import coreTranslations from '@dnb/eufemia/src/shared/locales'
-import enUS from '@dnb/eufemia/src/shared/locales/en-US'
-import svSE from '@dnb/eufemia/src/shared/locales/sv-SE'
-import svSE_forms from '@dnb/eufemia/src/extensions/forms/constants/locales/sv-SE'
-import svSE_forms_countries from '@dnb/eufemia/src/extensions/forms/constants/locales/countries/sv-SE'
-import daDK from '@dnb/eufemia/src/shared/locales/da-DK'
-import daDK_forms from '@dnb/eufemia/src/extensions/forms/constants/locales/da-DK'
-import daDK_forms_countries from '@dnb/eufemia/src/extensions/forms/constants/locales/countries/da-DK'
 import PortalLayout, { type PortalLayoutProps } from './PortalLayout'
 import { useThemeHandler } from 'gatsby-plugin-eufemia-theme-handler'
-import type { InternalLocale } from '@dnb/eufemia/src/shared/Context'
+import type {
+  InternalLocale,
+  TranslationsLoader,
+} from '@dnb/eufemia/src/shared/Context'
 import IsolatedStyleScope from '@dnb/eufemia/src/shared/IsolatedStyleScope'
 
-// Enable other existing locales here
-export const translationsWithoutEnUS = mergeTranslations(
-  svSE,
-  svSE_forms,
-  svSE_forms_countries,
-  daDK,
-  daDK_forms,
-  daDK_forms_countries
-)
-export const translations = mergeTranslations(
-  translationsWithoutEnUS,
-  enUS
-)
+// Load additional locale translations on demand
+async function loadTranslations(locale: string) {
+  switch (locale) {
+    case 'en-US': {
+      const enUS = (await import('@dnb/eufemia/src/shared/locales/en-US'))
+        .default
+      return enUS
+    }
+    case 'sv-SE': {
+      const [svSE, svSE_forms, svSE_forms_countries] = await Promise.all([
+        import('@dnb/eufemia/src/shared/locales/sv-SE'),
+        import('@dnb/eufemia/src/extensions/forms/constants/locales/sv-SE'),
+        import('@dnb/eufemia/src/extensions/forms/constants/locales/countries/sv-SE'),
+      ])
+      return mergeTranslations(
+        svSE.default,
+        svSE_forms.default,
+        svSE_forms_countries.default
+      )
+    }
+    case 'da-DK': {
+      const [daDK, daDK_forms, daDK_forms_countries] = await Promise.all([
+        import('@dnb/eufemia/src/shared/locales/da-DK'),
+        import('@dnb/eufemia/src/extensions/forms/constants/locales/da-DK'),
+        import('@dnb/eufemia/src/extensions/forms/constants/locales/countries/da-DK'),
+      ])
+      return mergeTranslations(
+        daDK.default,
+        daDK_forms.default,
+        daDK_forms_countries.default
+      )
+    }
+    default:
+      return null
+  }
+}
+
 export const supportedTranslationsKey = [
   ...Object.keys(coreTranslations),
-  ...Object.keys(translations),
+  'en-US',
+  'sv-SE',
+  'da-DK',
 ]
 
 // This ensures we processes also the css prop during build
@@ -69,11 +92,7 @@ export const rootElement =
       <CacheProvider
         value={type === 'ssr' ? createCacheInstance() : emotionCache}
       >
-        <Provider
-          skeleton={getSkeletonEnabled()} // To simulate a whole page skeleton
-          locale={getLang()}
-          translations={translations} // extend the available locales
-        >
+        <EufemiaProvider>
           <IsolatedStyleScope
             disableCoreStyleWrapper // Make exception, because using "dnb-core-style" does not work well for screenshot tests (as of now).
             scopeHash={
@@ -87,10 +106,54 @@ export const rootElement =
               <ThemeProvider>{element}</ThemeProvider>
             </SkeletonEnabled>
           </IsolatedStyleScope>
-        </Provider>
+        </EufemiaProvider>
       </CacheProvider>
     )
   }
+
+function EufemiaProvider({ children }: { children: React.ReactNode }) {
+  const [translationError, setTranslationError] = useState<string | null>(
+    null
+  )
+  const [isLoadingTranslation, setIsLoadingTranslation] = useState(false)
+
+  const translationsLoader: TranslationsLoader = useCallback(
+    async (locale) => {
+      try {
+        setTranslationError(null)
+        setIsLoadingTranslation(true)
+        return await loadTranslations(locale)
+      } catch (error) {
+        setTranslationError(
+          `Failed to load translations for locale "${locale}"`
+        )
+        return null
+      } finally {
+        setIsLoadingTranslation(false)
+      }
+    },
+    []
+  )
+
+  return (
+    <Provider
+      skeleton={getSkeletonEnabled() || isLoadingTranslation}
+      locale={getLang()}
+      translationsLoader={translationsLoader}
+    >
+      {translationError && (
+        <GlobalStatus
+          state="error"
+          text={translationError}
+          top="x-large"
+          show
+          noAnimation
+        />
+      )}
+      {children}
+    </Provider>
+  )
+}
 
 /**
  * Because we do rewrite the import path many places from

--- a/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
@@ -6,8 +6,23 @@ import globalTranslations from '@dnb/eufemia/src/shared/locales'
 import formsTranslations from '@dnb/eufemia/src/extensions/forms/constants/locales'
 import { FormattedCode } from './PropertiesTable'
 import type { Translation } from '@dnb/eufemia/src/shared/Context'
-import { translationsWithoutEnUS } from '../../core/PortalProviders'
+import { mergeTranslations } from '@dnb/eufemia/src/shared'
+import svSE from '@dnb/eufemia/src/shared/locales/sv-SE'
+import svSE_forms from '@dnb/eufemia/src/extensions/forms/constants/locales/sv-SE'
+import svSE_forms_countries from '@dnb/eufemia/src/extensions/forms/constants/locales/countries/sv-SE'
+import daDK from '@dnb/eufemia/src/shared/locales/da-DK'
+import daDK_forms from '@dnb/eufemia/src/extensions/forms/constants/locales/da-DK'
+import daDK_forms_countries from '@dnb/eufemia/src/extensions/forms/constants/locales/countries/da-DK'
 import { languageDisplayNames } from '../../core/ChangeLocale'
+
+const additionalTranslations = mergeTranslations(
+  svSE,
+  svSE_forms,
+  svSE_forms_countries,
+  daDK,
+  daDK_forms,
+  daDK_forms_countries
+)
 
 const StyledTable = styled(Table)`
   td {
@@ -27,7 +42,7 @@ export default function TranslationsTable({
       source ||
       Object.assign(
         extendDeep({}, globalTranslations, formsTranslations),
-        translationsWithoutEnUS
+        additionalTranslations
       )
     )
   }, [source])


### PR DESCRIPTION
Move eager locale imports from PortalProviders to TranslationsTable so bundler can code-split the dynamic imports in translationsLoader. PortalProviders now uses the translationsLoader prop exclusively.

Preview: https://feat-translation-async-loade-yjlu.eufemia-e25.pages.dev/


<img width="1085" height="702" alt="Screenshot 2026-05-01 at 07 21 25" src="https://github.com/user-attachments/assets/8b72afad-0f50-4f75-9668-310e9eaf7dd4" />
