### PR TITLE
chore(Portal): simplify TabBar fullscreen button (tertiary) and cleanup styles

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/TabBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/TabBar.module.scss
@@ -1,42 +1,7 @@
-@use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
-
 .tabsWrapperStyle {
   :global {
     .dnb-tabs__tabs {
       justify-content: space-between;
-    }
-
-    .dnb-tabs__tabs .dnb-modal__close-button {
-      position: relative;
-      top: auto; /* to force the button to center */
-      right: auto;
-    }
-
-    .dnb-tabs__tabs .dnb-button.dnb-modal__close-button,
-    .dnb-tabs__tabs .dnb-button.fullscreen {
-      margin-left: 1rem;
-    }
-
-    .dnb-tabs__tabs .dnb-button--secondary {
-      box-shadow: none;
-      background-color: transparent;
-    }
-
-    @include utilities.allBelow(small) {
-      .fullscreen-page & {
-        top: 0;
-
-        /*
-				Will align the tab bar to the browser edges 
-				.dnb-tabs__tabs.dnb-tabs--has-scrollbar {
-				  margin: 0 -2rem;
-				}
-			  */
-      }
-
-      .dnb-tabs__tabs .dnb-button.fullscreen {
-        display: none;
-      }
     }
   }
 }

--- a/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
@@ -122,29 +122,21 @@ export default function TabBar({
             <Wrapper className={tabsWrapperStyle}>
               <TabsList>
                 <Tabs />
-                {wasFullscreen ? (
-                  <Button
-                    onClick={quitFullscreen}
-                    href={quitFullscreenPath}
-                    // @ts-expect-error -- strictFunctionTypes
-                    element={Link}
-                    variant="secondary"
-                    title="Quit Fullscreen"
-                    icon="close"
-                    className="fullscreen"
-                  />
-                ) : (
-                  <Button
-                    onClick={openFullscreen}
-                    href={fullscreenPath}
-                    // @ts-expect-error -- strictFunctionTypes
-                    element={Link}
-                    variant="secondary"
-                    title="Fullscreen"
-                    icon={fullscreenIcon}
-                    className="fullscreen"
-                  />
-                )}
+                <Button
+                  onClick={wasFullscreen ? quitFullscreen : openFullscreen}
+                  href={
+                    wasFullscreen ? quitFullscreenPath : fullscreenPath
+                  }
+                  // @ts-expect-error -- strictFunctionTypes
+                  element={Link}
+                  variant="tertiary"
+                  title={wasFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
+                  aria-label={
+                    wasFullscreen ? 'Quit Fullscreen' : 'Fullscreen'
+                  }
+                  icon={wasFullscreen ? 'close' : fullscreenIcon}
+                  className="fullscreen"
+                />
               </TabsList>
               {children}
               <Content />


### PR DESCRIPTION
The fullscreen button did not have an hover effect. Also, now Eufemia supports icon buttons as tertiary buttons.