### PR TITLE
chore: remove bottom border from properties table

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -200,7 +200,7 @@ export default function PropertiesTable({
 
   return (
     <Table.ScrollView>
-      <StyledTable outline>
+      <StyledTable border>
         <thead>
           <Tr>
             <Th

--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -200,7 +200,7 @@ export default function PropertiesTable({
 
   return (
     <Table.ScrollView>
-      <StyledTable outline border>
+      <StyledTable outline>
         <thead>
           <Tr>
             <Th


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/BankAccountNumber/properties/#translations

Deploy preview: https://chore-properties-table-borde.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/BankAccountNumber/properties/#translations

<img width="1237" height="935" alt="Screenshot 2026-05-04 at 11 56 52" src="https://github.com/user-attachments/assets/17d5322d-7d66-42f5-96a7-9ce14da5c129" />




