### PR TITLE
chore(Portal): replace hardcoded colors with design tokens in Layout

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -112,7 +112,7 @@
     :checked + .radio-label {
       position: relative;
       z-index: 1;
-      border-color: var(--color-sea-green);
+      border-color: var(--token-color-stroke-action);
     }
 
     .markdown-body::before {
@@ -141,7 +141,8 @@
       }
       a:hover img {
         border-radius: 0.25rem; /* 4/16 */
-        box-shadow: 0 0 0 0.125rem var(--color-mint-green-50);
+        box-shadow: 0 0 0 0.125rem
+          var(--token-color-stroke-action-focus-subtle);
       }
     }
 
@@ -167,7 +168,7 @@
       font-style: italic;
       text-align: center;
 
-      border-top: solid 1px #c4c4c4;
+      border-top: solid 1px var(--token-color-stroke-neutral-subtle);
 
       p {
         margin: 0;


### PR DESCRIPTION
Replace legacy color variables and hardcoded hex values with design tokens for dark mode support:

- #c4c4c4 → --token-color-stroke-neutral-subtle
- --color-sea-green → --token-color-stroke-action
- --color-mint-green-50 → --token-color-stroke-action-focus-subtle

