### PR TITLE
chore(Portal): replace hardcoded black/white with tokens in noscript banner

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
@@ -28,8 +28,8 @@
   padding: 1.25rem;
   text-align: center;
 
-  color: black;
-  background-color: white;
+  color: var(--token-color-text-neutral);
+  background-color: var(--token-color-background-neutral);
 }
 
 .dnb-live-preview {


### PR DESCRIPTION
Replace hardcoded color: black and background-color: white with token-based CSS custom properties in the #gatsby-noscript banner so it adapts correctly to dark mode.

