### PR TITLE
chore(Portal): remove hardcoded white Logo color in footer

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -176,7 +176,7 @@ const Footer = () => {
         Portal update: {packageJson.buildVersion}
       </P>
 
-      <Logo height="40" color="white" />
+      <Logo height="40" />
 
       <Anchor to="/license">Copyright (c) 2018-present DNB.no</Anchor>
     </Section>


### PR DESCRIPTION
The footer Logo had color="white" which relies on the Section background being dark. By removing it, the Logo uses its built-in theme-aware colors (teal in light mode, mint in dark mode), ensuring visibility in both light and dark color schemes.


light mode [today](https://eufemia.dnb.no/uilib/):

<img width="1249" height="75" alt="image" src="https://github.com/user-attachments/assets/172c91e3-627c-41a8-91a2-5fadc39ec50d" />


dark mode [today](https://eufemia.dnb.no/uilib/):

<img width="1244" height="67" alt="image" src="https://github.com/user-attachments/assets/4e4019f6-94fc-4f88-b917-52d37e5c7f73" />


After fix, [using this deploy preview](https://fix-portal-dark-mode-footer.eufemia-e25.pages.dev/uilib/):

<img width="1255" height="98" alt="image" src="https://github.com/user-attachments/assets/ce58d245-e54c-4850-9cd3-b74411107568" />

