### PR TITLE
chore(Portal): replace legacy color variables with design tokens in AutoLinkHeader

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
@@ -23,13 +23,13 @@
         0%,
         100% {
           visibility: visible;
-          color: var(--color-sea-green);
+          color: var(--token-color-text-action);
           background-color: transparent;
         }
 
         35% {
-          color: var(--color-white);
-          background-color: var(--color-sea-green);
+          color: var(--token-color-text-neutral-inverse);
+          background-color: var(--token-color-background-action);
         }
 
         // stylelint-disable-next-line
@@ -63,8 +63,8 @@
       }
 
       35% {
-        color: var(--color-white);
-        background-color: var(--color-sea-green);
+        color: var(--token-color-text-neutral-inverse);
+        background-color: var(--token-color-background-action);
       }
     }
 


### PR DESCRIPTION
Replace old --color-* variables with dark mode-aware design tokens in the anchor link attention-focus keyframe animations:

- --color-sea-green → --token-color-text-action (link text color)
- --color-sea-green → --token-color-background-action (highlight bg)
- --color-white → --token-color-text-neutral-inverse (contrast text)

