### PR TITLE
fix(Table): hide table bottom border when `border` is explicitly false

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/TranslationsTable.tsx
@@ -137,7 +137,7 @@ export default function TranslationsTable({
         docs.
       </P>
       <Table.ScrollView>
-        <StyledTable>
+        <StyledTable border={false}>
           <thead>
             <Tr>
               <Th>Key</Th>

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -155,6 +155,7 @@ const Table = (componentProps: TableAllProps) => {
       sticky && 'dnb-table--sticky',
       fixed && 'dnb-table--fixed',
       border && 'dnb-table--border',
+      border === false && 'dnb-table--no-border',
       outline && 'dnb-table--outline',
       mode === 'accordion' && 'dnb-table--accordion',
       mode === 'navigation' && 'dnb-table--navigation',

--- a/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/Table.test.tsx
@@ -132,6 +132,30 @@ describe('Table', () => {
     )
   })
 
+  it('should set the no-border class when border is false', () => {
+    render(
+      <Table border={false}>
+        <BasicTable />
+      </Table>
+    )
+
+    const classList = Array.from(screen.queryByRole('table').classList)
+    expect(classList).toContain('dnb-table--no-border')
+    expect(classList).not.toContain('dnb-table--border')
+  })
+
+  it('should not set border classes when border is undefined', () => {
+    render(
+      <Table>
+        <BasicTable />
+      </Table>
+    )
+
+    const classList = Array.from(screen.queryByRole('table').classList)
+    expect(classList).not.toContain('dnb-table--no-border')
+    expect(classList).not.toContain('dnb-table--border')
+  })
+
   it('should set the outline class', () => {
     render(
       <Table outline>

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -74,10 +74,10 @@ exports[`Table scss > should match default theme snapshot 1`] = `
 .dnb-table {
   /* stylelint-enable */
 }
-.dnb-table:not(.dnb-table--outline) > tbody {
+.dnb-table:not(.dnb-table--outline):not(.dnb-table--no-border) > tbody {
   position: relative;
 }
-.dnb-table:not(.dnb-table--outline) > tbody::after {
+.dnb-table:not(.dnb-table--outline):not(.dnb-table--no-border) > tbody::after {
   content: "";
   position: absolute;
   top: 0;
@@ -88,7 +88,7 @@ exports[`Table scss > should match default theme snapshot 1`] = `
   pointer-events: none;
   border-bottom: var(--table-border);
 }
-.dnb-table:not(.dnb-table--outline) > tbody:last-child::after {
+.dnb-table:not(.dnb-table--outline):not(.dnb-table--no-border) > tbody:last-child::after {
   right: 0;
 }"
 `;

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-ui.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-ui.scss
@@ -112,7 +112,7 @@
   /* stylelint-enable */
 
   // bottom border
-  &:not(&--outline) > tbody {
+  &:not(&--outline):not(&--no-border) > tbody {
     position: relative;
 
     @include table-mixins.tableBorder() {


### PR DESCRIPTION
Why do we enforce bottom border?

I think it looks quite strange in certain scenarios:

<img width="1237" height="935" alt="Screenshot 2026-05-04 at 11 56 52" src="https://github.com/user-attachments/assets/17d5322d-7d66-42f5-96a7-9ce14da5c129" />



Motivation: https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/BankAccountNumber/properties/#translations

Deploy preview: https://fix-translations-table-botto.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/BankAccountNumber/properties/#translations




The following is a PR which removes it https://github.com/dnbexperience/eufemia/pull/7896.
I'm not 100% sure what's the best thing to do here.