### PR TITLE
chore(Table): preserve textarea vertical navigation in useTableKeyboardNavigation

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/TableKeyboardNavigation.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableKeyboardNavigation.test.tsx
@@ -638,6 +638,192 @@ describe('useTableKeyboardNavigation', () => {
       expect(document.activeElement).toBe(prevCell)
     })
 
+    it('should not navigate ArrowUp when cursor is not on first line of textarea', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>Cell above</Td>
+            </tr>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+
+      textarea.focus()
+      textarea.value = 'line one\nline two\nline three'
+      // Cursor on the second line
+      textarea.setSelectionRange(12, 12)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(textarea)
+    })
+
+    it('should navigate ArrowUp when cursor is on first line of textarea', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>Cell above</Td>
+            </tr>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+      const cellAbove = document.querySelectorAll('td')[0]
+
+      textarea.focus()
+      textarea.value = 'line one\nline two'
+      // Cursor on the first line
+      textarea.setSelectionRange(4, 4)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(cellAbove)
+    })
+
+    it('should not navigate ArrowDown when cursor is not on last line of textarea', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+            <tr>
+              <Td>Cell below</Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+
+      textarea.focus()
+      textarea.value = 'line one\nline two\nline three'
+      // Cursor on the first line
+      textarea.setSelectionRange(4, 4)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(textarea)
+    })
+
+    it('should navigate ArrowDown when cursor is on last line of textarea', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+            <tr>
+              <Td>Cell below</Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+      const cellBelow = document.querySelectorAll('td')[1]
+
+      textarea.focus()
+      textarea.value = 'line one\nline two'
+      // Cursor on the last line
+      textarea.setSelectionRange(14, 14)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(cellBelow)
+    })
+
+    it('should not navigate vertically when textarea has a selection spanning lines', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>Cell above</Td>
+            </tr>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+
+      textarea.focus()
+      textarea.value = 'line one\nline two'
+      // Selection spanning both lines
+      textarea.setSelectionRange(4, 12)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(textarea)
+    })
+
+    it('should navigate ArrowUp/ArrowDown for single-line textarea', () => {
+      render(
+        <TableWithKeyboardNavigation>
+          <tbody>
+            <tr>
+              <Td>Cell above</Td>
+            </tr>
+            <tr>
+              <Td>
+                <textarea data-testid="textarea" />
+              </Td>
+            </tr>
+            <tr>
+              <Td>Cell below</Td>
+            </tr>
+          </tbody>
+        </TableWithKeyboardNavigation>
+      )
+
+      const textarea = document.querySelector(
+        '[data-testid="textarea"]'
+      ) as HTMLTextAreaElement
+      const cellAbove = document.querySelectorAll('td')[0]
+      const cellBelow = document.querySelectorAll('td')[2]
+
+      textarea.focus()
+      textarea.value = 'single line'
+      textarea.setSelectionRange(5, 5)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(cellAbove)
+
+      textarea.focus()
+      textarea.setSelectionRange(5, 5)
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(cellBelow)
+    })
+
     it('should respect boundary for tel input type', () => {
       render(
         <TableWithKeyboardNavigation>

--- a/packages/dnb-eufemia/src/components/table/useTableKeyboardNavigation.tsx
+++ b/packages/dnb-eufemia/src/components/table/useTableKeyboardNavigation.tsx
@@ -129,6 +129,28 @@ function isAtInputBoundary(
   return selectionEnd === value.length
 }
 
+function isTextareaAtVerticalBoundary(
+  textarea: HTMLTextAreaElement,
+  direction: 'up' | 'down'
+): boolean {
+  const { selectionStart, selectionEnd, value } = textarea
+
+  // If there's a selection range, let the textarea handle it
+  if (selectionStart !== selectionEnd) {
+    return false
+  }
+
+  if (direction === 'up') {
+    // At top boundary if no newline before cursor
+    const textBeforeCursor = value.substring(0, selectionStart)
+    return !textBeforeCursor.includes('\n')
+  }
+
+  // At bottom boundary if no newline after cursor
+  const textAfterCursor = value.substring(selectionStart)
+  return !textAfterCursor.includes('\n')
+}
+
 function handleKeyDown(event: KeyboardEvent, table: HTMLTableElement) {
   const { key } = event
 
@@ -147,6 +169,14 @@ function handleKeyDown(event: KeyboardEvent, table: HTMLTableElement) {
   // Elements like spinbuttons/number inputs use up/down internally
   if (!isHorizontal && shouldSkipVerticalNav(target)) {
     return // stop here
+  }
+
+  // Textareas: only navigate vertically when cursor is at the top/bottom line
+  if (!isHorizontal && target instanceof HTMLTextAreaElement) {
+    const direction = key === 'ArrowUp' ? 'up' : 'down'
+    if (!isTextareaAtVerticalBoundary(target, direction)) {
+      return // stop here
+    }
   }
 
   // Text inputs/textareas: only navigate when cursor is at the boundary


### PR DESCRIPTION
Motivation: https://main.eufemia-e25.pages.dev/uilib/components/table/demos/#table-with-keyboard-navigation

https://github.com/user-attachments/assets/8b5b3460-a737-4386-9f7e-02217f6efe44



Deploy preview: https://fix-table-keyboard-nav-texta.eufemia-e25.pages.dev/uilib/components/table/demos/#table-with-keyboard-navigation

Fix:


https://github.com/user-attachments/assets/ee0cbdc8-2868-4412-bf25-4411914407d2




ArrowUp/ArrowDown in multi-line textareas now stay within the textarea when the cursor is not on the first/last line. Navigation to adjacent rows only occurs when the cursor is on the boundary line (first line for ArrowUp, last line for ArrowDown), matching native textarea behavior.

