### PR TITLE
chore: prevent formatMessage from treating error messages as translation keys

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/__tests__/String.test.tsx
@@ -1474,6 +1474,22 @@ describe('Field.String', () => {
         ).toBe('At least 4.')
       })
 
+      it('should replace placeholders in pre-resolved error messages with spaces', () => {
+        render(
+          <Field.String
+            error={
+              new FormError('Must be at most {maxLength} characters.', {
+                messageValues: { maxLength: '10' },
+              })
+            }
+          />
+        )
+
+        expect(
+          document.querySelector('.dnb-form-status').textContent
+        ).toBe('Must be at most 10 characters.')
+      })
+
       it('should provide error message to the onBlurValidator', async () => {
         let collectCustomMessage = null
         const customMessage = 'Your custom error message'

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
@@ -384,8 +384,15 @@ export default function useFieldError<Value>({
                 message
               )
             }
-          } else if (message.includes('.')) {
+          } else if (message.includes('.') && !message.includes(' ')) {
             message = formatMessage(message, error.messageValues)
+          } else if (error.messageValues) {
+            message = Object.entries(error.messageValues).reduce(
+              (msg, [key, value]) => {
+                return msg.replace(`{${key}}`, value)
+              },
+              message
+            )
           }
 
           if (React.isValidElement(message)) {


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/25319551028/job/74224924734#step:9:278

Messages containing spaces (e.g. 'Dette feltet må fylles ut.') are natural language strings, not translation keys. Only attempt formatMessage lookup when the string contains a dot but no spaces.