### PR TITLE
chore: remove deprecated baseUrl from tsconfig files

### DIFF
--- a/packages/dnb-eufemia/tsconfig.definitions.json
+++ b/packages/dnb-eufemia/tsconfig.definitions.json
@@ -12,7 +12,6 @@
     "isolatedModules": true,
     "declarationDir": ".",
     "rootDir": ".",
-    "baseUrl": ".",
     "alwaysStrict": true,
     "strictBindCallApply": true,
     "noImplicitThis": true,

--- a/packages/dnb-eufemia/tsconfig.json
+++ b/packages/dnb-eufemia/tsconfig.json
@@ -12,7 +12,6 @@
     "types": ["node", "jest", "react", "react-dom"],
     "outDir": "./build",
     "rootDir": ".",
-    "baseUrl": ".",
     "alwaysStrict": true,
     "strictBindCallApply": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Motivation:

<img width="661" height="295" alt="Screenshot 2026-05-05 at 09 41 25" src="https://github.com/user-attachments/assets/893fefb8-62c9-482a-b230-e5362c4b60a9" />


Warning message:

```
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information.
```


The baseUrl option is deprecated in TypeScript 6.0 and will stop functioning in TypeScript 7.0. Since no paths mappings or bare specifier imports rely on it, it can be safely removed.

See: https://github.com/microsoft/TypeScript/issues/62508

