### PR TITLE
chore(Portal): add stroke="currentColor" to main menu SVG icons

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/MainMenuGraphics.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/MainMenuGraphics.tsx
@@ -11,6 +11,7 @@ export const BrandSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -64,6 +65,7 @@ export const QuickguideDesignerSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -123,6 +125,7 @@ export const DesignSystemSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -170,6 +173,7 @@ export const IconsSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -205,6 +209,7 @@ export const UilibSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -259,6 +264,7 @@ export const DevelopmentSvg = (props) => (
     height="48"
     viewBox="0 0 48 48"
     fill="none"
+    stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >


### PR DESCRIPTION
Small issue introduced in https://github.com/dnbexperience/eufemia/pull/7875/changes#diff-90c699bf0e44f2bf5a249a4d39ff84c3cfe3d0cff90dc552fcb8bbd0969bc938R97

The previous commit changed Card.tsx CSS from 'stroke' to 'color', but the SVGs in MainMenuGraphics.tsx had no stroke attribute on their paths. They relied on the CSS stroke property to render. Adding stroke="currentColor" to each SVG element so they inherit the color from the CSS color property.

