### PR TITLE
chore(Docs): make sure properties that are links gets storted alphabetically

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/PropertiesTable.tsx
@@ -120,7 +120,11 @@ export default function PropertiesTable({
 
   if (activeSortName === 'property') {
     const direction = sortState.property.reversed ? -1 : 1
-    entries.sort(([a], [b]) => direction * a.localeCompare(b))
+    entries.sort(
+      ([a], [b]) =>
+        direction *
+        sortablePropertyName(a).localeCompare(sortablePropertyName(b))
+    )
   }
 
   const tableRows = entries.map(([key, props]) => {
@@ -249,6 +253,11 @@ function typeWithoutArray(type: string) {
     return type.slice(6, -1)
   }
   return type
+}
+
+function sortablePropertyName(name: string): string {
+  const match = name.match(/^\[([^\]]+)\]/)
+  return match ? match[1] : name
 }
 
 export function formatIfMarkdown(name: string): React.ReactNode | string {


### PR DESCRIPTION
Not sure if this was intended or not, but properties in the tables that are links does not get sorted alphabetically. Just close that was the intended way for it to work

Before `DrawerList` property at the top
<img width="1170" height="804" alt="Screenshot 2026-05-05 at 09 59 03" src="https://github.com/user-attachments/assets/4ae428ed-888d-4faf-b1af-771e3f8ce7f2" />

After together with the other properties starting with a `D`
<img width="968" height="721" alt="Screenshot 2026-05-05 at 09 58 38" src="https://github.com/user-attachments/assets/f54500a5-1e0b-4b0e-9aae-4ec1df054ac9" />
