### PR TITLE
chore: fix command `yarn test:update X`

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -57,7 +57,7 @@
     "test:screenshots:ci:update": "start-server-and-test serve http://localhost:8000 'yarn workspace @dnb/eufemia test:screenshots:ci:update'",
     "test:types": "tsc --noEmit",
     "test:types:watch": "tsc --noEmit --watch",
-    "test:update": "vitest run --config vite/vitest.config.ts --update",
+    "test:update": "vitest run --config vite/vitest.config.ts --update=true",
     "test:watch": "vitest --config vite/vitest.config.ts"
   },
   "dependencies": {

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -87,7 +87,7 @@
     "test:screenshots:watch": "JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 jest --config=./jest.config.screenshots.js --watchAll --detectOpenHandles",
     "test:types": "tsc --noEmit",
     "test:types:watch": "tsc --noEmit --watch",
-    "test:update": "vitest run --update",
+    "test:update": "vitest run --update=true",
     "test:watch": "vitest",
     "verify:generated-entries:ci": "babel-node --extensions .js,.ts,.tsx ./scripts/prebuild/tasks/verifyGeneratedEntriesCommitted"
   },


### PR DESCRIPTION
vitest's --update flag accepts an optional [type] parameter. When running 'yarn test:update FormStatus', the CLI parser (cac) consumed 'FormStatus' as the value for --update instead of treating it as a test filter, causing all tests to run.

Using --update=true explicitly sets the flag value, so any additional arguments are correctly treated as test file name filters.

