### PR TITLE
fix(Forms): render help content in div instead of p to support block-level elements

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -303,7 +303,7 @@ function HelpButtonInlineContentComponent(
       >
         <Flex.Vertical gap="x-small">
           {title && <P weight="medium">{title}</P>}
-          {content && <P>{content}</P>}
+          {content && <P element="div">{content}</P>}
         </Flex.Vertical>
         {children}
       </Section>

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -716,4 +716,45 @@ describe('HelpButtonInlineContent Component', () => {
       'dnb-space__top--large'
     )
   })
+
+  it('should render block-level content without wrapping it in a p tag', () => {
+    render(
+      <HelpButtonInline
+        help={{
+          open: true,
+          title: 'Help title',
+          content: (
+            <div>
+              <ul>
+                <li>Item 1</li>
+              </ul>
+            </div>
+          ),
+        }}
+      />
+    )
+
+    const pElements = document.querySelectorAll(
+      '.dnb-help-button__content .dnb-p'
+    )
+    const contentElement = pElements[1]
+    expect(contentElement.tagName).toBe('DIV')
+  })
+
+  it('should render string content with paragraph styling', () => {
+    render(
+      <HelpButtonInline
+        help={{
+          open: true,
+          content: 'Simple text content',
+        }}
+      />
+    )
+
+    const contentElement = document.querySelector(
+      '.dnb-help-button__content .dnb-p'
+    )
+    expect(contentElement).toHaveTextContent('Simple text content')
+    expect(contentElement).toHaveClass('dnb-p')
+  })
 })


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777976623320689

The help prop's content was unconditionally wrapped in a `<P>` element, which renders as an HTML `<p>` tag. This caused browser warnings when block-level elements (e.g. Flex.Stack, div, ul) were passed as content, since `<p>` cannot contain block-level children. Changed the content wrapper to use `<P element="div">` which preserves the dnb-p typography styling while using a `<div>` that allows any content type.