### PR TITLE
fix(InputMasked): disable spellcheck to prevent false positives on currency suffix

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedElement.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedElement.tsx
@@ -36,6 +36,7 @@ export default function InputMaskedElement(): React.JSX.Element {
       inputElement={inputElement}
       value={localValue}
       className={clsx('dnb-input-masked', className)}
+      spellCheck={false}
     />
   )
 }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -18,6 +18,14 @@ const props: InputMaskedProps = {
 }
 
 describe('InputMasked component', () => {
+  it('should have spellCheck disabled', () => {
+    render(<InputMasked {...props} value="1234" currencyMask="kr" />)
+
+    expect(
+      document.querySelector('input').getAttribute('spellcheck')
+    ).toBe('false')
+  })
+
   it('should format "numberMask" accordingly the defined properties', () => {
     render(
       <InputMasked

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/ListAllProps.test.tsx
@@ -259,6 +259,7 @@ describe('Tools.ListAllProps', () => {
                 id="id-r1v"
                 inputmode="decimal"
                 name="myNumber"
+                spellcheck="false"
                 type="text"
               />,
             },
@@ -342,6 +343,7 @@ describe('Tools.ListAllProps', () => {
                 id="id-r45"
                 inputmode="decimal"
                 name="myNumber"
+                spellcheck="false"
                 type="text"
               />,
             },
@@ -431,6 +433,7 @@ describe('Tools.ListAllProps', () => {
                     id="id-r4v"
                     inputmode="decimal"
                     name="myObject/nested/withNumber"
+                    spellcheck="false"
                     type="text"
                   />,
                 },
@@ -511,6 +514,7 @@ describe('Tools.ListAllProps', () => {
                   id="id-r6f"
                   inputmode="decimal"
                   name="myObject/withNumber"
+                  spellcheck="false"
                   type="text"
                 />,
               },
@@ -611,6 +615,7 @@ describe('Tools.ListAllProps', () => {
                   inputmode="decimal"
                   name="id-r74"
                   role="spinbutton"
+                  spellcheck="false"
                   step="1"
                   type="text"
                   value="0suffix"
@@ -638,6 +643,7 @@ describe('Tools.ListAllProps', () => {
                   inputmode="decimal"
                   name="id-r7j"
                   role="spinbutton"
+                  spellcheck="false"
                   step="1"
                   type="text"
                   value="1suffix"


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777978669404549

Example in main branch: https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/Currency/demos/#label-and-value
Example from this deploy preview: https://fix-input-masked-spellcheck.eufemia-e25.pages.dev/uilib/extensions/forms/feature-fields/Currency/demos/#label-and-value


Not sure if we should make it conditional, or if it's safe to just disable `spellCheck` all together.