### PR TITLE
chore: support filter env var in Vite dev server

### DIFF
--- a/packages/dnb-design-system-portal/vite/README.md
+++ b/packages/dnb-design-system-portal/vite/README.md
@@ -13,6 +13,17 @@ yarn preview            # Preview the production build locally
 yarn test:e2e:portal    # Run e2e tests against a Vite preview server
 ```
 
+### Filtering pages
+
+To speed up the dev server by only loading specific pages, use the `filter` env var:
+
+```bash
+filter=button yarn start          # Only pages with "button" in the path
+filter=button,accordion yarn start # Multiple filters (comma or space separated)
+```
+
+This is useful when working on a single component — it reduces the number of routes and speeds up startup.
+
 ## Directory Structure
 
 ```

--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -163,7 +163,16 @@ export default function portalPagesPlugin(): Plugin {
 
     load(id) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        const files = scanPageFiles(docsDir)
+        let files = scanPageFiles(docsDir)
+
+        const filter = process.env.filter
+        if (filter?.length) {
+          const filterTerms = filter.split(/(,|\s)/).filter(Boolean)
+          files = files.filter((file) => {
+            const pagePath = `/${file.slug}/`
+            return filterTerms.some((term) => pagePath.includes(term))
+          })
+        }
 
         // Generate lazy import statements and route definitions
         const routeDefs: string[] = []


### PR DESCRIPTION
Motivation: `filter=button yarn start`

Could be that this is not needed? As it's not much of a build time difference doing filter than running the whole app 🤔 



