### PR TITLE
fix(Modal): preserve triggerAttributes onClick in Modal trigger button

### DIFF
--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
@@ -135,14 +135,13 @@ describe('DateFormat', () => {
       await waitFor(() => {
         const tooltipId = timeElem.getAttribute('aria-describedby')
         expect(tooltipId).toBeTruthy()
+
+        const tooltipElem = document.body.querySelector('#' + tooltipId)
+
+        // The tooltip should contain the year
+        expect(tooltipElem).toHaveTextContent('2025')
+        expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
       })
-
-      const tooltipId = timeElem.getAttribute('aria-describedby')
-      const tooltipElem = document.body.querySelector('#' + tooltipId)
-
-      // The tooltip should contain the year
-      expect(tooltipElem).toHaveTextContent('2025')
-      expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
     })
 
     it('should show year in tooltip when hideCurrentYear is true and date is in current year', async () => {
@@ -164,14 +163,13 @@ describe('DateFormat', () => {
       await waitFor(() => {
         const tooltipId = timeElem.getAttribute('aria-describedby')
         expect(tooltipId).toBeTruthy()
+
+        const tooltipElem = document.body.querySelector('#' + tooltipId)
+
+        // The tooltip should contain the year
+        expect(tooltipElem).toHaveTextContent('2025')
+        expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
       })
-
-      const tooltipId = timeElem.getAttribute('aria-describedby')
-      const tooltipElem = document.body.querySelector('#' + tooltipId)
-
-      // The tooltip should contain the year
-      expect(tooltipElem).toHaveTextContent('2025')
-      expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
 
       // Flush all pending timers and React updates before switching back to real timers
       jest.runOnlyPendingTimers()
@@ -200,15 +198,14 @@ describe('DateFormat', () => {
       await waitFor(() => {
         const tooltipId = timeElem.getAttribute('aria-describedby')
         expect(tooltipId).toBeTruthy()
+
+        const tooltipElem = document.body.querySelector('#' + tooltipId)
+
+        // The tooltip should contain the year and time
+        expect(tooltipElem).toHaveTextContent('2025')
+        expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
+        expect(tooltipElem).toHaveTextContent('14:30')
       })
-
-      const tooltipId = timeElem.getAttribute('aria-describedby')
-      const tooltipElem = document.body.querySelector('#' + tooltipId)
-
-      // The tooltip should contain the year and time
-      expect(tooltipElem).toHaveTextContent('2025')
-      expect(tooltipElem).toHaveTextContent('fredag 1. august 2025')
-      expect(tooltipElem).toHaveTextContent('14:30')
     })
 
     it.each([

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -147,6 +147,20 @@ describe('HelpButton', () => {
     expect(textContent).toContain(dialogContent)
   })
 
+  it('should fire onClick when children are given', () => {
+    const onClick = jest.fn()
+
+    render(
+      <HelpButton {...props} onClick={onClick}>
+        Help content
+      </HelpButton>
+    )
+
+    fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
   it('should return given render element', () => {
     render(
       <HelpButton

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -490,8 +490,10 @@ function ModalComponent(ownProps: ModalAllProps) {
           {...applySpacing(rest as SpacingProps, {
             id: _id.current,
             title,
-            onClick: (event: React.MouseEvent) =>
-              toggleOpenClose(event.nativeEvent),
+            onClick: (event: React.MouseEvent) => {
+              triggerAttributes?.onClick?.(event)
+              toggleOpenClose(event.nativeEvent)
+            },
             ref: triggerRef,
             className: clsx(
               'dnb-modal__trigger',

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1620,6 +1620,16 @@ describe('Modal component', () => {
     ).toBe(customText)
   })
 
+  it('should call triggerAttributes onClick', () => {
+    const onClick = jest.fn()
+
+    render(<Modal triggerAttributes={{ onClick }}>Modal content</Modal>)
+
+    fireEvent.click(document.querySelector('button.dnb-modal__trigger'))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
   describe('onClose', () => {
     it('should have triggeredBy with "unmount" when unmounting', async () => {
       const onClose = jest.fn()


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1777984135013359

Issue: https://eufemia.dnb.no/uilib/components/help-button/#help-button-in-different-sizes
Deploy preview: https://fix-help-button-onclick.eufemia-e25.pages.dev/uilib/components/help-button/#help-button-in-different-sizes


Cause: I think it was in https://github.com/dnbexperience/eufemia/pull/5932, guessing this overriden user's `onClick`