### PR TITLE
fix: render help title in div instead of p to support block-level elements

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -302,7 +302,11 @@ function HelpButtonInlineContentComponent(
         {...rest}
       >
         <Flex.Vertical gap="x-small">
-          {title && <P weight="medium">{title}</P>}
+          {title && (
+            <P weight="medium" element="div">
+              {title}
+            </P>
+          )}
           {content && <P element="div">{content}</P>}
         </Flex.Vertical>
         {children}

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -741,6 +741,26 @@ describe('HelpButtonInlineContent Component', () => {
     expect(contentElement.tagName).toBe('DIV')
   })
 
+  it('should render block-level title without wrapping it in a p tag', () => {
+    render(
+      <HelpButtonInline
+        help={{
+          open: true,
+          title: (
+            <div>
+              <span>Title with block content</span>
+            </div>
+          ),
+        }}
+      />
+    )
+
+    const titleElement = document.querySelector(
+      '.dnb-help-button__content .dnb-p'
+    )
+    expect(titleElement.tagName).toBe('DIV')
+  })
+
   it('should render string content with paragraph styling', () => {
     render(
       <HelpButtonInline


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/7930

I'm not so sure if this is actually needed and/or wanted, as the `title` is semantically a short label/heading (hence weight="medium"), so I guess users would rarely pass block-level elements like `Flex.Stack` or `<ul>` into it. Complex content would go into content.

That said, since title is typed as React.ReactNode, it's technically possible for someone to pass block-level elements and hit the same browser warning as in https://github.com/dnbexperience/eufemia/pull/7930. 