### PR TITLE
feat: generate markdown for all docs pages including MCP server docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
@@ -253,45 +253,44 @@ export const TabsExampleMaxWidth = () => (
   </ComponentBox>
 )
 
-export const TabsExampleReachRouterNavigation = () =>
-  typeof window === 'undefined' ? null : (
-    <Wrapper>
-      <ComponentBox scope={{ useLocation, Router, navigate }}>
-        {() => {
-          const Home = ({ path, default: d }) => <H2>Home</H2>
-          const About = ({ path }) => <H2>About</H2>
-          const Topics = ({ path }) => <H2>Topics</H2>
+export const TabsExampleReachRouterNavigation = () => (
+  <Wrapper>
+    <ComponentBox scope={{ useLocation, Router, navigate }}>
+      {() => {
+        const Home = ({ path, default: d }) => <H2>Home</H2>
+        const About = ({ path }) => <H2>About</H2>
+        const Topics = ({ path }) => <H2>Topics</H2>
 
-          const Component = () => {
-            const { pathname } = useLocation()
+        const Component = () => {
+          const { pathname } = useLocation()
 
-            return (
-              <Tabs
-                data={[
-                  { title: 'Home', key: '/' },
-                  { title: 'About', key: '/about' },
-                  { title: 'Topics', key: '/topics' },
-                ]}
-                selectedKey={pathname}
-                onChange={({ key }) => navigate(String(key))}
-                tabsStyle="information"
-              >
-                <Suspense fallback={<em>Loading ...</em>}>
-                  <Router>
-                    <Home path="/" default />
-                    <About path="/about" />
-                    <Topics path="/topics" />
-                  </Router>
-                </Suspense>
-              </Tabs>
-            )
-          }
+          return (
+            <Tabs
+              data={[
+                { title: 'Home', key: '/' },
+                { title: 'About', key: '/about' },
+                { title: 'Topics', key: '/topics' },
+              ]}
+              selectedKey={pathname}
+              onChange={({ key }) => navigate(String(key))}
+              tabsStyle="information"
+            >
+              <Suspense fallback={<em>Loading ...</em>}>
+                <Router>
+                  <Home path="/" default />
+                  <About path="/about" />
+                  <Topics path="/topics" />
+                </Router>
+              </Suspense>
+            </Tabs>
+          )
+        }
 
-          return <Component />
-        }}
-      </ComponentBox>
-    </Wrapper>
-  )
+        return <Component />
+      }}
+    </ComponentBox>
+  </Wrapper>
+)
 
 const exampleContent = {
   first: () => <h2 className="dnb-h--large">First</h2>,

--- a/packages/dnb-design-system-portal/src/e2e/llm-metadata.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/llm-metadata.spec.ts
@@ -50,11 +50,35 @@ test.describe('LLM integration', () => {
     expect(mdBody).not.toContain('hideTabs:')
   })
 
-  test('known .md pages have matching html pages', async () => {
+  test('top-level docs pages expose markdown copies', async ({ page }) => {
+    const mdPaths = ['/icons.md', '/uilib.md']
+
+    for (const mdPath of mdPaths) {
+      const mdBody = await page.request.get(mdPath).then((r) => r.text())
+      expect(mdBody.startsWith('---\n')).toBeTruthy()
+      expect(mdBody).toMatch(/^#\s+/m)
+    }
+
+    const iconsBody = await page.request
+      .get('/icons.md')
+      .then((r) => r.text())
+    expect(iconsBody).not.toContain('ListAllIcons')
+    expect(iconsBody).toContain('`bell`')
+    expect(iconsBody).toContain('`user_feedback`')
+    expect(iconsBody).toContain('## Essentials')
+  })
+
+  test('known .md pages have matching html pages', async ({ request }) => {
     const mdPaths = [
       '/uilib/components/button.md',
       '/uilib/components/card.md',
+      '/icons.md',
+      '/uilib.md',
     ]
+    const mdPathsWithCodeBlocks = new Set([
+      '/uilib/components/button.md',
+      '/uilib/components/card.md',
+    ])
     const publicDir = path.resolve(__dirname, '..', '..', 'public')
     const firstMdFile = path.join(publicDir, mdPaths[0].replace(/^\//, ''))
     if (!fs.existsSync(firstMdFile)) {
@@ -70,15 +94,19 @@ test.describe('LLM integration', () => {
       expect(fs.existsSync(mdFile)).toBeTruthy()
       const mdBody = fs.readFileSync(mdFile, 'utf-8')
       expect(mdBody).not.toContain('doc:')
-      expect(mdBody).toMatch(/```[a-z]*\n[\s\S]*```/)
 
-      const htmlFile = path.join(
-        publicDir,
-        mdPath.replace(/^\//, '').replace(/\.md$/, ''),
-        'index.html'
-      )
-      expect(fs.existsSync(htmlFile)).toBeTruthy()
-      const htmlBody = fs.readFileSync(htmlFile, 'utf-8')
+      if (mdPathsWithCodeBlocks.has(mdPath)) {
+        expect(mdBody).toMatch(/```[a-z]*\n[\s\S]*```/)
+      } else {
+        expect(mdBody).toMatch(/^#\s+/m)
+      }
+
+      const htmlPath = mdPath.replace(/\.md$/, '/')
+      const htmlResponse = await request.get(htmlPath)
+
+      expect(htmlResponse.ok()).toBeTruthy()
+
+      const htmlBody = await htmlResponse.text()
       expect(htmlBody.toLowerCase()).toContain('<!doctype html')
     }
   })

--- a/packages/dnb-design-system-portal/src/e2e/llm-metadata.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/llm-metadata.spec.ts
@@ -50,30 +50,57 @@ test.describe('LLM integration', () => {
     expect(mdBody).not.toContain('hideTabs:')
   })
 
-  test('top-level docs pages expose markdown copies', async ({ page }) => {
-    const mdPaths = ['/icons.md', '/uilib.md']
+  test('top-level docs pages generate markdown copies', async () => {
+    const mdPaths = ['/quickguide-designer.md', '/uilib.md']
+    const publicDir = path.resolve(__dirname, '..', '..', 'public')
 
     for (const mdPath of mdPaths) {
-      const mdBody = await page.request.get(mdPath).then((r) => r.text())
+      const mdFile = path.join(publicDir, mdPath.replace(/^\//, ''))
+      expect(fs.existsSync(mdFile)).toBeTruthy()
+      const mdBody = fs.readFileSync(mdFile, 'utf-8')
       expect(mdBody.startsWith('---\n')).toBeTruthy()
       expect(mdBody).toMatch(/^#\s+/m)
     }
 
-    const iconsBody = await page.request
-      .get('/icons.md')
-      .then((r) => r.text())
-    expect(iconsBody).not.toContain('ListAllIcons')
-    expect(iconsBody).toContain('`bell`')
-    expect(iconsBody).toContain('`user_feedback`')
-    expect(iconsBody).toContain('## Essentials')
+    const uilibBody = fs.readFileSync(
+      path.join(publicDir, 'uilib.md'),
+      'utf-8'
+    )
+    expect(uilibBody).toContain('# UI library')
+    expect(uilibBody).toContain('The DNB UI library contains ready-to-use')
+
+    const iconsMdFile = path.join(publicDir, 'icons.md')
+    expect(fs.existsSync(iconsMdFile)).toBeFalsy()
+  })
+
+  test('icons pages list concrete icons in rendered output', async ({
+    page,
+  }) => {
+    await page.goto('/icons/primary/')
+    await expect(
+      page.getByRole('heading', { name: 'Primary Icons', exact: true })
+    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'bell' })).toBeVisible()
+
+    await page.goto('/icons/secondary/')
+    await expect(page.locator('main')).toContainText(
+      'A list of all Secondary Icons'
+    )
+    await expect(
+      page.getByRole('heading', { name: 'user_feedback' })
+    ).toBeVisible()
   })
 
   test('known .md pages have matching html pages', async ({ request }) => {
     const mdPaths = [
       '/uilib/components/button.md',
       '/uilib/components/card.md',
-      '/icons.md',
+      '/quickguide-designer.md',
       '/uilib.md',
+    ]
+    const excludedMdPaths = [
+      '/icons.md',
+      '/uilib/extensions/payment-card/products.md',
     ]
     const mdPathsWithCodeBlocks = new Set([
       '/uilib/components/button.md',
@@ -108,6 +135,11 @@ test.describe('LLM integration', () => {
 
       const htmlBody = await htmlResponse.text()
       expect(htmlBody.toLowerCase()).toContain('<!doctype html')
+    }
+
+    for (const mdPath of excludedMdPaths) {
+      const mdFile = path.join(publicDir, mdPath.replace(/^\//, ''))
+      expect(fs.existsSync(mdFile)).toBeFalsy()
     }
   })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -493,8 +493,10 @@ describe('prerender-utils', () => {
       ).toBe('/uilib/components/slider.md')
     })
 
-    it('returns null for non-uilib pages', () => {
-      expect(getMdPath('/quickguide-designer/', allMdxNodes)).toBeNull()
+    it('returns .md path for non-uilib entry pages', () => {
+      expect(getMdPath('/quickguide-designer/', allMdxNodes)).toBe(
+        '/quickguide-designer.md'
+      )
     })
 
     it('returns null for uilib pages without a matching entry', () => {

--- a/packages/dnb-design-system-portal/vite/prod/generate-llm-metadata.mts
+++ b/packages/dnb-design-system-portal/vite/prod/generate-llm-metadata.mts
@@ -1,7 +1,8 @@
 /**
  * Generate LLM metadata for the Vite portal build.
  *
- * 1. Scans src/docs/uilib/ for MDX entry files
+ * Mirrors the Gatsby plugin's onPostBuild logic:
+ * 1. Scans src/docs/ for MDX entry files
  * 2. Extracts props/events from TypeScript docs and MDX tables
  * 3. Writes markdown copies of each doc to vite/dist/
  * 4. Writes llms.txt to vite/dist/
@@ -19,8 +20,7 @@ import {
   findDocExtras,
   findEntryMdxFiles,
   findSourceInfo,
-  LLM_DOCS_SLUG_PREFIX,
-  loadTsDocs,
+  loadTsDocsForDocPath,
   mergeDocs,
   resolveMetaText,
   toSlugAndDir,
@@ -32,7 +32,7 @@ const portalRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../..'
 )
-const docsRoot = path.join(portalRoot, 'src', 'docs', LLM_DOCS_SLUG_PREFIX)
+const docsRoot = path.join(portalRoot, 'src', 'docs')
 const outputRoot = path.join(portalRoot, 'public')
 
 async function main() {
@@ -54,7 +54,7 @@ async function main() {
 
   for (const file of entryFiles) {
     const rel = path.relative(docsRoot, file)
-    const { slug } = toSlugAndDir(rel)
+    const { slug } = toSlugAndDir(rel, '')
 
     if (!isAllowed(slug, robots)) {
       continue
@@ -65,7 +65,7 @@ async function main() {
     let props: Record<string, any> = {}
     let events: Record<string, any> = {}
 
-    const tsDocs = await loadTsDocs(rel)
+    const tsDocs = await loadTsDocsForDocPath(rel)
     props = mergeDocs(props, tsDocs.props)
     events = mergeDocs(events, tsDocs.events)
 
@@ -122,6 +122,7 @@ async function main() {
     siteDir: portalRoot,
     docsRoot,
     outputRoot,
+    slugBase: '',
     metadataBySlug,
     skipFormat: true,
   })

--- a/packages/dnb-design-system-portal/vite/prod/generate-llm-metadata.mts
+++ b/packages/dnb-design-system-portal/vite/prod/generate-llm-metadata.mts
@@ -17,11 +17,13 @@ import {
   buildMetadata,
   createMarkdownCopies,
   extractTableDocs,
+  formatUnhandledStandaloneMdxWarnings,
   findDocExtras,
   findEntryMdxFiles,
   findSourceInfo,
   loadTsDocsForDocPath,
   mergeDocs,
+  resetUnhandledStandaloneMdxWarnings,
   resolveMetaText,
   toSlugAndDir,
   writeLlmsText,
@@ -36,11 +38,13 @@ const docsRoot = path.join(portalRoot, 'src', 'docs')
 const outputRoot = path.join(portalRoot, 'public')
 
 async function main() {
+  resetUnhandledStandaloneMdxWarnings()
   console.log('[llm-metadata] Scanning MDX docs for entries')
 
   const version = await getNextReleaseVersion()
   const robots = await loadRobots(path.join(portalRoot, 'static'))
   const entryFiles = await findEntryMdxFiles(docsRoot)
+  const allowedEntryFiles: string[] = []
 
   const results: Array<any> = []
   const metadataBySlug = new Map<
@@ -59,6 +63,8 @@ async function main() {
     if (!isAllowed(slug, robots)) {
       continue
     }
+
+    allowedEntryFiles.push(file)
 
     const { propsFile, eventsFile, demosFile } = await findDocExtras(file)
 
@@ -122,6 +128,7 @@ async function main() {
     siteDir: portalRoot,
     docsRoot,
     outputRoot,
+    entryFiles: allowedEntryFiles,
     slugBase: '',
     metadataBySlug,
     skipFormat: true,
@@ -133,6 +140,12 @@ async function main() {
     results,
     outputRoot,
   })
+
+  const warningSummary = formatUnhandledStandaloneMdxWarnings()
+
+  if (warningSummary) {
+    console.warn(warningSummary)
+  }
 
   console.log('[llm-metadata] Markdown copies are ready')
 }

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -9,7 +9,6 @@
 
 import path from 'node:path'
 import { getContentScript } from '@dnb/eufemia/src/shared/ColorSchemeScript'
-import { LLM_DOCS_SLUG_PREFIX } from 'eufemia-llm-metadata'
 
 export type RouteEntry = {
   path?: string
@@ -96,20 +95,19 @@ export function getPageMeta(
 /**
  * Resolve the markdown alternate link path for a URL.
  *
- * Only /uilib/ pages get markdown links. The LLM metadata generator
- * creates .md files for "entry" MDX files (those with a title in
- * frontmatter), not for tab sub-pages. For tab pages, we walk up
- * the slug path to find the nearest entry parent.
+ * The LLM metadata generator creates .md files for "entry" MDX files
+ * (those with a title in frontmatter), not for tab sub-pages. For tab
+ * pages, we walk up the slug path to find the nearest entry parent.
  */
 export function getMdPath(
   url: string,
   allMdxNodes: MdxNode[]
 ): string | null {
-  if (!url.startsWith(`/${LLM_DOCS_SLUG_PREFIX}/`)) {
+  const slug = url.replace(/^\/|\/$/g, '')
+
+  if (!slug) {
     return null
   }
-
-  const slug = url.replace(/^\/|\/$/g, '')
 
   // Build a set of entry slugs — pages that get their own .md file
   // from the LLM metadata generator. Entry pages have a title in
@@ -117,10 +115,7 @@ export function getMdPath(
   const entrySlugs = new Set<string>()
   for (const node of allMdxNodes) {
     const s = node.fields.slug
-    if (
-      s.startsWith(`${LLM_DOCS_SLUG_PREFIX}/`) &&
-      node.frontmatter.title
-    ) {
+    if (node.frontmatter.title) {
       entrySlugs.add(s)
     }
   }

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -202,7 +202,7 @@ async function prerender() {
   const fontsSource = path.resolve(eufemiaRoot, 'assets', 'fonts')
   const fontsDest = path.resolve(outDir, 'fonts')
   fs.cpSync(fontsSource, fontsDest, { recursive: true })
-  console.log(`✓ Copied fonts to ${fontsDest}`)
+  console.log(`\n✓ Copied fonts to ${fontsDest}`)
 
   /**
    * Write HTML to the correct path in the output directory.

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -71,7 +71,9 @@ describe('type definitions', () => {
 
       const content = fs.readFileSync(file, 'utf-8')
       expect(content).toMatch(/export (type|interface) InputProps/)
-      expect(content).toContain("Omit<HTMLProps<HTMLInputElement>, 'ref'")
+      expect(content).toMatch(
+        /Omit<(?:React\.)?[A-Za-z]+<HTMLInputElement>, ['"]ref['"]/
+      )
       expect(content).toContain('SpacingProps')
     }
   )
@@ -420,34 +422,200 @@ describeDocsBuild('docs build', () => {
     expect(nonUilibMarkdown).toContain('# Tools')
   })
 
-  it('writes rendered icon markdown lists for primary and secondary icons', () => {
+  it('does not write markdown copies for docs excluded by robots', () => {
     const allIconsPath = path.join(docsRoot, 'icons.md')
     const primaryIconsPath = path.join(docsRoot, 'icons/primary.md')
     const secondaryIconsPath = path.join(docsRoot, 'icons/secondary.md')
 
-    expect(fs.existsSync(allIconsPath)).toBe(true)
-    expect(fs.existsSync(primaryIconsPath)).toBe(true)
-    expect(fs.existsSync(secondaryIconsPath)).toBe(true)
+    expect(fs.existsSync(allIconsPath)).toBe(false)
+    expect(fs.existsSync(primaryIconsPath)).toBe(false)
+    expect(fs.existsSync(secondaryIconsPath)).toBe(false)
+  })
 
-    const allIconsMarkdown = fs.readFileSync(allIconsPath, 'utf-8')
-    const primaryIconsMarkdown = fs.readFileSync(primaryIconsPath, 'utf-8')
-    const secondaryIconsMarkdown = fs.readFileSync(
-      secondaryIconsPath,
+  it('writes rendered markdown color tables for deprecated colors docs', () => {
+    const quickguideColorsPath = path.join(
+      docsRoot,
+      'quickguide-designer/colors.md'
+    )
+    const uilibColorsPath = path.join(
+      docsRoot,
+      'uilib/usage/customisation/colors.md'
+    )
+
+    expect(fs.existsSync(quickguideColorsPath)).toBe(true)
+    expect(fs.existsSync(uilibColorsPath)).toBe(true)
+
+    const quickguideColorsMarkdown = fs.readFileSync(
+      quickguideColorsPath,
+      'utf-8'
+    )
+    const uilibColorsMarkdown = fs.readFileSync(uilibColorsPath, 'utf-8')
+
+    for (const markdown of [
+      quickguideColorsMarkdown,
+      uilibColorsMarkdown,
+    ]) {
+      expect(markdown).not.toContain('ColorTable')
+      expect(markdown).not.toContain('ChangeStyleTheme')
+      expect(markdown).not.toContain('data-visual-test="color-table"')
+      expect(markdown).toContain('| Sample')
+      expect(markdown).toContain('CSS Custom Properties name |')
+      expect(markdown).toContain('`--color-black`')
+      expect(markdown).toContain('## DNB Colors')
+    }
+  })
+
+  it('writes inline token examples in design token docs', () => {
+    const designTokensPath = path.join(
+      docsRoot,
+      'uilib/usage/customisation/theming/design-tokens.md'
+    )
+    const designTokensColorsPath = path.join(
+      docsRoot,
+      'uilib/usage/customisation/theming/design-tokens/colors.md'
+    )
+
+    expect(fs.existsSync(designTokensPath)).toBe(true)
+    expect(fs.existsSync(designTokensColorsPath)).toBe(true)
+
+    const designTokensMarkdown = fs.readFileSync(designTokensPath, 'utf-8')
+    const designTokensColorsMarkdown = fs.readFileSync(
+      designTokensColorsPath,
       'utf-8'
     )
 
-    expect(allIconsMarkdown).not.toContain('ListAllIcons')
-    expect(allIconsMarkdown).toContain('`bell`')
-    expect(allIconsMarkdown).toContain('`user_feedback`')
-    expect(allIconsMarkdown).toContain('## Essentials')
+    for (const markdown of [
+      designTokensMarkdown,
+      designTokensColorsMarkdown,
+    ]) {
+      expect(markdown).not.toContain('TokenExample')
+    }
 
-    expect(primaryIconsMarkdown).not.toContain('ListAllIcons')
-    expect(primaryIconsMarkdown).toContain('`bell`')
-    expect(primaryIconsMarkdown).toContain('`chevron_right`')
+    expect(designTokensMarkdown).not.toContain('<br />')
 
-    expect(secondaryIconsMarkdown).not.toContain('ListAllIcons')
-    expect(secondaryIconsMarkdown).toContain('`user_feedback`')
-    expect(secondaryIconsMarkdown).toContain('`instagram`')
+    expect(designTokensMarkdown).toContain(
+      '- semantic token: `--token-color-text-neutral`'
+    )
+    expect(designTokensMarkdown).toContain(
+      '- semantic state token: `--token-color-background-action-hover-subtle`'
+    )
+    expect(designTokensMarkdown).toContain(
+      '- component token: `--token-color-component-button-background-action`'
+    )
+    expect(designTokensColorsMarkdown).toContain(
+      '`--token-color-component-button-background-action`.'
+    )
+  })
+
+  it('writes rendered token section tables in design token colors docs', () => {
+    const designTokensColorsPath = path.join(
+      docsRoot,
+      'uilib/usage/customisation/theming/design-tokens/colors.md'
+    )
+
+    expect(fs.existsSync(designTokensColorsPath)).toBe(true)
+
+    const designTokensColorsMarkdown = fs.readFileSync(
+      designTokensColorsPath,
+      'utf-8'
+    )
+
+    expect(designTokensColorsMarkdown).not.toContain('TokenSectionTable')
+    expect(designTokensColorsMarkdown).toMatch(
+      /\| Group\s+\| Token\s+\| DNB Light\s+\| DNB Dark\s+\| Sbanken Light\s+\| Sbanken Dark\s+\| Carnegie\s+\|/
+    )
+    expect(designTokensColorsMarkdown).toContain(
+      '`--token-color-text-neutral`'
+    )
+    expect(designTokensColorsMarkdown).toContain('## Text')
+  })
+
+  it('writes a rendered radius token table in design token docs', () => {
+    const designTokensRadiusPath = path.join(
+      docsRoot,
+      'uilib/usage/customisation/theming/design-tokens/radius.md'
+    )
+
+    expect(fs.existsSync(designTokensRadiusPath)).toBe(true)
+
+    const designTokensRadiusMarkdown = fs.readFileSync(
+      designTokensRadiusPath,
+      'utf-8'
+    )
+
+    expect(designTokensRadiusMarkdown).not.toContain('RadiusTokenTable')
+    expect(designTokensRadiusMarkdown).not.toContain('```tsx')
+    expect(designTokensRadiusMarkdown).toMatch(
+      /\| Token\s+\| DNB Light\s+\| DNB Dark\s+\| Sbanken Light\s+\| Sbanken Dark\s+\| Carnegie\s+\|/
+    )
+    expect(designTokensRadiusMarkdown).toContain('`--token-radius-sm`')
+    expect(designTokensRadiusMarkdown).toContain('`0.25rem`')
+  })
+
+  it('writes rendered properties tables for feature-field docs that use helper exports', () => {
+    const dateOfBirthPath = path.join(
+      docsRoot,
+      'uilib/extensions/forms/feature-fields/DateOfBirth.md'
+    )
+    const selectCurrencyPath = path.join(
+      docsRoot,
+      'uilib/extensions/forms/feature-fields/SelectCurrency.md'
+    )
+
+    expect(fs.existsSync(dateOfBirthPath)).toBe(true)
+    expect(fs.existsSync(selectCurrencyPath)).toBe(true)
+
+    const dateOfBirthMarkdown = fs.readFileSync(dateOfBirthPath, 'utf-8')
+    const selectCurrencyMarkdown = fs.readFileSync(
+      selectCurrencyPath,
+      'utf-8'
+    )
+
+    expect(dateOfBirthMarkdown).not.toContain('PropertiesTable')
+    expect(dateOfBirthMarkdown).toContain('"onBlur"')
+
+    expect(selectCurrencyMarkdown).not.toContain('PropertiesTable')
+    expect(selectCurrencyMarkdown).toContain('"currencies"')
+    expect(selectCurrencyMarkdown).toContain('"size"')
+  })
+
+  it('writes a rendered available countries table in form docs', () => {
+    const selectCountryPath = path.join(
+      docsRoot,
+      'uilib/extensions/forms/feature-fields/SelectCountry.md'
+    )
+    const countryFlagPath = path.join(
+      docsRoot,
+      'uilib/components/country-flag.md'
+    )
+
+    expect(fs.existsSync(selectCountryPath)).toBe(true)
+    expect(fs.existsSync(countryFlagPath)).toBe(true)
+
+    const selectCountryMarkdown = fs.readFileSync(
+      selectCountryPath,
+      'utf-8'
+    )
+    const countryFlagMarkdown = fs.readFileSync(countryFlagPath, 'utf-8')
+
+    for (const markdown of [selectCountryMarkdown, countryFlagMarkdown]) {
+      expect(markdown).not.toContain('AvailableCountriesTable')
+      expect(markdown).toMatch(
+        /\| ISO 3166-1 alpha-2 code\s+\| en\s+\| nb\s+\|/
+      )
+      expect(markdown).toMatch(
+        /\| `AF`\s+\| Afghanistan\s+\| Afghanistan\s+\|/
+      )
+    }
+  })
+
+  it('does not write markdown copies for payment-card docs excluded by robots', () => {
+    const paymentCardProductsPath = path.join(
+      docsRoot,
+      'uilib/extensions/payment-card/products.md'
+    )
+
+    expect(fs.existsSync(paymentCardProductsPath)).toBe(false)
   })
 })
 
@@ -466,7 +634,7 @@ describe('tsdown build', () => {
               ),
               'utf-8'
             )
-            expect(content).toMatch(/import\{.*\}from"react";/)
+            expect(content).toMatch(/import\s*(?:\w+,)?\{.*\}from"react";/)
             expect(content).toContain('}from"react-dom";')
             expect(content).toMatch(
               /import\*as \w from"\.\.\/icons\/dnb\/primary_icons";/ // "../icons/dnb/primary_icons"

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -384,6 +384,7 @@ describeDocsBuild('docs build', () => {
     expect(content).toContain(
       '/uilib/usage/first-steps/quick-reference.md'
     )
+    expect(content).toContain('/quickguide-designer/tools.md')
     expect(content).toContain('## Machine-readable docs')
     expect(content).not.toContain('https://eufemia.dnb.no')
   })
@@ -393,10 +394,16 @@ describeDocsBuild('docs build', () => {
       docsRoot,
       'uilib/components/breadcrumb.md'
     )
+    const nonUilibMarkdownPath = path.join(
+      docsRoot,
+      'quickguide-designer/tools.md'
+    )
 
     expect(fs.existsSync(markdownPath)).toBe(true)
+    expect(fs.existsSync(nonUilibMarkdownPath)).toBe(true)
 
     const markdown = fs.readFileSync(markdownPath, 'utf-8')
+    const nonUilibMarkdown = fs.readFileSync(nonUilibMarkdownPath, 'utf-8')
     expect(markdown).toContain('version:')
     expect(markdown).toContain('generatedAt:')
     expect(markdown).toContain('checksum:')
@@ -410,6 +417,37 @@ describeDocsBuild('docs build', () => {
     expect(markdown).toContain('## `Breadcrumb.Item` events')
     expect(markdown).toMatch(/```json[\s\S]*```/)
     expect(markdown).toMatch(/```tsx[\s\S]*render\(/)
+    expect(nonUilibMarkdown).toContain('# Tools')
+  })
+
+  it('writes rendered icon markdown lists for primary and secondary icons', () => {
+    const allIconsPath = path.join(docsRoot, 'icons.md')
+    const primaryIconsPath = path.join(docsRoot, 'icons/primary.md')
+    const secondaryIconsPath = path.join(docsRoot, 'icons/secondary.md')
+
+    expect(fs.existsSync(allIconsPath)).toBe(true)
+    expect(fs.existsSync(primaryIconsPath)).toBe(true)
+    expect(fs.existsSync(secondaryIconsPath)).toBe(true)
+
+    const allIconsMarkdown = fs.readFileSync(allIconsPath, 'utf-8')
+    const primaryIconsMarkdown = fs.readFileSync(primaryIconsPath, 'utf-8')
+    const secondaryIconsMarkdown = fs.readFileSync(
+      secondaryIconsPath,
+      'utf-8'
+    )
+
+    expect(allIconsMarkdown).not.toContain('ListAllIcons')
+    expect(allIconsMarkdown).toContain('`bell`')
+    expect(allIconsMarkdown).toContain('`user_feedback`')
+    expect(allIconsMarkdown).toContain('## Essentials')
+
+    expect(primaryIconsMarkdown).not.toContain('ListAllIcons')
+    expect(primaryIconsMarkdown).toContain('`bell`')
+    expect(primaryIconsMarkdown).toContain('`chevron_right`')
+
+    expect(secondaryIconsMarkdown).not.toContain('ListAllIcons')
+    expect(secondaryIconsMarkdown).toContain('`user_feedback`')
+    expect(secondaryIconsMarkdown).toContain('`instagram`')
   })
 })
 

--- a/packages/dnb-eufemia/scripts/tools/cliTools.js
+++ b/packages/dnb-eufemia/scripts/tools/cliTools.js
@@ -1,9 +1,9 @@
-const { exec } = require('child_process')
+const { execFile } = require('child_process')
 
 function runCommand(command) {
   return new Promise((resolve, reject) => {
     try {
-      exec(command, (error, stdout, stderr) => {
+      execFile('/bin/sh', ['-lc', command], (error, stdout, stderr) => {
         if (error) {
           return reject(error)
         }
@@ -27,17 +27,30 @@ function runCommand(command) {
  */
 const getCommittedFiles = async (countCommits = 10) => {
   try {
+    const history = await runCommand(
+      `git rev-list --max-count=${countCommits + 1} HEAD`
+    )
+    const commits = history.split('\n').filter(Boolean)
+
+    if (commits.length === 0) {
+      return []
+    }
+
     const files = (
-      await runCommand(
-        `git -c diff.renames=0 show --pretty="format:" --name-only HEAD...HEAD~${countCommits}`
-      )
+      commits.length === 1
+        ? await runCommand(
+            'git -c diff.renames=0 show --pretty="format:" --name-only HEAD'
+          )
+        : await runCommand(
+            `git -c diff.renames=0 diff --name-only ${commits[commits.length - 1]}..HEAD`
+          )
     )
       .split('\n')
       .filter(Boolean)
 
     return files
-  } catch (error) {
-    throw new Error(error)
+  } catch {
+    return []
   }
 }
 

--- a/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
@@ -8,9 +8,48 @@ jest.unstable_mockModule('prettier', () => ({
   default: { format: async (code: string) => code },
 }))
 
-const { convertMdxToMd } = await import('../../src/convertHelpers.ts')
+const { convertMdxToMd, loadTsDocsForDocPath, toPublicUrl, toSlugAndDir } =
+  await import('../../src/convertHelpers.ts')
 
 describe('convertMdxToMd', () => {
+  it('only loads ts docs for uilib doc paths', async () => {
+    const nonUilibTsDocs = await loadTsDocsForDocPath(
+      'quickguide-designer/tools.mdx'
+    )
+
+    expect(nonUilibTsDocs).toEqual({
+      tsDocsDir: null,
+      props: {},
+      events: {},
+      related: [],
+    })
+
+    const uilibTsDocs = await loadTsDocsForDocPath(
+      path.join('uilib', 'components', 'breadcrumb.mdx')
+    )
+
+    expect(uilibTsDocs.tsDocsDir).not.toBeNull()
+    expect(Object.keys(uilibTsDocs.props)).toContain('data')
+  })
+
+  it('normalizes repeated slashes in slug bases and public url bases', () => {
+    expect(
+      toSlugAndDir('guides/getting-started.mdx', '////uilib////')
+    ).toEqual({
+      slug: '/uilib/guides/getting-started/',
+      dirForExtras: 'uilib/guides/getting-started/',
+    })
+
+    expect(toSlugAndDir('icons.mdx', '////')).toEqual({
+      slug: '/icons/',
+      dirForExtras: 'icons/',
+    })
+
+    expect(toPublicUrl('/icons/', 'https://eufemia.dnb.no////')).toBe(
+      'https://eufemia.dnb.no/icons/'
+    )
+  })
+
   it('replaces PropertiesTable with JSON block', async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-json-'))
     const docsRoot = path.join(tmpRoot, 'docs')
@@ -172,5 +211,86 @@ describe('convertMdxToMd', () => {
 
     expect(output.startsWith('# Button')).toBe(true)
     expect(output).toContain('Some intro text.')
+  })
+
+  it('inlines imported mdx fragments from Docs aliases', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-imports-'))
+    const docsBaseRoot = path.join(tmpRoot, 'src')
+    const docsRoot = path.join(docsBaseRoot, 'docs')
+    const sectionDir = path.join(docsRoot, 'components', 'breadcrumb')
+    fs.mkdirSync(sectionDir, { recursive: true })
+
+    const infoPath = path.join(sectionDir, 'info.mdx')
+    fs.writeFileSync(
+      infoPath,
+      ['## Description', '', 'Breadcrumb description.'].join('\n')
+    )
+
+    const demosPath = path.join(sectionDir, 'demos.mdx')
+    fs.writeFileSync(
+      demosPath,
+      ['## Demos', '', '```tsx', 'render(<div />)', '```'].join('\n')
+    )
+
+    const mdxPath = path.join(sectionDir, 'breadcrumb.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        "import BreadcrumbInfo from 'Docs/components/breadcrumb/info'",
+        "import BreadcrumbDemos from 'Docs/components/breadcrumb/demos'",
+        '',
+        '# Breadcrumb',
+        '',
+        '<BreadcrumbInfo />',
+        '<BreadcrumbDemos />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain('## Description')
+    expect(output).toContain('Breadcrumb description.')
+    expect(output).toContain('## Demos')
+    expect(output).toContain('render(<div />)')
+    expect(output).not.toContain('<BreadcrumbInfo />')
+    expect(output).not.toContain('<BreadcrumbDemos />')
+  })
+
+  it('replaces ListAllIcons with a markdown icon list', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-icons-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    const mdxPath = path.join(docsRoot, 'icons.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        "import ListAllIcons from 'dnb-design-system-portal/src/shared/parts/icons/ListAllIcons'",
+        '',
+        '# Icons',
+        '',
+        '<ListAllIcons variant="primary" />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('ListAllIcons')
+    expect(output).toContain('`bell`')
+    expect(output).toContain('Category:')
   })
 })

--- a/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
@@ -8,10 +8,73 @@ jest.unstable_mockModule('prettier', () => ({
   default: { format: async (code: string) => code },
 }))
 
-const { convertMdxToMd, loadTsDocsForDocPath, toPublicUrl, toSlugAndDir } =
-  await import('../../src/convertHelpers.ts')
+const {
+  convertMdxToMd,
+  formatUnhandledStandaloneMdxWarnings,
+  findUnhandledStandaloneMdxComponents,
+  loadTsDocsForDocPath,
+  recordUnhandledStandaloneMdxWarning,
+  resetUnhandledStandaloneMdxWarnings,
+  toPublicUrl,
+  toSlugAndDir,
+} = await import('../../src/convertHelpers.ts')
 
 describe('convertMdxToMd', () => {
+  beforeEach(() => {
+    resetUnhandledStandaloneMdxWarnings()
+  })
+
+  it('finds unhandled standalone MDX components outside code fences', () => {
+    const content = [
+      '<UnhandledWidget />',
+      '<InlineImg />',
+      '<Anchor />',
+      '<Button />',
+      '',
+      '- inline <InlineThing />',
+      '',
+      '```tsx',
+      '<CodeOnlyWidget />',
+      '```',
+      '',
+      '<Another.Widget />',
+    ].join('\n')
+
+    expect(
+      findUnhandledStandaloneMdxComponents(content, {
+        importsByFile: new Map([['@dnb/eufemia/src', ['Button']]]),
+      })
+    ).toEqual(['Another.Widget', 'UnhandledWidget'])
+  })
+
+  it('groups repeated unhandled standalone MDX warnings into one summary', () => {
+    recordUnhandledStandaloneMdxWarning({
+      inputPath: '/repo/docs/uilib/layout/flex/item.mdx',
+      docsRoot: '/repo/docs',
+      components: [
+        'Examples.UnsupportedAdvanced',
+        'Examples.UnsupportedBasic',
+      ],
+    })
+    recordUnhandledStandaloneMdxWarning({
+      inputPath: '/repo/docs/uilib/layout/flex/item/demos.mdx',
+      docsRoot: '/repo/docs',
+      components: [
+        'Examples.UnsupportedBasic',
+        'Examples.UnsupportedAdvanced',
+      ],
+    })
+
+    expect(formatUnhandledStandaloneMdxWarnings()).toBe(
+      [
+        '[llm-metadata] warnings: unhandled standalone MDX components in 2 files',
+        '- Examples.UnsupportedAdvanced, Examples.UnsupportedBasic',
+        '  uilib/layout/flex/item.mdx',
+        '  uilib/layout/flex/item/demos.mdx',
+      ].join('\n')
+    )
+  })
+
   it('only loads ts docs for uilib doc paths', async () => {
     const nonUilibTsDocs = await loadTsDocsForDocPath(
       'quickguide-designer/tools.mdx'
@@ -292,5 +355,625 @@ describe('convertMdxToMd', () => {
     expect(output).not.toContain('ListAllIcons')
     expect(output).toContain('`bell`')
     expect(output).toContain('Category:')
+  })
+
+  it('replaces ListAllBlocks with markdown sections from matching docs', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'blocks',
+      'collection.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('ListAllBlocks')
+    expect(output).toContain(
+      '## [Block.ChildrenWithAge](/uilib/extensions/forms/blocks/ChildrenWithAge/)'
+    )
+    expect(output).toContain(
+      '`ChildrenWithAge` is a block for displaying children with age.'
+    )
+  })
+
+  it('replaces ListComponents with markdown sections from regex-matched docs', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(docsRoot, 'uilib', 'components.mdx')
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('ListComponents')
+    expect(output).toContain(
+      '## [Accordion](/uilib/components/accordion/)'
+    )
+    expect(output).toContain(
+      'The Accordion component is a combination of an accessible button (header area) and a content container.'
+    )
+  })
+
+  it('replaces ListElements with markdown list items', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(docsRoot, 'uilib', 'elements.mdx')
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('ListElements')
+    expect(output).toContain('- [Paragraph](/uilib/elements/paragraph/):')
+    expect(output).toContain('- [Span](/uilib/elements/span/):')
+  })
+
+  it('replaces re-exported examples referenced through a namespace import', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'Iterate',
+      'Array',
+      'demos.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<Examples.AnimatedContainer />')
+    expect(output).toContain(
+      '<Iterate.AnimatedContainer title="Title {itemNo}">'
+    )
+    expect(output).toContain('text="Add new item"')
+  })
+
+  it('replaces imported example aliases referenced through a namespace import', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'layout',
+      'flex',
+      'item',
+      'demos.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<Examples.BasicSizeExample />')
+    expect(output).not.toContain('<Examples.AdvancedSizeExample />')
+    expect(output).toContain('FlexItem (8)')
+    expect(output).toContain('sizeCount={4}')
+  })
+
+  it('replaces namespace-imported example usages that include JSX attributes', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'Value',
+      'Name',
+      'demos.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<Examples.FirstName value="Nora" />')
+    expect(output).not.toContain('<Examples.LastName value="Mørk" />')
+    expect(output).not.toContain('<Examples.CompanyName value="DNB" />')
+    expect(output).toContain('render(<Value.Name.First value="Nora" />)')
+    expect(output).toContain('render(<Value.Name.Last value="Mørk" />)')
+    expect(output).toContain('render(<Value.Name.Company value="DNB" />)')
+  })
+
+  it('injects MDX call-site props into extracted examples that depend on a props object', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'blocks',
+      'ChildrenWithAge',
+      'demos.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<Examples.ChildrenWithAge')
+    expect(output).toContain('const props = {}')
+    expect(output).toContain(
+      "const props = { enableAdditionalQuestions: ['joint-responsibility'] }"
+    )
+    expect(output).toContain(
+      "const props = { enableAdditionalQuestions: ['daycare', 'joint-responsibility'] }"
+    )
+    expect(output).toContain('<Blocks.ChildrenWithAge {...props} />')
+  })
+
+  it('replaces nested ColorsTable content with rendered markdown tables', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'usage',
+      'customisation',
+      'colors.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('ColorTable')
+    expect(output).not.toContain('ChangeStyleTheme')
+    expect(output).not.toContain('data-visual-test="color-table"')
+    expect(output).toContain(
+      '| Sample | Type | Brand name | Hex | RGB | Figma Library name | CSS Custom Properties name |'
+    )
+    expect(output).toContain('`--color-black`')
+    expect(output).toContain('## DNB Colors')
+  })
+
+  it('replaces TokenExample with inline markdown code', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-token-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    const mdxPath = path.join(docsRoot, 'tokens.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        "import { TokenExample } from './Examples'",
+        '',
+        '- semantic token: <TokenExample name="--token-color-text-neutral" />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('TokenExample')
+    expect(output).toContain(
+      '- semantic token: `--token-color-text-neutral`'
+    )
+  })
+
+  it('removes standalone br tags from markdown output', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-br-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    const mdxPath = path.join(docsRoot, 'breaks.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      ['## Naming contract', '', '<br />', '', 'Typical examples:'].join(
+        '\n'
+      )
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<br />')
+    expect(output).toContain('## Naming contract')
+    expect(output).toContain('Typical examples:')
+  })
+
+  it('replaces TokenSectionTable with markdown token tables', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'usage',
+      'customisation',
+      'theming',
+      'design-tokens',
+      'colors.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('TokenSectionTable')
+    expect(output).toContain(
+      '| Group | Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |'
+    )
+    expect(output).toContain(
+      '| Group | Name | Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |'
+    )
+    expect(output.indexOf('| First |')).toBeLessThan(
+      output.indexOf('| Second |')
+    )
+    expect(output).toContain('`--token-color-text-neutral`')
+    expect(output).toContain('## Text')
+  })
+
+  it('replaces RadiusTokenTable with a markdown radius table', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'usage',
+      'customisation',
+      'theming',
+      'design-tokens',
+      'radius.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('RadiusTokenTable')
+    expect(output).not.toContain('```tsx')
+    expect(output).toContain(
+      '| Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |'
+    )
+    expect(output.indexOf('`--token-radius-0`')).toBeLessThan(
+      output.indexOf('`--token-radius-xs`')
+    )
+    expect(output.indexOf('`--token-radius-xs`')).toBeLessThan(
+      output.indexOf('`--token-radius-sm`')
+    )
+    expect(output.indexOf('`--token-radius-sm`')).toBeLessThan(
+      output.indexOf('`--token-radius-md`')
+    )
+    expect(output).toContain('`--token-radius-sm`')
+    expect(output).toContain('`0.25rem`')
+  })
+
+  it('replaces real feature-field PropertiesTable content in docs that import helper exports', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+
+    const dateOfBirthEventsPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'feature-fields',
+      'DateOfBirth',
+      'events.mdx'
+    )
+    const selectCurrencyPropertiesPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'feature-fields',
+      'SelectCurrency',
+      'properties.mdx'
+    )
+
+    const [dateOfBirthEvents, selectCurrencyProperties] =
+      await Promise.all([
+        convertMdxToMd({
+          inputPath: dateOfBirthEventsPath,
+          docsRoot,
+          docsBaseRoot,
+          prettierConfig: {},
+          includeFrontmatter: false,
+          state: { mdxCache: new Map(), inProgress: new Set() },
+        }),
+        convertMdxToMd({
+          inputPath: selectCurrencyPropertiesPath,
+          docsRoot,
+          docsBaseRoot,
+          prettierConfig: {},
+          includeFrontmatter: false,
+          state: { mdxCache: new Map(), inProgress: new Set() },
+        }),
+      ])
+
+    expect(dateOfBirthEvents).not.toContain('PropertiesTable')
+    expect(dateOfBirthEvents).toContain('```json')
+    expect(dateOfBirthEvents).toContain('"onChange"')
+    expect(dateOfBirthEvents).toContain('"onBlur"')
+
+    expect(selectCurrencyProperties).not.toContain('PropertiesTable')
+    expect(selectCurrencyProperties).toContain('```json')
+    expect(selectCurrencyProperties).toContain('"currencies"')
+    expect(selectCurrencyProperties).toContain('"size"')
+  })
+
+  it('replaces AvailableCountriesTable with a markdown country table', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'feature-fields',
+      'SelectCountry',
+      'properties.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('AvailableCountriesTable')
+    expect(output).toContain('| ISO 3166-1 alpha-2 code | en | nb |')
+    expect(output).toContain('| `AF` | Afghanistan | Afghanistan |')
+  })
+
+  it('replaces CardProductsTable with a markdown card-product table', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'payment-card',
+      'products.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('CardProductsTable')
+    expect(output).toContain(
+      '| Product Id | Product name cards | Card name to show in app | Design | Bank Logo | Product Logo | Product Logo Variant | Type of Card | Type of Card Variant |'
+    )
+    expect(output).toContain(
+      '| 043 | Sølv MasterCard | Pluss Mastercard | Pluss |'
+    )
   })
 })

--- a/tools/eufemia-llm-metadata/scripts/__tests__/createMarkdownCopies.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/createMarkdownCopies.test.ts
@@ -8,9 +8,8 @@ jest.unstable_mockModule('prettier', () => ({
   default: { format: async (code: string) => code },
 }))
 
-const { createMarkdownCopies } = await import(
-  '../../src/convertHelpers.ts'
-)
+const { createMarkdownCopies } =
+  await import('../../src/convertHelpers.ts')
 
 describe('createMarkdownCopies', () => {
   it('appends properties and events markdown to output', async () => {
@@ -121,6 +120,48 @@ describe('createMarkdownCopies', () => {
     )
     expect(fs.existsSync(propsPath)).toBe(false)
     expect(fs.existsSync(eventsPath)).toBe(false)
+  })
+
+  it('writes markdown copies for non-uilib routes when no slug base is used', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-md-route-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    const outputRoot = path.join(tmpRoot, 'out')
+    const entryDir = path.join(docsRoot, 'quickguide-designer')
+    const entryFile = path.join(entryDir, 'tools.mdx')
+
+    fs.mkdirSync(entryDir, { recursive: true })
+
+    fs.writeFileSync(
+      entryFile,
+      [
+        '---',
+        "title: 'Tools'",
+        '---',
+        '',
+        '# Tools',
+        '',
+        'Designer tooling docs.',
+      ].join('\n')
+    )
+
+    await createMarkdownCopies({
+      siteDir: tmpRoot,
+      docsRoot,
+      outputRoot,
+      publicUrlBase: '',
+      slugBase: '',
+    })
+
+    const outputPath = path.join(
+      outputRoot,
+      'quickguide-designer',
+      'tools.md'
+    )
+
+    expect(fs.existsSync(outputPath)).toBe(true)
+    expect(fs.readFileSync(outputPath, 'utf-8')).toContain(
+      'Designer tooling docs.'
+    )
   })
 
   it('adds metadata fields to frontmatter when available', async () => {

--- a/tools/eufemia-llm-metadata/scripts/__tests__/utils.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/utils.test.ts
@@ -1,0 +1,15 @@
+import { escapeMarkdownTableCell } from '../../src/extensions/mdx/utils.ts'
+
+describe('mdx utils', () => {
+  it('escapes pipes in markdown table cells', () => {
+    expect(escapeMarkdownTableCell('foo|bar')).toBe('foo\\|bar')
+  })
+
+  it('escapes existing backslashes in markdown table cells', () => {
+    expect(escapeMarkdownTableCell('foo\\bar')).toBe('foo\\\\bar')
+  })
+
+  it('escapes backslashes and pipes together', () => {
+    expect(escapeMarkdownTableCell('foo\\|bar')).toBe('foo\\\\\\|bar')
+  })
+})

--- a/tools/eufemia-llm-metadata/scripts/generateDocs.ts
+++ b/tools/eufemia-llm-metadata/scripts/generateDocs.ts
@@ -6,11 +6,13 @@ import {
   buildMetadata,
   createMarkdownCopies,
   extractTableDocs,
+  formatUnhandledStandaloneMdxWarnings,
   findDocExtras,
   findEntryMdxFiles,
   findSourceInfo,
   findRepoRoot,
   loadTsDocsForDocPath,
+  resetUnhandledStandaloneMdxWarnings,
   mergeDocs,
   resolveMetaText,
   toSlugAndDir,
@@ -40,6 +42,7 @@ export async function generateDocs() {
   }
 
   console.log('[llm-metadata] build started ...')
+  resetUnhandledStandaloneMdxWarnings()
 
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)
@@ -59,11 +62,12 @@ export async function generateDocs() {
     'static'
   )
   const outputRoot = path.join(packageRoot, 'build', 'docs')
-  await fs.ensureDir(outputRoot)
+  await fs.emptyDir(outputRoot)
 
   const version = await getNextReleaseVersion()
   const robots = await loadRobots(robotsRoot)
   const entryFiles = await findEntryMdxFiles(docsRoot)
+  const allowedEntryFiles: string[] = []
 
   const results: Array<any> = []
   const metadataBySlug = new Map<
@@ -81,6 +85,8 @@ export async function generateDocs() {
     if (!isAllowed(slug, robots)) {
       continue
     }
+
+    allowedEntryFiles.push(file)
 
     const { propsFile, eventsFile, demosFile } = await findDocExtras(file)
 
@@ -138,6 +144,7 @@ export async function generateDocs() {
     siteDir: repoRoot,
     docsRoot,
     outputRoot,
+    entryFiles: allowedEntryFiles,
     slugBase: '',
     publicUrlBase: PUBLIC_URL_BASE,
     metadataBySlug,
@@ -152,8 +159,14 @@ export async function generateDocs() {
     llmsFilename: 'llm.md',
   })
 
+  const warningSummary = formatUnhandledStandaloneMdxWarnings()
+
+  if (warningSummary) {
+    console.warn(warningSummary)
+  }
+
   console.info(
-    `[llm-metadata] build outputs: ${entryFiles.length} markdown copies, llm.md`
+    `[llm-metadata] build outputs: ${allowedEntryFiles.length} markdown copies, llm.md`
   )
   console.log('[llm-metadata] build done!')
 }

--- a/tools/eufemia-llm-metadata/scripts/generateDocs.ts
+++ b/tools/eufemia-llm-metadata/scripts/generateDocs.ts
@@ -10,7 +10,7 @@ import {
   findEntryMdxFiles,
   findSourceInfo,
   findRepoRoot,
-  loadTsDocs,
+  loadTsDocsForDocPath,
   mergeDocs,
   resolveMetaText,
   toSlugAndDir,
@@ -50,8 +50,7 @@ export async function generateDocs() {
     'packages',
     'dnb-design-system-portal',
     'src',
-    'docs',
-    'uilib'
+    'docs'
   )
   const robotsRoot = path.join(
     repoRoot,
@@ -77,7 +76,7 @@ export async function generateDocs() {
   >()
   for (const file of entryFiles) {
     const rel = path.relative(docsRoot, file)
-    const { slug } = toSlugAndDir(rel)
+    const { slug } = toSlugAndDir(rel, '')
 
     if (!isAllowed(slug, robots)) {
       continue
@@ -88,7 +87,7 @@ export async function generateDocs() {
     let props: Record<string, any> = {}
     let events: Record<string, any> = {}
 
-    const tsDocs = await loadTsDocs(rel)
+    const tsDocs = await loadTsDocsForDocPath(rel)
     props = mergeDocs(props, tsDocs.props)
     events = mergeDocs(events, tsDocs.events)
 
@@ -139,6 +138,7 @@ export async function generateDocs() {
     siteDir: repoRoot,
     docsRoot,
     outputRoot,
+    slugBase: '',
     publicUrlBase: PUBLIC_URL_BASE,
     metadataBySlug,
   })

--- a/tools/eufemia-llm-metadata/scripts/mdx-to-md.ts
+++ b/tools/eufemia-llm-metadata/scripts/mdx-to-md.ts
@@ -596,9 +596,13 @@ function replaceComponentUsages(
   content: string,
   componentCode: Map<string, ComponentEntry | string>
 ) {
-  const componentRegex = /<([A-Z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*)\s*\/>/g
+  const componentRegex = /<([A-Z][A-Za-z0-9_.]*)\s*\/>/g
 
   return content.replace(componentRegex, (match, name: string) => {
+    if (!isComponentReferenceName(name)) {
+      return match
+    }
+
     const entry = componentCode.get(name)
     if (!entry) {
       return match
@@ -614,6 +618,44 @@ function replaceComponentUsages(
     }
     return `\n\`\`\`tsx\n${entry.code}\n\`\`\`\n`
   })
+}
+
+function isComponentReferenceName(name: string) {
+  if (!name) {
+    return false
+  }
+
+  for (let index = 0; index < name.length; index++) {
+    const charCode = name.charCodeAt(index)
+    const isDot = charCode === 46
+    const isDigit = charCode >= 48 && charCode <= 57
+    const isUppercase = charCode >= 65 && charCode <= 90
+    const isUnderscore = charCode === 95
+    const isLowercase = charCode >= 97 && charCode <= 122
+
+    if (
+      !isDot &&
+      !isDigit &&
+      !isLowercase &&
+      !isUnderscore &&
+      !isUppercase
+    ) {
+      return false
+    }
+
+    if (isDot) {
+      if (
+        index === 0 ||
+        index === name.length - 1 ||
+        name.charCodeAt(index - 1) === 46
+      ) {
+        return false
+      }
+    }
+  }
+
+  const firstCharCode = name.charCodeAt(0)
+  return firstCharCode >= 65 && firstCharCode <= 90
 }
 
 function looksLikeMarkdown(code: string) {

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -8,7 +8,35 @@ import frontMatter, {
 } from 'front-matter'
 import * as prettier from 'prettier'
 import { extractMarkdownTables } from 'markdown-tables-utils'
-import type { File } from '@babel/types'
+import type { NodePath } from '@babel/traverse'
+import type {
+  ArrowFunctionExpression,
+  BlockStatement,
+  CallExpression,
+  ExpressionStatement,
+  ExportNamedDeclaration,
+  Expression,
+  File,
+  FunctionDeclaration,
+  FunctionExpression,
+  Identifier,
+  ImportDeclaration,
+  JSXElement,
+  JSXExpressionContainer,
+  JSXFragment,
+  JSXIdentifier,
+  JSXText,
+  Node,
+  ParenthesizedExpression,
+  ReturnStatement,
+  Statement,
+  VariableDeclaration,
+} from '@babel/types'
+import { findUnhandledStandaloneMdxComponents } from './extensions/mdx/detector.ts'
+import { applySpecialMdxComponentRenderers } from './extensions/mdx/registry.ts'
+import { findPackageRoot, toPascalCase } from './shared/workspaceUtils.ts'
+
+export { toPascalCase, findUnhandledStandaloneMdxComponents }
 
 type FrontMatterParser = {
   <T>(file: string, options?: FrontMatterOptions): FrontMatterResult<T>
@@ -47,8 +75,126 @@ type ConvertState = {
 type ComponentEntry = {
   code: string
   format: 'md' | 'tsx'
+  propsIdentifier?: string
+}
+type BabelGenerate = (node: Node) => { code: string }
+type BabelTraverse = (
+  ast: File,
+  visitor: {
+    ImportDeclaration?: (path: NodePath<ImportDeclaration>) => void
+    ExportNamedDeclaration: (
+      path: NodePath<ExportNamedDeclaration>
+    ) => void
+  }
+) => void
+type BabelTypes = {
+  callExpression: (
+    callee: Expression,
+    args: Expression[]
+  ) => CallExpression
+  expressionStatement: (expression: Expression) => ExpressionStatement
+  identifier: (name: string) => Identifier
+  isArrowFunctionExpression: (
+    node: Node
+  ) => node is ArrowFunctionExpression
+  isBlockStatement: (node: Node) => node is BlockStatement
+  isFunctionDeclaration: (node: Node) => node is FunctionDeclaration
+  isFunctionExpression: (node: Node) => node is FunctionExpression
+  isIdentifier: (node: Node) => node is Identifier
+  isJSXElement: (node: Node) => node is JSXElement
+  isJSXExpressionContainer: (node: Node) => node is JSXExpressionContainer
+  isJSXFragment: (node: Node) => node is JSXFragment
+  isJSXIdentifier: (node: Node) => node is JSXIdentifier
+  isJSXText: (node: Node) => node is JSXText
+  isParenthesizedExpression: (
+    node: Node
+  ) => node is ParenthesizedExpression
+  isReturnStatement: (node: Node) => node is ReturnStatement
+  isVariableDeclaration: (node: Node) => node is VariableDeclaration
+}
+type JSXRenderableNode = JSXElement | JSXFragment
+type JSXReturnableNode =
+  | ArrowFunctionExpression
+  | Expression
+  | FunctionDeclaration
+  | FunctionExpression
+  | null
+  | undefined
+type UnhandledStandaloneMdxWarningGroup = {
+  components: string[]
+  files: Set<string>
 }
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const unhandledStandaloneMdxWarningGroups = new Map<
+  string,
+  UnhandledStandaloneMdxWarningGroup
+>()
+
+export function resetUnhandledStandaloneMdxWarnings() {
+  unhandledStandaloneMdxWarningGroups.clear()
+}
+
+export function recordUnhandledStandaloneMdxWarning({
+  inputPath,
+  docsRoot,
+  components,
+}: {
+  inputPath: string
+  docsRoot: string
+  components: string[]
+}) {
+  if (components.length === 0) {
+    return
+  }
+
+  const relativeInputPath = path
+    .relative(docsRoot, inputPath)
+    .replace(/\\/g, '/')
+  const normalizedComponents = [...components].sort()
+  const key = normalizedComponents.join('\u0000')
+  const existing = unhandledStandaloneMdxWarningGroups.get(key)
+
+  if (existing) {
+    existing.files.add(relativeInputPath)
+    return
+  }
+
+  unhandledStandaloneMdxWarningGroups.set(key, {
+    components: normalizedComponents,
+    files: new Set([relativeInputPath]),
+  })
+}
+
+export function formatUnhandledStandaloneMdxWarnings() {
+  if (unhandledStandaloneMdxWarningGroups.size === 0) {
+    return ''
+  }
+
+  const groups = Array.from(
+    unhandledStandaloneMdxWarningGroups.values()
+  ).sort((a, b) => {
+    const firstFileA = Array.from(a.files).sort()[0] || ''
+    const firstFileB = Array.from(b.files).sort()[0] || ''
+
+    return firstFileA.localeCompare(firstFileB)
+  })
+  const fileCount = groups.reduce((sum, group) => {
+    return sum + group.files.size
+  }, 0)
+  const lines = [
+    `[llm-metadata] warnings: unhandled standalone MDX components in ${fileCount} file${fileCount === 1 ? '' : 's'}`,
+  ]
+
+  for (const group of groups) {
+    lines.push(`- ${group.components.join(', ')}`)
+
+    for (const file of Array.from(group.files).sort()) {
+      lines.push(`  ${file}`)
+    }
+  }
+
+  return lines.join('\n')
+}
 
 /**
  * The URL slug prefix for pages that get LLM markdown copies.
@@ -536,20 +682,6 @@ export function normalizeKeyCell(cell: string) {
   return cleaned.split(/\s+or\s+/i).map((s) => s.trim())
 }
 
-export function toPascalCase(s: string) {
-  return s
-    .split(/_/g)
-    .reduce(
-      (acc, cur) =>
-        acc +
-        cur.replace(
-          /(\w)(\w*)/g,
-          (g0, g1, g2) => g1.toUpperCase() + g2.toLowerCase()
-        ),
-      ''
-    )
-}
-
 export function cleanDescription(s: string) {
   return s
     .replace(/<em>\((optional|mandatory)\)<\/em>\s*/gi, '')
@@ -949,7 +1081,14 @@ export async function extractTsDocs(dir: string) {
   return out
 }
 
-async function evaluateTsModule(file: string) {
+async function evaluateTsModule(file: string, seen = new Set<string>()) {
+  if (seen.has(file)) {
+    return {}
+  }
+
+  const nextSeen = new Set(seen)
+  nextSeen.add(file)
+
   const { default: babel } = await import('@babel/core')
   const { default: transformTS } =
     await import('@babel/plugin-transform-typescript')
@@ -960,14 +1099,19 @@ async function evaluateTsModule(file: string) {
   const localRequire = (moduleApi as any).createRequire(file)
 
   let code = await fs.readFile(file, 'utf-8')
-  const injection = await buildDocsInjectionPrelude(file, code)
+  const bindings = await buildModuleInjectionBindings(
+    file,
+    code,
+    localRequire,
+    nextSeen
+  )
 
   code = code.replace(
     /(^\s*import[\s\S]*?from\s+['"][^'"]+['"][^\n]*$)/gm,
     ''
   )
 
-  const result = await babel.transformAsync(injection + '\n' + code, {
+  const result = await babel.transformAsync(code, {
     filename: file,
     plugins: [
       [transformTS, { isTSX: true }],
@@ -983,15 +1127,27 @@ async function evaluateTsModule(file: string) {
     module: { exports: {} },
     exports: {},
     require: localRequire,
+    ...bindings,
   }
   vm.createContext(sandbox)
-  vm.runInContext(result.code, sandbox, { filename: file })
+
+  try {
+    vm.runInContext(result.code, sandbox, { filename: file })
+  } catch {
+    // Ignore runtime errors and keep any partial exports that were assigned.
+  }
+
   const exp = sandbox.exports
   const mod = sandbox.module && sandbox.module.exports
   return (exp && Object.keys(exp).length ? exp : mod) || {}
 }
 
-async function buildDocsInjectionPrelude(file: string, source: string) {
+async function buildModuleInjectionBindings(
+  file: string,
+  source: string,
+  localRequire: NodeJS.Require,
+  seen: Set<string>
+) {
   const parser = await import('@babel/parser')
   const dir = path.dirname(file)
   let ast
@@ -1002,117 +1158,121 @@ async function buildDocsInjectionPrelude(file: string, source: string) {
       plugins: ['typescript', 'jsx'],
     })
   } catch {
-    return ''
+    return {}
   }
 
-  const mappings: Array<{ names: string[]; mod: Record<string, any> }> = []
+  const bindings: Record<string, unknown> = {}
 
   for (const node of ast.program.body) {
     if (node.type !== 'ImportDeclaration') {
       continue
     }
+
+    if (node.importKind === 'type') {
+      continue
+    }
+
     const src = node.source && node.source.value
 
-    if (!src || !hasDocsModuleSuffix(src)) {
+    if (!src) {
       continue
     }
-    const names = node.specifiers
-      .filter((s: any) => s.type === 'ImportSpecifier')
-      .map((s: any) => (s.imported && s.imported.name) || s.local.name)
-      .filter(Boolean)
 
-    if (names.length === 0) {
+    const mod = await loadImportedModuleForEvaluation({
+      baseDir: dir,
+      source: src,
+      localRequire,
+      seen,
+    })
+
+    if (!mod) {
       continue
     }
-    const abs = await resolveDocsModulePath(dir, src)
 
-    if (!abs) {
-      continue
-    }
-    const mod = await evaluateTsModule(abs)
-    mappings.push({ names, mod })
-  }
-
-  let prelude = ''
-
-  for (const { names, mod } of mappings) {
-    for (const n of names) {
-      const val =
-        mod && Object.prototype.hasOwnProperty.call(mod, n) ? mod[n] : {}
-      prelude += `const ${n} = ${JSON.stringify(val)};\n`
-    }
-  }
-  return prelude
-}
-
-function hasDocsModuleSuffix(source: string) {
-  const normalizedSource = source.toLowerCase()
-
-  return (
-    normalizedSource.endsWith('docs') ||
-    normalizedSource.endsWith('docs.ts') ||
-    normalizedSource.endsWith('docs.tsx') ||
-    normalizedSource.endsWith('docs.js') ||
-    normalizedSource.endsWith('docs.jsx')
-  )
-}
-
-async function resolveDocsModulePath(baseDir: string, modPath: string) {
-  const candidates = [
-    path.resolve(baseDir, modPath + '.ts'),
-    path.resolve(baseDir, modPath + '.tsx'),
-    path.resolve(baseDir, modPath),
-  ]
-
-  for (const c of candidates) {
-    try {
-      const st = await fs.stat(c)
-
-      if (st.isFile()) {
-        return c
+    for (const specifier of node.specifiers) {
+      if (specifier.type === 'ImportSpecifier') {
+        const importedName =
+          specifier.imported.type === 'Identifier'
+            ? specifier.imported.name
+            : specifier.imported.value
+        bindings[specifier.local.name] =
+          mod && Object.prototype.hasOwnProperty.call(mod, importedName)
+            ? mod[importedName]
+            : undefined
+        continue
       }
-    } catch {
-      // ignore
+
+      if (specifier.type === 'ImportDefaultSpecifier') {
+        bindings[specifier.local.name] =
+          mod && Object.prototype.hasOwnProperty.call(mod, 'default')
+            ? mod.default
+            : mod
+        continue
+      }
+
+      if (specifier.type === 'ImportNamespaceSpecifier') {
+        bindings[specifier.local.name] = mod
+      }
     }
   }
-  return null
+
+  return bindings
 }
 
-function findPackageRoot(pkgName: string) {
-  const root = path.parse(process.cwd()).root
-  let current = process.cwd()
-  const workspaceName =
-    pkgName === '@dnb/eufemia'
-      ? 'dnb-eufemia'
-      : pkgName.replace(/^@[^/]+\//, '')
+async function loadImportedModuleForEvaluation({
+  baseDir,
+  source,
+  localRequire,
+  seen,
+}: {
+  baseDir: string
+  source: string
+  localRequire: NodeJS.Require
+  seen: Set<string>
+}) {
+  const resolvedPath = resolveModulePathForEvaluation(baseDir, source)
 
-  while (true) {
-    const workspaceCandidate = path.join(
-      current,
-      'packages',
-      workspaceName,
-      'package.json'
+  if (resolvedPath) {
+    return evaluateTsModule(resolvedPath, seen)
+  }
+
+  try {
+    return localRequire(source)
+  } catch {
+    return null
+  }
+}
+
+function resolveModulePathForEvaluation(baseDir: string, modPath: string) {
+  if (modPath.startsWith('@dnb/eufemia/')) {
+    const pkgRoot = findPackageRoot('@dnb/eufemia')
+
+    if (!pkgRoot) {
+      return null
+    }
+
+    return resolveWithExtension(
+      path.join(pkgRoot, modPath.replace(/^@dnb\/eufemia\//, ''))
     )
+  }
 
-    if (fs.existsSync(workspaceCandidate)) {
-      return path.dirname(workspaceCandidate)
+  if (modPath.startsWith('dnb-design-system-portal/')) {
+    const portalRoot = findPackageRoot('dnb-design-system-portal')
+
+    if (!portalRoot) {
+      return null
     }
 
-    const candidate = path.join(
-      current,
-      'node_modules',
-      ...pkgName.split('/'),
-      'package.json'
+    return resolveWithExtension(
+      path.join(
+        portalRoot,
+        modPath.replace(/^dnb-design-system-portal\//, '')
+      )
     )
+  }
 
-    if (fs.existsSync(candidate)) {
-      return path.dirname(candidate)
-    }
-
-    if (current === root) {
-      break
-    }
-    current = path.dirname(current)
+  if (modPath.startsWith('.') || modPath.startsWith('/')) {
+    return resolveWithExtension(path.resolve(baseDir, modPath))
   }
 
   return null
@@ -1160,6 +1320,7 @@ export async function createMarkdownCopies({
   siteDir,
   docsRoot,
   outputRoot,
+  entryFiles,
   slugBase = LLM_DOCS_SLUG_PREFIX,
   publicUrlBase = DEFAULT_PUBLIC_URL,
   metadataBySlug,
@@ -1168,6 +1329,7 @@ export async function createMarkdownCopies({
   siteDir: string
   docsRoot: string
   outputRoot?: string
+  entryFiles?: string[]
   slugBase?: string
   publicUrlBase?: string
   skipFormat?: boolean
@@ -1191,13 +1353,14 @@ export async function createMarkdownCopies({
   }
 
   const docsBaseRoot = path.resolve(docsRoot, '..')
-  const entryFiles = await findEntryMdxFiles(docsRoot)
+  const markdownEntryFiles =
+    entryFiles || (await findEntryMdxFiles(docsRoot))
   const state: ConvertState = {
     mdxCache: new Map(),
     inProgress: new Set(),
   }
 
-  for (const file of entryFiles) {
+  for (const file of markdownEntryFiles) {
     const rel = path.relative(docsRoot, file)
     const { slug } = toSlugAndDir(rel, slugBase)
     const resolvedOutputRoot = outputRoot || path.join(siteDir, 'public')
@@ -1310,7 +1473,20 @@ export async function convertMdxToMd({
     'VisibilityByTheme',
     'VisibleWhenVisualTest',
   ])
-  outputBody = await replaceListAllIcons(outputBody)
+  outputBody = removeSelfClosingComponents(outputBody, [
+    'ChangeStyleTheme',
+  ])
+  outputBody = stripStandaloneBreakTags(outputBody)
+  outputBody = stripDataVisualTestWrappers(outputBody)
+  outputBody = await applySpecialMdxComponentRenderers(outputBody, {
+    findPackageRoot,
+    inputDir: path.dirname(inputPath),
+    docsRoot,
+    importsByFile,
+    loadModuleDefault,
+    toPascalCase,
+    toSlugAndDir,
+  })
   outputBody = replaceComponentUsages(outputBody, componentCode)
 
   const links = frontmatterLinks || {}
@@ -1328,6 +1504,19 @@ export async function convertMdxToMd({
     docsRoot,
     docsBaseRoot,
   })
+
+  const unhandledStandaloneMdxComponents =
+    findUnhandledStandaloneMdxComponents(outputBody, {
+      importsByFile,
+    })
+
+  if (unhandledStandaloneMdxComponents.length > 0) {
+    recordUnhandledStandaloneMdxWarning({
+      inputPath,
+      docsRoot,
+      components: unhandledStandaloneMdxComponents,
+    })
+  }
 
   // Extract title from frontmatter and add as heading if not already present
   let titleHeading = ''
@@ -2301,14 +2490,14 @@ async function collectComponentCode({
   skipFormat?: boolean
 }) {
   const componentCode = new Map<string, ComponentEntry>()
-  const parsedFiles = new Map<string, Map<string, string>>()
+  const parsedFiles = new Map<string, Map<string, ComponentEntry>>()
   const mdxCache = state.mdxCache
   const inProgress = state.inProgress
   const parser = await import('@babel/parser')
   const traverseModule = await import('@babel/traverse')
   const generateModule = await import('@babel/generator')
   const typesModule = await import('@babel/types')
-  const resolveModuleDefault = <T>(mod: T): T => {
+  const resolveModuleDefault = <T>(mod: unknown): T => {
     const maybeDefault = (mod as { default?: unknown }).default
     if (
       maybeDefault &&
@@ -2319,9 +2508,46 @@ async function collectComponentCode({
     }
     return (maybeDefault ?? mod) as T
   }
-  const traverse = resolveModuleDefault(traverseModule)
-  const generate = resolveModuleDefault(generateModule)
-  const t = typesModule.default || typesModule
+  const traverse = resolveModuleDefault<BabelTraverse>(traverseModule)
+  const generate = resolveModuleDefault<BabelGenerate>(generateModule)
+  const t = resolveModuleDefault<BabelTypes>(typesModule)
+
+  const loadExportsForPath = async (filePath: string) => {
+    const cached = parsedFiles.get(filePath)
+
+    if (cached) {
+      return cached
+    }
+
+    const exportsMap = new Map<string, ComponentEntry>()
+    parsedFiles.set(filePath, exportsMap)
+
+    const sourceCode = await fs.readFile(filePath, 'utf-8')
+    const ast = parser.parse(sourceCode, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    })
+    const extractedExports = await extractExports(
+      ast,
+      t,
+      traverse,
+      generate,
+      prettierConfig,
+      {
+        docsRoot,
+        docsBaseRoot,
+        filePath,
+        loadExportsForPath,
+        skipFormat,
+      }
+    )
+
+    for (const [name, entry] of Array.from(extractedExports.entries())) {
+      exportsMap.set(name, entry)
+    }
+
+    return exportsMap
+  }
 
   for (const [source, names] of Array.from(importsByFile.entries())) {
     const resolvedPath = resolveImportPath({
@@ -2369,24 +2595,7 @@ async function collectComponentCode({
       continue
     }
 
-    let fileCode = parsedFiles.get(resolvedPath)
-
-    if (!fileCode) {
-      const sourceCode = await fs.readFile(resolvedPath, 'utf-8')
-      const ast = parser.parse(sourceCode, {
-        sourceType: 'module',
-        plugins: ['typescript', 'jsx'],
-      })
-      fileCode = await extractExports(
-        ast,
-        t,
-        traverse,
-        generate,
-        prettierConfig,
-        skipFormat
-      )
-      parsedFiles.set(resolvedPath, fileCode)
-    }
+    const fileCode = await loadExportsForPath(resolvedPath)
 
     for (const name of names) {
       if (name.startsWith('* as ')) {
@@ -2397,17 +2606,20 @@ async function collectComponentCode({
             fileCode.entries()
           )) {
             componentCode.set(`${ns}.${exportName}`, {
-              code: exportCode,
+              ...exportCode,
               format: 'tsx',
             })
           }
         }
         continue
       }
-      const code = fileCode.get(name)
+      const entry = fileCode.get(name)
 
-      if (code) {
-        componentCode.set(name, { code, format: 'tsx' })
+      if (entry) {
+        componentCode.set(name, {
+          ...entry,
+          format: 'tsx',
+        })
       }
     }
   }
@@ -2469,6 +2681,16 @@ function resolveWithExtension(basePath: string) {
     return basePath
   }
 
+  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
+    for (const ext of extensions) {
+      const indexPath = path.join(basePath, `index${ext}`)
+
+      if (fs.existsSync(indexPath)) {
+        return indexPath
+      }
+    }
+  }
+
   for (const ext of extensions) {
     const withExt = `${basePath}${ext}`
 
@@ -2482,17 +2704,74 @@ function resolveWithExtension(basePath: string) {
 
 async function extractExports(
   ast: File,
-  t: any,
-  traverse: any,
-  generate: any,
+  t: BabelTypes,
+  traverse: BabelTraverse,
+  generate: BabelGenerate,
   prettierConfig: PrettierConfig,
-  skipFormat = false
+  {
+    docsRoot,
+    docsBaseRoot,
+    filePath,
+    loadExportsForPath,
+    skipFormat = false,
+  }: {
+    docsRoot: string
+    docsBaseRoot: string
+    filePath: string
+    loadExportsForPath: (
+      filePath: string
+    ) => Promise<Map<string, ComponentEntry>>
+    skipFormat?: boolean
+  }
 ) {
-  const exportsMap = new Map<string, string>()
-  const exportEntries: Array<{ name: string; jsxNode: any }> = []
+  const exportsMap = new Map<string, ComponentEntry>()
+  const exportEntries: Array<{
+    name: string
+    jsxNode: JSXRenderableNode
+    propsIdentifier?: string
+  }> = []
+  const importedBindings = new Map<
+    string,
+    {
+      importedName: string
+      source: string
+    }
+  >()
+  const reExportEntries: Array<{
+    exportName: string
+    localName: string
+    source: string
+  }> = []
 
   traverse(ast, {
-    ExportNamedDeclaration(path: any) {
+    ImportDeclaration(path: NodePath<ImportDeclaration>) {
+      const source = path.node.source.value
+
+      if (typeof source !== 'string') {
+        return
+      }
+
+      for (const specifier of path.node.specifiers) {
+        if (specifier.type === 'ImportSpecifier') {
+          const imported = specifier.imported
+          const importedName = t.isIdentifier(imported)
+            ? imported.name
+            : imported.value
+
+          importedBindings.set(specifier.local.name, {
+            importedName,
+            source,
+          })
+        } else if (specifier.type === 'ImportDefaultSpecifier') {
+          importedBindings.set(specifier.local.name, {
+            importedName: 'default',
+            source,
+          })
+        }
+      }
+    },
+
+    ExportNamedDeclaration(path: NodePath<ExportNamedDeclaration>) {
       const declaration = path.node.declaration
 
       if (t.isVariableDeclaration(declaration)) {
@@ -2503,17 +2782,57 @@ async function extractExports(
           const name = declarator.id.name
           const init = declarator.init
           const jsxNode = getReturnedJSX(init, t)
+          const propsIdentifier = getTopLevelPropsIdentifier(init, t)
 
           if (jsxNode) {
-            exportEntries.push({ name, jsxNode })
+            exportEntries.push({ name, jsxNode, propsIdentifier })
+            continue
+          }
+
+          if (t.isIdentifier(init)) {
+            const importedBinding = importedBindings.get(init.name)
+
+            if (importedBinding) {
+              reExportEntries.push({
+                exportName: name,
+                localName: importedBinding.importedName,
+                source: importedBinding.source,
+              })
+            }
           }
         }
       } else if (t.isFunctionDeclaration(declaration)) {
         const name = declaration.id?.name
         const jsxNode = getReturnedJSX(declaration, t)
+        const propsIdentifier = getTopLevelPropsIdentifier(declaration, t)
 
         if (name && jsxNode) {
-          exportEntries.push({ name, jsxNode })
+          exportEntries.push({ name, jsxNode, propsIdentifier })
+        }
+      } else if (
+        typeof path.node.source?.value === 'string' &&
+        path.node.specifiers.length > 0
+      ) {
+        for (const specifier of path.node.specifiers) {
+          if (
+            !('local' in specifier) ||
+            !('exported' in specifier) ||
+            !t.isIdentifier(specifier.local)
+          ) {
+            continue
+          }
+
+          const exported = specifier.exported
+
+          if (!t.isIdentifier(exported)) {
+            continue
+          }
+
+          reExportEntries.push({
+            exportName: exported.name,
+            localName: specifier.local.name,
+            source: path.node.source.value,
+          })
         }
       }
     },
@@ -2529,14 +2848,61 @@ async function extractExports(
     )
 
     if (code) {
-      exportsMap.set(entry.name, code)
+      exportsMap.set(entry.name, {
+        code,
+        format: 'tsx',
+        propsIdentifier: entry.propsIdentifier,
+      })
+    }
+  }
+
+  for (const entry of reExportEntries) {
+    const resolvedPath = resolveImportPath({
+      source: entry.source,
+      inputDir: path.dirname(filePath),
+      docsRoot,
+      docsBaseRoot,
+    })
+
+    if (!resolvedPath || !/\.[jt]sx?$/.test(resolvedPath)) {
+      continue
+    }
+
+    const reExportedCode = await loadExportsForPath(resolvedPath)
+    const reExportedEntry = reExportedCode.get(entry.localName)
+
+    if (reExportedEntry) {
+      exportsMap.set(entry.exportName, reExportedEntry)
     }
   }
 
   return exportsMap
 }
 
-function getReturnedJSX(fnNode: any, t: any) {
+function getTopLevelPropsIdentifier(
+  fnNode: JSXReturnableNode,
+  t: BabelTypes
+) {
+  if (
+    (t.isArrowFunctionExpression(fnNode) ||
+      t.isFunctionDeclaration(fnNode) ||
+      t.isFunctionExpression(fnNode)) &&
+    fnNode.params.length > 0
+  ) {
+    const firstParam = fnNode.params[0]
+
+    if (t.isIdentifier(firstParam)) {
+      return firstParam.name
+    }
+  }
+
+  return undefined
+}
+
+function getReturnedJSX(
+  fnNode: JSXReturnableNode,
+  t: BabelTypes
+): JSXRenderableNode | null {
   if (!fnNode) {
     return null
   }
@@ -2547,8 +2913,10 @@ function getReturnedJSX(fnNode: any, t: any) {
     }
 
     if (t.isBlockStatement(fnNode.body)) {
-      const returnStmt = fnNode.body.body.find((node: any) =>
-        t.isReturnStatement(node)
+      const returnStmt = fnNode.body.body.find(
+        (node: Statement): node is ReturnStatement => {
+          return t.isReturnStatement(node)
+        }
       )
       const arg = returnStmt?.argument
 
@@ -2559,8 +2927,10 @@ function getReturnedJSX(fnNode: any, t: any) {
   }
 
   if (t.isFunctionDeclaration(fnNode) || t.isFunctionExpression(fnNode)) {
-    const returnStmt = fnNode.body.body.find((node: any) =>
-      t.isReturnStatement(node)
+    const returnStmt = fnNode.body.body.find(
+      (node: Statement): node is ReturnStatement => {
+        return t.isReturnStatement(node)
+      }
     )
     const arg = returnStmt?.argument
 
@@ -2573,13 +2943,13 @@ function getReturnedJSX(fnNode: any, t: any) {
 }
 
 async function formatJSXChildren(
-  jsxNode: any,
-  t: any,
-  generate: any,
+  jsxNode: JSXRenderableNode,
+  t: BabelTypes,
+  generate: BabelGenerate,
   prettierConfig: PrettierConfig,
   skipFormat = false
 ) {
-  let children: any[] = []
+  let children: Array<JSXElement['children'][number]> = []
 
   if (t.isJSXElement(jsxNode)) {
     const name = jsxNode.openingElement.name
@@ -2632,9 +3002,9 @@ async function formatJSXChildren(
             childCode = statements
               .slice(0, -1)
               .concat(renderCall)
-              .map((stmt: any) => generate(stmt).code)
+              .map((stmt) => generate(stmt).code)
           } else {
-            childCode = statements.map((stmt: any) => generate(stmt).code)
+            childCode = statements.map((stmt) => generate(stmt).code)
           }
         } else if (t.isJSXElement(body) || t.isJSXFragment(body)) {
           childCode = [generate(body).code]
@@ -2695,191 +3065,367 @@ function stripWrapperTags(content: string, tagNames: string[]) {
   return output
 }
 
-type IconMetadataEntry = {
-  name?: string
-  tags?: string[]
-  created?: number
-  variant?: string
-  category?: string
+function removeSelfClosingComponents(content: string, tagNames: string[]) {
+  let output = content
+
+  for (const tag of tagNames) {
+    const tagPattern = new RegExp(`<${tag}\\b[^>]*\\/>\\s*`, 'g')
+    output = output.replace(tagPattern, '')
+  }
+
+  return output
 }
 
-let cachedIconMetadata: Array<
-  Required<Pick<IconMetadataEntry, 'name' | 'tags' | 'created'>> &
-    Pick<IconMetadataEntry, 'variant' | 'category'>
-> | null = null
+function stripStandaloneBreakTags(content: string) {
+  return content
+    .split('\n')
+    .filter((line) => !/^\s*<br\s*\/?\s*>\s*$/i.test(line))
+    .join('\n')
+}
 
-async function replaceListAllIcons(content: string) {
-  const regex = /<ListAllIcons\b([^>]*)\/>/g
+function stripDataVisualTestWrappers(content: string) {
+  const lines = content.split('\n')
+  const output: string[] = []
+  let wrapperDepth = 0
 
-  if (!regex.test(content)) {
-    return content
-  }
-
-  regex.lastIndex = 0
-  const icons = await loadListAllIconsMetadata()
-
-  if (icons.length === 0) {
-    return content
-  }
-
-  return content.replace(regex, (_match, attrsSource) => {
-    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
-    const variant = attrs.variant
-    const groupBy = attrs.groupBy
-    const filteredIcons = icons.filter((icon) => {
-      return !variant || icon.variant === variant
-    })
-
-    if (filteredIcons.length === 0) {
-      return ''
+  for (const line of lines) {
+    if (/<div\b[^>]*data-visual-test=/.test(line)) {
+      wrapperDepth += 1
+      continue
     }
 
-    return `\n${renderIconsMarkdown(filteredIcons, groupBy)}\n`
-  })
-}
-
-async function loadListAllIconsMetadata() {
-  if (cachedIconMetadata) {
-    return cachedIconMetadata
-  }
-
-  const eufemiaRoot = findPackageRoot('@dnb/eufemia')
-
-  if (!eufemiaRoot) {
-    return []
-  }
-
-  const metadataPath = path.join(
-    eufemiaRoot,
-    'src',
-    'icons',
-    'dnb',
-    'icons-meta.json'
-  )
-
-  try {
-    const raw = await fs.readFile(metadataPath, 'utf-8')
-    const metadata = JSON.parse(raw) as Record<string, IconMetadataEntry>
-
-    cachedIconMetadata = Object.entries(metadata)
-      .filter(([iconKey, icon]) => {
-        return !iconKey.endsWith('_medium') && Boolean(icon?.name)
-      })
-      .map(([_iconKey, icon]) => {
-        return {
-          name: String(icon.name),
-          tags: Array.isArray(icon.tags) ? icon.tags : [],
-          created: Number(icon.created || 0),
-          variant: icon.variant,
-          category: icon.category,
-        }
-      })
-      .sort((a, b) => a.created - b.created)
-
-    return cachedIconMetadata
-  } catch {
-    return []
-  }
-}
-
-function parseSimpleJsxStringAttributes(source: string) {
-  const attrs: Record<string, string> = {}
-  const regex = /([A-Za-z0-9_-]+)\s*=\s*(["'])(.*?)\2/g
-  let match: RegExpExecArray | null
-
-  while ((match = regex.exec(source))) {
-    const [, name, , value] = match
-
-    if (name) {
-      attrs[name] = value || ''
-    }
-  }
-
-  return attrs
-}
-
-function renderIconsMarkdown(
-  icons: Array<{
-    name: string
-    tags: string[]
-    created: number
-    variant?: string
-    category?: string
-  }>,
-  groupBy?: string
-) {
-  if (groupBy === 'category') {
-    const groups = new Map<string, typeof icons>()
-
-    for (const icon of icons) {
-      const key = icon.category || 'uncategorized'
-      const existing = groups.get(key) || []
-      existing.push(icon)
-      groups.set(key, existing)
+    if (wrapperDepth > 0 && line.trim() === '</div>') {
+      wrapperDepth -= 1
+      continue
     }
 
-    return Array.from(groups.entries())
-      .map(([category, groupedIcons]) => {
-        const heading = toPascalCase(category.replace(/[-_]/g, ' '))
-        const lines = groupedIcons.map((icon) => {
-          return renderIconMarkdownLine(icon, false)
-        })
-
-        return [`## ${heading}`, '', ...lines].join('\n')
-      })
-      .join('\n\n')
+    output.push(line)
   }
 
-  return icons.map((icon) => renderIconMarkdownLine(icon, true)).join('\n')
-}
-
-function renderIconMarkdownLine(
-  icon: {
-    name: string
-    tags: string[]
-    category?: string
-  },
-  includeCategory: boolean
-) {
-  const parts = [`- \`${icon.name}\``]
-
-  if (includeCategory && icon.category) {
-    parts.push(`Category: ${icon.category}.`)
-  }
-
-  if (icon.tags.length > 0) {
-    parts.push(`Tags: ${icon.tags.join(', ')}.`)
-  }
-
-  return parts.join(' ')
+  return output.join('\n')
 }
 
 function replaceComponentUsages(
   content: string,
   componentCode: Map<string, ComponentEntry | string>
 ) {
-  const componentRegex = /<([A-Z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*)\s*\/>/g
+  let output = ''
+  let index = 0
 
-  return content.replace(componentRegex, (match, name) => {
-    const entry = componentCode.get(name)
+  while (index < content.length) {
+    const start = content.indexOf('<', index)
+
+    if (start === -1) {
+      output += content.slice(index)
+      break
+    }
+
+    output += content.slice(index, start)
+
+    const parsedTag = parseSelfClosingComponentTag(content, start)
+
+    if (!parsedTag || !isComponentReferenceName(parsedTag.name)) {
+      output += content[start]
+      index = start + 1
+      continue
+    }
+
+    const entry = componentCode.get(parsedTag.name)
 
     if (!entry) {
-      return match
+      output += parsedTag.raw
+      index = parsedTag.end
+      continue
     }
 
-    if (typeof entry === 'string') {
-      return `\n\`\`\`tsx\n${entry}\n\`\`\`\n`
+    output += formatComponentEntryReplacement(entry, parsedTag)
+    index = parsedTag.end
+  }
+
+  return output
+}
+
+function parseSelfClosingComponentTag(
+  content: string,
+  startIndex: number
+) {
+  const nameStart = startIndex + 1
+  let nameEnd = nameStart
+
+  while (nameEnd < content.length) {
+    const char = content[nameEnd]
+
+    if (
+      (char >= 'A' && char <= 'Z') ||
+      (char >= 'a' && char <= 'z') ||
+      (char >= '0' && char <= '9') ||
+      char === '_' ||
+      char === '.'
+    ) {
+      nameEnd += 1
+      continue
     }
 
-    if (entry.format === 'md') {
-      return `\n${entry.code}\n`
+    break
+  }
+
+  if (nameEnd === nameStart) {
+    return null
+  }
+
+  let cursor = nameEnd
+  let quote = ''
+  let braceDepth = 0
+  let bracketDepth = 0
+  let parenDepth = 0
+
+  while (cursor < content.length) {
+    const char = content[cursor]
+
+    if (quote) {
+      if (char === '\\' && cursor + 1 < content.length) {
+        cursor += 2
+        continue
+      }
+
+      if (char === quote) {
+        quote = ''
+      }
+
+      cursor += 1
+      continue
     }
 
-    if (looksLikeMarkdown(entry.code)) {
-      return `\n${entry.code}\n`
+    if (char === '"' || char === "'") {
+      quote = char
+      cursor += 1
+      continue
     }
-    return `\n\`\`\`tsx\n${entry.code}\n\`\`\`\n`
-  })
+
+    if (char === '{') {
+      braceDepth += 1
+      cursor += 1
+      continue
+    }
+
+    if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1)
+      cursor += 1
+      continue
+    }
+
+    if (char === '[') {
+      bracketDepth += 1
+      cursor += 1
+      continue
+    }
+
+    if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1)
+      cursor += 1
+      continue
+    }
+
+    if (char === '(') {
+      parenDepth += 1
+      cursor += 1
+      continue
+    }
+
+    if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1)
+      cursor += 1
+      continue
+    }
+
+    if (char === '>') {
+      if (
+        braceDepth === 0 &&
+        bracketDepth === 0 &&
+        parenDepth === 0 &&
+        cursor > startIndex &&
+        content[cursor - 1] === '/'
+      ) {
+        const raw = content.slice(startIndex, cursor + 1)
+        return {
+          name: content.slice(nameStart, nameEnd),
+          raw,
+          attrsSource: raw.slice(1 + (nameEnd - nameStart), -2).trim(),
+          end: cursor + 1,
+        }
+      }
+
+      return null
+    }
+
+    if (
+      char === '<' &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      parenDepth === 0
+    ) {
+      return null
+    }
+
+    cursor += 1
+  }
+
+  return null
+}
+
+function formatComponentEntryReplacement(
+  entry: ComponentEntry | string,
+  parsedTag?: { attrsSource?: string }
+) {
+  if (typeof entry === 'string') {
+    return `\n\`\`\`tsx\n${entry}\n\`\`\`\n`
+  }
+
+  const code = injectComponentCallSiteProps(entry, parsedTag?.attrsSource)
+
+  if (entry.format === 'md') {
+    return `\n${code}\n`
+  }
+
+  if (looksLikeMarkdown(code)) {
+    return `\n${code}\n`
+  }
+
+  return `\n\`\`\`tsx\n${code}\n\`\`\`\n`
+}
+
+function injectComponentCallSiteProps(
+  entry: ComponentEntry,
+  attrsSource = ''
+) {
+  if (
+    entry.format !== 'tsx' ||
+    !entry.propsIdentifier ||
+    !containsIdentifier(entry.code, entry.propsIdentifier)
+  ) {
+    return entry.code
+  }
+
+  const propsObjectSource = buildCallSitePropsObjectSource(attrsSource)
+
+  return `const ${entry.propsIdentifier} = ${propsObjectSource}\n\n${entry.code}`
+}
+
+function containsIdentifier(code: string, identifier: string) {
+  return new RegExp(`\\b${escapeRegExp(identifier)}\\b`).test(code)
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function buildCallSitePropsObjectSource(attrsSource: string) {
+  const entries: string[] = []
+  let index = 0
+
+  while (index < attrsSource.length) {
+    index = skipWhitespace(attrsSource, index)
+
+    if (index >= attrsSource.length) {
+      break
+    }
+
+    let name = ''
+
+    while (
+      index < attrsSource.length &&
+      /[A-Za-z0-9_-]/.test(attrsSource[index])
+    ) {
+      name += attrsSource[index++]
+    }
+
+    if (!name) {
+      index += 1
+      continue
+    }
+
+    index = skipWhitespace(attrsSource, index)
+
+    const objectKey = formatObjectKey(name)
+
+    if (attrsSource[index] !== '=') {
+      entries.push(`${objectKey}: true`)
+      continue
+    }
+
+    index += 1
+    index = skipWhitespace(attrsSource, index)
+
+    if (attrsSource[index] === '{') {
+      const { value, nextIndex } = readBalancedExpression(
+        attrsSource,
+        index + 1,
+        '{',
+        '}'
+      )
+      const expressionValue = value.trim() || 'undefined'
+      entries.push(`${objectKey}: ${expressionValue}`)
+      index = nextIndex
+      continue
+    }
+
+    if (attrsSource[index] === '"' || attrsSource[index] === "'") {
+      const { value, nextIndex } = readString(attrsSource, index)
+      entries.push(`${objectKey}: ${JSON.stringify(value)}`)
+      index = nextIndex
+      continue
+    }
+
+    const value = readWord(attrsSource, index)
+    entries.push(`${objectKey}: ${JSON.stringify(value)}`)
+    index += value.length
+  }
+
+  return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
+}
+
+function formatObjectKey(name: string) {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)
+    ? name
+    : JSON.stringify(name)
+}
+
+function isComponentReferenceName(name: string) {
+  if (!name) {
+    return false
+  }
+
+  for (let index = 0; index < name.length; index++) {
+    const charCode = name.charCodeAt(index)
+    const isDot = charCode === 46
+    const isDigit = charCode >= 48 && charCode <= 57
+    const isUppercase = charCode >= 65 && charCode <= 90
+    const isUnderscore = charCode === 95
+    const isLowercase = charCode >= 97 && charCode <= 122
+
+    if (
+      !isDot &&
+      !isDigit &&
+      !isLowercase &&
+      !isUnderscore &&
+      !isUppercase
+    ) {
+      return false
+    }
+
+    if (isDot) {
+      if (
+        index === 0 ||
+        index === name.length - 1 ||
+        name.charCodeAt(index - 1) === 46
+      ) {
+        return false
+      }
+    }
+  }
+
+  const firstCharCode = name.charCodeAt(0)
+  return firstCharCode >= 65 && firstCharCode <= 90
 }
 
 function looksLikeMarkdown(code: string) {

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -2,12 +2,37 @@ import fs from 'fs-extra'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import crypto from 'crypto'
-import frontMatter from 'front-matter'
+import frontMatter, {
+  type FrontMatterOptions,
+  type FrontMatterResult,
+} from 'front-matter'
 import * as prettier from 'prettier'
 import { extractMarkdownTables } from 'markdown-tables-utils'
 import type { File } from '@babel/types'
 
-const fm = frontMatter as unknown as typeof import('front-matter').default
+type FrontMatterParser = {
+  <T>(file: string, options?: FrontMatterOptions): FrontMatterResult<T>
+  test(file: string): boolean
+}
+
+function resolveFrontMatterParser(module: unknown): FrontMatterParser {
+  if (typeof module === 'function') {
+    return module as FrontMatterParser
+  }
+
+  if (
+    module &&
+    typeof module === 'object' &&
+    'default' in module &&
+    typeof module.default === 'function'
+  ) {
+    return module.default as FrontMatterParser
+  }
+
+  throw new TypeError('Unable to resolve front-matter parser')
+}
+
+const fm = resolveFrontMatterParser(frontMatter)
 
 const DEFAULT_PUBLIC_URL =
   process.env.CF_PAGES_URL || 'https://eufemia.dnb.no'
@@ -35,7 +60,7 @@ export const LLM_DOCS_SLUG_PREFIX = 'uilib'
 export function getPortalPaths(store: any) {
   const { program } = store.getState()
   const siteDir = program.directory
-  const docsRoot = path.join(siteDir, 'src', 'docs', LLM_DOCS_SLUG_PREFIX)
+  const docsRoot = path.join(siteDir, 'src', 'docs')
   const metadataRoot = path.join(siteDir, 'public')
   return { siteDir, docsRoot, metadataRoot }
 }
@@ -139,6 +164,25 @@ export async function loadTsDocs(rel: string) {
   }
 
   return { tsDocsDir, props, events, related }
+}
+
+function createEmptyTsDocs(): Awaited<ReturnType<typeof loadTsDocs>> {
+  return {
+    tsDocsDir: null,
+    props: {},
+    events: {},
+    related: [],
+  }
+}
+
+export async function loadTsDocsForDocPath(rel: string) {
+  const uilibPrefix = `uilib${path.sep}`
+
+  if (!rel.startsWith(uilibPrefix)) {
+    return createEmptyTsDocs()
+  }
+
+  return loadTsDocs(rel.slice(uilibPrefix.length))
 }
 
 export function mergeDocs(
@@ -302,12 +346,17 @@ export function toWorkspacePath(abs: string, siteDir: string) {
   return path.relative(siteDir, abs)
 }
 
-export function toSlugAndDir(rel: string) {
+export function toSlugAndDir(
+  rel: string,
+  slugBase: string = LLM_DOCS_SLUG_PREFIX
+) {
   const noExt = rel.replace(/\.[^/.]+$/, '')
-  const slug = `/${path.posix.join(
-    LLM_DOCS_SLUG_PREFIX,
-    noExt.split(path.sep).join('/')
-  )}/`
+  const normalizedSlugBase = trimEdgeSlashes(slugBase)
+  const slugSegments = [
+    normalizedSlugBase,
+    noExt.split(path.sep).join('/'),
+  ].filter(Boolean)
+  const slug = `/${path.posix.join(...slugSegments)}/`
   const dirForExtras = path.posix.join(slug).replace(/^\//, '')
   return { slug, dirForExtras }
 }
@@ -317,8 +366,32 @@ export function joinSlug(slug: string, sub: string) {
 }
 
 function normalizePublicUrlBase(publicUrlBase: string) {
-  // Remove trailing slashes - use non-greedy quantifier to prevent ReDoS
-  return publicUrlBase.replace(/\/+?$/, '')
+  return trimTrailingSlashes(publicUrlBase)
+}
+
+function trimEdgeSlashes(value: string) {
+  let start = 0
+  let end = value.length
+
+  while (start < end && value.charCodeAt(start) === 47) {
+    start++
+  }
+
+  while (end > start && value.charCodeAt(end - 1) === 47) {
+    end--
+  }
+
+  return value.slice(start, end)
+}
+
+function trimTrailingSlashes(value: string) {
+  let end = value.length
+
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end--
+  }
+
+  return value.slice(0, end)
 }
 
 export function toPublicUrl(
@@ -940,7 +1013,7 @@ async function buildDocsInjectionPrelude(file: string, source: string) {
     }
     const src = node.source && node.source.value
 
-    if (!src || !/Docs(\.[tj]sx?)?$/i.test(src)) {
+    if (!src || !hasDocsModuleSuffix(src)) {
       continue
     }
     const names = node.specifiers
@@ -970,6 +1043,18 @@ async function buildDocsInjectionPrelude(file: string, source: string) {
     }
   }
   return prelude
+}
+
+function hasDocsModuleSuffix(source: string) {
+  const normalizedSource = source.toLowerCase()
+
+  return (
+    normalizedSource.endsWith('docs') ||
+    normalizedSource.endsWith('docs.ts') ||
+    normalizedSource.endsWith('docs.tsx') ||
+    normalizedSource.endsWith('docs.js') ||
+    normalizedSource.endsWith('docs.jsx')
+  )
 }
 
 async function resolveDocsModulePath(baseDir: string, modPath: string) {
@@ -1075,6 +1160,7 @@ export async function createMarkdownCopies({
   siteDir,
   docsRoot,
   outputRoot,
+  slugBase = LLM_DOCS_SLUG_PREFIX,
   publicUrlBase = DEFAULT_PUBLIC_URL,
   metadataBySlug,
   skipFormat = false,
@@ -1082,6 +1168,7 @@ export async function createMarkdownCopies({
   siteDir: string
   docsRoot: string
   outputRoot?: string
+  slugBase?: string
   publicUrlBase?: string
   skipFormat?: boolean
   metadataBySlug?: Map<
@@ -1112,7 +1199,7 @@ export async function createMarkdownCopies({
 
   for (const file of entryFiles) {
     const rel = path.relative(docsRoot, file)
-    const { slug } = toSlugAndDir(rel)
+    const { slug } = toSlugAndDir(rel, slugBase)
     const resolvedOutputRoot = outputRoot || path.join(siteDir, 'public')
     const mdOutputPath = path.join(
       resolvedOutputRoot,
@@ -1223,6 +1310,7 @@ export async function convertMdxToMd({
     'VisibilityByTheme',
     'VisibleWhenVisualTest',
   ])
+  outputBody = await replaceListAllIcons(outputBody)
   outputBody = replaceComponentUsages(outputBody, componentCode)
 
   const links = frontmatterLinks || {}
@@ -2341,7 +2429,7 @@ function resolveImportPath({
   let candidate: string | null = null
 
   if (source.startsWith('Docs/')) {
-    candidate = path.join(docsBaseRoot, source.replace(/^Docs\//, ''))
+    candidate = path.join(docsRoot, source.replace(/^Docs\//, ''))
   } else if (source.startsWith('.')) {
     candidate = path.resolve(inputDir, source)
   } else {
@@ -2605,6 +2693,165 @@ function stripWrapperTags(content: string, tagNames: string[]) {
     output = output.replace(openTag, '').replace(closeTag, '')
   }
   return output
+}
+
+type IconMetadataEntry = {
+  name?: string
+  tags?: string[]
+  created?: number
+  variant?: string
+  category?: string
+}
+
+let cachedIconMetadata: Array<
+  Required<Pick<IconMetadataEntry, 'name' | 'tags' | 'created'>> &
+    Pick<IconMetadataEntry, 'variant' | 'category'>
+> | null = null
+
+async function replaceListAllIcons(content: string) {
+  const regex = /<ListAllIcons\b([^>]*)\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const icons = await loadListAllIconsMetadata()
+
+  if (icons.length === 0) {
+    return content
+  }
+
+  return content.replace(regex, (_match, attrsSource) => {
+    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
+    const variant = attrs.variant
+    const groupBy = attrs.groupBy
+    const filteredIcons = icons.filter((icon) => {
+      return !variant || icon.variant === variant
+    })
+
+    if (filteredIcons.length === 0) {
+      return ''
+    }
+
+    return `\n${renderIconsMarkdown(filteredIcons, groupBy)}\n`
+  })
+}
+
+async function loadListAllIconsMetadata() {
+  if (cachedIconMetadata) {
+    return cachedIconMetadata
+  }
+
+  const eufemiaRoot = findPackageRoot('@dnb/eufemia')
+
+  if (!eufemiaRoot) {
+    return []
+  }
+
+  const metadataPath = path.join(
+    eufemiaRoot,
+    'src',
+    'icons',
+    'dnb',
+    'icons-meta.json'
+  )
+
+  try {
+    const raw = await fs.readFile(metadataPath, 'utf-8')
+    const metadata = JSON.parse(raw) as Record<string, IconMetadataEntry>
+
+    cachedIconMetadata = Object.entries(metadata)
+      .filter(([iconKey, icon]) => {
+        return !iconKey.endsWith('_medium') && Boolean(icon?.name)
+      })
+      .map(([_iconKey, icon]) => {
+        return {
+          name: String(icon.name),
+          tags: Array.isArray(icon.tags) ? icon.tags : [],
+          created: Number(icon.created || 0),
+          variant: icon.variant,
+          category: icon.category,
+        }
+      })
+      .sort((a, b) => a.created - b.created)
+
+    return cachedIconMetadata
+  } catch {
+    return []
+  }
+}
+
+function parseSimpleJsxStringAttributes(source: string) {
+  const attrs: Record<string, string> = {}
+  const regex = /([A-Za-z0-9_-]+)\s*=\s*(["'])(.*?)\2/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(source))) {
+    const [, name, , value] = match
+
+    if (name) {
+      attrs[name] = value || ''
+    }
+  }
+
+  return attrs
+}
+
+function renderIconsMarkdown(
+  icons: Array<{
+    name: string
+    tags: string[]
+    created: number
+    variant?: string
+    category?: string
+  }>,
+  groupBy?: string
+) {
+  if (groupBy === 'category') {
+    const groups = new Map<string, typeof icons>()
+
+    for (const icon of icons) {
+      const key = icon.category || 'uncategorized'
+      const existing = groups.get(key) || []
+      existing.push(icon)
+      groups.set(key, existing)
+    }
+
+    return Array.from(groups.entries())
+      .map(([category, groupedIcons]) => {
+        const heading = toPascalCase(category.replace(/[-_]/g, ' '))
+        const lines = groupedIcons.map((icon) => {
+          return renderIconMarkdownLine(icon, false)
+        })
+
+        return [`## ${heading}`, '', ...lines].join('\n')
+      })
+      .join('\n\n')
+  }
+
+  return icons.map((icon) => renderIconMarkdownLine(icon, true)).join('\n')
+}
+
+function renderIconMarkdownLine(
+  icon: {
+    name: string
+    tags: string[]
+    category?: string
+  },
+  includeCategory: boolean
+) {
+  const parts = [`- \`${icon.name}\``]
+
+  if (includeCategory && icon.category) {
+    parts.push(`Category: ${icon.category}.`)
+  }
+
+  if (icon.tags.length > 0) {
+    parts.push(`Tags: ${icon.tags.join(', ')}.`)
+  }
+
+  return parts.join(' ')
 }
 
 function replaceComponentUsages(

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/availableCountriesTable.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/availableCountriesTable.ts
@@ -1,0 +1,110 @@
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import { escapeMarkdownTableCell } from './utils.ts'
+
+type AvailableCountryEntry = {
+  iso: string
+  i18n: Record<string, string>
+}
+
+let cachedAvailableCountries: AvailableCountryEntry[] | null = null
+
+export function createAvailableCountriesTableExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'AvailableCountriesTable',
+    replace: (content) => replaceAvailableCountriesTables(content, deps),
+  }
+}
+
+async function replaceAvailableCountriesTables(
+  content: string,
+  deps: SpecialMdxRendererDeps
+) {
+  const regex = /<AvailableCountriesTable\b[^>]*\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const countries = await loadAvailableCountries(deps)
+
+  if (countries.length === 0) {
+    return content
+  }
+
+  return content.replace(regex, () => {
+    return `\n${renderAvailableCountriesMarkdown(countries)}\n`
+  })
+}
+
+async function loadAvailableCountries(deps: SpecialMdxRendererDeps) {
+  if (cachedAvailableCountries) {
+    return cachedAvailableCountries
+  }
+
+  const countries = await deps.loadModuleDefault(
+    '@dnb/eufemia/src/extensions/forms/constants/countries'
+  )
+
+  if (!Array.isArray(countries)) {
+    return []
+  }
+
+  cachedAvailableCountries = countries
+    .filter((country): country is AvailableCountryEntry => {
+      return Boolean(
+        country &&
+        typeof country === 'object' &&
+        typeof country.iso === 'string' &&
+        country.i18n &&
+        typeof country.i18n === 'object'
+      )
+    })
+    .map((country) => {
+      return {
+        iso: country.iso,
+        i18n: Object.fromEntries(
+          Object.entries(country.i18n).filter(([, value]) => {
+            return typeof value === 'string'
+          })
+        ),
+      }
+    })
+
+  return cachedAvailableCountries
+}
+
+function renderAvailableCountriesMarkdown(
+  countries: AvailableCountryEntry[]
+) {
+  if (countries.length === 0) {
+    return 'No countries are available.'
+  }
+
+  const locales = Object.keys(countries[0].i18n)
+  const header = ['ISO 3166-1 alpha-2 code', ...locales].map(
+    escapeMarkdownTableCell
+  )
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `| ${header.map(() => '---').join(' | ')} |`,
+  ]
+
+  for (const country of countries) {
+    const row = [
+      `\`${country.iso}\``,
+      ...locales.map((locale) => {
+        return escapeMarkdownTableCell(country.i18n[locale] || '')
+      }),
+    ]
+
+    lines.push(`| ${row.join(' | ')} |`)
+  }
+
+  return lines.join('\n')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/cardProductsTable.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/cardProductsTable.ts
@@ -1,0 +1,480 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type {
+  ArgumentPlaceholder,
+  Expression,
+  MemberExpression,
+  ObjectExpression,
+  ObjectProperty,
+  SpreadElement,
+} from '@babel/types'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import { escapeMarkdownTableCell } from './utils.ts'
+
+type CardProductDesignVariant = {
+  tag?: string
+  color?: string
+}
+
+type CardProductEntry = {
+  productCode: string
+  productName: string
+  displayName: string
+  cardDesign: {
+    name?: string
+    bankLogo?: CardProductDesignVariant
+    visa?: CardProductDesignVariant
+    mastercard?: CardProductDesignVariant
+    saga?: CardProductDesignVariant
+    privateBanking?: CardProductDesignVariant
+  }
+  productType: {
+    tag?: string
+  }
+  cardType: {
+    tag?: string
+  }
+}
+
+let cachedCardProducts: CardProductEntry[] | null = null
+
+export function createCardProductsTableExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'CardProductsTable',
+    replace: (content) => replaceCardProductsTables(content, deps),
+  }
+}
+
+async function replaceCardProductsTables(
+  content: string,
+  deps: SpecialMdxRendererDeps
+) {
+  const regex = /<CardProductsTable\b[^>]*\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const cardProducts = await loadCardProducts(deps)
+
+  if (cardProducts.length === 0) {
+    return content
+  }
+
+  return content.replace(regex, () => {
+    return `\n${renderCardProductsMarkdown(cardProducts)}\n`
+  })
+}
+
+async function loadCardProducts(deps: SpecialMdxRendererDeps) {
+  if (cachedCardProducts) {
+    return cachedCardProducts
+  }
+
+  const eufemiaRoot = deps.findPackageRoot('@dnb/eufemia')
+
+  if (!eufemiaRoot) {
+    return []
+  }
+
+  const cardProductsPath = path.join(
+    eufemiaRoot,
+    'src/extensions/payment-card/utils/cardProducts.ts'
+  )
+  const cardDesignsPath = path.join(
+    eufemiaRoot,
+    'src/extensions/payment-card/utils/CardDesigns.ts'
+  )
+  const properties = await deps.loadModuleDefault(
+    '@dnb/eufemia/src/style/themes/ui/properties'
+  )
+
+  const designsByIdentifier = await loadCardProductDesigns({
+    cardDesignsPath,
+    properties:
+      properties && typeof properties === 'object'
+        ? (properties as Record<string, string>)
+        : {},
+  })
+
+  cachedCardProducts = await parseCardProductsSource({
+    cardProductsPath,
+    designsByIdentifier,
+  })
+
+  return cachedCardProducts
+}
+
+async function loadCardProductDesigns({
+  cardDesignsPath,
+  properties,
+}: {
+  cardDesignsPath: string
+  properties: Record<string, string>
+}) {
+  const parser = await import('@babel/parser')
+  const source = await fs.readFile(cardDesignsPath, 'utf-8')
+  const ast = parser.parse(source, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  })
+  const designs: Record<string, CardProductEntry['cardDesign']> = {}
+
+  for (const node of ast.program.body) {
+    if (node.type !== 'VariableDeclaration') {
+      continue
+    }
+
+    for (const declaration of node.declarations) {
+      if (
+        declaration.id.type !== 'Identifier' ||
+        declaration.init?.type !== 'ObjectExpression'
+      ) {
+        continue
+      }
+
+      const design = extractCardProductDesign(declaration.init, properties)
+
+      if (design.name) {
+        designs[declaration.id.name] = design
+      }
+    }
+  }
+
+  return designs
+}
+
+function extractCardProductDesign(
+  node: ObjectExpression,
+  properties: Record<string, string>
+) {
+  return {
+    name: readObjectStringProperty(node, 'name') || undefined,
+    bankLogo: readCardProductDesignVariant(node, 'bankLogo', properties),
+    visa: readCardProductDesignVariant(node, 'visa', properties),
+    mastercard: readCardProductDesignVariant(
+      node,
+      'mastercard',
+      properties
+    ),
+    saga: readCardProductDesignVariant(node, 'saga', properties),
+    privateBanking: readCardProductDesignVariant(
+      node,
+      'privateBanking',
+      properties
+    ),
+  }
+}
+
+function readCardProductDesignVariant(
+  node: ObjectExpression,
+  key: string,
+  properties: Record<string, string>
+) {
+  const property = getObjectProperty(node, key)
+
+  if (!property) {
+    return undefined
+  }
+
+  if (property.value.type === 'MemberExpression') {
+    return {
+      tag: readMemberExpressionPropertyName(property.value),
+    }
+  }
+
+  if (property.value.type === 'CallExpression') {
+    const callee = property.value.callee
+
+    if (callee.type !== 'MemberExpression') {
+      return undefined
+    }
+
+    const firstArgument = property.value.arguments[0]
+
+    return {
+      tag: readMemberExpressionPropertyName(callee),
+      color: readExpressionStringValue(firstArgument, properties),
+    }
+  }
+
+  return undefined
+}
+
+async function parseCardProductsSource({
+  cardProductsPath,
+  designsByIdentifier,
+}: {
+  cardProductsPath: string
+  designsByIdentifier: Record<string, CardProductEntry['cardDesign']>
+}) {
+  const parser = await import('@babel/parser')
+  const source = await fs.readFile(cardProductsPath, 'utf-8')
+  const ast = parser.parse(source, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  })
+  const rows: CardProductEntry[] = []
+
+  for (const node of ast.program.body) {
+    if (node.type !== 'VariableDeclaration') {
+      continue
+    }
+
+    for (const declaration of node.declarations) {
+      if (
+        declaration.id.type !== 'Identifier' ||
+        declaration.id.name !== 'cardData' ||
+        declaration.init?.type !== 'ArrayExpression'
+      ) {
+        continue
+      }
+
+      for (const element of declaration.init.elements) {
+        if (!element || element.type !== 'ObjectExpression') {
+          continue
+        }
+
+        const row = extractCardProductRow(element, designsByIdentifier)
+
+        if (row) {
+          rows.push(row)
+        }
+      }
+    }
+  }
+
+  return rows
+}
+
+function extractCardProductRow(
+  node: ObjectExpression,
+  designsByIdentifier: Record<string, CardProductEntry['cardDesign']>
+) {
+  const productCode = readObjectStringProperty(node, 'productCode')
+  const productName = readObjectStringProperty(node, 'productName')
+  const displayName = readObjectStringProperty(node, 'displayName')
+  const cardDesignIdentifier = readObjectIdentifierProperty(
+    node,
+    'cardDesign'
+  )
+  const productTypeTag = readObjectMemberPropertyTag(node, 'productType')
+  const cardTypeTag = readObjectMemberPropertyTag(node, 'cardType')
+
+  if (
+    !productCode ||
+    !productName ||
+    !displayName ||
+    !cardDesignIdentifier ||
+    !productTypeTag ||
+    !cardTypeTag
+  ) {
+    return null
+  }
+
+  return {
+    productCode,
+    productName,
+    displayName,
+    cardDesign: designsByIdentifier[cardDesignIdentifier] || {},
+    productType: { tag: productTypeTag },
+    cardType: { tag: cardTypeTag },
+  }
+}
+
+function getObjectProperty(
+  node: ObjectExpression,
+  key: string
+): ObjectProperty | undefined {
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      continue
+    }
+
+    if (property.key.type === 'Identifier') {
+      if (property.key.name === key) {
+        return property
+      }
+
+      continue
+    }
+
+    if (property.key.type === 'StringLiteral') {
+      if (property.key.value === key) {
+        return property
+      }
+    }
+
+    continue
+  }
+
+  return undefined
+}
+
+function readObjectStringProperty(node: ObjectExpression, key: string) {
+  const property = getObjectProperty(node, key)
+
+  if (!property || property.value.type !== 'StringLiteral') {
+    return null
+  }
+
+  return property.value.value
+}
+
+function readObjectIdentifierProperty(
+  node: ObjectExpression,
+  key: string
+) {
+  const property = getObjectProperty(node, key)
+
+  if (!property || property.value.type !== 'Identifier') {
+    return null
+  }
+
+  return property.value.name
+}
+
+function readObjectMemberPropertyTag(node: ObjectExpression, key: string) {
+  const property = getObjectProperty(node, key)
+
+  if (!property || property.value.type !== 'MemberExpression') {
+    return null
+  }
+
+  return readMemberExpressionPropertyName(property.value)
+}
+
+function readMemberExpressionPropertyName(node: MemberExpression) {
+  if (node.property.type === 'Identifier') {
+    return node.property.name
+  }
+
+  if (node.property.type === 'StringLiteral') {
+    return node.property.value
+  }
+
+  return undefined
+}
+
+function readExpressionStringValue(
+  node:
+    | ArgumentPlaceholder
+    | Expression
+    | SpreadElement
+    | null
+    | undefined,
+  properties: Record<string, string>
+) {
+  if (!node || typeof node !== 'object') {
+    return undefined
+  }
+
+  if (
+    node.type === 'ArgumentPlaceholder' ||
+    node.type === 'SpreadElement'
+  ) {
+    return undefined
+  }
+
+  if (node.type === 'StringLiteral') {
+    return node.value
+  }
+
+  if (node.type === 'MemberExpression') {
+    if (
+      node.object.type === 'Identifier' &&
+      node.object.name === 'properties' &&
+      node.computed &&
+      node.property.type === 'StringLiteral'
+    ) {
+      return properties[node.property.value] || node.property.value
+    }
+  }
+
+  return undefined
+}
+
+function renderCardProductsMarkdown(cardProducts: CardProductEntry[]) {
+  if (cardProducts.length === 0) {
+    return 'No card products are available.'
+  }
+
+  const lines = [
+    '| Product Id | Product name cards | Card name to show in app | Design | Bank Logo | Product Logo | Product Logo Variant | Type of Card | Type of Card Variant |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const card of cardProducts) {
+    lines.push(
+      `| ${[
+        card.productCode,
+        card.productName,
+        card.displayName,
+        card.cardDesign.name || '-',
+        getCardProductLogo(card.cardDesign.bankLogo),
+        getTagLabel(card.productType),
+        getCardProductVariant(card.productType, card.cardDesign),
+        getTagLabel(card.cardType),
+        getCardTypeVariant(card.cardType, card.cardDesign),
+      ]
+        .map((value) => escapeMarkdownTableCell(value))
+        .join(' | ')} |`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+function getTagLabel(value: { tag?: string } | undefined) {
+  if (!value?.tag || value.tag === 'None') {
+    return '-'
+  }
+
+  return value.tag
+}
+
+function getCardProductLogo(
+  bankLogo: CardProductDesignVariant | undefined
+) {
+  switch (bankLogo?.tag) {
+    case 'Colored':
+    case 'Sbanken':
+      return bankLogo.color || '-'
+    default:
+      return '-'
+  }
+}
+
+function getCardProductVariant(
+  type: { tag?: string },
+  design: CardProductEntry['cardDesign']
+) {
+  switch (type.tag) {
+    case 'Saga':
+      return getTagLabel(design.saga)
+    case 'PrivateBanking':
+      return getTagLabel(design.privateBanking)
+    default:
+      return '-'
+  }
+}
+
+function getCardTypeVariant(
+  type: { tag?: string },
+  design: CardProductEntry['cardDesign']
+) {
+  switch (type.tag) {
+    case 'Visa':
+      return getTagLabel(design.visa)
+    case 'Mastercard':
+      return getTagLabel(design.mastercard)
+    default:
+      return '-'
+  }
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/colorTable.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/colorTable.ts
@@ -1,0 +1,316 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type { ObjectExpression, ObjectProperty } from '@babel/types'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import {
+  escapeMarkdownTableCell,
+  parseSimpleJsxStringAttributes,
+  toRgbString,
+} from './utils.ts'
+
+type ColorTableRow = {
+  name: string
+  type: string
+  brandName: string
+  figmaName: string
+}
+
+type ColorTableThemeData = {
+  data: ColorTableRow[]
+  properties: Record<string, string>
+}
+
+let cachedColorTableThemes: Record<string, ColorTableThemeData> | null =
+  null
+
+export function createColorTableExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'ColorTable',
+    replace: (content) => replaceColorTables(content, deps),
+  }
+}
+
+async function replaceColorTables(
+  content: string,
+  deps: SpecialMdxRendererDeps
+) {
+  const regex = /<ColorTable\b([^>]*)\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const themes = await loadColorTableThemes(deps)
+
+  if (Object.keys(themes).length === 0) {
+    return content
+  }
+
+  return content.replace(regex, (_match, attrsSource) => {
+    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
+    const theme = attrs.theme
+
+    if (!theme || !themes[theme]) {
+      return ''
+    }
+
+    return `\n${renderColorTableMarkdown(themes[theme])}\n`
+  })
+}
+
+async function loadColorTableThemes(deps: SpecialMdxRendererDeps) {
+  if (cachedColorTableThemes) {
+    return cachedColorTableThemes
+  }
+
+  const portalRoot = deps.findPackageRoot('dnb-design-system-portal')
+
+  if (!portalRoot) {
+    return {}
+  }
+
+  const colorTablePath = path.join(
+    portalRoot,
+    'src/docs/quickguide-designer/colors/ColorTable.tsx'
+  )
+  const { rowsByTheme, propertyModulePaths } =
+    await loadColorTableSourceData(colorTablePath)
+
+  if (Object.keys(rowsByTheme).length === 0) {
+    return {}
+  }
+
+  const propertiesByTheme: Record<string, Record<string, string>> = {}
+
+  for (const [theme, modulePath] of Object.entries(propertyModulePaths)) {
+    const properties = await deps.loadModuleDefault(modulePath)
+
+    if (properties && typeof properties === 'object') {
+      propertiesByTheme[theme] = properties as Record<string, string>
+    }
+  }
+
+  cachedColorTableThemes = Object.fromEntries(
+    Object.entries(rowsByTheme)
+      .filter(([theme]) => Boolean(propertiesByTheme[theme]))
+      .map(([theme, data]) => {
+        return [theme, { data, properties: propertiesByTheme[theme] }]
+      })
+  )
+
+  return cachedColorTableThemes
+}
+
+async function loadColorTableSourceData(colorTablePath: string) {
+  const parser = await import('@babel/parser')
+  const source = await fs.readFile(colorTablePath, 'utf-8')
+  const ast = parser.parse(source, {
+    sourceType: 'module',
+    plugins: ['typescript', 'jsx'],
+  })
+  const rowsByTheme: Record<string, ColorTableRow[]> = {}
+  const importSources: Record<string, string> = {}
+  let propertyModulePaths: Record<string, string> = {}
+
+  for (const node of ast.program.body) {
+    if (node.type === 'ImportDeclaration') {
+      const defaultSpecifier = node.specifiers.find((specifier) => {
+        return specifier.type === 'ImportDefaultSpecifier'
+      })
+
+      if (
+        defaultSpecifier?.type === 'ImportDefaultSpecifier' &&
+        typeof node.source.value === 'string' &&
+        node.source.value.startsWith('@dnb/eufemia/')
+      ) {
+        importSources[defaultSpecifier.local.name] = node.source.value
+      }
+
+      continue
+    }
+
+    if (node.type !== 'VariableDeclaration') {
+      continue
+    }
+
+    for (const declaration of node.declarations) {
+      if (declaration.id.type !== 'Identifier') {
+        continue
+      }
+
+      const name = declaration.id.name
+
+      if (
+        name === 'themes' &&
+        declaration.init?.type === 'ObjectExpression'
+      ) {
+        propertyModulePaths = extractThemePropertyModulePaths(
+          declaration.init,
+          importSources
+        )
+        continue
+      }
+
+      if (!/^data[A-Z]/.test(name)) {
+        continue
+      }
+
+      if (declaration.init?.type !== 'ArrayExpression') {
+        continue
+      }
+
+      const theme = name.replace(/^data/, '').toLowerCase()
+      const rows: ColorTableRow[] = []
+
+      for (const element of declaration.init.elements) {
+        if (!element || element.type !== 'ObjectExpression') {
+          continue
+        }
+
+        const row = extractColorTableRow(element)
+
+        if (row) {
+          rows.push(row)
+        }
+      }
+
+      if (rows.length > 0) {
+        rowsByTheme[theme] = rows
+      }
+    }
+  }
+
+  return { rowsByTheme, propertyModulePaths }
+}
+
+function extractThemePropertyModulePaths(
+  node: ObjectExpression,
+  importSources: Record<string, string>
+) {
+  const modulePaths: Record<string, string> = {}
+
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      continue
+    }
+
+    const themeName = readObjectPropertyKey(property)
+
+    if (!themeName || property.value.type !== 'ObjectExpression') {
+      continue
+    }
+
+    const propertiesIdentifier = readNestedIdentifierProperty(
+      property.value,
+      'properties'
+    )
+
+    if (!propertiesIdentifier || !importSources[propertiesIdentifier]) {
+      continue
+    }
+
+    modulePaths[themeName] = importSources[propertiesIdentifier]
+  }
+
+  return modulePaths
+}
+
+function readNestedIdentifierProperty(
+  node: ObjectExpression,
+  propertyName: string
+) {
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      continue
+    }
+
+    if (readObjectPropertyKey(property) !== propertyName) {
+      continue
+    }
+
+    return property.value.type === 'Identifier'
+      ? property.value.name
+      : null
+  }
+
+  return null
+}
+
+function readObjectPropertyKey(property: ObjectProperty) {
+  return property.key.type === 'Identifier'
+    ? property.key.name
+    : property.key.type === 'StringLiteral'
+      ? property.key.value
+      : null
+}
+
+function extractColorTableRow(
+  node: ObjectExpression
+): ColorTableRow | null {
+  const row: Partial<ColorTableRow> = {}
+
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      continue
+    }
+
+    const key = readObjectPropertyKey(property)
+
+    if (!key || property.value.type !== 'StringLiteral') {
+      continue
+    }
+
+    if (
+      key === 'name' ||
+      key === 'type' ||
+      key === 'brandName' ||
+      key === 'figmaName'
+    ) {
+      row[key] = property.value.value
+    }
+  }
+
+  if (row.name && row.type && row.brandName && row.figmaName) {
+    return row as ColorTableRow
+  }
+
+  return null
+}
+
+function renderColorTableMarkdown(themeData: ColorTableThemeData) {
+  const lines = [
+    '| Sample | Type | Brand name | Hex | RGB | Figma Library name | CSS Custom Properties name |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const color of themeData.data) {
+    const hex = themeData.properties[color.name]?.toLowerCase()
+
+    if (!hex) {
+      lines.push(
+        `| Missing | ${escapeMarkdownTableCell(color.type)} | ${escapeMarkdownTableCell(color.brandName)} | Missing | Missing | ${escapeMarkdownTableCell(color.figmaName)} | \`${color.name}\` |`
+      )
+      continue
+    }
+
+    lines.push(
+      [
+        `| ${escapeMarkdownTableCell(hex)}`,
+        escapeMarkdownTableCell(color.type),
+        escapeMarkdownTableCell(color.brandName),
+        `\`${hex}\``,
+        `\`${toRgbString(hex)}\``,
+        escapeMarkdownTableCell(color.figmaName),
+        `\`${color.name}\` |`,
+      ].join(' | ')
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/config.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/config.ts
@@ -1,0 +1,35 @@
+export const mdxExtensionConfig = {
+  ignoredStandaloneComponents: [
+    'CSSDiagram',
+    'Card',
+    'ChangeLocale',
+    'InlineImg',
+    'Intro',
+    'IntroFooter',
+    'License',
+    'Logo',
+    'PortalSkeleton',
+    'Toc',
+  ],
+}
+
+export const providedStandaloneMdxComponents = new Set([
+  'Anchor',
+  'Blockquote',
+  'Details',
+  'Hr',
+  'Ul',
+  'Li',
+  'TypographyBox',
+  'VisibleWhenNotVisualTest',
+])
+
+export const ignoredStandaloneImportSourcePatterns = [
+  /^@dnb\/eufemia(?:\/|$)/,
+  /^dnb-eufemia\/components(?:\/|$)/,
+  /^dnb-ui-lib\/components(?:\/|$)/,
+]
+
+export const ignoredStandaloneMdxComponents = new Set(
+  mdxExtensionConfig.ignoredStandaloneComponents
+)

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/detector.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/detector.ts
@@ -1,0 +1,71 @@
+import {
+  ignoredStandaloneImportSourcePatterns,
+  ignoredStandaloneMdxComponents,
+  providedStandaloneMdxComponents,
+} from './config.ts'
+
+const mdxComponentCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+export function findUnhandledStandaloneMdxComponents(
+  content: string,
+  {
+    importsByFile,
+  }: {
+    importsByFile?: Map<string, string[]>
+  } = {}
+) {
+  const contentWithoutCodeFences = content.replace(/```[\s\S]*?```/g, '')
+  const regex = /^\s*<([A-Z][A-Za-z0-9_.]*)\b[^>]*\/?>\s*$/gm
+  const components = new Set<string>()
+  const ignoredImportedComponents =
+    getIgnoredImportedComponents(importsByFile)
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(contentWithoutCodeFences))) {
+    const [, name] = match
+
+    if (
+      name &&
+      !ignoredStandaloneMdxComponents.has(name) &&
+      !providedStandaloneMdxComponents.has(name) &&
+      !ignoredImportedComponents.has(name)
+    ) {
+      components.add(name)
+    }
+  }
+
+  return Array.from(components).sort(mdxComponentCollator.compare)
+}
+
+function getIgnoredImportedComponents(
+  importsByFile?: Map<string, string[]>
+) {
+  const ignoredImportedComponents = new Set<string>()
+
+  if (!importsByFile) {
+    return ignoredImportedComponents
+  }
+
+  for (const [source, importedNames] of Array.from(
+    importsByFile.entries()
+  )) {
+    if (
+      !ignoredStandaloneImportSourcePatterns.some((pattern) => {
+        return pattern.test(source)
+      })
+    ) {
+      continue
+    }
+
+    for (const importedName of importedNames) {
+      if (!importedName.startsWith('* as ')) {
+        ignoredImportedComponents.add(importedName)
+      }
+    }
+  }
+
+  return ignoredImportedComponents
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/listAllIcons.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/listAllIcons.ts
@@ -1,0 +1,177 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+
+type IconMetadataEntry = {
+  name?: string
+  tags?: string[]
+  created?: number
+  variant?: string
+  category?: string
+}
+
+let cachedIconMetadata: Array<
+  Required<Pick<IconMetadataEntry, 'name' | 'tags' | 'created'>> &
+    Pick<IconMetadataEntry, 'variant' | 'category'>
+> | null = null
+
+export function createListAllIconsExtension(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot' | 'toPascalCase'>
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'ListAllIcons',
+    replace: (content) => replaceListAllIcons(content, deps),
+  }
+}
+
+async function replaceListAllIcons(
+  content: string,
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot' | 'toPascalCase'>
+) {
+  const regex = /<ListAllIcons\b([^>]*)\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const icons = await loadListAllIconsMetadata(deps)
+
+  if (icons.length === 0) {
+    return content
+  }
+
+  return content.replace(regex, (_match, attrsSource) => {
+    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
+    const variant = attrs.variant
+    const groupBy = attrs.groupBy
+    const filteredIcons = icons.filter((icon) => {
+      return !variant || icon.variant === variant
+    })
+
+    if (filteredIcons.length === 0) {
+      return ''
+    }
+
+    return `\n${renderIconsMarkdown(filteredIcons, groupBy, deps)}\n`
+  })
+}
+
+async function loadListAllIconsMetadata(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  if (cachedIconMetadata) {
+    return cachedIconMetadata
+  }
+
+  const eufemiaRoot = deps.findPackageRoot('@dnb/eufemia')
+
+  if (!eufemiaRoot) {
+    return []
+  }
+
+  const metadataPath = path.join(
+    eufemiaRoot,
+    'src/icons/dnb/icons-meta.json'
+  )
+
+  try {
+    const raw = await fs.readFile(metadataPath, 'utf-8')
+    const metadata = JSON.parse(raw) as Record<string, IconMetadataEntry>
+
+    cachedIconMetadata = Object.entries(metadata)
+      .filter(([iconKey, icon]) => {
+        return !iconKey.endsWith('_medium') && Boolean(icon?.name)
+      })
+      .map(([_iconKey, icon]) => {
+        return {
+          name: String(icon.name),
+          tags: Array.isArray(icon.tags) ? icon.tags : [],
+          created: Number(icon.created || 0),
+          variant: icon.variant,
+          category: icon.category,
+        }
+      })
+      .sort((a, b) => a.created - b.created)
+
+    return cachedIconMetadata
+  } catch {
+    return []
+  }
+}
+
+function parseSimpleJsxStringAttributes(source: string) {
+  const attrs: Record<string, string> = {}
+  const regex = /([A-Za-z0-9_-]+)\s*=\s*(["'])(.*?)\2/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(source))) {
+    const [, name, , value] = match
+
+    if (name) {
+      attrs[name] = value || ''
+    }
+  }
+
+  return attrs
+}
+
+function renderIconsMarkdown(
+  icons: Array<{
+    name: string
+    tags: string[]
+    created: number
+    variant?: string
+    category?: string
+  }>,
+  groupBy: string | undefined,
+  deps: Pick<SpecialMdxRendererDeps, 'toPascalCase'>
+) {
+  if (groupBy === 'category') {
+    const groups = new Map<string, typeof icons>()
+
+    for (const icon of icons) {
+      const key = icon.category || 'uncategorized'
+      const existing = groups.get(key) || []
+      existing.push(icon)
+      groups.set(key, existing)
+    }
+
+    return Array.from(groups.entries())
+      .map(([category, groupedIcons]) => {
+        const heading = deps.toPascalCase(category.replace(/[-_]/g, ' '))
+        const lines = groupedIcons.map((icon) => {
+          return renderIconMarkdownLine(icon, false)
+        })
+
+        return [`## ${heading}`, '', ...lines].join('\n')
+      })
+      .join('\n\n')
+  }
+
+  return icons.map((icon) => renderIconMarkdownLine(icon, true)).join('\n')
+}
+
+function renderIconMarkdownLine(
+  icon: {
+    name: string
+    tags: string[]
+    category?: string
+  },
+  includeCategory: boolean
+) {
+  const parts = [`- \`${icon.name}\``]
+
+  if (includeCategory && icon.category) {
+    parts.push(`Category: ${icon.category}.`)
+  }
+
+  if (icon.tags.length > 0) {
+    parts.push(`Tags: ${icon.tags.join(', ')}.`)
+  }
+
+  return parts.join(' ')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/listSummaryFromEdges.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/listSummaryFromEdges.ts
@@ -1,0 +1,831 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import { parseSimpleJsxStringAttributes } from './utils.ts'
+
+type ListSummaryFrontmatter = {
+  title?: string | null
+  description?: string | null
+  order?: number | string | null
+  draft?: boolean | null
+  hideInMenu?: boolean | null
+  componentType?: string | null
+  showTabs?: boolean | null
+}
+
+type ListEntry = {
+  slug: string
+  title: string
+  description: string | null
+  frontmatter: ListSummaryFrontmatter
+}
+
+type PathFilter =
+  | {
+      type: 'glob'
+      value: string
+    }
+  | {
+      type: 'regex'
+      value: RegExp
+    }
+
+type FrontmatterFilter = {
+  field: string
+  operator: 'ne' | 'regex'
+  value: boolean | null | RegExp | string
+}
+
+type SortField = {
+  field: string
+  direction: 'ASC' | 'DESC'
+}
+
+type ListSummaryConfig = {
+  pathFilter: PathFilter | null
+  frontmatterFilters: FrontmatterFilter[]
+  sortFields: SortField[]
+  returnListItems: boolean
+}
+
+type ListSummaryData = {
+  config: ListSummaryConfig
+  entries: ListEntry[]
+}
+
+const docsFilesCache = new Map<string, string[]>()
+const listSummaryCache = new Map<string, ListSummaryData | null>()
+
+export function createListSummaryFromEdgesExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'ListSummaryFromEdges',
+    replace: (content) => replaceListSummaryFromEdges(content, deps),
+  }
+}
+
+async function replaceListSummaryFromEdges(
+  content: string,
+  deps: SpecialMdxRendererDeps
+) {
+  let output = content
+  const candidates = findRenderableListComponents(
+    content,
+    deps.importsByFile
+  )
+
+  for (const candidate of candidates) {
+    const regex = new RegExp(`<${candidate.name}\\b([^>]*)\\/>`, 'g')
+
+    if (!regex.test(output)) {
+      continue
+    }
+
+    regex.lastIndex = 0
+
+    const wrapperPath = await resolveImportedComponentPath(
+      candidate.source,
+      deps
+    )
+
+    if (!wrapperPath) {
+      continue
+    }
+
+    const listSummaryData = await loadListSummaryData(wrapperPath, deps)
+
+    if (!listSummaryData || listSummaryData.entries.length === 0) {
+      continue
+    }
+
+    output = output.replace(regex, (_match, attrsSource) => {
+      const attrs = parseSimpleJsxStringAttributes(
+        String(attrsSource || '')
+      )
+      const level = parseHeadingLevel(String(attrs.level || ''))
+      const description = attrs.description ?? null
+
+      return `\n${renderListEntriesMarkdown(listSummaryData.entries, {
+        returnListItems: listSummaryData.config.returnListItems,
+        level,
+        description,
+      })}\n`
+    })
+  }
+
+  return output
+}
+
+function findRenderableListComponents(
+  content: string,
+  importsByFile: Map<string, string[]>
+) {
+  const candidates: Array<{ name: string; source: string }> = []
+
+  for (const [source, importedNames] of Array.from(
+    importsByFile.entries()
+  )) {
+    for (const importedName of importedNames) {
+      if (
+        importedName.startsWith('* as ') ||
+        !/^List[A-Z]/.test(importedName) ||
+        !content.includes(`<${importedName}`)
+      ) {
+        continue
+      }
+
+      candidates.push({ name: importedName, source })
+    }
+  }
+
+  return candidates
+}
+
+async function resolveImportedComponentPath(
+  source: string,
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot' | 'inputDir'>
+) {
+  if (source.startsWith('.') || source.startsWith('/')) {
+    return resolveSourceWithExtension(path.resolve(deps.inputDir, source))
+  }
+
+  if (source.startsWith('dnb-design-system-portal/')) {
+    const portalRoot = deps.findPackageRoot('dnb-design-system-portal')
+
+    if (!portalRoot) {
+      return null
+    }
+
+    return resolveSourceWithExtension(
+      path.join(
+        portalRoot,
+        source.replace(/^dnb-design-system-portal\//, '')
+      )
+    )
+  }
+
+  return null
+}
+
+async function resolveSourceWithExtension(basePath: string) {
+  const candidates = [
+    basePath,
+    `${basePath}.tsx`,
+    `${basePath}.ts`,
+    `${basePath}.jsx`,
+    `${basePath}.js`,
+    path.join(basePath, 'index.tsx'),
+    path.join(basePath, 'index.ts'),
+    path.join(basePath, 'index.jsx'),
+    path.join(basePath, 'index.js'),
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const stat = await fs.stat(candidate)
+
+      if (stat.isFile()) {
+        return candidate
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return null
+}
+
+async function loadListSummaryData(
+  wrapperPath: string,
+  deps: Pick<SpecialMdxRendererDeps, 'docsRoot' | 'toSlugAndDir'>
+) {
+  const cacheKey = `${wrapperPath}::${deps.docsRoot}`
+
+  if (listSummaryCache.has(cacheKey)) {
+    return listSummaryCache.get(cacheKey) || null
+  }
+
+  try {
+    const source = await fs.readFile(wrapperPath, 'utf-8')
+
+    if (!source.includes('ListSummaryFromEdges')) {
+      listSummaryCache.set(cacheKey, null)
+      return null
+    }
+
+    const querySource = extractTemplateLiteral(source, 'graphql`')
+
+    if (!querySource) {
+      listSummaryCache.set(cacheKey, null)
+      return null
+    }
+
+    const config = parseListSummaryConfig(querySource, source)
+    const docsFiles = await findAllDocFiles(deps.docsRoot)
+    const entries: ListEntry[] = []
+
+    for (const filePath of docsFiles) {
+      const relativePath = path
+        .relative(deps.docsRoot, filePath)
+        .replace(/\\/g, '/')
+
+      if (!matchesPathFilter(relativePath, config.pathFilter)) {
+        continue
+      }
+
+      const frontmatter = await readListSummaryFrontmatter(filePath)
+
+      if (
+        !frontmatter ||
+        !matchesFrontmatterFilters(frontmatter, config)
+      ) {
+        continue
+      }
+
+      if (typeof frontmatter.title !== 'string' || !frontmatter.title) {
+        continue
+      }
+
+      entries.push({
+        slug: deps.toSlugAndDir(relativePath, '').slug,
+        title: frontmatter.title,
+        description:
+          typeof frontmatter.description === 'string'
+            ? frontmatter.description
+            : null,
+        frontmatter,
+      })
+    }
+
+    entries.sort((a, b) => compareListEntries(a, b, config.sortFields))
+
+    const data = { config, entries }
+    listSummaryCache.set(cacheKey, data)
+
+    return data
+  } catch {
+    listSummaryCache.set(cacheKey, null)
+    return null
+  }
+}
+
+function extractTemplateLiteral(source: string, anchor: string) {
+  const start = source.indexOf(anchor)
+
+  if (start < 0) {
+    return null
+  }
+
+  const contentStart = start + anchor.length
+  const end = source.indexOf('`', contentStart)
+
+  if (end < 0) {
+    return null
+  }
+
+  return source.slice(contentStart, end)
+}
+
+function parseListSummaryConfig(
+  querySource: string,
+  componentSource: string
+): ListSummaryConfig {
+  return {
+    pathFilter: parsePathFilter(querySource),
+    frontmatterFilters: parseFrontmatterFilters(querySource),
+    sortFields: parseSortFields(querySource),
+    returnListItems:
+      /<ListSummaryFromEdges\b[^>]*\breturnListItems\b/.test(
+        componentSource
+      ),
+  }
+}
+
+function parsePathFilter(querySource: string): PathFilter | null {
+  const contentFilePathBlock = extractNamedBlock(
+    querySource,
+    'contentFilePath'
+  )
+
+  if (!contentFilePathBlock) {
+    return null
+  }
+
+  const globMatch = contentFilePathBlock.match(
+    /\bglob\s*:\s*(["'])([\s\S]*?)\1/
+  )
+
+  if (globMatch?.[2]) {
+    return {
+      type: 'glob',
+      value: globMatch[2],
+    }
+  }
+
+  const regexMatch = contentFilePathBlock.match(
+    /\bregex\s*:\s*(["'])([\s\S]*?)\1/
+  )
+
+  if (regexMatch?.[2]) {
+    return {
+      type: 'regex',
+      value: new RegExp(
+        regexMatch[2].replace(/^\//, '').replace(/\/$/, '')
+      ),
+    }
+  }
+
+  return null
+}
+
+function parseFrontmatterFilters(querySource: string) {
+  const frontmatterBlock = extractNamedBlock(querySource, 'frontmatter')
+
+  if (!frontmatterBlock) {
+    return []
+  }
+
+  const filters: FrontmatterFilter[] = []
+  const regex =
+    /(\w+)\s*:\s*\{\s*(ne|regex)\s*:\s*(null|true|false|"[^"]*"|'[^']*')\s*\}/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(frontmatterBlock))) {
+    const [, field, operator, rawValue] = match
+
+    if (!field || !operator || !rawValue) {
+      continue
+    }
+
+    filters.push({
+      field,
+      operator: operator as 'ne' | 'regex',
+      value: parseFilterValue(operator as 'ne' | 'regex', rawValue),
+    })
+  }
+
+  return filters
+}
+
+function parseSortFields(querySource: string) {
+  const sortBlock = extractNamedArrayBlock(querySource, 'sort')
+
+  if (!sortBlock) {
+    return []
+  }
+
+  const fields: SortField[] = []
+  const regex = /frontmatter\s*:\s*\{\s*(\w+)\s*:\s*(ASC|DESC)\s*\}/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(sortBlock))) {
+    const [, field, direction] = match
+
+    if (!field || !direction) {
+      continue
+    }
+
+    fields.push({
+      field,
+      direction: direction as 'ASC' | 'DESC',
+    })
+  }
+
+  return fields
+}
+
+function extractNamedBlock(source: string, fieldName: string) {
+  const fieldRegex = new RegExp(`\\b${fieldName}\\s*:`)
+  const fieldMatch = fieldRegex.exec(source)
+
+  if (!fieldMatch) {
+    return null
+  }
+
+  const openIndex = source.indexOf('{', fieldMatch.index)
+
+  if (openIndex < 0) {
+    return null
+  }
+
+  return extractBalancedBlock(source, openIndex, '{', '}')
+}
+
+function extractNamedArrayBlock(source: string, fieldName: string) {
+  const fieldRegex = new RegExp(`\\b${fieldName}\\s*:`)
+  const fieldMatch = fieldRegex.exec(source)
+
+  if (!fieldMatch) {
+    return null
+  }
+
+  const openIndex = source.indexOf('[', fieldMatch.index)
+
+  if (openIndex < 0) {
+    return null
+  }
+
+  return extractBalancedBlock(source, openIndex, '[', ']')
+}
+
+function extractBalancedBlock(
+  source: string,
+  openIndex: number,
+  openChar: string,
+  closeChar: string
+) {
+  let depth = 0
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index]
+
+    if (char === openChar) {
+      depth += 1
+    } else if (char === closeChar) {
+      depth -= 1
+
+      if (depth === 0) {
+        return source.slice(openIndex, index + 1)
+      }
+    }
+  }
+
+  return null
+}
+
+function parseFilterValue(
+  operator: 'ne' | 'regex',
+  rawValue: string
+): boolean | null | RegExp | string {
+  if (operator === 'regex') {
+    return new RegExp(rawValue.slice(2, -2))
+  }
+
+  if (rawValue === 'null') {
+    return null
+  }
+
+  if (rawValue === 'true') {
+    return true
+  }
+
+  if (rawValue === 'false') {
+    return false
+  }
+
+  return rawValue.slice(1, -1)
+}
+
+async function findAllDocFiles(docsRoot: string) {
+  if (docsFilesCache.has(docsRoot)) {
+    return docsFilesCache.get(docsRoot) || []
+  }
+
+  const files: string[] = []
+
+  async function walk(currentPath: string): Promise<void> {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name)
+
+      if (entry.isDirectory()) {
+        await walk(fullPath)
+        continue
+      }
+
+      if (entry.isFile() && fullPath.endsWith('.mdx')) {
+        files.push(fullPath)
+      }
+    }
+  }
+
+  await walk(docsRoot)
+  docsFilesCache.set(docsRoot, files)
+
+  return files
+}
+
+async function readListSummaryFrontmatter(filePath: string) {
+  try {
+    const source = await fs.readFile(filePath, 'utf-8')
+    return parseSimpleFrontmatter(source)
+  } catch {
+    return null
+  }
+}
+
+function parseSimpleFrontmatter(source: string): ListSummaryFrontmatter {
+  const match = source.match(/^---\n([\s\S]*?)\n---/)
+
+  if (!match?.[1]) {
+    return {}
+  }
+
+  const frontmatter: ListSummaryFrontmatter = {}
+
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim()
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const separatorIndex = trimmed.indexOf(':')
+
+    if (separatorIndex < 0) {
+      continue
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim()
+    const rawValue = trimmed.slice(separatorIndex + 1).trim()
+
+    if (!key) {
+      continue
+    }
+
+    frontmatter[key as keyof ListSummaryFrontmatter] =
+      parseFrontmatterScalar(rawValue) as never
+  }
+
+  return frontmatter
+}
+
+function parseFrontmatterScalar(value: string) {
+  if (!value) {
+    return ''
+  }
+
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  if (value === 'null') {
+    return null
+  }
+
+  if (isNumericScalar(value)) {
+    return Number(value)
+  }
+
+  return value.replace(/^['"]|['"]$/g, '')
+}
+
+function isNumericScalar(value: string) {
+  let hasDigits = false
+  let hasDecimalSeparator = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+
+    if (char >= '0' && char <= '9') {
+      hasDigits = true
+      continue
+    }
+
+    if (char === '-' && index === 0) {
+      continue
+    }
+
+    if (char === '.' && !hasDecimalSeparator) {
+      hasDecimalSeparator = true
+      continue
+    }
+
+    return false
+  }
+
+  return hasDigits
+}
+
+function matchesPathFilter(
+  relativePath: string,
+  pathFilter: PathFilter | null
+) {
+  if (!pathFilter) {
+    return true
+  }
+
+  if (pathFilter.type === 'regex') {
+    return pathFilter.value.test(relativePath)
+  }
+
+  return globToRegExp(pathFilter.value).test(relativePath)
+}
+
+function matchesFrontmatterFilters(
+  frontmatter: ListSummaryFrontmatter,
+  config: Pick<ListSummaryConfig, 'frontmatterFilters'>
+) {
+  return config.frontmatterFilters.every((filter) => {
+    const value = frontmatter[filter.field as keyof ListSummaryFrontmatter]
+
+    if (filter.operator === 'regex') {
+      return filter.value instanceof RegExp
+        ? filter.value.test(String(value || ''))
+        : false
+    }
+
+    return value !== filter.value
+  })
+}
+
+function compareListEntries(
+  a: ListEntry,
+  b: ListEntry,
+  sortFields: SortField[]
+) {
+  for (const sortField of sortFields) {
+    const left =
+      a.frontmatter[sortField.field as keyof ListSummaryFrontmatter]
+    const right =
+      b.frontmatter[sortField.field as keyof ListSummaryFrontmatter]
+    const compared = compareListValues(left, right)
+
+    if (compared !== 0) {
+      return sortField.direction === 'DESC' ? compared * -1 : compared
+    }
+  }
+
+  return a.title.localeCompare(b.title)
+}
+
+function compareListValues(
+  left: ListSummaryFrontmatter[keyof ListSummaryFrontmatter],
+  right: ListSummaryFrontmatter[keyof ListSummaryFrontmatter]
+) {
+  const leftMissing = left === null || left === undefined
+  const rightMissing = right === null || right === undefined
+
+  if (leftMissing && rightMissing) {
+    return 0
+  }
+
+  if (leftMissing) {
+    return 1
+  }
+
+  if (rightMissing) {
+    return -1
+  }
+
+  if (typeof left === 'number' && typeof right === 'number') {
+    return left - right
+  }
+
+  return String(left).localeCompare(String(right))
+}
+
+function parseHeadingLevel(value: string) {
+  const parsed = parseInt(value, 10)
+
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 6) {
+    return 2
+  }
+
+  return parsed
+}
+
+function renderListEntriesMarkdown(
+  entries: ListEntry[],
+  options: {
+    returnListItems: boolean
+    level: number
+    description: string | null
+  }
+) {
+  if (options.returnListItems) {
+    return entries
+      .map((entry) => {
+        const description = options.description ?? entry.description
+
+        return description
+          ? `- [${entry.title}](${entry.slug}): ${description}`
+          : `- [${entry.title}](${entry.slug})`
+      })
+      .join('\n')
+  }
+
+  const headingPrefix = '#'.repeat(options.level)
+
+  return entries
+    .map((entry) => {
+      const description = options.description ?? entry.description
+
+      return description
+        ? `${headingPrefix} [${entry.title}](${entry.slug})\n\n${description}`
+        : `${headingPrefix} [${entry.title}](${entry.slug})`
+    })
+    .join('\n\n')
+}
+
+function globToRegExp(pattern: string) {
+  return new RegExp(`^${convertGlobSegment(pattern)}$`)
+}
+
+function convertGlobSegment(pattern: string): string {
+  let output = ''
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index]
+    const nextChar = pattern[index + 1]
+
+    if (char === '*' && nextChar === '*' && pattern[index + 2] === '/') {
+      output += '(?:.*\\/)?'
+      index += 2
+      continue
+    }
+
+    if (char === '*' && nextChar === '*') {
+      output += '.*'
+      index += 1
+      continue
+    }
+
+    if (char === '*') {
+      output += '[^/]*'
+      continue
+    }
+
+    if (char === '?') {
+      output += '[^/]'
+      continue
+    }
+
+    if (char === '{') {
+      const endIndex = findClosingBraceIndex(pattern, index)
+
+      if (endIndex > index) {
+        const inner = pattern.slice(index + 1, endIndex)
+        const parts = splitBraceAlternatives(inner)
+
+        output += `(?:${parts
+          .map((part) => convertGlobSegment(part))
+          .join('|')})`
+        index = endIndex
+        continue
+      }
+    }
+
+    output += escapeRegExp(char)
+  }
+
+  return output
+}
+
+function findClosingBraceIndex(pattern: string, startIndex: number) {
+  let depth = 0
+
+  for (let index = startIndex; index < pattern.length; index += 1) {
+    const char = pattern[index]
+
+    if (char === '{') {
+      depth += 1
+    } else if (char === '}') {
+      depth -= 1
+
+      if (depth === 0) {
+        return index
+      }
+    }
+  }
+
+  return -1
+}
+
+function splitBraceAlternatives(value: string) {
+  const parts: string[] = []
+  let current = ''
+  let depth = 0
+
+  for (const char of value) {
+    if (char === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+
+    if (char === '{') {
+      depth += 1
+    } else if (char === '}') {
+      depth -= 1
+    }
+
+    current += char
+  }
+
+  parts.push(current)
+  return parts
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/radiusTokenTable.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/radiusTokenTable.ts
@@ -1,0 +1,289 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import {
+  createEmptyTokenThemeReferences,
+  isTokenThemeLeaf,
+  loadTokenThemeConfig,
+  readTokenThemeSource,
+  tokenValueCollator,
+  type TokenThemeName,
+  type TokenThemeSource,
+} from './tokenTheme.ts'
+
+type RadiusTokenEntry = {
+  name: string
+  references: Record<TokenThemeName, string>
+}
+
+type RadiusTokenOrder = Record<string, number>
+
+let cachedRadiusTokenTable: RadiusTokenEntry[] | null = null
+let cachedRadiusTokenOrder: RadiusTokenOrder | null = null
+
+export function createRadiusTokenTableExtension(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'RadiusTokenTable',
+    replace: (content) => replaceRadiusTokenTables(content, deps),
+  }
+}
+
+async function replaceRadiusTokenTables(
+  content: string,
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  const regex = /<RadiusTokenTable\b[^>]*\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const tokens = await loadRadiusTokenTable(deps)
+
+  return content.replace(regex, () => {
+    return `\n${renderRadiusTokenMarkdown(tokens)}\n`
+  })
+}
+
+async function loadRadiusTokenTable(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  if (cachedRadiusTokenTable) {
+    return cachedRadiusTokenTable
+  }
+
+  const themeConfig = await loadTokenThemeConfig(deps)
+
+  if (themeConfig.themeOrder.length === 0) {
+    return []
+  }
+
+  const portalRoot = deps.findPackageRoot('dnb-design-system-portal')
+  const radiusTokenOrder = portalRoot
+    ? await loadRadiusTokenOrder(portalRoot)
+    : {}
+
+  const tokenMap = new Map<string, RadiusTokenEntry>()
+
+  for (const theme of themeConfig.themeOrder) {
+    const themeSource = await readTokenThemeSource(
+      themeConfig.themePaths[theme]
+    )
+
+    if (!themeSource) {
+      continue
+    }
+
+    for (const entry of collectRadiusTokenEntries(
+      themeSource,
+      theme,
+      themeConfig.themeOrder
+    )) {
+      const existing = tokenMap.get(entry.name)
+
+      if (existing) {
+        existing.references[theme] = entry.references[theme]
+        continue
+      }
+
+      tokenMap.set(entry.name, entry)
+    }
+  }
+
+  cachedRadiusTokenTable = Array.from(tokenMap.values()).sort((a, b) => {
+    const suffixA = a.name.replace('--token-radius-', '')
+    const suffixB = b.name.replace('--token-radius-', '')
+    const orderA = radiusTokenOrder[suffixA] ?? Number.MAX_SAFE_INTEGER
+    const orderB = radiusTokenOrder[suffixB] ?? Number.MAX_SAFE_INTEGER
+
+    if (orderA !== orderB) {
+      return orderA - orderB
+    }
+
+    return tokenValueCollator.compare(a.name, b.name)
+  })
+
+  return cachedRadiusTokenTable
+}
+
+async function loadRadiusTokenOrder(portalRoot: string) {
+  if (cachedRadiusTokenOrder) {
+    return cachedRadiusTokenOrder
+  }
+
+  const designTokensPath = path.join(
+    portalRoot,
+    'src/uilib/utils/designTokens.ts'
+  )
+  const source = await fs.readFile(designTokensPath, 'utf-8')
+  const radiusOrderSource = readObjectLiteralSource(
+    source,
+    'const radiusSizeOrder'
+  )
+
+  cachedRadiusTokenOrder = parseRadiusTokenOrder(radiusOrderSource)
+
+  return cachedRadiusTokenOrder
+}
+
+function readObjectLiteralSource(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker)
+
+  if (markerIndex === -1) {
+    return ''
+  }
+
+  const openBraceIndex = source.indexOf('{', markerIndex)
+
+  if (openBraceIndex === -1) {
+    return ''
+  }
+
+  let depth = 0
+
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    const char = source[index]
+
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+
+    if (char === '}') {
+      depth -= 1
+
+      if (depth === 0) {
+        return source.slice(openBraceIndex + 1, index)
+      }
+    }
+  }
+
+  return ''
+}
+
+function parseRadiusTokenOrder(source: string) {
+  const order: RadiusTokenOrder = {}
+
+  for (const line of source.split('\n')) {
+    const trimmed = line.trim().replace(/,$/, '')
+
+    if (!trimmed) {
+      continue
+    }
+
+    const separatorIndex = trimmed.indexOf(':')
+
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const rawKey = trimmed.slice(0, separatorIndex).trim()
+    const rawValue = trimmed.slice(separatorIndex + 1).trim()
+    const key = rawKey.replace(/^['"]|['"]$/g, '')
+    const value = Number(rawValue)
+
+    if (!key || !Number.isFinite(value)) {
+      continue
+    }
+
+    order[key] = value
+  }
+
+  return order
+}
+
+function collectRadiusTokenEntries(
+  source: TokenThemeSource,
+  theme: TokenThemeName,
+  themeOrder: TokenThemeName[],
+  currentPath: string[] = []
+) {
+  const entries: RadiusTokenEntry[] = []
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key.startsWith('$') || !value || typeof value !== 'object') {
+      continue
+    }
+
+    const nextPath = [...currentPath, key]
+
+    if (isTokenThemeLeaf(value)) {
+      if (nextPath[0] !== 'radius') {
+        continue
+      }
+
+      const name = `--token-${nextPath.join('-')}`
+
+      entries.push({
+        name,
+        references: createEmptyTokenThemeReferences(themeOrder),
+      })
+
+      entries[entries.length - 1].references[theme] =
+        readRadiusTokenReference(value)
+      continue
+    }
+
+    entries.push(
+      ...collectRadiusTokenEntries(value, theme, themeOrder, nextPath)
+    )
+  }
+
+  return entries
+}
+
+function readRadiusTokenReference(value: {
+  $type: string
+  $value?: unknown
+}) {
+  if (value.$type !== 'number' || typeof value.$value !== 'number') {
+    return 'n/a'
+  }
+
+  return formatRadiusNumberValue(value.$value)
+}
+
+function formatRadiusNumberValue(value: number) {
+  if (value === 0) {
+    return '0'
+  }
+
+  if (value >= 9999) {
+    return '9999px'
+  }
+
+  const rem = value / 16
+  return `${parseFloat(rem.toFixed(4))}rem`
+}
+
+function renderRadiusTokenMarkdown(tokens: RadiusTokenEntry[]) {
+  if (tokens.length === 0) {
+    return 'No radius tokens are available.'
+  }
+
+  const lines = [
+    '| Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const token of tokens) {
+    lines.push(
+      [
+        `| \`${token.name}\``,
+        `\`${token.references.uiLight}\``,
+        `\`${token.references.uiDark}\``,
+        `\`${token.references.sbankenLight}\``,
+        `\`${token.references.sbankenDark}\``,
+        `\`${token.references.carnegie}\` |`,
+      ].join(' | ')
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
@@ -1,0 +1,40 @@
+import { createAvailableCountriesTableExtension } from './availableCountriesTable.ts'
+import { createCardProductsTableExtension } from './cardProductsTable.ts'
+import { createColorTableExtension } from './colorTable.ts'
+import { createListAllIconsExtension } from './listAllIcons.ts'
+import { createListSummaryFromEdgesExtension } from './listSummaryFromEdges.ts'
+import { createRadiusTokenTableExtension } from './radiusTokenTable.ts'
+import { createTokenExampleExtension } from './tokenExample.ts'
+import { createTokenSectionTableExtension } from './tokenSectionTable.ts'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+
+export async function applySpecialMdxComponentRenderers(
+  content: string,
+  deps: SpecialMdxRendererDeps
+) {
+  let output = content
+
+  for (const renderer of createSpecialMdxExtensions(deps)) {
+    output = await renderer.replace(output)
+  }
+
+  return output
+}
+
+function createSpecialMdxExtensions(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer[] {
+  return [
+    createTokenExampleExtension(),
+    createTokenSectionTableExtension(deps),
+    createRadiusTokenTableExtension(deps),
+    createColorTableExtension(deps),
+    createListSummaryFromEdgesExtension(deps),
+    createListAllIconsExtension(deps),
+    createAvailableCountriesTableExtension(deps),
+    createCardProductsTableExtension(deps),
+  ]
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/tokenExample.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/tokenExample.ts
@@ -1,0 +1,30 @@
+import type { SpecialMdxComponentRenderer } from './types.ts'
+import { parseSimpleJsxStringAttributes } from './utils.ts'
+
+export function createTokenExampleExtension(): SpecialMdxComponentRenderer {
+  return {
+    name: 'TokenExample',
+    replace: replaceTokenExamples,
+  }
+}
+
+function replaceTokenExamples(content: string) {
+  const regex = /<TokenExample\b([^>]*)\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+
+  return content.replace(regex, (_match, attrsSource) => {
+    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
+    const name = attrs.name?.trim()
+
+    if (!name) {
+      return ''
+    }
+
+    return `\`${name}\``
+  })
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/tokenSectionTable.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/tokenSectionTable.ts
@@ -1,0 +1,527 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import {
+  createEmptyTokenThemeReferences,
+  isTokenThemeLeaf,
+  loadTokenThemeConfig,
+  readTokenThemeSource,
+  tokenValueCollator,
+  type TokenThemeLeaf,
+  type TokenThemeName,
+  type TokenThemeSource,
+} from './tokenTheme.ts'
+import {
+  escapeMarkdownTableCell,
+  parseSimpleJsxStringAttributes,
+} from './utils.ts'
+
+type TokenSectionTableId =
+  | 'background'
+  | 'text'
+  | 'icon'
+  | 'stroke'
+  | 'decorative'
+  | 'component'
+
+type TokenSectionEntry = {
+  name: string
+  path: string[]
+  section: TokenSectionTableId
+  group: string
+  references: Record<TokenThemeName, string>
+}
+
+type TokenSectionTableConfig = {
+  sectionIds: TokenSectionTableId[]
+  decorativeGroupLabels: Record<string, string>
+  decorativeGroupOrder: Record<string, number>
+}
+
+let cachedTokenSectionTables: Record<
+  TokenSectionTableId,
+  TokenSectionEntry[]
+> | null = null
+let cachedTokenSectionConfig: TokenSectionTableConfig | null = null
+
+export function createTokenSectionTableExtension(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'TokenSectionTable',
+    replace: (content) => replaceTokenSectionTables(content, deps),
+  }
+}
+
+async function replaceTokenSectionTables(
+  content: string,
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  const regex = /<TokenSectionTable\b([^>]*)\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  regex.lastIndex = 0
+  const { sections, config, themeOrder } =
+    await loadTokenSectionTables(deps)
+
+  return content.replace(regex, (_match, attrsSource) => {
+    const attrs = parseSimpleJsxStringAttributes(String(attrsSource || ''))
+    const section = attrs.section as TokenSectionTableId | undefined
+
+    if (!section || !sections[section]) {
+      return ''
+    }
+
+    return `\n${renderTokenSectionMarkdown(
+      section,
+      sections[section],
+      config,
+      themeOrder
+    )}\n`
+  })
+}
+
+async function loadTokenSectionTables(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  const config = await loadTokenSectionConfig(deps)
+  const themeConfig = await loadTokenThemeConfig(deps)
+
+  if (cachedTokenSectionTables) {
+    return {
+      sections: cachedTokenSectionTables,
+      config,
+      themeOrder: themeConfig.themeOrder,
+    }
+  }
+
+  if (themeConfig.themeOrder.length === 0) {
+    return {
+      sections: {} as Record<TokenSectionTableId, TokenSectionEntry[]>,
+      config,
+      themeOrder: [],
+    }
+  }
+
+  const tokenMap = new Map<string, TokenSectionEntry>()
+  const supportedSections = new Set<TokenSectionTableId>(config.sectionIds)
+
+  for (const theme of themeConfig.themeOrder) {
+    const themeSource = await readTokenThemeSource(
+      themeConfig.themePaths[theme]
+    )
+
+    if (!themeSource) {
+      continue
+    }
+
+    for (const entry of collectTokenSectionEntries(
+      themeSource,
+      theme,
+      themeConfig.themeOrder,
+      supportedSections
+    )) {
+      const existing = tokenMap.get(entry.name)
+
+      if (existing) {
+        existing.references[theme] = entry.references[theme]
+        continue
+      }
+
+      tokenMap.set(entry.name, entry)
+    }
+  }
+
+  cachedTokenSectionTables = Object.fromEntries(
+    config.sectionIds.map((section) => {
+      const tokens = Array.from(tokenMap.values()).filter((token) => {
+        return token.section === section
+      })
+
+      return [section, sortTokenSectionEntries(section, tokens, config)]
+    })
+  ) as Record<TokenSectionTableId, TokenSectionEntry[]>
+
+  return {
+    sections: cachedTokenSectionTables,
+    config,
+    themeOrder: themeConfig.themeOrder,
+  }
+}
+
+async function loadTokenSectionConfig(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  if (cachedTokenSectionConfig) {
+    return cachedTokenSectionConfig
+  }
+
+  const portalRoot = deps.findPackageRoot('dnb-design-system-portal')
+
+  if (!portalRoot) {
+    cachedTokenSectionConfig = {
+      sectionIds: [],
+      decorativeGroupLabels: {},
+      decorativeGroupOrder: {},
+    }
+
+    return cachedTokenSectionConfig
+  }
+
+  const designTokensPath = path.join(
+    portalRoot,
+    'src/uilib/utils/designTokens.ts'
+  )
+  const examplesPath = path.join(
+    portalRoot,
+    'src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx'
+  )
+
+  const designTokensSource = await fs.readFile(designTokensPath, 'utf-8')
+  const examplesSource = await fs.readFile(examplesPath, 'utf-8')
+
+  cachedTokenSectionConfig = {
+    sectionIds: parseTokenSectionIds(
+      readArrayLiteralSource(
+        designTokensSource,
+        'export const tokenSectionOrder'
+      )
+    ),
+    decorativeGroupLabels: parseStringRecord(
+      readObjectLiteralSource(
+        examplesSource,
+        'const decorativeGroupLabels'
+      )
+    ),
+    decorativeGroupOrder: parseNumberRecord(
+      readObjectLiteralSource(
+        examplesSource,
+        'const decorativeGroupSortOrder'
+      )
+    ),
+  }
+
+  return cachedTokenSectionConfig
+}
+
+function collectTokenSectionEntries(
+  source: TokenThemeSource,
+  theme: TokenThemeName,
+  themeOrder: TokenThemeName[],
+  supportedSections: ReadonlySet<TokenSectionTableId>,
+  currentPath: string[] = []
+) {
+  const entries: TokenSectionEntry[] = []
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key.startsWith('$') || !value || typeof value !== 'object') {
+      continue
+    }
+
+    const nextPath = [...currentPath, key]
+
+    if (isTokenThemeLeaf(value)) {
+      const category = nextPath[0]
+      const section = nextPath[1] as TokenSectionTableId | undefined
+
+      if (
+        category !== 'color' ||
+        !section ||
+        !supportedSections.has(section)
+      ) {
+        continue
+      }
+
+      const group = nextPath[2] || 'general'
+      const name = `--token-${nextPath.join('-')}`
+
+      entries.push({
+        name,
+        path: nextPath,
+        section,
+        group,
+        references: createEmptyTokenThemeReferences(themeOrder),
+      })
+
+      entries[entries.length - 1].references[theme] =
+        readTokenSectionReference(value)
+      continue
+    }
+
+    entries.push(
+      ...collectTokenSectionEntries(
+        value,
+        theme,
+        themeOrder,
+        supportedSections,
+        nextPath
+      )
+    )
+  }
+
+  return entries
+}
+
+function readTokenSectionReference(node: TokenThemeLeaf) {
+  const value = node.$value
+  const hex = value?.hex
+  const alpha = value?.alpha
+  const components = value?.components
+
+  if (
+    Array.isArray(components) &&
+    components.length === 3 &&
+    typeof alpha === 'number' &&
+    alpha !== 1
+  ) {
+    const [red, green, blue] = components.map((channel) => {
+      return Math.round(channel * 255)
+    })
+
+    return `rgba(${red} ${green} ${blue} / ${formatTokenAlpha(alpha)})`
+  }
+
+  return hex || 'n/a'
+}
+
+function formatTokenAlpha(alpha: number) {
+  return `${parseFloat((alpha * 100).toFixed(2))}%`
+}
+
+function sortTokenSectionEntries(
+  section: TokenSectionTableId,
+  tokens: TokenSectionEntry[],
+  config: TokenSectionTableConfig
+) {
+  return [...tokens].sort((a, b) => {
+    if (section === 'decorative') {
+      const groupOrderA =
+        config.decorativeGroupOrder[a.group] ?? Number.MAX_SAFE_INTEGER
+      const groupOrderB =
+        config.decorativeGroupOrder[b.group] ?? Number.MAX_SAFE_INTEGER
+
+      if (groupOrderA !== groupOrderB) {
+        return groupOrderA - groupOrderB
+      }
+    }
+
+    const groupCompare = tokenValueCollator.compare(
+      getTokenSectionGroupLabel(a, config),
+      getTokenSectionGroupLabel(b, config)
+    )
+
+    if (groupCompare !== 0) {
+      return groupCompare
+    }
+
+    return tokenValueCollator.compare(a.name, b.name)
+  })
+}
+
+function getTokenSectionGroupLabel(
+  token: TokenSectionEntry,
+  config: TokenSectionTableConfig
+) {
+  if (token.section === 'decorative') {
+    return config.decorativeGroupLabels[token.group] || token.group
+  }
+
+  return token.group
+}
+
+function getTokenSectionNameLabel(token: TokenSectionEntry) {
+  return token.path[token.path.length - 1] || token.name
+}
+
+function renderTokenSectionMarkdown(
+  section: TokenSectionTableId,
+  tokens: TokenSectionEntry[],
+  config: TokenSectionTableConfig,
+  themeOrder: TokenThemeName[]
+) {
+  if (tokens.length === 0) {
+    return `No ${section} tokens are available.`
+  }
+
+  const isDecorative = section === 'decorative'
+  const lines = isDecorative
+    ? [
+        '| Group | Name | Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |',
+        '| --- | --- | --- | --- | --- | --- | --- | --- |',
+      ]
+    : [
+        '| Group | Token | DNB Light | DNB Dark | Sbanken Light | Sbanken Dark | Carnegie |',
+        '| --- | --- | --- | --- | --- | --- | --- |',
+      ]
+
+  for (const token of tokens) {
+    const cells = [
+      escapeMarkdownTableCell(getTokenSectionGroupLabel(token, config)),
+    ]
+
+    if (isDecorative) {
+      cells.push(escapeMarkdownTableCell(getTokenSectionNameLabel(token)))
+    }
+
+    cells.push(`\`${token.name}\``)
+    cells.push(
+      ...themeOrder.map((theme) => {
+        return `\`${token.references[theme]}\``
+      })
+    )
+
+    lines.push(`| ${cells.join(' | ')} |`)
+  }
+
+  return lines.join('\n')
+}
+
+function readArrayLiteralSource(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker)
+
+  if (markerIndex === -1) {
+    return ''
+  }
+
+  const openIndex = source.indexOf('[', markerIndex)
+
+  if (openIndex === -1) {
+    return ''
+  }
+
+  return readDelimitedBlock(source, openIndex, '[', ']')
+}
+
+function readObjectLiteralSource(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker)
+
+  if (markerIndex === -1) {
+    return ''
+  }
+
+  const openIndex = source.indexOf('{', markerIndex)
+
+  if (openIndex === -1) {
+    return ''
+  }
+
+  return readDelimitedBlock(source, openIndex, '{', '}')
+}
+
+function readDelimitedBlock(
+  source: string,
+  openIndex: number,
+  openChar: string,
+  closeChar: string
+) {
+  let depth = 0
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index]
+
+    if (char === openChar) {
+      depth += 1
+      continue
+    }
+
+    if (char === closeChar) {
+      depth -= 1
+
+      if (depth === 0) {
+        return source.slice(openIndex + 1, index)
+      }
+    }
+  }
+
+  return ''
+}
+
+function parseTokenSectionIds(source: string) {
+  return source
+    .split('\n')
+    .map((line) => line.trim().replace(/,$/, ''))
+    .map((value) => value.replace(/^['"]|['"]$/g, ''))
+    .filter((value): value is TokenSectionTableId => {
+      return (
+        value === 'background' ||
+        value === 'text' ||
+        value === 'icon' ||
+        value === 'stroke' ||
+        value === 'decorative' ||
+        value === 'component'
+      )
+    })
+}
+
+function parseStringRecord(source: string) {
+  const record: Record<string, string> = {}
+
+  for (const line of source.split('\n')) {
+    const parsed = parseRecordEntry(line)
+
+    if (!parsed) {
+      continue
+    }
+
+    record[parsed.key] = parsed.value
+  }
+
+  return record
+}
+
+function parseNumberRecord(source: string) {
+  const record: Record<string, number> = {}
+
+  for (const line of source.split('\n')) {
+    const parsed = parseRecordEntry(line)
+
+    if (!parsed) {
+      continue
+    }
+
+    const value = Number(parsed.value)
+
+    if (!Number.isFinite(value)) {
+      continue
+    }
+
+    record[parsed.key] = value
+  }
+
+  return record
+}
+
+function parseRecordEntry(line: string) {
+  const trimmed = line.trim().replace(/,$/, '')
+
+  if (!trimmed) {
+    return null
+  }
+
+  const separatorIndex = trimmed.indexOf(':')
+
+  if (separatorIndex === -1) {
+    return null
+  }
+
+  const key = trimmed
+    .slice(0, separatorIndex)
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+  const value = trimmed
+    .slice(separatorIndex + 1)
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+
+  if (!key) {
+    return null
+  }
+
+  return { key, value }
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/tokenTheme.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/tokenTheme.ts
@@ -1,0 +1,225 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type { SpecialMdxRendererDeps } from './types.ts'
+
+export type TokenThemeName =
+  | 'uiLight'
+  | 'uiDark'
+  | 'sbankenLight'
+  | 'sbankenDark'
+  | 'carnegie'
+
+export type TokenThemeSource = {
+  [key: string]: TokenThemeSource | TokenThemeLeaf
+}
+
+export type TokenThemeLeaf = {
+  $type: string
+  $value?: {
+    alpha?: number
+    hex?: string
+    components?: number[]
+  }
+}
+
+type TokenThemeConfig = {
+  themeOrder: TokenThemeName[]
+  themePaths: Partial<Record<TokenThemeName, string>>
+}
+
+let cachedTokenThemeConfig: TokenThemeConfig | null = null
+
+export const tokenValueCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+export async function loadTokenThemeConfig(
+  deps: Pick<SpecialMdxRendererDeps, 'findPackageRoot'>
+) {
+  if (cachedTokenThemeConfig) {
+    return cachedTokenThemeConfig
+  }
+
+  const portalRoot = deps.findPackageRoot('dnb-design-system-portal')
+  const eufemiaRoot = deps.findPackageRoot('@dnb/eufemia')
+
+  if (!portalRoot || !eufemiaRoot) {
+    cachedTokenThemeConfig = {
+      themeOrder: [],
+      themePaths: {},
+    }
+
+    return cachedTokenThemeConfig
+  }
+
+  const designTokensPath = path.join(
+    portalRoot,
+    'src/uilib/utils/designTokens.ts'
+  )
+  const source = await fs.readFile(designTokensPath, 'utf-8')
+  const importSources = parseEufemiaImports(source)
+  const themeSources = parseThemeSources(
+    readObjectLiteralSource(source, 'const themeSources')
+  )
+
+  cachedTokenThemeConfig = {
+    themeOrder: themeSources.map(({ theme }) => theme),
+    themePaths: Object.fromEntries(
+      themeSources.flatMap(({ theme, identifier }) => {
+        const importSource = importSources[identifier]
+
+        if (!importSource) {
+          return []
+        }
+
+        return [
+          [theme, resolveEufemiaImportPath(eufemiaRoot, importSource)],
+        ]
+      })
+    ) as Partial<Record<TokenThemeName, string>>,
+  }
+
+  return cachedTokenThemeConfig
+}
+
+export function createEmptyTokenThemeReferences(
+  themeOrder: TokenThemeName[]
+) {
+  return Object.fromEntries(
+    themeOrder.map((theme) => [theme, 'n/a'])
+  ) as Record<TokenThemeName, string>
+}
+
+export async function readTokenThemeSource(filePath?: string) {
+  if (!filePath) {
+    return null
+  }
+
+  try {
+    return JSON.parse(
+      await fs.readFile(filePath, 'utf-8')
+    ) as TokenThemeSource
+  } catch {
+    return null
+  }
+}
+
+export function isTokenThemeLeaf(
+  value: TokenThemeSource | TokenThemeLeaf
+): value is TokenThemeLeaf {
+  return '$type' in value
+}
+
+function parseEufemiaImports(source: string) {
+  const imports: Record<string, string> = {}
+  const regex =
+    /^import\s+([A-Za-z0-9_]+)\s+from\s+['"](@dnb\/eufemia\/[^'"]+)['"]/gm
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(source))) {
+    const [, identifier, importSource] = match
+
+    if (identifier && importSource) {
+      imports[identifier] = importSource
+    }
+  }
+
+  return imports
+}
+
+function parseThemeSources(source: string) {
+  return source
+    .split('\n')
+    .map(parseThemeSourceEntry)
+    .filter(
+      (entry): entry is { theme: TokenThemeName; identifier: string } => {
+        return Boolean(entry)
+      }
+    )
+}
+
+function parseThemeSourceEntry(line: string) {
+  const trimmed = line.trim().replace(/,$/, '')
+
+  if (!trimmed) {
+    return null
+  }
+
+  const separatorIndex = trimmed.indexOf(':')
+
+  if (separatorIndex === -1) {
+    return null
+  }
+
+  const rawTheme = trimmed.slice(0, separatorIndex).trim()
+  const theme = rawTheme.replace(/^['"]|['"]$/g, '')
+
+  if (!isTokenThemeName(theme)) {
+    return null
+  }
+
+  const rawValue = trimmed.slice(separatorIndex + 1).trim()
+  const identifierMatch = rawValue.match(/^([A-Za-z0-9_]+)/)
+  const identifier = identifierMatch?.[1]
+
+  if (!identifier) {
+    return null
+  }
+
+  return { theme, identifier }
+}
+
+function isTokenThemeName(value: string): value is TokenThemeName {
+  return (
+    value === 'uiLight' ||
+    value === 'uiDark' ||
+    value === 'sbankenLight' ||
+    value === 'sbankenDark' ||
+    value === 'carnegie'
+  )
+}
+
+function readObjectLiteralSource(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker)
+
+  if (markerIndex === -1) {
+    return ''
+  }
+
+  const openIndex = source.indexOf('{', markerIndex)
+
+  if (openIndex === -1) {
+    return ''
+  }
+
+  let depth = 0
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index]
+
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+
+    if (char === '}') {
+      depth -= 1
+
+      if (depth === 0) {
+        return source.slice(openIndex + 1, index)
+      }
+    }
+  }
+
+  return ''
+}
+
+function resolveEufemiaImportPath(
+  eufemiaRoot: string,
+  importSource: string
+) {
+  const relativePath = importSource.replace(/^@dnb\/eufemia\//, '')
+
+  return path.join(eufemiaRoot, relativePath)
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/types.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/types.ts
@@ -1,0 +1,17 @@
+export type SpecialMdxRendererDeps = {
+  loadModuleDefault: (modulePath: string) => Promise<unknown>
+  findPackageRoot: (pkgName: string) => string | null
+  toPascalCase: (value: string) => string
+  inputDir: string
+  docsRoot: string
+  importsByFile: Map<string, string[]>
+  toSlugAndDir: (
+    relFilePath: string,
+    slugBase: string
+  ) => { slug: string; dirForExtras: string }
+}
+
+export type SpecialMdxComponentRenderer = {
+  name: string
+  replace: (content: string) => string | Promise<string>
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/utils.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/utils.ts
@@ -1,0 +1,44 @@
+export function parseSimpleJsxStringAttributes(source: string) {
+  const attrs: Record<string, string> = {}
+  const regex = /([A-Za-z0-9_-]+)\s*=\s*(["'])(.*?)\2/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(source))) {
+    const [, name, , value] = match
+
+    if (name) {
+      attrs[name] = value || ''
+    }
+  }
+
+  return attrs
+}
+
+export function escapeMarkdownTableCell(value: string) {
+  return value.replace(/[\\|]/g, '\\$&').trim()
+}
+
+export function toRgbString(hex: string) {
+  try {
+    let hexOnly = hex.replace(/^#/, '')
+
+    if (hexOnly.length === 3) {
+      hexOnly = hexOnly
+        .split('')
+        .map((char) => char + char)
+        .join('')
+    }
+
+    if (hexOnly.length !== 6) {
+      return 'N/A'
+    }
+
+    const red = parseInt(hexOnly.slice(0, 2), 16)
+    const green = parseInt(hexOnly.slice(2, 4), 16)
+    const blue = parseInt(hexOnly.slice(4, 6), 16)
+
+    return `${red} ${green} ${blue}`
+  } catch {
+    return 'N/A'
+  }
+}

--- a/tools/eufemia-llm-metadata/src/shared/workspaceUtils.ts
+++ b/tools/eufemia-llm-metadata/src/shared/workspaceUtils.ts
@@ -1,0 +1,57 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+export function toPascalCase(s: string) {
+  return s
+    .split(/_/g)
+    .reduce(
+      (acc, cur) =>
+        acc +
+        cur.replace(
+          /(\w)(\w*)/g,
+          (g0, g1, g2) => g1.toUpperCase() + g2.toLowerCase()
+        ),
+      ''
+    )
+}
+
+export function findPackageRoot(pkgName: string) {
+  const root = path.parse(process.cwd()).root
+  let current = process.cwd()
+  const workspaceName =
+    pkgName === '@dnb/eufemia'
+      ? 'dnb-eufemia'
+      : pkgName.replace(/^@[^/]+\//, '')
+
+  while (true) {
+    const workspaceCandidate = path.join(
+      current,
+      'packages',
+      workspaceName,
+      'package.json'
+    )
+
+    if (fs.existsSync(workspaceCandidate)) {
+      return path.dirname(workspaceCandidate)
+    }
+
+    const candidate = path.join(
+      current,
+      'node_modules',
+      ...pkgName.split('/'),
+      'package.json'
+    )
+
+    if (fs.existsSync(candidate)) {
+      return path.dirname(candidate)
+    }
+
+    if (current === root) {
+      break
+    }
+
+    current = path.dirname(current)
+  }
+
+  return null
+}


### PR DESCRIPTION
Until now we only did this for the UI library docs, but we want to have the same for all docs pages, including the MCP server docs. This is needed to be able to use the metadata in the MCP server docs for the MCP agent.

