### PR TITLE
chore(Portal): remove unused process polyfill

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -92,7 +92,6 @@
     "prettier-package-json": "2.8.0",
     "prism-react-renderer": "2.4.1",
     "prismjs": "1.30.0",
-    "process": "0.11.10",
     "react-live-ssr": "workspace:*",
     "react-markdown": "9.1.0",
     "react-router-dom": "7.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9991,7 +9991,6 @@ __metadata:
     prettier-package-json: "npm:2.8.0"
     prism-react-renderer: "npm:2.4.1"
     prismjs: "npm:1.30.0"
-    process: "npm:0.11.10"
     react: "npm:19.2.5"
     react-dom: "npm:19.2.5"
     react-live-ssr: "workspace:*"
@@ -19869,13 +19868,6 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 10/1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
-  languageName: node
-  linkType: hard
-
-"process@npm:0.11.10":
-  version: 0.11.10
-  resolution: "process@npm:0.11.10"
-  checksum: 10/dbaa7e8d1d5cf375c36963ff43116772a989ef2bb47c9bdee20f38fd8fc061119cf38140631cf90c781aca4d3f0f0d2c834711952b728953f04fd7d238f59f5b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `process` npm package was a leftover from the Gatsby/webpack era. Vite handles `process.env` references via its `define` config, making this polyfill unnecessary. No source files import from `process`.

