### PR TITLE
chore: remove stale lmdb and msgpackr resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "prettier": "3.8.1"
   },
   "resolutions": {
-    "lmdb": "3.5.1",
-    "msgpackr": "1.11.8",
     "sharp": "0.33.5",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3"


### PR DESCRIPTION
These were Gatsby-era workarounds. The portal has since migrated to Vite and neither package is depended on by anything in the workspace (yarn why returns empty for both).

