### PR TITLE
fix(Field.Expiry): prevent focus when clicking outside the component

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/style/dnb-expiry.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/style/dnb-expiry.scss
@@ -1,4 +1,10 @@
 .dnb-forms-field-expiry {
+  width: fit-content;
+
+  .dnb-forms-field-block__contents {
+    width: fit-content;
+  }
+
   .dnb-segmented-field__fieldset {
     width: var(--forms-field-width--small);
   }


### PR DESCRIPTION
[Motivation](https://eufemia.dnb.no/uilib/extensions/forms/feature-fields/Expiry/demos/#empty):


https://github.com/user-attachments/assets/e96acce3-a204-4c9e-b2e5-51f3dbfb8f8f

[Deploy Preview](https://fix-field-expiry-focus-area.eufemia-e25.pages.dev//uilib/extensions/forms/feature-fields/Expiry/demos/#empty):




https://github.com/user-attachments/assets/30b49a1e-a901-4896-b562-7f8462687ae5



The contents container had width: 100% while the actual input was only 80px, leaving a large empty clickable area. The browser's default mousedown behavior on a block element containing contenteditable children caused the nearest editable span to receive focus when clicking in the empty space.

Setting width: fit-content on the contents wrapper constrains it to the actual field size, eliminating the spurious click target.

