### PR TITLE
chore: remove @tujoworker from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# pings tujoworker when PRs are made to these packages
-packages/dnb-design-system-portal/*  @tujoworker
-packages/eufemia/*  @tujoworker
+


### PR DESCRIPTION
I'm not sure if you still want this @tujoworker?
Very often when I make changes in these packages, you automatically get added as a reviewer, so from my point of view, I feel like this setup is spamming you. Your call 🔫 