### PR TITLE
docs: add dark mode guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
@@ -61,37 +61,6 @@ Since Figma has different rules and limitations than CSS we have established som
 - Variables are not case-sensitive. (`onDark` and `ondark` are considered the same variable)
 - We use dashes (`-`) to separate groups and words.
 
-## How to use
-
-The css variables are imported in the `style/themes/*/*-theme-basis.scss` file and are therefore part of each theme's basis import:
-
-```
-import '@dnb/eufemia/style/'
-import '@dnb/eufemia/style/themes/ui'
-import '@dnb/eufemia/style/themes/ui/basis'
-
-```
-
-Dark mode tokens are generated into a separate `tokens-dark.scss` file per theme. They are **not** included in the theme basis import and must be imported separately to opt in:
-
-```
-// DNB theme
-import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css'
-
-// Sbanken theme
-import '@dnb/eufemia/style/themes/sbanken/sbanken-theme-dark-mode.scss'
-```
-
-For Tailwind, dark tokens are in a separate file per theme:
-
-```css
-/* DNB theme */
-@import '@dnb/eufemia/style/themes/ui/tokens-dark-tailwind.css';
-
-/* Sbanken theme */
-@import '@dnb/eufemia/style/themes/sbanken/tokens-dark-tailwind.css';
-```
-
 ### Transforms
 
 During the CSS generation, Figma variables are converted to lower case. And groups are separated by dashes (`-`).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/icons/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/icons/Examples.tsx
@@ -44,7 +44,7 @@ export const IconsSVGExample = () => (
             fillRule="evenodd"
             clipRule="evenodd"
             d="M4.03 5.22a.75.75 0 0 0-1.06 1.06l4.5 4.5a.75.75 0 0 0 1.06 0l4.5-4.5a.75.75 0 0 0-1.06-1.06L8 9.19 4.03 5.22z"
-            fill="#000"
+            fill="currentColor"
           />
         </svg>
       )

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -87,16 +87,21 @@ When set to `"auto"`, it follows the user's system color preference unless overr
 Dark mode tokens are not included in the default theme import. You need to import them separately:
 
 ```tsx
-import { Theme } from '@dnb/eufemia/shared'
+// DNB theme
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode.min.css' // Use --isolated.min.css for style isolation
 
-// Required: import dark mode tokens
-import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css' // If style isolation is used
+// Sbanken theme
+import '@dnb/eufemia/style/themes/sbanken/sbanken-theme-dark-mode.min.css'
+```
 
-render(
-  <Theme colorScheme="auto">
-    <App />
-  </Theme>
-)
+For Tailwind, dark tokens are in a separate file per theme:
+
+```css
+/* DNB theme */
+@import '@dnb/eufemia/style/themes/ui/tokens-dark-tailwind.css';
+
+/* Sbanken theme */
+@import '@dnb/eufemia/style/themes/sbanken/tokens-dark-tailwind.css';
 ```
 
 When the `eufemia-theme__color-scheme--dark` class is active, the dark tokens override the same CSS custom property names with dark-appropriate values. For example, `--token-color-background-page-background` switches from `--dnb-greyscale-0` (white) to `--dnb-greyscale-1000` (dark).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -1,6 +1,14 @@
 ---
 title: 'Theming'
 order: 7
+showTabs: true
+tabs:
+  - title: Overview
+    key: /uilib/usage/customisation/theming
+  - title: Theme component
+    key: /uilib/usage/customisation/theming/theme
+  - title: Design Tokens
+    key: /uilib/usage/customisation/theming/design-tokens
 ---
 
 # Theming
@@ -60,17 +68,7 @@ Use the `var()` function to reference a token in your CSS:
 }
 ```
 
-### Using tokens in your own styles
-
-When writing custom component styles, you can use design tokens with the `var(--token-*)` syntax. For example:
-
-```scss
-.my-component__title--warning {
-  color: var(--token-color-text-warning);
-}
-```
-
-### Dark surfaces
+## Dark surfaces
 
 Use `surface="dark"` on the [Theme](/src/docs/uilib/usage/customisation/theming/theme/) component to tell Eufemia that an area has a dark background. Components inside that area will automatically pick the right colors. The `ondark` tokens are the color values they switch to.
 
@@ -104,3 +102,5 @@ render(
 When the `eufemia-theme__color-scheme--dark` class is active, the dark tokens override the same CSS custom property names with dark-appropriate values. For example, `--token-color-background-page-background` switches from `--dnb-greyscale-0` (white) to `--dnb-greyscale-1000` (dark).
 
 Read more about the [colorScheme](/uilib/usage/customisation/theming/theme/) property, including [preventing dark mode flash (FOUC)](/uilib/usage/customisation/theming/theme/#preventing-dark-mode-flash-fouc) for SSR considerations.
+
+For guidance on choosing between base, `inverse`, and `ondark` token variants in dark mode, see the [Design Tokens dark mode guide](/uilib/usage/customisation/theming/design-tokens/dark-mode).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens.mdx
@@ -8,6 +8,8 @@ tabs:
     key: /info
   - title: Guide
     key: /guide
+  - title: Dark mode
+    key: /dark-mode
   - title: Colors
     key: /colors
   - title: Radius

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
@@ -9,7 +9,7 @@ import type { CSSProperties, ReactNode } from 'react'
 import { basicComponents } from '../../../../../../shared/tags'
 import Table from '../../../../../../shared/tags/Table'
 import Anchor from '../../../../../../shared/tags/Anchor'
-import { Td, Th, Tooltip, Tr, Card, P, Lead } from '@dnb/eufemia/src'
+import { Td, Th, Tooltip, Tr, Card, P, Lead, Flex } from '@dnb/eufemia/src'
 import { Theme, useTheme } from '@dnb/eufemia/src/shared'
 import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
@@ -172,15 +172,10 @@ const darkModeSwatchRows: DarkModeSwatch[] = [
 ]
 
 const darkModeGridStyle: CSSProperties = {
-  display: 'grid',
+  display: 'inline-grid',
   gap: '1rem',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(16rem, 1fr))',
-  marginBlock: '1.5rem',
-}
-
-const darkModeSwatchListStyle: CSSProperties = {
-  display: 'grid',
-  gap: '0.75rem',
+  gridTemplateColumns: 'repeat(2, auto)',
+  placeItems: 'start',
 }
 
 const darkModeCardInnerStyle: CSSProperties = {
@@ -190,21 +185,12 @@ const darkModeCardInnerStyle: CSSProperties = {
   justifyContent: 'space-between',
 }
 
-const darkModeCardLabelStyle: CSSProperties = {
-  display: 'grid',
-  gap: '0.25rem',
-}
-
 const darkModeCardNameStyle: CSSProperties = {
   margin: 0,
-  // fontSize: '1rem',
-  // fontWeight: 600,
-  // lineHeight: 1.2,
 }
 
 const darkModeCardSurfaceStyle: CSSProperties = {
   margin: 0,
-  // fontSize: '0.75rem',
   opacity: 0.8,
 }
 
@@ -275,27 +261,16 @@ const DarkModeCard = ({
   const surfaceStyle = getCardSurfaceStyle(scheme, row.surface, theme)
 
   return (
-    <Card style={surfaceStyle} stack>
+    <Card style={surfaceStyle} stack gap="small">
       <div style={darkModeCardInnerStyle}>
-        <div style={darkModeCardLabelStyle}>
-          <Lead
-            style={{
-              ...darkModeCardNameStyle,
-              color: `var(${row.textToken})`,
-            }}
-          >
-            {row.label}
-          </Lead>
-          <P
-            className="dnb-t__size--x-small"
-            style={{
-              ...darkModeCardSurfaceStyle,
-              color: `var(${row.textToken})`,
-            }}
-          >
-            {getSurfaceLabel(row.surface)}
-          </P>
-        </div>
+        <Lead
+          style={{
+            ...darkModeCardNameStyle,
+            color: `var(${row.textToken})`,
+          }}
+        >
+          {row.label}
+        </Lead>
         <span
           aria-hidden
           style={{
@@ -314,6 +289,15 @@ const DarkModeCard = ({
           </svg>
         </span>
       </div>
+      <P
+        className="dnb-t__size--x-small"
+        style={{
+          ...darkModeCardSurfaceStyle,
+          color: `var(${row.textToken})`,
+        }}
+      >
+        {getSurfaceLabel(row.surface)}
+      </P>
       <div style={darkModeCardTokensStyle}>
         <MDXCode>{row.textToken}</MDXCode>
       </div>
@@ -336,7 +320,7 @@ export function DarkModeTokenSwatches() {
           }
         >
           <Theme colorScheme={scheme}>
-            <div style={darkModeSwatchListStyle}>
+            <Flex.Stack gap="small">
               {darkModeSwatchRows.map((row) => (
                 <DarkModeCard
                   key={`${scheme}-${row.label}`}
@@ -344,7 +328,7 @@ export function DarkModeTokenSwatches() {
                   row={row}
                 />
               ))}
-            </div>
+            </Flex.Stack>
           </Theme>
         </Card>
       ))}

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
@@ -9,7 +9,8 @@ import type { CSSProperties, ReactNode } from 'react'
 import { basicComponents } from '../../../../../../shared/tags'
 import Table from '../../../../../../shared/tags/Table'
 import Anchor from '../../../../../../shared/tags/Anchor'
-import { Td, Th, Tooltip, Tr } from '@dnb/eufemia/src'
+import { Td, Th, Tooltip, Tr, Card, P, Lead } from '@dnb/eufemia/src'
+import { Theme, useTheme } from '@dnb/eufemia/src/shared'
 import useHandleSortState from '@dnb/eufemia/src/components/table/useHandleSortState'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 import {
@@ -118,6 +119,236 @@ const renderColorValue = (value: string) => {
       </span>
       <MDXCode>{value}</MDXCode>
     </span>
+  )
+}
+
+type ColorScheme = 'light' | 'dark'
+type SurfaceVariant = 'default' | 'inverse' | 'ondark'
+
+type DarkModeSwatch = {
+  label: string
+  textToken: string
+  iconToken: string
+  surface: SurfaceVariant
+}
+
+const darkModeSwatchRows: DarkModeSwatch[] = [
+  {
+    label: 'neutral',
+    textToken: '--token-color-text-neutral',
+    iconToken: '--token-color-icon-neutral',
+    surface: 'default',
+  },
+  {
+    label: 'neutral-inverse',
+    textToken: '--token-color-text-neutral-inverse',
+    iconToken: '--token-color-icon-neutral-inverse',
+    surface: 'inverse',
+  },
+  {
+    label: 'neutral-ondark',
+    textToken: '--token-color-text-neutral-ondark',
+    iconToken: '--token-color-icon-neutral-ondark',
+    surface: 'ondark',
+  },
+  {
+    label: 'action',
+    textToken: '--token-color-text-action',
+    iconToken: '--token-color-icon-action',
+    surface: 'default',
+  },
+  {
+    label: 'action-inverse',
+    textToken: '--token-color-text-action-inverse',
+    iconToken: '--token-color-icon-action-inverse',
+    surface: 'inverse',
+  },
+  {
+    label: 'action-ondark',
+    textToken: '--token-color-text-action-ondark',
+    iconToken: '--token-color-icon-action-ondark',
+    surface: 'ondark',
+  },
+]
+
+const darkModeGridStyle: CSSProperties = {
+  display: 'grid',
+  gap: '1rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(16rem, 1fr))',
+  marginBlock: '1.5rem',
+}
+
+const darkModeSwatchListStyle: CSSProperties = {
+  display: 'grid',
+  gap: '0.75rem',
+}
+
+const darkModeCardInnerStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: '0.75rem',
+  justifyContent: 'space-between',
+}
+
+const darkModeCardLabelStyle: CSSProperties = {
+  display: 'grid',
+  gap: '0.25rem',
+}
+
+const darkModeCardNameStyle: CSSProperties = {
+  margin: 0,
+  // fontSize: '1rem',
+  // fontWeight: 600,
+  // lineHeight: 1.2,
+}
+
+const darkModeCardSurfaceStyle: CSSProperties = {
+  margin: 0,
+  // fontSize: '0.75rem',
+  opacity: 0.8,
+}
+
+const darkModeCardTokensStyle: CSSProperties = {
+  display: 'grid',
+  gap: '0.125rem',
+  marginTop: '0.75rem',
+}
+
+const darkModeCardIconStyle: CSSProperties = {
+  display: 'inline-flex',
+  flexShrink: 0,
+}
+
+const getSurfaceLabel = (surface: SurfaceVariant) => {
+  if (surface === 'ondark') {
+    return 'Dark surface'
+  }
+
+  if (surface === 'inverse') {
+    return 'Opposite scheme'
+  }
+
+  return 'Current scheme'
+}
+
+const getCardSurfaceStyle = (
+  scheme: ColorScheme,
+  surface: SurfaceVariant,
+  theme: ReturnType<typeof useTheme>
+): CSSProperties => {
+  if (surface === 'ondark') {
+    return {
+      backgroundColor: 'var(--token-color-decorative-first-bold-static)',
+      borderColor: 'var(--token-stroke-color-neutral-subtle)',
+    }
+  }
+
+  if (surface === 'inverse') {
+    // In light scheme, inverse surface is dark, and vice versa. This ensures that the swatch surface always has some contrast with the text and icon colors.
+    if (scheme === 'light' && theme.colorScheme === 'dark') {
+      scheme = 'dark'
+    }
+
+    return scheme === 'light'
+      ? {
+          backgroundColor: '#000',
+          borderColor: 'var(--token-stroke-color-neutral-subtle)',
+        }
+      : {
+          backgroundColor: '#fff',
+        }
+  }
+
+  return {
+    backgroundColor: 'var(--token-color-background-neutral)',
+  }
+}
+
+const DarkModeCard = ({
+  scheme,
+  row,
+}: {
+  scheme: ColorScheme
+  row: DarkModeSwatch
+}) => {
+  const theme = useTheme()
+  const surfaceStyle = getCardSurfaceStyle(scheme, row.surface, theme)
+
+  return (
+    <Card style={surfaceStyle} stack>
+      <div style={darkModeCardInnerStyle}>
+        <div style={darkModeCardLabelStyle}>
+          <Lead
+            style={{
+              ...darkModeCardNameStyle,
+              color: `var(${row.textToken})`,
+            }}
+          >
+            {row.label}
+          </Lead>
+          <P
+            className="dnb-t__size--x-small"
+            style={{
+              ...darkModeCardSurfaceStyle,
+              color: `var(${row.textToken})`,
+            }}
+          >
+            {getSurfaceLabel(row.surface)}
+          </P>
+        </div>
+        <span
+          aria-hidden
+          style={{
+            ...darkModeCardIconStyle,
+            color: `var(${row.iconToken})`,
+          }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="12" r="4" fill="currentColor" />
+            <path
+              d="M12 2.5v3M12 18.5v3M21.5 12h-3M5.5 12h-3M18.72 5.28l-2.12 2.12M7.4 16.6l-2.12 2.12M18.72 18.72l-2.12-2.12M7.4 7.4 5.28 5.28"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeWidth="1.5"
+            />
+          </svg>
+        </span>
+      </div>
+      <div style={darkModeCardTokensStyle}>
+        <MDXCode>{row.textToken}</MDXCode>
+      </div>
+    </Card>
+  )
+}
+
+export function DarkModeTokenSwatches() {
+  const theme = useTheme()
+  const schemes: ColorScheme[] =
+    theme?.colorScheme === 'dark' ? ['dark', 'light'] : ['light', 'dark']
+
+  return (
+    <div style={darkModeGridStyle}>
+      {schemes.map((scheme) => (
+        <Card
+          key={scheme}
+          title={
+            scheme === 'dark' ? 'Dark color scheme' : 'Light color scheme'
+          }
+        >
+          <Theme colorScheme={scheme}>
+            <div style={darkModeSwatchListStyle}>
+              {darkModeSwatchRows.map((row) => (
+                <DarkModeCard
+                  key={`${scheme}-${row.label}`}
+                  scheme={scheme}
+                  row={row}
+                />
+              ))}
+            </div>
+          </Theme>
+        </Card>
+      ))}
+    </div>
   )
 }
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/dark-mode.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/dark-mode.mdx
@@ -63,16 +63,11 @@ If you are styling Eufemia components, prefer `surface="dark"` where supported. 
 Dark mode tokens are not included in the default theme import. Import the extra dark mode stylesheet before using `colorScheme`:
 
 ```tsx
-import { Theme } from '@dnb/eufemia/shared'
+// DNB theme
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode.min.css' // Use --isolated.min.css for style isolation
 
-// Required: import dark mode tokens
-import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css' // If style isolation is used
-
-render(
-  <Theme colorScheme="auto">
-    <App />
-  </Theme>
-)
+// Sbanken theme
+import '@dnb/eufemia/style/themes/sbanken/sbanken-theme-dark-mode.min.css' // Use --isolated.min.css for style isolation
 ```
 
 For runtime setup, persistence, and SSR details, see the [`colorScheme` property](/uilib/usage/customisation/theming/theme/#the-colorscheme-property-dark-mode).

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/dark-mode.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/dark-mode.mdx
@@ -1,0 +1,133 @@
+---
+showTabs: true
+---
+
+import * as Examples from './Examples'
+
+# Dark mode guide
+
+Dark mode changes the active color scheme. It does not change how you choose semantic tokens.
+
+Start with the same semantic token family you would use in light mode, then adjust only when the surface relationship changes:
+
+- Use the base token when the content sits on the current color scheme's default surface.
+- Use the `inverse` variant when the content sits on a surface that follows the opposite color scheme.
+- Use the `ondark` variant when the content sits on a local dark surface, regardless of the surrounding color scheme.
+
+## Choosing the right variant
+
+### Base tokens follow the current scheme
+
+`--token-color-text-neutral`, `--token-color-icon-neutral`, `--token-color-text-action`, and `--token-color-icon-action` are the default choice for content that lives on the page's normal surface.
+
+If the application changes from light mode to dark mode, those same token names adapt automatically. In most cases, this is all you need.
+
+### `inverse` is for the opposite scheme
+
+Use `inverse` when the surrounding surface should feel like the opposite color scheme.
+
+Typical examples are overlays, promotional blocks, or embedded areas that intentionally contrast with the current page mode. The token keeps the semantic role, but flips the contrast relationship.
+
+### `ondark` is for local dark surfaces
+
+Use `ondark` when the background is dark because of the component or section itself, not because the whole app switched to dark mode.
+
+That distinction matters because a local dark card inside light mode and a full dark-mode page are not the same thing. `ondark` communicates that the content must stay readable on a dark surface in either case.
+
+### Variant behavior in each scheme
+
+#### Light color scheme
+
+Use the base token on the current surface, switch to `inverse` when the surface follows the opposite scheme, and use `ondark` for a local dark surface.
+
+#### Dark color scheme
+
+The same semantic token names adapt automatically in dark mode. Only `inverse` and `ondark` change the surface relationship.
+
+### Color token swatches
+
+<Examples.DarkModeTokenSwatches />
+
+## Practical rule
+
+Choose the token by semantic role first, then by surface relationship:
+
+1. Is this neutral content or action content?
+2. Is it on the current scheme, the opposite scheme, or a local dark surface?
+3. Pick the base, `inverse`, or `ondark` variant accordingly.
+
+If you are styling Eufemia components, prefer `surface="dark"` where supported. Components already switch to the correct `ondark` variants automatically.
+
+## Common pattern
+
+Dark mode tokens are not included in the default theme import. Import the extra dark mode stylesheet before using `colorScheme`:
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+// Required: import dark mode tokens
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css' // If style isolation is used
+
+render(
+  <Theme colorScheme="auto">
+    <App />
+  </Theme>
+)
+```
+
+For runtime setup, persistence, and SSR details, see the [`colorScheme` property](/uilib/usage/customisation/theming/theme/#the-colorscheme-property-dark-mode).
+
+If you render on the server, also read [Preventing dark mode flash (FOUC)](/uilib/usage/customisation/theming/theme/#preventing-dark-mode-flash-fouc).
+
+When your app switches the whole UI to dark mode, keep using the base semantic tokens once the dark mode stylesheet is loaded:
+
+```tsx
+import { Theme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme colorScheme="dark">
+    <App />
+  </Theme>
+)
+```
+
+When a single component can appear on a dark surface, swap only the local token references:
+
+```scss
+.my-card {
+  --card-text-color: var(--token-color-text-neutral);
+  --card-icon-color: var(--token-color-icon-neutral);
+}
+
+.my-card--on-dark {
+  --card-text-color: var(--token-color-text-neutral-ondark);
+  --card-icon-color: var(--token-color-icon-neutral-ondark);
+}
+
+.my-card__title {
+  color: var(--card-text-color);
+}
+
+.my-card__icon {
+  color: var(--card-icon-color);
+}
+```
+
+Use the same pattern for action-colored content:
+
+```scss
+.my-link-card {
+  --card-link-color: var(--token-color-text-action);
+  --card-link-icon-color: var(--token-color-icon-action);
+}
+
+.my-link-card--inverse {
+  --card-link-color: var(--token-color-text-action-inverse);
+  --card-link-icon-color: var(--token-color-icon-action-inverse);
+}
+
+.my-link-card--on-dark {
+  --card-link-color: var(--token-color-text-action-ondark);
+  --card-link-icon-color: var(--token-color-icon-action-ondark);
+}
+```

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/info.mdx
@@ -24,7 +24,7 @@ They follow the naming pattern `--token-color-{section}-{role}` and are the reco
 
 ## Getting started
 
-Design tokens are included when you import a Eufemia theme. No separate import is needed, except if you need [dark mode support](/uilib/usage/customisation/theming#dark-mode--color-scheme).
+Design tokens are included when you import a Eufemia theme. No separate import is needed, except if you need dark mode support. In that case, import the extra dark mode stylesheet described in the [Dark mode guide](/uilib/usage/customisation/theming/design-tokens/dark-mode).
 
 Read more about how to use design tokens in your own styles, and how Eufemia components use them internally, in the [Theming](/uilib/usage/customisation/theming#design-tokens) section.
 
@@ -105,7 +105,7 @@ And the component internally moves that value to a token-based custom property, 
 
 The `ondark` suffix identifies token variants designed for use on dark backgrounds. Eufemia components use these tokens automatically when `surface="dark"` is active — you do not need to select them yourself.
 
-For practical guidance on using `ondark` tokens in your own components, see the [Guide](/uilib/usage/customisation/theming/design-tokens/guide#dark-surfaces-use-ondark-tokens).
+For practical guidance on using `ondark`, `inverse`, and base tokens in your own components, see the [Dark mode guide](/uilib/usage/customisation/theming/design-tokens/dark-mode).
 
 ## Tailwind CSS integration
 
@@ -123,7 +123,7 @@ Tokens are organized into sections. Each section covers a specific surface:
 | Stroke     | `--token-color-stroke-*`     | Borders, dividers, outlines, focus rings |
 | Decorative | `--token-color-decorative-*` | Advanced decorative use cases            |
 
-See the [Tokens](/uilib/usage/customisation/theming/design-tokens/tokens) tab for the full catalog.
+See the [Color Tokens](/uilib/usage/customisation/theming/design-tokens/colors/) tab for the full catalog.
 
 ## Naming contract
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -160,8 +160,13 @@ The `Theme` component accepts a `colorScheme` prop that controls dark and light 
 
 When set to `"auto"`, it follows the user's system color preference unless overridden by a parent theme or application setting. It uses the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme) media query to detect the system preference.
 
+Dark mode tokens are not included in the default theme import. Import the extra dark mode stylesheet before using `colorScheme`:
+
 ```tsx
 import { Theme } from '@dnb/eufemia/shared'
+
+// Required: import dark mode tokens
+import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode--isolated.min.css' // If style isolation is used
 
 render(
   <Theme colorScheme="auto">
@@ -169,6 +174,8 @@ render(
   </Theme>
 )
 ```
+
+For guidance on choosing between base, `inverse`, and `ondark` token variants in your own components, see the [Design Tokens dark mode guide](/uilib/usage/customisation/theming/design-tokens/dark-mode).
 
 ## Persisting the theme with `getTheme` and `setTheme`
 


### PR DESCRIPTION
Preview: https://chore-color-swatches.eufemia-e25.pages.dev/uilib/usage/customisation/theming/design-tokens/dark-mode/