### PR TITLE
refactor(Tooltip): add correct border radius token

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -109,7 +109,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -109,7 +109,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -121,7 +121,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -122,7 +122,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/__snapshots__/NumberFormat.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`NumberFormat scss > has to match style dependencies css 1`] = `
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -682,9 +682,17 @@ function PopoverContainer(props: PopoverContainerProps) {
     const marginRight = computedElementStyle
       ? parseFloat(computedElementStyle.marginRight) || 0
       : 0
-    const borderRadius = computedElementStyle
+    const rawBorderRadius = computedElementStyle
       ? parseFloat(computedElementStyle.borderRadius) || 0
       : 0
+    // Cap border-radius to actual visual maximum, since the browser
+    // clamps it to half the element size but getComputedStyle returns
+    // the raw value (e.g. 9999px from --token-radius-full).
+    const borderRadius = Math.min(
+      rawBorderRadius,
+      elementWidth / 2,
+      elementHeight / 2
+    )
 
     let actualLeft = nextLeft
 

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -2308,6 +2308,82 @@ describe('Popover', () => {
       targetElement.remove()
     })
 
+    it('caps border-radius to half the element size for arrow clamping', async () => {
+      const targetElement = document.createElement('div')
+      document.body.appendChild(targetElement)
+
+      const windowWidthDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        'innerWidth'
+      )
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 320,
+      })
+
+      Object.defineProperty(targetElement, 'offsetWidth', {
+        configurable: true,
+        value: 24,
+      })
+      Object.defineProperty(targetElement, 'offsetHeight', {
+        configurable: true,
+        value: 40,
+      })
+
+      assignRect(
+        targetElement,
+        createRect({ left: 10, top: 120, width: 24, height: 40 })
+      )
+
+      setElementSize(220, 40)
+
+      const originalGetComputedStyle = window.getComputedStyle
+      jest.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+        const style = originalGetComputedStyle(el)
+        if (
+          el instanceof HTMLElement &&
+          el.classList.contains('dnb-popover')
+        ) {
+          return {
+            ...style,
+            borderRadius: '9999px',
+          } as CSSStyleDeclaration
+        }
+        return style
+      })
+
+      render(
+        <Popover
+          open
+          noAnimation
+          placement="bottom"
+          arrowEdgeOffset={4}
+          targetElement={targetElement}
+        >
+          Large border-radius tooltip
+        </Popover>
+      )
+
+      await waitFor(() => {
+        const arrow = document.querySelector(
+          '.dnb-popover__arrow'
+        ) as HTMLElement
+
+        // Without clamping, 9999px border-radius makes arrowBoundary
+        // so large that arrowMin === arrowMax === maxLeft (204px),
+        // locking the arrow at the far edge.
+        // With clamping to half the element height (40/2 = 20),
+        // the arrow boundary becomes 20px instead.
+        expect(arrow?.style.left).toBe('20px')
+      })
+
+      jest.restoreAllMocks()
+      if (windowWidthDescriptor) {
+        Object.defineProperty(window, 'innerWidth', windowWidthDescriptor)
+      }
+      targetElement.remove()
+    })
+
     it('flips to top placement when there is limited space below', async () => {
       const targetElement = document.createElement('div')
       document.body.appendChild(targetElement)

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -113,7 +113,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -314,7 +314,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Tooltip scss > has to match style dependencies css 1`] = `
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral

--- a/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
+++ b/packages/dnb-eufemia/src/components/tooltip/style/dnb-tooltip.scss
@@ -11,7 +11,7 @@
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
 
   // Set design tokens for tooltip
   --popover-text-color: var(--token-color-text-neutral-inverse);

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -117,7 +117,7 @@ p > .dnb-icon {
 
 .dnb-tooltip {
   --inner-space: 0;
-  --tooltip-border-radius: var(--token-radius-lg);
+  --tooltip-border-radius: var(--token-radius-full);
   --popover-text-color: var(--token-color-text-neutral-inverse);
   --popover-background-color: var(
     --token-color-component-tooltip-background-neutral


### PR DESCRIPTION
Using `--token-radius-full` as defined in the sketches, required a small rewrite of the `borderRadius` value used in `PopoverContainer`, since `--token-radius-full` resolves to `9999px` which threw off the position of the `Tooltip`