### PR TITLE
chore: remove unused markdown-tables-utils devDependency

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -217,7 +217,6 @@
     "lockfile-lint": "4.14.1",
     "lodash.isequal": "4.5.0",
     "lodash.isequalwith": "4.4.0",
-    "markdown-tables-utils": "workspace:*",
     "mock-match-media": "0.3.0",
     "nodemon": "2.0.15",
     "opentype.js": "1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,7 +2550,6 @@ __metadata:
     lockfile-lint: "npm:4.14.1"
     lodash.isequal: "npm:4.5.0"
     lodash.isequalwith: "npm:4.4.0"
-    markdown-tables-utils: "workspace:*"
     mock-match-media: "npm:0.3.0"
     nodemon: "npm:2.0.15"
     opentype.js: "npm:1.3.4"


### PR DESCRIPTION
The markdown-tables-utils workspace package is not imported anywhere in packages/dnb-eufemia. It is only used by tools/eufemia-llm-metadata, which has its own dependency declaration.

