### PR TITLE
chore(CodeBlock): fix bottom border not shown

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -81,9 +81,13 @@
     display: none;
   }
 
-  background-color: var(--token-color-background-neutral);
+  position: relative;
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
 
-  :global(.background--plain) & {
     border-top: 0.0625rem solid var(--token-color-stroke-neutral-subtle);
   }
 


### PR DESCRIPTION
Before: 

<img width="599" height="76" alt="Screenshot 2026-05-06 at 21 56 15" src="https://github.com/user-attachments/assets/498513b3-c17d-4e54-9b2f-cce34169e76e" />



After:

<img width="599" height="84" alt="Screenshot 2026-05-06 at 21 55 53" src="https://github.com/user-attachments/assets/050123e4-4ec0-4c43-bfe4-bafd95e151cf" />
