### PR TITLE
chore(CI): fix postbuild test timeout on CI

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -138,7 +138,10 @@ describe('babel build', () => {
 
       files
         .filter((filePath) => {
-          return filePath.includes('/dnb-eufemia/src/')
+          return (
+            filePath.includes('/dnb-eufemia/src/') &&
+            /\.(ts|tsx|js|jsx)$/.test(filePath)
+          )
         })
         .map((filePath) => {
           return filePath.replace('packages/dnb-eufemia/', '')
@@ -147,7 +150,7 @@ describe('babel build', () => {
           const absolutePath = path.resolve(process.cwd(), filePath)
           if (fs.existsSync(absolutePath)) {
             const content = fs.readFileSync(absolutePath, 'utf-8')
-            const regex = /.*import.*(\/src\/)/
+            const regex = /^.*import.*\/src\//m
 
             if (regex.test(content)) {
               console.error('Failed in this file:', absolutePath)


### PR DESCRIPTION
The previous fix (e21d80a) addressed shell startup overhead by switching from login shell (-lc) to plain (-c) and adding a 10s exec timeout, but the test still timed out because of two issues in the test itself:

1. No file-extension filter – every changed file under src/ was read and checked (scss, json, snap, md, etc.), not just JS/TS files.

2. Backtracking regex – /.*import.*(\/src\/)/ applied against entire file contents without line anchoring causes quadratic backtracking on files with many import lines.

Filter to .ts/.tsx/.js/.jsx and use a line-anchored regex instead.


Followup on #7973