### PR TITLE
fix(Iterate.Array): clear open-delay timeout on unmount in ArrayItemArea

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
@@ -102,6 +102,7 @@ function ArrayItemArea(
 
   const openRef = useRef(open ?? (containerMode === mode && !isNew))
   const isRemoving = useRef(false)
+  const openDelayRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   const setOpenState = useCallback((open: boolean) => {
     openRef.current = open
@@ -117,7 +118,7 @@ function ArrayItemArea(
         // - Open the block with animation, if it's in the right mode
         if (openRef.current !== (containerMode === mode)) {
           if (isNew) {
-            setTimeout(() => {
+            openDelayRef.current = setTimeout(() => {
               setOpenState(containerMode === mode)
             }, openDelay) // in order to apply the animation
           } else {
@@ -125,6 +126,10 @@ function ArrayItemArea(
           }
         }
       }
+    }
+
+    return () => {
+      clearTimeout(openDelayRef.current)
     }
   }, [containerMode, isNew, mode, open, openDelay, setOpenState])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/ArrayItemArea.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/ArrayItemArea.test.tsx
@@ -171,7 +171,7 @@ describe('ArrayItemArea', () => {
       </IterateItemContext>
     )
 
-    const { rerender } = render(
+    render(
       <ArrayItemArea mode="view" openDelay={1}>
         Content
       </ArrayItemArea>,
@@ -179,14 +179,6 @@ describe('ArrayItemArea', () => {
     )
 
     const block = document.querySelector('.dnb-forms-section-block')
-    expect(block).toHaveClass('dnb-height-animation--hidden')
-
-    rerender(
-      <ArrayItemArea mode="edit" openDelay={1}>
-        Content
-      </ArrayItemArea>
-    )
-
     expect(block).toHaveClass('dnb-height-animation--hidden')
 
     await waitFor(() => {


### PR DESCRIPTION
The setTimeout for the open animation could fire after the test environment was torn down, causing a 'window is not defined' error in unrelated test files.

Have seen this test fail several times: https://github.com/dnbexperience/eufemia/actions/runs/25477347773/job/74753577277
