### PR TITLE
chore(Portal): use radius token for code blocks

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -106,7 +106,7 @@
 }
 
 .liveCodeEditorStyle {
-  --border-radius: 1rem;
+  --border-radius: var(--token-radius-lg);
   border-radius: var(--border-radius);
 
   // Outline


### PR DESCRIPTION
DNB
<img width="165" height="189" alt="Screenshot 2026-05-07 at 09 40 21" src="https://github.com/user-attachments/assets/f95d4214-08a2-4049-bb3e-a8c66d5f0c7c" />

Carnegie
<img width="151" height="184" alt="Screenshot 2026-05-07 at 09 40 07" src="https://github.com/user-attachments/assets/e1238758-a755-473f-a004-021f33cba0e2" />
