### PR TITLE
chore(Portal): recover from stale chunk URLs after deploy

### DIFF
--- a/packages/dnb-design-system-portal/static/sw.js
+++ b/packages/dnb-design-system-portal/static/sw.js
@@ -1,0 +1,52 @@
+/**
+ * Kill-switch service worker.
+ *
+ * The Eufemia portal does not use a service worker, but earlier
+ * versions (running on Gatsby) may have shipped one to production
+ * through `gatsby-plugin-offline`. Existing installs would continue
+ * intercepting requests and serve cached HTML / chunk URLs that no
+ * longer exist on the new build, causing ChunkLoadError on soft
+ * reload.
+ *
+ * Serving an empty worker at the same scope replaces the old one and
+ * uninstalls itself, restoring normal HTTP fetching for those users.
+ *
+ * Once this has been live long enough for all returning users to
+ * have visited at least once, this file can be deleted.
+ */
+
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        if (self.registration && self.registration.unregister) {
+          await self.registration.unregister()
+        }
+        if (self.caches && typeof self.caches.keys === 'function') {
+          const keys = await self.caches.keys()
+          await Promise.all(keys.map((key) => self.caches.delete(key)))
+        }
+        if (self.clients && typeof self.clients.matchAll === 'function') {
+          const clients = await self.clients.matchAll({
+            type: 'window',
+          })
+          for (const client of clients) {
+            if (client && typeof client.navigate === 'function') {
+              try {
+                await client.navigate(client.url)
+              } catch {
+                // Ignore navigation errors (cross-origin, etc.)
+              }
+            }
+          }
+        }
+      } catch {
+        // Best-effort cleanup; ignore errors.
+      }
+    })()
+  )
+})

--- a/packages/dnb-design-system-portal/vite/__tests__/chunk-load-error-handler.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/chunk-load-error-handler.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isChunkLoadError,
+  setupChunkLoadErrorHandler,
+} from '../client/chunk-load-error-handler'
+
+describe('isChunkLoadError', () => {
+  it('matches errors with name ChunkLoadError', () => {
+    const error = Object.assign(new Error('boom'), {
+      name: 'ChunkLoadError',
+    })
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('matches the webpack chunk load error message', () => {
+    const error = new Error('Loading chunk 58333 failed.')
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('matches the Vite dynamic import error message', () => {
+    const error = new Error(
+      'Failed to fetch dynamically imported module: /assets/foo.js'
+    )
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('matches the alternative Vite import error message', () => {
+    const error = new Error('error loading dynamically imported module')
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('matches Safari "Importing a module script failed" wording', () => {
+    const error = new Error('Importing a module script failed.')
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('matches "Unable to preload CSS" from Vite', () => {
+    const error = new Error('Unable to preload CSS for /assets/foo.css')
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isChunkLoadError(new Error('something else'))).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+  })
+
+  it('handles plain string reasons', () => {
+    expect(isChunkLoadError('Loading chunk 1 failed')).toBe(true)
+    expect(isChunkLoadError('totally fine')).toBe(false)
+  })
+})
+
+describe('setupChunkLoadErrorHandler', () => {
+  let storage: Map<string, string>
+  let storageLike: {
+    getItem: (key: string) => string | null
+    setItem: (key: string, value: string) => void
+    removeItem: (key: string) => void
+  }
+  let reload: () => void
+  let cleanup: (() => void) | undefined
+
+  beforeEach(() => {
+    storage = new Map()
+    storageLike = {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => {
+        storage.set(key, value)
+      },
+      removeItem: (key) => {
+        storage.delete(key)
+      },
+    }
+    reload = vi.fn<() => void>()
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+  })
+
+  function dispatchRejection(reason: unknown) {
+    const event = new Event(
+      'unhandledrejection'
+    ) as unknown as PromiseRejectionEvent
+
+    Object.defineProperty(event, 'reason', { value: reason })
+    Object.defineProperty(event, 'promise', {
+      value: Promise.resolve(),
+    })
+    window.dispatchEvent(event)
+  }
+
+  it('reloads the page when an unhandled rejection is a chunk load error', () => {
+    cleanup = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    dispatchRejection(new Error('Loading chunk 58333 failed.'))
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload for unrelated errors', () => {
+    cleanup = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    dispatchRejection(new Error('totally unrelated'))
+
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not reload twice within the same session', () => {
+    storage.set('eufemia-portal:chunk-error-reloaded', '1')
+
+    cleanup = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    // The handler clears the flag on successful boot — simulate the
+    // case where the second boot ALSO encounters a chunk error by
+    // setting the flag again before dispatching.
+    storage.set('eufemia-portal:chunk-error-reloaded', '1')
+
+    dispatchRejection(new Error('Loading chunk 1 failed'))
+
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('clears the reload flag when the new page boots successfully', () => {
+    storage.set('eufemia-portal:chunk-error-reloaded', '1')
+
+    cleanup = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    expect(storage.has('eufemia-portal:chunk-error-reloaded')).toBe(false)
+  })
+
+  it('reacts to window error events with a chunk load error', () => {
+    cleanup = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    const errorEvent = new ErrorEvent('error', {
+      error: new Error('Failed to fetch dynamically imported module'),
+      message: 'Failed to fetch dynamically imported module',
+    })
+
+    window.dispatchEvent(errorEvent)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes its listeners on cleanup', () => {
+    const dispose = setupChunkLoadErrorHandler({
+      storage: storageLike,
+      reload,
+    })
+
+    dispose()
+
+    dispatchRejection(new Error('Loading chunk 1 failed'))
+
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('survives storage that throws on access', () => {
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('blocked')
+      },
+      removeItem: () => {
+        throw new Error('blocked')
+      },
+    }
+
+    cleanup = setupChunkLoadErrorHandler({
+      storage: throwingStorage,
+      reload,
+    })
+
+    expect(() =>
+      dispatchRejection(new Error('Loading chunk 1 failed'))
+    ).not.toThrow()
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dnb-design-system-portal/vite/__tests__/unregister-legacy-service-workers.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/unregister-legacy-service-workers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { unregisterLegacyServiceWorkers } from '../client/unregister-legacy-service-workers'
+
+describe('unregisterLegacyServiceWorkers', () => {
+  it('does nothing when serviceWorker is unavailable', async () => {
+    await expect(
+      unregisterLegacyServiceWorkers({})
+    ).resolves.toBeUndefined()
+  })
+
+  it('unregisters every existing registration', async () => {
+    const unregister1 = vi.fn().mockResolvedValue(true)
+    const unregister2 = vi.fn().mockResolvedValue(true)
+
+    const navigatorRef = {
+      serviceWorker: {
+        getRegistrations: vi
+          .fn()
+          .mockResolvedValue([
+            { unregister: unregister1 },
+            { unregister: unregister2 },
+          ]),
+      },
+    }
+
+    await unregisterLegacyServiceWorkers(navigatorRef)
+
+    expect(unregister1).toHaveBeenCalledTimes(1)
+    expect(unregister2).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows errors thrown while unregistering', async () => {
+    const navigatorRef = {
+      serviceWorker: {
+        getRegistrations: vi.fn().mockResolvedValue([
+          {
+            unregister: vi.fn().mockRejectedValue(new Error('nope')),
+          },
+        ]),
+      },
+    }
+
+    await expect(
+      unregisterLegacyServiceWorkers(navigatorRef)
+    ).resolves.toBeUndefined()
+  })
+
+  it('swallows errors from getRegistrations()', async () => {
+    const navigatorRef = {
+      serviceWorker: {
+        getRegistrations: vi.fn().mockRejectedValue(new Error('nope')),
+      },
+    }
+
+    await expect(
+      unregisterLegacyServiceWorkers(navigatorRef)
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/chunk-load-error-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/chunk-load-error-handler.ts
@@ -1,0 +1,127 @@
+/**
+ * Recover from stale dynamic imports after a deploy.
+ *
+ * When the production build is updated, returning users may still have
+ * the previous app shell in memory (or restored from Firefox's bfcache
+ * on a soft reload). Their cached JS will then try to `import()` a
+ * chunk URL that no longer exists, throwing `ChunkLoadError` or
+ * `Failed to fetch dynamically imported module`.
+ *
+ * To rescue these users we listen for those specific errors and force
+ * a single hard reload. A sessionStorage flag prevents reload loops in
+ * the unlikely case the error keeps reproducing on the fresh page.
+ */
+
+const RELOAD_FLAG = 'eufemia-portal:chunk-error-reloaded'
+
+const CHUNK_ERROR_PATTERNS = [
+  /Loading chunk [^\s]+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Unable to preload CSS/i,
+]
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+type ChunkLoadErrorHandlerOptions = {
+  storage?: StorageLike | null
+  reload?: () => void
+  onReload?: () => void
+}
+
+export function isChunkLoadError(reason: unknown): boolean {
+  if (!reason) {
+    return false
+  }
+
+  const errorName =
+    typeof reason === 'object' && reason !== null && 'name' in reason
+      ? String((reason as { name?: unknown }).name ?? '')
+      : ''
+
+  if (errorName === 'ChunkLoadError') {
+    return true
+  }
+
+  const message =
+    typeof reason === 'string'
+      ? reason
+      : typeof reason === 'object' &&
+          reason !== null &&
+          'message' in reason
+        ? String((reason as { message?: unknown }).message ?? '')
+        : ''
+
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+export function setupChunkLoadErrorHandler({
+  storage = typeof sessionStorage !== 'undefined' ? sessionStorage : null,
+  reload = () => window.location.reload(),
+  onReload,
+}: ChunkLoadErrorHandlerOptions = {}) {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const safeGet = (key: string) => {
+    try {
+      return storage?.getItem(key) ?? null
+    } catch {
+      return null
+    }
+  }
+
+  const safeSet = (key: string, value: string) => {
+    try {
+      storage?.setItem(key, value)
+    } catch {
+      // Ignore storage write errors (private mode, quota, etc.)
+    }
+  }
+
+  const safeRemove = (key: string) => {
+    try {
+      storage?.removeItem(key)
+    } catch {
+      // Ignore
+    }
+  }
+
+  // Clear the flag once the new page has booted successfully so a
+  // future stale-cache event can recover again.
+  safeRemove(RELOAD_FLAG)
+
+  const handleReason = (reason: unknown) => {
+    if (!isChunkLoadError(reason)) {
+      return
+    }
+
+    if (safeGet(RELOAD_FLAG)) {
+      // Already reloaded once for this kind of error in this session —
+      // do not loop. Let the user see the actual error.
+      return
+    }
+
+    safeSet(RELOAD_FLAG, '1')
+    onReload?.()
+    reload()
+  }
+
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    handleReason(event.reason)
+  }
+
+  const onError = (event: ErrorEvent) => {
+    handleReason(event.error ?? event.message)
+  }
+
+  window.addEventListener('unhandledrejection', onUnhandledRejection)
+  window.addEventListener('error', onError)
+
+  return () => {
+    window.removeEventListener('unhandledrejection', onUnhandledRejection)
+    window.removeEventListener('error', onError)
+  }
+}

--- a/packages/dnb-design-system-portal/vite/client/entry.tsx
+++ b/packages/dnb-design-system-portal/vite/client/entry.tsx
@@ -5,6 +5,8 @@
 import PortalApp from './portal-app'
 import { bootstrapPortalApp } from './bootstrap-portal-app'
 import { renderPortalApp } from './render-portal-app'
+import { setupChunkLoadErrorHandler } from './chunk-load-error-handler'
+import { unregisterLegacyServiceWorkers } from './unregister-legacy-service-workers'
 import { routes } from 'virtual:portal-pages'
 
 export const currentRoutes = routes
@@ -19,6 +21,16 @@ if (
   globalThis.IS_TEST = true
   document.documentElement.setAttribute('data-visual-test', 'true')
 }
+
+// Recover from stale chunk URLs after a deploy by reloading once when
+// a dynamic import fails (e.g. the previous app shell restored from
+// bfcache after we switched bundlers).
+setupChunkLoadErrorHandler()
+
+// Clean up service workers registered by previous portal versions
+// (e.g. Gatsby's offline plugin) so they no longer intercept fetches
+// with stale cached responses.
+unregisterLegacyServiceWorkers()
 
 void bootstrapPortalApp(PortalApp, currentRoutes, {
   pathname:

--- a/packages/dnb-design-system-portal/vite/client/unregister-legacy-service-workers.ts
+++ b/packages/dnb-design-system-portal/vite/client/unregister-legacy-service-workers.ts
@@ -1,0 +1,49 @@
+/**
+ * Unregister any service workers from previous portal versions.
+ *
+ * The portal does not register a service worker. Earlier versions
+ * (when the portal ran on Gatsby) may have shipped one through
+ * `gatsby-plugin-offline`, which is now removed. Returning users with
+ * such a worker still installed would otherwise keep serving stale
+ * HTML and chunk URLs that no longer exist.
+ *
+ * `/sw.js` itself is now a static no-op kill-switch served from
+ * static/sw.js — see that file. This helper picks up any other
+ * scopes a previous worker may have claimed.
+ */
+
+type RegistrationLike = {
+  unregister: () => Promise<boolean>
+}
+
+type ServiceWorkerContainerLike = {
+  getRegistrations?: () => Promise<ReadonlyArray<RegistrationLike>>
+}
+
+type NavigatorWithSW = {
+  serviceWorker?: ServiceWorkerContainerLike
+}
+
+export function unregisterLegacyServiceWorkers(
+  navigatorRef: NavigatorWithSW | undefined = typeof navigator !==
+  'undefined'
+    ? (navigator as NavigatorWithSW)
+    : undefined
+) {
+  const sw = navigatorRef?.serviceWorker
+  if (!sw?.getRegistrations) {
+    return Promise.resolve()
+  }
+
+  return sw
+    .getRegistrations()
+    .then((registrations) =>
+      Promise.all(
+        registrations.map((registration) =>
+          registration.unregister().catch(() => false)
+        )
+      )
+    )
+    .then(() => undefined)
+    .catch(() => undefined)
+}


### PR DESCRIPTION
Returning users may keep the previous app shell in memory or restore it from bfcache on a soft reload, then try to dynamically import chunk URLs that no longer exist on the new build (this surfaced when the portal moved from Gatsby to Vite, but applies to any future hash rotation).

- Listen for ChunkLoadError / 'Failed to fetch dynamically imported module' / 'Importing a module script failed' / 'Unable to preload CSS' and force a single hard reload, guarded by a sessionStorage flag to avoid loops.
- Unregister any service workers from earlier portal versions (gatsby-plugin-offline) so they stop intercepting fetches with stale cached responses.
- Ship a kill-switch /sw.js that replaces the old worker, drops all caches and self-unregisters.

