### PR TITLE
refactor(Flex): rename --sizeCount CSS custom property to --size-count

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -250,7 +250,7 @@ function FlexContainer(props: FlexContainerAllProps) {
       data-media-key={mediaKey}
       style={
         hasSizeProp
-          ? ({ '--sizeCount': sizeCount, ...style } as CSSProperties)
+          ? ({ '--size-count': sizeCount, ...style } as CSSProperties)
           : style
       }
       {...rest}

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -1019,7 +1019,7 @@ describe('Flex.Container', () => {
 
       const element = document.querySelector('.dnb-flex-container')
 
-      expect(element.getAttribute('style')).toBe('--sizeCount: 12;')
+      expect(element.getAttribute('style')).toBe('--size-count: 12;')
 
       rerender(
         <Flex.Container sizeCount={6}>
@@ -1027,7 +1027,7 @@ describe('Flex.Container', () => {
         </Flex.Container>
       )
 
-      expect(element.getAttribute('style')).toBe('--sizeCount: 6;')
+      expect(element.getAttribute('style')).toBe('--size-count: 6;')
 
       rerender(
         <Flex.Container>

--- a/packages/dnb-eufemia/src/components/flex/style/flex-item.scss
+++ b/packages/dnb-eufemia/src/components/flex/style/flex-item.scss
@@ -31,7 +31,7 @@
 
   // Handle column spans
   &--responsive {
-    --sizeCount--default: 12;
+    --size-count--default: 12;
     --span--default: var(--small);
 
     .dnb-flex-container[data-media-key='small'] & {
@@ -45,7 +45,7 @@
     }
 
     --flex-basis: calc(
-      100% / var(--sizeCount, var(--sizeCount--default)) *
+      100% / var(--size-count, var(--size-count--default)) *
         var(--span, var(--span--default))
     );
 


### PR DESCRIPTION
Aligns with the kebab-case convention used by all other CSS custom properties in the codebase. The JS prop name `sizeCount` remains unchanged (camelCase is correct for React props).

