### PR TITLE
chore: move misplaced dependencies to devDependencies

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -57,7 +57,6 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@mdx-js/react": "3.1.0",
-    "algoliasearch": "4.12.0",
     "clsx": "2.1.1",
     "react": "19.2.5",
     "react-dom": "19.2.5"
@@ -74,6 +73,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
+    "algoliasearch": "4.12.0",
     "babel-plugin-react-live": "1.4.5",
     "date-fns": "4.1.0",
     "eslint": "9.39.2",

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -114,6 +114,7 @@
     "core-js-pure": "3.47.0",
     "date-fns": "4.1.0",
     "intl-messageformat": "11.2.3",
+    "postcss-selector-parser": "7.1.0",
     "zod": "4.1.8"
   },
   "peerDependencies": {
@@ -215,7 +216,6 @@
     "packpath": "0.1.0",
     "postcss": "8.4.32",
     "postcss-preset-env": "9.6.0",
-    "postcss-selector-parser": "7.1.0",
     "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",
     "react": "19.2.5",

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -114,7 +114,6 @@
     "core-js-pure": "3.47.0",
     "date-fns": "4.1.0",
     "intl-messageformat": "11.2.3",
-    "postcss-selector-parser": "7.1.0",
     "zod": "4.1.8"
   },
   "peerDependencies": {
@@ -216,6 +215,7 @@
     "packpath": "0.1.0",
     "postcss": "8.4.32",
     "postcss-preset-env": "9.6.0",
+    "postcss-selector-parser": "7.1.0",
     "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",
     "react": "19.2.5",

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
@@ -1,5 +1,9 @@
 /**
  * This is written in JavaScript, because it is used directly by PostCSS.
+ *
+ * NOTE: "postcss-selector-parser" must be a production dependency (not devDependency)
+ * because this plugin ships in the published package (build/plugins/) and is used
+ * at build-time by consumers for style isolation.
  */
 
 const path = require('path')


### PR DESCRIPTION
- Move postcss-selector-parser from dependencies to devDependencies in @dnb/eufemia (only used in a build-time PostCSS plugin)
- Move algoliasearch from dependencies to devDependencies in dnb-design-system-portal (only used in build script push-algolia.mjs)

