### PR TITLE
docs(List): add example for List.Item.Action with custom element

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -205,6 +205,39 @@ export const NavigableItemWithHref = () => {
   )
 }
 
+export const NavigableItemWithCustomElement = () => {
+  return (
+    <ComponentBox scope={{ fish_medium }}>
+      {() => {
+        // Example using a custom link component (e.g. React Router's Link).
+        // Pass the component via the `element` prop and the route via `to`.
+        function MyLink({ to, children, ...rest }) {
+          return (
+            <a href={to} {...rest}>
+              {children}
+            </a>
+          )
+        }
+
+        return (
+          <List.Container>
+            <List.Item.Action
+              element={MyLink}
+              to="#custom-route"
+              icon={fish_medium}
+              title="Navigate with custom element"
+            >
+              <List.Cell.End>
+                <NumberFormat.Currency value={1234} />
+              </List.Cell.End>
+            </List.Item.Action>
+          </List.Container>
+        )
+      }}
+    </ComponentBox>
+  )
+}
+
 export const WithAnchor = () => {
   return (
     <ComponentBox scope={{ fish_medium }}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
@@ -22,6 +22,12 @@ Use the `href` property on `List.Item.Action` to render a native link. Use `targ
 
 <Examples.NavigableItemWithHref />
 
+### Navigable item with custom element
+
+Use the `element` prop to render a custom link component such as React Router's `Link`. Pass the route via the `to` prop directly on `List.Item.Action` — the entire row will be clickable.
+
+<Examples.NavigableItemWithCustomElement />
+
 ### With anchor
 
 List items containing [Anchor](/uilib/components/anchor) links.


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1778142972996869
Deploy preview example: https://fix-list-item-action-custom.eufemia-e25.pages.dev/uilib/components/list/demos/#navigable-item-with-custom-element

Add a demo showing how to use the element prop with a custom link component (e.g. React Router's Link). The to prop should be passed directly on List.Item.Action, not via elementProps — this ensures the entire row is clickable.

