### PR TITLE
fix: prevent whatinput from interfering with React hydration (SSR)

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import whatInput from '../whatInput'
 
 const dispatchMouse = () =>
@@ -69,5 +70,69 @@ describe('whatInput', () => {
 
     // Reset
     whatInput.specificKeys([])
+  })
+})
+
+describe('whatInput deferred setup', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.resetModules()
+    document.documentElement.removeAttribute('data-whatinput')
+    document.documentElement.removeAttribute('data-whatintent')
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('defers setup via requestIdleCallback when not in test mode', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const ric = vi.fn()
+    vi.stubGlobal('requestIdleCallback', ric)
+
+    await import('../whatInput')
+
+    expect(ric).toHaveBeenCalledTimes(1)
+    expect(
+      document.documentElement.getAttribute('data-whatinput')
+    ).toBeNull()
+
+    // Fire the deferred callback
+    ric.mock.calls[0][0]()
+
+    expect(document.documentElement.getAttribute('data-whatinput')).toBe(
+      'initial'
+    )
+  })
+
+  it('falls back to setTimeout when requestIdleCallback is unavailable', async () => {
+    process.env.NODE_ENV = 'production'
+
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.useFakeTimers()
+
+    await import('../whatInput')
+
+    expect(
+      document.documentElement.getAttribute('data-whatinput')
+    ).toBeNull()
+
+    vi.runAllTimers()
+
+    expect(document.documentElement.getAttribute('data-whatinput')).toBe(
+      'initial'
+    )
+  })
+
+  it('sets up synchronously in test mode', async () => {
+    await import('../whatInput')
+
+    expect(document.documentElement.getAttribute('data-whatinput')).toBe(
+      'initial'
+    )
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/whatInput.ts
@@ -195,8 +195,21 @@ function specificKeys(arr: string[]) {
 
 // -- Init -------------------------------------------------------------
 
+// Delay setup so event listeners and initial data-whatinput /
+// data-whatintent attributes are not added during SSR hydration.
+// The attributes are set on <html> (outside React's hydration root)
+// but the event listeners should not fire until the page is
+// interactive. In test environments, set up synchronously so
+// assertions work immediately after dispatching events.
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
-  setUp()
+  if (process.env.NODE_ENV === 'test') {
+    setUp()
+  } else if (typeof requestIdleCallback === 'function') {
+    // eslint-disable-next-line compat/compat
+    requestIdleCallback(setUp)
+  } else {
+    setTimeout(setUp, 0)
+  }
 }
 
 const whatInput = { specificKeys }


### PR DESCRIPTION
Defer event listener registration and data-whatinput / data-whatintent attribute setting via requestIdleCallback (or setTimeout fallback). This delays the setup until the browser is idle, avoiding early DOM manipulation on <html> while React hydration is in progress. In test environments, setup still runs synchronously so existing assertions continue to work.

