### PR TITLE
chore(Examples): replace deprecated backgroundColor with variant

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
@@ -47,11 +47,11 @@ export function HeightAnimationDefault() {
                 Change height inside
               </ToggleButton>
 
-              <Section backgroundColor="lavender" top>
+              <Section variant="information" top>
                 <HeightAnimation open={openState}>
                   <Section
                     innerSpace={{ block: 'large' }}
-                    backgroundColor="lavender"
+                    variant="information"
                   >
                     <P space={0}>Your content</P>
                   </Section>
@@ -142,7 +142,7 @@ export function HeightAnimationKeepInDOM() {
                 Change height inside
               </ToggleButton>
 
-              <StyledSection backgroundColor="lavender" top>
+              <StyledSection variant="information" top>
                 <HeightAnimation
                   open={openState}
                   keepInDOM={true}
@@ -150,7 +150,7 @@ export function HeightAnimationKeepInDOM() {
                 >
                   <Section
                     innerSpace={{ block: 'large' }}
-                    backgroundColor="lavender"
+                    variant="information"
                   >
                     <P space={0}>Your content</P>
                   </Section>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
@@ -118,7 +118,7 @@ export const StepIndicatorCustomized = () => (
               bottom
               {...props}
             />
-            <Section backgroundColor="lavender" innerSpace>
+            <Section variant="information" innerSpace>
               {children(step)}
             </Section>
           </>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData/Examples.tsx
@@ -60,7 +60,7 @@ export function FilterData() {
         return (
           <Flex.Stack>
             <Component />
-            <Section backgroundColor="sand-yellow" innerSpace>
+            <Section variant="information" innerSpace>
               <pre>{JSON.stringify(filterData(filterDataPaths))}</pre>
               <pre>{JSON.stringify(filterData(filterDataHandler))}</pre>
             </Section>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/Examples.tsx
@@ -354,7 +354,7 @@ export const DependentSchemaValidation = () => {
                       bottom: 'small',
                     }}
                     bottom
-                    backgroundColor="lavender"
+                    variant="information"
                   >
                     <Field.String
                       itemPath="/name"
@@ -560,7 +560,7 @@ export const DependentSchemaValidationWithZod = () => {
                       bottom: 'small',
                     }}
                     bottom
-                    backgroundColor="lavender"
+                    variant="information"
                   >
                     <Field.String
                       itemPath="/name"

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
@@ -136,7 +136,7 @@ export function WithToolbar({ children }) {
         </Tools.GenerateSchema>
       </Tools.ListAllProps>
 
-      <Section backgroundColor="sand-yellow" innerSpace>
+      <Section variant="information" innerSpace>
         <Flex.Horizontal align="center">
           <Form.SubmitButton text="Submit" />
           <Field.Selection

--- a/packages/dnb-eufemia/src/components/height-animation/stories/HeightAnimation.stories.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/stories/HeightAnimation.stories.tsx
@@ -51,7 +51,7 @@ export const HeightAnimationSandbox = () => {
         {count}
       </Button>
 
-      <StyledSection backgroundColor="lavender" top>
+      <StyledSection variant="information" top>
         <HeightAnimation
           open={openState}
           element="div" // Optional
@@ -60,10 +60,7 @@ export const HeightAnimationSandbox = () => {
           duration={1000}
           onOpen={setIsOpen}
         >
-          <Section
-            innerSpace={{ block: 'large' }}
-            backgroundColor="lavender"
-          >
+          <Section innerSpace={{ block: 'large' }} variant="information">
             <P>Your content</P>
           </Section>
           {contentState && <P>More content</P>}
@@ -116,12 +113,9 @@ export function HeightAnimationKeepInDOM() {
           Change height inside
         </ToggleButton>
 
-        <StyledSection backgroundColor="lavender" top>
+        <StyledSection variant="information" top>
           <HeightAnimation open={openState} duration={1000}>
-            <Section
-              innerSpace={{ block: 'large' }}
-              backgroundColor="lavender"
-            >
+            <Section innerSpace={{ block: 'large' }} variant="information">
               <P space={0}>Your content</P>
             </Section>
             {contentState && <P space={0}>More content</P>}


### PR DESCRIPTION
Replace deprecated `backgroundColor` prop with `variant` in Examples and Stories files.