### PR TITLE
fix(HelpButtonInline): remove backgroundColor from Section

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -305,7 +305,6 @@ function HelpButtonInlineContentComponent(
                 right: 'x-small',
               }
         }
-        backgroundColor="lavender"
         {...rest}
       >
         <Flex.Vertical gap="x-small">

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -777,4 +777,21 @@ describe('HelpButtonInlineContent Component', () => {
     expect(contentElement).toHaveTextContent('Simple text content')
     expect(contentElement).toHaveClass('dnb-p')
   })
+
+  it('should not set a backgroundColor on the Section', () => {
+    render(
+      <HelpButtonInlineContent
+        contentId="test-content"
+        help={{ open: true, content: 'Help content' }}
+      />
+    )
+
+    const section = document.querySelector(
+      '.dnb-help-button__content .dnb-section'
+    )
+    expect(section).toBeInTheDocument()
+    expect(section.getAttribute('style')).not.toContain(
+      '--background-color'
+    )
+  })
 })


### PR DESCRIPTION
Remove the hardcoded `backgroundColor="lavender"` from the Section in HelpButtonInlineContent. The background color should be inherited from the theme/variant instead of being set explicitly.

Adds a test verifying the Section does not set a `--background-color` style.