### PR TITLE
chore(Portal): enable React hydration and fix SSR/SSG mismatches

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
@@ -55,7 +55,7 @@ test.describe('Page Navigation', () => {
       await page.goto('/uilib/components/button/demos/')
 
       const title = await page.title()
-      expect(title).toContain('Button | Eufemia')
+      expect(title).toContain('Button → Demos | Eufemia')
 
       const heading = await page.textContent('h2')
       expect(heading).toContain('Demos')

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -80,18 +80,40 @@ export default function PortalToolsMenu({
 }: Props) {
   const { skeleton } = useContext(Context)
   const storageKey = getPortalToolsOpenStorageKey(hideWhenMediaLarge)
-  const [isOpen, setIsOpen] = useState(() =>
-    getStoredPortalToolsOpen(storageKey)
-  )
+  const [isOpen, setIsOpen] = useState(false)
   const { name: themeName, colorScheme } = getTheme()
   const themeKey = `${themeName}:${colorScheme || 'auto'}`
-  const [disableAnimation, setDisableAnimation] = useState(isOpen)
+  // Start with animation disabled so the initial open=false render
+  // uses the immediate close path in Modal, avoiding a 300ms timer
+  // that would race with the restore effect and close the drawer.
+  const [disableAnimation, setDisableAnimation] = useState(true)
   const previousThemeKeyRef = useRef(themeKey)
   const themeChanged = previousThemeKeyRef.current !== themeKey
+  const restoredRef = useRef(false)
   const noAnimation = disableAnimation || themeChanged
 
+  // Restore open state from sessionStorage after hydration to avoid
+  // a mismatch between server (always closed) and client.
   useEffect(() => {
-    if (!disableAnimation) {
+    if (restoredRef.current) {
+      return
+    }
+    const stored = getStoredPortalToolsOpen(storageKey)
+    if (stored) {
+      restoredRef.current = true
+      setDisableAnimation(true)
+      setIsOpen(true)
+    }
+  }, [storageKey])
+
+  useEffect(() => {
+    if (!disableAnimation || restoredRef.current) {
+      return
+    }
+
+    // Only reset after the drawer has been opened at least once,
+    // so the initial true value doesn't get cleared prematurely.
+    if (!isOpen) {
       return
     }
 
@@ -102,7 +124,7 @@ export default function PortalToolsMenu({
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [disableAnimation])
+  }, [disableAnimation, isOpen])
 
   useLayoutEffect(() => {
     if (themeChanged && isOpen) {
@@ -113,11 +135,14 @@ export default function PortalToolsMenu({
   }, [isOpen, themeChanged, themeKey])
 
   const handleOpen = useCallback(() => {
+    restoredRef.current = false
     setIsOpen(true)
     setStoredPortalToolsOpen(true, storageKey)
   }, [storageKey])
 
   const handleClose = useCallback(() => {
+    restoredRef.current = false
+    setDisableAnimation(false)
     setIsOpen(false)
     setStoredPortalToolsOpen(false, storageKey)
   }, [storageKey])

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
-import type { CSSProperties, RefObject } from 'react'
+import type { RefObject } from 'react'
 import clsx from 'clsx'
 import Anchor from '../tags/Anchor'
 import { useStaticQuery, graphql } from 'portal-query'
@@ -289,6 +289,13 @@ function ListItem({
     isAccordion ? isInsideActivePath || isActive : true
   )
   const [manualClick, setManualClick] = useState(false)
+
+  useEffect(() => {
+    if (ref.current && nr && nr < 20) {
+      ref.current.style.setProperty('--delay', `${nr * 12}ms`)
+    }
+  }, [nr])
+
   if (hideInMenu) {
     return null
   }
@@ -345,13 +352,6 @@ function ListItem({
           className
         )}
         ref={ref}
-        style={
-          {
-            '--delay': `${
-              nr && nr < 20 ? nr * 12 : 0 // random(1, 160)
-            }ms`,
-          } as CSSProperties /* Casting to allow css variable in JSX inline styling */
-        }
       >
         <div className="dnb-sidebar-menu__item">
           <Anchor

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -6,6 +6,7 @@
 import {
   useCallback,
   useContext,
+  useEffect,
   useId,
   useMemo,
   useRef,
@@ -189,7 +190,15 @@ function LiveCode(props: LiveCodeProps) {
 
   const scope = useMemo(() => scopeProp || {}, [scopeProp])
   const theme = context.theme || {}
-  const inheritedDark = theme.colorScheme === 'dark'
+
+  // During SSR, colorScheme resolves to 'light' (no matchMedia).
+  // The blocking script may flip it to 'dark' before hydration,
+  // so we defer the resolved value to avoid a text mismatch
+  // ("Dark mode" vs "Light mode").
+  const [inheritedDark, setInheritedDark] = useState(false)
+  useEffect(() => {
+    setInheritedDark(theme.colorScheme === 'dark')
+  }, [theme.colorScheme])
 
   const codeToUse = useMemo(() => {
     const code =

--- a/packages/dnb-design-system-portal/vite/__tests__/mocks/virtual-build-info.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/mocks/virtual-build-info.ts
@@ -1,0 +1,3 @@
+export const releaseVersion = '[LOCAL BUILD]'
+export const buildVersion = '1.1.2026, 12:00:00'
+export const changelogVersion = '[LOCAL BUILD]'

--- a/packages/dnb-design-system-portal/vite/__tests__/pre-resolve-current-route.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/pre-resolve-current-route.test.ts
@@ -40,4 +40,48 @@ describe('preResolveCurrentRoute', () => {
     ).resolves.toBeUndefined()
     expect(routes[0].lazy).toBe(lazy)
   })
+
+  it('pre-resolves index routes when pathname is /', async () => {
+    const lazy = vi.fn(async () => ({ Component: () => null }))
+    const routes = [
+      { index: true, lazy },
+      {
+        path: '/about',
+        lazy: vi.fn(async () => ({ Component: () => null })),
+      },
+    ]
+
+    await preResolveCurrentRoute(routes, '/')
+
+    expect(lazy).toHaveBeenCalledTimes(1)
+    expect(routes[0].lazy).toBeUndefined()
+    expect(routes[0]).toHaveProperty('Component')
+    expect(routes[1].lazy).toBeDefined()
+  })
+
+  it('does not pre-resolve index routes for non-root paths', async () => {
+    const lazy = vi.fn(async () => ({ Component: () => null }))
+    const routes = [{ index: true, lazy }]
+
+    await preResolveCurrentRoute(routes, '/about/')
+
+    expect(lazy).not.toHaveBeenCalled()
+    expect(routes[0].lazy).toBe(lazy)
+  })
+
+  it('resolves both trailing-slash variants of the same route', async () => {
+    const lazy1 = vi.fn(async () => ({ Component: () => null }))
+    const lazy2 = vi.fn(async () => ({ Component: () => null }))
+    const routes = [
+      { path: '/button', lazy: lazy1 },
+      { path: '/button/', lazy: lazy2 },
+    ]
+
+    await preResolveCurrentRoute(routes, '/button/')
+
+    expect(lazy1).toHaveBeenCalledTimes(1)
+    expect(lazy2).toHaveBeenCalledTimes(1)
+    expect(routes[0].lazy).toBeUndefined()
+    expect(routes[1].lazy).toBeUndefined()
+  })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -88,7 +88,11 @@ describe('prerender-utils', () => {
       },
       {
         fields: { slug: 'uilib/components/button/info' },
-        frontmatter: { title: '', description: '' },
+        frontmatter: { title: '', description: '', showTabs: true },
+      },
+      {
+        fields: { slug: 'uilib/components/button/demos' },
+        frontmatter: { title: '', description: '', showTabs: true },
       },
       {
         fields: { slug: 'uilib/components/card' },
@@ -111,10 +115,33 @@ describe('prerender-utils', () => {
       })
     })
 
-    it('inherits title from parent for tab sub-pages', () => {
+    it('constructs tab title for tab sub-pages with showTabs', () => {
       const meta = getPageMeta('/uilib/components/button/info/', nodes)
-      expect(meta.title).toBe('Button')
+      expect(meta.title).toBe('Button → Info')
       expect(meta.description).toBe('A button component')
+    })
+
+    it('constructs tab title for demos tab', () => {
+      const meta = getPageMeta('/uilib/components/button/demos/', nodes)
+      expect(meta.title).toBe('Button → Demos')
+    })
+
+    it('inherits parent title without tab suffix when showTabs is not set', () => {
+      const noTabNodes = [
+        {
+          fields: { slug: 'uilib/components/button' },
+          frontmatter: { title: 'Button', description: '' },
+        },
+        {
+          fields: { slug: 'uilib/components/button/info' },
+          frontmatter: { title: '', description: '' },
+        },
+      ]
+      const meta = getPageMeta(
+        '/uilib/components/button/info/',
+        noTabNodes
+      )
+      expect(meta.title).toBe('Button')
     })
 
     it('returns empty strings for unknown routes', () => {

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -434,6 +434,29 @@ describe('prerender-utils', () => {
       expect(result).toContain('href="/uilib/components/button.md"')
       expect(result).not.toContain('/demos.md')
     })
+
+    it('strips React 19 inline preload links from app HTML and moves them to head', () => {
+      const appHtml =
+        '<link rel="preload" href="/img/a.png" as="image"/><h1>Hello</h1><link rel="preload" href="/img/b.png" as="image"/>'
+      const result = injectHtml(template, appHtml, { js: [], css: [] })
+
+      // Links should not appear inside #root
+      expect(result).toContain('<div id="root"><h1>Hello</h1></div>')
+
+      // Links should appear in <head>
+      const headContent = result.slice(0, result.indexOf('</head>'))
+      expect(headContent).toContain('href="/img/a.png"')
+      expect(headContent).toContain('href="/img/b.png"')
+    })
+
+    it('strips staticRouterHydrationData script from app HTML', () => {
+      const appHtml =
+        '<h1>Hello</h1><script>window.__staticRouterHydrationData = {"loaderData":{}}</script>'
+      const result = injectHtml(template, appHtml, { js: [], css: [] })
+
+      expect(result).not.toContain('__staticRouterHydrationData')
+      expect(result).toContain('<div id="root"><h1>Hello</h1></div>')
+    })
   })
 
   describe('getMdPath', () => {

--- a/packages/dnb-design-system-portal/vite/__tests__/render-portal-app.test.tsx
+++ b/packages/dnb-design-system-portal/vite/__tests__/render-portal-app.test.tsx
@@ -7,6 +7,7 @@ describe('renderPortalApp', () => {
     const render = vi.fn()
     const unmount = vi.fn()
     const createRootFn = vi.fn(() => ({ render, unmount }))
+    const hydrateRootFn = vi.fn(() => ({ render, unmount }))
     const rootStore: {
       __portalRoot?: { render: typeof render; unmount: typeof unmount }
     } = {}
@@ -19,11 +20,76 @@ describe('renderPortalApp', () => {
       return <div>Two</div>
     }
 
-    renderPortalApp(AppOne, { container, rootStore, createRootFn })
-    renderPortalApp(AppTwo, { container, rootStore, createRootFn })
+    renderPortalApp(AppOne, {
+      container,
+      rootStore,
+      createRootFn,
+      hydrateRootFn,
+    })
+    renderPortalApp(AppTwo, {
+      container,
+      rootStore,
+      createRootFn,
+      hydrateRootFn,
+    })
 
     expect(createRootFn).toHaveBeenCalledTimes(1)
     expect(render).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses hydrateRoot when container has pre-rendered content', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<div>Pre-rendered</div>'
+
+    const render = vi.fn()
+    const unmount = vi.fn()
+    const createRootFn = vi.fn(() => ({ render, unmount }))
+    const hydrateRootFn = vi.fn(() => ({ render, unmount }))
+    const rootStore: {
+      __portalRoot?: { render: typeof render; unmount: typeof unmount }
+    } = {}
+
+    function App() {
+      return <div>App</div>
+    }
+
+    renderPortalApp(App, {
+      container,
+      rootStore,
+      createRootFn,
+      hydrateRootFn,
+    })
+
+    expect(hydrateRootFn).toHaveBeenCalledTimes(1)
+    expect(createRootFn).not.toHaveBeenCalled()
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('uses createRoot when container is empty', () => {
+    const container = document.createElement('div')
+
+    const render = vi.fn()
+    const unmount = vi.fn()
+    const createRootFn = vi.fn(() => ({ render, unmount }))
+    const hydrateRootFn = vi.fn(() => ({ render, unmount }))
+    const rootStore: {
+      __portalRoot?: { render: typeof render; unmount: typeof unmount }
+    } = {}
+
+    function App() {
+      return <div>App</div>
+    }
+
+    renderPortalApp(App, {
+      container,
+      rootStore,
+      createRootFn,
+      hydrateRootFn,
+    })
+
+    expect(createRootFn).toHaveBeenCalledTimes(1)
+    expect(hydrateRootFn).not.toHaveBeenCalled()
+    expect(render).toHaveBeenCalledTimes(1)
   })
 
   it('throws when the root container is missing', () => {
@@ -34,5 +100,40 @@ describe('renderPortalApp', () => {
     expect(() => renderPortalApp(App, { container: null })).toThrow(
       'Expected #root container for portal app'
     )
+  })
+
+  it('passes onRecoverableError to hydrateRoot to suppress mismatch warnings', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<div>Pre-rendered</div>'
+
+    const render = vi.fn()
+    const unmount = vi.fn()
+    const createRootFn = vi.fn(() => ({ render, unmount }))
+    const hydrateRootFn = vi.fn(() => ({ render, unmount }))
+    const rootStore: {
+      __portalRoot?: { render: typeof render; unmount: typeof unmount }
+    } = {}
+
+    function App() {
+      return <div>App</div>
+    }
+
+    renderPortalApp(App, {
+      container,
+      rootStore,
+      createRootFn,
+      hydrateRootFn,
+    })
+
+    const options = (hydrateRootFn.mock.calls[0] as unknown[])[2] as
+      | { onRecoverableError?: (error: unknown) => void }
+      | undefined
+    expect(options).toHaveProperty('onRecoverableError')
+    expect(typeof options?.onRecoverableError).toBe('function')
+
+    // The handler silently swallows errors instead of rethrowing
+    expect(() =>
+      options?.onRecoverableError?.(new Error('hydration mismatch'))
+    ).not.toThrow()
   })
 })

--- a/packages/dnb-design-system-portal/vite/client/plugins/build-info.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/build-info.ts
@@ -73,6 +73,17 @@ export function getBuildInfo({
 export default function buildInfoPlugin(): Plugin {
   const buildInfoFile = path.resolve(portalRoot, 'src/shared/buildInfo.ts')
 
+  // Compute build info once and store in an env var so the SSR prerender
+  // worker (which spawns a separate Vite server in a worker thread)
+  // uses the same timestamp as the client build.
+  let info: BuildInfo
+  if (process.env.__PORTAL_BUILD_INFO) {
+    info = JSON.parse(process.env.__PORTAL_BUILD_INFO)
+  } else {
+    info = getBuildInfo()
+    process.env.__PORTAL_BUILD_INFO = JSON.stringify(info)
+  }
+
   return {
     name: 'portal-build-info',
 
@@ -88,7 +99,6 @@ export default function buildInfoPlugin(): Plugin {
         id === buildInfoFile ||
         id.replace(/\?.*$/, '') === buildInfoFile
       ) {
-        const info = getBuildInfo()
         return [
           `export const releaseVersion = ${JSON.stringify(info.releaseVersion)}`,
           `export const buildVersion = ${JSON.stringify(info.buildVersion)}`,

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -119,28 +119,13 @@ type PortalAppProps = {
 }
 
 function createPortalRouter(routes: RouteObject[]) {
-  const router = createBrowserRouter([
+  return createBrowserRouter([
     {
       path: '/',
       element: <RootLayout />,
       children: routes,
     },
   ])
-
-  router.subscribe(({ location }) => {
-    const { pathname } = location
-    if (
-      pathname !== '/' &&
-      !pathname.endsWith('/') &&
-      !pathname.includes('.')
-    ) {
-      router.navigate(pathname + '/' + location.search + location.hash, {
-        replace: true,
-      })
-    }
-  })
-
-  return router
 }
 
 export default function PortalApp({ routes }: PortalAppProps) {

--- a/packages/dnb-design-system-portal/vite/client/pre-resolve-current-route.ts
+++ b/packages/dnb-design-system-portal/vite/client/pre-resolve-current-route.ts
@@ -1,5 +1,6 @@
 type RouteLike = {
   path?: string
+  index?: boolean
   lazy?: (() => Promise<Record<string, unknown>>) | undefined
 } & Record<string, unknown>
 
@@ -7,26 +8,29 @@ export async function preResolveCurrentRoute(
   routes: RouteLike[],
   pathname: string
 ) {
-  for (const route of routes) {
-    if (!route.lazy || !route.path) {
-      continue
+  const currentPath = pathname.replace(/\/+$/, '') || '/'
+
+  const matchingRoutes = routes.filter((route) => {
+    if (!route.lazy) {
+      return false
     }
 
-    const routePath = route.path.replace(/\/+$/, '') || '/'
-    const currentPath = pathname.replace(/\/+$/, '') || '/'
+    // Index routes match when the parent path matches the current URL
+    return route.index
+      ? currentPath === '/'
+      : route.path &&
+          (route.path.replace(/\/+$/, '') || '/') === currentPath
+  })
 
-    if (routePath !== currentPath) {
-      continue
-    }
-
-    try {
-      const resolved = await route.lazy()
-      Object.assign(route, resolved)
-      route.lazy = undefined
-    } catch {
-      // If pre-resolution fails, React Router will handle it.
-    }
-
-    break
-  }
+  await Promise.all(
+    matchingRoutes.map(async (route) => {
+      try {
+        const resolved = await route.lazy()
+        Object.assign(route, resolved)
+        route.lazy = undefined
+      } catch {
+        // If pre-resolution fails, React Router will handle it.
+      }
+    })
+  )
 }

--- a/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
@@ -1,4 +1,4 @@
-import { createRoot } from 'react-dom/client'
+import { createRoot, hydrateRoot } from 'react-dom/client'
 import type { Root } from 'react-dom/client'
 
 type RootStore = {
@@ -6,29 +6,13 @@ type RootStore = {
 }
 
 type CreateRootFn = (container: Element) => Root
+type HydrateRootFn = typeof hydrateRoot
 
 type RenderPortalAppOptions = {
   container?: Element | null
   rootStore?: RootStore
   createRootFn?: CreateRootFn
-}
-
-export function getOrCreatePortalRoot(
-  container: Element,
-  {
-    rootStore = globalThis as RootStore,
-    createRootFn = createRoot,
-  }: Omit<RenderPortalAppOptions, 'container'> = {}
-) {
-  const existingRoot = rootStore.__portalRoot
-
-  if (existingRoot) {
-    return existingRoot
-  }
-
-  const nextRoot = createRootFn(container)
-  rootStore.__portalRoot = nextRoot
-  return nextRoot
+  hydrateRootFn?: HydrateRootFn
 }
 
 export function renderPortalApp<Props extends object>(
@@ -37,6 +21,7 @@ export function renderPortalApp<Props extends object>(
     container = document.getElementById('root'),
     rootStore = globalThis as RootStore,
     createRootFn = createRoot,
+    hydrateRootFn = hydrateRoot,
     props,
   }: RenderPortalAppOptions & { props?: Props } = {}
 ) {
@@ -44,12 +29,42 @@ export function renderPortalApp<Props extends object>(
     throw new Error('Expected #root container for portal app')
   }
 
-  const root = getOrCreatePortalRoot(container, {
-    rootStore,
-    createRootFn,
-  })
+  const existingRoot = rootStore.__portalRoot
 
-  root.render(<AppComponent {...props} />)
+  if (existingRoot) {
+    existingRoot.render(<AppComponent {...props} />)
+    return existingRoot
+  }
+
+  const element = <AppComponent {...(props as Props)} />
+
+  const hasPreRenderedContent = container.childElementCount > 0
+
+  let root: Root
+
+  if (hasPreRenderedContent) {
+    // The pre-rendered HTML from SSG is already in the DOM. Use
+    // hydrateRoot so React adopts the existing nodes without
+    // rebuilding the tree. The current route's lazy chunk was
+    // pre-resolved before this call, so React Router won't
+    // render a HydrateFallback.
+    //
+    // Minor hydration mismatches (e.g. AriaLive spans from Tooltips
+    // that only render client-side) are expected and handled
+    // gracefully by React's recovery mechanism.
+    root = hydrateRootFn(container, element, {
+      onRecoverableError() {
+        // Suppress hydration mismatch warnings in production.
+        // Known causes: Tooltip AriaLive spans, inline style
+        // formatting differences.
+      },
+    })
+  } else {
+    root = createRootFn(container)
+    root.render(element)
+  }
+
+  rootStore.__portalRoot = root
 
   return root
 }

--- a/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
@@ -1,5 +1,6 @@
 import { createRoot, hydrateRoot } from 'react-dom/client'
 import type { Root } from 'react-dom/client'
+import { releaseVersion } from 'virtual:build-info'
 
 type RootStore = {
   __portalRoot?: Root
@@ -53,10 +54,20 @@ export function renderPortalApp<Props extends object>(
     // that only render client-side) are expected and handled
     // gracefully by React's recovery mechanism.
     root = hydrateRootFn(container, element, {
-      onRecoverableError() {
-        // Suppress hydration mismatch warnings in production.
-        // Known causes: Tooltip AriaLive spans, inline style
-        // formatting differences.
+      onRecoverableError(error, errorInfo) {
+        // Only log hydration mismatches on local and preview builds
+        // so they surface during development without cluttering
+        // production error reporting.
+        if (releaseVersion !== '[LOCAL BUILD]') {
+          return
+        }
+
+        console.group('React recoverable hydration error')
+        console.error(error)
+        if (errorInfo?.componentStack) {
+          console.log(errorInfo.componentStack)
+        }
+        console.groupEnd()
       },
     })
   } else {

--- a/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
+++ b/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
@@ -6,7 +6,7 @@
  * pages only load the JS they actually need.
  */
 
-import { Component } from 'react'
+import { Component, Suspense } from 'react'
 import type { ReactNode } from 'react'
 import { renderToString } from 'react-dom/server'
 import {
@@ -151,7 +151,9 @@ function SSRPageWrapper() {
       pageContext={{ frontmatter: {} }}
     >
       <SSRErrorBoundary>
-        <Outlet />
+        <Suspense fallback={<div>Loading...</div>}>
+          <Outlet />
+        </Suspense>
       </SSRErrorBoundary>
     </PortalLayout>
   )

--- a/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
+++ b/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
@@ -132,7 +132,7 @@ function RootLayout() {
         disableCoreStyleWrapper
         scopeHash="eufemia-scope--portal"
       >
-        <Theme colorScheme="light">
+        <Theme name="ui" colorScheme="auto">
           <MDXProvider components={tags}>
             <SSRPageWrapper />
           </MDXProvider>

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -82,6 +82,25 @@ export function getPageMeta(
 
     if (parent?.frontmatter?.title) {
       title = parent.frontmatter.title as string
+
+      // For tab pages (showTabs but no own title), construct
+      // "ParentTitle → TabTitle" to match the client-side title.
+      if (node.frontmatter.showTabs) {
+        const tabKey = '/' + slug.split('/').pop()
+        const defaultTabs = [
+          { title: 'Info', key: '/info' },
+          { title: 'Demos', key: '/demos' },
+          { title: 'Properties', key: '/properties' },
+          { title: 'Events', key: '/events' },
+        ]
+        const tabs =
+          (parent.frontmatter.tabs as typeof defaultTabs) || defaultTabs
+        const tab = tabs.find((t) => t.key === tabKey)
+
+        if (tab?.title) {
+          title = `${parent.frontmatter.title} → ${tab.title}`
+        }
+      }
     }
 
     if (!description && parent?.frontmatter?.description) {
@@ -213,13 +232,40 @@ export function injectHtml(
     ''
   )
 
+  // React's renderToString serializes CSS custom properties in inline
+  // styles without spaces (e.g. "--var:value") while the browser
+  // normalizes them with spaces ("--var: value;"). This causes
+  // hydration mismatches. Normalize the format to match the browser.
+  appHtml = appHtml.replace(
+    /style="([^"]*)"/g,
+    (_match: string, styleContent: string) => {
+      const normalized = styleContent
+        .split(';')
+        .filter(Boolean)
+        .map((decl: string) => {
+          const colonIdx = decl.indexOf(':')
+          if (colonIdx === -1) return decl
+          const prop = decl.slice(0, colonIdx).trim()
+          const value = decl.slice(colonIdx + 1).trim()
+          return `${prop}: ${value}`
+        })
+        .join('; ')
+      return normalized ? `style="${normalized};"` : 'style=""'
+    }
+  )
+
   // Inject the prerendered HTML into the root div, followed by a
   // blocking script that swaps color-scheme classes on Theme elements
   // before the browser paints — preventing a dark-mode FOUC.
   const contentScript = getContentScript()
+
+  // Restore sidebar scroll position before first paint so the menu
+  // doesn't flash at the top before jumping to the saved position.
+  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(localStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
+
   let html = template.replace(
     '<div id="root"></div>',
-    `<div id="root">${appHtml}</div>\n\t<script>${contentScript}</script>`
+    `<div id="root">${appHtml}</div>\n\t<script>${contentScript};${scrollRestoreScript}</script>`
   )
 
   // Inject <link> tags for ALL brand theme CSS chunks.

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -194,13 +194,32 @@ export function injectHtml(
   },
   themeCssPaths?: Record<string, string>
 ): string {
+  // React 19 injects <link rel="preload"> elements inline during
+  // renderToString for resources like images. Strip them from the app
+  // HTML and move them to <head> so they don't break client-side
+  // hydration (React can't match the DOM when unexpected <link>
+  // elements appear before the root component's first element).
+  const reactPreloadLinks: string[] = []
+  appHtml = appHtml.replace(/<link rel="preload"[^>]*\/>/g, (match) => {
+    reactPreloadLinks.push(match)
+    return ''
+  })
+
+  // StaticRouterProvider injects a <script> with hydration data that
+  // is not needed for our hydration approach. Strip it so it doesn't
+  // appear inside the root container as unexpected DOM content.
+  appHtml = appHtml.replace(
+    /<script>window\.__staticRouterHydrationData\s*=[^<]*<\/script>/,
+    ''
+  )
+
   // Inject the prerendered HTML into the root div, followed by a
   // blocking script that swaps color-scheme classes on Theme elements
   // before the browser paints — preventing a dark-mode FOUC.
   const contentScript = getContentScript()
   let html = template.replace(
     '<div id="root"></div>',
-    `<div id="root">${appHtml}</div>\n	<script>${contentScript}</script>`
+    `<div id="root">${appHtml}</div>\n\t<script>${contentScript}</script>`
   )
 
   // Inject <link> tags for ALL brand theme CSS chunks.
@@ -297,6 +316,13 @@ export function injectHtml(
       .map((p) => `<link rel="modulepreload" crossorigin href="${p}">`)
       .join('\n    ')
     html = html.replace('</head>', `    ${preloadTags}\n  </head>`)
+  }
+
+  // Inject React-generated preload links that were stripped from the
+  // app HTML to avoid hydration mismatches.
+  if (reactPreloadLinks.length > 0) {
+    const linkTags = reactPreloadLinks.join('\n    ')
+    html = html.replace('</head>', `    ${linkTags}\n  </head>`)
   }
 
   return html

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -77,7 +77,7 @@ async function prerender() {
     : {}
 
   const contentScript = getContentScript()
-  const urls = collectUrls(routes)
+  let urls = collectUrls(routes)
   console.log(`  ${urls.length} pages to prerender`)
 
   // Find CSS chunks for ALL themes so we can inject render-blocking
@@ -264,6 +264,24 @@ function getPageMeta(url, allMdxNodes) {
 
     if (parent?.frontmatter?.title) {
       title = parent.frontmatter.title
+
+      // For tab pages (showTabs but no own title), construct
+      // "ParentTitle → TabTitle" to match the client-side title.
+      if (node.frontmatter.showTabs) {
+        const tabKey = '/' + slug.split('/').pop()
+        const defaultTabs = [
+          { title: 'Info', key: '/info' },
+          { title: 'Demos', key: '/demos' },
+          { title: 'Properties', key: '/properties' },
+          { title: 'Events', key: '/events' },
+        ]
+        const tabs = parent.frontmatter.tabs || defaultTabs
+        const tab = tabs.find((t) => t.key === tabKey)
+
+        if (tab?.title) {
+          title = `${parent.frontmatter.title} → ${tab.title}`
+        }
+      }
     }
 
     if (!description && parent?.frontmatter?.description) {
@@ -379,9 +397,31 @@ function injectHtml(
     ''
   )
 
+  // React's renderToString serializes CSS custom properties in inline
+  // styles without spaces (e.g. "--var:value") while the browser
+  // normalizes them with spaces ("--var: value;"). This causes
+  // hydration mismatches. Normalize the format to match the browser.
+  appHtml = appHtml.replace(/style="([^"]*)"/g, (_match, styleContent) => {
+    const normalized = styleContent
+      .split(';')
+      .filter(Boolean)
+      .map((decl) => {
+        const colonIdx = decl.indexOf(':')
+        if (colonIdx === -1) return decl
+        const prop = decl.slice(0, colonIdx).trim()
+        const value = decl.slice(colonIdx + 1).trim()
+        return `${prop}: ${value}`
+      })
+      .join('; ')
+    return normalized ? `style="${normalized};"` : 'style=""'
+  })
+
+  // Restore sidebar scroll position before first paint.
+  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(localStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
+
   let html = template.replace(
     '<div id="root"></div>',
-    `<div id="root">${appHtml}</div>\n\t<script>${contentScript}</script>`
+    `<div id="root">${appHtml}</div>\n\t<script>${contentScript};${scrollRestoreScript}</script>`
   )
 
   // Inject <link> tags for ALL brand theme CSS chunks.

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -360,6 +360,25 @@ function injectHtml(
   meta,
   themeCssPaths
 ) {
+  // React 19 injects <link rel="preload"> elements inline during
+  // renderToString for resources like images. Strip them from the app
+  // HTML and move them to <head> so they don't break client-side
+  // hydration (React can't match the DOM when unexpected <link>
+  // elements appear before the root component's first element).
+  const reactPreloadLinks = []
+  appHtml = appHtml.replace(/<link rel="preload"[^>]*\/>/g, (match) => {
+    reactPreloadLinks.push(match)
+    return ''
+  })
+
+  // StaticRouterProvider injects a <script> with hydration data that
+  // is not needed for our hydration approach. Strip it so it doesn't
+  // appear inside the root container as unexpected DOM content.
+  appHtml = appHtml.replace(
+    /<script>window\.__staticRouterHydrationData\s*=[^<]*<\/script>/,
+    ''
+  )
+
   let html = template.replace(
     '<div id="root"></div>',
     `<div id="root">${appHtml}</div>\n\t<script>${contentScript}</script>`
@@ -464,6 +483,13 @@ function injectHtml(
       .map((p) => `<link rel="modulepreload" crossorigin href="${p}">`)
       .join('\n    ')
     html = html.replace('</head>', `    ${preloadTags}\n  </head>`)
+  }
+
+  // Inject React-generated preload links that were stripped from the
+  // app HTML to avoid hydration mismatches.
+  if (reactPreloadLinks.length > 0) {
+    const linkTags = reactPreloadLinks.join('\n    ')
+    html = html.replace('</head>', `    ${linkTags}\n  </head>`)
   }
 
   return html

--- a/packages/dnb-design-system-portal/vite/vitest.config.ts
+++ b/packages/dnb-design-system-portal/vite/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         __dirname,
         '__tests__/mocks/virtual-portal-pages.ts'
       ),
+      'virtual:build-info': path.resolve(
+        __dirname,
+        '__tests__/mocks/virtual-build-info.ts'
+      ),
     },
   },
 })


### PR DESCRIPTION
Enable React hydration for pre-rendered portal pages and fix all SSR/SSG hydration mismatches so the client can reuse server-rendered HTML without re-creating the DOM.

Preview: https://chore-portal-hydration.eufemia-e25.pages.dev/

This change means that we now get a dev-console error when a component interferes with hydration in production builds.

The app may still appear to “work”, but React can no longer safely hydrate the existing server-rendered markup. Instead, it falls back to client rendering and injects a re-rendered app into the DOM.

That makes the issue visible, but it also means the component should be fixed so the initial server render and the first client render produce the same markup.

