### PR TITLE
chore(Portal): remove viewTransition from RouterLink in Anchor

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
@@ -21,7 +21,6 @@ function PortalLink({ href, onClick = null, ref, ...props }: AnchorProps) {
       ref={ref as Ref<HTMLAnchorElement>}
       {...(props as Omit<LinkProps, 'ref' | 'onClick' | 'to'>)}
       onClick={onClick}
-      viewTransition
     />
   )
 }


### PR DESCRIPTION
Motivation: As of now when testing and navigating between pages in https://main.eufemia-e25.pages.dev the app/portal feels sluggish on my computer. Slow animations, feels unresponsive, etc.
But on my iPhone it behaves as expected. Perhaps we should test this in a browser with reduced hardware simulation, or perhaps if someone has access to old machines.

Deploy preview: https://revert-remove-view-transitio-pj9w.eufemia-e25.pages.dev/

Without `viewTransition`, it feels responsive, and not lagging, etc.