### PR TITLE
chore(Portal): fix release version showing 'Not released'

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -26,7 +26,7 @@ async function getNextReleaseVersion() {
 
   if (releaseBranches.includes(branchName)) {
     try {
-      const log = await runCommand(command)
+      const log = await runCommand(command, { timeout: 120000 })
       const nextVersion = log.match(
         /The next release version is ([^\n]*)/
       )?.[1]

--- a/packages/dnb-eufemia/scripts/tools/__tests__/cliTools.test.ts
+++ b/packages/dnb-eufemia/scripts/tools/__tests__/cliTools.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+
+const { DEFAULT_TIMEOUT, runCommand } = require('../cliTools')
+
+describe('runCommand', () => {
+  it('should export a default timeout of 10 000 ms', () => {
+    expect(DEFAULT_TIMEOUT).toBe(10000)
+  })
+
+  it('should resolve with stdout', async () => {
+    const result = await runCommand('echo hello')
+    expect(result.trim()).toBe('hello')
+  })
+
+  it('should reject unsafe commands', async () => {
+    await expect(runCommand('echo foo; echo bar')).rejects.toThrow(
+      'Unsafe shell command rejected'
+    )
+  })
+
+  it(
+    'should use the default timeout when none is provided',
+    async () => {
+      const start = Date.now()
+
+      await expect(runCommand('sleep 60')).rejects.toThrow()
+
+      const elapsed = Date.now() - start
+
+      expect(elapsed).toBeGreaterThanOrEqual(DEFAULT_TIMEOUT - 500)
+      expect(elapsed).toBeLessThan(DEFAULT_TIMEOUT + 5000)
+    },
+    DEFAULT_TIMEOUT + 10000
+  )
+
+  it('should accept a custom timeout', async () => {
+    const start = Date.now()
+
+    await expect(
+      runCommand('sleep 60', { timeout: 200 })
+    ).rejects.toThrow()
+
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeLessThan(2000)
+  })
+})

--- a/packages/dnb-eufemia/scripts/tools/cliTools.js
+++ b/packages/dnb-eufemia/scripts/tools/cliTools.js
@@ -1,5 +1,7 @@
 const { execFile } = require('child_process')
 
+const DEFAULT_TIMEOUT = 10000
+
 function assertSafeCommand(command) {
   // Reject potentially dangerous shell control characters when using `/bin/sh -c`.
   // This keeps existing API while preventing command injection from dynamic values.
@@ -8,14 +10,14 @@ function assertSafeCommand(command) {
   }
 }
 
-function runCommand(command) {
+function runCommand(command, options = {}) {
   return new Promise((resolve, reject) => {
     try {
       assertSafeCommand(command)
       execFile(
         '/bin/sh',
         ['-c', command],
-        { timeout: 10000 },
+        { timeout: options.timeout ?? DEFAULT_TIMEOUT },
         (error, stdout, stderr) => {
           if (error) {
             return reject(error)
@@ -68,5 +70,6 @@ const getCommittedFiles = async (countCommits = 10) => {
   }
 }
 
+exports.DEFAULT_TIMEOUT = DEFAULT_TIMEOUT
 exports.runCommand = runCommand
 exports.getCommittedFiles = getCommittedFiles


### PR DESCRIPTION
The 10s timeout on runCommand was killing semantic-release --dry-run before it could finish. Allow callers to override the timeout and give getNextReleaseVersion 2 minutes.

