### PR TITLE
chore(Portal): persist and restore window scroll position on refresh

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
@@ -15,7 +15,7 @@ describe('scroll-position plugin', () => {
       ) => string | undefined
 
       expect(resolveId('virtual:scroll-position')).toBe(
-        '\0virtual:scroll-position'
+        '\0virtual:scroll-position.ts'
       )
     })
 
@@ -32,7 +32,7 @@ describe('scroll-position plugin', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
 
-      const result = load('\0virtual:scroll-position')
+      const result = load('\0virtual:scroll-position.ts')
 
       expect(result).toBeDefined()
       expect(result).toContain('saveScrollPosition')
@@ -52,7 +52,7 @@ describe('scroll-position plugin', () => {
     it('configures the sidebar menu element', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('#portal-sidebar-menu')
       expect(code).toContain('is-active')
@@ -61,7 +61,7 @@ describe('scroll-position plugin', () => {
     it('exports saveScrollPosition function', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('export function saveScrollPosition()')
     })
@@ -69,7 +69,7 @@ describe('scroll-position plugin', () => {
     it('exports restoreScrollPosition function', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('export function restoreScrollPosition(')
     })
@@ -77,7 +77,7 @@ describe('scroll-position plugin', () => {
     it('exports useScrollPosition hook', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('export function useScrollPosition()')
     })
@@ -85,7 +85,7 @@ describe('scroll-position plugin', () => {
     it('uses sessionStorage for persistence', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('sessionStorage.setItem')
       expect(code).toContain('sessionStorage.getItem')
@@ -94,7 +94,7 @@ describe('scroll-position plugin', () => {
     it('handles beforeunload and pagehide events', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain("'beforeunload'")
       expect(code).toContain("'pagehide'")
@@ -103,7 +103,7 @@ describe('scroll-position plugin', () => {
     it('uses requestAnimationFrame for rendering', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('requestAnimationFrame')
     })
@@ -111,7 +111,7 @@ describe('scroll-position plugin', () => {
     it('supports smooth scrolling option', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('smooth')
       expect(code).toContain('scrollBehavior')
@@ -120,7 +120,7 @@ describe('scroll-position plugin', () => {
     it('has ensureInView logic for active menu items', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('ensureInView')
       expect(code).toContain('offsetTop')
@@ -196,7 +196,7 @@ describe('scroll-position plugin', () => {
     it('saves window.scrollY to sessionStorage', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('scroll-window')
       expect(code).toContain('window.scrollY')
@@ -205,7 +205,7 @@ describe('scroll-position plugin', () => {
     it('restores window scroll via window.scrollTo', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('window.scrollTo')
     })
@@ -213,7 +213,7 @@ describe('scroll-position plugin', () => {
     it('supports restoreWindow option to skip window scroll restore', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('restoreWindow')
     })
@@ -221,7 +221,7 @@ describe('scroll-position plugin', () => {
     it('scrolls window to top on route change instead of restoring', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position')!
+      const code = load('\0virtual:scroll-position.ts')!
 
       expect(code).toContain('window.scrollTo({ top: 0 })')
       expect(code).toContain('restoreWindow: false')

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
@@ -82,13 +82,13 @@ describe('scroll-position plugin', () => {
       expect(code).toContain('export function useScrollPosition()')
     })
 
-    it('uses localStorage for persistence', () => {
+    it('uses sessionStorage for persistence', () => {
       const plugin = scrollPositionPlugin()
       const load = plugin.load as (id: string) => string | undefined
       const code = load('\0virtual:scroll-position')!
 
-      expect(code).toContain('localStorage.setItem')
-      expect(code).toContain('localStorage.getItem')
+      expect(code).toContain('sessionStorage.setItem')
+      expect(code).toContain('sessionStorage.getItem')
     })
 
     it('handles beforeunload and pagehide events', () => {
@@ -131,7 +131,7 @@ describe('scroll-position plugin', () => {
     let sidebarEl: HTMLElement
 
     beforeEach(() => {
-      localStorage.clear()
+      sessionStorage.clear()
 
       sidebarEl = document.createElement('nav')
       sidebarEl.id = 'portal-sidebar-menu'
@@ -144,33 +144,33 @@ describe('scroll-position plugin', () => {
 
     afterEach(() => {
       document.body.innerHTML = ''
-      localStorage.clear()
+      sessionStorage.clear()
     })
 
-    it('saves scrollTop to localStorage', () => {
+    it('saves scrollTop to sessionStorage', () => {
       sidebarEl.scrollTop = 150
 
       // Simulate saveScrollPosition logic
       const selector = '#portal-sidebar-menu'
       const el = document.querySelector(selector)
       if (el) {
-        localStorage.setItem('scroll-' + selector, String(el.scrollTop))
+        sessionStorage.setItem('scroll-' + selector, String(el.scrollTop))
       }
 
-      expect(localStorage.getItem('scroll-#portal-sidebar-menu')).toBe(
+      expect(sessionStorage.getItem('scroll-#portal-sidebar-menu')).toBe(
         '150'
       )
     })
 
-    it('restores scrollTop from localStorage', () => {
-      localStorage.setItem('scroll-#portal-sidebar-menu', '200')
+    it('restores scrollTop from sessionStorage', () => {
+      sessionStorage.setItem('scroll-#portal-sidebar-menu', '200')
 
       // Simulate restoreScrollPosition logic
       const selector = '#portal-sidebar-menu'
       const el = document.querySelector(selector)
       if (el) {
         const stored = parseFloat(
-          localStorage.getItem('scroll-' + selector) || '0'
+          sessionStorage.getItem('scroll-' + selector) || '0'
         )
         ;(el as HTMLElement).scrollTop = stored
       }
@@ -183,12 +183,48 @@ describe('scroll-position plugin', () => {
       const el = document.querySelector(selector)
       if (el) {
         const stored = parseFloat(
-          localStorage.getItem('scroll-' + selector) || '0'
+          sessionStorage.getItem('scroll-' + selector) || '0'
         )
         ;(el as HTMLElement).scrollTop = stored
       }
 
       expect(sidebarEl.scrollTop).toBe(0)
+    })
+  })
+
+  describe('runtime code – window scroll', () => {
+    it('saves window.scrollY to sessionStorage', () => {
+      const plugin = scrollPositionPlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:scroll-position')!
+
+      expect(code).toContain('scroll-window')
+      expect(code).toContain('window.scrollY')
+    })
+
+    it('restores window scroll via window.scrollTo', () => {
+      const plugin = scrollPositionPlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:scroll-position')!
+
+      expect(code).toContain('window.scrollTo')
+    })
+
+    it('supports restoreWindow option to skip window scroll restore', () => {
+      const plugin = scrollPositionPlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:scroll-position')!
+
+      expect(code).toContain('restoreWindow')
+    })
+
+    it('scrolls window to top on route change instead of restoring', () => {
+      const plugin = scrollPositionPlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:scroll-position')!
+
+      expect(code).toContain('window.scrollTo({ top: 0 })')
+      expect(code).toContain('restoreWindow: false')
     })
   })
 })

--- a/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.runtime.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.runtime.ts
@@ -1,0 +1,132 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const SCROLL_ELEMENTS = [
+  {
+    selector: '#portal-sidebar-menu',
+    ensureInView:
+      '#portal-sidebar-menu ul li.is-active > .dnb-sidebar-menu__item',
+  },
+]
+
+const WINDOW_SCROLL_KEY = 'scroll-window'
+
+export function saveScrollPosition() {
+  try {
+    sessionStorage.setItem(WINDOW_SCROLL_KEY, String(window.scrollY))
+
+    for (const { selector } of SCROLL_ELEMENTS) {
+      const el = document.querySelector(selector)
+      if (el) {
+        sessionStorage.setItem('scroll-' + selector, String(el.scrollTop))
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+}
+
+export function restoreScrollPosition({
+  smooth = false,
+  restoreWindow = true,
+} = {}) {
+  try {
+    if (restoreWindow) {
+      const storedWindowScroll = parseFloat(
+        sessionStorage.getItem(WINDOW_SCROLL_KEY) || '0'
+      )
+
+      if (storedWindowScroll) {
+        window.scrollTo({
+          top: storedWindowScroll,
+          behavior: smooth ? 'smooth' : 'auto',
+        })
+      }
+    }
+
+    for (const { selector, ensureInView } of SCROLL_ELEMENTS) {
+      const el = document.querySelector(selector)
+      if (!el) {
+        continue
+      }
+
+      const stored = parseFloat(
+        sessionStorage.getItem('scroll-' + selector) || '0'
+      )
+      let scrollTop = stored || 0
+
+      if (ensureInView) {
+        const fallback = document.querySelector(ensureInView)
+        if (fallback) {
+          const offsetTop = (fallback as HTMLElement).offsetTop
+          const inView =
+            scrollTop <= offsetTop &&
+            scrollTop >=
+              offsetTop -
+                (el as HTMLElement).offsetHeight +
+                (fallback as HTMLElement).offsetHeight
+
+          if (!inView) {
+            scrollTop = offsetTop
+          }
+        }
+      }
+
+      ;(el as HTMLElement).style.scrollBehavior = 'auto'
+
+      if (smooth) {
+        el.scrollTop = stored
+        ;(el as HTMLElement).style.scrollBehavior = 'smooth'
+      }
+
+      el.scrollTop = scrollTop
+      ;(el as HTMLElement).style.scrollBehavior = ''
+    }
+  } catch (e) {
+    // ignore
+  }
+}
+
+/**
+ * React hook that saves and restores sidebar scroll position on route
+ * changes and page lifecycle events (beforeunload, pagehide).
+ */
+export function useScrollPosition() {
+  const location = useLocation()
+  const prevPathRef = useRef(location.pathname)
+
+  // Save and restore on route changes
+  useEffect(() => {
+    const prevPath = prevPathRef.current
+    prevPathRef.current = location.pathname
+
+    if (prevPath !== location.pathname) {
+      saveScrollPosition()
+
+      window.scrollTo({ top: 0 })
+
+      requestAnimationFrame(() => {
+        restoreScrollPosition({ smooth: true, restoreWindow: false })
+      })
+    }
+  }, [location])
+
+  // Restore on initial render and persist on unload
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      restoreScrollPosition()
+    })
+
+    window.addEventListener('beforeunload', saveScrollPosition)
+
+    // iOS Safari support
+    if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+      window.addEventListener('pagehide', saveScrollPosition)
+    }
+
+    return () => {
+      window.removeEventListener('beforeunload', saveScrollPosition)
+      window.removeEventListener('pagehide', saveScrollPosition)
+    }
+  }, [])
+}

--- a/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
@@ -48,12 +48,16 @@ const SCROLL_ELEMENTS = [
   },
 ]
 
+const WINDOW_SCROLL_KEY = 'scroll-window'
+
 export function saveScrollPosition() {
   try {
+    sessionStorage.setItem(WINDOW_SCROLL_KEY, String(window.scrollY))
+
     for (const { selector } of SCROLL_ELEMENTS) {
       const el = document.querySelector(selector)
       if (el) {
-        localStorage.setItem('scroll-' + selector, String(el.scrollTop))
+        sessionStorage.setItem('scroll-' + selector, String(el.scrollTop))
       }
     }
   } catch (e) {
@@ -61,8 +65,21 @@ export function saveScrollPosition() {
   }
 }
 
-export function restoreScrollPosition({ smooth = false } = {}) {
+export function restoreScrollPosition({ smooth = false, restoreWindow = true } = {}) {
   try {
+    if (restoreWindow) {
+      const storedWindowScroll = parseFloat(
+        sessionStorage.getItem(WINDOW_SCROLL_KEY) || '0'
+      )
+
+      if (storedWindowScroll) {
+        window.scrollTo({
+          top: storedWindowScroll,
+          behavior: smooth ? 'smooth' : 'auto',
+        })
+      }
+    }
+
     for (const { selector, ensureInView } of SCROLL_ELEMENTS) {
       const el = document.querySelector(selector)
       if (!el) {
@@ -70,7 +87,7 @@ export function restoreScrollPosition({ smooth = false } = {}) {
       }
 
       const stored = parseFloat(
-        localStorage.getItem('scroll-' + selector) || '0'
+        sessionStorage.getItem('scroll-' + selector) || '0'
       )
       let scrollTop = stored || 0
 
@@ -120,8 +137,10 @@ export function useScrollPosition() {
     if (prevPath !== location.pathname) {
       saveScrollPosition()
 
+      window.scrollTo({ top: 0 })
+
       requestAnimationFrame(() => {
-        restoreScrollPosition({ smooth: true })
+        restoreScrollPosition({ smooth: true, restoreWindow: false })
       })
     }
   }, [location])

--- a/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
@@ -6,10 +6,12 @@
  * that exports helper functions and a React hook.
  */
 
+import fs from 'node:fs'
+import path from 'node:path'
 import type { Plugin } from 'vite'
 
 const VIRTUAL_MODULE_ID = 'virtual:scroll-position'
-const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID + '.ts'
 
 export default function scrollPositionPlugin(): Plugin {
   return {
@@ -23,145 +25,12 @@ export default function scrollPositionPlugin(): Plugin {
 
     load(id) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        return RUNTIME_CODE
+        const runtimeFile = path.resolve(
+          __dirname,
+          'scroll-position.runtime.ts'
+        )
+        return fs.readFileSync(runtimeFile, 'utf-8')
       }
     },
   }
 }
-
-/**
- * Client-side runtime code served as the virtual module.
- *
- * Saves and restores scroll positions for configured elements using
- * localStorage. Handles iOS Safari's pagehide event for back-forward
- * cache compatibility.
- */
-const RUNTIME_CODE = `
-import { useEffect, useRef } from 'react'
-import { useLocation } from 'react-router-dom'
-
-const SCROLL_ELEMENTS = [
-  {
-    selector: '#portal-sidebar-menu',
-    ensureInView:
-      '#portal-sidebar-menu ul li.is-active > .dnb-sidebar-menu__item',
-  },
-]
-
-const WINDOW_SCROLL_KEY = 'scroll-window'
-
-export function saveScrollPosition() {
-  try {
-    sessionStorage.setItem(WINDOW_SCROLL_KEY, String(window.scrollY))
-
-    for (const { selector } of SCROLL_ELEMENTS) {
-      const el = document.querySelector(selector)
-      if (el) {
-        sessionStorage.setItem('scroll-' + selector, String(el.scrollTop))
-      }
-    }
-  } catch (e) {
-    // ignore
-  }
-}
-
-export function restoreScrollPosition({ smooth = false, restoreWindow = true } = {}) {
-  try {
-    if (restoreWindow) {
-      const storedWindowScroll = parseFloat(
-        sessionStorage.getItem(WINDOW_SCROLL_KEY) || '0'
-      )
-
-      if (storedWindowScroll) {
-        window.scrollTo({
-          top: storedWindowScroll,
-          behavior: smooth ? 'smooth' : 'auto',
-        })
-      }
-    }
-
-    for (const { selector, ensureInView } of SCROLL_ELEMENTS) {
-      const el = document.querySelector(selector)
-      if (!el) {
-        continue
-      }
-
-      const stored = parseFloat(
-        sessionStorage.getItem('scroll-' + selector) || '0'
-      )
-      let scrollTop = stored || 0
-
-      if (ensureInView) {
-        const fallback = document.querySelector(ensureInView)
-        if (fallback) {
-          const offsetTop = fallback.offsetTop
-          const inView =
-            scrollTop <= offsetTop &&
-            scrollTop >=
-              offsetTop - el.offsetHeight + fallback.offsetHeight
-
-          if (!inView) {
-            scrollTop = offsetTop
-          }
-        }
-      }
-
-      el.style.scrollBehavior = 'auto'
-
-      if (smooth) {
-        el.scrollTop = stored
-        el.style.scrollBehavior = 'smooth'
-      }
-
-      el.scrollTop = scrollTop
-      el.style.scrollBehavior = ''
-    }
-  } catch (e) {
-    // ignore
-  }
-}
-
-/**
- * React hook that saves and restores sidebar scroll position on route
- * changes and page lifecycle events (beforeunload, pagehide).
- */
-export function useScrollPosition() {
-  const location = useLocation()
-  const prevPathRef = useRef(location.pathname)
-
-  // Save and restore on route changes
-  useEffect(() => {
-    const prevPath = prevPathRef.current
-    prevPathRef.current = location.pathname
-
-    if (prevPath !== location.pathname) {
-      saveScrollPosition()
-
-      window.scrollTo({ top: 0 })
-
-      requestAnimationFrame(() => {
-        restoreScrollPosition({ smooth: true, restoreWindow: false })
-      })
-    }
-  }, [location])
-
-  // Restore on initial render and persist on unload
-  useEffect(() => {
-    requestAnimationFrame(() => {
-      restoreScrollPosition()
-    })
-
-    window.addEventListener('beforeunload', saveScrollPosition)
-
-    // iOS Safari support
-    if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
-      window.addEventListener('pagehide', saveScrollPosition)
-    }
-
-    return () => {
-      window.removeEventListener('beforeunload', saveScrollPosition)
-      window.removeEventListener('pagehide', saveScrollPosition)
-    }
-  }, [])
-}
-`

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -261,7 +261,7 @@ export function injectHtml(
 
   // Restore sidebar scroll position before first paint so the menu
   // doesn't flash at the top before jumping to the saved position.
-  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(localStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
+  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(sessionStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
 
   let html = template.replace(
     '<div id="root"></div>',

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -417,7 +417,7 @@ function injectHtml(
   })
 
   // Restore sidebar scroll position before first paint.
-  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(localStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
+  const scrollRestoreScript = `(function(){try{var el=document.getElementById('portal-sidebar-menu');if(el){var s=parseFloat(sessionStorage.getItem('scroll-#portal-sidebar-menu')||'0');if(s){el.style.scrollBehavior='auto';el.scrollTop=s;el.style.scrollBehavior=''}}}catch(e){}})()`
 
   let html = template.replace(
     '<div id="root"></div>',


### PR DESCRIPTION
Save window.scrollY to sessionStorage alongside the sidebar scroll position. On refresh the saved position is restored; on SPA navigation the window scrolls to top while only the sidebar position is restored.

Switch all scroll storage from localStorage to sessionStorage so positions are tab-scoped and cleared when the tab closes. Update the inline prerender scripts to match.

This helps keeping the scroll position during development.
