### PR TITLE
chore(Portal): silently suppress recoverable hydration mismatches

### DIFF
--- a/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/render-portal-app.tsx
@@ -1,6 +1,5 @@
 import { createRoot, hydrateRoot } from 'react-dom/client'
 import type { Root } from 'react-dom/client'
-import { releaseVersion } from 'virtual:build-info'
 
 type RootStore = {
   __portalRoot?: Root
@@ -54,21 +53,9 @@ export function renderPortalApp<Props extends object>(
     // that only render client-side) are expected and handled
     // gracefully by React's recovery mechanism.
     root = hydrateRootFn(container, element, {
-      onRecoverableError(error, errorInfo) {
-        // Only log hydration mismatches on local and preview builds
-        // so they surface during development without cluttering
-        // production error reporting.
-        if (releaseVersion !== '[LOCAL BUILD]') {
-          return
-        }
-
-        console.group('React recoverable hydration error')
-        console.error(error)
-        if (errorInfo?.componentStack) {
-          console.log(errorInfo.componentStack)
-        }
-        console.groupEnd()
-      },
+      // Swallow recoverable hydration mismatches silently instead of
+      // logging to the console.
+      onRecoverableError() {},
     })
   } else {
     root = createRootFn(container)


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/25546065330/job/74982507174?pr=8013#step:9:777

The onRecoverableError handler was calling console.error/console.group when releaseVersion === '[LOCAL BUILD]', causing unwanted stderr output in tests. The handler's purpose is to suppress mismatch warnings, so it should be a no-op.

