### PR TITLE
chore: verify @babel/runtime-corejs3 is a listed runtime dependency

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -942,3 +942,22 @@ describe('style build', () => {
     })
   })
 })
+
+describe('package.json dependencies', () => {
+  it('includes @babel/runtime-corejs3 as a runtime dependency', () => {
+    // The published build artifacts contain imports from
+    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
+    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
+    // tools like esbuild or Vite will get a build error if this package is not
+    // listed as a dependency in the published package.json.
+    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
+    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    const packageJson = fs.readJsonSync(
+      path.resolve(packpath.self(), 'package.json')
+    )
+
+    expect(packageJson.dependencies).toMatchObject({
+      '@babel/runtime-corejs3': expect.any(String),
+    })
+  })
+})

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -26,6 +26,26 @@ describe('cleanupPackage', () => {
     expect(cleanedPackage).toHaveProperty('peerDependencies')
     expect(cleanedPackage.license).toBe('SEE LICENSE IN LICENSE FILE')
   })
+
+  it('includes @babel/runtime-corejs3 as a runtime dependency', async () => {
+    // The published build artifacts contain imports from
+    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
+    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
+    // tools like esbuild or Vite will get a build error if this package is not
+    // listed as a dependency in the published package.json.
+    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
+    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    const filepath = path.resolve(packpath.self(), 'package.json')
+    const packageString = await fs.readFile(filepath, 'utf-8')
+    const cleanedPackage = await cleanupPackage({
+      packageString,
+    })
+
+    const deps = cleanedPackage.dependencies as Record<string, string>
+    expect(deps).toMatchObject({
+      '@babel/runtime-corejs3': expect.any(String),
+    })
+  })
 })
 
 describe('buildExportsMap', () => {
@@ -113,6 +133,21 @@ describe('package.json', () => {
         'react-dom': expect.anything(),
       })
     )
+  })
+
+  it('has @babel/runtime-corejs3 as a dependency', () => {
+    // The published build artifacts (e.g. build/shared/useTranslation.js) contain
+    // imports from "@babel/runtime-corejs3/helpers/esm/*" because they were compiled
+    // with @babel/plugin-transform-runtime using corejs: 3. Consumers who do not have
+    // this package installed (e.g. via bundlers like esbuild or Vite) will get a
+    // build error if this runtime dependency is missing from the published package.
+    // See: https://github.com/dnbexperience/eufemia/issues/7994
+    expect(
+      (packageJson as { dependencies?: Record<string, string> })
+        .dependencies
+    ).toMatchObject({
+      '@babel/runtime-corejs3': expect.any(String),
+    })
   })
 
   it('has main and module fields to be equal', () => {


### PR DESCRIPTION
The build artifacts reference @babel/runtime-corejs3 at runtime, so consumers bundling with tools like esbuild or Vite will fail if it is not declared as a dependency in the published package.json.

- Added check to postbuild.test.ts (runs after every build in CI)
- Added check to prepareForRelease.test.ts (runs during release prep)

See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
     https://github.com/dnbexperience/eufemia/pull/8016 (re-added)

