### PR TITLE
chore(Portal): fix scroll-position virtual module TypeScript transform

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/scroll-position.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('vite', () => ({
+  transformWithEsbuild: vi.fn(async (code: string) => ({ code })),
+}))
+
 import scrollPositionPlugin from '../../client/plugins/scroll-position'
 
 describe('scroll-position plugin', () => {
@@ -15,7 +20,7 @@ describe('scroll-position plugin', () => {
       ) => string | undefined
 
       expect(resolveId('virtual:scroll-position')).toBe(
-        '\0virtual:scroll-position.ts'
+        '\0virtual:scroll-position'
       )
     })
 
@@ -28,11 +33,13 @@ describe('scroll-position plugin', () => {
       expect(resolveId('other-module')).toBeUndefined()
     })
 
-    it('loads virtual module with runtime code', () => {
+    it('loads virtual module with runtime code', async () => {
       const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
+      const load = plugin.load as (
+        id: string
+      ) => Promise<string | undefined>
 
-      const result = load('\0virtual:scroll-position.ts')
+      const result = await load('\0virtual:scroll-position')
 
       expect(result).toBeDefined()
       expect(result).toContain('saveScrollPosition')
@@ -40,87 +47,77 @@ describe('scroll-position plugin', () => {
       expect(result).toContain('useScrollPosition')
     })
 
-    it('does not load other module IDs', () => {
+    it('does not load other module IDs', async () => {
       const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
+      const load = plugin.load as (
+        id: string
+      ) => Promise<string | undefined>
 
-      expect(load('other-id')).toBeUndefined()
+      expect(await load('other-id')).toBeUndefined()
     })
   })
 
   describe('runtime code', () => {
-    it('configures the sidebar menu element', () => {
+    async function loadRuntimeCode() {
       const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+      const load = plugin.load as (id: string) => Promise<string>
+      return await load('\0virtual:scroll-position')
+    }
+
+    it('configures the sidebar menu element', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('#portal-sidebar-menu')
       expect(code).toContain('is-active')
     })
 
-    it('exports saveScrollPosition function', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('exports saveScrollPosition function', async () => {
+      const code = await loadRuntimeCode()
 
-      expect(code).toContain('export function saveScrollPosition()')
+      expect(code).toContain('saveScrollPosition')
     })
 
-    it('exports restoreScrollPosition function', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('exports restoreScrollPosition function', async () => {
+      const code = await loadRuntimeCode()
 
-      expect(code).toContain('export function restoreScrollPosition(')
+      expect(code).toContain('restoreScrollPosition')
     })
 
-    it('exports useScrollPosition hook', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('exports useScrollPosition hook', async () => {
+      const code = await loadRuntimeCode()
 
-      expect(code).toContain('export function useScrollPosition()')
+      expect(code).toContain('useScrollPosition')
     })
 
-    it('uses sessionStorage for persistence', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('uses sessionStorage for persistence', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('sessionStorage.setItem')
       expect(code).toContain('sessionStorage.getItem')
     })
 
-    it('handles beforeunload and pagehide events', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('handles beforeunload and pagehide events', async () => {
+      const code = await loadRuntimeCode()
 
-      expect(code).toContain("'beforeunload'")
-      expect(code).toContain("'pagehide'")
+      expect(code).toContain('beforeunload')
+      expect(code).toContain('pagehide')
     })
 
-    it('uses requestAnimationFrame for rendering', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('uses requestAnimationFrame for rendering', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('requestAnimationFrame')
     })
 
-    it('supports smooth scrolling option', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('supports smooth scrolling option', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('smooth')
       expect(code).toContain('scrollBehavior')
     })
 
-    it('has ensureInView logic for active menu items', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('has ensureInView logic for active menu items', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('ensureInView')
       expect(code).toContain('offsetTop')
@@ -193,35 +190,33 @@ describe('scroll-position plugin', () => {
   })
 
   describe('runtime code – window scroll', () => {
-    it('saves window.scrollY to sessionStorage', () => {
+    async function loadRuntimeCode() {
       const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+      const load = plugin.load as (id: string) => Promise<string>
+      return await load('\0virtual:scroll-position')
+    }
+
+    it('saves window.scrollY to sessionStorage', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('scroll-window')
       expect(code).toContain('window.scrollY')
     })
 
-    it('restores window scroll via window.scrollTo', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('restores window scroll via window.scrollTo', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('window.scrollTo')
     })
 
-    it('supports restoreWindow option to skip window scroll restore', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('supports restoreWindow option to skip window scroll restore', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('restoreWindow')
     })
 
-    it('scrolls window to top on route change instead of restoring', () => {
-      const plugin = scrollPositionPlugin()
-      const load = plugin.load as (id: string) => string | undefined
-      const code = load('\0virtual:scroll-position.ts')!
+    it('scrolls window to top on route change instead of restoring', async () => {
+      const code = await loadRuntimeCode()
 
       expect(code).toContain('window.scrollTo({ top: 0 })')
       expect(code).toContain('restoreWindow: false')

--- a/packages/dnb-design-system-portal/vite/__tests__/scroll-position.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/scroll-position.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  saveScrollPosition,
+  restoreScrollPosition,
+} from '../client/plugins/scroll-position.runtime'
+
+beforeEach(() => {
+  sessionStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('saveScrollPosition', () => {
+  it('should save window scroll position to sessionStorage', () => {
+    Object.defineProperty(window, 'scrollY', {
+      value: 200,
+      writable: true,
+    })
+
+    saveScrollPosition()
+
+    expect(sessionStorage.getItem('scroll-window')).toBe('200')
+  })
+
+  it('should save element scroll position when element exists', () => {
+    const el = document.createElement('div')
+    el.id = 'portal-sidebar-menu'
+    Object.defineProperty(el, 'scrollTop', { value: 150, writable: true })
+    document.body.appendChild(el)
+
+    saveScrollPosition()
+
+    expect(sessionStorage.getItem('scroll-#portal-sidebar-menu')).toBe(
+      '150'
+    )
+
+    document.body.removeChild(el)
+  })
+
+  it('should not throw when element does not exist', () => {
+    expect(() => saveScrollPosition()).not.toThrow()
+  })
+})
+
+describe('restoreScrollPosition', () => {
+  it('should restore window scroll position', () => {
+    const scrollToSpy = vi.fn()
+    window.scrollTo = scrollToSpy
+    sessionStorage.setItem('scroll-window', '300')
+
+    restoreScrollPosition()
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 300,
+      behavior: 'auto',
+    })
+  })
+
+  it('should use smooth behavior when smooth is true', () => {
+    const scrollToSpy = vi.fn()
+    window.scrollTo = scrollToSpy
+    sessionStorage.setItem('scroll-window', '100')
+
+    restoreScrollPosition({ smooth: true })
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 100,
+      behavior: 'smooth',
+    })
+  })
+
+  it('should skip window restore when restoreWindow is false', () => {
+    const scrollToSpy = vi.fn()
+    window.scrollTo = scrollToSpy
+    sessionStorage.setItem('scroll-window', '100')
+
+    restoreScrollPosition({ restoreWindow: false })
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  it('should restore element scroll position', () => {
+    const el = document.createElement('div')
+    el.id = 'portal-sidebar-menu'
+    Object.defineProperty(el, 'offsetHeight', { value: 500 })
+    document.body.appendChild(el)
+
+    sessionStorage.setItem('scroll-#portal-sidebar-menu', '120')
+
+    restoreScrollPosition({ restoreWindow: false })
+
+    expect(el.scrollTop).toBe(120)
+
+    document.body.removeChild(el)
+  })
+
+  it('should not throw when no stored positions exist', () => {
+    expect(() => restoreScrollPosition()).not.toThrow()
+  })
+
+  it('should snap to active item when stored position is not in view', () => {
+    const sidebar = document.createElement('div')
+    sidebar.id = 'portal-sidebar-menu'
+    Object.defineProperty(sidebar, 'offsetHeight', { value: 400 })
+    document.body.appendChild(sidebar)
+
+    const ul = document.createElement('ul')
+    sidebar.appendChild(ul)
+    const li = document.createElement('li')
+    li.classList.add('is-active')
+    ul.appendChild(li)
+    const item = document.createElement('div')
+    item.classList.add('dnb-sidebar-menu__item')
+    Object.defineProperty(item, 'offsetTop', { value: 800 })
+    Object.defineProperty(item, 'offsetHeight', { value: 40 })
+    li.appendChild(item)
+
+    sessionStorage.setItem('scroll-#portal-sidebar-menu', '50')
+
+    restoreScrollPosition({ restoreWindow: false })
+
+    expect(sidebar.scrollTop).toBe(800)
+
+    document.body.removeChild(sidebar)
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.ts
@@ -8,10 +8,11 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { transformWithEsbuild } from 'vite'
 import type { Plugin } from 'vite'
 
 const VIRTUAL_MODULE_ID = 'virtual:scroll-position'
-const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID + '.ts'
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
 
 export default function scrollPositionPlugin(): Plugin {
   return {
@@ -23,13 +24,17 @@ export default function scrollPositionPlugin(): Plugin {
       }
     },
 
-    load(id) {
+    async load(id) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
         const runtimeFile = path.resolve(
           __dirname,
           'scroll-position.runtime.ts'
         )
-        return fs.readFileSync(runtimeFile, 'utf-8')
+        const code = fs.readFileSync(runtimeFile, 'utf-8')
+        const result = await transformWithEsbuild(code, runtimeFile, {
+          loader: 'ts',
+        })
+        return result.code
       }
     },
   }


### PR DESCRIPTION
The scroll-position Vite plugin served the virtual module with a `.ts` suffix in the resolved ID, which caused Vite to skip its TypeScript transform pipeline (due to the `\0` prefix). This resulted in a `SyntaxError` at runtime when TypeScript `as` casts were left in the served code.
