### PR TITLE
chore: support PORT env var for screenshot tests

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -63,6 +63,9 @@ yarn test:screenshots breadcrumb avatar
 
 # You can also start it in watch mode
 yarn test:screenshots:watch breadcrumb avatar
+
+# To run against a portal on a different port, set the PORT env variable
+PORT=8001 yarn test:screenshots breadcrumb
 ```
 
 Visual tests uses this naming convention: `/__tests__/{ComponentName}.e2e.spec.ts`

--- a/packages/dnb-eufemia/playwright.config.screenshots.ts
+++ b/packages/dnb-eufemia/playwright.config.screenshots.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: `http://localhost:8000`,
+    baseURL: `http://localhost:${process.env.PORT || 8000}`,
     browserName: 'firefox',
     viewport: { width: 1280, height: 2048 },
     actionTimeout: 30_000,

--- a/packages/dnb-eufemia/src/core/playwright/screenshotSetup.ts
+++ b/packages/dnb-eufemia/src/core/playwright/screenshotSetup.ts
@@ -71,7 +71,7 @@ const log = ora()
 
 export const config = {
   testScreenshotOnHost: 'localhost',
-  testScreenshotOnPort: 8000,
+  testScreenshotOnPort: Number(process.env.PORT) || 8000,
   pixelGrid: 8,
   pageViewport: {
     width: 1280,


### PR DESCRIPTION
Allows running screenshot tests against a portal on a custom port by setting the `PORT` environment variable. Defaults to `8000`.

```sh
PORT=8001 yarn test:screenshots breadcrumb
```

### Changes

- `playwright.config.screenshots.ts`: read `baseURL` port from `process.env.PORT`
- `screenshotSetup.ts`: read `testScreenshotOnPort` from `process.env.PORT`
- `make-and-run-tests.mdx`: document the `PORT` env var usage