### PR TITLE
chore: accept both PORT and port env var for screenshot tests

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -64,7 +64,7 @@ yarn test:screenshots breadcrumb avatar
 # You can also start it in watch mode
 yarn test:screenshots:watch breadcrumb avatar
 
-# To run against a portal on a different port, set the PORT env variable
+# To run against a portal on a different port, set the PORT (or port) env variable
 PORT=8001 yarn test:screenshots breadcrumb
 ```
 

--- a/packages/dnb-eufemia/playwright.config.screenshots.ts
+++ b/packages/dnb-eufemia/playwright.config.screenshots.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: `http://localhost:${process.env.PORT || 8000}`,
+    baseURL: `http://localhost:${process.env.PORT || process.env.port || 8000}`,
     browserName: 'firefox',
     viewport: { width: 1280, height: 2048 },
     actionTimeout: 30_000,

--- a/packages/dnb-eufemia/src/core/playwright/screenshotSetup.ts
+++ b/packages/dnb-eufemia/src/core/playwright/screenshotSetup.ts
@@ -71,7 +71,8 @@ const log = ora()
 
 export const config = {
   testScreenshotOnHost: 'localhost',
-  testScreenshotOnPort: Number(process.env.PORT) || 8000,
+  testScreenshotOnPort:
+    Number(process.env.PORT || process.env.port) || 8000,
   pixelGrid: 8,
   pageViewport: {
     width: 1280,


### PR DESCRIPTION
Accept both `PORT` and `port` (lowercase) env var for screenshot tests, so `port=8001 yarn test:screenshots` works the same as `PORT=8001`.

- Updated `playwright.config.screenshots.ts` and `screenshotSetup.ts` to read both
- `PORT` takes precedence over `port` when both are set
- Added `portResolution.test.ts` with 4 tests