### PR TITLE
chore: replace dotenv library with process.loadEnvFile

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -184,7 +184,6 @@
     "current-git-branch": "1.1.0",
     "dependency-cruiser": "17.3.8",
     "dnb-design-system-portal": "workspace:*",
-    "dotenv": "10.0.0",
     "dotenv-cli": "4.1.0",
     "eslint": "9.39.2",
     "eslint-plugin-compat": "6.1.0",

--- a/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
@@ -14,10 +14,12 @@ import Color from 'color'
 import { ErrorHandler, ERROR_HARMLESS } from '../../lib/error'
 import { log } from '../../lib'
 import crypto from 'crypto'
-import dotenv from 'dotenv'
 
-// import .env variables
-dotenv.config()
+try {
+  process.loadEnvFile()
+} catch {
+  // .env is optional — CI provides env vars directly
+}
 
 const Figma = Client({
   personalAccessToken: process.env.FIGMA_TOKEN,

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -9,9 +9,12 @@
 
 const { runCommand } = require('../tools/cliTools')
 const getBranchName = require('current-git-branch')
-const dotenv = require('dotenv')
 
-dotenv.config()
+try {
+  process.loadEnvFile()
+} catch {
+  // .env is optional — CI provides env vars directly
+}
 
 const command = 'yarn workspace @dnb/eufemia semantic-release --dry-run'
 const releaseBranches = ['release', 'beta', 'alpha']

--- a/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
+++ b/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
@@ -3,14 +3,16 @@
  *
  */
 
-const dotenv = require('dotenv')
 const { isCI } = require('repo-utils')
 const ora = require('ora')
 const path = require('path')
 const simpleGit = require('simple-git') // More info: https://github.com/steveukx/git-js#readme
 
-// import .env variables
-dotenv.config()
+try {
+  process.loadEnvFile()
+} catch {
+  // .env is optional — CI provides env vars directly
+}
 
 const log = ora()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,7 +2289,6 @@ __metadata:
     date-fns: "npm:4.1.0"
     dependency-cruiser: "npm:17.3.8"
     dnb-design-system-portal: "workspace:*"
-    dotenv: "npm:10.0.0"
     dotenv-cli: "npm:4.1.0"
     eslint: "npm:9.39.2"
     eslint-plugin-compat: "npm:6.1.0"
@@ -9183,13 +9182,6 @@ __metadata:
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
   checksum: 10/d52af2a6e4642979ae4221408f1b75102508dbe4f5bac1c0613f92a3cf3880d5c31f86b2f5cff3273f7c23e10421e75028546e8b6cd0376fcd20e3803b374e15
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:10.0.0":
-  version: 10.0.0
-  resolution: "dotenv@npm:10.0.0"
-  checksum: 10/55f701ae213e3afe3f4232fae5edfb6e0c49f061a363ff9f1c5a0c2bf3fb990a6e49aeada11b2a116efb5fdc3bc3f1ef55ab330be43033410b267f7c0809a9dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces the `dotenv` library with the built-in `process.loadEnvFile()` (Node.js v20.12+) in three scripts:

- `scripts/prebuild/commitToBranch.js`
- `scripts/postbuild/getNextReleaseVersion.js`
- `scripts/figma/helpers/docHelpers.js`

Removes `dotenv` from devDependencies. `dotenv-cli` is kept since it's used as a shell command in `publish-release.sh` and npm scripts.

`process.loadEnvFile()` was added in Node.js v20.12.0 (March 2024).