### PR TITLE
chore(Pagination): fix flaky intersection observer test

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -344,6 +344,15 @@ describe('Infinity scroller', () => {
       })
 
     const intersect = async () => {
+      // Ensure the observer callback is initialized before calling it
+      let attempts = 0
+      while (!callObserver && attempts < 50) {
+        await wait(10)
+        attempts++
+      }
+      if (!callObserver) {
+        throw new Error('IntersectionObserver was not initialized')
+      }
       callObserver([{ isIntersecting: true }])
       await waitForComponent()
     }


### PR DESCRIPTION
Fixes a race condition in the 'should load pages with intersection observer (after)' test where callObserver was being called before the IntersectionObserver mock callback was initialized.

The fix adds a polling mechanism to ensure the observer callback is initialized before attempting to call it, preventing the `callObserver is not a function` error that caused CI flakiness.