### PR TITLE
chore: add build:lebab to local prebuild script

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/local-prebuild.sh
+++ b/packages/dnb-eufemia/scripts/prebuild/local-prebuild.sh
@@ -7,6 +7,7 @@ echo 'Prebuild started ...'
 yarn build:prebuild
 yarn build:esm
 yarn build:types:esm
+yarn build:lebab
 yarn build:copy
 rm -rf build/esm
 


### PR DESCRIPTION
## Why

The local prebuild script (`local-prebuild.sh`) was missing a call to `yarn build:lebab`. This caused the PostCSS plugin build output in `build/plugins/postcss-isolated-style-scope/` to contain a mix of ESM and CJS syntax — Babel injects `import` polyfill statements (e.g. `core-js-pure`) into the output, but without `build:lebab` running, the remaining `require()` calls are never converted to `import` statements.

This broke Vite's dev server with:
```
ReferenceError: require is not defined in ES module scope
    at ...build/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
```

The CI build (`build:ci`) already calls `yarn build:lebab` via `postbuild.sh`, so CI was unaffected.

## What

Added `yarn build:lebab` to `local-prebuild.sh` so local builds produce correct ESM output, consistent with CI.