### PR TITLE
docs(v11): note z-index tokens missing from basis stylesheet

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -3138,6 +3138,12 @@ You can override these on `:root` or any wrapper element to adjust Eufemia's lay
 }
 ```
 
+> **Note for `basis`-only imports:** These z-index tokens are included in the `core` stylesheet (`@dnb/eufemia/style/core`) and the full style bundle, but **not** in the `basis` stylesheet (`@dnb/eufemia/style/basis`). If you import only `basis`, components like Modal, Dialog, Tooltip, and Popover will have broken z-index layering (e.g. rendering behind other content). To fix this, either switch to importing `core`, or add the z-index tokens explicitly:
+>
+> ```js
+> import '@dnb/eufemia/style/core/z-index.scss'
+> ```
+
 - Replace import from path `style/themes/theme-ui/` with `style/themes/ui/`.
 - Replace import from path `style/themes/theme-sbanken/` with `style/themes/sbanken/`.
 - Replace import from path `style/themes/theme-eiendom/` with `style/themes/eiendom/`.


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1778481226297109

Thoughts, either this or this https://github.com/dnbexperience/eufemia/pull/8044

The z-index CSS custom properties introduced in #7356 are included in the core stylesheet but not in the basis stylesheet. Users who import only @dnb/eufemia/style/basis will have broken z-index layering for Modal, Dialog, Tooltip, and Popover components.

Add a note to the v11 migration guide documenting this gap and providing a workaround.

