### PR TITLE
fix: include z-index tokens in basis stylesheet

### DIFF
--- a/packages/dnb-eufemia/src/style/dnb-ui-basis.scss
+++ b/packages/dnb-eufemia/src/style/dnb-ui-basis.scss
@@ -6,6 +6,7 @@
 // core imports
 @use 'sass:meta';
 @use './core/scopes.scss' as scopes;
+@use './core/z-index.scss';
 
 // make sure we have dynamic root font size
 @include scopes.htmlDefault();


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1778481226297109

The z-index CSS custom properties were only imported in dnb-ui-core.scss but not in dnb-ui-basis.scss. Users importing only @dnb/eufemia/style/basis got broken z-index layering for Modal, Dialog, Tooltip, and Popover.

Fixes #7356 oversight.

