### PR TITLE
chore(Portal): stop background code blocks from rendering in focus mode

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -177,6 +177,7 @@ function LiveCode(props: LiveCodeProps) {
   const { fullscreenCodeId, setFullscreenCodeId, savedScrollY } =
     useFullscreenCode()
   const isFullscreen = fullscreenCodeId === fullscreenId
+  const anotherIsFullscreen = fullscreenCodeId !== null && !isFullscreen
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   const {
@@ -269,6 +270,11 @@ function LiveCode(props: LiveCodeProps) {
     return code
   }, [props.code])
 
+  const transformCode = useCallback(
+    (code: string) => (!noInline && noFragments ? `<>${code}</>` : code),
+    [noInline, noFragments]
+  )
+
   return (
     <div
       ref={wrapperRef}
@@ -281,162 +287,166 @@ function LiveCode(props: LiveCodeProps) {
         surface && `surface--${surface}`
       )}
     >
-      <LiveProvider
-        theme={prismTheme}
-        code={codeToUse}
-        scope={scope}
-        language={language}
-        transformCode={useCallback(
-          (code: string) =>
-            !noInline && noFragments ? `<>${code}</>` : code,
-          [noInline, noFragments]
-        )}
-        noInline={noInline}
-        {...restProps}
-      >
-        {!hidePreview && (
-          <Theme colorScheme={colorScheme} surface={surface}>
-            {omitWrapper ? (
-              <LivePreview
-                className={clsx('dnb-live-preview')}
-                data-visual-test={visualTest}
-              />
-            ) : (
-              <div className={clsx('example-box', exampleBoxStyle)}>
+      {!anotherIsFullscreen && (
+        <LiveProvider
+          theme={prismTheme}
+          code={codeToUse}
+          scope={scope}
+          language={language}
+          transformCode={transformCode}
+          noInline={noInline}
+          {...restProps}
+        >
+          {!hidePreview && (
+            <Theme colorScheme={colorScheme} surface={surface}>
+              {omitWrapper ? (
                 <LivePreview
                   className={clsx('dnb-live-preview')}
                   data-visual-test={visualTest}
                 />
-              </div>
-            )}
-          </Theme>
-        )}
-
-        {!global.IS_TEST && !hideToolbar && (
-          <Space
-            // align="center"
-            element="section"
-            aria-label="Customize appearance"
-            className={clsx('dnb-live-toolbar', toolbarStyle)}
-          >
-            {(omitWrapper && (
-              <Button
-                variant="tertiary"
-                icon={hideCode ? 'chevron_down' : 'chevron_up'}
-                onClick={() => setHideCode((checked) => !checked)}
-                size="medium"
-                left
-              >
-                {hideCode ? 'Show Code' : 'Hide Code'}
-              </Button>
-            )) || (
-              <>
-                {hideCodeProp && (
-                  <ToggleButton
-                    checked={!hideCode}
-                    onChange={({ checked }) => setHideCode(!checked)}
-                    size="medium"
-                  >
-                    {hideCode ? 'Show Code' : 'Hide Code'}
-                  </ToggleButton>
-                )}
-
-                {hidePreviewProp && (
-                  <ToggleButton
-                    checked={!hidePreview}
-                    onChange={({ checked }) => setHidePreview(!checked)}
-                    size="medium"
-                  >
-                    Preview
-                  </ToggleButton>
-                )}
-
-                {isFullscreen && (
-                  <ChangeStyleTheme
-                    variant="button"
-                    size="medium"
-                    optionsLayout="horizontal"
-                    labelSrOnly
+              ) : (
+                <div className={clsx('example-box', exampleBoxStyle)}>
+                  <LivePreview
+                    className={clsx('dnb-live-preview')}
+                    data-visual-test={visualTest}
                   />
-                )}
+                </div>
+              )}
+            </Theme>
+          )}
 
-                <Checkbox
-                  checked={
-                    colorScheme === (inheritedDark ? 'light' : 'dark')
-                  }
-                  onChange={({ checked }) => {
-                    setColorScheme(
-                      checked
-                        ? inheritedDark
-                          ? 'light'
-                          : 'dark'
-                        : undefined
-                    )
-                  }}
+          {!global.IS_TEST && !hideToolbar && (
+            <Space
+              // align="center"
+              element="section"
+              aria-label="Customize appearance"
+              className={clsx('dnb-live-toolbar', toolbarStyle)}
+            >
+              {(omitWrapper && (
+                <Button
+                  variant="tertiary"
+                  icon={hideCode ? 'chevron_down' : 'chevron_up'}
+                  onClick={() => setHideCode((checked) => !checked)}
                   size="medium"
-                  label={inheritedDark ? 'Light mode' : 'Dark mode'}
-                />
+                  left
+                >
+                  {hideCode ? 'Show Code' : 'Hide Code'}
+                </Button>
+              )) || (
+                <>
+                  {hideCodeProp && (
+                    <ToggleButton
+                      checked={!hideCode}
+                      onChange={({ checked }) => setHideCode(!checked)}
+                      size="medium"
+                    >
+                      {hideCode ? 'Show Code' : 'Hide Code'}
+                    </ToggleButton>
+                  )}
 
-                {surfaceProp === 'dark' && (
+                  {hidePreviewProp && (
+                    <ToggleButton
+                      checked={!hidePreview}
+                      onChange={({ checked }) => setHidePreview(!checked)}
+                      size="medium"
+                    >
+                      Preview
+                    </ToggleButton>
+                  )}
+
+                  {isFullscreen && (
+                    <ChangeStyleTheme
+                      variant="button"
+                      size="medium"
+                      optionsLayout="horizontal"
+                      labelSrOnly
+                    />
+                  )}
+
                   <Checkbox
-                    checked={colorScheme !== 'dark' && surface === 'dark'}
-                    onChange={({ checked }) =>
-                      setSurface(checked ? 'dark' : undefined)
+                    checked={
+                      colorScheme === (inheritedDark ? 'light' : 'dark')
                     }
+                    onChange={({ checked }) => {
+                      setColorScheme(
+                        checked
+                          ? inheritedDark
+                            ? 'light'
+                            : 'dark'
+                          : undefined
+                      )
+                    }}
                     size="medium"
-                    label="Dark surface"
+                    label={inheritedDark ? 'Light mode' : 'Dark mode'}
                   />
-                )}
-              </>
-            )}
 
-            <Button
-              onClick={() => {
-                if (!isFullscreen) {
-                  savedScrollY.current = window.scrollY
+                  {surfaceProp === 'dark' && (
+                    <Checkbox
+                      checked={
+                        colorScheme !== 'dark' && surface === 'dark'
+                      }
+                      onChange={({ checked }) =>
+                        setSurface(checked ? 'dark' : undefined)
+                      }
+                      size="medium"
+                      label="Dark surface"
+                    />
+                  )}
+                </>
+              )}
 
-                  try {
-                    sessionStorage.setItem(
-                      'scroll-window',
-                      String(window.scrollY)
-                    )
-                  } catch {
-                    // ignore
+              <Button
+                onClick={() => {
+                  if (!isFullscreen) {
+                    savedScrollY.current = window.scrollY
+
+                    try {
+                      sessionStorage.setItem(
+                        'scroll-window',
+                        String(window.scrollY)
+                      )
+                    } catch {
+                      // ignore
+                    }
+
+                    window.scrollTo({ top: 0 })
                   }
+
+                  setFullscreenCodeId(isFullscreen ? null : fullscreenId)
+                }}
+                variant="tertiary"
+                title={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
+                aria-label={
+                  isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'
                 }
+                icon={isFullscreen ? 'close' : fullscreenIcon}
+                size="medium"
+              />
+            </Space>
+          )}
 
-                setFullscreenCodeId(isFullscreen ? null : fullscreenId)
-              }}
-              variant="tertiary"
-              title={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
-              aria-label={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
-              icon={isFullscreen ? 'close' : fullscreenIcon}
-              size="medium"
-            />
-          </Space>
-        )}
+          {!global.IS_TEST && !hideCode && (
+            <Space
+              title="Code Editor"
+              element="section"
+              className={clsx(
+                'dnb-live-editor',
+                createSkeletonClass('code', context.skeleton)
+              )}
+              ref={editorElementRef}
+            >
+              <LiveEditor
+                prism={Prism}
+                id={id}
+                tabMode={tabMode}
+                className="dnb-live-editor__editable dnb-pre"
+              />
+            </Space>
+          )}
 
-        {!global.IS_TEST && !hideCode && (
-          <Space
-            title="Code Editor"
-            element="section"
-            className={clsx(
-              'dnb-live-editor',
-              createSkeletonClass('code', context.skeleton)
-            )}
-            ref={editorElementRef}
-          >
-            <LiveEditor
-              prism={Prism}
-              id={id}
-              tabMode={tabMode}
-              className="dnb-live-editor__editable dnb-pre"
-            />
-          </Space>
-        )}
-
-        <LiveError className="dnb-form-status dnb-form-status__text dnb-form-status--error" />
-      </LiveProvider>
+          <LiveError className="dnb-form-status dnb-form-status__text dnb-form-status--error" />
+        </LiveProvider>
+      )}
     </div>
   )
 }

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -13,6 +13,7 @@ import type {
   ReactNode,
 } from 'react'
 import { act, render } from '@testing-library/react'
+import * as FullscreenCodeContext from '../../../core/FullscreenCodeContext'
 
 // Mock CSS modules
 vi.mock('../CodeBlock.module.scss', () => ({
@@ -153,6 +154,7 @@ describe('CodeBlock', () => {
   beforeEach(() => {
     mockLiveEditorOnChange = undefined
     mockLiveProviderCode = undefined
+    vi.restoreAllMocks()
   })
 
   afterAll(() => {
@@ -293,6 +295,44 @@ describe('CodeBlock', () => {
     expect(queryByLabelText('Dark surface')).toBeTruthy()
   })
 
+  it('should not render LiveProvider when another code block is in focusmode', () => {
+    // Simulate a block that is NOT in this render tree being in fullscreen.
+    // Using an unmatched id means neither block below enters isFullscreen,
+    // so ChangeStyleTheme never renders and we avoid pulling in extra mocks.
+    vi.spyOn(FullscreenCodeContext, 'useFullscreenCode').mockReturnValue({
+      fullscreenCodeId: 'some-other-block',
+      setFullscreenCodeId: vi.fn(),
+      savedScrollY: { current: 0 },
+    })
+
+    const { container } = render(
+      <>
+        <CodeBlock
+          reactLive
+          scope={{}}
+          language="jsx"
+          data-visual-test="block-a"
+        >
+          {'<div>A</div>'}
+        </CodeBlock>
+
+        <CodeBlock
+          reactLive
+          scope={{}}
+          language="jsx"
+          data-visual-test="block-b"
+        >
+          {'<div>B</div>'}
+        </CodeBlock>
+      </>
+    )
+
+    // Both blocks see anotherIsFullscreen=true and suppress their LiveProvider
+    expect(
+      container.querySelectorAll('[data-testid="live-provider"]')
+    ).toHaveLength(0)
+  })
+
   it('should toggle color scheme class when clicking Dark mode checkbox', () => {
     const { container } = render(
       <CodeBlock reactLive scope={{}} language="jsx">
@@ -328,5 +368,41 @@ describe('CodeBlock', () => {
     expect(
       themeWrapper.classList.contains('eufemia-theme__color-scheme--dark')
     ).toBe(false)
+  })
+
+  it('should scroll to top when entering focusmode', () => {
+    const scrollTo = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {})
+
+    const mockSetFullscreenCodeId = vi.fn()
+    vi.spyOn(FullscreenCodeContext, 'useFullscreenCode').mockReturnValue({
+      fullscreenCodeId: null,
+      setFullscreenCodeId: mockSetFullscreenCodeId,
+      savedScrollY: { current: 0 },
+    })
+
+    const { container } = render(
+      <CodeBlock
+        reactLive
+        scope={{}}
+        language="jsx"
+        data-visual-test="block-a"
+      >
+        {'<div>Hello</div>'}
+      </CodeBlock>
+    )
+
+    const fullscreenButton = container.querySelector(
+      'button[aria-label="Fullscreen"]'
+    ) as HTMLButtonElement
+    expect(fullscreenButton).toBeTruthy()
+
+    act(() => {
+      fullscreenButton.click()
+    })
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0 })
+    expect(mockSetFullscreenCodeId).toHaveBeenCalledWith('block-a')
   })
 })


### PR DESCRIPTION
When entering focus mode, other LiveCode instances were still rendering their LiveProvider/LivePreview trees in the background.

Changes:
- Skip rendering LiveProvider for non-active blocks when another is in focus mode
- Hoist transformCode useCallback above the conditional to fix "Rendered fewer hooks than expected" error
- Scroll to top immediately on entering focus mode (in the click handler, not the effect)
- Two new unit tests for both behaviors