### PR TITLE
fix(Form.SubmitButton): show loading indicator inside Field.Composition

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
@@ -1,8 +1,8 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { JSONSchema } from '../../..'
 import { Field, Form, makeAjvInstance } from '../../..'
-import { axeComponent } from '../../../../../core/jest/jestSetup'
+import { axeComponent, wait } from '../../../../../core/jest/jestSetup'
 
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
@@ -781,5 +781,35 @@ describe('Field.Composition', () => {
 
       expect(await axeComponent(result)).toHaveNoViolations()
     })
+  })
+
+  it('should show submit indicator on Form.SubmitButton inside Field.Composition', async () => {
+    const onSubmit = async () => {
+      await wait(100)
+    }
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.Composition width="large">
+          <Field.String path="/value" value="test" />
+          <Form.SubmitButton text="Submit" />
+        </Field.Composition>
+      </Form.Handler>
+    )
+
+    const button = document.querySelector('button')
+    const indicator = button.querySelector('.dnb-forms-submit-indicator')
+
+    expect(indicator).not.toHaveClass(
+      'dnb-forms-submit-indicator--state-pending'
+    )
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(indicator).toHaveClass(
+      'dnb-forms-submit-indicator--state-pending'
+    )
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, act } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { JSONSchema } from '../../..'
 import { Field, Form, makeAjvInstance } from '../../..'
@@ -804,9 +804,7 @@ describe('Field.Composition', () => {
       'dnb-forms-submit-indicator--state-pending'
     )
 
-    await act(async () => {
-      fireEvent.click(button)
-    })
+    await userEvent.click(button)
 
     expect(indicator).toHaveClass(
       'dnb-forms-submit-indicator--state-pending'

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -303,13 +303,18 @@ fieldset.dnb-forms-field-block {
 
   // Because we want to hide / show the indicator responsively,
   // we render both, but hide the one we don't want to show.
+  // Use the specific __indicator class to avoid hiding the
+  // SubmitIndicator inside Form.SubmitButton.
   @include utilities.allBelow(x-small) {
-    &__composition > &__grid > .dnb-forms-submit-indicator {
+    &__composition > &__grid > .dnb-forms-field-block__indicator {
       display: none;
     }
   }
   @include utilities.allAbove(x-small) {
-    &__composition > &__grid > &__contents .dnb-forms-submit-indicator {
+    &__composition
+      > &__grid
+      > &__contents
+      .dnb-forms-field-block__indicator {
       display: none;
     }
   }


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1778577849938149
Issue reprod: https://stackblitz.com/edit/u6dlg7ok-whc6dyff?file=src%2FApp.tsx
Fix reprod: https://stackblitz.com/edit/u6dlg7ok-gzktxvmj?file=src%2FApp.tsx


The CSS selectors hiding FieldBlock's responsive SubmitIndicator were too broad — they matched .dnb-forms-submit-indicator, which also caught the SubmitIndicator inside Form.SubmitButton. Narrowed the selectors to target .dnb-forms-field-block__indicator instead.

