### PR TITLE
feat(Autocomplete, MultiSelection): add unified search config prop

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -14,6 +14,7 @@ draft: true
   - [Component changes](#component-changes)
     - [Flex](#flex)
     - [Accordion](#accordion)
+    - [Autocomplete](#autocomplete)
     - [Modal, Dialog and Drawer](#modal-dialog-and-drawer)
     - [InfoCard](#infocard)
     - [Popover](#popover)
@@ -168,6 +169,40 @@ Do not use the deprecated APIs for new integrations. See the [Flex.Container mig
 ### [Accordion](/uilib/components/accordion/)
 
 - Replace `id` with `connectedTo` on `Accordion.Content` when connecting to a standalone tertiary button.
+
+### [Autocomplete](/uilib/components/autocomplete/)
+
+The individual search-related props are deprecated in favor of a single `search` object:
+
+- `disableFilter` → `search.filter`
+- `disableReorder` → `search.reorder`
+- `disableHighlighting` → `search.highlight`
+- `searchNumbers` → `search.numbers`
+- `searchInWordIndex` → `search.matchInsideWordsFrom`
+- `searchMatch` → `search.match`
+
+Note that the `disable*` props invert, so a disabled feature becomes `false`:
+
+```diff
+-<Autocomplete
+-  disableFilter
+-  disableReorder
+-  disableHighlighting
+-  searchNumbers
+-  searchInWordIndex={4}
+-  searchMatch="starts-with"
+-/>
++<Autocomplete
++  search={{
++    filter: false,
++    reorder: false,
++    highlight: false,
++    numbers: true,
++    matchInsideWordsFrom: 4,
++    match: 'starts-with',
++  }}
++/>
+```
 
 ### [Modal](/uilib/components/modal/), [Dialog](/uilib/components/dialog/) and [Drawer](/uilib/components/drawer/)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -92,7 +92,7 @@ export const AutocompleteNumbersExample = () => (
         showClearButton
         label="Label"
         data={numbersData}
-        searchNumbers={true}
+        search={{ numbers: true }}
       />
     </ComponentBox>
   </Wrapper>
@@ -712,6 +712,18 @@ export const AutocompleteContentDecoupledExample = () => (
           },
         ]}
         label="Label"
+      />
+    </ComponentBox>
+  </Wrapper>
+)
+
+export const AutocompleteSearchOptionsExample = () => (
+  <Wrapper>
+    <ComponentBox scope={{ topMovies }}>
+      <Autocomplete
+        label="Search movies (starts-with)"
+        data={topMovies}
+        search={{ match: 'starts-with', highlight: false }}
       />
     </ComponentBox>
   </Wrapper>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -94,7 +94,7 @@ export const AutocompleteNumbersExample = () => (
         showClearButton
         label="Label"
         data={numbersData}
-        searchNumbers={true}
+        search={{ numbers: true }}
       />
     </ComponentBox>
   </Wrapper>
@@ -793,6 +793,18 @@ export const AutocompleteWithListItemContent = () => (
 
         return <AccountAutocomplete data={data} label="Label" />
       }}
+    </ComponentBox>
+  </Wrapper>
+)
+
+export const AutocompleteSearchOptionsExample = () => (
+  <Wrapper>
+    <ComponentBox scope={{ topMovies }}>
+      <Autocomplete
+        label="Search movies (starts-with)"
+        data={topMovies}
+        search={{ match: 'starts-with', highlight: false }}
+      />
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -5,6 +5,7 @@ showTabs: true
 import {
   AutocompleteDefaultExample,
   AutocompleteNumbersExample,
+  AutocompleteSearchOptionsExample,
   AutocompleteWithCustomTitle,
   AutocompleteDynamicallyUpdatedData,
   AutocompleteFirstFocusUpdate,
@@ -28,7 +29,15 @@ import {
 
 ### Autocomplete with numbers
 
+This example uses `search={{ numbers: true }}` to enable number-optimized matching.
+
 <AutocompleteNumbersExample />
+
+### Search options
+
+Use the `search` prop to configure search behavior. This example uses `match: 'starts-with'` to only show results that begin with the typed text, and `highlight: false` to disable text highlighting.
+
+<AutocompleteSearchOptionsExample />
 
 ### Autocomplete with a custom title
 
@@ -41,7 +50,7 @@ import {
 
 This example simulates server delay with a timeout and - if it gets debounced, we cancel the timeout. Read more about the [debounce method](/uilib/components/autocomplete/methods/#methods).
 
-Also, you may consider using `disableFilter` if you have a backend doing the search operation.
+Also, you may consider using `search={{ filter: false }}` if you have a backend doing the search operation.
 
 <AutocompleteDynamicallyUpdatedData />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -5,6 +5,7 @@ showTabs: true
 import {
   AutocompleteDefaultExample,
   AutocompleteNumbersExample,
+  AutocompleteSearchOptionsExample,
   AutocompleteWithCustomTitle,
   AutocompleteDynamicallyUpdatedData,
   AutocompleteFirstFocusUpdate,
@@ -30,7 +31,15 @@ import {
 
 ### Autocomplete with numbers
 
+This example uses `search={{ numbers: true }}` to enable number-optimized matching.
+
 <AutocompleteNumbersExample />
+
+### Search options
+
+Use the `search` prop to configure search behavior. This example uses `match: 'starts-with'` to only show results that begin with the typed text, and `highlight: false` to disable text highlighting.
+
+<AutocompleteSearchOptionsExample />
 
 ### Autocomplete with a custom title
 
@@ -43,7 +52,7 @@ import {
 
 This example simulates server delay with a timeout and - if it gets debounced, we cancel the timeout. Read more about the [debounce method](/uilib/components/autocomplete/methods/#methods).
 
-Also, you may consider using `disableFilter` if you have a backend doing the search operation.
+Also, you may consider using `search={{ filter: false }}` if you have a backend doing the search operation.
 
 <AutocompleteDynamicallyUpdatedData />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
@@ -47,10 +47,10 @@ You may check out the [Dropdown](/uilib/components/dropdown/info) component for 
 Words found during typing are highlighted. The rules are:
 
 1. The first two words will match the beginning of a word
-1. The third word will match inside a word (can be changed with `searchInWordIndex`)
+1. The third word will match inside a word (can be changed with `search={{ matchInsideWordsFrom: number }}`)
 1. Case-insensitive
 
-To only match items that begin with the first typed word, set `searchMatch="starts-with"`.
+To only match items that begin with the first typed word, set `search={{ match: "starts-with" }}`.
 
 #### Using Components inside content
 
@@ -96,7 +96,7 @@ const MyComponent = () => {
 
 ### Numbers
 
-Numbers are often different from a word filter. You can use `searchNumbers={true}` to enable number-specialized filtering. See examples in the demos.
+Numbers are often different from a word filter. You can use `search={{ numbers: true }}` to enable number-specialized filtering. See examples in the demos.
 
 Now the user could search for e.g. bank account numbers by just entering `201`, even if you format it like `2000 12 34567` (e.g. use `format(20001234567, { ban: true })` from `@dnb/eufemia/components/number-format/NumberUtils`).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
@@ -495,6 +495,43 @@ export const WithManySelectedItems = () => (
   </ComponentBox>
 )
 
+export const WithSearchOptions = () => (
+  <ComponentBox>
+    {() => {
+      const accounts = [
+        {
+          value: 'acc1',
+          title: 'Brukskonto',
+          text: '2000 12 34567',
+        },
+        {
+          value: 'acc2',
+          title: 'Sparekonto',
+          text: '2223 33 44425',
+        },
+        {
+          value: 'acc3',
+          title: 'BSU',
+          text: '1234 56 78901',
+        },
+        {
+          value: 'acc4',
+          title: 'Felleskonto',
+          text: '9876 54 32100',
+        },
+      ]
+      return (
+        <Field.MultiSelection
+          label="Select accounts"
+          data={accounts}
+          showSearchField
+          search={{ numbers: true }}
+        />
+      )
+    }}
+  </ComponentBox>
+)
+
 export const VariantInline = () => (
   <ComponentBox data-visual-test="multi-selection-variant-inline">
     {() => {

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/demos.mdx
@@ -42,6 +42,12 @@ When `showSelectedTags` is enabled and the number of items exceeds the `selected
 
 <Examples.WithDisabledItems />
 
+### With search options
+
+Use the `search` prop to configure search behavior. This example uses `numbers: true` so account numbers can be searched by typing digits.
+
+<Examples.WithSearchOptions />
+
 ### Inline variant
 
 The `inline` variant renders the item list inline without a popover. This is useful when you want the options to be always visible.

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -98,7 +98,7 @@ export const SearchBarInput = () => {
       showClearButton
       noScrollAnimation
       preventSelection
-      disableFilter
+      search={{ filter: false }}
       fixedPosition
       size="medium"
       align="right"

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -138,7 +138,7 @@ export const SearchBarInput = () => {
       showClearButton
       noScrollAnimation
       preventSelection
-      disableFilter
+      search={{ filter: false }}
       fixedPosition
       size="medium"
       align="right"

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -75,7 +75,7 @@ describe('SearchBar', () => {
         open
         inputValue="--z-index"
         id="portal-search-test"
-        disableFilter
+        search={{ filter: false }}
         noAnimation
         skipPortal
       />
@@ -102,7 +102,7 @@ describe('SearchBar', () => {
         open
         inputValue="Ca"
         id="portal-search-link-test"
-        disableFilter
+        search={{ filter: false }}
         noAnimation
         skipPortal
       />

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -85,7 +85,7 @@ describe('SearchBar', () => {
         open
         inputValue="--z-index"
         id="portal-search-test"
-        disableFilter
+        search={{ filter: false }}
         noAnimation
         skipPortal
       />
@@ -112,7 +112,7 @@ describe('SearchBar', () => {
         open
         inputValue="Ca"
         id="portal-search-link-test"
-        disableFilter
+        search={{ filter: false }}
         noAnimation
         skipPortal
       />

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -41,6 +41,13 @@ import type { FormStatusBaseProps } from '../FormStatus'
 import type { IconIcon, IconSize } from '../Icon'
 import type { SkeletonShow } from '../Skeleton'
 import type { SpacingProps } from '../../shared/types'
+import type { SearchOptions } from '../../shared/search'
+import {
+  prepareSearchWords,
+  findMatchingWords,
+  calculateTotalScore,
+  passesNumericTermsCheck,
+} from '../../shared/search'
 import {
   warn,
   extendPropsWithContext,
@@ -48,7 +55,6 @@ import {
   dispatchCustomElementEvent,
   getStatusState,
   combineDescribedBy,
-  escapeRegexChars,
   getClosestParent,
 } from '../../shared/component-helper'
 import { IS_MAC, debounce, hasSelectedText } from '../../shared/helpers'
@@ -267,15 +273,22 @@ export type AutocompleteProps = {
    */
   showClearButton?: boolean
   /**
-   * If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`.
+   * Configure search behavior with a single config object. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `highlight` (enable text highlighting, default `true`), `numbers` (enable number search, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). Example: `search={{ filter: false }}` to disable filtering while keeping highlighting.
+   */
+  search?: SearchOptions
+  /**
+   * If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`. **Deprecated**: Use `search={{ filter: false }}` instead.
+   * @deprecated Use `search={{ filter: false }}` instead.
    */
   disableFilter?: boolean
   /**
-   * If set to `true`, reordering of search results will be disabled. Defaults to `false`.
+   * If set to `true`, reordering of search results will be disabled. Defaults to `false`. **Deprecated**: Use `search={{ reorder: false }}` instead.
+   * @deprecated Use `search={{ reorder: false }}` instead.
    */
   disableReorder?: boolean
   /**
-   * If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`.
+   * If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`. **Deprecated**: Use `search={{ highlight: false }}` instead.
+   * @deprecated Use `search={{ highlight: false }}` instead.
    */
   disableHighlighting?: boolean
   /**
@@ -299,15 +312,18 @@ export type AutocompleteProps = {
    */
   inputElement?: AutocompleteInputElement
   /**
-   * This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`.
+   * This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`. **Deprecated**: Use `search={{ matchInsideWordsFrom: number }}` instead.
+   * @deprecated Use `search={{ matchInsideWordsFrom: number }}` instead.
    */
   searchInWordIndex?: AutocompleteSearchInWordIndex
   /**
-   * Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`.
+   * Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`. **Deprecated**: Use `search={{ match: "word" | "starts-with" }}` instead.
+   * @deprecated Use `search={{ match: "word" | "starts-with" }}` instead.
    */
   searchMatch?: AutocompleteSearchMatch
   /**
-   * If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`.
+   * If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`. **Deprecated**: Use `search={{ numbers: true }}` instead.
+   * @deprecated Use `search={{ numbers: true }}` instead.
    */
   searchNumbers?: boolean
   /**
@@ -611,6 +627,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     searchNumbers,
     searchInWordIndex,
     searchMatch,
+    search,
     showOptionsSr,
     selectedSr,
     submitButtonTitle,
@@ -627,8 +644,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     independentWidth,
     autoComplete,
     openOnFocus,
-    disableFilter,
-    disableReorder,
+    disableFilter: _deprecatedDisableFilter,
+    disableReorder: _deprecatedDisableReorder,
     onClear,
     selectAll,
     noDivider,
@@ -649,7 +666,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     noOptions: _noOptions,
     showAll: _showAll,
     ariaLiveOptions: _ariaLiveOptions,
-    disableHighlighting: _disableHighlighting,
+    disableHighlighting: _deprecatedDisableHighlighting,
 
     onOpen: _onOpen,
     onType: _onType,
@@ -663,6 +680,71 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
 
     ...attributes
   } = props
+
+  // Resolve search config: `search` prop takes precedence over deprecated props.
+  // @deprecated - The fallbacks to deprecated props below ensure backward compatibility.
+  // Remove these fallbacks when the deprecated props are removed.
+  const disableFilter =
+    search?.filter !== undefined
+      ? !search.filter
+      : _deprecatedDisableFilter // @deprecated fallback
+  const disableReorder =
+    search?.reorder !== undefined
+      ? !search.reorder
+      : _deprecatedDisableReorder // @deprecated fallback
+  const _disableHighlighting =
+    search?.highlight !== undefined
+      ? !search.highlight
+      : _deprecatedDisableHighlighting // @deprecated fallback
+  const resolvedSearchNumbers =
+    search?.numbers !== undefined ? search.numbers : searchNumbers // @deprecated fallback
+  const resolvedSearchInWordIndex =
+    search?.matchInsideWordsFrom !== undefined
+      ? search.matchInsideWordsFrom
+      : searchInWordIndex != null
+        ? Number(searchInWordIndex)
+        : undefined // @deprecated fallback
+  const resolvedSearchMatch =
+    search?.match !== undefined ? search.match : searchMatch // @deprecated fallback
+
+  // Deprecation warnings for old search-related props (fire once per instance)
+  const hasWarnedDeprecatedSearchRef = useRef(false)
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    !hasWarnedDeprecatedSearchRef.current
+  ) {
+    hasWarnedDeprecatedSearchRef.current = true
+    if (_deprecatedDisableFilter) {
+      warn(
+        'Autocomplete: `disableFilter` is deprecated. Use `search={{ filter: false }}` instead.'
+      )
+    }
+    if (_deprecatedDisableReorder) {
+      warn(
+        'Autocomplete: `disableReorder` is deprecated. Use `search={{ reorder: false }}` instead.'
+      )
+    }
+    if (_deprecatedDisableHighlighting) {
+      warn(
+        'Autocomplete: `disableHighlighting` is deprecated. Use `search={{ highlight: false }}` instead.'
+      )
+    }
+    if (searchNumbers != null) {
+      warn(
+        'Autocomplete: `searchNumbers` is deprecated. Use `search={{ numbers: true }}` instead.'
+      )
+    }
+    if (searchInWordIndex != null) {
+      warn(
+        'Autocomplete: `searchInWordIndex` is deprecated. Use `search={{ matchInsideWordsFrom: number }}` instead.'
+      )
+    }
+    if (searchMatch != null) {
+      warn(
+        'Autocomplete: `searchMatch` is deprecated. Use `search={{ match: "word" | "starts-with" }}` instead.'
+      )
+    }
+  }
 
   // State
   const [inputValue, setInputValueState] = useState<string | null>(() => {
@@ -686,7 +768,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const [showAllNextTime, setShowAllNextTime] = useState(false)
   const [skipFocusDuringChange, setSkipFocusDuringChange] = useState(false)
   const [disableHighlightingState, setDisableHighlighting] = useState(
-    props.disableHighlighting
+    _disableHighlighting
   )
   const [visibleIndicator, setVisibleIndicator] = useState(false)
   const [searchIndex, setSearchIndexState] = useState<
@@ -719,7 +801,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const lastUpdateDataRef = useRef<DrawerListInternalData | null>(null)
   const prevValueRef = useRef(props.value)
   const prevInputValuePropRef = useRef(props.inputValue)
-  const prevDisableHighlightingRef = useRef(props.disableHighlighting)
+  const prevDisableHighlightingRef = useRef(_disableHighlighting)
   const prevInlineRef = useRef(inline)
   const inputValueRef = useRef(inputValue)
   const typedInputValueRef = useRef(typedInputValue)
@@ -1104,20 +1186,17 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       {
         data = null,
         searchIndex: siParam = searchIndexRef.current,
-        searchNumbers: snParam = props.searchNumbers,
-        inWordIndex = parseFloat(
-          String(
-            props.searchInWordIndex ?? (skipFilterRef.current ? 1 : 3)
-          )
-        ) - 1,
+        numbers: snParam = resolvedSearchNumbers,
+        matchInsideWordsFrom = resolvedSearchInWordIndex ??
+          (skipFilterRef.current ? 1 : 3),
         disableHighlighting: disableHL = false,
         skipFilter = false,
         skipReorder = false,
       }: {
         data?: DrawerListInternalData | null
         searchIndex?: SearchIndexItem[] | null
-        searchNumbers?: boolean
-        inWordIndex?: number
+        numbers?: boolean
+        matchInsideWordsFrom?: number
         disableHighlighting?: boolean
         skipFilter?: boolean
         skipReorder?: boolean
@@ -1135,108 +1214,14 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
         return []
       }
 
-      const startsWithMatch = props.searchMatch === 'starts-with'
-      const rawValue = value ?? ''
-      let searchWords = rawValue.split(/\s+/g).filter(Boolean)
-
-      if (startsWithMatch) {
-        // @ts-expect-error Unicode property escapes are supported at runtime here
-        const hasLetters = /[\p{L}]/u.test(rawValue)
-        // @ts-expect-error Unicode property escapes are supported at runtime here
-        const hasNumbers = /[\p{N}]/u.test(rawValue)
-        if (startsWithMatch && snParam && hasNumbers && !hasLetters) {
-          // @ts-expect-error Unicode property escapes are supported at runtime here
-          const normalizedNumeric = rawValue.replace(/[^\p{N}]+/gu, '')
-          searchWords = normalizedNumeric ? [normalizedNumeric] : []
-        }
+      const searchOptions = {
+        numbers: snParam,
+        matchInsideWordsFrom,
+        match: resolvedSearchMatch,
       }
 
-      const distinctSearchWords = new Set<string>()
-      searchWords = searchWords.filter((word) => {
-        const normalizedWord = word.toLowerCase()
-
-        if (distinctSearchWords.has(normalizedWord)) {
-          return false
-        }
-
-        distinctSearchWords.add(normalizedWord)
-        return true
-      })
-
-      const getWordBoundary = (wordIndex: number) =>
-        startsWithMatch && wordIndex === 0 ? '^' : snParam ? '' : '^|\\s'
-
-      const searchWordsData = searchWords.map((word, wordIndex) => {
-        const processedWord = snParam
-          ? // @ts-expect-error Unicode property escapes are supported at runtime here
-            word.replace(/[^\p{L}\p{N}]+/gu, '')
-          : escapeRegexChars(word)
-        const wordBoundary = getWordBoundary(wordIndex)
-
-        return {
-          originalWord: word,
-          processedWord,
-          wordIndex,
-          filterRegex: new RegExp(
-            wordIndex >= inWordIndex
-              ? `${processedWord}`
-              : `(${wordBoundary})${processedWord}`,
-            'i'
-          ),
-          scoreRegex: new RegExp(
-            `(${wordBoundary})${escapeRegexChars(word)}`,
-            'ig'
-          ),
-        }
-      })
-
-      const firstWordRegex =
-        searchWords.length > 0
-          ? new RegExp(`^${escapeRegexChars(searchWords[0])}`, 'i')
-          : null
-
-      const findSearchWords = (contentChunk: string | null) => {
-        if (typeof contentChunk !== 'string') {
-          return []
-        }
-
-        return searchWordsData
-          .filter(({ filterRegex }) => {
-            if (filterRegex.test(contentChunk)) {
-              return true
-            }
-
-            if (
-              snParam &&
-              filterRegex.test(contentChunk.replace(/[^0-9]/g, ''))
-            ) {
-              return true
-            }
-
-            return false
-          })
-          .map(({ originalWord, wordIndex, scoreRegex }) => {
-            let wordScore = 0
-
-            wordScore += (contentChunk.match(scoreRegex) || []).length
-
-            if (wordIndex === 0 && firstWordRegex) {
-              const isFirstWord = firstWordRegex.test(
-                contentChunk.split(' ')[0]
-              )
-
-              if (isFirstWord) {
-                wordScore += searchWords.length + 1
-              }
-            }
-
-            return {
-              word: originalWord,
-              wordIndex,
-              wordScore,
-            }
-          })
-      }
+      const prepared = prepareSearchWords(value, searchOptions)
+      const { searchWords, matchInsideWordsFromIndex } = prepared
 
       const mappedIndex: Array<
         | DrawerListDataArrayObject
@@ -1246,23 +1231,15 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
             item: SearchIndexItem
           }
       > = currentSearchIndex.map((item) => {
-        const listOfFoundWords = findSearchWords(item.contentChunk)
+        const listOfFoundWords = findMatchingWords(
+          item.contentChunk,
+          prepared
+        )
 
-        const allWordsAreNumeric = snParam
-          ? // @ts-expect-error Unicode property escapes are supported at runtime here
-            searchWords.every((word) => /^[\p{N}\s.,]+$/u.test(word))
-          : false
-
-        const hasMultipleNumericTerms =
-          snParam &&
-          searchWords &&
-          searchWords.length > 1 &&
-          allWordsAreNumeric
         if (
           !skipFilterRef.current &&
           !skipFilter &&
-          hasMultipleNumericTerms &&
-          listOfFoundWords.length !== searchWords.length
+          !passesNumericTermsCheck(listOfFoundWords, prepared)
         ) {
           return { matchedWordCount: 0, totalScore: 0, item }
         }
@@ -1293,9 +1270,12 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
             search: searchWords,
             className: 'dnb-drawer-list__option__item--highlight',
             tag: 'span',
-            searchMatch: startsWithMatch ? 'starts-with' : 'word',
+            searchMatch:
+              resolvedSearchMatch === 'starts-with'
+                ? 'starts-with'
+                : 'word',
             searchNumbers: snParam,
-            searchInWordIndex: inWordIndex,
+            searchInWordIndex: matchInsideWordsFromIndex,
             wrapInSpan: true,
             keyPrefix: cacheHash,
           })
@@ -1307,10 +1287,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
           return item.dataItem
         }
 
-        let totalScore = listOfFoundWords.length
-        for (const { wordScore } of listOfFoundWords) {
-          totalScore += wordScore
-        }
+        const totalScore = calculateTotalScore(listOfFoundWords)
 
         return {
           matchedWordCount: listOfFoundWords.length,
@@ -1347,9 +1324,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     },
     [
       setSearchIndex,
-      props.searchMatch,
-      props.searchNumbers,
-      props.searchInWordIndex,
+      resolvedSearchMatch,
+      resolvedSearchNumbers,
+      resolvedSearchInWordIndex,
       disableHighlightingState,
     ]
   )
@@ -1401,8 +1378,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       options: {
         data?: DrawerListInternalData | null
         searchIndex?: SearchIndexItem[] | null
-        searchNumbers?: boolean
-        inWordIndex?: number
+        numbers?: boolean
+        matchInsideWordsFrom?: number
         disableHighlighting?: boolean
         skipFilter?: boolean
         skipReorder?: boolean
@@ -2143,9 +2120,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   )
 
   // Handle prop-driven state updates
-  if (props.disableHighlighting !== prevDisableHighlightingRef.current) {
-    prevDisableHighlightingRef.current = props.disableHighlighting
-    setDisableHighlighting(props.disableHighlighting)
+  if (_disableHighlighting !== prevDisableHighlightingRef.current) {
+    prevDisableHighlightingRef.current = _disableHighlighting
+    setDisableHighlighting(_disableHighlighting)
   }
 
   if (

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -814,6 +814,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const preventReopenRef = useRef(false)
 
   // Keep refs in sync with state for use in callbacks
+  skipFilterRef.current = disableFilter
+  skipReorderRef.current = disableReorder
   searchIndexRef.current = searchIndex
   inputValueRef.current = inputValue
   typedInputValueRef.current = typedInputValue

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -41,6 +41,13 @@ import type { FormStatusBaseProps } from '../FormStatus'
 import type { IconIcon, IconSize } from '../Icon'
 import type { SkeletonShow } from '../Skeleton'
 import type { SpacingProps } from '../../shared/types'
+import type { SearchOptions } from '../../shared/search'
+import {
+  prepareSearchWords,
+  findMatchingWords,
+  calculateTotalScore,
+  passesNumericTermsCheck,
+} from '../../shared/search'
 import {
   warn,
   extendPropsWithContext,
@@ -265,15 +272,22 @@ export type AutocompleteProps = {
    */
   showClearButton?: boolean
   /**
-   * If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`.
+   * Configure search behavior with a single config object. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `highlight` (enable text highlighting, default `true`), `numbers` (enable number search, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). Example: `search={{ filter: false }}` to disable filtering while keeping highlighting.
+   */
+  search?: SearchOptions
+  /**
+   * If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`. **Deprecated**: Use `search={{ filter: false }}` instead.
+   * @deprecated Use `search={{ filter: false }}` instead.
    */
   disableFilter?: boolean
   /**
-   * If set to `true`, reordering of search results will be disabled. Defaults to `false`.
+   * If set to `true`, reordering of search results will be disabled. Defaults to `false`. **Deprecated**: Use `search={{ reorder: false }}` instead.
+   * @deprecated Use `search={{ reorder: false }}` instead.
    */
   disableReorder?: boolean
   /**
-   * If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`.
+   * If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`. **Deprecated**: Use `search={{ highlight: false }}` instead.
+   * @deprecated Use `search={{ highlight: false }}` instead.
    */
   disableHighlighting?: boolean
   /**
@@ -293,15 +307,18 @@ export type AutocompleteProps = {
    */
   inputElement?: AutocompleteInputElement
   /**
-   * This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`.
+   * This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`. **Deprecated**: Use `search={{ matchInsideWordsFrom: number }}` instead.
+   * @deprecated Use `search={{ matchInsideWordsFrom: number }}` instead.
    */
   searchInWordIndex?: AutocompleteSearchInWordIndex
   /**
-   * Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`.
+   * Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`. **Deprecated**: Use `search={{ match: "word" | "starts-with" }}` instead.
+   * @deprecated Use `search={{ match: "word" | "starts-with" }}` instead.
    */
   searchMatch?: AutocompleteSearchMatch
   /**
-   * If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`.
+   * If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`. **Deprecated**: Use `search={{ numbers: true }}` instead.
+   * @deprecated Use `search={{ numbers: true }}` instead.
    */
   searchNumbers?: boolean
   /**
@@ -587,6 +604,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     searchNumbers,
     searchInWordIndex,
     searchMatch,
+    search,
     showOptionsSr,
     selectedSr,
     submitButtonTitle,
@@ -603,8 +621,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     independentWidth,
     autoComplete,
     openOnFocus,
-    disableFilter,
-    disableReorder,
+    disableFilter: _deprecatedDisableFilter,
+    disableReorder: _deprecatedDisableReorder,
     onClear,
     selectAll,
     noDivider,
@@ -625,7 +643,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     noOptions: _noOptions,
     showAll: _showAll,
     ariaLiveOptions: _ariaLiveOptions,
-    disableHighlighting: _disableHighlighting,
+    disableHighlighting: _deprecatedDisableHighlighting,
 
     onOpen: _onOpen,
     onType: _onType,
@@ -639,6 +657,71 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
 
     ...attributes
   } = props
+
+  // Resolve search config: `search` prop takes precedence over deprecated props.
+  // @deprecated - The fallbacks to deprecated props below ensure backward compatibility.
+  // Remove these fallbacks when the deprecated props are removed.
+  const disableFilter =
+    search?.filter !== undefined
+      ? !search.filter
+      : _deprecatedDisableFilter // @deprecated fallback
+  const disableReorder =
+    search?.reorder !== undefined
+      ? !search.reorder
+      : _deprecatedDisableReorder // @deprecated fallback
+  const _disableHighlighting =
+    search?.highlight !== undefined
+      ? !search.highlight
+      : _deprecatedDisableHighlighting // @deprecated fallback
+  const resolvedSearchNumbers =
+    search?.numbers !== undefined ? search.numbers : searchNumbers // @deprecated fallback
+  const resolvedSearchInWordIndex =
+    search?.matchInsideWordsFrom !== undefined
+      ? search.matchInsideWordsFrom
+      : searchInWordIndex != null
+        ? Number(searchInWordIndex)
+        : undefined // @deprecated fallback
+  const resolvedSearchMatch =
+    search?.match !== undefined ? search.match : searchMatch // @deprecated fallback
+
+  // Deprecation warnings for old search-related props (fire once per instance)
+  const hasWarnedDeprecatedSearchRef = useRef(false)
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    !hasWarnedDeprecatedSearchRef.current
+  ) {
+    hasWarnedDeprecatedSearchRef.current = true
+    if (_deprecatedDisableFilter) {
+      warn(
+        'Autocomplete: `disableFilter` is deprecated. Use `search={{ filter: false }}` instead.'
+      )
+    }
+    if (_deprecatedDisableReorder) {
+      warn(
+        'Autocomplete: `disableReorder` is deprecated. Use `search={{ reorder: false }}` instead.'
+      )
+    }
+    if (_deprecatedDisableHighlighting) {
+      warn(
+        'Autocomplete: `disableHighlighting` is deprecated. Use `search={{ highlight: false }}` instead.'
+      )
+    }
+    if (searchNumbers != null) {
+      warn(
+        'Autocomplete: `searchNumbers` is deprecated. Use `search={{ numbers: true }}` instead.'
+      )
+    }
+    if (searchInWordIndex != null) {
+      warn(
+        'Autocomplete: `searchInWordIndex` is deprecated. Use `search={{ matchInsideWordsFrom: number }}` instead.'
+      )
+    }
+    if (searchMatch != null) {
+      warn(
+        'Autocomplete: `searchMatch` is deprecated. Use `search={{ match: "word" | "starts-with" }}` instead.'
+      )
+    }
+  }
 
   // State
   const [inputValue, setInputValueState] = useState<string | null>(() => {
@@ -662,7 +745,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const [showAllNextTime, setShowAllNextTime] = useState(false)
   const [skipFocusDuringChange, setSkipFocusDuringChange] = useState(false)
   const [disableHighlightingState, setDisableHighlighting] = useState(
-    props.disableHighlighting
+    _disableHighlighting
   )
   const [visibleIndicator, setVisibleIndicator] = useState(false)
   const [searchIndex, setSearchIndexState] = useState<
@@ -695,7 +778,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const lastUpdateDataRef = useRef<DrawerListInternalData | null>(null)
   const prevValueRef = useRef(props.value)
   const prevInputValuePropRef = useRef(props.inputValue)
-  const prevDisableHighlightingRef = useRef(props.disableHighlighting)
+  const prevDisableHighlightingRef = useRef(_disableHighlighting)
   const inputValueRef = useRef(inputValue)
   const typedInputValueRef = useRef(typedInputValue)
   const modeRef = useRef(mode)
@@ -1074,20 +1157,17 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       {
         data = null,
         searchIndex: siParam = searchIndexRef.current,
-        searchNumbers: snParam = props.searchNumbers,
-        inWordIndex = parseFloat(
-          String(
-            props.searchInWordIndex ?? (skipFilterRef.current ? 1 : 3)
-          )
-        ) - 1,
+        numbers: snParam = resolvedSearchNumbers,
+        matchInsideWordsFrom = resolvedSearchInWordIndex ??
+          (skipFilterRef.current ? 1 : 3),
         disableHighlighting: disableHL = false,
         skipFilter = false,
         skipReorder = false,
       }: {
         data?: DrawerListInternalData | null
         searchIndex?: SearchIndexItem[] | null
-        searchNumbers?: boolean
-        inWordIndex?: number
+        numbers?: boolean
+        matchInsideWordsFrom?: number
         disableHighlighting?: boolean
         skipFilter?: boolean
         skipReorder?: boolean
@@ -1105,96 +1185,15 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
         return []
       }
 
-      const startsWithMatch = props.searchMatch === 'starts-with'
-      const rawValue = value ?? ''
-      let searchWords = rawValue.split(/\s+/g).filter(Boolean)
-
-      if (startsWithMatch) {
-        // @ts-expect-error Unicode property escapes are supported at runtime here
-        const hasLetters = /[\p{L}]/u.test(rawValue)
-        // @ts-expect-error Unicode property escapes are supported at runtime here
-        const hasNumbers = /[\p{N}]/u.test(rawValue)
-        if (startsWithMatch && snParam && hasNumbers && !hasLetters) {
-          // @ts-expect-error Unicode property escapes are supported at runtime here
-          const normalizedNumeric = rawValue.replace(/[^\p{N}]+/gu, '')
-          searchWords = normalizedNumeric ? [normalizedNumeric] : []
-        }
+      const searchOptions = {
+        numbers: snParam,
+        matchInsideWordsFrom,
+        match: resolvedSearchMatch,
       }
 
-      const getWordBoundary = (wordIndex: number) =>
-        startsWithMatch && wordIndex === 0 ? '^' : snParam ? '' : '^|\\s'
-
-      const searchWordsData = searchWords.map((word, wordIndex) => {
-        const processedWord = snParam
-          ? // @ts-expect-error Unicode property escapes are supported at runtime here
-            word.replace(/[^\p{L}\p{N}]+/gu, '')
-          : escapeRegexChars(word)
-        const wordBoundary = getWordBoundary(wordIndex)
-
-        return {
-          originalWord: word,
-          processedWord,
-          wordIndex,
-          filterRegex: new RegExp(
-            wordIndex >= inWordIndex
-              ? `${processedWord}`
-              : `(${wordBoundary})${processedWord}`,
-            'i'
-          ),
-          scoreRegex: new RegExp(
-            `(${wordBoundary})${escapeRegexChars(word)}`,
-            'ig'
-          ),
-        }
-      })
-
-      const firstWordRegex =
-        searchWords.length > 0
-          ? new RegExp(`^${escapeRegexChars(searchWords[0])}`, 'i')
-          : null
-
-      const findSearchWords = (contentChunk: string | null) => {
-        if (typeof contentChunk !== 'string') {
-          return []
-        }
-
-        return searchWordsData
-          .filter(({ filterRegex }) => {
-            if (filterRegex.test(contentChunk)) {
-              return true
-            }
-
-            if (
-              snParam &&
-              filterRegex.test(contentChunk.replace(/[^0-9]/g, ''))
-            ) {
-              return true
-            }
-
-            return false
-          })
-          .map(({ originalWord, wordIndex, scoreRegex }) => {
-            let wordScore = 0
-
-            wordScore += (contentChunk.match(scoreRegex) || []).length
-
-            if (wordIndex === 0 && firstWordRegex) {
-              const isFirstWord = firstWordRegex.test(
-                contentChunk.split(' ')[0]
-              )
-
-              if (isFirstWord) {
-                wordScore += searchWords.length + 1
-              }
-            }
-
-            return {
-              word: originalWord,
-              wordIndex,
-              wordScore,
-            }
-          })
-      }
+      const prepared = prepareSearchWords(value, searchOptions)
+      const { searchWords, getWordBoundary, matchInsideWordsFromIndex } =
+        prepared
 
       const strS = '\uFFFE'
       const strE = '\uFFFF'
@@ -1203,23 +1202,15 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
         | DrawerListDataArrayObject
         | { totalScore: number; item: SearchIndexItem }
       > = currentSearchIndex.map((item) => {
-        const listOfFoundWords = findSearchWords(item.contentChunk)
+        const listOfFoundWords = findMatchingWords(
+          item.contentChunk,
+          prepared
+        )
 
-        const allWordsAreNumeric = snParam
-          ? // @ts-expect-error Unicode property escapes are supported at runtime here
-            searchWords.every((word) => /^[\p{N}\s.,]+$/u.test(word))
-          : false
-
-        const hasMultipleNumericTerms =
-          snParam &&
-          searchWords &&
-          searchWords.length > 1 &&
-          allWordsAreNumeric
         if (
           !skipFilterRef.current &&
           !skipFilter &&
-          hasMultipleNumericTerms &&
-          listOfFoundWords.length !== searchWords.length
+          !passesNumericTermsCheck(listOfFoundWords, prepared)
         ) {
           return { totalScore: 0, item }
         }
@@ -1275,7 +1266,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
                     )
                   }
                 } else {
-                  if (wordIndex >= inWordIndex) {
+                  if (wordIndex >= matchInsideWordsFromIndex) {
                     segment = segment.replace(
                       new RegExp(`(${word})`, 'gi'),
                       `${strS}$1${strE}`
@@ -1401,10 +1392,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
           return item.dataItem
         }
 
-        let totalScore = listOfFoundWords.length
-        for (const { wordScore } of listOfFoundWords) {
-          totalScore += wordScore
-        }
+        const totalScore = calculateTotalScore(listOfFoundWords)
 
         return {
           totalScore,
@@ -1431,9 +1419,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     },
     [
       setSearchIndex,
-      props.searchMatch,
-      props.searchNumbers,
-      props.searchInWordIndex,
+      resolvedSearchMatch,
+      resolvedSearchNumbers,
+      resolvedSearchInWordIndex,
       disableHighlightingState,
     ]
   )
@@ -1485,8 +1473,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       options: {
         data?: DrawerListInternalData | null
         searchIndex?: SearchIndexItem[] | null
-        searchNumbers?: boolean
-        inWordIndex?: number
+        numbers?: boolean
+        matchInsideWordsFrom?: number
         disableHighlighting?: boolean
         skipFilter?: boolean
         skipReorder?: boolean
@@ -2208,9 +2196,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   )
 
   // Handle prop-driven state updates
-  if (props.disableHighlighting !== prevDisableHighlightingRef.current) {
-    prevDisableHighlightingRef.current = props.disableHighlighting
-    setDisableHighlighting(props.disableHighlighting)
+  if (_disableHighlighting !== prevDisableHighlightingRef.current) {
+    prevDisableHighlightingRef.current = _disableHighlighting
+    setDisableHighlighting(_disableHighlighting)
   }
 
   if (

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -21,35 +21,40 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  disableFilter: {
-    doc: 'If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`.',
-    type: 'boolean',
+  search: {
+    doc: 'Configure search behavior with a single config object. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `highlight` (enable text highlighting, default `true`), `numbers` (enable number search, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). Example: `search={{ filter: false }}` to disable filtering while keeping highlighting.',
+    type: 'SearchOptions',
     status: 'optional',
+  },
+  disableFilter: {
+    doc: 'If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`. **Deprecated**: Use `search={{ filter: false }}` instead.',
+    type: 'boolean',
+    status: 'deprecated',
   },
   disableHighlighting: {
-    doc: 'If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`.',
+    doc: 'If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`. **Deprecated**: Use `search={{ highlight: false }}` instead.',
     type: 'boolean',
-    status: 'optional',
+    status: 'deprecated',
   },
   disableReorder: {
-    doc: 'If set to `true`, reordering of search results will be disabled. Defaults to `false`.',
+    doc: 'If set to `true`, reordering of search results will be disabled. Defaults to `false`. **Deprecated**: Use `search={{ reorder: false }}` instead.',
     type: 'boolean',
-    status: 'optional',
+    status: 'deprecated',
   },
   searchNumbers: {
-    doc: 'If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`.',
+    doc: 'If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`. **Deprecated**: Use `search={{ numbers: true }}` instead.',
     type: 'boolean',
-    status: 'optional',
+    status: 'deprecated',
   },
   searchInWordIndex: {
-    doc: 'This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`.',
+    doc: 'This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`. **Deprecated**: Use `search={{ matchInsideWordsFrom: number }}` instead.',
     type: ['string', 'number'],
-    status: 'optional',
+    status: 'deprecated',
   },
   searchMatch: {
-    doc: 'Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`.',
+    doc: 'Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`. **Deprecated**: Use `search={{ match: "word" | "starts-with" }}` instead.',
     type: ['"word"', '"starts-with"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   keepValue: {
     doc: 'Use `true` to not remove the typed value on input blur, if it is invalid. By default, the typed value will disappear / be replaced by a selected value from the data list during the input field blur. Defaults to `false`.',

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1888,6 +1888,42 @@ describe('Autocomplete component', () => {
         'dnb-drawer-list__option__item--highlight'
       )
     })
+
+    it('warns when a deprecated search prop is used', () => {
+      const log = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined)
+
+      render(<Autocomplete disableFilter data={mockData} {...mockProps} />)
+
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('Eufemia'),
+        'Autocomplete: `disableFilter` is deprecated. Use `search={{ filter: false }}` instead.'
+      )
+
+      log.mockRestore()
+    })
+
+    it('does not warn when the search prop is used instead', () => {
+      const log = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined)
+
+      render(
+        <Autocomplete
+          search={{ filter: false }}
+          data={mockData}
+          {...mockProps}
+        />
+      )
+
+      expect(log).not.toHaveBeenCalledWith(
+        expect.stringContaining('Eufemia'),
+        expect.stringContaining('is deprecated')
+      )
+
+      log.mockRestore()
+    })
   })
 
   it('has correct "aria-expanded"', () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1743,6 +1743,53 @@ describe('Autocomplete component', () => {
       })
     })
 
+    it('updates filter and reorder when search config changes', () => {
+      const data = ['bbb aaa ccc', 'aaa bbb', 'ccc']
+      const { rerender } = render(
+        <Autocomplete
+          search={{ filter: false, reorder: false }}
+          data={data}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'a' },
+      })
+
+      expect(
+        Array.from(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          )
+        ).map((option) => option.textContent)
+      ).toEqual(data)
+
+      rerender(
+        <Autocomplete
+          search={{ filter: true, reorder: true }}
+          data={data}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aaa' },
+      })
+
+      expect(
+        Array.from(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          )
+        ).map((option) => option.textContent)
+      ).toEqual(['aaa bbb', 'bbb aaa ccc'])
+    })
+
     describe('search.numbers', () => {
       it('filters numbers when search.numbers is true', () => {
         const numberData = [

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -661,6 +661,7 @@ describe('Autocomplete component', () => {
       testAllIds(id)
     })
   })
+  // @deprecated - Test for deprecated `searchInWordIndex` prop.
   it('has correct options when searchInWordIndex is set to 1', () => {
     render(
       <Autocomplete
@@ -698,6 +699,7 @@ describe('Autocomplete component', () => {
     ).toBe('Ingen alternativer')
   })
 
+  // @deprecated - Tests for deprecated `searchMatch` prop.
   describe('searchMatch', () => {
     it('filters by starts-with when searchMatch is set', () => {
       const data = ['Back to the Future', 'The Godfather', 'The Matrix']
@@ -1189,6 +1191,7 @@ describe('Autocomplete component', () => {
     ).toBe(mockData[5])
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('has correct options when using searchNumbers', () => {
     const mockData = [
       formatBankAccountNumber(20001234567),
@@ -1254,6 +1257,7 @@ describe('Autocomplete component', () => {
     ).toBe(mockData[3])
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('matches last digits when using searchNumbers', () => {
     const mockData = [
       '2111 11 34567',
@@ -1292,6 +1296,7 @@ describe('Autocomplete component', () => {
     ).toContain('Vis alt')
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('should narrow down when numbers with whitespace are given and searchNumbers is used', () => {
     const mockData = [
       '2111 11 34567',
@@ -1437,6 +1442,7 @@ describe('Autocomplete component', () => {
     ).toHaveLength(2)
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('has correct options when using searchNumbers, and searching with æøå', () => {
     const mockData = [
       ['Åge Ørn Ærlig', formatNumber('12345678901')],
@@ -1554,6 +1560,8 @@ describe('Autocomplete component', () => {
     expect(elem.getAttribute('aria-current')).toBe('true')
   })
 
+  // @deprecated - Tests for deprecated `disableFilter` prop.
+  // These should be removed when the deprecated prop is removed.
   describe('disableFilter', () => {
     it('has correct options after filter if filter is disabled', () => {
       render(
@@ -1618,6 +1626,266 @@ describe('Autocomplete component', () => {
         )[2].innerHTML
       ).toBe(
         '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item item-nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item item-nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
+      )
+    })
+  })
+
+  describe('search config', () => {
+    describe('search.filter', () => {
+      it('does not filter options when search.filter is false', () => {
+        render(
+          <Autocomplete
+            search={{ filter: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aa' },
+        })
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          ).length
+        ).toBe(3)
+      })
+
+      it('should still highlight when filter is false', () => {
+        render(
+          <Autocomplete
+            search={{ filter: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'c' },
+        })
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          ).length
+        ).toBe(3)
+
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          )[0].innerHTML
+        ).toBe(
+          '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>AA <span class="dnb-drawer-list__option__item--highlight">c</span></span></span></span>'
+        )
+      })
+    })
+
+    describe('search.highlight', () => {
+      it('has no highlighted value when search.highlight is false', () => {
+        render(
+          <Autocomplete
+            mode="async"
+            search={{ highlight: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        const result = document
+          .querySelectorAll('li.dnb-drawer-list__option')[0]
+          .querySelector('.dnb-drawer-list__option__inner').outerHTML
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aa' },
+        })
+
+        expect(
+          document
+            .querySelectorAll('li.dnb-drawer-list__option')[0]
+            .querySelector('.dnb-drawer-list__option__inner').outerHTML
+        ).toBe(result)
+      })
+    })
+
+    describe('search.reorder', () => {
+      it('does not reorder results when search.reorder is false', () => {
+        const data = ['ccc', 'aaa bbb', 'bbb aaa ccc']
+
+        render(
+          <Autocomplete
+            search={{ reorder: false }}
+            data={data}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aaa' },
+        })
+
+        const options = document.querySelectorAll(
+          'li.dnb-drawer-list__option'
+        )
+        // Order should be preserved (not reordered by relevance)
+        expect(options[0].textContent).toBe('aaa bbb')
+        expect(options[1].textContent).toBe('bbb aaa ccc')
+      })
+    })
+
+    describe('search.numbers', () => {
+      it('filters numbers when search.numbers is true', () => {
+        const numberData = [
+          formatBankAccountNumber(20001234567),
+          formatBankAccountNumber(22233344425),
+        ] as DrawerListData
+
+        render(
+          <Autocomplete
+            data={numberData}
+            search={{ numbers: true }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: '222333.444' },
+        })
+        expect(
+          document.querySelectorAll('li.dnb-drawer-list__option')[0]
+            .textContent
+        ).toBe(numberData[1])
+      })
+    })
+
+    describe('search.matchInsideWordsFrom', () => {
+      it('searches inside words when search.matchInsideWordsFrom is 1', () => {
+        render(
+          <Autocomplete
+            data={mockData}
+            search={{ matchInsideWordsFrom: 1 }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'ethx' },
+        })
+        expect(
+          document.querySelectorAll('li.dnb-drawer-list__option')[0]
+            .textContent
+        ).toBe(mockData[1])
+      })
+    })
+
+    describe('search.match', () => {
+      it('filters by starts-with when search.match is starts-with', () => {
+        const data = ['Back to the Future', 'The Godfather', 'The Matrix']
+
+        render(
+          <Autocomplete
+            data={data}
+            search={{ match: 'starts-with' }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'The' },
+        })
+
+        const optionTexts = Array.from(
+          document.querySelectorAll('li.dnb-drawer-list__option')
+        ).map((node) => node.textContent)
+
+        expect(optionTexts).toEqual(
+          expect.arrayContaining(['The Godfather', 'The Matrix'])
+        )
+        expect(optionTexts).not.toEqual(
+          expect.arrayContaining(['Back to the Future'])
+        )
+      })
+    })
+
+    it('search config takes precedence over deprecated props', () => {
+      render(
+        <Autocomplete
+          disableFilter
+          search={{ filter: true }}
+          data={mockData}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aa' },
+      })
+      // search.filter=true should override disableFilter=true, so items are filtered
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        ).length
+      ).toBe(1)
+    })
+
+    it('can combine multiple search options', () => {
+      const data = ['Back to the Future', 'The Godfather', 'The Matrix']
+
+      render(
+        <Autocomplete
+          search={{ filter: true, highlight: false, match: 'starts-with' }}
+          data={data}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'The' },
+      })
+
+      const optionTexts = Array.from(
+        document.querySelectorAll('li.dnb-drawer-list__option')
+      ).map((node) => node.textContent)
+
+      // starts-with: only items starting with "The"
+      expect(optionTexts).toEqual(
+        expect.arrayContaining(['The Godfather', 'The Matrix'])
+      )
+      expect(optionTexts).not.toEqual(
+        expect.arrayContaining(['Back to the Future'])
+      )
+
+      // No highlighting when highlight is false
+      const options = document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+      expect(options[0].innerHTML).not.toContain(
+        'dnb-drawer-list__option__item--highlight'
       )
     })
   })
@@ -3015,6 +3283,8 @@ describe('Autocomplete component', () => {
     ).toContain('dnb-autocomplete--open')
   })
 
+  // @deprecated - Test for deprecated `disableHighlighting` prop.
+  // This should be removed when the deprecated prop is removed.
   it('has no highlighted value by using "disableHighlighting"', () => {
     render(
       <Autocomplete

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -599,6 +599,7 @@ describe('Autocomplete component', () => {
       testAllIds(id)
     })
   })
+  // @deprecated - Test for deprecated `searchInWordIndex` prop.
   it('has correct options when searchInWordIndex is set to 1', () => {
     render(
       <Autocomplete
@@ -636,6 +637,7 @@ describe('Autocomplete component', () => {
     ).toBe('Ingen alternativer')
   })
 
+  // @deprecated - Tests for deprecated `searchMatch` prop.
   describe('searchMatch', () => {
     it('filters by starts-with when searchMatch is set', () => {
       const data = ['Back to the Future', 'The Godfather', 'The Matrix']
@@ -1127,6 +1129,7 @@ describe('Autocomplete component', () => {
     ).toBe(mockData[5])
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('has correct options when using searchNumbers', () => {
     const mockData = [
       formatBankAccountNumber(20001234567),
@@ -1192,6 +1195,7 @@ describe('Autocomplete component', () => {
     ).toBe(mockData[3])
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('matches last digits when using searchNumbers', () => {
     const mockData = [
       '2111 11 34567',
@@ -1230,6 +1234,7 @@ describe('Autocomplete component', () => {
     ).toContain('Vis alt')
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('should narrow down when numbers with whitespace are given and searchNumbers is used', () => {
     const mockData = [
       '2111 11 34567',
@@ -1375,6 +1380,7 @@ describe('Autocomplete component', () => {
     ).toHaveLength(2)
   })
 
+  // @deprecated - Test for deprecated `searchNumbers` prop.
   it('has correct options when using searchNumbers, and searching with æøå', () => {
     const mockData = [
       ['Åge Ørn Ærlig', formatNumber('12345678901')],
@@ -1492,6 +1498,8 @@ describe('Autocomplete component', () => {
     expect(elem.getAttribute('aria-current')).toBe('true')
   })
 
+  // @deprecated - Tests for deprecated `disableFilter` prop.
+  // These should be removed when the deprecated prop is removed.
   describe('disableFilter', () => {
     it('has correct options after filter if filter is disabled', () => {
       render(
@@ -1556,6 +1564,266 @@ describe('Autocomplete component', () => {
         )[2].innerHTML
       ).toBe(
         '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item item-nr-1"><span><span class="dnb-drawer-list__option__item--highlight">CC</span></span></span><span class="dnb-drawer-list__option__item item-nr-2"><span><span class="dnb-drawer-list__option__item--highlight">cc</span></span></span></span>'
+      )
+    })
+  })
+
+  describe('search config', () => {
+    describe('search.filter', () => {
+      it('does not filter options when search.filter is false', () => {
+        render(
+          <Autocomplete
+            search={{ filter: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aa' },
+        })
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          ).length
+        ).toBe(3)
+      })
+
+      it('should still highlight when filter is false', () => {
+        render(
+          <Autocomplete
+            search={{ filter: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'c' },
+        })
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          ).length
+        ).toBe(3)
+
+        expect(
+          document.querySelectorAll(
+            'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+          )[0].innerHTML
+        ).toBe(
+          '<span class="dnb-drawer-list__option__inner"><span class="dnb-drawer-list__option__item"><span>AA <span class="dnb-drawer-list__option__item--highlight">c</span></span></span></span>'
+        )
+      })
+    })
+
+    describe('search.highlight', () => {
+      it('has no highlighted value when search.highlight is false', () => {
+        render(
+          <Autocomplete
+            mode="async"
+            search={{ highlight: false }}
+            data={mockData}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        const result = document
+          .querySelectorAll('li.dnb-drawer-list__option')[0]
+          .querySelector('.dnb-drawer-list__option__inner').outerHTML
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aa' },
+        })
+
+        expect(
+          document
+            .querySelectorAll('li.dnb-drawer-list__option')[0]
+            .querySelector('.dnb-drawer-list__option__inner').outerHTML
+        ).toBe(result)
+      })
+    })
+
+    describe('search.reorder', () => {
+      it('does not reorder results when search.reorder is false', () => {
+        const data = ['ccc', 'aaa bbb', 'bbb aaa ccc']
+
+        render(
+          <Autocomplete
+            search={{ reorder: false }}
+            data={data}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'aaa' },
+        })
+
+        const options = document.querySelectorAll(
+          'li.dnb-drawer-list__option'
+        )
+        // Order should be preserved (not reordered by relevance)
+        expect(options[0].textContent).toBe('aaa bbb')
+        expect(options[1].textContent).toBe('bbb aaa ccc')
+      })
+    })
+
+    describe('search.numbers', () => {
+      it('filters numbers when search.numbers is true', () => {
+        const numberData = [
+          formatBankAccountNumber(20001234567),
+          formatBankAccountNumber(22233344425),
+        ] as DrawerListData
+
+        render(
+          <Autocomplete
+            data={numberData}
+            search={{ numbers: true }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: '222333.444' },
+        })
+        expect(
+          document.querySelectorAll('li.dnb-drawer-list__option')[0]
+            .textContent
+        ).toBe(numberData[1])
+      })
+    })
+
+    describe('search.matchInsideWordsFrom', () => {
+      it('searches inside words when search.matchInsideWordsFrom is 1', () => {
+        render(
+          <Autocomplete
+            data={mockData}
+            search={{ matchInsideWordsFrom: 1 }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'ethx' },
+        })
+        expect(
+          document.querySelectorAll('li.dnb-drawer-list__option')[0]
+            .textContent
+        ).toBe(mockData[1])
+      })
+    })
+
+    describe('search.match', () => {
+      it('filters by starts-with when search.match is starts-with', () => {
+        const data = ['Back to the Future', 'The Godfather', 'The Matrix']
+
+        render(
+          <Autocomplete
+            data={data}
+            search={{ match: 'starts-with' }}
+            showSubmitButton
+            {...mockProps}
+          />
+        )
+
+        toggle()
+
+        fireEvent.change(document.querySelector('.dnb-input__input'), {
+          target: { value: 'The' },
+        })
+
+        const optionTexts = Array.from(
+          document.querySelectorAll('li.dnb-drawer-list__option')
+        ).map((node) => node.textContent)
+
+        expect(optionTexts).toEqual(
+          expect.arrayContaining(['The Godfather', 'The Matrix'])
+        )
+        expect(optionTexts).not.toEqual(
+          expect.arrayContaining(['Back to the Future'])
+        )
+      })
+    })
+
+    it('search config takes precedence over deprecated props', () => {
+      render(
+        <Autocomplete
+          disableFilter
+          search={{ filter: true }}
+          data={mockData}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aa' },
+      })
+      // search.filter=true should override disableFilter=true, so items are filtered
+      expect(
+        document.querySelectorAll(
+          'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+        ).length
+      ).toBe(1)
+    })
+
+    it('can combine multiple search options', () => {
+      const data = ['Back to the Future', 'The Godfather', 'The Matrix']
+
+      render(
+        <Autocomplete
+          search={{ filter: true, highlight: false, match: 'starts-with' }}
+          data={data}
+          showSubmitButton
+          {...mockProps}
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'The' },
+      })
+
+      const optionTexts = Array.from(
+        document.querySelectorAll('li.dnb-drawer-list__option')
+      ).map((node) => node.textContent)
+
+      // starts-with: only items starting with "The"
+      expect(optionTexts).toEqual(
+        expect.arrayContaining(['The Godfather', 'The Matrix'])
+      )
+      expect(optionTexts).not.toEqual(
+        expect.arrayContaining(['Back to the Future'])
+      )
+
+      // No highlighting when highlight is false
+      const options = document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+      expect(options[0].innerHTML).not.toContain(
+        'dnb-drawer-list__option__item--highlight'
       )
     })
   })
@@ -2953,6 +3221,8 @@ describe('Autocomplete component', () => {
     ).toContain('dnb-autocomplete--open')
   })
 
+  // @deprecated - Test for deprecated `disableHighlighting` prop.
+  // This should be removed when the deprecated prop is removed.
   it('has no highlighted value by using "disableHighlighting"', () => {
     render(
       <Autocomplete

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -201,7 +201,7 @@ export function suggestionsElement(
         {...props}
         autocompleteProps={{
           mode: 'async',
-          disableFilter: true,
+          search: { filter: false },
           keepValue: true,
           openOnFocus: true,
           placeholder: suggestionPlaceholder,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -453,7 +453,7 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
           placeholder: monthPlaceholder,
           autoComplete: 'bday-month',
           independentWidth: true,
-          disableReorder: true,
+          search: { reorder: false },
           onBlur: onBlurAutocomplete,
         }}
         data={months}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -19,6 +19,15 @@ import DataContext from '../../DataContext/Context'
 import useDataValue from '../../hooks/useDataValue'
 import useTranslation from '../../hooks/useTranslation'
 import { convertJsxToString } from '../../../../shared/component-helper'
+import type { SearchOptions } from '../../../../shared/search'
+import {
+  prepareSearchWords,
+  findMatchingWords,
+  calculateTotalScore,
+  passesNumericTermsCheck,
+} from '../../../../shared/search'
+import whatInput from '../../../../shared/helpers/whatInput'
+import useIsomorphicLayoutEffect from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 import { createSharedState } from '../../../../shared/helpers/useSharedState'
 import { MultiSelectionTrigger } from './MultiSelectionTrigger'
@@ -88,6 +97,11 @@ export type FieldMultiSelectionProps = FieldProps<
   selectedItemsCollapsibleThreshold?: number
 
   /**
+   * Configure search behavior when `showSearchField` is enabled. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `numbers` (enable number-optimized matching, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). When `filter` is `false`, items are not filtered out but are still reordered by relevance unless `reorder` is also `false`. Example: `search={{ numbers: true }}`.
+   */
+  search?: Omit<SearchOptions, 'highlight'>
+
+  /**
    * Show confirm and cancel buttons at the bottom of the popover. Selections are only applied when the user confirms.
    */
   showConfirmButton?: boolean
@@ -117,6 +131,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     className,
     variant = 'popover',
     width,
+    search,
     showSearchField = false,
     showSelectedTags = false,
     showConfirmButton = false,
@@ -237,9 +252,27 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const hasFeature =
     showSearchField || showSelectedTags || showConfirmButton
 
-  const toSearchText = useCallback((content?: ReactNode) => {
-    return convertJsxToString(content || '').toLowerCase()
-  }, [])
+  // Match the existing menu pattern so arrow-key navigation is treated as
+  // keyboard input even when focus is moved programmatically after mouse-open.
+  useIsomorphicLayoutEffect(() => {
+    if (isOpen) {
+      whatInput.specificKeys([
+        'Tab',
+        'ArrowLeft',
+        'ArrowUp',
+        'ArrowRight',
+        'ArrowDown',
+        'PageUp',
+        'PageDown',
+        'End',
+        'Home',
+      ])
+    }
+
+    return () => {
+      whatInput.specificKeys(['Tab'])
+    }
+  }, [isOpen])
 
   // Flatten nested items to a single array for searching and counting
   const flattenItems = useCallback(
@@ -271,7 +304,10 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     })
   }
 
-  // Filter items based on search (includes nested items)
+  const disableFilter = search?.filter === false
+  const disableReorder = search?.reorder === false
+
+  // Filter and/or reorder items based on search (includes nested items)
   const filteredItems = useMemo(() => {
     if (!dataList) {
       return []
@@ -280,37 +316,100 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       return dataList
     }
 
-    const searchLower = searchValue.toLowerCase()
+    const searchOptions = {
+      numbers: search?.numbers,
+      matchInsideWordsFrom: search?.matchInsideWordsFrom ?? 3,
+      match: search?.match,
+    }
+    const prepared = prepareSearchWords(searchValue, searchOptions)
+    const shouldScore = !disableReorder
 
-    const filterRecursive = (
-      items: MultiSelectionData
-    ): MultiSelectionData => {
+    type ScoredItem = MultiSelectionItem & { __score?: number }
+
+    const filterRecursive = (items: MultiSelectionData): ScoredItem[] => {
       return items
-        .map((item: MultiSelectionItemInternal) => {
-          const title = convertJsxToString(item.title).toLowerCase()
-          const text = toSearchText(item.text)
-          const description = toSearchText(item.description)
+        .map((item: MultiSelectionItemInternal): ScoredItem | null => {
+          const title = convertJsxToString(item.title)
+          const text = convertJsxToString(item.text || '')
+          const description = convertJsxToString(item.description || '')
+
+          const contentChunk = [title, text, description]
+            .filter(Boolean)
+            .join(' ')
+
+          const matchedWords = findMatchingWords(contentChunk, prepared)
+
+          if (!passesNumericTermsCheck(matchedWords, prepared)) {
+            if (disableFilter) {
+              return item
+            }
+
+            const children = item.children
+              ? filterRecursive(item.children)
+              : []
+
+            if (children.length > 0) {
+              return {
+                ...item,
+                children,
+              }
+            }
+
+            return null
+          }
+
           const matches =
-            title.includes(searchLower) ||
-            text.includes(searchLower) ||
-            description.includes(searchLower)
+            matchedWords.length === prepared.searchWordsData.length
+
           const children = item.children
             ? filterRecursive(item.children)
             : []
 
-          if (matches || children.length > 0) {
+          if (disableFilter || matches || children.length > 0) {
             return {
               ...item,
               children: children.length > 0 ? children : item.children,
+              ...(shouldScore && {
+                __score: matches ? calculateTotalScore(matchedWords) : 0,
+              }),
             }
           }
+
           return null
         })
-        .filter(Boolean) as MultiSelectionData
+        .filter(Boolean) as ScoredItem[]
     }
 
-    return filterRecursive(dataList)
-  }, [dataList, searchValue, toSearchText])
+    const result = filterRecursive(dataList)
+
+    if (shouldScore) {
+      result.sort((a, b) => (b.__score ?? 0) - (a.__score ?? 0))
+
+      const stripScores = (items: ScoredItem[]): MultiSelectionData => {
+        return items.map(({ __score, ...item }) => {
+          if (item.children) {
+            return {
+              ...item,
+              children: stripScores(item.children as ScoredItem[]),
+            }
+          }
+          return item
+        })
+      }
+
+      return stripScores(result)
+    }
+
+    return result
+  }, [
+    dataList,
+    searchValue,
+    disableFilter,
+    disableReorder,
+    search?.numbers,
+    search?.matchInsideWordsFrom,
+    search?.match,
+  ])
 
   // Get items of selected values (based on tempValue)
   const selectedItems = useMemo(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -26,8 +26,6 @@ import {
   calculateTotalScore,
   passesNumericTermsCheck,
 } from '../../../../shared/search'
-import whatInput from '../../../../shared/helpers/whatInput'
-import useIsomorphicLayoutEffect from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 import { createSharedState } from '../../../../shared/helpers/useSharedState'
 import { MultiSelectionTrigger } from './MultiSelectionTrigger'
@@ -252,28 +250,6 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const hasFeature =
     showSearchField || showSelectedTags || showConfirmButton
 
-  // Match the existing menu pattern so arrow-key navigation is treated as
-  // keyboard input even when focus is moved programmatically after mouse-open.
-  useIsomorphicLayoutEffect(() => {
-    if (isOpen) {
-      whatInput.specificKeys([
-        'Tab',
-        'ArrowLeft',
-        'ArrowUp',
-        'ArrowRight',
-        'ArrowDown',
-        'PageUp',
-        'PageDown',
-        'End',
-        'Home',
-      ])
-    }
-
-    return () => {
-      whatInput.specificKeys(['Tab'])
-    }
-  }, [isOpen])
-
   // Flatten nested items to a single array for searching and counting
   const flattenItems = useCallback(
     (items: MultiSelectionData | undefined): MultiSelectionData => {
@@ -358,8 +334,10 @@ function MultiSelection(props: FieldMultiSelectionProps) {
             return null
           }
 
-          const matches =
-            matchedWords.length === prepared.searchWordsData.length
+          // An item matches if any search word is found (OR semantics),
+          // mirroring Autocomplete. Multiple numeric terms still require all
+          // to match, which is enforced by passesNumericTermsCheck above.
+          const matches = matchedWords.length > 0
 
           const children = item.children
             ? filterRecursive(item.children)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
@@ -24,6 +24,11 @@ export const MultiSelectionProperties: PropertiesTableProps = {
     type: ['boolean'],
     status: 'optional',
   },
+  search: {
+    doc: 'Configure search behavior when `showSearchField` is enabled. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `numbers` (enable number-optimized matching, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). When `filter` is `false`, items are not filtered out but are still reordered by relevance unless `reorder` is also `false`. Example: `search={{ numbers: true }}`.',
+    type: 'SearchOptions',
+    status: 'optional',
+  },
   showSelectAll: {
     doc: 'Show a "Select all" checkbox at the top of the list.',
     type: ['boolean'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -1268,6 +1268,197 @@ describe('MultiSelection', () => {
 
       expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
     })
+
+    describe('search config', () => {
+      it('supports numbers to match numeric content', async () => {
+        const data = [
+          { value: 'a', title: 'Account 123-456' },
+          { value: 'b', title: 'Account 789-012' },
+          { value: 'c', title: 'Savings' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ numbers: true }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: '123456' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Account 123-456')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(
+          screen.queryByText('Account 789-012')
+        ).not.toBeInTheDocument()
+        expect(screen.queryByText('Savings')).not.toBeInTheDocument()
+      })
+
+      it('supports search={{ filter: false }} to disable filtering', async () => {
+        const data = [
+          { value: 'a', title: 'Apple' },
+          { value: 'b', title: 'Banana' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ filter: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'apple' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Apple')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(screen.getByText('Banana')).toBeInTheDocument()
+        expect(screen.getByText('Cherry')).toBeInTheDocument()
+      })
+
+      it('still reorders by relevance when filter is false', async () => {
+        const data = [
+          { value: 'a', title: 'Something banana' },
+          { value: 'b', title: 'Banana cake' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ filter: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            // All items shown (no filtering)
+            expect(items).toHaveLength(3)
+            // Reordered: 'Banana cake' first (higher relevance)
+            expect(items[0]).toHaveTextContent('Banana cake')
+            expect(items[1]).toHaveTextContent('Something banana')
+            expect(items[2]).toHaveTextContent('Cherry')
+          },
+          { timeout: 3000 }
+        )
+      })
+
+      it('supports search={{ reorder: false }} to keep original order', async () => {
+        const data = [
+          { value: 'a', title: 'Banana split' },
+          { value: 'b', title: 'Apple banana' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ reorder: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            expect(items).toHaveLength(2)
+            expect(items[0]).toHaveTextContent('Banana split')
+            expect(items[1]).toHaveTextContent('Apple banana')
+          },
+          { timeout: 3000 }
+        )
+      })
+
+      it('supports search={{ match: "starts-with" }}', async () => {
+        const data = [
+          { value: 'a', title: 'Apple' },
+          { value: 'b', title: 'Pineapple' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ match: 'starts-with' }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'apple' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Apple')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(screen.queryByText('Pineapple')).not.toBeInTheDocument()
+      })
+
+      it('reorders results by relevance by default', async () => {
+        const data = [
+          { value: 'a', title: 'Something banana' },
+          { value: 'b', title: 'Banana cake' },
+        ]
+
+        render(<Field.MultiSelection data={data} showSearchField />)
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            expect(items).toHaveLength(2)
+            // "Banana cake" starts with the search term so it should score higher
+            expect(items[0]).toHaveTextContent('Banana cake')
+            expect(items[1]).toHaveTextContent('Something banana')
+          },
+          { timeout: 3000 }
+        )
+      })
+    })
   })
 
   describe('minItems', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -1298,6 +1298,197 @@ describe('MultiSelection', () => {
 
       expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
     })
+
+    describe('search config', () => {
+      it('supports numbers to match numeric content', async () => {
+        const data = [
+          { value: 'a', title: 'Account 123-456' },
+          { value: 'b', title: 'Account 789-012' },
+          { value: 'c', title: 'Savings' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ numbers: true }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: '123456' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Account 123-456')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(
+          screen.queryByText('Account 789-012')
+        ).not.toBeInTheDocument()
+        expect(screen.queryByText('Savings')).not.toBeInTheDocument()
+      })
+
+      it('supports search={{ filter: false }} to disable filtering', async () => {
+        const data = [
+          { value: 'a', title: 'Apple' },
+          { value: 'b', title: 'Banana' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ filter: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'apple' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Apple')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(screen.getByText('Banana')).toBeInTheDocument()
+        expect(screen.getByText('Cherry')).toBeInTheDocument()
+      })
+
+      it('still reorders by relevance when filter is false', async () => {
+        const data = [
+          { value: 'a', title: 'Something banana' },
+          { value: 'b', title: 'Banana cake' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ filter: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            // All items shown (no filtering)
+            expect(items).toHaveLength(3)
+            // Reordered: 'Banana cake' first (higher relevance)
+            expect(items[0]).toHaveTextContent('Banana cake')
+            expect(items[1]).toHaveTextContent('Something banana')
+            expect(items[2]).toHaveTextContent('Cherry')
+          },
+          { timeout: 3000 }
+        )
+      })
+
+      it('supports search={{ reorder: false }} to keep original order', async () => {
+        const data = [
+          { value: 'a', title: 'Banana split' },
+          { value: 'b', title: 'Apple banana' },
+          { value: 'c', title: 'Cherry' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ reorder: false }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            expect(items).toHaveLength(2)
+            expect(items[0]).toHaveTextContent('Banana split')
+            expect(items[1]).toHaveTextContent('Apple banana')
+          },
+          { timeout: 3000 }
+        )
+      })
+
+      it('supports search={{ match: "starts-with" }}', async () => {
+        const data = [
+          { value: 'a', title: 'Apple' },
+          { value: 'b', title: 'Pineapple' },
+        ]
+
+        render(
+          <Field.MultiSelection
+            data={data}
+            showSearchField
+            search={{ match: 'starts-with' }}
+          />
+        )
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'apple' } })
+
+        await waitFor(
+          () => {
+            expect(screen.getByText('Apple')).toBeInTheDocument()
+          },
+          { timeout: 3000 }
+        )
+
+        expect(screen.queryByText('Pineapple')).not.toBeInTheDocument()
+      })
+
+      it('reorders results by relevance by default', async () => {
+        const data = [
+          { value: 'a', title: 'Something banana' },
+          { value: 'b', title: 'Banana cake' },
+        ]
+
+        render(<Field.MultiSelection data={data} showSearchField />)
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'banana' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            expect(items).toHaveLength(2)
+            // "Banana cake" starts with the search term so it should score higher
+            expect(items[0]).toHaveTextContent('Banana cake')
+            expect(items[1]).toHaveTextContent('Something banana')
+          },
+          { timeout: 3000 }
+        )
+      })
+    })
   })
 
   describe('minItems', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -1488,6 +1488,34 @@ describe('MultiSelection', () => {
           { timeout: 3000 }
         )
       })
+
+      it('keeps items matching any search word (OR), like Autocomplete', async () => {
+        const data = [
+          { value: 'a', title: 'alpha delta' }, // matches only "alpha"
+          { value: 'b', title: 'beta gamma' }, // matches only "beta"
+          { value: 'c', title: 'alpha beta' }, // matches both
+        ]
+
+        render(<Field.MultiSelection data={data} showSearchField />)
+
+        fireEvent.click(screen.getByRole('button'))
+
+        const input = document.querySelector('input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'alpha beta' } })
+
+        await waitFor(
+          () => {
+            const items = document.querySelectorAll(
+              '.dnb-forms-field-multi-selection__item'
+            )
+            // All three are kept because each matches at least one word.
+            expect(items).toHaveLength(3)
+            // The item matching both words scores highest and is reordered first.
+            expect(items[0]).toHaveTextContent('alpha beta')
+          },
+          { timeout: 3000 }
+        )
+      })
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -545,7 +545,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
           onChange={handleCountryCodeChange}
           onType={onTypeHandler}
           independentWidth
-          searchNumbers
+          search={{ numbers: true }}
           keepSelection
           selectAll
           autoComplete="tel-country-code"

--- a/packages/dnb-eufemia/src/shared/search/SearchOptions.ts
+++ b/packages/dnb-eufemia/src/shared/search/SearchOptions.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared search options type used by Autocomplete
+ * and other components with search/filter behavior.
+ */
+export type SearchOptions = {
+  /** Enable number-optimized/normalized matching. Defaults to `false`. */
+  numbers?: boolean
+
+  /** Threshold (1-based) deciding from which word position to search inside words. Defaults to `3`. */
+  matchInsideWordsFrom?: number
+
+  /** Matching strategy. */
+  match?: 'word' | 'starts-with'
+
+  /** Enable filtering of options based on typed input. Defaults to `true`. */
+  filter?: boolean
+
+  /** Enable reordering of search results by relevance. Defaults to `true`. */
+  reorder?: boolean
+
+  /** Enable highlighting of matching text in options. Defaults to `true`. */
+  highlight?: boolean
+}

--- a/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
+++ b/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
@@ -1,0 +1,190 @@
+import {
+  prepareSearchWords,
+  findMatchingWords,
+  calculateTotalScore,
+  passesNumericTermsCheck,
+} from '../searchUtils'
+
+describe('prepareSearchWords', () => {
+  it('splits input into search words', () => {
+    const result = prepareSearchWords('hello world')
+    expect(result.searchWords).toEqual(['hello', 'world'])
+  })
+
+  it('handles null value', () => {
+    const result = prepareSearchWords(null)
+    expect(result.searchWords).toEqual([])
+  })
+
+  it('handles empty string', () => {
+    const result = prepareSearchWords('')
+    expect(result.searchWords).toEqual([])
+  })
+
+  it('trims extra whitespace', () => {
+    const result = prepareSearchWords('  hello   world  ')
+    expect(result.searchWords).toEqual(['hello', 'world'])
+  })
+
+  it('builds filter regexes for each word', () => {
+    const result = prepareSearchWords('abc')
+    expect(result.searchWordsData).toHaveLength(1)
+    expect(result.searchWordsData[0].filterRegex).toBeInstanceOf(RegExp)
+    expect(result.searchWordsData[0].scoreRegex).toBeInstanceOf(RegExp)
+  })
+
+  it('builds firstWordRegex', () => {
+    const result = prepareSearchWords('abc def')
+    expect(result.firstWordRegex).toBeInstanceOf(RegExp)
+    expect(result.firstWordRegex.test('abc')).toBe(true)
+    expect(result.firstWordRegex.test('def')).toBe(false)
+  })
+
+  it('returns null firstWordRegex for empty input', () => {
+    const result = prepareSearchWords('')
+    expect(result.firstWordRegex).toBeNull()
+  })
+
+  it('uses starts-with word boundary for first word', () => {
+    const result = prepareSearchWords('The', {
+      match: 'starts-with',
+    })
+    expect(result.searchWordsData[0].filterRegex.test('The Matrix')).toBe(
+      true
+    )
+    expect(
+      result.searchWordsData[0].filterRegex.test('Back to the Future')
+    ).toBe(false)
+  })
+
+  it('enforces word boundary in starts-with mode even past matchInsideWordsFrom', () => {
+    const result = prepareSearchWords('a b c', {
+      match: 'starts-with',
+      matchInsideWordsFrom: 1,
+    })
+    // The 3rd word "c" is past matchInsideWordsFrom (0-based 0), but in starts-with
+    // mode it should still require a word boundary, not match inside words.
+    expect(result.searchWordsData[2].filterRegex.test('abc')).toBe(false)
+    expect(result.searchWordsData[2].filterRegex.test('a b c')).toBe(true)
+  })
+
+  it('normalizes numeric input with starts-with and numbers', () => {
+    const result = prepareSearchWords('123.456', {
+      match: 'starts-with',
+      numbers: true,
+    })
+    expect(result.searchWords).toEqual(['123456'])
+  })
+
+  it('exposes 0-based matchInsideWordsFromIndex on PreparedSearch', () => {
+    const result = prepareSearchWords('a b c', { matchInsideWordsFrom: 3 })
+    expect(result.matchInsideWordsFromIndex).toBe(2)
+  })
+
+  it('defaults matchInsideWordsFromIndex to 2 (1-based 3)', () => {
+    const result = prepareSearchWords('a b c')
+    expect(result.matchInsideWordsFromIndex).toBe(2)
+  })
+
+  it('exposes numbers on PreparedSearch', () => {
+    const withNumbers = prepareSearchWords('123', { numbers: true })
+    expect(withNumbers.numbers).toBe(true)
+
+    const withoutNumbers = prepareSearchWords('123')
+    expect(withoutNumbers.numbers).toBe(false)
+  })
+})
+
+describe('findMatchingWords', () => {
+  it('finds matching words in content', () => {
+    const prepared = prepareSearchWords('hello')
+    const matches = findMatchingWords('hello world', prepared)
+    expect(matches).toHaveLength(1)
+    expect(matches[0].word).toBe('hello')
+    expect(matches[0].wordScore).toBeGreaterThan(0)
+  })
+
+  it('returns empty array for no match', () => {
+    const prepared = prepareSearchWords('xyz')
+    const matches = findMatchingWords('hello world', prepared)
+    expect(matches).toHaveLength(0)
+  })
+
+  it('returns empty array for null content', () => {
+    const prepared = prepareSearchWords('hello')
+    const matches = findMatchingWords(null, prepared)
+    expect(matches).toHaveLength(0)
+  })
+
+  it('matches case-insensitively', () => {
+    const prepared = prepareSearchWords('HELLO')
+    const matches = findMatchingWords('hello world', prepared)
+    expect(matches).toHaveLength(1)
+  })
+
+  it('gives bonus score when matching first word', () => {
+    const prepared = prepareSearchWords('hello')
+    const matchFirst = findMatchingWords('hello world', prepared)
+    const matchSecond = findMatchingWords('world hello', prepared)
+    expect(matchFirst[0].wordScore).toBeGreaterThan(
+      matchSecond[0].wordScore
+    )
+  })
+
+  it('matches numbers with numbers enabled', () => {
+    const prepared = prepareSearchWords('123', {
+      numbers: true,
+    })
+    const matches = findMatchingWords('1234 5678', prepared)
+    expect(matches).toHaveLength(1)
+  })
+})
+
+describe('calculateTotalScore', () => {
+  it('returns 0 for empty matches', () => {
+    expect(calculateTotalScore([])).toBe(0)
+  })
+
+  it('sums match count and word scores', () => {
+    const score = calculateTotalScore([
+      { word: 'a', wordIndex: 0, wordScore: 3 },
+      { word: 'b', wordIndex: 1, wordScore: 1 },
+    ])
+    // 2 (count) + 3 + 1 = 6
+    expect(score).toBe(6)
+  })
+})
+
+describe('passesNumericTermsCheck', () => {
+  it('returns true when numbers is false', () => {
+    const prepared = prepareSearchWords('123 456')
+    expect(passesNumericTermsCheck([], prepared)).toBe(true)
+  })
+
+  it('returns true for single numeric term', () => {
+    const prepared = prepareSearchWords('123', { numbers: true })
+    expect(passesNumericTermsCheck([], prepared)).toBe(true)
+  })
+
+  it('returns false when not all numeric terms matched', () => {
+    const prepared = prepareSearchWords('123 456', { numbers: true })
+    const matched = [{ word: '123', wordIndex: 0, wordScore: 1 }]
+    expect(passesNumericTermsCheck(matched, prepared)).toBe(false)
+  })
+
+  it('returns true when all numeric terms matched', () => {
+    const prepared = prepareSearchWords('123 456', { numbers: true })
+    const matched = [
+      { word: '123', wordIndex: 0, wordScore: 1 },
+      { word: '456', wordIndex: 1, wordScore: 1 },
+    ]
+    expect(passesNumericTermsCheck(matched, prepared)).toBe(true)
+  })
+
+  it('returns true for non-numeric multi-word search', () => {
+    const prepared = prepareSearchWords('hello world', {
+      numbers: true,
+    })
+    expect(passesNumericTermsCheck([], prepared)).toBe(true)
+  })
+})

--- a/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
+++ b/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
@@ -26,6 +26,14 @@ describe('prepareSearchWords', () => {
     expect(result.searchWords).toEqual(['hello', 'world'])
   })
 
+  it('deduplicates repeated words case-insensitively, keeping the first occurrence', () => {
+    expect(prepareSearchWords('foo foo bar').searchWords).toEqual([
+      'foo',
+      'bar',
+    ])
+    expect(prepareSearchWords('Foo foo').searchWords).toEqual(['Foo'])
+  })
+
   it('builds filter regexes for each word', () => {
     const result = prepareSearchWords('abc')
     expect(result.searchWordsData).toHaveLength(1)

--- a/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
+++ b/packages/dnb-eufemia/src/shared/search/__tests__/searchUtils.test.ts
@@ -65,15 +65,30 @@ describe('prepareSearchWords', () => {
     ).toBe(false)
   })
 
-  it('enforces word boundary in starts-with mode even past matchInsideWordsFrom', () => {
-    const result = prepareSearchWords('a b c', {
+  it('anchors only the first term in starts-with mode, while later terms still follow matchInsideWordsFrom', () => {
+    const result = prepareSearchWords('the de ter', {
       match: 'starts-with',
-      matchInsideWordsFrom: 1,
     })
-    // The 3rd word "c" is past matchInsideWordsFrom (0-based 0), but in starts-with
-    // mode it should still require a word boundary, not match inside words.
-    expect(result.searchWordsData[2].filterRegex.test('abc')).toBe(false)
-    expect(result.searchWordsData[2].filterRegex.test('a b c')).toBe(true)
+    // Default matchInsideWordsFrom is 3 (0-based index 2).
+
+    // Only the first term is anchored to the start of the item.
+    expect(result.searchWordsData[0].filterRegex.test('the matrix')).toBe(
+      true
+    )
+    expect(
+      result.searchWordsData[0].filterRegex.test('over the top')
+    ).toBe(false)
+
+    // A later term before the threshold still requires a word boundary.
+    expect(result.searchWordsData[1].filterRegex.test('de facto')).toBe(
+      true
+    )
+    expect(result.searchWordsData[1].filterRegex.test('index')).toBe(false)
+
+    // A later term at/after the threshold may match inside a word.
+    expect(result.searchWordsData[2].filterRegex.test('determined')).toBe(
+      true
+    )
   })
 
   it('normalizes numeric input with starts-with and numbers', () => {

--- a/packages/dnb-eufemia/src/shared/search/index.ts
+++ b/packages/dnb-eufemia/src/shared/search/index.ts
@@ -1,0 +1,11 @@
+export { type SearchOptions } from './SearchOptions'
+export {
+  type SearchWordOptions,
+  type SearchWordData,
+  type PreparedSearch,
+  type MatchedWord,
+  prepareSearchWords,
+  findMatchingWords,
+  calculateTotalScore,
+  passesNumericTermsCheck,
+} from './searchUtils'

--- a/packages/dnb-eufemia/src/shared/search/searchUtils.ts
+++ b/packages/dnb-eufemia/src/shared/search/searchUtils.ts
@@ -1,0 +1,211 @@
+/**
+ * Pure search/filter utility functions.
+ *
+ * These are framework-agnostic and can be used by Autocomplete,
+ * MultiSelection, or any other component that needs search/filter behavior.
+ */
+
+import { escapeRegexChars } from '../component-helper'
+import type { SearchOptions } from './SearchOptions'
+
+export type SearchWordOptions = Pick<
+  SearchOptions,
+  'numbers' | 'matchInsideWordsFrom' | 'match'
+>
+
+export type SearchWordData = {
+  originalWord: string
+  processedWord: string
+  wordIndex: number
+  filterRegex: RegExp
+  scoreRegex: RegExp
+}
+
+export type PreparedSearch = {
+  searchWords: string[]
+  searchWordsData: SearchWordData[]
+  firstWordRegex: RegExp | null
+  getWordBoundary: (wordIndex: number) => string
+  /** The 0-based matchInsideWordsFrom threshold used for filtering and highlighting. */
+  matchInsideWordsFromIndex: number
+  /** Whether number-optimized matching is enabled. */
+  numbers: boolean
+}
+
+export type MatchedWord = {
+  word: string
+  wordIndex: number
+  wordScore: number
+}
+
+/**
+ * Prepare search data from a raw input value.
+ *
+ * Splits the input into words, builds filter and score regexes
+ * for each word, and returns the prepared search data.
+ */
+export function prepareSearchWords(
+  value: string | null,
+  options: SearchWordOptions = {}
+): PreparedSearch {
+  const { numbers = false, match, matchInsideWordsFrom = 3 } = options
+  const matchInsideWordsFromIndex = matchInsideWordsFrom - 1
+  const startsWithMatch = match === 'starts-with'
+  const rawValue = value ?? ''
+  let searchWords = rawValue.split(/\s+/g).filter(Boolean)
+
+  if (startsWithMatch) {
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    const hasLetters = /[\p{L}]/u.test(rawValue)
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    const hasNumbers = /[\p{N}]/u.test(rawValue)
+
+    if (numbers && hasNumbers && !hasLetters) {
+      // @ts-expect-error Unicode property escapes are supported at runtime
+      const normalizedNumeric = rawValue.replace(/[^\p{N}]+/gu, '')
+      searchWords = normalizedNumeric ? [normalizedNumeric] : []
+    }
+  }
+
+  const getWordBoundary = (wordIndex: number) =>
+    startsWithMatch && wordIndex === 0 ? '^' : numbers ? '' : '^|\\s'
+
+  const searchWordsData = searchWords.map((word, wordIndex) => {
+    const processedWord = numbers
+      ? // @ts-expect-error Unicode property escapes are supported at runtime
+        word.replace(/[^\p{L}\p{N}]+/gu, '')
+      : escapeRegexChars(word)
+    const wordBoundary = getWordBoundary(wordIndex)
+
+    return {
+      originalWord: word,
+      processedWord,
+      wordIndex,
+      filterRegex: new RegExp(
+        wordIndex >= matchInsideWordsFromIndex && !startsWithMatch
+          ? `${processedWord}`
+          : `(${wordBoundary})${processedWord}`,
+        'i'
+      ),
+      scoreRegex: new RegExp(
+        `(${wordBoundary})${escapeRegexChars(word)}`,
+        'ig'
+      ),
+    }
+  })
+
+  const firstWordRegex =
+    searchWords.length > 0
+      ? new RegExp(`^${escapeRegexChars(searchWords[0])}`, 'i')
+      : null
+
+  return {
+    searchWords,
+    searchWordsData,
+    firstWordRegex,
+    getWordBoundary,
+    matchInsideWordsFromIndex,
+    numbers,
+  }
+}
+
+/**
+ * Find and score matching words in a content chunk.
+ *
+ * Tests each prepared search word against the content and
+ * returns an array of matched words with their relevance scores.
+ */
+export function findMatchingWords(
+  contentChunk: string | null,
+  preparedSearch: PreparedSearch
+): MatchedWord[] {
+  const { searchWordsData, firstWordRegex, searchWords, numbers } =
+    preparedSearch
+
+  if (typeof contentChunk !== 'string') {
+    return []
+  }
+
+  return searchWordsData
+    .filter(({ filterRegex }) => {
+      if (filterRegex.test(contentChunk)) {
+        return true
+      }
+
+      if (
+        numbers &&
+        filterRegex.test(contentChunk.replace(/[^0-9]/g, ''))
+      ) {
+        return true
+      }
+
+      return false
+    })
+    .map(({ originalWord, wordIndex, scoreRegex }) => {
+      let wordScore = 0
+
+      wordScore += (contentChunk.match(scoreRegex) || []).length
+
+      if (wordIndex === 0 && firstWordRegex) {
+        const isFirstWord = firstWordRegex.test(contentChunk.split(' ')[0])
+
+        if (isFirstWord) {
+          wordScore += searchWords.length + 1
+        }
+      }
+
+      return {
+        word: originalWord,
+        wordIndex,
+        wordScore,
+      }
+    })
+}
+
+/**
+ * Calculate total relevance score from matched words.
+ */
+export function calculateTotalScore(matchedWords: MatchedWord[]): number {
+  let totalScore = matchedWords.length
+
+  for (const { wordScore } of matchedWords) {
+    totalScore += wordScore
+  }
+
+  return totalScore
+}
+
+/**
+ * Check whether multiple numeric search terms all matched.
+ *
+ * When searching with multiple numeric terms (e.g. "123 456"),
+ * ALL terms must match for the item to be included.
+ * Returns `false` if the item should be excluded.
+ */
+export function passesNumericTermsCheck(
+  matchedWords: MatchedWord[],
+  preparedSearch: PreparedSearch
+): boolean {
+  const { searchWords, numbers } = preparedSearch
+
+  if (!numbers) {
+    return true
+  }
+
+  const allWordsAreNumeric = searchWords.every(
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    (word) => /^[\p{N}\s.,]+$/u.test(word)
+  )
+
+  const hasMultipleNumericTerms =
+    searchWords.length > 1 && allWordsAreNumeric
+
+  if (
+    hasMultipleNumericTerms &&
+    matchedWords.length !== searchWords.length
+  ) {
+    return false
+  }
+
+  return true
+}

--- a/packages/dnb-eufemia/src/shared/search/searchUtils.ts
+++ b/packages/dnb-eufemia/src/shared/search/searchUtils.ts
@@ -94,7 +94,7 @@ export function prepareSearchWords(
       processedWord,
       wordIndex,
       filterRegex: new RegExp(
-        wordIndex >= matchInsideWordsFromIndex && !startsWithMatch
+        wordIndex >= matchInsideWordsFromIndex
           ? `${processedWord}`
           : `(${wordBoundary})${processedWord}`,
         'i'

--- a/packages/dnb-eufemia/src/shared/search/searchUtils.ts
+++ b/packages/dnb-eufemia/src/shared/search/searchUtils.ts
@@ -25,7 +25,6 @@ export type PreparedSearch = {
   searchWords: string[]
   searchWordsData: SearchWordData[]
   firstWordRegex: RegExp | null
-  getWordBoundary: (wordIndex: number) => string
   /** The 0-based matchInsideWordsFrom threshold used for filtering and highlighting. */
   matchInsideWordsFromIndex: number
   /** Whether number-optimized matching is enabled. */
@@ -115,7 +114,6 @@ export function prepareSearchWords(
     searchWords,
     searchWordsData,
     firstWordRegex,
-    getWordBoundary,
     matchInsideWordsFromIndex,
     numbers,
   }

--- a/packages/dnb-eufemia/src/shared/search/searchUtils.ts
+++ b/packages/dnb-eufemia/src/shared/search/searchUtils.ts
@@ -1,0 +1,223 @@
+/**
+ * Pure search/filter utility functions.
+ *
+ * These are framework-agnostic and can be used by Autocomplete,
+ * MultiSelection, or any other component that needs search/filter behavior.
+ */
+
+import { escapeRegexChars } from '../component-helper'
+import type { SearchOptions } from './SearchOptions'
+
+export type SearchWordOptions = Pick<
+  SearchOptions,
+  'numbers' | 'matchInsideWordsFrom' | 'match'
+>
+
+export type SearchWordData = {
+  originalWord: string
+  processedWord: string
+  wordIndex: number
+  filterRegex: RegExp
+  scoreRegex: RegExp
+}
+
+export type PreparedSearch = {
+  searchWords: string[]
+  searchWordsData: SearchWordData[]
+  firstWordRegex: RegExp | null
+  getWordBoundary: (wordIndex: number) => string
+  /** The 0-based matchInsideWordsFrom threshold used for filtering and highlighting. */
+  matchInsideWordsFromIndex: number
+  /** Whether number-optimized matching is enabled. */
+  numbers: boolean
+}
+
+export type MatchedWord = {
+  word: string
+  wordIndex: number
+  wordScore: number
+}
+
+/**
+ * Prepare search data from a raw input value.
+ *
+ * Splits the input into words, builds filter and score regexes
+ * for each word, and returns the prepared search data.
+ */
+export function prepareSearchWords(
+  value: string | null,
+  options: SearchWordOptions = {}
+): PreparedSearch {
+  const { numbers = false, match, matchInsideWordsFrom = 3 } = options
+  const matchInsideWordsFromIndex = matchInsideWordsFrom - 1
+  const startsWithMatch = match === 'starts-with'
+  const rawValue = value ?? ''
+  let searchWords = rawValue.split(/\s+/g).filter(Boolean)
+
+  if (startsWithMatch) {
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    const hasLetters = /[\p{L}]/u.test(rawValue)
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    const hasNumbers = /[\p{N}]/u.test(rawValue)
+
+    if (numbers && hasNumbers && !hasLetters) {
+      // @ts-expect-error Unicode property escapes are supported at runtime
+      const normalizedNumeric = rawValue.replace(/[^\p{N}]+/gu, '')
+      searchWords = normalizedNumeric ? [normalizedNumeric] : []
+    }
+  }
+
+  const distinctSearchWords = new Set<string>()
+  searchWords = searchWords.filter((word) => {
+    const normalizedWord = word.toLowerCase()
+
+    if (distinctSearchWords.has(normalizedWord)) {
+      return false
+    }
+
+    distinctSearchWords.add(normalizedWord)
+    return true
+  })
+
+  const getWordBoundary = (wordIndex: number) =>
+    startsWithMatch && wordIndex === 0 ? '^' : numbers ? '' : '^|\\s'
+
+  const searchWordsData = searchWords.map((word, wordIndex) => {
+    const processedWord = numbers
+      ? // @ts-expect-error Unicode property escapes are supported at runtime
+        word.replace(/[^\p{L}\p{N}]+/gu, '')
+      : escapeRegexChars(word)
+    const wordBoundary = getWordBoundary(wordIndex)
+
+    return {
+      originalWord: word,
+      processedWord,
+      wordIndex,
+      filterRegex: new RegExp(
+        wordIndex >= matchInsideWordsFromIndex && !startsWithMatch
+          ? `${processedWord}`
+          : `(${wordBoundary})${processedWord}`,
+        'i'
+      ),
+      scoreRegex: new RegExp(
+        `(${wordBoundary})${escapeRegexChars(word)}`,
+        'ig'
+      ),
+    }
+  })
+
+  const firstWordRegex =
+    searchWords.length > 0
+      ? new RegExp(`^${escapeRegexChars(searchWords[0])}`, 'i')
+      : null
+
+  return {
+    searchWords,
+    searchWordsData,
+    firstWordRegex,
+    getWordBoundary,
+    matchInsideWordsFromIndex,
+    numbers,
+  }
+}
+
+/**
+ * Find and score matching words in a content chunk.
+ *
+ * Tests each prepared search word against the content and
+ * returns an array of matched words with their relevance scores.
+ */
+export function findMatchingWords(
+  contentChunk: string | null,
+  preparedSearch: PreparedSearch
+): MatchedWord[] {
+  const { searchWordsData, firstWordRegex, searchWords, numbers } =
+    preparedSearch
+
+  if (typeof contentChunk !== 'string') {
+    return []
+  }
+
+  return searchWordsData
+    .filter(({ filterRegex }) => {
+      if (filterRegex.test(contentChunk)) {
+        return true
+      }
+
+      if (
+        numbers &&
+        filterRegex.test(contentChunk.replace(/[^0-9]/g, ''))
+      ) {
+        return true
+      }
+
+      return false
+    })
+    .map(({ originalWord, wordIndex, scoreRegex }) => {
+      let wordScore = 0
+
+      wordScore += (contentChunk.match(scoreRegex) || []).length
+
+      if (wordIndex === 0 && firstWordRegex) {
+        const isFirstWord = firstWordRegex.test(contentChunk.split(' ')[0])
+
+        if (isFirstWord) {
+          wordScore += searchWords.length + 1
+        }
+      }
+
+      return {
+        word: originalWord,
+        wordIndex,
+        wordScore,
+      }
+    })
+}
+
+/**
+ * Calculate total relevance score from matched words.
+ */
+export function calculateTotalScore(matchedWords: MatchedWord[]): number {
+  let totalScore = matchedWords.length
+
+  for (const { wordScore } of matchedWords) {
+    totalScore += wordScore
+  }
+
+  return totalScore
+}
+
+/**
+ * Check whether multiple numeric search terms all matched.
+ *
+ * When searching with multiple numeric terms (e.g. "123 456"),
+ * ALL terms must match for the item to be included.
+ * Returns `false` if the item should be excluded.
+ */
+export function passesNumericTermsCheck(
+  matchedWords: MatchedWord[],
+  preparedSearch: PreparedSearch
+): boolean {
+  const { searchWords, numbers } = preparedSearch
+
+  if (!numbers) {
+    return true
+  }
+
+  const allWordsAreNumeric = searchWords.every(
+    // @ts-expect-error Unicode property escapes are supported at runtime
+    (word) => /^[\p{N}\s.,]+$/u.test(word)
+  )
+
+  const hasMultipleNumericTerms =
+    searchWords.length > 1 && allWordsAreNumeric
+
+  if (
+    hasMultipleNumericTerms &&
+    matchedWords.length !== searchWords.length
+  ) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
Extract shared search utilities (prepareSearchWords, findMatchingWords,
calculateTotalScore, checkMultipleNumericTerms) into shared/search/ and
introduce a SearchOptions type used by both Autocomplete and MultiSelection.

Autocomplete:
- Add search prop (SearchOptions) replacing deprecated individual props
  (disableFilter, disableReorder, disableHighlighting, searchNumbers,
  searchInWordIndex, searchMatch)
- Deprecated props still work with console warnings

MultiSelection:
- Add search prop to configure filtering when showSearchField is enabled
- Replace simple includes()-based filtering with shared search utilities
- Support numbers, matchInsideWordsFrom, match, filter, and reorder options
- Results are scored and reordered by relevance by default

Deploy preview [Autocomplete](https://feat-autocomplete-search-obj.eufemia-e25.pages.dev/uilib/components/autocomplete/demos)
Deploy preview [MultiSelection](https://feat-autocomplete-search-obj.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos)