### PR TITLE
chore: add sync-docs-jsdoc ESLint rule

### DIFF
--- a/packages/dnb-eufemia/eslint.config.mjs
+++ b/packages/dnb-eufemia/eslint.config.mjs
@@ -521,6 +521,28 @@ export default [
     },
   },
   {
+    files: [
+      'src/components/**/*.{ts,tsx}',
+      'src/elements/**/*.{ts,tsx}',
+      'src/fragments/**/*.{ts,tsx}',
+      'src/extensions/**/*.{ts,tsx}',
+    ],
+    ignores: [
+      '**/*Docs.{ts,tsx}',
+      '**/__tests__/**',
+      '**/*.test.*',
+      '**/*.spec.*',
+      '**/*.stories.*',
+      '**/*.d.ts',
+    ],
+    plugins: {
+      'docs-types': docsTypesPlugin,
+    },
+    rules: {
+      'docs-types/sync-docs-jsdoc': 'warn',
+    },
+  },
+  {
     files: ['**/*.screenshot.test.{ts,tsx}', '**/*.e2e.spec.{ts,tsx}'],
     ...playwrightPlugin.configs['flat/recommended'],
     plugins: {

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/basic/BasicDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/basic/BasicDocs.ts
@@ -1,0 +1,22 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const BasicProperties: PropertiesTableProps = {
+  content: {
+    doc: 'Content of the component.',
+    type: 'string',
+    status: 'optional',
+  },
+  label: {
+    doc: 'Label for the component.',
+    type: 'string',
+    status: 'optional',
+  },
+  size: {
+    doc: 'The size of the component. Defaults to `medium`.',
+    type: ['"small"', '"medium"', '"large"'],
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-export/MultiDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-export/MultiDocs.ts
@@ -1,0 +1,30 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const MultiProperties: PropertiesTableProps = {
+  value: {
+    doc: 'The current value.',
+    type: 'string',
+    status: 'optional',
+  },
+  label: {
+    doc: 'Label for the field.',
+    type: 'string',
+    status: 'optional',
+  },
+}
+
+export const MultiEvents: PropertiesTableProps = {
+  onChange: {
+    doc: 'Called when the value changes.',
+    type: 'function',
+    status: 'optional',
+  },
+  onFocus: {
+    doc: 'Called when the field receives focus.',
+    type: 'function',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/no-docs/placeholder.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/no-docs/placeholder.ts
@@ -1,0 +1,1 @@
+// This directory intentionally has no *Docs file.

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/string-keys/StringKeysDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/string-keys/StringKeysDocs.ts
@@ -1,0 +1,22 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const StringKeysProperties: PropertiesTableProps = {
+  'aria-label': {
+    doc: 'Accessible label for the component.',
+    type: 'string',
+    status: 'optional',
+  },
+  'data-testid': {
+    doc: 'Test ID for the component.',
+    type: 'string',
+    status: 'optional',
+  },
+  name: {
+    doc: 'The name attribute.',
+    type: 'string',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
@@ -1,0 +1,654 @@
+import path from 'path'
+import { RuleTester } from 'eslint'
+import rule from '../rules/sync-docs-jsdoc'
+
+const ruleExports = rule as typeof rule & {
+  extractDocsFromFile: (filePath: string) => Map<string, string>
+  extractJsdocText: (commentValue: string) => string
+  extractJsdocTags: (commentValue: string) => string[]
+}
+
+const fixturesDir = path.resolve(__dirname, 'fixtures/sync-docs-jsdoc')
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+tester.run('sync-docs-jsdoc', rule, {
+  valid: [
+    // ── JSDoc matches the doc string ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Content of the component. */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── Multiple matching properties ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Content of the component. */
+          content?: string
+
+          /** Label for the component. */
+          label?: string
+
+          /** The size of the component. Defaults to \`medium\`. */
+          size?: 'small' | 'medium' | 'large'
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── Property not in the Docs file — no error ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Some internal thing. */
+          internalProp?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── No JSDoc on a documented property (requireJsdoc default false) ──
+    {
+      code: `
+        export type BasicProps = {
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── No Docs file in the directory — no error ──
+    {
+      code: `
+        export type SomeProps = {
+          /** Anything goes. */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'no-docs/types.ts'),
+    },
+
+    // ── File is a *Docs file itself — skipped ──
+    {
+      code: `
+        export type Something = {
+          /** Wrong text. */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/BasicDocs.ts'),
+    },
+
+    // ── Test file — skipped ──
+    {
+      code: `
+        export type TestProps = {
+          /** Wrong text. */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/Basic.test.ts'),
+    },
+
+    // ── JSDoc with @deprecated tag and matching description ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           * @deprecated Use newProp instead.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── Multi-export: matching docs from both exports ──
+    {
+      code: `
+        export type MultiProps = {
+          /** The current value. */
+          value?: string
+
+          /** Called when the value changes. */
+          onChange?: () => void
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-export/types.ts'),
+    },
+
+    // ── String-key property with matching JSDoc ──
+    {
+      code: `
+        export type StringKeysProps = {
+          /** Accessible label for the component. */
+          'aria-label'?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'string-keys/types.ts'),
+    },
+
+    // ── Interface (not just type alias) with matching JSDoc ──
+    {
+      code: `
+        export interface BasicInterface {
+          /** Content of the component. */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+  ],
+
+  invalid: [
+    // ── Mismatched JSDoc — single property ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Wrong description. */
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'BasicDocs.ts',
+            expected: 'Content of the component.',
+          },
+        },
+      ],
+    },
+
+    // ── Mismatched JSDoc — multiple properties ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Wrong content doc. */
+          content?: string
+
+          /** Wrong label doc. */
+          label?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+
+          /**
+           * Label for the component.
+           */
+          label?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'BasicDocs.ts',
+            expected: 'Content of the component.',
+          },
+        },
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'BasicDocs.ts',
+            expected: 'Label for the component.',
+          },
+        },
+      ],
+    },
+
+    // ── Multi-line JSDoc that doesn't match ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Old multi-line description.
+           */
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Multi-export docs: event description mismatch ──
+    {
+      code: `
+        export type MultiProps = {
+          /** Wrong event description. */
+          onChange?: () => void
+        }
+      `,
+      output: `
+        export type MultiProps = {
+          /**
+           * Called when the value changes.
+           */
+          onChange?: () => void
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-export/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'MultiDocs.ts',
+            expected: 'Called when the value changes.',
+          },
+        },
+      ],
+    },
+
+    // ── String-key property mismatch ──
+    {
+      code: `
+        export type StringKeysProps = {
+          /** Wrong label. */
+          'aria-label'?: string
+        }
+      `,
+      output: `
+        export type StringKeysProps = {
+          /**
+           * Accessible label for the component.
+           */
+          'aria-label'?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'string-keys/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'StringKeysDocs.ts',
+            expected: 'Accessible label for the component.',
+          },
+        },
+      ],
+    },
+
+    // ── Interface property mismatch ──
+    {
+      code: `
+        export interface BasicInterface {
+          /** Old description. */
+          label?: string
+        }
+      `,
+      output: `
+        export interface BasicInterface {
+          /**
+           * Label for the component.
+           */
+          label?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── requireJsdoc: true — missing JSDoc reported ──
+    {
+      code: `
+        export type BasicProps = {
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      options: [{ requireJsdoc: true }],
+      errors: [
+        {
+          messageId: 'missingJsdoc',
+          data: {
+            docsFile: 'BasicDocs.ts',
+            expected: 'Content of the component.',
+          },
+        },
+      ],
+    },
+
+    // ── requireJsdoc: true — missing JSDoc on multiple properties ──
+    {
+      code: `
+        export type BasicProps = {
+          content?: string
+          label?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+          /**
+           * Label for the component.
+           */
+          label?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      options: [{ requireJsdoc: true }],
+      errors: [
+        { messageId: 'missingJsdoc' },
+        { messageId: 'missingJsdoc' },
+      ],
+    },
+
+    // ── Mismatch with backtick content in doc string ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Wrong size doc. */
+          size?: 'small' | 'medium' | 'large'
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * The size of the component. Defaults to \`medium\`.
+           */
+          size?: 'small' | 'medium' | 'large'
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Only the documented property is flagged, others are ignored ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Wrong content doc. */
+          content?: string
+
+          /** Internal undocumented prop. */
+          internalProp?: boolean
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           */
+          content?: string
+
+          /** Internal undocumented prop. */
+          internalProp?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Mismatched description with @deprecated tag — preserves tag ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Wrong description here.
+           * @deprecated Use newProp instead.
+           */
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           * @deprecated Use newProp instead.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'BasicDocs.ts',
+            expected: 'Content of the component.',
+          },
+        },
+      ],
+    },
+
+    // ── Mismatched description with multiple tags — preserves all tags ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Old wrong text.
+           * @internal
+           * @deprecated Will be removed.
+           */
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           * @internal
+           * @deprecated Will be removed.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Only @deprecated tag, no description — adds description before tag ──
+    {
+      code: `
+        export type BasicProps = {
+          /** @deprecated Use newProp instead. */
+          content?: string
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Content of the component.
+           * @deprecated Use newProp instead.
+           */
+          content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+  ],
+})
+
+// ── Unit tests for extractDocsFromFile ──
+
+describe('extractDocsFromFile', () => {
+  const { extractDocsFromFile } = ruleExports
+
+  it('extracts doc strings from a basic Docs file', () => {
+    const docsPath = path.join(fixturesDir, 'basic/BasicDocs.ts')
+    const docs = extractDocsFromFile(docsPath)
+
+    expect(docs.get('content')).toBe('Content of the component.')
+    expect(docs.get('label')).toBe('Label for the component.')
+    expect(docs.get('size')).toBe(
+      'The size of the component. Defaults to `medium`.'
+    )
+    expect(docs.size).toBe(3)
+  })
+
+  it('extracts docs from a multi-export Docs file', () => {
+    const docsPath = path.join(fixturesDir, 'multi-export/MultiDocs.ts')
+    const docs = extractDocsFromFile(docsPath)
+
+    expect(docs.get('value')).toBe('The current value.')
+    expect(docs.get('label')).toBe('Label for the field.')
+    expect(docs.get('onChange')).toBe('Called when the value changes.')
+    expect(docs.get('onFocus')).toBe(
+      'Called when the field receives focus.'
+    )
+    expect(docs.size).toBe(4)
+  })
+
+  it('extracts docs from a Docs file with string-key properties', () => {
+    const docsPath = path.join(
+      fixturesDir,
+      'string-keys/StringKeysDocs.ts'
+    )
+    const docs = extractDocsFromFile(docsPath)
+
+    expect(docs.get('aria-label')).toBe(
+      'Accessible label for the component.'
+    )
+    expect(docs.get('data-testid')).toBe('Test ID for the component.')
+    expect(docs.get('name')).toBe('The name attribute.')
+    expect(docs.size).toBe(3)
+  })
+})
+
+// ── Unit tests for extractJsdocText ──
+
+describe('extractJsdocText', () => {
+  const { extractJsdocText } = ruleExports
+
+  it('extracts text from single-line JSDoc', () => {
+    // comment.value for /** Some text. */
+    expect(extractJsdocText('* Some text. ')).toBe('Some text.')
+  })
+
+  it('extracts text from multi-line JSDoc', () => {
+    // comment.value for:
+    // /**
+    //  * Some text.
+    //  */
+    expect(extractJsdocText('*\n * Some text.\n ')).toBe('Some text.')
+  })
+
+  it('joins multiple content lines', () => {
+    expect(extractJsdocText('*\n * First line.\n * Second line.\n ')).toBe(
+      'First line. Second line.'
+    )
+  })
+
+  it('handles text with backticks', () => {
+    expect(extractJsdocText('* Defaults to `0`. ')).toBe(
+      'Defaults to `0`.'
+    )
+  })
+
+  it('handles empty JSDoc', () => {
+    expect(extractJsdocText('* ')).toBe('')
+  })
+
+  it('trims extra whitespace', () => {
+    expect(extractJsdocText('*   Lots of space.   ')).toBe(
+      'Lots of space.'
+    )
+  })
+
+  it('excludes @tag lines from the text', () => {
+    expect(
+      extractJsdocText(
+        '*\n * Some description.\n * @deprecated Use something else.\n '
+      )
+    ).toBe('Some description.')
+  })
+
+  it('excludes multiple tags from the text', () => {
+    expect(
+      extractJsdocText(
+        '*\n * Description text.\n * @internal\n * @deprecated Will be removed.\n '
+      )
+    ).toBe('Description text.')
+  })
+
+  it('returns empty when only tags are present', () => {
+    expect(extractJsdocText('* @deprecated Use newProp instead. ')).toBe(
+      ''
+    )
+  })
+})
+
+// ── Unit tests for extractJsdocTags ──
+
+describe('extractJsdocTags', () => {
+  const { extractJsdocTags } = ruleExports
+
+  it('extracts a single tag', () => {
+    expect(
+      extractJsdocTags('*\n * Description.\n * @deprecated Use X.\n ')
+    ).toEqual(['@deprecated Use X.'])
+  })
+
+  it('extracts multiple tags', () => {
+    expect(
+      extractJsdocTags(
+        '*\n * Description.\n * @internal\n * @deprecated Will be removed.\n '
+      )
+    ).toEqual(['@internal', '@deprecated Will be removed.'])
+  })
+
+  it('returns empty array when no tags', () => {
+    expect(extractJsdocTags('* Just a description. ')).toEqual([])
+  })
+
+  it('handles tag with multi-line continuation', () => {
+    expect(
+      extractJsdocTags(
+        '*\n * Description.\n * @deprecated This is deprecated\n *   and will be removed.\n '
+      )
+    ).toEqual(['@deprecated This is deprecated and will be removed.'])
+  })
+
+  it('extracts tag from single-line JSDoc', () => {
+    expect(
+      extractJsdocTags('* @deprecated Use newProp instead. ')
+    ).toEqual(['@deprecated Use newProp instead.'])
+  })
+})

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/index.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/index.js
@@ -3,6 +3,7 @@ const warnSupportedTypes = require('./rules/warn-supported-types')
 const docTrailingPeriod = require('./rules/doc-trailing-period')
 const defaultvalueInnerQuotes = require('./rules/defaultvalue-inner-quotes')
 const docNoDoubleSpaces = require('./rules/doc-no-double-spaces')
+const syncDocsJsdoc = require('./rules/sync-docs-jsdoc')
 
 module.exports = {
   rules: {
@@ -11,5 +12,6 @@ module.exports = {
     'doc-trailing-period': docTrailingPeriod,
     'defaultvalue-inner-quotes': defaultvalueInnerQuotes,
     'doc-no-double-spaces': docNoDoubleSpaces,
+    'sync-docs-jsdoc': syncDocsJsdoc,
   },
 }

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
@@ -1,0 +1,330 @@
+const fs = require('fs')
+const path = require('path')
+
+let ts
+try {
+  ts = require('typescript')
+} catch {
+  // TypeScript not available — rule will be disabled
+}
+
+/**
+ * Extracts property name → doc string pairs from a *Docs file.
+ * Uses the TypeScript compiler API for robust parsing.
+ */
+function extractDocsFromFile(filePath) {
+  if (!ts) {
+    return new Map()
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  )
+
+  const docs = new Map()
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      extractFromObjectLiteral(node.initializer, docs)
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return docs
+}
+
+function extractFromObjectLiteral(objLiteral, docs) {
+  for (const prop of objLiteral.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      continue
+    }
+
+    const propName = getTsPropertyName(prop)
+    if (!propName) {
+      continue
+    }
+
+    if (!ts.isObjectLiteralExpression(prop.initializer)) {
+      continue
+    }
+
+    for (const innerProp of prop.initializer.properties) {
+      if (!ts.isPropertyAssignment(innerProp)) {
+        continue
+      }
+
+      const innerName = getTsPropertyName(innerProp)
+      if (innerName !== 'doc') {
+        continue
+      }
+
+      const docValue = getStringLiteralValue(innerProp.initializer)
+      if (docValue !== null) {
+        docs.set(propName, docValue)
+      }
+    }
+  }
+}
+
+function getTsPropertyName(prop) {
+  if (ts.isIdentifier(prop.name)) {
+    return prop.name.text
+  }
+
+  if (ts.isStringLiteral(prop.name)) {
+    return prop.name.text
+  }
+
+  return null
+}
+
+function getStringLiteralValue(node) {
+  if (
+    ts.isStringLiteral(node) ||
+    ts.isNoSubstitutionTemplateLiteral(node)
+  ) {
+    return node.text
+  }
+
+  return null
+}
+
+function getEslintPropertyName(node) {
+  if (node.key.type === 'Identifier') {
+    return node.key.name
+  }
+
+  if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+    return node.key.value
+  }
+
+  return null
+}
+
+function extractJsdocText(commentValue) {
+  return commentValue
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*\s?/, ''))
+    .filter(
+      (line) => line.trim().length > 0 && !line.trim().startsWith('@')
+    )
+    .join(' ')
+    .trim()
+}
+
+function extractJsdocTags(commentValue) {
+  const tags = []
+  const lines = commentValue.split('\n')
+
+  let currentTag = null
+
+  for (const line of lines) {
+    const stripped = line.replace(/^\s*\*\s?/, '')
+
+    if (/^\s*@\w+/.test(stripped)) {
+      if (currentTag) {
+        tags.push(currentTag)
+      }
+
+      currentTag = stripped.trim()
+    } else if (currentTag && stripped.trim().length > 0) {
+      currentTag += ' ' + stripped.trim()
+    }
+  }
+
+  if (currentTag) {
+    tags.push(currentTag)
+  }
+
+  return tags
+}
+
+function getDocsMap(dir) {
+  let files
+
+  try {
+    files = fs.readdirSync(dir).filter((f) => /Docs\.[jt]sx?$/.test(f))
+  } catch {
+    return null
+  }
+
+  if (files.length === 0) {
+    return null
+  }
+
+  const docs = new Map()
+  const fileMap = new Map()
+
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+
+    try {
+      const extracted = extractDocsFromFile(filePath)
+
+      for (const [key, value] of extracted) {
+        docs.set(key, value)
+        fileMap.set(key, file)
+      }
+    } catch {
+      // Skip files that fail to parse
+    }
+  }
+
+  if (docs.size === 0) {
+    return null
+  }
+
+  return { docs, fileMap }
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Ensures JSDoc comments on type properties match the doc strings in sibling *Docs files.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          requireJsdoc: {
+            type: 'boolean',
+            description:
+              'When true, also reports missing JSDoc for properties documented in the *Docs file.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      mismatchedJsdoc:
+        'JSDoc does not match the doc string in {{ docsFile }}. Expected: "{{ expected }}".',
+      missingJsdoc:
+        'Missing JSDoc for documented property. Expected (from {{ docsFile }}): "{{ expected }}".',
+    },
+  },
+
+  create(context) {
+    if (!ts) {
+      return {}
+    }
+
+    const filename = context.filename || context.getFilename()
+
+    if (/Docs\.[jt]sx?$/.test(path.basename(filename))) {
+      return {} // stop here
+    }
+
+    if (/\.(test|spec|stories)\.[jt]sx?$/.test(filename)) {
+      return {} // stop here
+    }
+
+    const resolvedPath = path.resolve(filename)
+    const dir = path.dirname(resolvedPath)
+    const docsData = getDocsMap(dir)
+
+    if (!docsData) {
+      return {} // stop here
+    }
+
+    const options = context.options[0] || {}
+    const requireJsdoc = options.requireJsdoc === true
+    const sourceCode = context.sourceCode || context.getSourceCode()
+
+    function checkProperty(node) {
+      const propName = getEslintPropertyName(node)
+
+      if (!propName || !docsData.docs.has(propName)) {
+        return // stop here
+      }
+
+      const expectedDoc = docsData.docs.get(propName)
+      const docsFile = docsData.fileMap.get(propName)
+
+      const comments = sourceCode.getCommentsBefore(node)
+
+      let jsdocComment = null
+      for (const c of comments) {
+        if (c.type === 'Block' && c.value.startsWith('*')) {
+          jsdocComment = c
+        }
+      }
+
+      if (!jsdocComment) {
+        if (requireJsdoc) {
+          context.report({
+            node: node.key,
+            messageId: 'missingJsdoc',
+            data: { docsFile, expected: expectedDoc },
+            fix(fixer) {
+              const line = sourceCode.lines[node.loc.start.line - 1]
+              const match = line.match(/^(\s*)/)
+              const indent = match ? match[1] : ''
+              const jsdoc = `/**\n${indent} * ${expectedDoc}\n${indent} */\n${indent}`
+              return fixer.insertTextBefore(node, jsdoc)
+            },
+          })
+        }
+
+        return // stop here
+      }
+
+      const existingDoc = extractJsdocText(jsdocComment.value)
+      const tags = extractJsdocTags(jsdocComment.value)
+
+      if (existingDoc !== expectedDoc) {
+        context.report({
+          node: node.key,
+          messageId: 'mismatchedJsdoc',
+          data: { docsFile, expected: expectedDoc },
+          fix(fixer) {
+            let replacement
+
+            if (tags.length > 0) {
+              const commentNode = jsdocComment
+              const startLine =
+                sourceCode.lines[commentNode.loc.start.line - 1]
+              const indentMatch = startLine.match(/^(\s*)/)
+              const indent = indentMatch ? indentMatch[1] : ''
+              const tagLines = tags
+                .map((tag) => `${indent} * ${tag}`)
+                .join('\n')
+              replacement = `/**\n${indent} * ${expectedDoc}\n${tagLines}\n${indent} */`
+            } else {
+              const commentNode = jsdocComment
+              const startLine =
+                sourceCode.lines[commentNode.loc.start.line - 1]
+              const indentMatch = startLine.match(/^(\s*)/)
+              const indent = indentMatch ? indentMatch[1] : ''
+              replacement = `/**\n${indent} * ${expectedDoc}\n${indent} */`
+            }
+
+            return fixer.replaceTextRange(jsdocComment.range, replacement)
+          },
+        })
+      }
+    }
+
+    return {
+      TSPropertySignature: checkProperty,
+      TSMethodSignature: checkProperty,
+    }
+  },
+}
+
+module.exports.extractDocsFromFile = extractDocsFromFile
+module.exports.extractJsdocText = extractJsdocText
+module.exports.extractJsdocTags = extractJsdocTags


### PR DESCRIPTION
Ensures JSDoc comments on type/interface properties match the doc strings defined in sibling *Docs files. Mismatches are auto-fixable.

Related to #8057

In the editor

https://github.com/user-attachments/assets/6050cd96-9b8e-46db-a2a8-6ecf8765c5e3



Or we could run it in the CLI as well in a bulk run.