### PR TITLE
chore: add globals as explicit devDependency

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -198,6 +198,7 @@
     "figma-js": "1.14.0",
     "fontmin": "0.9.9",
     "fs-extra": "10.0.0",
+    "globals": "16.4.0",
     "globby": "11.0.4",
     "jest-axe": "10.0.0",
     "jest-matchmedia-mock": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,6 +2303,7 @@ __metadata:
     figma-js: "npm:1.14.0"
     fontmin: "npm:0.9.9"
     fs-extra: "npm:10.0.0"
+    globals: "npm:16.4.0"
     globby: "npm:11.0.4"
     intl-messageformat: "npm:11.2.3"
     jest-axe: "npm:10.0.0"


### PR DESCRIPTION
globals is imported directly in eslint.config.mjs but was not listed as a devDependency, relying on transitive resolution from other eslint plugins. This is fragile and could break if those transitive dependencies change their globals version.

Adds globals@16.4.0 (matching eufemia-starter) as an explicit devDependency in @dnb/eufemia.

