### PR TITLE
chore(MultiSelection): preserve disabled items on clear all and tag removal

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -774,7 +774,9 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       onRemoveTag={handleRemoveTag}
       onClearAll={() => {
         const disabledValues = allFlatItems
-          .filter((item) => item.disabled && tempValue.includes(item.value))
+          .filter(
+            (item) => item.disabled && tempValue.includes(item.value)
+          )
           .map((item) => item.value)
         setTempValue(disabledValues)
         setShowSelectedItemsList(true)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -540,6 +540,10 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
   const handleRemoveTag = useCallback(
     (itemValue: number | string) => {
+      const item = allFlatItems.find((i) => i.value === itemValue)
+      if (item?.disabled) {
+        return
+      }
       const next = tempValue.filter((v) => v !== itemValue)
       pendingCheckedCountAnnouncementRef.current = true
       setTempValue(next)
@@ -547,7 +551,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
         applyChange(next)
       }
     },
-    [tempValue, showConfirmButton, applyChange]
+    [allFlatItems, tempValue, showConfirmButton, applyChange]
   )
 
   const handleConfirm = useCallback(() => {
@@ -769,10 +773,13 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       onToggleList={setShowSelectedItemsList}
       onRemoveTag={handleRemoveTag}
       onClearAll={() => {
-        setTempValue([])
+        const disabledValues = allFlatItems
+          .filter((item) => item.disabled && tempValue.includes(item.value))
+          .map((item) => item.value)
+        setTempValue(disabledValues)
         setShowSelectedItemsList(true)
         if (!showConfirmButton) {
-          applyChange([])
+          applyChange(disabledValues)
         }
       }}
     />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
@@ -89,9 +89,11 @@ export function MultiSelectionSelectedTags({
             selectedItems.map((item) => (
               <Tag
                 key={item.value}
-                variant="removable"
+                variant={item.disabled ? 'default' : 'removable'}
                 hasLabel
-                onClick={() => onRemoveTag(item.value)}
+                onClick={
+                  item.disabled ? undefined : () => onRemoveTag(item.value)
+                }
               >
                 {item.title}
               </Tag>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -2241,6 +2241,7 @@ describe('MultiSelection', () => {
 
   describe('disabled items', () => {
     it('preserves disabled items when "Clear all" is clicked', async () => {
+      const onChange = vi.fn()
       const data = [
         { value: 'option1', title: 'Option 1' },
         { value: 'option2', title: 'Option 2', disabled: true },
@@ -2252,6 +2253,7 @@ describe('MultiSelection', () => {
           <Field.MultiSelection
             data={data}
             value={['option1', 'option2', 'option3']}
+            onChange={onChange}
             showSelectedTags
             selectedItemsCollapsibleThreshold={0}
           />
@@ -2276,6 +2278,12 @@ describe('MultiSelection', () => {
         expect(checkboxes[1]).toBeChecked() // Option 2 (disabled)
         expect(checkboxes[2]).not.toBeChecked() // Option 3
       })
+
+      // Verify onChange was called with only the disabled item's value
+      expect(onChange).toHaveBeenLastCalledWith(
+        ['option2'],
+        expect.anything()
+      )
     })
 
     it('does not remove a disabled item via tag click', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -2238,4 +2238,123 @@ describe('MultiSelection', () => {
       )
     })
   })
+
+  describe('disabled items', () => {
+    it('preserves disabled items when "Clear all" is clicked', async () => {
+      const data = [
+        { value: 'option1', title: 'Option 1' },
+        { value: 'option2', title: 'Option 2', disabled: true },
+        { value: 'option3', title: 'Option 3' },
+      ]
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection
+            data={data}
+            value={['option1', 'option2', 'option3']}
+            showSelectedTags
+            selectedItemsCollapsibleThreshold={0}
+          />
+        </Provider>
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__items'
+          )
+        ).toBeInTheDocument()
+      })
+
+      // Click "Clear all"
+      fireEvent.click(screen.getByText('Clear all'))
+
+      // Option 2 (disabled) should still be selected
+      await waitFor(() => {
+        const checkboxes = screen.getAllByRole('checkbox')
+        expect(checkboxes[0]).not.toBeChecked() // Option 1
+        expect(checkboxes[1]).toBeChecked() // Option 2 (disabled)
+        expect(checkboxes[2]).not.toBeChecked() // Option 3
+      })
+    })
+
+    it('does not remove a disabled item via tag click', async () => {
+      const data = [
+        { value: 'option1', title: 'Option 1' },
+        { value: 'option2', title: 'Option 2', disabled: true },
+      ]
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection
+            data={data}
+            value={['option1', 'option2']}
+            showSelectedTags
+          />
+        </Provider>
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__items'
+          )
+        ).toBeInTheDocument()
+      })
+
+      // The disabled item's tag should not be removable
+      const tags = document.querySelectorAll(
+        '.dnb-forms-field-multi-selection__selected-items .dnb-tag'
+      )
+      expect(tags).toHaveLength(2)
+
+      // The disabled tag should not have the removable variant
+      const disabledTag = tags[1]
+      expect(disabledTag).not.toHaveClass('dnb-tag--removable')
+    })
+
+    it('renders disabled tags as default variant and enabled tags as removable', async () => {
+      const data = [
+        { value: 'option1', title: 'Option 1' },
+        { value: 'option2', title: 'Option 2', disabled: true },
+        { value: 'option3', title: 'Option 3' },
+      ]
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection
+            data={data}
+            value={['option1', 'option2', 'option3']}
+            showSelectedTags
+          />
+        </Provider>
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__items'
+          )
+        ).toBeInTheDocument()
+      })
+
+      const tags = document.querySelectorAll(
+        '.dnb-forms-field-multi-selection__selected-items .dnb-tag'
+      )
+      expect(tags).toHaveLength(3)
+
+      // Option 1 - enabled, should be removable
+      expect(tags[0]).toHaveClass('dnb-tag--removable')
+      // Option 2 - disabled, should not be removable
+      expect(tags[1]).not.toHaveClass('dnb-tag--removable')
+      // Option 3 - enabled, should be removable
+      expect(tags[2]).toHaveClass('dnb-tag--removable')
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -2262,9 +2262,7 @@ describe('MultiSelection', () => {
 
       await waitFor(() => {
         expect(
-          document.querySelector(
-            '.dnb-forms-field-multi-selection__items'
-          )
+          document.querySelector('.dnb-forms-field-multi-selection__items')
         ).toBeInTheDocument()
       })
 
@@ -2300,9 +2298,7 @@ describe('MultiSelection', () => {
 
       await waitFor(() => {
         expect(
-          document.querySelector(
-            '.dnb-forms-field-multi-selection__items'
-          )
+          document.querySelector('.dnb-forms-field-multi-selection__items')
         ).toBeInTheDocument()
       })
 
@@ -2338,9 +2334,7 @@ describe('MultiSelection', () => {
 
       await waitFor(() => {
         expect(
-          document.querySelector(
-            '.dnb-forms-field-multi-selection__items'
-          )
+          document.querySelector('.dnb-forms-field-multi-selection__items')
         ).toBeInTheDocument()
       })
 


### PR DESCRIPTION
Deploy preview: https://fix-multi-selection-clear-al.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos/#with-selected-item-tags
Main preview: https://main.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos/#with-selected-item-tags

Previously 'Clear all' removed every item including disabled ones, and
disabled items rendered as removable tags. Since disabled checkboxes
cannot be re-selected, this created an inconsistent one-way removal.

- onClearAll now preserves disabled items in the selection
- handleRemoveTag skips disabled items
- Disabled items render as non-removable (default variant) tags



From:

https://github.com/user-attachments/assets/6eba6d19-c069-454d-936c-6023bffb57e4




To:
<img width="500" height="644" alt="Screenshot 2026-05-13 at 12 10 55" src="https://github.com/user-attachments/assets/802c4d77-19ba-4cb6-a007-293c9316bb0d" />


From:



https://github.com/user-attachments/assets/d0d69bfd-04d9-4b70-97bf-aac0706c9aff


To:

https://github.com/user-attachments/assets/f5741350-f3b9-490d-ba95-644d384a1ebc


