### PR TITLE
fix(BankAccountNumber): sync valueRef with external value changes

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -55,6 +55,10 @@ function BankAccountNumber(props: FieldBankAccountNumberProps) {
   const [maskValue, setMaskValue] = useState(value ?? defaultValue)
 
   useEffect(() => {
+    valueRef.current = value ?? defaultValue
+  }, [value, defaultValue])
+
+  useEffect(() => {
     if (value !== undefined && hasVariableMask(bankAccountType)) {
       setMaskValue(value)
     }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
@@ -1292,4 +1292,66 @@ describe('Field.BankAccountNumber', () => {
       expect(onChange).toHaveBeenLastCalledWith(undefined)
     })
   })
+
+  describe('external value sync', () => {
+    it('should sync valueRef when value prop changes externally', async () => {
+      const { rerender } = render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="1234567"
+          validate={false}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('123-4567')
+
+      // Change value externally
+      rerender(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="9876543"
+          validate={false}
+        />
+      )
+
+      // Focus and blur to trigger handleBlur which uses valueRef
+      fireEvent.focus(input)
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('987-6543')
+      })
+    })
+
+    it('should sync valueRef when value is cleared externally', async () => {
+      const { rerender } = render(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value="1234567"
+          validate={false}
+        />
+      )
+
+      const input = document.querySelector('input')
+      expect(input).toHaveValue('123-4567')
+
+      // Clear value externally
+      rerender(
+        <Field.BankAccountNumber
+          bankAccountType="swedishBankgiro"
+          value={undefined}
+          validate={false}
+        />
+      )
+
+      // Focus and blur to trigger handleBlur which uses valueRef
+      fireEvent.focus(input)
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(input).toHaveValue('')
+      })
+    })
+  })
 })


### PR DESCRIPTION
valueRef was only updated inside handleChange (user input) but never when the external value prop changed. Add a useEffect that syncs valueRef.current when value or defaultValue changes, so handleBlur computes the correct mask after external updates.

