### PR TITLE
fix(DateOfBirth): sync day/month/year refs with external value changes

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -258,8 +258,26 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
 
         forceUpdate()
       }
+    } else {
+      // Clear refs when the external value is reset (e.g. form reset).
+      // Only clear when the refs still form a complete date, which means
+      // the reset came from outside. During normal editing the individual
+      // change handlers already set the cleared ref to emptyValue, so
+      // joinValue will return undefined and we skip the clear.
+      const currentValues = joinValue(
+        [yearRef.current, monthRef.current, dayRef.current],
+        dateFormat
+      )
+
+      if (currentValues) {
+        dayRef.current = emptyValue
+        monthRef.current = emptyValue
+        yearRef.current = emptyValue
+
+        forceUpdate()
+      }
     }
-  }, [fieldValue, dateFormat])
+  }, [fieldValue, dateFormat, emptyValue])
 
   const handleDayChange = useCallback(
     (value: string) => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/__tests__/DateOfBirth.test.tsx
@@ -1402,4 +1402,65 @@ describe('Field.DateOfBirth', () => {
       (Field.DateOfBirth as ComponentMarkers)._supportsSpacingProps
     ).toBe(undefined)
   })
+
+  describe('external value sync', () => {
+    it('should clear day/month/year inputs when value is reset to undefined', () => {
+      const { rerender } = render(<Field.DateOfBirth value="1990-01-15" />)
+
+      const [day, month, year] = Array.from(
+        document.querySelectorAll('input')
+      )
+      expect(day).toHaveValue('15')
+      expect(month).toHaveValue('Januar')
+      expect(year).toHaveValue('1990')
+
+      rerender(<Field.DateOfBirth value={undefined} />)
+
+      expect(day).toHaveValue('')
+      expect(month).toHaveValue('')
+      expect(year).toHaveValue('')
+    })
+
+    it('should clear inputs when Form.Handler data is reset', () => {
+      const { rerender } = render(
+        <Form.Handler data={{ birthDate: '1990-01-15' }}>
+          <Field.DateOfBirth path="/birthDate" />
+        </Form.Handler>
+      )
+
+      const [day, month, year] = Array.from(
+        document.querySelectorAll('input')
+      )
+      expect(day).toHaveValue('15')
+      expect(month).toHaveValue('Januar')
+      expect(year).toHaveValue('1990')
+
+      rerender(
+        <Form.Handler data={{ birthDate: undefined }}>
+          <Field.DateOfBirth path="/birthDate" />
+        </Form.Handler>
+      )
+
+      expect(day).toHaveValue('')
+      expect(month).toHaveValue('')
+      expect(year).toHaveValue('')
+    })
+
+    it('should update inputs when value changes externally', () => {
+      const { rerender } = render(<Field.DateOfBirth value="1990-01-15" />)
+
+      const [day, month, year] = Array.from(
+        document.querySelectorAll('input')
+      )
+      expect(day).toHaveValue('15')
+      expect(month).toHaveValue('Januar')
+      expect(year).toHaveValue('1990')
+
+      rerender(<Field.DateOfBirth value="2000-06-25" />)
+
+      expect(day).toHaveValue('25')
+      expect(month).toHaveValue('Juni')
+      expect(year).toHaveValue('2000')
+    })
+  })
 })


### PR DESCRIPTION
When the external value is reset (e.g. form reset, Form.Handler data change), the day/month/year refs were not cleared because the useEffect only handled truthy fieldValue. Add an else branch that clears all refs when fieldValue becomes falsy and the refs still form a complete date, indicating the reset came from outside rather than from the user clearing a single field during editing.

