### PR TITLE
fix: guard AccordionStore localStorage access for SSR safety

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
@@ -82,7 +82,7 @@ export class Store {
         }
 
         const storeId = this.storeId(id)
-        if (storeId) {
+        if (storeId && typeof window !== 'undefined') {
           window.localStorage.setItem(storeId, JSON.stringify(store))
         }
       } catch (e) {
@@ -96,7 +96,7 @@ export class Store {
   getData(id = this.id): AccordionStoreDataReturn {
     const storeId = this.storeId(id)
 
-    if (storeId) {
+    if (storeId && typeof window !== 'undefined') {
       try {
         if (Object.hasOwn(window.localStorage, storeId)) {
           return JSON.parse(window.localStorage.getItem(storeId))
@@ -129,7 +129,7 @@ export class Store {
     if (id) {
       try {
         const storeId = this.storeId(id)
-        if (storeId) {
+        if (storeId && typeof window !== 'undefined') {
           window.localStorage.setItem(storeId, null)
         }
       } catch (e) {

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -203,6 +203,37 @@ describe('Accordion store API', () => {
     expect(inst.getState('remembered-state-2')).toBe(null)
     expect(inst.getData()).toBe(null)
   })
+
+  it('will return null from getData when window is undefined (SSR)', () => {
+    const originalWindow = globalThis.window
+    delete (globalThis as Record<string, unknown>).window
+
+    const inst = Accordion.Store('ssr-test-id')
+    expect(inst.getData()).toBe(null)
+    expect(inst.getState()).toBe(null)
+
+    globalThis.window = originalWindow
+  })
+
+  it('will not throw from saveState when window is undefined (SSR)', () => {
+    const originalWindow = globalThis.window
+    delete (globalThis as Record<string, unknown>).window
+
+    const inst = Accordion.Store('ssr-test-id')
+    expect(() => inst.saveState(true)).not.toThrow()
+
+    globalThis.window = originalWindow
+  })
+
+  it('will not throw from flush when window is undefined (SSR)', () => {
+    const originalWindow = globalThis.window
+    delete (globalThis as Record<string, unknown>).window
+
+    const inst = Accordion.Store('ssr-test-id')
+    expect(() => inst.flush()).not.toThrow()
+
+    globalThis.window = originalWindow
+  })
 })
 
 describe('Accordion group component', () => {


### PR DESCRIPTION
Can be experienced when used together with `rememberState`