### PR TITLE
fix: add SSR guards to text selection helpers

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.tsx
@@ -13,6 +13,7 @@ import {
   getSelectedElement,
   hasSelectedText,
   getSelectedText,
+  emptySelectedText,
   isiOS,
   isSafari,
   isWin,
@@ -311,5 +312,34 @@ describe('"warn" should', () => {
       'message-1',
       'message-2'
     )
+  })
+})
+
+describe('SSR safety', () => {
+  let originalWindow: typeof globalThis.window
+
+  beforeEach(() => {
+    originalWindow = globalThis.window
+    delete (globalThis as Record<string, unknown>).window
+  })
+
+  afterEach(() => {
+    globalThis.window = originalWindow
+  })
+
+  it('getSelectedText returns undefined when window is undefined', () => {
+    expect(getSelectedText()).toBeUndefined()
+  })
+
+  it('emptySelectedText does not throw when window is undefined', () => {
+    expect(() => emptySelectedText()).not.toThrow()
+  })
+
+  it('hasSelectedText returns false when window is undefined', () => {
+    expect(hasSelectedText()).toBe(false)
+  })
+
+  it('getSelectedElement returns null when window is undefined', () => {
+    expect(getSelectedElement()).toBeNull()
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers.ts
@@ -249,6 +249,9 @@ export function scrollToLocationHashId({
 }
 
 export function getSelectedText() {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
   try {
     return window.getSelection().toString()
   } catch (e) {
@@ -258,6 +261,9 @@ export function getSelectedText() {
 }
 
 export function emptySelectedText() {
+  if (typeof window === 'undefined') {
+    return
+  }
   try {
     if (window.getSelection && window.getSelection().empty) {
       window.getSelection().empty()
@@ -268,10 +274,13 @@ export function emptySelectedText() {
 }
 
 export function hasSelectedText() {
-  return getSelectedText().length > 0
+  return (getSelectedText() || '').length > 0
 }
 
 export function getSelectedElement() {
+  if (typeof window === 'undefined') {
+    return null
+  }
   try {
     const selection = window.getSelection()
     if (selection.rangeCount > 0) {


### PR DESCRIPTION
Add typeof window !== 'undefined' checks to getSelectedText, emptySelectedText, getSelectedElement, and fix hasSelectedText to handle undefined return from getSelectedText during SSR.

These functions access window.getSelection() which is unavailable during server-side rendering. While previously protected by try/catch, the explicit guards make the SSR behavior clear and avoid relying on error handling for normal control flow.

