### PR TITLE
chore: return default LOCALE when resolveLocale('auto') runs during SSR

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -23,6 +23,7 @@ import {
   formatPercent,
   formatBankAccountNumberByType,
 } from '../NumberUtils'
+import { resolveLocale } from '../utils/formatCore'
 
 const locale = LOCALE
 const value = 12345678.9876
@@ -1462,5 +1463,28 @@ describe('formatPhoneNumber', () => {
       expect(result.number).toBe('47 12 34 56 78')
       expect(result.aria).toBe('47 12 34 56 78')
     })
+  })
+})
+
+describe('resolveLocale', () => {
+  it('should return LOCALE when locale is null', () => {
+    expect(resolveLocale(null)).toBe(LOCALE)
+  })
+
+  it('should return LOCALE when locale is empty string', () => {
+    expect(resolveLocale('')).toBe(LOCALE)
+  })
+
+  it('should return the given locale when it is a specific value', () => {
+    expect(resolveLocale('en-US')).toBe('en-US')
+  })
+
+  it('should return LOCALE when locale is "auto" and window is undefined', () => {
+    const originalWindow = globalThis.window
+    delete (globalThis as Record<string, unknown>).window
+
+    expect(resolveLocale('auto')).toBe(LOCALE)
+
+    globalThis.window = originalWindow
   })
 })

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -39,10 +39,13 @@ export function resolveLocale(locale: string | null): string {
   }
   if (locale === 'auto') {
     try {
-      return window.navigator.language
+      if (typeof window !== 'undefined') {
+        return window.navigator.language
+      }
     } catch (e) {
       warn(e)
     }
+    return LOCALE
   }
   return locale
 }


### PR DESCRIPTION
Motivation: https://main.eufemia-e25.pages.dev/uilib/components/number-format/demos
Deploy preview https://fix-ssr-resolve-locale-fallb.eufemia-e25.pages.dev/uilib/components/number-format/demos


