### PR TITLE
feat(Space): add useSpacing hook and apply to all components and deprecate applySpacing

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -231,7 +231,7 @@ import {
   validateDOMAttributes,
   extendPropsWithContext,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 import type { SpacingProps } from '../../shared/types'
 
@@ -256,8 +256,8 @@ function MyComponent(props: ComponentAllProps) {
   // This helper will remove e.g. all spacing properties so you get only valid HTML attributes
   validateDOMAttributes(props, rest)
 
-  // This helper applies spacing classes and CSS custom properties to the root element props
-  const rootParams = applySpacing(props, {
+  // This hook applies spacing classes and CSS custom properties to the root element props
+  const rootParams = useSpacing(props, {
     ...rest,
     className: clsx('dnb-my-component', className),
   })

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -3182,11 +3182,11 @@ For example, update:
 
 An ESLint rule (`naming-conventions/no-bare-props-export`) is now enforced to prevent re-introducing bare `Props` exports.
 
-## `createSpacingClasses` replaced with `applySpacing`
+## `createSpacingClasses` replaced with `useSpacing`
 
-The internal spacing helper `createSpacingClasses` has been removed and replaced by `applySpacing` that returns both the spacing CSS classes and any CSS custom properties in one call:
+The internal spacing helper `createSpacingClasses` has been removed and replaced by `useSpacing` that returns both the spacing CSS classes and any CSS custom properties in one call:
 
-- `applySpacing(props, target)` – merges spacing into an existing props object (append to `className`, merge into `style`). Recommended for most component root elements.
+- `useSpacing(props, target)` – merges spacing into an existing props object (append to `className`, merge into `style`). Recommended for most component root elements.
 
 It is re-exported from `@dnb/eufemia/components/space/SpacingUtils`.
 
@@ -3209,9 +3209,9 @@ const mainParams = {
 **After (v11):**
 
 ```tsx
-import { applySpacing } from '@dnb/eufemia/components/space/SpacingUtils'
+import { useSpacing } from '@dnb/eufemia/components/space/SpacingUtils'
 
-const mainParams = applySpacing(props, {
+const mainParams = useSpacing(props, {
   className: clsx('dnb-my-component', className),
 })
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/Examples.tsx
@@ -8,7 +8,7 @@ import ComponentBox from '../../../../shared/tags/ComponentBox'
 import styled from '@emotion/styled'
 import { Space, Input, Button, P, Code } from '@dnb/eufemia/src'
 import { Provider } from '@dnb/eufemia/src/shared'
-import { applySpacing } from '@dnb/eufemia/src/components/space/SpacingUtils'
+import { useSpacing } from '@dnb/eufemia/src/components/space/SpacingUtils'
 import type { Theme } from '@emotion/react'
 
 export const Method1 = () => (
@@ -40,7 +40,7 @@ export const Method3 = () => (
     <ComponentBox
       scope={{
         RedBox,
-        applySpacing,
+        useSpacing,
       }}
       data-visual-test="spacing-method-form-row"
     >
@@ -50,7 +50,7 @@ export const Method3 = () => (
           style = null,
           ...props
         }) => {
-          const params = applySpacing(props, {
+          const params = useSpacing(props, {
             ...props,
             className: `my-component dnb-space ${className || ''}`.trim(),
             style,

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
@@ -20,7 +20,7 @@ Define the space directly.
 
 ### Spacing method #3
 
-Using `useSpacing`, `applySpacing` or `createSpacing`.
+Using the `useSpacing` hook.
 
 <Examples.Method3 />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
@@ -20,7 +20,7 @@ Define the space directly.
 
 ### Spacing method #3
 
-Using `createSpacing` or `applySpacing`.
+Using `useSpacing`, `applySpacing` or `createSpacing`.
 
 <Examples.Method3 />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
@@ -13,7 +13,7 @@ import { Space } from '@dnb/eufemia'
 
 ## Description
 
-The Space component provides `margins` within the [provided spacing patterns](/uilib/usage/layout/spacing#spacing-helpers).
+The Space component provides `margins` and inner `padding` within the [provided spacing patterns](/uilib/usage/layout/spacing#spacing-helpers).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
@@ -2,7 +2,7 @@
 draft: true
 ---
 
-| Pixel | Type       | Rem     | Custom Property      |
+| Pixel | Type       | Rem     | CSS Variable         |
 | ----- | ---------- | ------- | -------------------- |
 | 8     | `x-small`  | **0.5** | `--spacing-x-small`  |
 | 16    | `small`    | **1**   | `--spacing-small`    |

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -20,7 +20,7 @@ import {
   validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import useId from '../../shared/helpers/useId'
 
 import type { ButtonIconPosition } from '../Button'
@@ -379,7 +379,7 @@ function Accordion({
     ...restOfExtendedProps
   } = extendedProps
 
-  const mainParams = applySpacing(extendedProps, {
+  const mainParams = useSpacing(extendedProps, {
     id,
     className: clsx(
       'dnb-accordion',

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -15,7 +15,7 @@ import {
 import { useMediaQuery } from '../../shared'
 import type { AccordionContextValue } from './AccordionContext'
 import AccordionContext from './AccordionContext'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import HeightAnimation from '../height-animation/HeightAnimation'
 import type { SpacingProps } from '../../shared/types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
@@ -148,7 +148,7 @@ export default function AccordionContent(props: AccordionContentProps) {
 
   const keepInDOMContent = keepInDOM || preventRerender
 
-  const innerParams = applySpacing(rest, {
+  const innerParams = useSpacing(rest, {
     id: `${id}-content`,
     'aria-labelledby': `${id}-header`,
     className: 'dnb-accordion__content__inner',

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -12,7 +12,7 @@ import {
   validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import useId from '../../shared/helpers/useId'
 
 import Context from '../../shared/Context'
@@ -97,7 +97,7 @@ const AccordionGroup = (props: AccordionGroupProps) => {
     }
   }, [collapseAllHandleRef])
 
-  const rootProps = applySpacing(extendedProps, {
+  const rootProps = useSpacing(extendedProps, {
     className: clsx(
       'dnb-accordion-group',
       singleContainer && 'dnb-accordion-group--single-container',

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -19,7 +19,7 @@ import {
 import IconPrimary from '../icon-primary/IconPrimary'
 import clsx from 'clsx'
 import AccordionContext from './AccordionContext'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -45,7 +45,7 @@ function AccordionHeaderTitle({
 }: AccordionHeaderTitleProps) {
   return (
     <span
-      {...applySpacing(rest, {
+      {...useSpacing(rest, {
         className: 'dnb-accordion__header__title',
       })}
     >
@@ -62,15 +62,11 @@ function AccordionHeaderDescription({
   children = null,
   ...rest
 }: AccordionHeaderDescriptionProps) {
-  return children ? (
-    <span
-      {...applySpacing(rest, {
-        className: 'dnb-accordion__header__description',
-      })}
-    >
-      {children}
-    </span>
-  ) : null
+  const spacingProps = useSpacing(rest, {
+    className: 'dnb-accordion__header__description',
+  })
+
+  return children ? <span {...spacingProps}>{children}</span> : null
 }
 
 export type AccordionHeaderContainerProps = SpacingProps & {
@@ -81,15 +77,11 @@ function AccordionHeaderContainer({
   children = null,
   ...rest
 }: AccordionHeaderContainerProps) {
-  return children ? (
-    <span
-      {...applySpacing(rest, {
-        className: 'dnb-accordion__header__container',
-      })}
-    >
-      {children}
-    </span>
-  ) : null
+  const spacingProps = useSpacing(rest, {
+    className: 'dnb-accordion__header__container',
+  })
+
+  return children ? <span {...spacingProps}>{children}</span> : null
 }
 
 type AccordionHeaderIconIcon =
@@ -349,7 +341,7 @@ export const AccordionHeader = ({
     }
   }
 
-  const headerParams = applySpacing(rest, {
+  const headerParams = useSpacing(rest, {
     id: `${id}-header`,
     'aria-controls': `${id}-content`,
     'aria-expanded': context.expanded,

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -57,7 +57,7 @@ import { IS_MAC, debounce, hasSelectedText } from '../../shared/helpers'
 import useId from '../../shared/helpers/useId'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import Suffix from '../../shared/helpers/Suffix'
@@ -2351,7 +2351,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   attributesRef.current = validateDOMAttributes(null, attributes)
   Object.assign(drawerList.attributes, attributesRef.current)
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-autocomplete',
       direction && `dnb-autocomplete--${direction}`,

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import type {
 import clsx from 'clsx'
 
 // Components
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { IconIcon, IconAllProps } from '../icon/Icon'
 import Icon from '../icon/Icon'
@@ -205,7 +205,7 @@ const Avatar = (localProps: AvatarAllProps) => {
     }),
   } as CSSProperties
 
-  const rootProps = applySpacing(allProps, {
+  const rootProps = useSpacing(allProps, {
     ...props,
     className: clsx(
       'dnb-avatar',

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -3,7 +3,7 @@ import type { HTMLProps, ReactNode } from 'react'
 import clsx from 'clsx'
 
 // Components
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { AvatarSizes, AvatarVariants } from './Avatar'
 
 // Shared
@@ -132,11 +132,11 @@ const AvatarGroup = (localProps: AvatarGroupAllProps) => {
       ))
   }
 
-  const rootProps = applySpacing(props, {
+  const rootProps = useSpacing(props, {
     className: clsx('dnb-avatar__group', className),
   })
 
-  // validateDOMAttributes mutates props, so call it after applySpacing
+  // validateDOMAttributes mutates props, so call it after useSpacing
   const { skeleton, ...attributes } = validateDOMAttributes({}, props)
 
   return (

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -4,7 +4,7 @@ import type { CSSProperties, HTMLProps, JSX, ReactNode } from 'react'
 import clsx from 'clsx'
 
 // Components
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 
 // Shared
@@ -111,22 +111,18 @@ function Badge(localProps: BadgeAllProps) {
   )
   const { children, className } = allProps
 
+  const spacingProps = useSpacing(allProps, { className })
+
   if (children) {
     return (
-      <BadgeRoot {...applySpacing(allProps, {})}>
+      <BadgeRoot {...spacingProps}>
         {children}
         <BadgeElem context={context} {...allProps} className={className} />
       </BadgeRoot>
     )
   }
 
-  return (
-    <BadgeElem
-      context={context}
-      {...allProps}
-      {...applySpacing(allProps, { className })}
-    />
-  )
+  return <BadgeElem context={context} {...allProps} {...spacingProps} />
 }
 
 function BadgeRoot({

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -18,7 +18,7 @@ import clsx from 'clsx'
 
 // Components
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type {
   SectionBackgroundColor,
   SectionVariants,
@@ -261,7 +261,7 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
       : spacing
     : undefined
 
-  const navProps = applySpacing(allProps, {
+  const navProps = useSpacing(allProps, {
     ...props,
     'aria-label': convertJsxToString(navText),
     className: clsx(

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -27,7 +27,7 @@ import {
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -357,7 +357,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
 
   const titleString = convertJsxToString(title) || undefined
 
-  const params = applySpacing(props, {
+  const params = useSpacing(props, {
     className: clsx(
       'dnb-button',
       `dnb-button--${usedVariant || 'primary'}`,

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -27,7 +27,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -299,7 +299,7 @@ function Checkbox(localProps: CheckboxProps) {
     suffix,
   ])
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-checkbox',
       status && `dnb-checkbox__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
@@ -22,7 +22,7 @@ import {
 import { format } from 'date-fns'
 import type { SpacingProps } from '../../shared/types'
 import clsx from 'clsx'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { SkeletonShow } from '../Skeleton'
 import Tooltip from '../Tooltip'
 import {
@@ -115,18 +115,14 @@ function DateFormat(props: DateFormatProps) {
     return getDuration('full')
   }, [getDuration])
 
-  const attributes = useMemo(() => {
-    const attrs = applySpacing(props, {
-      className: clsx(
-        'dnb-date-format',
-        createSkeletonClass('font', skeleton, context)
-      ),
-      lang: locale, // Makes sure that screen readers are reading the date correctly in the system language.
-    })
-    skeletonDOMAttributes(attrs, skeleton, context)
-
-    return attrs
-  }, [props, skeleton, context, locale])
+  const attributes = useSpacing(props, {
+    className: clsx(
+      'dnb-date-format',
+      createSkeletonClass('font', skeleton, context)
+    ),
+    lang: locale, // Makes sure that screen readers are reading the date correctly in the system language.
+  })
+  skeletonDOMAttributes(attributes, skeleton, context)
 
   const getAbsoluteDateTime = useCallback(
     (style = 'yyyy-MM-dd') => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -30,7 +30,7 @@ import {
   validateDOMAttributes,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { skeletonDOMAttributes } from '../skeleton/SkeletonHelper'
 
 import Context from '../../shared/Context'
@@ -635,7 +635,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
       : selectedDate.replace(/%s/, formatDate(startDate, options))
   }, [range, translation, dates, context.locale])
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-date-picker',
       status && `dnb-date-picker__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -34,7 +34,7 @@ import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLay
 import useId from '../../shared/helpers/useId'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
 import Suffix from '../../shared/helpers/Suffix'
@@ -510,7 +510,7 @@ const DropdownInstance = memo(function DropdownInstance({
     validateDOMAttributes(null, attributes)
   )
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-dropdown',
       `dnb-dropdown--${direction}`,

--- a/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/Container.test.tsx
@@ -5,7 +5,7 @@ import { axeComponent } from '../../../core/jest/jestSetup'
 import 'mock-match-media/jest-setup'
 import { setMedia, matchMedia } from 'mock-match-media'
 import Flex from '../Flex'
-import { applySpacing } from '../../space/SpacingUtils'
+import { useSpacing } from '../../space/SpacingUtils'
 import type { SpaceProps } from '../../Space'
 import { Form } from '../../../extensions/forms'
 import H1 from '../../../elements/H1'
@@ -490,7 +490,7 @@ describe('Flex.Container', () => {
       Wrapper._supportsSpacingProps = undefined
 
       const TestComponent = (props: SpaceProps) => {
-        const params = applySpacing(props, { className: 'test-item' })
+        const params = useSpacing(props, { className: 'test-item' })
         return <div {...params}>content</div>
       }
       TestComponent._supportsSpacingProps = undefined

--- a/packages/dnb-eufemia/src/components/flex/stories/Flex.stories.tsx
+++ b/packages/dnb-eufemia/src/components/flex/stories/Flex.stories.tsx
@@ -8,7 +8,7 @@ import { P } from '../../../elements'
 import { Field, Form, TestElement } from '../../../extensions/forms'
 import type { SpaceProps } from '../../Space'
 import { Section } from '../../lib'
-import { applySpacing } from '../../space/SpacingUtils'
+import { useSpacing } from '../../space/SpacingUtils'
 import Flex from '../Flex'
 
 export default {
@@ -23,7 +23,7 @@ const Wrapper = Flex.withChildren(
 
 export function FlexWithVisibility() {
   const TestComponent = (props: SpaceProps) => {
-    const params = applySpacing(props, { className: 'test-item' })
+    const params = useSpacing(props, { className: 'test-item' })
     return <div {...params}>content</div>
   }
   TestComponent._supportsSpacingProps = true

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -17,7 +17,7 @@ import {
   extendPropsWithContext,
   validateDOMAttributes,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   createSkeletonClass,
   skeletonDOMAttributes,
@@ -99,7 +99,7 @@ function FormLabel(localProps: FormLabelAllProps) {
     (typeof props.onClick === 'function' || forId)
   )
 
-  const params = applySpacing(
+  const params = useSpacing(
     content ? { right: 'small', ...props } : omitSpacingProps(props),
     {
       className: clsx(

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -24,7 +24,7 @@ import {
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import HeightAnimation from '../height-animation/HeightAnimation'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Icon from '../icon/Icon'
 import GlobalStatusProvider from '../global-status/GlobalStatusProvider'
 import {
@@ -496,7 +496,7 @@ function FormStatusComponent(
     ...rest
   } = restOfProps
 
-  const params: Record<string, unknown> = applySpacing(props, {
+  const params: Record<string, unknown> = useSpacing(props, {
     className: clsx(
       'dnb-form-status',
       state && `dnb-form-status--${state}`,
@@ -530,7 +530,7 @@ function FormStatusComponent(
     id: !String(textId).startsWith('null') ? textId : null,
   }
 
-  const shellParams = applySpacing(
+  const shellParams = useSpacing(
     { space: shellSpace },
     {
       className: 'dnb-form-status__shell',

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -12,7 +12,7 @@ import {
   processChildren,
   extendPropsWithContext,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Anchor from '../anchor/Anchor'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import Skeleton from '../skeleton/Skeleton'
@@ -133,7 +133,7 @@ export default function GlobalError(localProps: GlobalErrorAllProps) {
     children: text,
   }
 
-  const params = applySpacing(attributes, {
+  const params = useSpacing(attributes, {
     className: clsx(
       'dnb-global-error',
       `dnb-global-error--${statusCode}`,

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -38,7 +38,7 @@ import {
   skeletonDOMAttributes,
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Hr from '../../elements/hr/Hr'
 import GlobalStatusController, {
   GlobalStatusInterceptor,
@@ -684,7 +684,7 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
     ...attributes
   } = props as GlobalStatusProps & Record<string, unknown>
 
-  const wrapperParams = applySpacing(props, {
+  const wrapperParams = useSpacing(props, {
     id,
     className: clsx(
       'dnb-global-status__wrapper',

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -8,7 +8,7 @@ import type { HTMLProps, JSX, ReactNode } from 'react'
 import clsx from 'clsx'
 import { validateDOMAttributes } from '../../shared/component-helper'
 import '../../shared/helpers'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { HeadingContextValue } from './HeadingContext'
 import HeadingContext from './HeadingContext'
 import HeadingProvider from './HeadingProvider'
@@ -280,7 +280,7 @@ export default function Heading(props: HeadingAllProps) {
     | string
     | ((props: HTMLProps<HTMLElement>) => JSX.Element) // typecasting to avoid typescript parser error ts(2590)
 
-  const elementProps = applySpacing(props, {
+  const elementProps = useSpacing(props, {
     ...attributes,
     ref: _ref,
     className: clsx(

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -10,7 +10,7 @@ import {
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import Context from '../../shared/Context'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { ButtonProps } from '../button/Button'
 import Button from '../button/Button'
 
@@ -31,7 +31,7 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
 
   const { size, icon, onClick, className, ...rest } = props
 
-  const params = applySpacing(props, {
+  const params = useSpacing(props, {
     className: clsx('dnb-help-button', className),
     size,
     icon,

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
@@ -3,6 +3,7 @@ import Context from '../../shared/Context'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import type { IconAllProps, IconProps } from '../icon/Icon'
 import { prerenderIcon, prepareIcon } from '../icon/Icon'
+import { useSpacing } from '../space/SpacingUtils'
 
 // NB: The path reflects the tsdown.config.ts -> external: '../../icons/dnb/primary_icons'
 import * as primaryIcons from '../../icons/dnb/primary_icons'
@@ -33,6 +34,11 @@ export default function IconPrimary(localProps: IconAllProps) {
     context
   )
 
+  const spacingProps = useSpacing(props, {
+    className: wrapperParams.className,
+    style: wrapperParams.style,
+  })
+
   const IconContainer = prerenderIcon({
     icon,
     size,
@@ -45,7 +51,7 @@ export default function IconPrimary(localProps: IconAllProps) {
   }
 
   return (
-    <span {...wrapperParams}>
+    <span {...wrapperParams} {...spacingProps}>
       <IconContainer {...iconParams} />
     </span>
   )

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../shared/component-helper'
 import type { ContextProps } from '../../shared/Context'
 import Context from '../../shared/Context'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import { iconCase } from './IconHelpers'
 import type { SpacingProps } from '../../shared/types'
@@ -341,7 +341,7 @@ function prepareIconParams({
   return { params, sizeAsString }
 }
 
-function prepareIconCore(
+export function prepareIcon(
   props: IconAllProps,
   context: ContextProps,
   cachedValues?: {
@@ -411,21 +411,15 @@ function prepareIconCore(
     delete wrapperParams['aria-label']
   }
 
-  Object.assign(
-    wrapperParams,
-    applySpacing(props, {
-      className: clsx(
-        'dnb-icon',
-        modifier && `dnb-icon--${modifier}`,
-        border && 'dnb-icon--border',
-        isFilled && 'dnb-icon--filled',
-        inheritColor !== false && 'dnb-icon--inherit-color',
-        sizeAsString ? `dnb-icon--${sizeAsString}` : 'dnb-icon--default',
-        createSkeletonClass(null, skeleton, context),
-        className
-      ),
-      style: wrapperParams.style,
-    })
+  wrapperParams.className = clsx(
+    'dnb-icon',
+    modifier && `dnb-icon--${modifier}`,
+    border && 'dnb-icon--border',
+    isFilled && 'dnb-icon--filled',
+    inheritColor !== false && 'dnb-icon--inherit-color',
+    sizeAsString ? `dnb-icon--${sizeAsString}` : 'dnb-icon--default',
+    createSkeletonClass(null, skeleton, context),
+    className
   )
 
   const iconToRender = getIcon(props)
@@ -454,18 +448,24 @@ function usePrepareIcon(props: IconAllProps, context: ContextProps) {
     [icon]
   )
 
-  return useMemo(
+  const result = useMemo(
     () =>
-      prepareIconCore(props, context, {
+      prepareIcon(props, context, {
         ...cachedCalcSize,
         label,
       }),
     [props, context, cachedCalcSize, label]
   )
-}
 
-export function prepareIcon(props: IconAllProps, context: ContextProps) {
-  return prepareIconCore(props, context)
+  const spacingProps = useSpacing(props, {
+    className: result.wrapperParams.className,
+    style: result.wrapperParams.style,
+  })
+
+  return {
+    ...result,
+    wrapperParams: { ...result.wrapperParams, ...spacingProps },
+  }
 }
 
 export function prerenderIcon(

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -16,7 +16,7 @@ import P from '../../elements/P'
 import { lightbulb_medium as LightbulbIcon } from '../../icons'
 
 // Shared
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
@@ -166,7 +166,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
 
   validateDOMAttributes(allProps, props)
 
-  const rootProps = applySpacing(allProps, {
+  const rootProps = useSpacing(allProps, {
     ...props,
     className: clsx(
       'dnb-info-card',

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
@@ -6,7 +6,7 @@ import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
 import useId from '../../../shared/helpers/useId'
 import Input from '../../Input'
 import FormLabel from '../../FormLabel'
-import { applySpacing } from '../../space/SpacingUtils'
+import { useSpacing } from '../../space/SpacingUtils'
 import { useSegmentedFieldValues } from '../hooks/useSegmentedFieldValues'
 import SegmentedFieldSection from './SegmentedFieldSection'
 import { ensureTextNode, listAllSections } from './dom'
@@ -362,7 +362,7 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
     </FormLabel>
   )
 
-  const wrapperProps = applySpacing(rest, {
+  const wrapperProps = useSpacing(rest, {
     ref: (element: HTMLFieldSetElement | HTMLDivElement | null) => {
       if (!hasExternalScopeRef && !scopeRef.current) {
         scopeRef.current = element as HTMLElement | null

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -48,7 +48,7 @@ import {
   convertJsxToString,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -587,7 +587,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
       ? 'medium'
       : iconSize
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-input',
       'dnb-input__border--tokens',

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -15,7 +15,7 @@ import {
   validateDOMAttributes,
   extendPropsWithContext,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { DnbDefault } from './LogoSvg'
 import type { UseThemeReturn } from '../../shared/useTheme'
 
@@ -156,7 +156,7 @@ function Logo(localProps: LogoProps) {
     inheritColor,
   ])
 
-  const rootParams = applySpacing(props, {
+  const rootParams = useSpacing(props, {
     role: 'img',
     'aria-hidden': true,
     className,

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -29,7 +29,7 @@ import {
   processChildren,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import HelpButtonInstance from '../help-button/HelpButtonInstance'
 import { getListOfModalRoots, getModalRoot } from './helpers'
 import ModalInner from './parts/ModalInner'
@@ -489,24 +489,23 @@ function ModalComponent(ownProps: ModalAllProps) {
     ? (trigger as () => JSX.Element)
     : HelpButtonInstance
 
+  const triggerSpacingProps = useSpacing(rest as SpacingProps, {
+    id: _id.current,
+    title,
+    onClick: (event: MouseEvent) => {
+      triggerAttributes?.onClick?.(event)
+      toggleOpenClose(event.nativeEvent)
+    },
+    ref: triggerRef,
+    className: clsx('dnb-modal__trigger', usedTriggerAttributes.className),
+  })
+
   return (
     <>
       {TriggerButton && !omitTriggerButton && (
         <TriggerButton
           {...usedTriggerAttributes}
-          {...applySpacing(rest as SpacingProps, {
-            id: _id.current,
-            title,
-            onClick: (event: MouseEvent) => {
-              triggerAttributes?.onClick?.(event)
-              toggleOpenClose(event.nativeEvent)
-            },
-            ref: triggerRef,
-            className: clsx(
-              'dnb-modal__trigger',
-              usedTriggerAttributes.className
-            ),
-          })}
+          {...triggerSpacingProps}
         />
       )}
 

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
@@ -34,7 +34,7 @@ import {
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import { hasSelectedText, IS_IOS } from '../../shared/helpers'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -505,7 +505,7 @@ function NumberFormat(ownProps: NumberFormatAllProps) {
     rest = injectTooltipSemantic(rest)
   }
 
-  const attributes = applySpacing(ownProps, {
+  const attributes = useSpacing(ownProps, {
     lang,
     ref: elRef,
     className: clsx(

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -21,7 +21,7 @@ import {
   extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 import { PaginationIndicator } from './PaginationHelpers'
 import InfinityScroller from './PaginationInfinity'
@@ -345,19 +345,19 @@ const PaginationInstance = memo(function PaginationInstance(
   const { currentPageInternal, items, fallbackElement, indicatorElement } =
     ctx.pagination
 
+  const mainParams = useSpacing(props, {
+    className: clsx(
+      'dnb-pagination',
+      align && `dnb-pagination--${align}`,
+      paginationBarLayout &&
+        `dnb-pagination--layout-${paginationBarLayout}`,
+      className
+    ),
+    ...attributes,
+  })
+
   // Pagination mode
   if (ctx.pagination.mode === 'pagination') {
-    const mainParams = applySpacing(props, {
-      className: clsx(
-        'dnb-pagination',
-        align && `dnb-pagination--${align}`,
-        paginationBarLayout &&
-          `dnb-pagination--layout-${paginationBarLayout}`,
-        className
-      ),
-      ...attributes,
-    })
-
     validateDOMAttributes(props, mainParams)
 
     const content = items.find(

--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -22,7 +22,7 @@ import IconPrimary from '../icon-primary/IconPrimary'
 import styleProperties from '../../style/themes/ui/properties'
 import type { LocaleProps, SpaceTypeAll } from '../../shared/types'
 import type { SkeletonShow } from '../Skeleton'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type PaginationBarProps = {
@@ -184,7 +184,7 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
   return (
     <div
       ref={paginationBarRef}
-      {...applySpacing(
+      {...useSpacing(
         { space },
         {
           className: clsx(

--- a/packages/dnb-eufemia/src/components/popover/internal/PopoverCloseButton.tsx
+++ b/packages/dnb-eufemia/src/components/popover/internal/PopoverCloseButton.tsx
@@ -2,7 +2,7 @@ import { createElement, isValidElement, useContext } from 'react'
 import type { ButtonHTMLAttributes, ComponentType, ReactNode } from 'react'
 import clsx from 'clsx'
 import Context from '../../../shared/Context'
-import { applySpacing } from '../../space/SpacingUtils'
+import { useSpacing } from '../../space/SpacingUtils'
 import { createSkeletonClass } from '../../skeleton/SkeletonHelper'
 import type { IconIcon, IconSize } from '../../icon/Icon'
 import type { SkeletonShow } from '../../skeleton/Skeleton'
@@ -96,7 +96,7 @@ export default function PopoverCloseButton({
     resolvedIconSize = 'medium'
   }
 
-  const buttonProps = applySpacing(
+  const buttonProps = useSpacing(
     { ...rest, stretch, wrap, skeleton },
     {
       title,

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
@@ -19,7 +19,7 @@ import {
   dispatchCustomElementEvent,
   extendPropsWithContext,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import ProgressIndicatorCircular from './ProgressIndicatorCircular'
 import ProgressIndicatorLinear from './ProgressIndicatorLinear'
 import { formatPercent } from '../number-format/NumberUtils'
@@ -101,7 +101,7 @@ function ProgressIndicator(props: ProgressIndicatorAllProps) {
 
   return (
     <span
-      {...applySpacing(allProps, {
+      {...useSpacing(allProps, {
         className: clsx(
           'dnb-progress-indicator',
           show && 'dnb-progress-indicator--show',

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -26,7 +26,7 @@ import {
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -390,7 +390,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
 
   const showStatus = getStatusState(status)
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-radio',
       status && `dnb-radio__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -16,7 +16,7 @@ import {
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import Space from '../Space'
 import FormLabel from '../FormLabel'
@@ -197,7 +197,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
 
   const showStatus = getStatusState(status)
 
-  const rootProps = applySpacing(props, {
+  const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-radio-group',
       status && `dnb-radio-group__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../shared/component-helper'
 import { LOCALE } from '../../shared/defaults'
 import Space from '../space/Space'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
 import type { SpacingProps } from '../../shared/types'
@@ -156,7 +156,7 @@ function Skeleton(props: SkeletonProps) {
   const showSkeleton =
     typeof show === 'boolean' || typeof show === 'string' ? show : skeleton
 
-  const params = applySpacing(extendedProps, {
+  const params = useSpacing(extendedProps, {
     className: clsx(
       figure ? 'dnb-skeleton__figure' : 'dnb-skeleton__root',
       showSkeleton && 'dnb-skeleton',

--- a/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
@@ -7,7 +7,7 @@ import { useContext } from 'react'
 import type { ElementType } from 'react'
 import clsx from 'clsx'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   createSkeletonClass,
   skeletonDOMAttributes,
@@ -58,7 +58,7 @@ export function SliderInstance() {
     extensions,
   } = allProps
 
-  const mainParams = applySpacing(allProps, {
+  const mainParams = useSpacing(allProps, {
     className: clsx(
       'dnb-slider',
       isVertical && 'dnb-slider--vertical',

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -466,24 +466,8 @@ export type ApplySpacingTarget = {
 } & Record<string, unknown>
 
 /**
- * Applies spacing to an existing props object by appending spacing CSS
- * classes to `className` and merging spacing CSS custom properties
- * (from `innerSpace`) into `style`. Spacing props (`space`, `innerSpace`,
- * `top`, `right`, `bottom`, `left`, `noCollapse`) are removed from the
- * returned object so it can be spread directly onto a DOM element.
- * Returns a new object; the input is not mutated.
- *
- * @example
- *   const mainParams = applySpacing(props, {
- *     ...attributes,
- *     className: clsx('dnb-button', className),
- *   })
- *
- * @param props - component props containing spacing properties
- *                (top, right, bottom, left, space, innerSpace, noCollapse)
- * @param target - props object to merge spacing into
- * @param elementName - optional element name for inline detection
- * @returns a new object of the same shape as `target`, with spacing merged in
+ * @deprecated Use `useSpacing` instead. This plain-function variant
+ * does not support `Space.Responsive` context.
  */
 export const applySpacing = <T extends ApplySpacingTarget>(
   props: SpacingProps | SpacingUnknownProps,
@@ -524,11 +508,28 @@ export const applySpacing = <T extends ApplySpacingTarget>(
 }
 
 /**
- * Hook-style alias for `applySpacing`, intended for use at the top level
- * of React components. Follows the `use` naming convention so it can
- * adopt React hooks internally in the future without breaking call sites.
+ * Applies spacing to an existing props object by appending spacing CSS
+ * classes to `className` and merging spacing CSS custom properties
+ * (from `innerSpace`) into `style`. Spacing props (`space`, `innerSpace`,
+ * `top`, `right`, `bottom`, `left`, `noCollapse`) are removed from the
+ * returned object so it can be spread directly onto a DOM element.
+ * Returns a new object; the input is not mutated.
  *
- * @see applySpacing
+ * Must be called at the top level of a React component so it can read
+ * context (e.g. `Space.Responsive`). Follows the `use` naming convention
+ * because it may call React hooks internally.
+ *
+ * @example
+ *   const mainParams = useSpacing(props, {
+ *     ...attributes,
+ *     className: clsx('dnb-button', className),
+ *   })
+ *
+ * @param props - component props containing spacing properties
+ *                (top, right, bottom, left, space, innerSpace, noCollapse)
+ * @param target - props object to merge spacing into
+ * @param elementName - optional element name for inline detection
+ * @returns a new object of the same shape as `target`, with spacing merged in
  */
 export const useSpacing = <T extends ApplySpacingTarget>(
   props: SpacingProps | SpacingUnknownProps,

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -523,6 +523,21 @@ export const applySpacing = <T extends ApplySpacingTarget>(
   return result
 }
 
+/**
+ * Hook-style alias for `applySpacing`, intended for use at the top level
+ * of React components. Follows the `use` naming convention so it can
+ * adopt React hooks internally in the future without breaking call sites.
+ *
+ * @see applySpacing
+ */
+export const useSpacing = <T extends ApplySpacingTarget>(
+  props: SpacingProps | SpacingUnknownProps,
+  target: T,
+  elementName: string | null = null
+): T => {
+  return applySpacing(props, target, elementName)
+}
+
 const spacingKeys = [
   'space',
   'innerSpace',

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -732,6 +732,7 @@ describe('createMarginProperties', () => {
   })
 })
 
+// @deprecated
 describe('applySpacing', () => {
   it('should add spacing classes to an existing target className', () => {
     const result = applySpacing(

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CSSProperties } from 'react'
+import { renderHook } from '@testing-library/react'
 import '../../../core/jest/jestSetup'
 import {
   spacePatterns,
@@ -19,6 +20,7 @@ import {
   createSpacingProperties,
   createMarginProperties,
   applySpacing,
+  useSpacing,
 } from '../SpacingUtils'
 import type { SpaceType } from '../types'
 
@@ -841,6 +843,30 @@ describe('applySpacing', () => {
     const target = { className: 'dnb-my-component', id: 'my-id' }
     const result = applySpacing({}, target)
     expect(result).toBe(target)
+  })
+})
+
+describe('useSpacing', () => {
+  it('should add spacing classes like applySpacing', () => {
+    const { result } = renderHook(() =>
+      useSpacing({ top: 'large' }, { className: 'dnb-my-component' })
+    )
+    expect(result.current.className).toContain('dnb-my-component')
+    expect(result.current.className).toContain('dnb-space__top--large')
+  })
+
+  it('should strip spacing props from the target', () => {
+    const { result } = renderHook(() =>
+      useSpacing({ top: 'small' }, {
+        className: 'dnb-my-component',
+        top: 'small',
+        space: 'large',
+        id: 'my-id',
+      } as Parameters<typeof useSpacing>[1])
+    )
+    expect(result.current).not.toHaveProperty('top')
+    expect(result.current).not.toHaveProperty('space')
+    expect(result.current.id).toBe('my-id')
   })
 })
 

--- a/packages/dnb-eufemia/src/components/space/index.ts
+++ b/packages/dnb-eufemia/src/components/space/index.ts
@@ -6,3 +6,4 @@
 import Space from './Space'
 export default Space
 export * from './Space'
+export { useSpacing } from './SpacingUtils'

--- a/packages/dnb-eufemia/src/components/stat/Content.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Content.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import type { ElementType, HTMLProps } from 'react'
 import clsx from 'clsx'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
 import { validateDOMAttributes, warn } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
@@ -46,7 +46,7 @@ function Content(props: ContentProps) {
 
   const attributes = validateDOMAttributes(
     props,
-    applySpacing(props, {
+    useSpacing(props, {
       ...rest,
       style,
       className: clsx(

--- a/packages/dnb-eufemia/src/components/stat/Label.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Label.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import type { ElementType, HTMLProps } from 'react'
 import clsx from 'clsx'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
 import type {
   TypographySize,
@@ -65,7 +65,7 @@ function Label(props: LabelProps) {
 
   const attributes = validateDOMAttributes(
     props,
-    applySpacing(props, {
+    useSpacing(props, {
       ...rest,
       style,
       className: clsx(

--- a/packages/dnb-eufemia/src/components/stat/Text.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Text.tsx
@@ -1,6 +1,6 @@
 import type { ElementType, HTMLProps, ReactNode } from 'react'
 import clsx from 'clsx'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type {
   TypographySize,
   TypographyWeight,
@@ -68,7 +68,7 @@ function TextInternal(props: TextInternalProps) {
 
   const attributes = validateDOMAttributes(
     props,
-    applySpacing(props, {
+    useSpacing(props, {
       ...rest,
       'aria-label': ariaLabel,
       style,

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -5,7 +5,7 @@
 
 import { useContext } from 'react'
 import type { HTMLProps, MouseEvent, ReactNode } from 'react'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Card from '../Card'
 import CardContext from '../card/CardContext'
 import StepIndicatorTriggerButton from './StepIndicatorTriggerButton'
@@ -146,7 +146,7 @@ function StepIndicator({
       <div className="dnb-step-indicator-wrapper">
         <Card
           align="stretch"
-          {...applySpacing(restOfProps, {
+          {...useSpacing(restOfProps, {
             className: 'dnb-step-indicator',
           })}
           backgroundColor="var(--step-indicator-trigger-content-background)"

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../shared/component-helper'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -247,7 +247,7 @@ function Switch(props: SwitchProps) {
 
   const showStatus = useMemo(() => getStatusState(status), [status])
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-switch',
       size && `dnb-switch--${size}`,

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, Ref, RefObject, TableHTMLAttributes } from 'react'
 import clsx from 'clsx'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import {
   extendPropsWithContext,
@@ -152,7 +152,7 @@ const Table = (componentProps: TableAllProps) => {
 
   validateDOMAttributes(allProps, props)
 
-  const tableProps = applySpacing(allProps, {
+  const tableProps = useSpacing(allProps, {
     ...props,
     ref: mergedRef,
     className: clsx(

--- a/packages/dnb-eufemia/src/components/table/TableContainer.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableContainer.tsx
@@ -8,7 +8,7 @@ import type {
 import clsx from 'clsx'
 import type { TableScrollViewProps } from './TableScrollView'
 import TableScrollView from './TableScrollView'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 import type { TableProps } from './Table'
 import type { SpacingProps } from '../../shared/types'
@@ -44,7 +44,7 @@ export default function TableContainer(props: TableContainerAllProps) {
 
   validateDOMAttributes(props, rest)
 
-  const sectionProps = applySpacing(props, {
+  const sectionProps = useSpacing(props, {
     className: clsx('dnb-table__container', className),
     ...rest,
   })

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -36,7 +36,7 @@ import {
   combineLabelledBy,
 } from '../../shared/component-helper'
 import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithContext'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type {
   DynamicElement,
   InnerSpaceType,
@@ -1109,17 +1109,22 @@ function TabsComponent(ownProps: TabsProps) {
     useRef<(p?: Record<string, unknown>) => ReactElement>(null)
 
   // Update render functions with latest state on every render
+  const { className } = ownProps as TabsProps
+  const { ...attributes } = filterProps(ownProps, tabsDefaultProps)
+
+  const wrapperSpacingParams: Record<string, unknown> = useSpacing(
+    ownProps,
+    {
+      ...attributes,
+      className: clsx('dnb-tabs', className),
+    }
+  )
+
   renderWrapperRef.current = ({
     children,
     ...rest
   }: PropsWithChildren<Record<string, unknown>>) => {
-    const { className } = ownProps as TabsProps
-    const { ...attributes } = filterProps(ownProps, tabsDefaultProps)
-
-    const params: Record<string, unknown> = applySpacing(ownProps, {
-      ...attributes,
-      className: clsx('dnb-tabs', className),
-    })
+    const params = { ...wrapperSpacingParams }
 
     validateDOMAttributes(ownProps, params)
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
@@ -6,7 +6,7 @@ import {
   validateDOMAttributes,
   combineLabelledBy,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Section from '../section/Section'
 import {
   createSharedState,
@@ -70,6 +70,26 @@ export default function ContentWrapper({
     }
   }, [id])
 
+  const resolvedInnerSpace =
+    contentInnerSpace === true ? 'large' : contentInnerSpace
+
+  const spacingProps = useSpacing(
+    {
+      ...rest,
+      innerSpace:
+        !contentStyle && resolvedInnerSpace
+          ? resolvedInnerSpace
+          : undefined,
+    },
+    {
+      className: clsx(
+        'dnb-tabs__content',
+        'dnb-no-focus',
+        !contentStyle && resolvedInnerSpace && 'dnb-space'
+      ),
+    }
+  )
+
   if (!children) {
     return null
   }
@@ -108,9 +128,6 @@ export default function ContentWrapper({
     content = children(stateToPass) as ReactNode
   }
 
-  const resolvedInnerSpace =
-    contentInnerSpace === true ? 'large' : contentInnerSpace
-
   return (
     <HeightAnimation
       role="tabpanel"
@@ -136,22 +153,7 @@ export default function ContentWrapper({
             }
           : 'div') as DynamicElement
       }
-      {...applySpacing(
-        {
-          ...rest,
-          innerSpace:
-            !contentStyle && resolvedInnerSpace
-              ? resolvedInnerSpace
-              : undefined,
-        },
-        {
-          className: clsx(
-            'dnb-tabs__content',
-            'dnb-no-focus',
-            !contentStyle && resolvedInnerSpace && 'dnb-space'
-          ),
-        }
-      )}
+      {...spacingProps}
       duration={600}
       animate={animate === true}
       {...params}

--- a/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsCustomContent.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps, ReactNode } from 'react'
 import clsx from 'clsx'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
 import ContentWrapper, {
   type TabsContentWrapperProps,
@@ -52,6 +52,10 @@ function CustomContent(props: TabsCustomContentProps) {
     ...rest
   } = props
 
+  const spacingProps = useSpacing(rest, {
+    className: clsx('dnb-tabs__content__inner', className),
+  })
+
   if (id) {
     const contentWrapperProps = rest as unknown as Omit<
       TabsContentWrapperProps,
@@ -64,15 +68,7 @@ function CustomContent(props: TabsCustomContentProps) {
     )
   }
 
-  return (
-    <div
-      {...applySpacing(rest, {
-        className: clsx('dnb-tabs__content__inner', className),
-      })}
-    >
-      {children as ReactNode}
-    </div>
-  )
+  return <div {...spacingProps}>{children as ReactNode}</div>
 }
 
 export default CustomContent

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -21,7 +21,7 @@ import {
 // Internal
 import TagGroup from './TagGroup'
 import { TagGroupContext } from './TagContext'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 export type TagProps = {
   /**
@@ -134,7 +134,7 @@ const Tag = (
 
   const addIcon = usedVariant === 'removable' || variant === 'addable'
   const isInteractive = usedVariant !== 'default'
-  const tagProps = applySpacing(props, {
+  const tagProps = useSpacing(props, {
     className: clsx(
       'dnb-tag',
       className,

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, HTMLProps, ReactNode } from 'react'
 import clsx from 'clsx'
 
 // Components
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 // Shared
 import {
@@ -71,7 +71,7 @@ const TagGroup = (
     })
   }
 
-  const spacingProps = applySpacing(props, {
+  const spacingProps = useSpacing(props, {
     className: clsx('dnb-tag__group', className),
   })
   const { skeleton, ...attributes } = validateDOMAttributes({}, {

--- a/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
@@ -14,7 +14,7 @@ import Popover from '../popover/Popover'
 import useId from '../../shared/helpers/useId'
 import useTranslation from '../../shared/useTranslation'
 import type { SpacingProps } from '../../shared/types'
-import { applySpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
 import Context from '../../shared/Context'
 import { extendPropsWithContext } from '../../shared/component-helper'
 
@@ -102,7 +102,7 @@ export default function TermDefinition(
   return (
     <>
       <span
-        {...applySpacing(rest, {
+        {...useSpacing(rest, {
           role: 'button',
           tabIndex: 0,
           ref: triggerRef,

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -44,7 +44,7 @@ import {
 import { isWin, isMac } from '../../shared/helpers'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -530,7 +530,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     textareaParams['aria-readonly'] = textareaParams.readOnly = true
   }
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-textarea',
       `dnb-textarea--${textareaState}`,

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -3,7 +3,7 @@ import type { AllHTMLAttributes, ReactElement, Ref } from 'react'
 import clsx from 'clsx'
 
 // Components
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 // Shared
 import Context from '../../shared/Context'
@@ -75,7 +75,7 @@ const Timeline = (localProps: TimelineAllProps) => {
 
   validateDOMAttributes(allProps, props)
 
-  const olProps = applySpacing(allProps, {
+  const olProps = useSpacing(allProps, {
     ...props,
     className: clsx('dnb-timeline', 'dnb-space__reset', className),
   })

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 import Radio from '../radio/Radio'
 import Checkbox from '../checkbox/Checkbox'
@@ -315,7 +315,7 @@ function ToggleButton(ownProps: ToggleButtonProps) {
 
   const showStatus = getStatusState(status)
 
-  const mainParams = applySpacing(props, {
+  const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button',
       status && `dnb-toggle-button__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -16,7 +16,7 @@ import {
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import FormLabel from '../FormLabel'
 import FormStatus from '../FormStatus'
@@ -193,7 +193,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
 
   const showStatus = getStatusState(status)
 
-  const rootProps = applySpacing(props, {
+  const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button-group',
       status && `dnb-toggle-button-group__status--${statusState}`,

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -10,7 +10,7 @@ import Context from '../../shared/Context'
 import type { ContextProps } from '../../shared/Context'
 import { validateDOMAttributes } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import TooltipWithEvents from './TooltipWithEvents'
 import {
   defaultProps,
@@ -54,11 +54,7 @@ function Tooltip(localProps: TooltipAllProps) {
   const internalId = useId(id)
   const isControlled = typeof open === 'boolean'
 
-  if (targetSource && !target) {
-    return null
-  }
-
-  const attributes = applySpacing(props, {
+  const attributes = useSpacing(props, {
     ...attributeProps,
     className: clsx(
       'dnb-tooltip',
@@ -69,6 +65,11 @@ function Tooltip(localProps: TooltipAllProps) {
 
   // also used for code markup simulation
   validateDOMAttributes(localProps, attributes)
+
+  if (targetSource && !target) {
+    return null
+  }
+
   return (
     <TooltipContext value={{ isControlled, internalId, props }}>
       <TooltipWithEvents

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -3,7 +3,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import clsx from 'clsx'
 
 // Shared
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Provider from '../../shared/Provider'
 import Context from '../../shared/Context'
 import {
@@ -161,7 +161,7 @@ const Upload = (localProps: UploadAllProps) => {
     >
       <Provider skeleton={skeleton}>
         <UploadWrapper
-          {...applySpacing(props, {
+          {...useSpacing(props, {
             className: clsx(
               'dnb-upload',
               'dnb-form-component',

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
@@ -2,7 +2,7 @@ import Anchor from '../../components/Anchor'
 import Button from '../button/Button'
 import Span from '../../elements/Span'
 import type { SpacingProps } from '../../shared/types'
-import { applySpacing } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 export type UploadFileLinkProps = UploadFileAnchorProps &
   UploadFileButtonProps
@@ -48,7 +48,7 @@ const UploadFileButton = (props: UploadFileButtonProps) => {
       icon={false}
       variant="tertiary"
       onClick={onClick}
-      {...applySpacing(props, {})}
+      {...useSpacing(props, {})}
     >
       {text}
     </Button>
@@ -69,7 +69,7 @@ const UploadFileAnchor = (props: UploadFileAnchorProps) => {
       target="_blank"
       href={href}
       download={download ? text : null}
-      {...applySpacing(props, {
+      {...useSpacing(props, {
         className: 'dnb-anchor--no-launch-icon',
       })}
       rel="noopener noreferrer"

--- a/packages/dnb-eufemia/src/elements/Element.tsx
+++ b/packages/dnb-eufemia/src/elements/Element.tsx
@@ -11,7 +11,7 @@ import {
   validateDOMAttributes,
   extendPropsWithContext,
 } from '../shared/component-helper'
-import { applySpacing } from '../components/space/SpacingUtils'
+import { useSpacing } from '../components/space/SpacingUtils'
 import type { SkeletonMethods } from '../components/skeleton/SkeletonHelper'
 import {
   createSkeletonClass,
@@ -84,9 +84,9 @@ function Element(localProps: ElementAllProps) {
     createSkeletonClass(skeletonMethod, skeleton, context)
   )
 
-  // applySpacing must be called before validateDOMAttributes
+  // useSpacing must be called before validateDOMAttributes
   // because the validator removes non-DOM attributes like spacing props
-  const params = applySpacing(
+  const params = useSpacing(
     attributes,
     { ...attributes, className: internalClassName },
     typeof Tag === 'string' ? `dnb-${Tag}` : null

--- a/packages/dnb-eufemia/src/elements/img/Img.tsx
+++ b/packages/dnb-eufemia/src/elements/img/Img.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 import type { HTMLProps } from 'react'
 import E from '../Element'
 import {
-  applySpacing,
+  useSpacing,
   removeSpaceProps,
 } from '../../components/space/SpacingUtils'
 import type { DynamicElement, SpacingProps } from '../../shared/types'
@@ -42,7 +42,7 @@ const Img = ({
     <E
       as={element}
       internalClass="dnb-img"
-      {...applySpacing(p, { className }, p.is)}
+      {...useSpacing(p, { className }, p.is)}
       skeleton={skeleton}
       skeletonMethod="shape"
     >

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
@@ -11,7 +11,7 @@ import {
   extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
-import { applySpacing } from '../../components/space/SpacingUtils'
+import { useSpacing } from '../../components/space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -162,7 +162,7 @@ function PaymentCard(props: PaymentCardProps) {
 
   const cardData = rawData || getCardData(productCode)
 
-  const params = applySpacing(extendedProps, {
+  const params = useSpacing(extendedProps, {
     className: clsx(
       'dnb-payment-card',
       `dnb-payment-card--${variant}`,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -24,7 +24,7 @@ import {
 import type { SpacingProps } from '../../shared/types'
 import type { Translation } from '../../shared/Context'
 
-import { applySpacing } from '../../components/space/SpacingUtils'
+import { useSpacing } from '../../components/space/SpacingUtils'
 
 import E from '../../elements/Element'
 import type { DrawerListContextValue } from './DrawerListContext'
@@ -499,7 +499,7 @@ const DrawerListInstance = memo(function DrawerListInstance(
   const hasGroups =
     renderData.length > 1 || renderData[0]?.groupTitle !== undefined
 
-  const mainParams = applySpacing(propsWithDefaults, {
+  const mainParams = useSpacing(propsWithDefaults, {
     id: `${id}-drawer-list`,
     className: clsx(
       'dnb-drawer-list',

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
@@ -11,7 +11,7 @@ import {
   validateDOMAttributes,
 } from '../../shared/component-helper'
 import Context from '../../shared/Context'
-import { applySpacing } from '../../components/space/SpacingUtils'
+import { useSpacing } from '../../components/space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
@@ -56,7 +56,7 @@ function ScrollView(localProps: ScrollViewAllProps) {
   const mainParams: DetailedHTMLProps<
     HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
-  > = applySpacing(props, {
+  > = useSpacing(props, {
     ...(attributes as HTMLAttributes<unknown>),
     className: clsx(
       'dnb-scroll-view',

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/withComponentMarkers.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/withComponentMarkers.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../components/flex/utils'
 import FieldBlock from '../../../extensions/forms/FieldBlock/FieldBlock'
 import Flex from '../../../components/flex/Flex'
-import { applySpacing } from '../../../components/space/SpacingUtils'
+import { useSpacing } from '../../../components/space/SpacingUtils'
 import type { SpacingProps } from '../../../components/space/types'
 
 describe('withComponentMarkers', () => {
@@ -201,7 +201,7 @@ describe('withComponentMarkers', () => {
   describe('_supportsSpacingProps behavior', () => {
     it('should apply spacing classes directly when _supportsSpacingProps is true', () => {
       function TestItem(props: SpacingProps) {
-        const params = applySpacing(props, { className: 'test-item' })
+        const params = useSpacing(props, { className: 'test-item' })
         return <div {...params}>content</div>
       }
       withComponentMarkers(TestItem, { _supportsSpacingProps: true })
@@ -269,7 +269,7 @@ describe('withComponentMarkers', () => {
 
     it('should pass spacing to children when _supportsSpacingProps is "children"', () => {
       function ChildItem(props: SpacingProps) {
-        const params = applySpacing(props, { className: 'child-item' })
+        const params = useSpacing(props, { className: 'child-item' })
         return <div {...params}>child</div>
       }
       withComponentMarkers(ChildItem, { _supportsSpacingProps: true })


### PR DESCRIPTION
So we can use dynamic spacing with React Context instead of div wrapper.

The hook is as simple as this for now:
```tsx
export const useSpacing = <T extends ApplySpacingTarget>(
  props: SpacingProps | SpacingUnknownProps,
  target: T,
  elementName: string | null = null
): T => {
  return applySpacing(props, target, elementName)
}
```