### PR TITLE
chore(Portal): add focusmode CSS class and improve toolbar layout

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -163,10 +163,18 @@
 .mainStyle {
   width: 100%;
   min-height: 90vh;
-  padding: 0 32px;
+  padding: 0 2rem;
+  :global(.focusmode) & {
+    min-height: auto;
+    padding: 0;
+  }
 
   @include utilities.allBelow(small) {
-    padding: 0 16px;
+    padding: 0 1px;
+
+    :global(.focusmode) & {
+      padding: 0;
+    }
   }
 }
 
@@ -205,6 +213,9 @@
 
   /* we use padding here, instead of margin, because applyPageFocus is else scrolling the page unwanted height of StickyMenuBar */
   padding-top: 4rem;
+  :global(.focusmode) & {
+    padding-top: 0;
+  }
 
   background-color: var(--token-color-background-neutral);
   box-shadow: inset 1px 0 0 0 var(--token-color-stroke-neutral-subtle);

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -149,7 +149,13 @@ function Layout(props: LayoutProps) {
   }
 
   return (
-    <div className={clsx(portalStyle, fs && fullscreenStyle)}>
+    <div
+      className={clsx(
+        portalStyle,
+        fs && fullscreenStyle,
+        codeFullscreen && 'focusmode'
+      )}
+    >
       <a
         className="dnb-skip-link"
         href="#dnb-app-content"

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -2,6 +2,9 @@
 
 .codeBlockStyle {
   margin-bottom: 2rem;
+  :global(.focusmode) & {
+    margin-bottom: 0;
+  }
 
   :global {
     textarea {
@@ -20,6 +23,9 @@
   height: 100%;
 
   padding: 2rem;
+  :global(.focusmode) & {
+    padding: 0;
+  }
 
   border-start-start-radius: var(--border-radius);
   border-start-end-radius: var(--border-radius);
@@ -84,6 +90,11 @@
   margin: 0 0.0625rem; // So the border of the example box is not covered by the toolbar
   padding: 0.5rem 1rem;
 
+  :global(.focusmode) & {
+    justify-content: space-between;
+    padding: 1rem 0.5rem;
+  }
+
   &:empty {
     display: none;
   }
@@ -123,7 +134,8 @@
     box-shadow: none;
   }
 
-  // Remove the outline and border-radius in visual tests
+  // Remove the outline and border-radius in visual tests or focusmode
+  :global(.focusmode) &,
   :global(html[data-visual-test]) & {
     --border-radius: 0;
     box-shadow: none;

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -19,6 +19,7 @@ import Tag from './Tag'
 import {
   Button,
   Checkbox,
+  Flex,
   Space,
   ToggleButton,
 } from '@dnb/eufemia/src/components'
@@ -275,6 +276,31 @@ function LiveCode(props: LiveCodeProps) {
     [noInline, noFragments]
   )
 
+  const fullscreenButton = (
+    <Button
+      onClick={() => {
+        if (!isFullscreen) {
+          savedScrollY.current = window.scrollY
+
+          try {
+            sessionStorage.setItem('scroll-window', String(window.scrollY))
+          } catch {
+            // ignore
+          }
+
+          window.scrollTo({ top: 0 })
+        }
+
+        setFullscreenCodeId(isFullscreen ? null : fullscreenId)
+      }}
+      variant="tertiary"
+      title={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
+      aria-label={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
+      icon={isFullscreen ? 'close' : fullscreenIcon}
+      size="medium"
+    />
+  )
+
   return (
     <div
       ref={wrapperRef}
@@ -318,7 +344,6 @@ function LiveCode(props: LiveCodeProps) {
 
           {!global.IS_TEST && !hideToolbar && (
             <Space
-              // align="center"
               element="section"
               aria-label="Customize appearance"
               className={clsx('dnb-live-toolbar', toolbarStyle)}
@@ -334,95 +359,74 @@ function LiveCode(props: LiveCodeProps) {
                   {hideCode ? 'Show Code' : 'Hide Code'}
                 </Button>
               )) || (
-                <>
-                  {hideCodeProp && (
-                    <ToggleButton
-                      checked={!hideCode}
-                      onChange={({ checked }) => setHideCode(!checked)}
-                      size="medium"
-                    >
-                      {hideCode ? 'Show Code' : 'Hide Code'}
-                    </ToggleButton>
-                  )}
+                  <>
+                    {hideCodeProp && (
+                      <ToggleButton
+                        checked={!hideCode}
+                        onChange={({ checked }) => setHideCode(!checked)}
+                        size="medium"
+                      >
+                        {hideCode ? 'Show Code' : 'Hide Code'}
+                      </ToggleButton>
+                    )}
 
-                  {hidePreviewProp && (
-                    <ToggleButton
-                      checked={!hidePreview}
-                      onChange={({ checked }) => setHidePreview(!checked)}
-                      size="medium"
-                    >
-                      Preview
-                    </ToggleButton>
-                  )}
+                    {hidePreviewProp && (
+                      <ToggleButton
+                        checked={!hidePreview}
+                        onChange={({ checked }) =>
+                          setHidePreview(!checked)
+                        }
+                        size="medium"
+                      >
+                        Preview
+                      </ToggleButton>
+                    )}
 
-                  {isFullscreen && (
-                    <ChangeStyleTheme
-                      variant="button"
-                      size="medium"
-                      optionsLayout="horizontal"
-                      labelSrOnly
-                    />
-                  )}
+                    {isFullscreen && (
+                      <ChangeStyleTheme
+                        variant="button"
+                        size="medium"
+                        optionsLayout="horizontal"
+                        labelSrOnly
+                      />
+                    )}
 
-                  <Checkbox
-                    checked={
-                      colorScheme === (inheritedDark ? 'light' : 'dark')
-                    }
-                    onChange={({ checked }) => {
-                      setColorScheme(
-                        checked
-                          ? inheritedDark
-                            ? 'light'
-                            : 'dark'
-                          : undefined
-                      )
-                    }}
-                    size="medium"
-                    label={inheritedDark ? 'Light mode' : 'Dark mode'}
-                  />
+                    <Flex.Horizontal align="center">
+                      <Checkbox
+                        checked={
+                          colorScheme ===
+                          (inheritedDark ? 'light' : 'dark')
+                        }
+                        onChange={({ checked }) => {
+                          setColorScheme(
+                            checked
+                              ? inheritedDark
+                                ? 'light'
+                                : 'dark'
+                              : undefined
+                          )
+                        }}
+                        size="medium"
+                        label={inheritedDark ? 'Light mode' : 'Dark mode'}
+                      />
 
-                  {surfaceProp === 'dark' && (
-                    <Checkbox
-                      checked={
-                        colorScheme !== 'dark' && surface === 'dark'
-                      }
-                      onChange={({ checked }) =>
-                        setSurface(checked ? 'dark' : undefined)
-                      }
-                      size="medium"
-                      label="Dark surface"
-                    />
-                  )}
-                </>
-              )}
+                      {surfaceProp === 'dark' && (
+                        <Checkbox
+                          checked={
+                            colorScheme !== 'dark' && surface === 'dark'
+                          }
+                          onChange={({ checked }) =>
+                            setSurface(checked ? 'dark' : undefined)
+                          }
+                          size="medium"
+                          label="Dark surface"
+                        />
+                      )}
 
-              <Button
-                onClick={() => {
-                  if (!isFullscreen) {
-                    savedScrollY.current = window.scrollY
-
-                    try {
-                      sessionStorage.setItem(
-                        'scroll-window',
-                        String(window.scrollY)
-                      )
-                    } catch {
-                      // ignore
-                    }
-
-                    window.scrollTo({ top: 0 })
-                  }
-
-                  setFullscreenCodeId(isFullscreen ? null : fullscreenId)
-                }}
-                variant="tertiary"
-                title={isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
-                aria-label={
-                  isFullscreen ? 'Quit Fullscreen' : 'Fullscreen'
-                }
-                icon={isFullscreen ? 'close' : fullscreenIcon}
-                size="medium"
-              />
+                      {fullscreenButton}
+                    </Flex.Horizontal>
+                  </>
+                ) || <>{fullscreenButton}</>}
             </Space>
           )}
 

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -72,6 +72,10 @@ vi.mock('@dnb/eufemia/src/components', async () => {
       ),
     Space: ({ children, ref, ...rest }: any) =>
       createElement('div', { ref: ref, ...rest }, children),
+    Flex: {
+      Horizontal: ({ children, ...rest }: any) =>
+        createElement('div', rest, children),
+    },
     ToggleButton: ({ children, checked, onChange, ...rest }: any) =>
       createElement(
         'button',


### PR DESCRIPTION
This makes the focus mode 100% "fullscreen". No additional padding.

After:
<img width="517" height="553" alt="Screenshot 2026-05-14 at 06 57 53" src="https://github.com/user-attachments/assets/600fb33b-28f8-4774-a1c0-598279785bf1" />

Before:
<img width="532" height="512" alt="Screenshot 2026-05-14 at 06 57 06" src="https://github.com/user-attachments/assets/a783ff8e-f429-4706-9774-8a41184aa530" />
