### PR TITLE
chore(Portal): rebuild routes when page files are added or removed

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
-import {
+import { EventEmitter } from 'node:events'
+import portalPagesPlugin, {
   getVirtualModuleSignature,
   readPageFileInfo,
   shouldIgnore,
@@ -10,7 +11,6 @@ import {
   slugify,
   extractTableOfContents,
 } from '../../client/plugins/portal-pages'
-import portalPagesPlugin from '../../client/plugins/portal-pages'
 
 describe('portal-pages plugin', () => {
   describe('shouldIgnore', () => {
@@ -651,6 +651,154 @@ describe('portal-pages plugin', () => {
 
       const files = scanPageFiles(tmpDir)
       expect(files[0].tableOfContents).toBeUndefined()
+    })
+  })
+
+  describe('configureServer file watcher', () => {
+    let tmpDir: string
+
+    function createMockServer() {
+      const watcher = new EventEmitter()
+      const mod = { id: '\0virtual:portal-pages' }
+      const invalidateModule = vi.fn()
+      const getModuleById = vi.fn(() => mod)
+      const send = vi.fn()
+
+      return {
+        watcher,
+        moduleGraph: { getModuleById, invalidateModule },
+        ws: { send },
+        mocks: { invalidateModule, getModuleById, send, mod },
+      }
+    }
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'portal-pages-watcher-')
+      )
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('invalidates routes when an MDX page file is added', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('add', path.join(tmpDir, 'new-page.mdx'))
+
+      expect(server.mocks.invalidateModule).toHaveBeenCalledWith(
+        server.mocks.mod
+      )
+      expect(server.mocks.send).toHaveBeenCalledWith({
+        type: 'full-reload',
+      })
+    })
+
+    it('invalidates routes when a TSX page file is added', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('add', path.join(tmpDir, 'new-page.tsx'))
+
+      expect(server.mocks.invalidateModule).toHaveBeenCalledWith(
+        server.mocks.mod
+      )
+      expect(server.mocks.send).toHaveBeenCalledWith({
+        type: 'full-reload',
+      })
+    })
+
+    it('invalidates routes when a page file is removed', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('unlink', path.join(tmpDir, 'old-page.mdx'))
+
+      expect(server.mocks.invalidateModule).toHaveBeenCalledWith(
+        server.mocks.mod
+      )
+      expect(server.mocks.send).toHaveBeenCalledWith({
+        type: 'full-reload',
+      })
+    })
+
+    it('does not invalidate routes for non-page files', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('add', path.join(tmpDir, 'styles.scss'))
+      server.watcher.emit('add', path.join(tmpDir, 'utils.js'))
+
+      expect(server.mocks.invalidateModule).not.toHaveBeenCalled()
+      expect(server.mocks.send).not.toHaveBeenCalled()
+    })
+
+    it('does not invalidate routes for ignored files', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('add', path.join(tmpDir, 'button/Examples.tsx'))
+
+      expect(server.mocks.invalidateModule).not.toHaveBeenCalled()
+      expect(server.mocks.send).not.toHaveBeenCalled()
+    })
+
+    it('does not invalidate routes for files outside docsDir', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('add', '/some/other/dir/page.mdx')
+
+      expect(server.mocks.invalidateModule).not.toHaveBeenCalled()
+      expect(server.mocks.send).not.toHaveBeenCalled()
+    })
+
+    it('handles a rename as unlink + add', () => {
+      const plugin = portalPagesPlugin({ docsDir: tmpDir })
+      const server = createMockServer()
+
+      const configureServer = plugin.configureServer as (
+        server: unknown
+      ) => void
+      configureServer(server)
+
+      server.watcher.emit('unlink', path.join(tmpDir, 'old-name.mdx'))
+      server.watcher.emit('add', path.join(tmpDir, 'new-name.mdx'))
+
+      expect(server.mocks.invalidateModule).toHaveBeenCalledTimes(2)
+      expect(server.mocks.send).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -349,6 +349,42 @@ ${nodeEntries.join('\n')}
       }
     },
 
+    configureServer(server) {
+      function isPageFile(file: string) {
+        const normalized = file.replace(/\\/g, '/')
+        return (
+          normalized.startsWith(normalizedDocsDir + '/') &&
+          !shouldIgnore(normalized) &&
+          (normalized.endsWith('.mdx') || normalized.endsWith('.tsx'))
+        )
+      }
+
+      function invalidateRoutes() {
+        const mod = server.moduleGraph.getModuleById(
+          RESOLVED_VIRTUAL_MODULE_ID
+        )
+        if (mod) {
+          server.moduleGraph.invalidateModule(mod)
+          server.ws.send({ type: 'full-reload' })
+        }
+      }
+
+      // Rebuild routes when page files are added or removed (renames
+      // show up as an unlink + add pair). handleHotUpdate only fires
+      // for files already in the module graph, so it cannot detect new pages.
+      server.watcher.on('add', (file) => {
+        if (isPageFile(file)) {
+          invalidateRoutes()
+        }
+      })
+      server.watcher.on('unlink', (file) => {
+        if (isPageFile(file)) {
+          pageSignatures.delete(file.replace(/\\/g, '/'))
+          invalidateRoutes()
+        }
+      })
+    },
+
     handleHotUpdate({ file, modules, server }) {
       const normalizedFile = file.replace(/\\/g, '/')
 


### PR DESCRIPTION
Adds a `configureServer` hook to the `portal-pages` Vite plugin that watches for `add` and `unlink` file system events on `.mdx`/`.tsx` files in `src/docs/`.

Previously, adding a new page file or renaming one required restarting the dev server because `handleHotUpdate` only fires for files already in the module graph. Now the virtual `portal-pages` module is invalidated and a full reload is triggered automatically.

Includes tests for the watcher covering add, unlink, rename (unlink+add), ignored files, non-page files, and files outside the docs directory.