### PR TITLE
chore(Portal): disable deprecated color variable lint for internal SCSS

### DIFF
--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -43,5 +43,18 @@
       true,
       { "severity": "warning" }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "src/style/**/*.scss",
+        "src/elements/**/*.scss",
+        "src/extensions/**/*.scss",
+        "src/components/**/style/**/*.scss"
+      ],
+      "rules": {
+        "eufemia/no-deprecated-color-variables": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The `eufemia/no-deprecated-color-variables` Stylelint rule is meant for library consumers, not Eufemia's own source files. Adds an `overrides` block in `.stylelintrc` to disable the rule for internal paths (`src/style/`, `src/elements/`, `src/extensions/`, `src/components/**/style/`).

This silences ~130 warnings that were noise when running `yarn lint:styles` in `dnb-eufemia`.