### PR TITLE
chore(DateFormat): move Hr outside P element in demo

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/Examples.tsx
@@ -52,29 +52,33 @@ export const HideCurrentYear = () => {
           const dateInOtherYear = `${currentYear - 1}-02-04`
 
           return (
-            <P>
-              <DateFormat
-                value={dateInCurrentYear}
-                dateStyle="medium"
-                hideCurrentYear
-              />
-              <DateFormat
-                value={dateInOtherYear}
-                dateStyle="medium"
-                hideCurrentYear
-              />
+            <>
+              <P>
+                <DateFormat
+                  value={dateInCurrentYear}
+                  dateStyle="medium"
+                  hideCurrentYear
+                />
+                <DateFormat
+                  value={dateInOtherYear}
+                  dateStyle="medium"
+                  hideCurrentYear
+                />
+              </P>
               <Hr />
-              <DateFormat
-                value={dateInCurrentYear}
-                dateStyle="long"
-                hideCurrentYear
-              />
-              <DateFormat
-                value={dateInOtherYear}
-                dateStyle="long"
-                hideCurrentYear
-              />
-            </P>
+              <P>
+                <DateFormat
+                  value={dateInCurrentYear}
+                  dateStyle="long"
+                  hideCurrentYear
+                />
+                <DateFormat
+                  value={dateInOtherYear}
+                  dateStyle="long"
+                  hideCurrentYear
+                />
+              </P>
+            </>
           )
         }}
       </ComponentBox>


### PR DESCRIPTION
The HideCurrentYear demo had an `<Hr />` inside a `<P>`, which is invalid HTML (`<hr>` cannot be a descendant of `<p>`). Split into two separate `<P>` elements with `<Hr />` between them.

