### PR TITLE
chore(SkipContent): use mode="accordion" instead of accordion prop on Table

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/Examples.tsx
@@ -89,7 +89,7 @@ const LargeTableWithInteractiveElements = (props) => {
 
   return (
     <Table.ScrollView top>
-      <Table accordion border outline size="medium" {...props}>
+      <Table mode="accordion" border outline size="medium" {...props}>
         <caption className="dnb-sr-only">A Table Caption</caption>
 
         <thead>


### PR DESCRIPTION
The SkipContent demo was passing 'accordion' as a boolean prop to Table, which is not a valid Table prop. This caused:
1. The 'accordion' attribute to be passed to the DOM <table> element
2. The Tr component to not activate accordion mode, resulting in <tr> nested inside <tr> (invalid HTML nesting)

