### PR TITLE
chore: suppress test console output and fix CodeBlock icon prop warning

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@dnb/eufemia/src/components', async () => {
     createElement: typeof CreateElement
   }
   return {
-    Button: ({ text, onClick, ...rest }: any) =>
+    Button: ({ text, onClick, icon: _icon, ...rest }: any) =>
       createElement('button', { onClick, ...rest }, text),
     Checkbox: ({ label, checked, onChange, ...rest }: any) =>
       createElement(

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -110,6 +110,7 @@ describe('mcp-http-server', () => {
       docsRoot,
       port: 0,
       host: '127.0.0.1',
+      silent: true,
     })
   }, 15000)
 
@@ -236,6 +237,7 @@ describe('mcp-http-server docs root validation', () => {
         docsRoot: missing,
         port: 0,
         host: '127.0.0.1',
+        silent: true,
       })
     ).rejects.toThrow(/does not exist/)
   })
@@ -251,6 +253,7 @@ describe('mcp-http-server docs root validation', () => {
           docsRoot: emptyDir,
           port: 0,
           host: '127.0.0.1',
+          silent: true,
         })
       ).rejects.toThrow(/empty or unbuilt/)
     } finally {
@@ -274,6 +277,7 @@ describe('mcp-http-server with auth token', () => {
       port: 0,
       host: '127.0.0.1',
       authToken: 'secret-token',
+      silent: true,
     })
   }, 15000)
 

--- a/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
@@ -64,8 +64,12 @@ type Middleware = (
 
 type DocsToolsOptions = { docsRoot?: string }
 
-function logErr(...args: unknown[]) {
-  console.error(...args)
+function createLogger(silent: boolean) {
+  return (...args: unknown[]) => {
+    if (!silent) {
+      console.error(...args)
+    }
+  }
 }
 
 function parseAllowedHosts(): string[] | undefined {
@@ -121,7 +125,10 @@ function authMiddleware(token: string | undefined): Middleware {
   }
 }
 
-function hostAllowlistMiddleware(allowed?: string[]): Middleware {
+function hostAllowlistMiddleware(
+  allowed: string[] | undefined,
+  logErr: (...args: unknown[]) => void
+): Middleware {
   if (!allowed || allowed.length === 0) {
     return (_req, _res, next) => next()
   }
@@ -148,6 +155,8 @@ export type HttpServerOptions = DocsToolsOptions & {
   host?: string
   allowedHosts?: string[]
   authToken?: string
+  /** Suppress console output (useful for tests). */
+  silent?: boolean
 }
 
 export type RunningHttpServer = {
@@ -165,11 +174,12 @@ export async function startHttpServer(
   const host = options.host ?? process.env.HOST ?? '0.0.0.0'
   const allowedHosts = options.allowedHosts ?? parseAllowedHosts()
   const authToken = options.authToken ?? process.env.MCP_AUTH_TOKEN
+  const logErr = createLogger(options.silent ?? false)
 
   const app = express()
   app.disable('x-powered-by')
   app.use(express.json({ limit: '4mb' }))
-  app.use(hostAllowlistMiddleware(allowedHosts))
+  app.use(hostAllowlistMiddleware(allowedHosts, logErr))
 
   app.get('/healthz', (_req: ExpressRequest, res: ExpressResponse) => {
     res.json({
@@ -378,7 +388,7 @@ const shouldRun = (() => {
 
 if (shouldRun) {
   startHttpServer().catch((e) => {
-    logErr('[eufemia] fatal:', e)
+    console.error('[eufemia] fatal:', e)
     process.exit(1)
   })
 }


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/25905805371/job/76139273285#step:9:535

- Add 'silent' option to MCP HTTP server to suppress logs during tests
- Refactor hostAllowlistMiddleware to accept logger as parameter
- Filter out 'icon' prop in CodeBlock Button mock to avoid React warning

