### PR TITLE
fix(Field.String): use showClearButton instead of clear prop

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -320,7 +320,7 @@ function StringComponent(props: FieldStringProps) {
 
   const inputProps = {
     type,
-    clear,
+    showClearButton: clear,
     size,
     align,
     selectAll,


### PR DESCRIPTION
Motivation: https://main.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/String/#clear
Fix: https://fix-field-string-clear-prop.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/String/#clear

The `clear` prop was passed directly to Input's inputProps, but Input expects showClearButton, not clear. This caused 'clear' to leak as an unknown attribute to the DOM element.

