### PR TITLE
fix(ToggleButton): fix setState-during-render in group context registration

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -3,7 +3,14 @@
  */
 
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
-import { memo, useCallback, useContext, useRef, useState } from 'react'
+import {
+  memo,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import type {
   HTMLProps,
   KeyboardEvent,
@@ -126,10 +133,7 @@ function ToggleButton(ownProps: ToggleButtonProps) {
   skipNextPropSync.current = false
 
   // Register initial checked value with group context
-  const didInitRef = useRef(false)
-  if (!didInitRef.current) {
-    didInitRef.current = true
-
+  useLayoutEffect(() => {
     if (
       groupContext.name &&
       typeof ownProps.value !== 'undefined' &&
@@ -151,7 +155,7 @@ function ToggleButton(ownProps: ToggleButtonProps) {
         })
       }
     }
-  }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const callOnChange = useCallback(
     ({

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { fireEvent, render, cleanup } from '@testing-library/react'
-import { useState } from 'react'
+import { StrictMode, useState } from 'react'
 import { axeComponent } from '../../../core/jest/jestSetup'
 import ToggleButton from '../ToggleButton'
 import { Provider } from '../../../shared'
@@ -566,5 +566,30 @@ describe('ToggleButton group component', () => {
       </ToggleButton.Group>
     )
     expect(await axeComponent(Comp)).toHaveNoViolations()
+  })
+
+  it('should not trigger setState-during-render warning when registering initial checked value', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    render(
+      <StrictMode>
+        <ToggleButton.Group label="Label" id="group">
+          <ToggleButton id="toggle-button-1" text="First" value="first" />
+          <ToggleButton
+            id="toggle-button-2"
+            text="Second"
+            value="second"
+            checked
+          />
+        </ToggleButton.Group>
+      </StrictMode>
+    )
+
+    expect(consoleError).not.toHaveBeenCalled()
+
+    const checkedButton = document.querySelector('button#toggle-button-2')
+    expect(checkedButton).toHaveAttribute('aria-pressed', 'true')
+
+    consoleError.mockRestore()
   })
 })


### PR DESCRIPTION
Motivation http://localhost:8000/uilib/components/toggle-button/demos/

<img width="1280" height="332" alt="Screenshot 2026-05-15 at 11 20 30" src="https://github.com/user-attachments/assets/4f6c17b8-fc74-4f6e-818a-df077fad50ec" />

Error message:

```js
Cannot update a component (`ToggleButtonGroup`) while rendering a different component (`ToggleButton`). To locate the bad setState() call inside `ToggleButton`, follow the stack trace as described in https://react.dev/link/setstate-in-render
```


The initial checked value registration with the group context was calling
groupContext.setContext() synchronously during render via a didInitRef
guard, which triggers a setState-during-render warning in React StrictMode.

Replace the synchronous didInitRef pattern with useLayoutEffect:
- Runs after DOM mutation but before paint, avoiding visual flicker
- Empty dependency array ensures it only runs once on mount
- Eliminates the setState-during-render warning in StrictMode

Add a StrictMode test to verify no console.error is triggered and
the checked button has the correct aria-pressed attribute.
