### PR TITLE
fix(TermDefinition): add skeleton support

### DIFF
--- a/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
@@ -12,6 +12,8 @@ import type {
 import clsx from 'clsx'
 import Popover from '../popover/Popover'
 import useId from '../../shared/helpers/useId'
+import type { SkeletonShow } from '../skeleton/Skeleton'
+import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import useTranslation from '../../shared/useTranslation'
 import type { SpacingProps } from '../../shared/types'
 import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
@@ -35,6 +37,10 @@ export type TermDefinitionProps = {
    * Tooltip placement relative to the trigger.
    */
   placement?: 'top' | 'right' | 'bottom' | 'left'
+  /**
+   * If set to `true`, an overlaying skeleton with animation will be shown.
+   */
+  skeleton?: SkeletonShow
 }
 
 export type TermDefinitionAllProps = TermDefinitionProps &
@@ -57,7 +63,10 @@ export default function TermDefinition(
     context?.TermDefinition
   )
 
-  const { children, content, className, placement, ...rest } = allProps
+  const { children, content, className, placement, skeleton, ...rest } =
+    allProps
+
+  const skeletonClasses = createSkeletonClass('font', skeleton, context)
 
   const [active, setActive] = useState(false)
   const triggerRef = useRef<HTMLSpanElement | null>(null)
@@ -110,6 +119,7 @@ export default function TermDefinition(
             'dnb-term-definition__trigger',
             'dnb-anchor',
             active && 'dnb-anchor--hover',
+            skeletonClasses,
             className
           ),
           'aria-expanded': active,

--- a/packages/dnb-eufemia/src/components/term-definition/TermDefinitionDocs.ts
+++ b/packages/dnb-eufemia/src/components/term-definition/TermDefinitionDocs.ts
@@ -17,6 +17,11 @@ export const TermDefinitionProperties: PropertiesTableProps = {
     defaultValue: '"bottom"',
     status: 'optional',
   },
+  skeleton: {
+    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
+    type: 'boolean',
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `left` or `right` are supported.',
     type: ['string', 'object'],


### PR DESCRIPTION
The skeleton prop was not destructured from allProps, causing it to leak through ...rest into triggerProps and onto a <span> element. Destructure skeleton to prevent the non-DOM attribute from reaching the DOM.

Motivation: http://localhost:8000/uilib/components/term-definition/

`The error: React logged Received 'false' for a non-boolean attribute 'skeleton' — the skeleton prop was leaking onto a <span> DOM element.`

Root cause: The portal wraps all demo pages in an Eufemia Provider that passes skeleton via context. In TermDefinition.tsx, props are merged via useSpacingProps into allProps, which includes the context skeleton value. The destructuring line was

