### PR TITLE
fix(Icon): prevent skeleton and other props leaking to SVG element

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -515,6 +515,9 @@ function getIcon(props) {
   if (props.icon) {
     return props.icon
   }
+  if (typeof props.children === 'function') {
+    return props.children
+  }
   return processChildren(props)
 }
 

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -287,6 +287,15 @@ describe('Icon component', () => {
   })
 })
 
+describe('Icon with function children', () => {
+  it('should not leak Icon props like skeleton to the SVG element', () => {
+    render(<Icon skeleton>{question}</Icon>)
+    const svg = document.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+    expect(svg.getAttribute('skeleton')).toBeNull()
+  })
+})
+
 describe('Icon fill', () => {
   it('should have filled class when fill prop is true', () => {
     render(<Icon icon={star} fill />)


### PR DESCRIPTION
Motivation: http://localhost:8000/uilib/components/list/demos#skeleton

Error: 
```js
react-dom_client.js?v=ee224a09:1951 Received `false` for a non-boolean attribute `skeleton`.

If you want to write it to the DOM, pass a string instead: skeleton="false" or skeleton={value.toString()}.

If you used to conditionally omit it with skeleton={condition && value}, pass skeleton={condition ? value : undefined} instead.
```

When Icon receives a function component as children (e.g. an icon SVG), processChildren(props) was calling children(props), passing ALL Icon props (including skeleton, size, etc.) to the icon function. Since icon SVGs spread {...props} onto the <svg> element, these non-SVG attributes leaked to the DOM, causing React warnings like:
'Received false for a non-boolean attribute skeleton'.

Fix: return function children directly so prerenderIcon handles them with only the clean iconParams (width/height/color).

