### PR TITLE
chore(HorizontalRule): move Hr outside P element in demos

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/horizontal-rule/Examples.tsx
@@ -8,30 +8,24 @@ import { Hr, P } from '@dnb/eufemia/src'
 
 export const HorizontalRuleDefaultExample = () => (
   <ComponentBox background="plain" hideCode data-visual-test="hr-default">
-    <P>
-      Before
-      <Hr space={{ top: '0.5rem', bottom: '0.5rem' }} />
-      After
-    </P>
+    <P>Before</P>
+    <Hr space={{ top: '0.5rem', bottom: '0.5rem' }} />
+    <P>After</P>
   </ComponentBox>
 )
 
 export const HorizontalRuleBreakoutExample = () => (
   <ComponentBox background="plain" hideCode data-visual-test="hr-breakout">
-    <P>
-      Before
-      <Hr breakout space={{ top: '0.5rem', bottom: '0.5rem' }} />
-      After
-    </P>
+    <P>Before</P>
+    <Hr breakout space={{ top: '0.5rem', bottom: '0.5rem' }} />
+    <P>After</P>
   </ComponentBox>
 )
 
 export const HorizontalRuleDashedExample = () => (
   <ComponentBox background="plain" hideCode data-visual-test="hr-dashed">
-    <P>
-      Before
-      <Hr dashed space={{ top: '0.5rem', bottom: '0.5rem' }} />
-      After
-    </P>
+    <P>Before</P>
+    <Hr dashed space={{ top: '0.5rem', bottom: '0.5rem' }} />
+    <P>After</P>
   </ComponentBox>
 )


### PR DESCRIPTION
The Hr demos had `<Hr />` inside `<P>`, which is invalid HTML since `<hr>` cannot be a descendant of `<p>`. Split into separate `<P>` elements with `<Hr />` between them.

