### PR TITLE
fix(Provider): use createSharedState to prevent infinite render loop

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -41,6 +41,7 @@ import { isAsync } from '../../../../shared/helpers/isAsync'
 import type { SharedStateId } from '../../../../shared/helpers/useSharedState'
 import {
   createReferenceKey,
+  createSharedState,
   preSeedSharedState,
   shallowEqual,
   useSharedState,
@@ -899,9 +900,17 @@ export default function Provider<Data extends JsonObject>(
   const sharedAttachments = useSharedState<SharedAttachments<Data>>(
     id ? createReferenceKey(id, 'attachments') : undefined
   )
-  const sharedDataContext = useSharedState<ContextState>(
-    id ? createReferenceKey(id, 'data-context') : undefined
-  )
+  // Use createSharedState (non-reactive) instead of useSharedState here
+  // because the Provider only writes to this store during render.
+  // Using useSharedState (which subscribes via useSyncExternalStore)
+  // would cause an infinite loop: the render-phase write updates the
+  // snapshot, useSyncExternalStore detects the change, and forces a
+  // re-render — repeatedly.
+  const sharedDataContext = id
+    ? createSharedState<ContextState>(
+        createReferenceKey(id, 'data-context')
+      )
+    : null
 
   const setSharedData = sharedData.set
   const extendSharedData = sharedData.extend
@@ -1837,7 +1846,7 @@ export default function Provider<Data extends JsonObject>(
   }
 
   if (id) {
-    sharedDataContext.set(contextValue, { silent: true })
+    sharedDataContext?.set(contextValue, { silent: true })
   }
 
   const show = Boolean(showAllErrorsRef.current)

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -6534,4 +6534,30 @@ describe('DataContext.Provider', () => {
       })
     })
   })
+
+  it('should not cause Maximum update depth exceeded when Form.useData is used outside Form.Handler with same id', () => {
+    const log = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const MyForm = () => {
+      const { data } = Form.useData(identifier, {
+        locale: 'en-GB',
+      })
+
+      return (
+        <Form.Handler id={identifier} locale={data?.locale}>
+          <Field.String path="/myField" />
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(log).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.stringContaining('Maximum update depth exceeded')
+    )
+
+    log.mockRestore()
+  })
 })


### PR DESCRIPTION
Motivation: https://main.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Handler/
Deploy preview: https://fix-provider-shared-state-lo.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Handler/

This PR fixes `Error: Minified React error #185` in https://main.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Handler/

The Provider used useSharedState for sharedDataContext, which subscribes via useSyncExternalStore. Since the Provider only writes to this store (never reads), the reactive subscription was unnecessary. Because the Provider updates the store during render with a new contextValue object each time, useSyncExternalStore detects the snapshot change during commit and forces a re-render, causing 'Maximum update depth exceeded'.

Switch to createSharedState which creates/returns the store instance without subscribing to it.

