### PR TITLE
chore(Portal): stabilize focusmode ID across HMR remounts

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/focusmode.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/focusmode.spec.ts
@@ -128,7 +128,9 @@ test.describe('Focusmode', () => {
   test('should enter focusmode when visiting a focusmode URL directly', async ({
     page,
   }) => {
-    await page.goto('/uilib/components/radio/demos/?focusmode=radio-sizes')
+    await page.goto(
+      '/uilib/components/radio/demos/?focusmode=RadioExampleSizes'
+    )
     await waitForApp(page)
 
     // Should be in focusmode

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -7,7 +7,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
@@ -71,6 +70,9 @@ export type CodeSectionProps = {
   children: string | ReactNode | (() => ReactNode)
   tabMode?: 'focus' | 'indentation'
   'data-visual-test'?: string
+
+  /** Injected by the babel transform — enclosing export name, stable across HMR. */
+  stableName?: string
 }
 
 const CodeBlock = ({
@@ -162,8 +164,7 @@ function prepareCode(code: string) {
 function LiveCode(props: LiveCodeProps) {
   const context = useContext(Context)
   const editorElementRef = useRef<HTMLDivElement>(null)
-  const id = useId()
-  const fullscreenId = props['data-visual-test'] || id.replace(/:/g, '')
+  const fullscreenId = props.stableName
 
   const [hideCode, setHideCode] = useState(props.hideCode)
   const [hidePreview, setHidePreview] = useState(props.hidePreview)
@@ -195,6 +196,7 @@ function LiveCode(props: LiveCodeProps) {
     hidePreview: hidePreviewProp,
     surface: surfaceProp,
     'data-visual-test': visualTest,
+    stableName: _stableName,
 
     ...restProps
   } = props
@@ -442,7 +444,6 @@ function LiveCode(props: LiveCodeProps) {
             >
               <LiveEditor
                 prism={Prism}
-                id={id}
                 tabMode={tabMode}
                 className="dnb-live-editor__editable dnb-pre"
               />

--- a/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
@@ -30,11 +30,12 @@ function ComponentBox(props: CodeSectionProps) {
   const { children, scope = {}, ...rest } = props
 
   const hash = children as string
+
   if (globalThis.ComponentBoxMemo[hash]) {
     return globalThis.ComponentBoxMemo[hash]
   }
 
-  return (globalThis.ComponentBoxMemo[hash] = (
+  const element = (
     <CodeBlock
       scope={{
         ...getComponents(),
@@ -68,7 +69,11 @@ function ComponentBox(props: CodeSectionProps) {
     >
       {children}
     </CodeBlock>
-  ))
+  )
+
+  globalThis.ComponentBoxMemo[hash] = element
+
+  return element
 }
 
 export default ComponentBox

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -386,7 +386,7 @@ describe('CodeBlock', () => {
         reactLive
         scope={{}}
         language="jsx"
-        data-visual-test="my-live-block"
+        stableName="my-live-block"
       >
         {'<div>Hello</div>'}
       </CodeBlock>
@@ -409,12 +409,7 @@ describe('CodeBlock', () => {
     })
 
     const { container } = render(
-      <CodeBlock
-        reactLive
-        scope={{}}
-        language="jsx"
-        data-visual-test="block-a"
-      >
+      <CodeBlock reactLive scope={{}} language="jsx" stableName="block-a">
         {'<div>Hello</div>'}
       </CodeBlock>
     )

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { injectStableName } from '../../client/plugins/react-live-babel'
+
+async function transform(code: string) {
+  const babel = await import('@babel/core')
+  const result = await babel.transformAsync(code, {
+    filename: 'Examples.tsx',
+    presets: [
+      ['@babel/preset-react', { runtime: 'automatic' }],
+      '@babel/preset-typescript',
+    ],
+    plugins: [injectStableName],
+  })
+
+  return result?.code || ''
+}
+
+describe('injectStableName babel plugin', () => {
+  it('injects stableName from enclosing function declaration', async () => {
+    const input = `
+      export function MyExample() {
+        return <ComponentBox>code here</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('stableName: "MyExample"')
+  })
+
+  it('injects stableName from enclosing variable declarator', async () => {
+    const input = `
+      export const ArrowExample = () => {
+        return <ComponentBox>code here</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('stableName: "ArrowExample"')
+  })
+
+  it('appends counter suffix for multiple ComponentBoxes in the same function', async () => {
+    const input = `
+      export function MultiBox() {
+        return (
+          <>
+            <ComponentBox>first</ComponentBox>
+            <ComponentBox>second</ComponentBox>
+            <ComponentBox>third</ComponentBox>
+          </>
+        )
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('stableName: "MultiBox"')
+    expect(output).toContain('stableName: "MultiBox_2"')
+    expect(output).toContain('stableName: "MultiBox_3"')
+  })
+
+  it('uses separate counters for different functions', async () => {
+    const input = `
+      export function First() {
+        return <ComponentBox>a</ComponentBox>
+      }
+      export function Second() {
+        return <ComponentBox>b</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('stableName: "First"')
+    expect(output).toContain('stableName: "Second"')
+    expect(output).not.toContain('First_2')
+    expect(output).not.toContain('Second_2')
+  })
+
+  it('skips ComponentBox without an enclosing named function', async () => {
+    const input = `
+      export default () => {
+        return <ComponentBox>orphan</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).not.toContain('stableName')
+  })
+
+  it('ignores non-ComponentBox elements', async () => {
+    const input = `
+      export function Demo() {
+        return <SomeOther>content</SomeOther>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).not.toContain('stableName')
+  })
+
+  it('resets counters between separate transform calls', async () => {
+    const input = `
+      export function Repeated() {
+        return (
+          <>
+            <ComponentBox>a</ComponentBox>
+            <ComponentBox>b</ComponentBox>
+          </>
+        )
+      }
+    `
+
+    const first = await transform(input)
+    const second = await transform(input)
+
+    expect(first).toContain('stableName: "Repeated"')
+    expect(first).toContain('stableName: "Repeated_2"')
+    expect(second).toContain('stableName: "Repeated"')
+    expect(second).toContain('stableName: "Repeated_2"')
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import type { Plugin } from 'vite'
+import type BabelTypes from '@babel/types'
 
 const portalRoot = path.resolve(__dirname, '..', '..', '..')
 
@@ -22,6 +23,7 @@ export default function reactLiveBabelPlugin(): Plugin {
           '@babel/preset-typescript',
         ],
         plugins: [
+          injectStableName,
           [
             require.resolve('babel-plugin-react-live'),
             {
@@ -39,6 +41,82 @@ export default function reactLiveBabelPlugin(): Plugin {
       }
 
       return null
+    },
+  }
+}
+
+/**
+ * Babel plugin that injects a `stableName` prop on each <ComponentBox>,
+ * derived from the enclosing export function name.
+ * This gives each box a stable identity that survives HMR remounts.
+ *
+ * Must run before babel-plugin-react-live, which replaces JSX elements
+ * with serialized code strings inside a Program visitor.
+ * We use Program.enter + manual traverse so our visitor fires first.
+ */
+export function injectStableName(babel: { types: typeof BabelTypes }) {
+  const { types: t } = babel
+
+  return {
+    visitor: {
+      Program: {
+        enter(programPath: {
+          traverse: (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            visitors: Record<string, (path: any) => void>
+          ) => void
+        }) {
+          const counters = new Map<string, number>()
+
+          programPath.traverse({
+            JSXOpeningElement(nodePath: {
+              node: {
+                name: { type: string; name: string }
+                attributes: unknown[]
+              }
+              findParent: (
+                cb: (p: {
+                  node: { id?: { type: string; name: string } }
+                  isFunctionDeclaration: () => boolean
+                  isVariableDeclarator: () => boolean
+                }) => boolean
+              ) => { node: { id?: { name: string } } } | null
+            }) {
+              const { node } = nodePath
+              if (
+                node.name.type !== 'JSXIdentifier' ||
+                node.name.name !== 'ComponentBox'
+              ) {
+                return // stop here
+              }
+
+              const parent = nodePath.findParent(
+                (p) =>
+                  (p.isFunctionDeclaration() ||
+                    p.isVariableDeclarator()) &&
+                  p.node.id?.type === 'Identifier'
+              )
+
+              if (!parent?.node.id?.name) {
+                return // stop here
+              }
+
+              const funcName = parent.node.id.name
+              const count = (counters.get(funcName) || 0) + 1
+              counters.set(funcName, count)
+              const stableName =
+                count === 1 ? funcName : `${funcName}_${count}`
+
+              node.attributes.push(
+                t.jsxAttribute(
+                  t.jsxIdentifier('stableName'),
+                  t.stringLiteral(stableName)
+                )
+              )
+            },
+          })
+        },
+      },
     },
   }
 }


### PR DESCRIPTION
Adds a babel plugin (`injectStableName`) that injects a `stableName` prop on each `<ComponentBox>`, derived from the enclosing export function name. This gives each code example a stable identity that survives hot module replacement, fixing focus mode breaking during HMR.
