### PR TITLE
chore(Portal): watch docs dir for new page files

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
@@ -658,7 +658,9 @@ describe('portal-pages plugin', () => {
     let tmpDir: string
 
     function createMockServer() {
-      const watcher = new EventEmitter()
+      const watcher = Object.assign(new EventEmitter(), {
+        add: vi.fn(),
+      })
       const mod = { id: '\0virtual:portal-pages' }
       const invalidateModule = vi.fn()
       const getModuleById = vi.fn(() => mod)

--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -350,6 +350,10 @@ ${nodeEntries.join('\n')}
     },
 
     configureServer(server) {
+      // Vite's root is vite/client/, so src/docs/ isn't watched by default.
+      // Add it explicitly so new page files trigger the 'add' event.
+      server.watcher.add(docsDir)
+
       function isPageFile(file: string) {
         const normalized = file.replace(/\\/g, '/')
         return (


### PR DESCRIPTION
Vite's root is `vite/client/`, so `src/docs/` isn't watched by default. This adds it explicitly to the file watcher so new page files trigger the `add` event and are picked up without a dev server restart.

Also updates the test mock to include the `watcher.add` method.