### PR TITLE
fix(Flex): omit wrapper for spacing props in context-only providers

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -124,6 +124,27 @@ export function renderWithSpacing(
     return element
   }
 
+  if (variant === 'passthrough') {
+    const childElement = element as ReactElement<any>
+    const children = childElement?.props?.children
+    const childKey = childElement?.key
+    const childProps = childElement?.props || {}
+
+    return Children.toArray(children).map((child, i) => {
+      const wrapped = wrapWithSpace({
+        element: child as ReactNode,
+        spaceProps,
+        wrapInSpace,
+      })
+
+      return createElement(
+        childElement.type as ComponentType<any>,
+        { ...childProps, key: childKey ? `${childKey}-${i}` : `${i}` },
+        wrapped
+      )
+    })
+  }
+
   if (variant === 'children') {
     return (Children.toArray(element) as ReactElement[]).map(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
@@ -61,7 +61,7 @@ function FieldProviderProvider(props: FieldProviderProps) {
 }
 
 withComponentMarkers(FieldProviderProvider, {
-  _supportsSpacingProps: 'children',
+  _supportsSpacingProps: 'passthrough',
 })
 
 export default FieldProviderProvider

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/FieldProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/FieldProvider.test.tsx
@@ -7,10 +7,10 @@ import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('Field.Provider', () => {
-  it('should have constant of _supportsSpacingProps="children"', () => {
+  it('should have constant of _supportsSpacingProps="passthrough"', () => {
     expect(
       (Field.Provider as ComponentMarkers)._supportsSpacingProps
-    ).toBe('children')
+    ).toBe('passthrough')
   })
 
   it('should merge inheritedContext with props passed to extend', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Appearance/Appearance.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Appearance/Appearance.tsx
@@ -23,7 +23,7 @@ function FormAppearance({ children, size, ...rest }: FormAppearanceProps) {
 }
 
 withComponentMarkers(FormAppearance, {
-  _supportsSpacingProps: 'children',
+  _supportsSpacingProps: 'passthrough',
 })
 
 export default FormAppearance

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Appearance/__tests__/Appearance.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Appearance/__tests__/Appearance.test.tsx
@@ -3,10 +3,10 @@ import { Form, Field } from '../../..'
 import type { ComponentMarkers } from '../../../../../shared/helpers/withComponentMarkers'
 
 describe('Form.Appearance', () => {
-  it('should have constant of _supportsSpacingProps="children"', () => {
+  it('should have constant of _supportsSpacingProps="passthrough"', () => {
     expect(
       (Form.Appearance as ComponentMarkers)._supportsSpacingProps
-    ).toBe('children')
+    ).toBe('passthrough')
   })
 
   describe('size', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Provider/ValueProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Provider/ValueProvider.tsx
@@ -23,7 +23,7 @@ function ValueProviderProvider(props: ValueProviderProps) {
 }
 
 withComponentMarkers(ValueProviderProvider, {
-  _supportsSpacingProps: 'children',
+  _supportsSpacingProps: 'passthrough',
 })
 
 export default ValueProviderProvider

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -103,7 +103,7 @@ Theme.Context = ({ element, ...themeProps }: ThemeAllProps) => {
   return <Theme {...themeProps} element={false} />
 }
 withComponentMarkers(Theme.Context, {
-  _supportsSpacingProps: 'children',
+  _supportsSpacingProps: 'passthrough',
 })
 
 export function ThemeWrapper({

--- a/packages/dnb-eufemia/src/shared/helpers/withComponentMarkers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/withComponentMarkers.ts
@@ -10,7 +10,7 @@
  * pattern with a single type-safe call.
  */
 
-export type SpacingPropsVariant = boolean | 'children'
+export type SpacingPropsVariant = boolean | 'children' | 'passthrough'
 
 export type ComponentMarkers = {
   /**
@@ -23,7 +23,8 @@ export type ComponentMarkers = {
   /**
    * Whether the component accepts spacing props directly.
    * - `true` — spacing props are cloned onto the element
-   * - `'children'` — spacing is applied to the component's children
+   * - `'children'` — spacing is applied to the component's children inside a nested flex context
+   * - `'passthrough'` — spacing passes through to children directly (no flex wrapper)
    * - `false` — the component explicitly opts out of spacing
    *
    * Used by `Flex.Container` and `renderWithSpacing` to decide how


### PR DESCRIPTION
Context-only providers (SpaceResponsive, Theme.Context, Form.Appearance, Field.Provider, Value.Provider) now use `'passthrough'` instead of `'children'` for `_supportsSpacingProps`.

This avoids creating a nested FlexContainer wrapper when these components appear inside Flex, since they don't render their own DOM.

### Changes

- Added `'passthrough'` as a new `_supportsSpacingProps` variant in `withComponentMarkers`
- `renderWithSpacing` handles `'passthrough'` by applying spacing to children directly without FlexContainer wrapping
- Switched 5 context-only providers from `'children'` to `'passthrough'`:
  - `SpaceResponsive` / `Space.Responsive`
  - `Theme.Context`
  - `Form.Appearance`
  - `Field.Provider`
  - `Value.Provider`
- Components that render their own DOM (`HeightAnimation`, `SubmitConfirmation`, `AriaLive`) remain on `'children'`