### PR TITLE
chore: skip disabled stylesheets in hover emulation

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
@@ -603,6 +603,10 @@ const emulatePseudoStateViaCSS = async (
       }
 
       for (const sheet of Array.from(document.styleSheets)) {
+        if (sheet.disabled) {
+          continue
+        }
+
         try {
           for (const rule of Array.from(sheet.cssRules)) {
             processRule(rule)


### PR DESCRIPTION
Happens when running visual tests with dev server. e.g. with accordion.