### PR TITLE
chore(Portal): use automatic JSX runtime in react-live-ssr

### DIFF
--- a/tools/react-live-ssr/Readme.md
+++ b/tools/react-live-ssr/Readme.md
@@ -3,3 +3,7 @@
 This build (v3.1.1) includes this [PR](https://github.com/FormidableLabs/react-live/pull/322). We may use the original as soon as it is released with SSR support.
 
 The `use-editable` dependency has been replaced with an inline implementation in `src/useEditable.ts` to ensure React 19 compatibility and remove the unmaintained package.
+
+## Local modifications
+
+The dist files have been modified to use the automatic JSX runtime (`jsxRuntime: 'automatic'`) instead of the classic `React.createElement` approach. This prevents the console warning "Your app (or one of its dependencies) is using an outdated JSX transform."

--- a/tools/react-live-ssr/dist/index.js
+++ b/tools/react-live-ssr/dist/index.js
@@ -586,6 +586,7 @@ var LiveContext_default = LiveContext
 
 // src/utils/transpile/index.ts
 var import_react4 = __toESM(require('react'))
+var import_jsx_runtime_scope = require('react/jsx-runtime')
 
 // src/utils/transpile/transform.ts
 var import_sucrase = require('sucrase')
@@ -594,7 +595,19 @@ function transform(opts = {}) {
   const transforms = Array.isArray(opts.transforms)
     ? opts.transforms.filter(Boolean)
     : defaultTransforms
-  return (code) => (0, import_sucrase.transform)(code, { transforms }).code
+  return (code) => {
+    const result = (0, import_sucrase.transform)(code, {
+      transforms,
+      jsxRuntime: 'automatic',
+      jsxImportSource: 'react',
+      // Use production mode for smaller output; dev mode's jsxDEV isn't needed
+      // since errors are already handled by the ErrorBoundary wrapper
+      production: true
+    }).code
+    // Strip the jsx-runtime require/import since we inject it via scope.
+    // The 'imports' transform normalizes to CJS require() even in ESM context.
+    return result.replace(/"use strict";\s*var _jsxruntime\s*=\s*require\("react\/jsx-runtime"\);?/, '')
+  }
 }
 
 // src/utils/transpile/errorBoundary.tsx
@@ -634,22 +647,16 @@ function compose(...functions) {
 }
 
 // src/utils/transpile/index.ts
-var jsxConst = 'const _jsxFileName = "";'
 var trimCode = (code) => code.trim().replace(/;$/, '')
-var spliceJsxConst = (code) => code.replace(jsxConst, '').trim()
-var addJsxConst = (code) => jsxConst + code
 var wrapReturn = (code) => `return (${code})`
 var generateElement = (
   { code = '', scope = {}, enableTypeScript = true },
   errorCallback
 ) => {
-  const firstPassTransforms = ['jsx']
+  const firstPassTransforms = ['jsx', 'imports']
   enableTypeScript && firstPassTransforms.push('typescript')
   const transformed = compose(
-    addJsxConst,
-    transform({ transforms: ['imports'] }),
     wrapReturn,
-    spliceJsxConst,
     trimCode,
     transform({ transforms: firstPassTransforms }),
     trimCode
@@ -657,7 +664,7 @@ var generateElement = (
   return errorBoundary_default(
     evalCode_default(
       transformed,
-      __spreadValues({ React: import_react4.default }, scope)
+      __spreadValues({ React: import_react4.default, _jsxruntime: import_jsx_runtime_scope }, scope)
     ),
     errorCallback
   )
@@ -686,7 +693,7 @@ var renderElementAsync = (
   evalCode_default(
     transform({ transforms })(code),
     __spreadProps(
-      __spreadValues({ React: import_react4.default }, scope),
+      __spreadValues({ React: import_react4.default, _jsxruntime: import_jsx_runtime_scope }, scope),
       { render }
     )
   )

--- a/tools/react-live-ssr/dist/index.mjs
+++ b/tools/react-live-ssr/dist/index.mjs
@@ -533,6 +533,7 @@ var LiveContext_default = LiveContext
 
 // src/utils/transpile/index.ts
 import React2 from 'react'
+import * as _jsxRuntime from 'react/jsx-runtime'
 
 // src/utils/transpile/transform.ts
 import { transform as _transform } from 'sucrase'
@@ -541,7 +542,19 @@ function transform(opts = {}) {
   const transforms = Array.isArray(opts.transforms)
     ? opts.transforms.filter(Boolean)
     : defaultTransforms
-  return (code) => _transform(code, { transforms }).code
+  return (code) => {
+    const result = _transform(code, {
+      transforms,
+      jsxRuntime: 'automatic',
+      jsxImportSource: 'react',
+      // Use production mode for smaller output; dev mode's jsxDEV isn't needed
+      // since errors are already handled by the ErrorBoundary wrapper
+      production: true
+    }).code
+    // Strip the jsx-runtime require/import since we inject it via scope.
+    // The 'imports' transform normalizes to CJS require() even in ESM context.
+    return result.replace(/"use strict";\s*var _jsxruntime\s*=\s*require\("react\/jsx-runtime"\);?/, '')
+  }
 }
 
 // src/utils/transpile/errorBoundary.tsx
@@ -581,22 +594,16 @@ function compose(...functions) {
 }
 
 // src/utils/transpile/index.ts
-var jsxConst = 'const _jsxFileName = "";'
 var trimCode = (code) => code.trim().replace(/;$/, '')
-var spliceJsxConst = (code) => code.replace(jsxConst, '').trim()
-var addJsxConst = (code) => jsxConst + code
 var wrapReturn = (code) => `return (${code})`
 var generateElement = (
   { code = '', scope = {}, enableTypeScript = true },
   errorCallback
 ) => {
-  const firstPassTransforms = ['jsx']
+  const firstPassTransforms = ['jsx', 'imports']
   enableTypeScript && firstPassTransforms.push('typescript')
   const transformed = compose(
-    addJsxConst,
-    transform({ transforms: ['imports'] }),
     wrapReturn,
-    spliceJsxConst,
     trimCode,
     transform({ transforms: firstPassTransforms }),
     trimCode
@@ -604,7 +611,7 @@ var generateElement = (
   return errorBoundary_default(
     evalCode_default(
       transformed,
-      __spreadValues({ React: React2 }, scope)
+      __spreadValues({ React: React2, _jsxruntime: _jsxRuntime }, scope)
     ),
     errorCallback
   )
@@ -632,7 +639,7 @@ var renderElementAsync = (
   enableTypeScript && transforms.splice(1, 0, 'typescript')
   evalCode_default(
     transform({ transforms })(code),
-    __spreadProps(__spreadValues({ React: React2 }, scope), { render })
+    __spreadProps(__spreadValues({ React: React2, _jsxruntime: _jsxRuntime }, scope), { render })
   )
 }
 


### PR DESCRIPTION


Motivation: console warning: `Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform`

<img width="1085" height="728" alt="Screenshot 2026-05-18 at 10 02 16" src="https://github.com/user-attachments/assets/ab724ff2-33bc-4e45-9010-e76d22a424f2" />

Deploy preview: https://fix-jsx-transform-warning.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/String/demos
