### PR TITLE
chore(Portal): add tab focus styling to home link in StickyMenuBar

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -49,7 +49,7 @@ export default function StickyMenuBar({
 
         <Link
           href="/"
-          className={centerWrapperStyle}
+          className={clsx(centerWrapperStyle, 'dnb-tab-focus')}
           title="Go to Eufemia home"
         >
           <PortalLogo />


### PR DESCRIPTION
From:
<img width="182" height="54" alt="Screenshot 2026-05-18 at 10 55 18" src="https://github.com/user-attachments/assets/9d54f8a1-ea51-427c-aae3-8e87165451cf" />

To:
<img width="167" height="52" alt="Screenshot 2026-05-18 at 10 55 26" src="https://github.com/user-attachments/assets/f8f99a9e-07af-479e-9e80-8aa414a86bf7" />

