### PR TITLE
Fix icon-only button labels in portal sidebar and Tabs

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -329,6 +329,10 @@ function ListItem({
     params['aria-current'] = true
   }
 
+  const expandButtonTitle = isExpanded
+    ? `Collapse ${title}`
+    : `Expand ${title}`
+
   return (
     <>
       <li
@@ -390,6 +394,7 @@ function ListItem({
               className="dnb-sidebar-menu__expand-button"
               variant="tertiary"
               size="small"
+              title={expandButtonTitle}
               aria-expanded={isExpanded}
               icon={isExpanded ? 'subtract' : 'add'}
               onClick={() => {

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1120,6 +1120,9 @@ function TabsComponent(ownProps: TabsProps) {
     }
   )
 
+  const { prevButtonTitle, nextButtonTitle } =
+    context.getTranslation?.(props)?.Tabs || {}
+
   renderWrapperRef.current = ({
     children,
     ...rest
@@ -1181,6 +1184,7 @@ function TabsComponent(ownProps: TabsProps) {
         <ScrollNavButton
           onMouseDown={openPrevTab}
           icon="chevron_left"
+          title={prevButtonTitle}
           className={clsx(
             hasScrollbarRef.current &&
               (typeof isFirstRef.current !== 'undefined' ||
@@ -1195,6 +1199,7 @@ function TabsComponent(ownProps: TabsProps) {
         <ScrollNavButton
           onMouseDown={openNextTab}
           icon="chevron_right"
+          title={nextButtonTitle}
           className={clsx(
             hasScrollbarRef.current &&
               (typeof isLastRef.current !== 'undefined' ||

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -7,6 +7,8 @@ import { StrictMode } from 'react'
 import type { ReactNode } from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { act, fireEvent, render } from '@testing-library/react'
+import { Provider } from '../../../shared'
+import defaultLocales from '../../../shared/locales'
 import type { TabsProps } from '../Tabs'
 import Tabs from '../Tabs'
 import Input from '../../input/Input'
@@ -273,6 +275,74 @@ describe('Tabs component', () => {
     const tabs = document.querySelector('.dnb-tabs__tabs')
 
     expect(tabs.className).not.toContain('--breakout')
+  })
+
+  it('adds labels to the scroll navigation buttons', () => {
+    const translations = defaultLocales['nb-NO'].Tabs
+
+    render(
+      <Tabs {...props} data={tablistData} selectedKey={startupSelectedKey}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const buttons = document.querySelectorAll(
+      '.dnb-tabs__scroll-nav-button'
+    )
+
+    expect(buttons[0]).toHaveAttribute(
+      'title',
+      translations.prevButtonTitle
+    )
+    expect(buttons[0]).toHaveAttribute(
+      'aria-label',
+      translations.prevButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'title',
+      translations.nextButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'aria-label',
+      translations.nextButtonTitle
+    )
+  })
+
+  it('translates the scroll navigation button labels', () => {
+    const translations = defaultLocales['en-GB'].Tabs
+
+    render(
+      <Provider locale="en-GB">
+        <Tabs
+          {...props}
+          data={tablistData}
+          selectedKey={startupSelectedKey}
+        >
+          {contentWrapperData}
+        </Tabs>
+      </Provider>
+    )
+
+    const buttons = document.querySelectorAll(
+      '.dnb-tabs__scroll-nav-button'
+    )
+
+    expect(buttons[0]).toHaveAttribute(
+      'title',
+      translations.prevButtonTitle
+    )
+    expect(buttons[0]).toHaveAttribute(
+      'aria-label',
+      translations.prevButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'title',
+      translations.nextButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'aria-label',
+      translations.nextButtonTitle
+    )
   })
 
   it('warns when not providing any content', () => {

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -125,6 +125,10 @@ export default {
       isLoadingText: 'Indlæser nyt indhold',
       loadButtonText: 'Vis mere indhold',
     },
+    Tabs: {
+      prevButtonTitle: 'Forrige fane',
+      nextButtonTitle: 'Næste fane',
+    },
     Skeleton: {
       ariaBusy: 'Behandler data ...',
       ariaReady: 'Klar til at interagere',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -128,6 +128,10 @@ export default {
       isLoadingText: 'Loading new content',
       loadButtonText: 'Show more content',
     },
+    Tabs: {
+      prevButtonTitle: 'Previous tab',
+      nextButtonTitle: 'Next tab',
+    },
     StepIndicator: {
       overviewTitle: 'Steps Overview',
       stepTitle: 'Step %step of %count:',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -123,6 +123,10 @@ export default {
       isLoadingText: 'Laster nytt innhold',
       loadButtonText: 'Vis mer innhold',
     },
+    Tabs: {
+      prevButtonTitle: 'Forrige fane',
+      nextButtonTitle: 'Neste fane',
+    },
     Skeleton: {
       ariaBusy: 'Behandler data ...',
       ariaReady: 'Klar til å samhandle',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -124,6 +124,10 @@ export default {
       isLoadingText: 'Laddar nytt innehåll',
       loadButtonText: 'Visa mer innehåll',
     },
+    Tabs: {
+      prevButtonTitle: 'Föregående flik',
+      nextButtonTitle: 'Nästa flik',
+    },
     Skeleton: {
       ariaBusy: 'Bearbetar data ...',
       ariaReady: 'Klar att interagera',


### PR DESCRIPTION
## Summary
- add accessible labels to the portal sidebar accordion toggle buttons
- translate the Tabs scroll navigation button labels via the shared locale bundle
- add focused Tabs tests for default and provider-driven translations

## Verification
- `yarn workspace @dnb/eufemia test --run src/components/tabs/__tests__/Tabs.test.tsx -t 'scroll navigation button'`
- reloaded `http://localhost:8001/uilib/components/radio` and confirmed the icon-only button accessibility warning no longer appears