### PR TITLE
chore(Portal): label portal sidebar accordion buttons

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -329,6 +329,10 @@ function ListItem({
     params['aria-current'] = true
   }
 
+  const expandButtonTitle = isExpanded
+    ? `Collapse ${title}`
+    : `Expand ${title}`
+
   return (
     <>
       <li
@@ -390,6 +394,7 @@ function ListItem({
               className="dnb-sidebar-menu__expand-button"
               variant="tertiary"
               size="small"
+              title={expandButtonTitle}
               aria-expanded={isExpanded}
               icon={isExpanded ? 'subtract' : 'add'}
               onClick={() => {


### PR DESCRIPTION
## Summary
- add accessible labels to the portal sidebar accordion toggle buttons
- remove the icon-only button accessibility warning caused by unlabeled sidebar expand/collapse controls

## Verification
- reloaded `http://localhost:8001/uilib/components/radio`
- confirmed the sidebar accordion buttons receive labels and no longer contribute to the icon-only button accessibility warning