### PR TITLE
fix(Tabs): add scroll navigation labels

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/properties.mdx
@@ -2,6 +2,7 @@
 showTabs: true
 ---
 
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import {
   TabsProperties,
@@ -42,3 +43,7 @@ const tabsData = [
 ## Current tab
 
 The current Tab content can be a `string`, a function returning content or a `React component`.
+
+## Translations
+
+<TranslationsTable localeKey="Tabs" />

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1120,6 +1120,9 @@ function TabsComponent(ownProps: TabsProps) {
     }
   )
 
+  const { prevButtonTitle, nextButtonTitle } =
+    context.getTranslation?.(props)?.Tabs || {}
+
   renderWrapperRef.current = ({
     children,
     ...rest
@@ -1181,6 +1184,7 @@ function TabsComponent(ownProps: TabsProps) {
         <ScrollNavButton
           onMouseDown={openPrevTab}
           icon="chevron_left"
+          title={prevButtonTitle}
           className={clsx(
             hasScrollbarRef.current &&
               (typeof isFirstRef.current !== 'undefined' ||
@@ -1195,6 +1199,7 @@ function TabsComponent(ownProps: TabsProps) {
         <ScrollNavButton
           onMouseDown={openNextTab}
           icon="chevron_right"
+          title={nextButtonTitle}
           className={clsx(
             hasScrollbarRef.current &&
               (typeof isLastRef.current !== 'undefined' ||

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -7,6 +7,8 @@ import { StrictMode } from 'react'
 import type { ReactNode } from 'react'
 import { axeComponent, loadScss } from '../../../core/jest/jestSetup'
 import { act, fireEvent, render } from '@testing-library/react'
+import { Provider } from '../../../shared'
+import defaultLocales from '../../../shared/locales'
 import type { TabsProps } from '../Tabs'
 import Tabs from '../Tabs'
 import Input from '../../input/Input'
@@ -273,6 +275,74 @@ describe('Tabs component', () => {
     const tabs = document.querySelector('.dnb-tabs__tabs')
 
     expect(tabs.className).not.toContain('--breakout')
+  })
+
+  it('adds labels to the scroll navigation buttons', () => {
+    const translations = defaultLocales['nb-NO'].Tabs
+
+    render(
+      <Tabs {...props} data={tablistData} selectedKey={startupSelectedKey}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const buttons = document.querySelectorAll(
+      '.dnb-tabs__scroll-nav-button'
+    )
+
+    expect(buttons[0]).toHaveAttribute(
+      'title',
+      translations.prevButtonTitle
+    )
+    expect(buttons[0]).toHaveAttribute(
+      'aria-label',
+      translations.prevButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'title',
+      translations.nextButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'aria-label',
+      translations.nextButtonTitle
+    )
+  })
+
+  it('translates the scroll navigation button labels', () => {
+    const translations = defaultLocales['en-GB'].Tabs
+
+    render(
+      <Provider locale="en-GB">
+        <Tabs
+          {...props}
+          data={tablistData}
+          selectedKey={startupSelectedKey}
+        >
+          {contentWrapperData}
+        </Tabs>
+      </Provider>
+    )
+
+    const buttons = document.querySelectorAll(
+      '.dnb-tabs__scroll-nav-button'
+    )
+
+    expect(buttons[0]).toHaveAttribute(
+      'title',
+      translations.prevButtonTitle
+    )
+    expect(buttons[0]).toHaveAttribute(
+      'aria-label',
+      translations.prevButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'title',
+      translations.nextButtonTitle
+    )
+    expect(buttons[1]).toHaveAttribute(
+      'aria-label',
+      translations.nextButtonTitle
+    )
   })
 
   it('warns when not providing any content', () => {

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -125,6 +125,10 @@ export default {
       isLoadingText: 'Indlæser nyt indhold',
       loadButtonText: 'Vis mere indhold',
     },
+    Tabs: {
+      prevButtonTitle: 'Forrige fane',
+      nextButtonTitle: 'Næste fane',
+    },
     Skeleton: {
       ariaBusy: 'Behandler data ...',
       ariaReady: 'Klar til at interagere',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -128,6 +128,10 @@ export default {
       isLoadingText: 'Loading new content',
       loadButtonText: 'Show more content',
     },
+    Tabs: {
+      prevButtonTitle: 'Previous tab',
+      nextButtonTitle: 'Next tab',
+    },
     StepIndicator: {
       overviewTitle: 'Steps Overview',
       stepTitle: 'Step %step of %count:',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -123,6 +123,10 @@ export default {
       isLoadingText: 'Laster nytt innhold',
       loadButtonText: 'Vis mer innhold',
     },
+    Tabs: {
+      prevButtonTitle: 'Forrige fane',
+      nextButtonTitle: 'Neste fane',
+    },
     Skeleton: {
       ariaBusy: 'Behandler data ...',
       ariaReady: 'Klar til å samhandle',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -124,6 +124,10 @@ export default {
       isLoadingText: 'Laddar nytt innehåll',
       loadButtonText: 'Visa mer innehåll',
     },
+    Tabs: {
+      prevButtonTitle: 'Föregående flik',
+      nextButtonTitle: 'Nästa flik',
+    },
     Skeleton: {
       ariaBusy: 'Bearbetar data ...',
       ariaReady: 'Klar att interagera',


### PR DESCRIPTION
## Summary
- replace hardcoded Tabs scroll button labels with locale-driven translations
- add locale entries for the Tabs scroll navigation button titles
- cover both default and provider-driven translations in focused Tabs tests

## Verification
- `yarn workspace @dnb/eufemia test --run src/components/tabs/__tests__/Tabs.test.tsx -t 'scroll navigation button'`
- reloaded `http://localhost:8001/uilib/components/radio` and confirmed the icon-only button warning no longer appears