### PR TITLE
chore(Forms): flush pending timers in useQueryLocator tests

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
@@ -14,6 +14,16 @@ describe('useQueryLocator', () => {
     identifier = makeUniqueId()
   })
 
+  afterEach(async () => {
+    // The Form.Handler's useFormStatusBuffer has setTimeout callbacks that may
+    // still be pending when the test ends. If these fire after vitest tears down
+    // the jsdom environment, React's forceUpdate() fails with "window is not defined".
+    // This delay lets pending timers (1-2ms in test mode) complete before teardown.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+  })
+
   const previousButton = () => {
     return document.querySelector('.dnb-forms-previous-button')
   }


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/26029885511/job/76512781250#step:9:702

Not exactly sure how to improve this yet, or if it's actually needed...
