### PR TITLE
fix(Tabs): prevent setState during render in shared state initialization

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -845,15 +845,20 @@ function TabsComponent(ownProps: TabsProps) {
     }
   }, [scrollToTab])
 
-  // Synchronous shared state initialization (must happen during render, not in useEffect)
+  // Synchronous shared state initialization (must happen during render, not in useEffect).
+  // Use silent: true to avoid triggering subscribers during render, which would cause
+  // "Cannot update a component while rendering a different component" errors.
   if (ownProps.id && !sharedStateRef.current) {
     sharedStateRef.current = createSharedState(ownProps.id)
-    sharedStateRef.current.set({
-      key: selectedKey,
-      selectedKey,
-      focusKey,
-      title: getCurrentTitle(selectedKey),
-    })
+    sharedStateRef.current.set(
+      {
+        key: selectedKey,
+        selectedKey,
+        focusKey,
+        title: getCurrentTitle(selectedKey),
+      },
+      { silent: true }
+    )
   }
 
   // Init on mount / window load

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -33,6 +33,44 @@ const contentWrapperData = {
 }
 
 describe('Tabs component', () => {
+  it('should not trigger setState warnings when using shared state with ContentWrapper', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    const sharedId = 'shared-tabs-id'
+
+    // First render ContentWrapper alone so it subscribes to shared state
+    const { rerender } = render(
+      <Tabs.ContentWrapper id={sharedId}>
+        <p>External content</p>
+      </Tabs.ContentWrapper>
+    )
+
+    // Then add Tabs - this simulates the navigation scenario where
+    // ContentWrapper is already subscribed when Tabs mounts and calls set()
+    rerender(
+      <>
+        <Tabs id={sharedId} data={tablistData}>
+          {contentWrapperData}
+        </Tabs>
+        <Tabs.ContentWrapper id={sharedId}>
+          <p>External content</p>
+        </Tabs.ContentWrapper>
+      </>
+    )
+
+    // Verify no "Cannot update a component while rendering" error was logged
+    const setStateWarnings = consoleError.mock.calls.filter((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === 'string' &&
+          arg.includes('Cannot update a component')
+      )
+    )
+    expect(setStateWarnings).toHaveLength(0)
+
+    consoleError.mockRestore()
+  })
+
   it('have a "selectedKey" state have to be same as prop from startup', () => {
     render(
       <Tabs {...props} data={tablistData} selectedKey={startupSelectedKey}>


### PR DESCRIPTION
Use silent: true when setting initial shared state data during render to avoid triggering subscribers. This fixes the React warning 'Cannot update a component while rendering a different component' that occurred when navigating between tab pages.

Can be experienced when navigation from http://localhost:8000/uilib/components/fragments to http://localhost:8000/uilib/components/fragments/drawer-list by clicking the DrawerList link/menu item in the menu:

Error message: `Cannot update a component (`ContentWrapper`) while rendering a different component (`Tabs`). To locate the bad setState() call inside `Tabs`, follow the stack trace as described in https://react.dev/link/setstate-in-render`

Image:
<img width="1760" height="1233" alt="image" src="https://github.com/user-attachments/assets/b301f4c2-b746-4267-8ac5-42f3abf78156" />

