### PR TITLE
fix(Accordion): memoize store (`rememberState`)

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -198,7 +198,10 @@ function AccordionDefault({
   const group = props.group || context?.group
   const id = useId(props.id)
 
-  const store = new Store({ id: props.id, group })
+  const store = useMemo(
+    () => new Store({ id: props.id, group }),
+    [props.id, group]
+  )
 
   // States ordered last here to make sure that the getInitialExpandedState have access to the store
   const [previousExpanded, setPreviousExpanded] = useState(props.expanded)


### PR DESCRIPTION
## Summary
Memoize the `Store` instance in `AccordionDefault` so the `useEffect` dependency no longer changes on every render.

## Validation
- `yarn test --run src/components/accordion/__tests__/Accordion.test.tsx`