### PR TITLE
chore(Skeleton): remove useless concat() call in figure components

### DIFF
--- a/packages/dnb-eufemia/src/components/skeleton/figures/Article.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Article.tsx
@@ -27,10 +27,10 @@ function SkeletonArticle({
     // Do this so we get the same result each time
     // because of static generated markup
     const fill = [70, 80, 60, 40, 50, 20, 0]
-    return new Array(Number(rows)).fill(true).map((_, i) => {
+    return Array.from({ length: Number(rows) }, (_, i) => {
       const c = i % fill.length
       if (c === fill.length - 1) {
-        fill.concat(fill.reverse())
+        fill.reverse()
       }
       return fill[c]
     })

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Circle.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Circle.tsx
@@ -24,10 +24,10 @@ function SkeletonCircle({
     // Do this so we get the same result each time
     // because of static generated markup
     const fill = [70, 80, 60, 40, 50, 20, 0]
-    return new Array(Number(rows)).fill(true).map((_, i) => {
+    return Array.from({ length: Number(rows) }, (_, i) => {
       const c = i % fill.length
       if (c === fill.length - 1) {
-        fill.concat(fill.reverse())
+        fill.reverse()
       }
       return fill[c]
     })

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Product.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Product.tsx
@@ -28,10 +28,10 @@ function SkeletonProduct({
     // Do this so we get the same result each time
     // because of static generated markup
     const fill = [70, 80, 60, 40, 50, 20, 0]
-    return new Array(Number(rows)).fill(true).map((_, i) => {
+    return Array.from({ length: Number(rows) }, (_, i) => {
       const c = i % fill.length
       if (c === fill.length - 1) {
-        fill.concat(fill.reverse())
+        fill.reverse()
       }
       return fill[c]
     })

--- a/packages/dnb-eufemia/src/components/skeleton/figures/Table.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/figures/Table.tsx
@@ -24,10 +24,10 @@ function SkeletonTable({
     // Do this so we get the same result each time
     // because of static generated markup
     const fill = [70, 80, 60, 40, 50, 20, 0]
-    return new Array(Number(rows)).fill(true).map((_, i) => {
+    return Array.from({ length: Number(rows) }, (_, i) => {
       const c = i % fill.length
       if (c === fill.length - 1) {
-        fill.concat(fill.reverse())
+        fill.reverse()
       }
       return fill[c]
     })


### PR DESCRIPTION
The concat() return value was being discarded. Since reverse() already mutates the array in place, the concat() call served no purpose.

Also modernized new Array(n).fill().map() to Array.from() for clarity.

