### PR TITLE
chore(CopyOnClick): simplify redundant boolean check

### DIFF
--- a/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
+++ b/packages/dnb-eufemia/src/components/copy-on-click/CopyOnClick.tsx
@@ -47,7 +47,7 @@ const CopyOnClick = ({
 
     try {
       const success = await copyToClipboard(str)
-      if (success === true) {
+      if (success) {
         setActive(true)
 
         timeoutRef.current = setTimeout(() => setActive(false), 2000)


### PR DESCRIPTION
Replace 'success === true' with 'success' since copyToClipboard returns boolean
