### PR TITLE
fix(MCP): make @modelcontextprotocol/sdk a optional dependency — ⚠️ install it yourself to use the MCP server (beta)

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -105,7 +105,6 @@
   "typings": "./index.d.ts",
   "dependencies": {
     "@babel/runtime-corejs3": "7.28.4",
-    "@modelcontextprotocol/sdk": "1.26.0",
     "@navikt/fnrvalidator": "2.1.5",
     "@ungap/structured-clone": "1.2.0",
     "ajv": "8.18.0",
@@ -158,6 +157,7 @@
     "@emotion/styled": "11.11.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@playwright/test": "1.49.1",
     "@semantic-release/changelog": "6.0.2",
     "@semantic-release/commit-analyzer": "9.0.2",

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -639,13 +639,13 @@ describe('MCP dependency configuration', () => {
       fs.readFileSync(packageJsonPath, 'utf8')
     )
 
-    expect(packageJson.dependencies).toBeDefined()
-    expect(
-      packageJson.dependencies['@modelcontextprotocol/sdk']
-    ).toBeDefined()
-    expect(
-      packageJson.dependencies['@modelcontextprotocol/sdk']
-    ).toBeTruthy()
+    const sdkVersion =
+      packageJson.optionalDependencies?.['@modelcontextprotocol/sdk'] ??
+      packageJson.dependencies?.['@modelcontextprotocol/sdk'] ??
+      packageJson.devDependencies?.['@modelcontextprotocol/sdk']
+
+    expect(sdkVersion).toBeDefined()
+    expect(sdkVersion).toBeTruthy()
   })
 
   it('has .vscode/mcp.json with correct eufemia server configuration', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4360,7 +4360,7 @@ __metadata:
     "@emotion/styled": "npm:11.11.0"
     "@eslint/eslintrc": "npm:3.3.3"
     "@eslint/js": "npm:9.39.2"
-    "@modelcontextprotocol/sdk": "npm:1.26.0"
+    "@modelcontextprotocol/sdk": "npm:1.29.0"
     "@navikt/fnrvalidator": "npm:2.1.5"
     "@playwright/test": "npm:1.49.1"
     "@semantic-release/changelog": "npm:6.0.2"
@@ -6752,9 +6752,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:1.26.0":
-  version: 1.26.0
-  resolution: "@modelcontextprotocol/sdk@npm:1.26.0"
+"@modelcontextprotocol/sdk@npm:1.29.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
   dependencies:
     "@hono/node-server": "npm:^1.19.9"
     ajv: "npm:^8.17.1"
@@ -6781,7 +6781,7 @@ __metadata:
       optional: true
     zod:
       optional: false
-  checksum: 10/a206b2a4d61a23be8b8f4c886528dd9348d11b17ce36013b350edf5c082b1c1f07941d52ea098f721daf3828085b6f6276bb844c484a0e9913edbc028517a3d5
+  checksum: 10/ff551b97e06b661f95fec8fd34e112c446e69894a84a9979cdac369fb5de27f0a1a5c1f4e2a1f270cc60f93e54c28a8059a94ca51c3d528d2670ade874b244f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1778831865098279?thread_ts=1777356189.425229&cid=CMXABCHEY
Target: v10.104.2