### PR TITLE
chore(CI): allow maintenance release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,8 @@ jobs:
         run: yarn workspace @dnb/eufemia postbuild:ci
 
       - name: Release
-        if: (github.ref == 'refs/heads/release' ||
+        if: github.repository == 'dnbexperience/eufemia' &&
+          (github.ref == 'refs/heads/release' ||
           github.ref == 'refs/heads/beta' ||
           github.ref == 'refs/heads/alpha' ||
           github.ref == 'refs/heads/next' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,5 +97,6 @@ jobs:
         if: (github.ref == 'refs/heads/release' ||
           github.ref == 'refs/heads/beta' ||
           github.ref == 'refs/heads/alpha' ||
-          github.ref == 'refs/heads/next')
+          github.ref == 'refs/heads/next' ||
+          endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci


### PR DESCRIPTION
## Summary
Allow the release workflow to publish from maintenance branches.

## What changed
- keep the workflow trigger on `*.x` maintenance branches
- update the `Release` step condition so it also runs for refs ending in `.x`

## Why
The workflow was starting on maintenance branch pushes, but the publish step was skipped because the branch gate only allowed `release`, `beta`, `alpha`, and `next`.