### PR TITLE
chore(Portal): use fallback colors for noscript

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss
@@ -27,8 +27,9 @@
   padding: 1.25rem;
   text-align: center;
 
-  color: var(--token-color-text-neutral);
-  background-color: var(--token-color-background-neutral);
+  // Design tokens can not be used outside of Theme Provider
+  color: #000;
+  background-color: #fff;
 }
 
 .dnb-live-preview {


### PR DESCRIPTION
## Summary

Use fallback hex colors for the Portal noscript banner instead of design tokens.

## Why

The noscript content renders outside the Theme Provider, so design tokens are not available there.

## Testing

- `yarn exec prettier --check packages/dnb-design-system-portal/src/shared/parts/PortalStyle.scss`
- Verified `PortalStyle.scss` has no diagnostics
