### PR TITLE
chore(Space): scope responsive spacing variables

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
@@ -119,3 +119,5 @@ See the [Responsive layout gap demo](/uilib/layout/space/demos/#responsive-layou
 | `--responsive-spacing-large`    | 2rem (32px)       | 2.5rem (40px)          | 3rem (48px)         |
 | `--responsive-spacing-x-large`  | 2.5rem (40px)     | 3rem (48px)            | 3.5rem (56px)       |
 | `--responsive-spacing-xx-large` | 3rem (48px)       | 3.5rem (56px)          | 4rem (64px)         |
+
+All `--responsive-spacing-*` CSS variables are scoped to the `.dnb-space` class as of now.

--- a/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Space scss > should match style dependencies css 1`] = `
  *
  */
 @media screen and (max-width: 40em) {
-  :root {
+  .dnb-space {
     --responsive-spacing-xx-small: 0.25rem;
     --responsive-spacing-x-small: 0.5rem;
     --responsive-spacing-small: 1rem;
@@ -32,7 +32,7 @@ exports[`Space scss > should match style dependencies css 1`] = `
   }
 }
 @media screen and (max-width: 60em) and (min-width: 40.00625em) {
-  :root {
+  .dnb-space {
     --responsive-spacing-xx-small: 0.5rem;
     --responsive-spacing-x-small: 1rem;
     --responsive-spacing-small: 1.5rem;
@@ -43,7 +43,7 @@ exports[`Space scss > should match style dependencies css 1`] = `
   }
 }
 @media screen and (min-width: 60.00625em) {
-  :root {
+  .dnb-space {
     --responsive-spacing-xx-small: 1rem;
     --responsive-spacing-x-small: 1.5rem;
     --responsive-spacing-small: 2rem;

--- a/packages/dnb-eufemia/src/components/space/style/responsive-spacing.scss
+++ b/packages/dnb-eufemia/src/components/space/style/responsive-spacing.scss
@@ -1,6 +1,11 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
-:root {
+// If we need it later, we may open this up to :root.
+// For now, we scope it to the component because,
+// if we ever serve token values from brand files at some point,
+// we need a way to make that compatible with :root.
+// The theme is not compatible with :root today.
+.dnb-space {
   @include utilities.allBelow(small) {
     --responsive-spacing-xx-small: 0.25rem; // 4px
     --responsive-spacing-x-small: 0.5rem; // 8px


### PR DESCRIPTION
## Summary
- scope the responsive spacing CSS variables to `.dnb-space` instead of `:root`
- update the Space snapshots to reflect the new selector
- document the current variable scoping in the Space docs

