### PR TITLE
feat(Helpers): add isModifiedClickEvent

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/functions.mdx
@@ -255,6 +255,18 @@ debounced.addCancelEvent(myCancelMethod) // Alternatively, you can add the cance
 
 In order to use `this.addCancelEvent`, you need to use a `function()` and not an arrow function.
 
+### isModifiedClickEvent
+
+Checks if a click event uses modifier keys or a non-primary mouse button. This is useful when you want to preserve the browser's default link behavior, such as opening a link in a new tab or window.
+
+```js
+import { isModifiedClickEvent } from '@dnb/eufemia/shared/helpers'
+
+isModifiedClickEvent(event) // returns Boolean
+```
+
+The helper returns `true` when the event has `metaKey`, `ctrlKey`, `shiftKey`, `altKey` or a non-primary `button` value.
+
 ### copyToClipboard
 
 Copies the given string to the device's clipboard.

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -56,6 +56,7 @@ You can use the internal Eufemia easing function.
 - [applyPageFocus](/uilib/helpers/functions#applypagefocus): Applies a page focus to an element given by the setPageFocusElement.
 - [setPageFocusElement](/uilib/helpers/functions#setpagefocuselement): Defines a focus element to applyPageFocus.
 - [debounce](/uilib/helpers/functions#debounce): Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
+- [isModifiedClickEvent](/uilib/helpers/functions#ismodifiedclickevent): Checks if a click event uses modifier keys or a non-primary mouse button.
 - [copyToClipboard](/uilib/helpers/functions#copytoclipboard): Copies a given string to the clipboard.
 
 ### Device checks

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -17,7 +17,10 @@ import {
   drawerClassStyle,
 } from './SearchBar.module.scss'
 import { scrollToAnimation } from '../parts/layout-utils'
-import { applyPageFocus } from '@dnb/eufemia/src/shared/helpers'
+import {
+  applyPageFocus,
+  isModifiedClickEvent,
+} from '@dnb/eufemia/src/shared/helpers'
 
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
@@ -222,17 +225,13 @@ const handleSearchResultNavigation = ({
   allowBrowserDefaultOnModified = false,
 }: SearchResultNavigationArgs) => {
   const url = `/${slug}${hash ? `#${hash}` : ''}`.replace('//', '/')
-  const modifiedClick =
-    event?.metaKey || event?.ctrlKey || event?.shiftKey || event?.altKey
-  const isMouseEvent =
-    !!event && 'button' in event && typeof event.button === 'number'
-  const isMiddleClick = isMouseEvent && (event as MouseEvent).button !== 0
+  const modifiedClick = isModifiedClickEvent(event)
 
-  if ((modifiedClick || isMiddleClick) && allowBrowserDefaultOnModified) {
+  if (modifiedClick && allowBrowserDefaultOnModified) {
     return false
   }
 
-  if (modifiedClick || isMiddleClick) {
+  if (modifiedClick) {
     if (typeof window !== 'undefined') {
       window.open(url, '_blank', 'noopener')
     }

--- a/packages/dnb-eufemia/src/shared/__tests__/helpers.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/helpers.test.tsx
@@ -13,6 +13,7 @@ import {
   getSelectedElement,
   hasSelectedText,
   getSelectedText,
+  isModifiedClickEvent,
   isiOS,
   isSafari,
   isWin,
@@ -241,6 +242,25 @@ describe('selection related methods', () => {
   })
   it('hasSelectedText should be true', () => {
     expect(hasSelectedText()).toBe(true)
+  })
+})
+
+describe('"isModifiedClickEvent" should', () => {
+  it('be true on modifier keys', () => {
+    expect(isModifiedClickEvent({ metaKey: true })).toBe(true)
+    expect(isModifiedClickEvent({ ctrlKey: true })).toBe(true)
+    expect(isModifiedClickEvent({ shiftKey: true })).toBe(true)
+    expect(isModifiedClickEvent({ altKey: true })).toBe(true)
+  })
+
+  it('be true on non-primary mouse buttons', () => {
+    expect(isModifiedClickEvent({ button: 1 })).toBe(true)
+    expect(isModifiedClickEvent({ button: 2 })).toBe(true)
+  })
+
+  it('be false on a plain primary click', () => {
+    expect(isModifiedClickEvent({ button: 0 })).toBe(false)
+    expect(isModifiedClickEvent({})).toBe(false)
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/helpers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers.ts
@@ -257,6 +257,30 @@ export function getSelectedText() {
   return undefined
 }
 
+type ModifiedClickLikeEvent = {
+  metaKey?: boolean
+  ctrlKey?: boolean
+  shiftKey?: boolean
+  altKey?: boolean
+  button?: number
+}
+
+export function isModifiedClickEvent(
+  event?: ModifiedClickLikeEvent | null
+) {
+  if (!event) {
+    return false
+  }
+
+  return Boolean(
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    (typeof event.button === 'number' && event.button !== 0)
+  )
+}
+
 export function emptySelectedText() {
   try {
     if (window.getSelection && window.getSelection().empty) {


### PR DESCRIPTION
## Summary
- add a shared `isModifiedClickEvent` helper for detecting modifier-key and non-primary-button clicks
- reuse the helper in portal `SearchBar` navigation so browser default link behavior stays centralized in shared code
- document the helper in the helpers docs and add unit coverage

## Testing
- `yarn test src/shared/__tests__/helpers.test.tsx`
