### PR TITLE
chore: add default reporter to screenshot tests

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest-screenshots/liveReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/liveReporter.ts
@@ -8,9 +8,9 @@
  * data across the suite.
  *
  * Pairs with `ScreenshotReporter` (which writes the HTML diff at the
- * end). Vitest's own banner and the final
- * `Test Files / Tests / Duration` block come from the runner, so we
- * can omit `'default'` and keep the output clean.
+ * end). The screenshot config also includes Vitest's `'default'`
+ * reporter so the run keeps the standard final summary and timing
+ * breakdown.
  */
 
 import type {

--- a/packages/dnb-eufemia/vitest.config.screenshots.ts
+++ b/packages/dnb-eufemia/vitest.config.screenshots.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     include: process.env.SCREENSHOT_INCLUDE
       ? process.env.SCREENSHOT_INCLUDE.split(',')
       : ['src/**/*.screenshot.test.{ts,tsx}'],
-    reporters: [new LiveReporter(), new ScreenshotReporter()],
+    reporters: ['default', new LiveReporter(), new ScreenshotReporter()],
 
     // Each worker gets its own forked process. The screenshot engine
     // launches a dedicated Firefox process per worker slot (via a


### PR DESCRIPTION
## Summary
- add Vitest's `default` reporter to the screenshot test config
- keep the existing custom screenshot reporters in place
- update the live reporter comment to reflect the final summary/timing output

## Testing
- `SCREENSHOT_INCLUDE=src/__does_not_exist__.screenshot.test.ts yarn exec vitest run --config vitest.config.screenshots.ts --passWithNoTests`
