### PR TITLE
chore: replace glob with globby

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-workspaces": "0.11.1",
     "fs-extra": "10.0.0",
     "github-slugger": "1.4.0",
-    "glob": "11.0.3",
+    "globby": "11.0.4",
     "gray-matter": "4.0.3",
     "jsdom": "29.1.1",
     "mdast-util-to-string": "4.0.0",

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type * as EufemiaPrebuildModule from '../../client/plugins/eufemia-prebuild'
-import type * as GlobModule from 'glob'
+import type * as GlobbyModule from 'globby'
 import eufemiaThemePlugin, {
   getDefaultConfig,
 } from '../../client/plugins/eufemia-theme'
@@ -167,12 +167,12 @@ describe('eufemia-theme plugin', () => {
         }
       })
 
-      vi.doMock('glob', async () => {
-        const actual = await vi.importActual<typeof GlobModule>('glob')
+      vi.doMock('globby', async () => {
+        const actual = await vi.importActual<typeof GlobbyModule>('globby')
 
         return {
           ...actual,
-          globSync: vi.fn((pattern: string) => {
+          sync: vi.fn((pattern: string) => {
             const normalized = pattern.replace(/\\/g, '/')
 
             if (normalized.includes('/build/style/dnb-ui-core.scss')) {
@@ -211,7 +211,7 @@ describe('eufemia-theme plugin', () => {
         expect(code).not.toContain('/src/style/')
       } finally {
         vi.doUnmock('../../client/plugins/eufemia-prebuild')
-        vi.doUnmock('glob')
+        vi.doUnmock('globby')
         vi.resetModules()
       }
     })

--- a/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
@@ -12,7 +12,7 @@
 
 import { type Plugin } from 'vite'
 import path from 'node:path'
-import { globSync } from 'glob'
+import { sync as globSync } from 'globby'
 import micromatch from 'micromatch'
 import { hasPrebuild } from './eufemia-prebuild'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3336,13 +3336,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/cliui@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@isaacs/cliui@npm:9.0.0"
-  checksum: 10/8ea3d1009fd29071419209bb91ede20cf27e6e2a1630c5e0702d8b3f47f9e1a3f1c5a587fa2cb96d22d18219790327df49db1bcced573346bbaf4577cf46b643
-  languageName: node
-  linkType: hard
-
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -8919,7 +8912,7 @@ __metadata:
     eslint-plugin-workspaces: "npm:0.11.1"
     fs-extra: "npm:10.0.0"
     github-slugger: "npm:1.4.0"
-    glob: "npm:11.0.3"
+    globby: "npm:11.0.4"
     gray-matter: "npm:4.0.3"
     jsdom: "npm:29.1.1"
     mdast-util-to-string: "npm:4.0.0"
@@ -10756,16 +10749,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "foreground-child@npm:3.3.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.6"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10/427b33f997a98073c0424e5c07169264a62cda806d8d2ded159b5b903fdfc8f0a1457e06b5fc35506497acb3f1e353f025edee796300209ac6231e80edece835
-  languageName: node
-  linkType: hard
-
 "form-data@npm:^4.0.0, form-data@npm:^4.0.4":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
@@ -11165,22 +11148,6 @@ __metadata:
     to-absolute-glob: "npm:^2.0.0"
     unique-stream: "npm:^2.0.2"
   checksum: 10/7c9ec7be266974186b762ad686813025868067f2ea64a0428c0365b4046cb955d328b1e7498124392ec0026c5826ce2cfa4b41614584fb63edd02421e61db556
-  languageName: node
-  linkType: hard
-
-"glob@npm:11.0.3":
-  version: 11.0.3
-  resolution: "glob@npm:11.0.3"
-  dependencies:
-    foreground-child: "npm:^3.3.1"
-    jackspeak: "npm:^4.1.1"
-    minimatch: "npm:^10.0.3"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^2.0.0"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/2ae536c1360c0266b523b2bfa6aadc10144a8b7e08869b088e37ac3c27cd30774f82e4bfb291cde796776e878f9e13200c7ff44010eb7054e00f46f649397893
   languageName: node
   linkType: hard
 
@@ -12806,15 +12773,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^4.1.1":
-  version: 4.2.3
-  resolution: "jackspeak@npm:4.2.3"
-  dependencies:
-    "@isaacs/cliui": "npm:^9.0.0"
-  checksum: 10/b88e3fe5fa04d34f0f939a15b7cef4a8589999b7a366ef89a3e0f2c45d2a7666066b67cbf46d57c3a4796a76d27b9d869b23d96a803dd834200d222c2a70de7e
   languageName: node
   linkType: hard
 
@@ -15045,7 +15003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3, minimatch@npm:^10.2.2":
+"minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -16815,7 +16773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^2.0.0, path-scurry@npm:^2.0.2":
+"path-scurry@npm:^2.0.2":
   version: 2.0.2
   resolution: "path-scurry@npm:2.0.2"
   dependencies:


### PR DESCRIPTION
Replace the glob package with globby (v11) in dnb-design-system-portal. The rest of the monorepo already uses globby, so this aligns the portal package with the existing convention.

- Update import in eufemia-theme.ts: globSync → sync (aliased)
- Update mock and type import in eufemia-theme.test.ts
- Swap dependency in package.json (glob 11.0.3 → globby 11.0.4)

