### PR TITLE
chore: consolidate current-git-branch into simple-git

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -183,7 +183,6 @@
     "conventional-changelog-conventionalcommits": "5.0.0",
     "cross-env": "7.0.3",
     "cssnano": "6.0.1",
-    "current-git-branch": "1.1.0",
     "dependency-cruiser": "17.3.8",
     "dnb-design-system-portal": "workspace:*",
     "dotenv-cli": "4.1.0",

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -8,7 +8,7 @@
 // run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
 const { runCommand } = require('../tools/cliTools')
-const getBranchName = require('current-git-branch')
+const simpleGit = require('simple-git')
 
 try {
   process.loadEnvFile()
@@ -25,7 +25,7 @@ if (require.main === module) {
 }
 
 async function getNextReleaseVersion() {
-  const branchName = getBranchName()
+  const branchName = (await simpleGit().branch()).current
 
   if (releaseBranches.includes(branchName)) {
     try {

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -6,9 +6,19 @@
 import fs from 'fs-extra'
 import { makeReleaseVersion } from '../makeReleaseVersion'
 import * as child_process from 'child_process'
-import * as getBranchName from 'current-git-branch'
+import simpleGit from 'simple-git'
+import type { SimpleGit } from 'simple-git'
 import * as getNextReleaseVersion from '../../../postbuild/getNextReleaseVersion'
 import { log } from '../../../lib'
+
+vi.mock('simple-git')
+const mockSimpleGit = vi.mocked(simpleGit)
+
+function mockBranchName(branchName: string) {
+  mockSimpleGit.mockReturnValue({
+    branch: vi.fn().mockResolvedValue({ current: branchName }),
+  } as unknown as SimpleGit)
+}
 
 vi.mock('../../../postbuild/getNextReleaseVersion', async () => {
   return {
@@ -69,10 +79,6 @@ vi.mock('repo-utils', async () => {
   }
 })
 
-vi.mock('current-git-branch', () => ({
-  default: vi.fn(),
-}))
-
 vi.mock('child_process', () => ({
   execSync: vi.fn(() => {
     return {
@@ -92,9 +98,7 @@ afterEach(() => {
 
 describe('makeReleaseVersion', () => {
   it('should log success', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -114,9 +118,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('should only run when on release branches', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -128,9 +130,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('should run on any branch', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'some-branch'
-    )
+    mockBranchName('some-branch')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -163,9 +163,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('write version in file', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -208,9 +206,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('write branch in file', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -243,9 +239,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('write sha in file', async () => {
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
       'test-sha' as any
     )
@@ -288,9 +282,7 @@ describe('makeReleaseVersion', () => {
 
   it('write buildDate (ISO) in BuildInfoData files', async () => {
     const beforeCall = Date.now()
-    vi.spyOn(getBranchName, 'default').mockImplementationOnce(
-      () => 'release'
-    )
+    mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -6,7 +6,7 @@
 import { execSync } from 'child_process'
 import fs from 'fs-extra'
 import { isCI } from 'repo-utils'
-import getBranchName from 'current-git-branch'
+import simpleGit from 'simple-git'
 import {
   getNextReleaseVersion,
   releaseBranches,
@@ -15,7 +15,7 @@ import { log } from '../../lib'
 import { getStyleScopeHash } from '../../../src/plugins/postcss-isolated-style-scope/plugin-scope-hash.js'
 
 export async function makeReleaseVersion() {
-  const branchName = getBranchName()
+  const branchName = (await simpleGit().branch()).current
 
   if (branchName.startsWith('icons/')) {
     return // stop here

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,7 +2292,6 @@ __metadata:
     core-js-pure: "npm:3.47.0"
     cross-env: "npm:7.0.3"
     cssnano: "npm:6.0.1"
-    current-git-branch: "npm:1.1.0"
     date-fns: "npm:4.1.0"
     dependency-cruiser: "npm:17.3.8"
     dnb-design-system-portal: "workspace:*"
@@ -6849,13 +6848,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-add-module-exports@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "babel-plugin-add-module-exports@npm:0.2.1"
-  checksum: 10/4d527062f4e08a23d13e31b8f4fb928e936f0c0436241dda84d0d7c002995824a04bef30405874f51bdecf77c6663f9223e94c775e9bc5a119c1d9071190f3a0
-  languageName: node
-  linkType: hard
-
 "babel-plugin-fully-specified@npm:1.3.1":
   version: 1.3.1
   resolution: "babel-plugin-fully-specified@npm:1.3.1"
@@ -8252,17 +8244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^5.0.1":
-  version: 5.1.0
-  resolution: "cross-spawn@npm:5.1.0"
-  dependencies:
-    lru-cache: "npm:^4.0.1"
-    shebang-command: "npm:^1.2.0"
-    which: "npm:^1.2.9"
-  checksum: 10/726939c9954fc70c20e538923feaaa33bebc253247d13021737c3c7f68cdc3e0a57f720c0fe75057c0387995349f3f12e20e9bfdbf12274db28019c7ea4ec166
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -8492,17 +8473,6 @@ __metadata:
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10/ad41baf7e2ffac65ab544d79107bf7cd1a4bb9bab9ac3302f59ab4ba655d5e30942a8ae46e10ba160c6f4ecea464cc95b975ca2fefbdeeacd6ac63f12f99fe1f
-  languageName: node
-  linkType: hard
-
-"current-git-branch@npm:1.1.0":
-  version: 1.1.0
-  resolution: "current-git-branch@npm:1.1.0"
-  dependencies:
-    babel-plugin-add-module-exports: "npm:^0.2.1"
-    execa: "npm:^0.6.1"
-    is-git-repository: "npm:^1.0.0"
-  checksum: 10/18476127b8ac52930e6d70eefdb688b7306f8a5e89dda57bd4202f74e3e7ee7608d3e3a6ea7ca7fff3c6a6421bf3913f355d3c0818d21b7d97a354402f3a7115
   languageName: node
   linkType: hard
 
@@ -10214,21 +10184,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^0.6.1":
-  version: 0.6.3
-  resolution: "execa@npm:0.6.3"
-  dependencies:
-    cross-spawn: "npm:^5.0.1"
-    get-stream: "npm:^3.0.0"
-    is-stream: "npm:^1.1.0"
-    npm-run-path: "npm:^2.0.0"
-    p-finally: "npm:^1.0.0"
-    signal-exit: "npm:^3.0.0"
-    strip-eof: "npm:^1.0.0"
-  checksum: 10/52fd1cfe47c4bd266076ebae04174ed9ab01188c2314314bca9574510ea74968eab3d1934e4e8a40ac02f885ddcfd31636869522c7eb0a1ed05f7a99e2d18710
-  languageName: node
-  linkType: hard
-
 "execa@npm:^2.0.3":
   version: 2.1.0
   resolution: "execa@npm:2.1.0"
@@ -11036,13 +10991,6 @@ __metadata:
   version: 9.0.0
   resolution: "get-stdin@npm:9.0.0"
   checksum: 10/5972bc34d05932b45512c8e2d67b040f1c1ca8afb95c56cbc480985f2d761b7e37fe90dc8abd22527f062cc5639a6930ff346e9952ae4c11a2d4275869459594
-  languageName: node
-  linkType: hard
-
-"get-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "get-stream@npm:3.0.0"
-  checksum: 10/de14fbb3b4548ace9ab6376be852eef9898c491282e29595bc908a1814a126d3961b11cd4b7be5220019fe3b2abb84568da7793ad308fc139925a217063fa159
   languageName: node
   linkType: hard
 
@@ -12306,16 +12254,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-git-repository@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "is-git-repository@npm:1.1.1"
-  dependencies:
-    execa: "npm:^0.6.1"
-    path-is-absolute: "npm:^1.0.1"
-  checksum: 10/5b5466f38a7496a05d466ca935f3812eadf557caddb6a7607af44f8bcb579af6b524203b0cabfe61305999156f04514e18c4a65186c2f15343abfcf924362823
-  languageName: node
-  linkType: hard
-
 "is-glob@npm:^3.1.0":
   version: 3.1.0
   resolution: "is-glob@npm:3.1.0"
@@ -12546,13 +12484,6 @@ __metadata:
   dependencies:
     call-bound: "npm:^1.0.3"
   checksum: 10/0380d7c60cc692856871526ffcd38a8133818a2ee42d47bb8008248a0cd2121d8c8b5f66b6da3cac24bc5784553cacb6faaf678f66bc88c6615b42af2825230e
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-stream@npm:1.1.0"
-  checksum: 10/351aa77c543323c4e111204482808cfad68d2e940515949e31ccd0b010fc13d5fba4b9c230e4887fd24284713040f43e542332fbf172f6b9944b7d62e389c0ec
   languageName: node
   linkType: hard
 
@@ -13926,16 +13857,6 @@ __metadata:
   version: 11.3.5
   resolution: "lru-cache@npm:11.3.5"
   checksum: 10/3701b77e87765a3aea453402a7850bdbf7e02445210f35bd5ba1561f601f605f488bf9932be4a3851a6664073924f671a1ec99c4a1a98c457e0d126872a3e04f
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^4.0.1":
-  version: 4.1.5
-  resolution: "lru-cache@npm:4.1.5"
-  dependencies:
-    pseudomap: "npm:^1.0.2"
-    yallist: "npm:^2.1.2"
-  checksum: 10/9ec7d73f11a32cba0e80b7a58fdf29970814c0c795acaee1a6451ddfd609bae6ef9df0837f5bbeabb571ecd49c1e2d79e10e9b4ed422cfba17a0cb6145b018a9
   languageName: node
   linkType: hard
 
@@ -15846,15 +15767,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "npm-run-path@npm:2.0.2"
-  dependencies:
-    path-key: "npm:^2.0.0"
-  checksum: 10/acd5ad81648ba4588ba5a8effb1d98d2b339d31be16826a118d50f182a134ac523172101b82eab1d01cb4c2ba358e857d54cfafd8163a1ffe7bd52100b741125
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^3.0.0":
   version: 3.1.0
   resolution: "npm-run-path@npm:3.1.0"
@@ -16349,13 +16261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-finally@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-finally@npm:1.0.0"
-  checksum: 10/93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
-  languageName: node
-  linkType: hard
-
 "p-finally@npm:^2.0.0":
   version: 2.0.1
   resolution: "p-finally@npm:2.0.1"
@@ -16770,17 +16675,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-is-absolute@npm:^1.0.0, path-is-absolute@npm:^1.0.1":
+"path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
   checksum: 10/060840f92cf8effa293bcc1bea81281bd7d363731d214cbe5c227df207c34cd727430f70c6037b5159c8a870b9157cba65e775446b0ab06fd5ecc7e54615a3b8
-  languageName: node
-  linkType: hard
-
-"path-key@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "path-key@npm:2.0.1"
-  checksum: 10/6e654864e34386a2a8e6bf72cf664dcabb76574dd54013add770b374384d438aca95f4357bb26935b514a4e4c2c9b19e191f2200b282422a76ee038b9258c5e7
   languageName: node
   linkType: hard
 
@@ -18023,13 +17921,6 @@ __metadata:
   bin:
     ps-tree: ./bin/ps-tree.js
   checksum: 10/0587defdc20c0768fad884623c0204c77e5228878a5cb043676b00529220ec12d9cb6a328a0580767a9909a317bff466fe4530a4676e3d145a9deb3b7fbbeef3
-  languageName: node
-  linkType: hard
-
-"pseudomap@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "pseudomap@npm:1.0.2"
-  checksum: 10/856c0aae0ff2ad60881168334448e898ad7a0e45fe7386d114b150084254c01e200c957cf378378025df4e052c7890c5bd933939b0e0d2ecfcc1dc2f0b2991f5
   languageName: node
   linkType: hard
 
@@ -19579,28 +19470,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-command@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "shebang-command@npm:1.2.0"
-  dependencies:
-    shebang-regex: "npm:^1.0.0"
-  checksum: 10/9eed1750301e622961ba5d588af2212505e96770ec376a37ab678f965795e995ade7ed44910f5d3d3cb5e10165a1847f52d3348c64e146b8be922f7707958908
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
   dependencies:
     shebang-regex: "npm:^3.0.0"
   checksum: 10/6b52fe87271c12968f6a054e60f6bde5f0f3d2db483a1e5c3e12d657c488a15474121a1d55cd958f6df026a54374ec38a4a963988c213b7570e1d51575cea7fa
-  languageName: node
-  linkType: hard
-
-"shebang-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "shebang-regex@npm:1.0.0"
-  checksum: 10/404c5a752cd40f94591dfd9346da40a735a05139dac890ffc229afba610854d8799aaa52f87f7e0c94c5007f2c6af55bdcaeb584b56691926c5eaf41dc8f1372
   languageName: node
   linkType: hard
 
@@ -19666,7 +19541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10/a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -20271,13 +20146,6 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 10/8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
-  languageName: node
-  linkType: hard
-
-"strip-eof@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "strip-eof@npm:1.0.0"
-  checksum: 10/40bc8ddd7e072f8ba0c2d6d05267b4e0a4800898c3435b5fb5f5a21e6e47dfaff18467e7aa0d1844bb5d6274c3097246595841fbfeb317e541974ee992cac506
   languageName: node
   linkType: hard
 
@@ -22225,7 +22093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -22513,13 +22381,6 @@ __metadata:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 10/5f1b5f95e3775de4514edbb142398a2c37849ccfaf04a015be5d75521e9629d3be29bd4432d23c57f37e5b61ade592fb0197022e9993f81a06a5afbdcda9346d
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "yallist@npm:2.1.2"
-  checksum: 10/75fc7bee4821f52d1c6e6021b91b3e079276f1a9ce0ad58da3c76b79a7e47d6f276d35e206a96ac16c1cf48daee38a8bb3af0b1522a3d11c8ffe18f898828832
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace 'current-git-branch' package with 'simple-git' which was already a dependency. This reduces the number of dependencies while maintaining the same functionality.

Changes:
- Update makeReleaseVersion.ts to use simpleGit().branch().current
- Update getNextReleaseVersion.js to use simpleGit().branch().current
- Update test mocks to use vi.mocked(simpleGit) pattern
- Remove current-git-branch from devDependencies

