### PR TITLE
chore: add design commit decorator

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
@@ -43,6 +43,7 @@ If you are working on a single component update, you can use a decoration and a 
 You can also use the following decorators – but keep in mind, they won't be included in the [releases change log](https://github.com/dnbexperience/eufemia/releases):
 
 - `chore:`
+- `design:`
 - `docs:`
 - `style:`
 - `build:`

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -308,6 +308,11 @@
                 "hidden": false
               },
               {
+                "type": "design",
+                "section": ":art: Design Changes",
+                "hidden": false
+              },
+              {
                 "type": "refactor",
                 "section": ":zap: Refactoring",
                 "hidden": false


### PR DESCRIPTION
Adds `design:` as a supported git commit decorator, alongside existing ones like `style:`, `docs:`, etc.

- Added to the git style guide documentation
- Added to the semantic-release notes generator config with the section `:art: Design Changes`