### PR TITLE
feat: upgrade @dnb/browserslist-config from 1.2.0 to 1.4.0

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "7.28.5",
     "@babel/eslint-parser": "7.28.5",
-    "@dnb/browserslist-config": "1.2.0",
+    "@dnb/browserslist-config": "1.4.0",
     "@mdx-js/rollup": "3.1.1",
     "@playwright/test": "1.59.1",
     "@testing-library/react": "16.3.2",

--- a/packages/dnb-design-system-portal/vite.config.ts
+++ b/packages/dnb-design-system-portal/vite.config.ts
@@ -6,6 +6,7 @@
 
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
 import { createRequire } from 'node:module'
 import stripMissingExampleImportsPlugin from './vite/client/plugins/strip-missing-example-imports'
 import reactLiveBabelPlugin from './vite/client/plugins/react-live-babel'
@@ -49,6 +50,7 @@ export default defineConfig({
 
   // pipelines work unchanged.
   build: {
+    target: buildTargets,
     outDir: path.resolve(__dirname, 'public'),
     emptyOutDir: true,
   },

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -147,7 +147,7 @@
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.28.5",
     "@blazediff/core": "1.9.1",
-    "@dnb/browserslist-config": "1.2.0",
+    "@dnb/browserslist-config": "1.4.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.0",
     "@eslint/eslintrc": "3.3.3",

--- a/packages/dnb-eufemia/tsdown.config.ts
+++ b/packages/dnb-eufemia/tsdown.config.ts
@@ -1,5 +1,6 @@
 import type { UserConfig } from 'tsdown'
 import path from 'node:path'
+import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
 import pkg from './package.json'
 
 export default [
@@ -116,6 +117,7 @@ function makeBundleConfig(
     entry: { [outName]: input },
     format,
     platform: 'browser',
+    target: buildTargets,
     outDir: format === 'esm' ? 'build/esm' : 'build/umd',
 
     // Use .mjs for ESM and .js for UMD

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,10 +2222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dnb/browserslist-config@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@dnb/browserslist-config@npm:1.2.0"
-  checksum: 10/62641b81b2fc5ac57225ef7a32beb5e8ce4f3e1b42d401b1778ba41bf66ebd9195e65ef4603499faf75fb69dbf92f72c15e7114fab4f2738a075f5101238795b
+"@dnb/browserslist-config@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@dnb/browserslist-config@npm:1.4.0"
+  checksum: 10/68f0e9509a7bc45eb62e56f6c6f199dca8183595b8f36d54ebe58cd6dc2a2ca218247460a3a8e74238114dbcc47a4635252816249d7d35801502f49b1db7f79e
   languageName: node
   linkType: hard
 
@@ -2247,7 +2247,7 @@ __metadata:
     "@babel/preset-typescript": "npm:7.28.5"
     "@babel/runtime-corejs3": "npm:7.28.4"
     "@blazediff/core": "npm:1.9.1"
-    "@dnb/browserslist-config": "npm:1.2.0"
+    "@dnb/browserslist-config": "npm:1.4.0"
     "@emotion/react": "npm:11.14.0"
     "@emotion/styled": "npm:11.14.0"
     "@eslint/eslintrc": "npm:3.3.3"
@@ -8895,7 +8895,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:7.28.5"
     "@babel/eslint-parser": "npm:7.28.5"
-    "@dnb/browserslist-config": "npm:1.2.0"
+    "@dnb/browserslist-config": "npm:1.4.0"
     "@dnb/eufemia": "workspace:*"
     "@emotion/cache": "npm:11.14.0"
     "@emotion/react": "npm:11.14.0"


### PR DESCRIPTION
Upgrades `@dnb/browserslist-config` from 1.2.0 to 1.4.0.

### Version changes

- **1.3.0**: Raised Apple, Samsung, and Chrome Android minimums
- **1.4.0**: Added `buildTargets` for Vite, esbuild, and other tools

### New buildTargets usage

Uses the new `buildTargets.mjs` export to align build output with the browserslist targets:

- **Portal** (`vite.config.ts`): Added `build.target: buildTargets`
- **Eufemia** (`tsdown.config.ts`): Added `target: buildTargets` to UMD/ESM bundle configs

Current targets: `['chrome109', 'edge109', 'firefox115', 'ios14.5', 'opera95', 'safari14.1']`