### PR TITLE
chore(CI): handle direct file paths in screenshot test runner

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/vitest/__tests__/renewScreenshotsLib.test.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/__tests__/renewScreenshotsLib.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { collectRenewScreenshotMatches } from '../renewScreenshotsLib'
+
+describe('collectRenewScreenshotMatches', () => {
+  it('resolves test files when given a direct screenshot test path', () => {
+    const testPath =
+      'src/components/pagination/__tests__/Pagination.screenshot.test.ts'
+
+    const [result] = collectRenewScreenshotMatches([testPath])
+
+    expect(result.filter).toBe(testPath)
+    expect(result.testFiles).toEqual([testPath])
+  })
+
+  it('resolves test files for multiple direct screenshot test paths', () => {
+    const paths = [
+      'src/components/pagination/__tests__/Pagination.screenshot.test.ts',
+      'src/components/step-indicator/__tests__/StepIndicator.screenshot.test.ts',
+    ]
+
+    const results = collectRenewScreenshotMatches(paths)
+
+    expect(results).toHaveLength(2)
+    expect(results[0].testFiles).toEqual([paths[0]])
+    expect(results[1].testFiles).toEqual([paths[1]])
+  })
+
+  it('returns empty test files for a non-existent direct path', () => {
+    const testPath =
+      'src/components/nonexistent/__tests__/Nonexistent.screenshot.test.ts'
+
+    const [result] = collectRenewScreenshotMatches([testPath])
+
+    expect(result.filter).toBe(testPath)
+    expect(result.testFiles).toEqual([])
+  })
+
+  it('resolves test files when given a component name filter', () => {
+    const [result] = collectRenewScreenshotMatches(['pagination'])
+
+    expect(result.filter).toBe('pagination')
+    expect(result.testFiles).toEqual([
+      'src/components/pagination/__tests__/Pagination.screenshot.test.ts',
+    ])
+  })
+})

--- a/packages/dnb-eufemia/scripts/tools/vitest/renewScreenshotsLib.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/renewScreenshotsLib.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import globby from 'globby'
 
 export type RenewScreenshotMatch = {
@@ -6,21 +8,51 @@ export type RenewScreenshotMatch = {
   testFiles: string[]
 }
 
+function isDirectScreenshotTestPath(filter: string): boolean {
+  return /\.screenshot\.test\.(ts|tsx)$/.test(filter)
+}
+
+function getSnapshotDirFromTestPath(testPath: string): string | null {
+  const dir = path.dirname(testPath)
+
+  if (dir.endsWith('__tests__')) {
+    const snapshotDir = path.join(dir, '__image_snapshots__')
+    return existsSync(snapshotDir) ? snapshotDir : null
+  }
+
+  return null
+}
+
 export function collectRenewScreenshotMatches(filters: string[]) {
-  return filters.map<RenewScreenshotMatch>((filter) => ({
-    filter,
-    snapshotDirs: globby.sync(
-      `src/**/*${filter}*/__tests__/__image_snapshots__`,
-      {
-        onlyDirectories: true,
-        caseSensitiveMatch: false,
+  return filters.map<RenewScreenshotMatch>((filter) => {
+    // Handle direct file paths (e.g., from conditional screenshot runner)
+    if (isDirectScreenshotTestPath(filter)) {
+      const testFiles = existsSync(filter) ? [filter] : []
+      const snapshotDir = getSnapshotDirFromTestPath(filter)
+
+      return {
+        filter,
+        snapshotDirs: snapshotDir ? [snapshotDir] : [],
+        testFiles,
       }
-    ),
-    testFiles: globby.sync(
-      `src/**/*${filter}*/**/*.screenshot.test.{ts,tsx}`,
-      {
-        caseSensitiveMatch: false,
-      }
-    ),
-  }))
+    }
+
+    // Handle filter patterns (e.g., component names like "pagination")
+    return {
+      filter,
+      snapshotDirs: globby.sync(
+        `src/**/*${filter}*/__tests__/__image_snapshots__`,
+        {
+          onlyDirectories: true,
+          caseSensitiveMatch: false,
+        }
+      ),
+      testFiles: globby.sync(
+        `src/**/*${filter}*/**/*.screenshot.test.{ts,tsx}`,
+        {
+          caseSensitiveMatch: false,
+        }
+      ),
+    }
+  })
 }


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/26155294248/job/76935392772

I think this started to happen after merging https://github.com/dnbexperience/eufemia/pull/8150

When the conditional runner passes full file paths like src/components/pagination/__tests__/Pagination.screenshot.test.ts, collectRenewScreenshotMatches now detects them and uses them directly instead of embedding them in a glob pattern that matches nothing.

