### PR TITLE
chore(Portal): add copy-to-clipboard button to code blocks

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
@@ -19,7 +19,7 @@ If your AI coding agent supports the Model Context Protocol (MCP), you have two 
 
 Point your MCP-aware client at the public Streamable HTTP endpoint:
 
-```
+```txt
 https://eufemia-mcp.eufemia.workers.dev/mcp
 ```
 

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -1,6 +1,8 @@
 @use './../parts/PortalStyle.mixins.scss' as PortalMixins;
 
 .codeBlockStyle {
+  position: relative;
+
   margin-bottom: 2rem;
   :global(.focusmode) & {
     margin-bottom: 0;
@@ -14,6 +16,20 @@
 
   :global(.eufemia-theme) {
     background-color: transparent;
+  }
+}
+
+.copyButtonStyle {
+  position: absolute;
+  top: 2.75rem;
+  left: calc(100% - 2.75rem);
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 200ms ease;
+
+  .codeBlockStyle:hover &,
+  .codeBlockStyle:focus-within & {
+    opacity: 1;
   }
 }
 

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -23,11 +23,14 @@ import {
   ToggleButton,
 } from '@dnb/eufemia/src/components'
 import {
+  copy as copyIcon,
+  check as checkIcon,
   fullscreen as focusModeIcon,
   close as focusModeCloseIcon,
   fullscreen as focusModePaddingIcon,
   layout_grid as focusModeCompactIcon,
 } from '@dnb/eufemia/src/icons'
+import { copyToClipboard } from '@dnb/eufemia/src/shared/helpers'
 import Theme from '@dnb/eufemia/src/shared/Theme'
 import type {
   ThemeColorScheme,
@@ -41,6 +44,7 @@ import {
   liveCodeEditorStyle,
   exampleBoxStyle,
   codeBlockStyle,
+  copyButtonStyle,
   showFocusModePaddingStyle,
   toolbarStyle,
 } from './CodeBlock.module.scss'
@@ -121,6 +125,8 @@ const CodeBlock = ({
               createSkeletonClass('code', context.skeleton)
             )}
           >
+            <CopyCodeButton code={String(exampleCode)} />
+
             <Tag as="pre" className={className} css={style}>
               {cleanTokens(tokens).map((line, i) => {
                 const { key, ...lineProps } = getLineProps({
@@ -148,6 +154,33 @@ const CodeBlock = ({
 }
 
 export default CodeBlock
+
+function CopyCodeButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const handleCopy = useCallback(async () => {
+    const success = await copyToClipboard(code)
+    if (success) {
+      setCopied(true)
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+    }
+  }, [code])
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current)
+  }, [])
+
+  return (
+    <Button
+      className={copyButtonStyle}
+      icon={copied ? checkIcon : copyIcon}
+      tooltip={copied ? 'Copied!' : 'Copy to clipboard'}
+      onClick={handleCopy}
+    />
+  )
+}
 
 type LiveCodeProps = {
   code: string
@@ -475,7 +508,7 @@ function LiveCode(props: LiveCodeProps) {
 
           {!global.IS_TEST && !hideCode && (
             <Space
-              title="Code Editor"
+              title="Make changes to see them live!"
               element="section"
               className={clsx(
                 'dnb-live-editor',

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -19,6 +19,7 @@ import * as FocusModeCodeContext from '../../../core/FocusModeCodeContext'
 vi.mock('../CodeBlock.module.scss', () => ({
   liveCodeEditorStyle: 'liveCodeEditorStyle',
   exampleBoxStyle: 'exampleBoxStyle',
+  copyButtonStyle: 'copyButtonStyle',
   showFocusModePaddingStyle: 'showFocusModePaddingStyle',
   toolbarStyle: 'toolbarStyle',
   codeBlockStyle: 'codeBlockStyle',
@@ -27,6 +28,18 @@ vi.mock('../CodeBlock.module.scss', () => ({
 vi.mock('../../../core/ChangeStyleTheme', () => ({
   default: () => null,
 }))
+
+// Mock copyToClipboard
+vi.mock('@dnb/eufemia/src/shared/helpers', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@dnb/eufemia/src/shared/helpers')
+    >()
+  return {
+    ...actual,
+    copyToClipboard: vi.fn().mockResolvedValue(true),
+  }
+})
 
 // Mock prism theme
 vi.mock('@dnb/eufemia/src/style/themes/ui/prism/dnb-prism-theme', () => ({


### PR DESCRIPTION
Adds a copy-to-clipboard button to code blocks in the portal. The button appears on hover/focus and provides visual feedback when code is copied.

Also fixes a code fence language hint and updates the live editor section title.



<img width="744" height="118" alt="Screenshot 2026-05-20 at 13 02 16" src="https://github.com/user-attachments/assets/ccfd0f50-863e-49a7-a0ee-3eeffb57c40e" />


The fix #8165 will come in handy here.