### PR TITLE
fix(Tooltip): reposition when children content changes

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
+++ b/packages/dnb-eufemia/src/components/popover/PopoverContainer.tsx
@@ -250,6 +250,12 @@ function PopoverContainer(props: PopoverContainerProps) {
     setResolvedPlacement(placement)
   }, [placement])
 
+  useEffect(() => {
+    if (isActive) {
+      requestRecalculation()
+    }
+  }, [children, isActive, requestRecalculation])
+
   useLayoutEffect(() => {
     if (typeof window === 'undefined') {
       return undefined

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -3044,6 +3044,75 @@ describe('Popover', () => {
       targetElement.remove()
     })
 
+    it('repositions when children content changes', async () => {
+      const targetElement = document.createElement('div')
+      document.body.appendChild(targetElement)
+
+      Object.defineProperty(targetElement, 'offsetWidth', {
+        configurable: true,
+        value: 100,
+      })
+      Object.defineProperty(targetElement, 'offsetHeight', {
+        configurable: true,
+        value: 40,
+      })
+
+      const rect = createRect({
+        left: 60,
+        top: 80,
+        width: 100,
+        height: 40,
+      })
+      assignRect(targetElement, rect)
+
+      setElementSize(120, 40)
+
+      const { rerender } = render(
+        <Popover
+          open
+          noAnimation
+          placement="top"
+          targetElement={targetElement}
+        >
+          Short
+        </Popover>
+      )
+
+      await waitFor(() => {
+        const popover = document.querySelector(
+          '.dnb-popover'
+        ) as HTMLElement
+        expect(popover?.style.left).toBeTruthy()
+      })
+
+      const initialLeft = (
+        document.querySelector('.dnb-popover') as HTMLElement
+      )?.style.left
+
+      // Simulate wider content by changing offsetWidth
+      setElementSize(240, 40)
+
+      rerender(
+        <Popover
+          open
+          noAnimation
+          placement="top"
+          targetElement={targetElement}
+        >
+          Much longer content that is wider
+        </Popover>
+      )
+
+      await waitFor(() => {
+        const popover = document.querySelector(
+          '.dnb-popover'
+        ) as HTMLElement
+        expect(popover?.style.left).not.toBe(initialLeft)
+      })
+
+      targetElement.remove()
+    })
+
     describe('Table.ScrollView guard', () => {
       const originalOffsetWidth = Object.getOwnPropertyDescriptor(
         HTMLElement.prototype,


### PR DESCRIPTION
Recalculates Popover/Tooltip position when `children` content changes while the popover is active. This ensures the tooltip stays correctly positioned when the content it's anchored to changes size.