### PR TITLE
chore(Portal): add padding on small screens

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -170,7 +170,7 @@
   }
 
   @include utilities.allBelow(small) {
-    padding: 0 1px;
+    padding: 0 1rem;
 
     :global(.focusmode) & {
       padding: 0;


### PR DESCRIPTION
The main content area had effectively no horizontal padding (`1px`) on small screens. Changed to `1rem` so the content doesn't touch the screen edges.

<img width="99" height="349" alt="Screenshot 2026-05-20 at 13 07 00" src="https://github.com/user-attachments/assets/b2ca84f8-4967-4476-85fd-8af47c716e6b" />
