### PR TITLE
chore(Pagination): preventDefault on anchor clicks to avoid double navigation

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationBar.tsx
@@ -169,11 +169,19 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
       return // stop here
     }
 
+    if (event?.currentTarget instanceof HTMLAnchorElement) {
+      event.preventDefault()
+    }
+
     setPage(props.currentPageInternal - 1)
   }
   const setNextPage = (event = null) => {
     if (isModifiedClickEvent(event)) {
       return // stop here
+    }
+
+    if (event?.currentTarget instanceof HTMLAnchorElement) {
+      event.preventDefault()
     }
 
     setPage(props.currentPageInternal + 1)
@@ -187,6 +195,10 @@ const PaginationBar = (localProps: PaginationBarAllProps) => {
 
     if (isAnchorLikeElement && isModifiedClickEvent(event)) {
       return // stop here
+    }
+
+    if (isAnchorLikeElement) {
+      event?.preventDefault()
     }
 
     setPage(pageNumber, event)

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -10,7 +10,7 @@ import {
   loadScss,
   wait,
 } from '../../../core/test-utils/testSetup'
-import { fireEvent, render } from '@testing-library/react'
+import { createEvent, fireEvent, render } from '@testing-library/react'
 import type { PaginationProps } from '../Pagination'
 import Pagination, { createPagination, Bar } from '../Pagination'
 import Anchor from '../../anchor/Anchor'
@@ -1125,7 +1125,12 @@ describe('Pagination transformNavigationItem', () => {
     const secondPage = document.querySelector(
       '.dnb-pagination__bar__inner a.dnb-pagination__button:nth-child(2)'
     )
-    fireEvent.click(secondPage, { metaKey: true })
+
+    // Use createEvent + preventDefault so jsdom does not attempt
+    // navigation (which emits "Not implemented" warnings).
+    const event = createEvent.click(secondPage, { metaKey: true })
+    event.preventDefault()
+    fireEvent(secondPage, event)
 
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -1145,9 +1150,32 @@ describe('Pagination transformNavigationItem', () => {
     const nextButton = document.querySelector(
       '.dnb-pagination__bar__inner a.dnb-pagination__button--next'
     )
-    fireEvent.click(nextButton, { ctrlKey: true })
+
+    // Use createEvent + preventDefault so jsdom does not attempt
+    // navigation (which emits "Not implemented" warnings).
+    const event = createEvent.click(nextButton, { ctrlKey: true })
+    event.preventDefault()
+    fireEvent(nextButton, event)
 
     expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('calls preventDefault on normal anchor clicks to avoid double navigation', () => {
+    render(
+      <Pagination
+        pageCount={5}
+        currentPage={1}
+        transformNavigationItem={transformNavigationItem}
+      />
+    )
+
+    const anchor = document.querySelector(
+      '.dnb-pagination__bar__inner a.dnb-pagination__button:nth-child(2)'
+    )
+    const event = createEvent.click(anchor)
+    fireEvent(anchor, event)
+
+    expect(event.defaultPrevented).toBe(true)
   })
 
   it('renders current page as a non-interactive span', () => {


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/26159692938/job/76953308961#step:9:212

Removing these warnings/logs from test output:

```
Not implemented: navigation to another Document
Not implemented: navigation to another Document
Not implemented: navigation to another Document
```

