### PR TITLE
docs(Table): document aria-label for highlighted cells

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -2139,6 +2139,7 @@ export const ColumnHighlight = () => (
     {() => {
       const ColumnHighlightTable = () => {
         const highlightRef = useTableHighlight()
+        const label = 'Table with highlighted column'
 
         return (
           <Table.ScrollView>
@@ -2150,15 +2151,19 @@ export const ColumnHighlight = () => (
               <thead>
                 <Tr>
                   <Th />
-                  <Th highlight>Column A</Th>
-                  <Th highlight>Column B</Th>
+                  <Th highlight aria-label={label}>
+                    Column A
+                  </Th>
+                  <Th highlight aria-label={label}>
+                    Column B
+                  </Th>
                   <Th>Column C</Th>
                   <Th>Column D</Th>
                 </Tr>
               </thead>
 
               <tbody>
-                <Tr highlight>
+                <Tr highlight aria-label={label}>
                   <Th>Row 1 Header</Th>
                   <Td>Row 1</Td>
                   <Td>Row 1</Td>
@@ -2176,7 +2181,9 @@ export const ColumnHighlight = () => (
                   <Th>Row 3 Header</Th>
                   <Td>Row 3</Td>
                   <Td>Row 3</Td>
-                  <Td highlight>Row 3</Td>
+                  <Td highlight aria-label={label}>
+                    Row 3
+                  </Td>
                   <Td>Row 3</Td>
                 </Tr>
               </tbody>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/demos.mdx
@@ -148,9 +148,11 @@ This example uses `scope="row"` with a table header (`<th>`) in each row.
 
 <Examples.ResponsiveInCard />
 
-### Column highlight
+### Cell highlighting
 
 Use `highlight` on `<Th>`, `<Tr>`, or `<Td>` to apply a subtle background and border. When set on a `<Tr>`, all cells in that row are highlighted. You can also set it on individual `<Td>` cells.
+
+**NB:** Highlighted cells should include an `aria-label` that conveys both the highlight state and the reason for it. Screen reader users cannot perceive the visual highlight, so this label is their only way to understand that a cell stands out and why.
 
 To adjust the border colors accordingly, use the `useTableHighlight` hook and pass the returned ref to `<Table>`.
 


### PR DESCRIPTION
- Renames the "Column highlight" section to "Cell highlighting" since the feature applies to rows and individual cells too
- Adds guidance that highlighted cells should include an `aria-label` so screen reader users can perceive the highlight and understand its purpose
- Adds `aria-label` to highlighted cells in the demo example